### PR TITLE
fix(export): emit bsi::ifc::material on IFCX export (Ifc5Exporter)

### DIFF
--- a/.changeset/ifc5-exporter-material-drop.md
+++ b/.changeset/ifc5-exporter-material-drop.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': minor
+---
+
+`Ifc5Exporter` (IFC → IFCX/IFC5) never wrote `bsi::ifc::material`, the only attribute IFCX carries an element's material on — an `IfcRelAssociatesMaterial` association from the STEP source was silently dropped on export, even though our own IFCX reader (`@ifc-lite/ifcx`'s `property-extractor.ts`) already unpacks that attribute into a "Material" pset. The exporter now emits `bsi::ifc::material: { code: <material name> }` for an entity with a resolved material. `uri` is intentionally omitted: unlike an IFC class name, a freeform IFC4 material name has no buildingSMART identifier registry to point at, and fabricating a resolvable-looking URI would misrepresent it as officially registered.

--- a/packages/export/src/ifc5-export-helpers.ts
+++ b/packages/export/src/ifc5-export-helpers.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Small standalone helpers for {@link Ifc5Exporter} — split out purely to
+ * keep ifc5-exporter.ts under its module-size budget; no behavior change.
+ */
+
+import { IfcTypeEnumToString, IfcTypeEnumFromString } from '@ifc-lite/data';
+
+/** IFCX node in output, matching the shape `collectRequiredImports` scans. */
+interface IfcxNodeOutputLike {
+  attributes?: Record<string, unknown>;
+}
+
+/** Standard IFC5 schema package URIs, keyed by the attribute prefix they provide. */
+export const IFCX_SCHEMA_IMPORTS = {
+  /** Core IFC: bsi::ifc::class, bsi::ifc::presentation::*, bsi::ifc::material, bsi::ifc::spaceBoundary */
+  IFC_CORE: 'https://ifcx.dev/@standards.buildingsmart.org/ifc/core/ifc@v5a.ifcx',
+  /** IFC properties: bsi::ifc::prop::* */
+  IFC_PROP: 'https://ifcx.dev/@standards.buildingsmart.org/ifc/core/prop@v5a.ifcx',
+  /** OpenUSD geometry: usd::usdgeom::mesh, usd::xformop, usd::usdgeom::visibility */
+  USD: 'https://ifcx.dev/@openusd.org/usd@v1.ifcx',
+} as const;
+
+/**
+ * Scan data nodes and return the list of standard IFCX import URIs needed
+ * for the attribute namespaces actually used.
+ */
+export function collectRequiredImports(nodes: IfcxNodeOutputLike[]): { uri: string }[] {
+  let needsIfcCore = false;
+  let needsIfcProp = false;
+  let needsUsd = false;
+
+  for (const node of nodes) {
+    if (!node.attributes) continue;
+    for (const key of Object.keys(node.attributes)) {
+      // IFC core schemas: class, presentation, material, spaceBoundary
+      if (!needsIfcCore && (
+        key === 'bsi::ifc::class' ||
+        key.startsWith('bsi::ifc::presentation::') ||
+        key === 'bsi::ifc::material' ||
+        key === 'bsi::ifc::spaceBoundary'
+      )) {
+        needsIfcCore = true;
+      }
+      // IFC property schemas: bsi::ifc::prop::*
+      if (!needsIfcProp && key.startsWith('bsi::ifc::prop::')) {
+        needsIfcProp = true;
+      }
+      // USD schemas: usd::*
+      if (!needsUsd && key.startsWith('usd::')) {
+        needsUsd = true;
+      }
+      if (needsIfcCore && needsIfcProp && needsUsd) break;
+    }
+    if (needsIfcCore && needsIfcProp && needsUsd) break;
+  }
+
+  const imports: { uri: string }[] = [];
+  if (needsIfcCore) imports.push({ uri: IFCX_SCHEMA_IMPORTS.IFC_CORE });
+  if (needsIfcProp) imports.push({ uri: IFCX_SCHEMA_IMPORTS.IFC_PROP });
+  if (needsUsd) imports.push({ uri: IFCX_SCHEMA_IMPORTS.USD });
+  return imports;
+}
+
+/**
+ * Generate a deterministic UUID-like string from an expressId.
+ * Format: 8-4-4-4-12 hex chars (UUID v4-like but deterministic).
+ */
+export function generateUuid(id: number): string {
+  const hex = id.toString(16).padStart(12, '0');
+  return `00000000-0000-4000-8000-${hex}`;
+}
+
+/**
+ * Convert STEP uppercase type name (e.g. "IFCWALL") to PascalCase class name (e.g. "IfcWall").
+ * Uses the IFC type enum lookup for canonical casing (e.g. "IfcRelAggregates", not "Ifcrelaggregates").
+ */
+export function stepTypeToClassName(stepType: string): string {
+  const enumVal = IfcTypeEnumFromString(stepType);
+  const name = IfcTypeEnumToString(enumVal);
+  if (name !== 'Unknown') return name;
+  // Fallback for types not in the enum: simple prefix normalisation
+  const lower = stepType.toLowerCase();
+  if (lower.startsWith('ifc')) {
+    return 'Ifc' + lower.charAt(3).toUpperCase() + lower.slice(4);
+  }
+  return stepType;
+}

--- a/packages/export/src/ifc5-exporter.test.ts
+++ b/packages/export/src/ifc5-exporter.test.ts
@@ -687,6 +687,61 @@ END-ISO-10303-21;`;
       expect(classCodes).toContain('IfcBuilding');
       expect(classCodes).toContain('IfcBuildingStorey');
     });
+
+    // bsi::ifc::material ({code, uri}) is the only channel IFCX carries which
+    // material an element is made of — our own reader (property-extractor.ts)
+    // already unpacks it into a "Material" pset, but the writer never emitted
+    // it: an IfcRelAssociatesMaterial association from the STEP source was
+    // silently dropped on export, so a round trip through our own writer lost
+    // every element's material.
+    it('emits bsi::ifc::material for an entity with an IfcRelAssociatesMaterial association', async () => {
+      const withMaterial = REAL_IFC4.replace(
+        'ENDSEC;\nEND-ISO-10303-21;',
+        "#500=IFCMATERIAL('Concrete',$,$);\n"
+        + "#501=IFCRELASSOCIATESMATERIAL('3xJf$b$MP7XLbaHy6XT9EM',#18,$,$,(#139),#500);\n"
+        + 'ENDSEC;\nEND-ISO-10303-21;',
+      );
+      const parser = new IfcParser();
+      const store = await parser.parseColumnar(
+        new TextEncoder().encode(withMaterial).buffer,
+      );
+
+      const exporter = new Ifc5Exporter(store);
+      const result = exporter.export({ includeGeometry: false });
+      const file = JSON.parse(result.content);
+
+      const wallNode = file.data.find(
+        (n: any) => n.attributes?.['bsi::ifc::class']?.code === 'IfcWall'
+          && n.attributes?.['bsi::ifc::prop::Name']?.startsWith('Basic Wall:Holz Aussenwand'),
+      );
+      expect(wallNode).toBeDefined();
+      expect(wallNode.attributes['bsi::ifc::material']).toEqual({ code: 'Concrete' });
+
+      // `code` matches the official schema's `String` restriction — `uri` is
+      // deliberately omitted rather than fabricated, since arbitrary IFC4
+      // material names have no buildingSMART identifier registry (unlike
+      // IFC classes, which resolve to a real one — see bsi::ifc::class above).
+      const schema = ALL_OFFICIAL_SCHEMAS['bsi::ifc::material'];
+      expect(schema.value.objectRestrictions?.values.code.dataType).toBe('String');
+    });
+
+    // Control: an entity with no material association still exports with no
+    // bsi::ifc::material attribute — proves the emission is conditional on a
+    // real association, not a blanket addition.
+    it('control: no bsi::ifc::material is emitted when nothing is associated', async () => {
+      const parser = new IfcParser();
+      const store = await parser.parseColumnar(
+        new TextEncoder().encode(REAL_IFC4).buffer,
+      );
+
+      const exporter = new Ifc5Exporter(store);
+      const result = exporter.export({ includeGeometry: false });
+      const file = JSON.parse(result.content);
+
+      for (const node of file.data) {
+        expect(node.attributes?.['bsi::ifc::material']).toBeUndefined();
+      }
+    });
   });
 
   // #2046: Ifc5Exporter never consulted the overlay for deletions — it walked

--- a/packages/export/src/ifc5-exporter.ts
+++ b/packages/export/src/ifc5-exporter.ts
@@ -20,13 +20,14 @@ import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { MeshData, GeometryResult } from '@ifc-lite/geometry';
 import {
   IfcTypeEnumToString,
-  IfcTypeEnumFromString,
   type IfcTypeEnum,
   PropertyValueType,
   IFCX_VERSION,
 } from '@ifc-lite/data';
 import { convertEntityType, type IfcSchemaVersion } from './schema-converter.js';
 import { getEffectiveEntityIndex } from './effective-index.js';
+import { buildMaterialAttribute } from './ifc5-material.js';
+import { collectRequiredImports, generateUuid, stepTypeToClassName } from './ifc5-export-helpers.js';
 
 /** Recursive spatial tree node type used when walking the hierarchy. */
 interface SpatialTreeNode {
@@ -34,20 +35,6 @@ interface SpatialTreeNode {
   name?: string;
   children: SpatialTreeNode[];
 }
-
-// ============================================================================
-// Standard IFCX schema imports
-// ============================================================================
-
-/** Standard IFC5 schema package URIs, keyed by the attribute prefix they provide. */
-const IFCX_SCHEMA_IMPORTS = {
-  /** Core IFC: bsi::ifc::class, bsi::ifc::presentation::*, bsi::ifc::material, bsi::ifc::spaceBoundary */
-  IFC_CORE: 'https://ifcx.dev/@standards.buildingsmart.org/ifc/core/ifc@v5a.ifcx',
-  /** IFC properties: bsi::ifc::prop::* */
-  IFC_PROP: 'https://ifcx.dev/@standards.buildingsmart.org/ifc/core/prop@v5a.ifcx',
-  /** OpenUSD geometry: usd::usdgeom::mesh, usd::xformop, usd::usdgeom::visibility */
-  USD: 'https://ifcx.dev/@openusd.org/usd@v1.ifcx',
-} as const;
 
 /**
  * Property names that have official IFC5 schema definitions in prop@v5a.ifcx.
@@ -312,6 +299,14 @@ export class Ifc5Exporter {
         for (const [key, value] of Object.entries(props)) {
           attributes[key] = value;
           propertyCount++;
+        }
+      }
+
+      // Material (bsi::ifc::material) — see ifc5-material.ts.
+      if (options.includeProperties !== false) {
+        const material = buildMaterialAttribute(this.dataStore, expressId);
+        if (material) {
+          attributes['bsi::ifc::material'] = material;
         }
       }
 
@@ -815,74 +810,4 @@ export class Ifc5Exporter {
 
     return visible;
   }
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/**
- * Scan data nodes and return the list of standard IFCX import URIs needed
- * for the attribute namespaces actually used.
- */
-function collectRequiredImports(nodes: IfcxNodeOutput[]): { uri: string }[] {
-  let needsIfcCore = false;
-  let needsIfcProp = false;
-  let needsUsd = false;
-
-  for (const node of nodes) {
-    if (!node.attributes) continue;
-    for (const key of Object.keys(node.attributes)) {
-      // IFC core schemas: class, presentation, material, spaceBoundary
-      if (!needsIfcCore && (
-        key === 'bsi::ifc::class' ||
-        key.startsWith('bsi::ifc::presentation::') ||
-        key === 'bsi::ifc::material' ||
-        key === 'bsi::ifc::spaceBoundary'
-      )) {
-        needsIfcCore = true;
-      }
-      // IFC property schemas: bsi::ifc::prop::*
-      if (!needsIfcProp && key.startsWith('bsi::ifc::prop::')) {
-        needsIfcProp = true;
-      }
-      // USD schemas: usd::*
-      if (!needsUsd && key.startsWith('usd::')) {
-        needsUsd = true;
-      }
-      if (needsIfcCore && needsIfcProp && needsUsd) break;
-    }
-    if (needsIfcCore && needsIfcProp && needsUsd) break;
-  }
-
-  const imports: { uri: string }[] = [];
-  if (needsIfcCore) imports.push({ uri: IFCX_SCHEMA_IMPORTS.IFC_CORE });
-  if (needsIfcProp) imports.push({ uri: IFCX_SCHEMA_IMPORTS.IFC_PROP });
-  if (needsUsd) imports.push({ uri: IFCX_SCHEMA_IMPORTS.USD });
-  return imports;
-}
-
-/**
- * Generate a deterministic UUID-like string from an expressId.
- * Format: 8-4-4-4-12 hex chars (UUID v4-like but deterministic).
- */
-function generateUuid(id: number): string {
-  const hex = id.toString(16).padStart(12, '0');
-  return `00000000-0000-4000-8000-${hex}`;
-}
-
-/**
- * Convert STEP uppercase type name (e.g. "IFCWALL") to PascalCase class name (e.g. "IfcWall").
- * Uses the IFC type enum lookup for canonical casing (e.g. "IfcRelAggregates", not "Ifcrelaggregates").
- */
-function stepTypeToClassName(stepType: string): string {
-  const enumVal = IfcTypeEnumFromString(stepType);
-  const name = IfcTypeEnumToString(enumVal);
-  if (name !== 'Unknown') return name;
-  // Fallback for types not in the enum: simple prefix normalisation
-  const lower = stepType.toLowerCase();
-  if (lower.startsWith('ifc')) {
-    return 'Ifc' + lower.charAt(3).toUpperCase() + lower.slice(4);
-  }
-  return stepType;
 }

--- a/packages/export/src/ifc5-material.ts
+++ b/packages/export/src/ifc5-material.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bsi::ifc::material` — the only channel IFCX carries which material an
+ * element is made of. Our own reader (`packages/ifcx/src/property-extractor.ts`)
+ * already unpacks this attribute into a "Material" pset (a real buildingSMART
+ * PCERT sample scene authors it as `{code, uri}` on most physical elements),
+ * but {@link Ifc5Exporter} never emitted it: an `IfcRelAssociatesMaterial`
+ * association from the STEP source was silently dropped on export, so a
+ * round trip through our own writer lost every element's material.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { extractMaterialsOnDemand } from '@ifc-lite/parser';
+
+/**
+ * Build the `bsi::ifc::material` attribute value for an entity, or
+ * `undefined` when it has no material association.
+ *
+ * `uri` is deliberately omitted rather than fabricated: unlike an IFC class
+ * name (`bsi::ifc::class`, which resolves to a real buildingSMART identifier
+ * registry entry), a freeform IFC4 `IfcMaterial.Name` has no such registry —
+ * inventing a resolvable-looking URI for it would misrepresent the material
+ * as officially registered.
+ */
+export function buildMaterialAttribute(
+  dataStore: IfcDataStore,
+  expressId: number,
+): { code: string } | undefined {
+  const material = extractMaterialsOnDemand(dataStore, expressId);
+  return material?.name ? { code: material.name } : undefined;
+}


### PR DESCRIPTION
## Summary

`Ifc5Exporter` (`packages/export/src/ifc5-exporter.ts`, the writer used by the viewer's export dialog and the CLI to go IFC → IFCX/IFC5) never wrote `bsi::ifc::material`. That attribute is the only channel IFCX carries which material an element is made of — the writer's own sibling reader (`packages/ifcx/src/property-extractor.ts`) already unpacks it into a "Material" pset (a real buildingSMART PCERT sample scene authors it as `{code, uri}` on most physical elements), but nothing on the write side ever produced it, even though `collectRequiredImports` already special-cased the key when deciding which schema imports to declare. An `IfcRelAssociatesMaterial` association from a STEP source was silently dropped: it survives everywhere else in the pipeline (query engine, viewer Material tab) but vanishes on IFCX export.

## Conformance matrix (writer output vs the committed v5a spec schemas)

| Attribute | Spec shape (`ifc@v5a.ifcx` / `prop@v5a.ifcx`) | Writer verdict before | Writer verdict after |
|---|---|---|---|
| `bsi::ifc::class` | `{code, uri}` | conformant | unchanged |
| `bsi::ifc::prop::Name` / `Description` | string | conformant | unchanged |
| `bsi::ifc::prop::*` (known psets) | typed value | conformant | unchanged |
| `usd::usdgeom::mesh` (points/faceVertexIndices) | array-of-arrays / int array | conformant | unchanged |
| `bsi::ifc::presentation::diffuseColor` / `opacity` | array / real | conformant | unchanged |
| **`bsi::ifc::material`** | `{code, uri}` | **never emitted — data loss** | `{code}` emitted; `uri` deliberately omitted (see below) |

## Fix

Emit `bsi::ifc::material: { code: <material name> }` for an entity that resolves to a material via `extractMaterialsOnDemand` (occurrence-level `IfcRelAssociatesMaterial`, falling back to the type's association). `uri` is intentionally **not** fabricated: unlike an IFC5 class name, which resolves to a real buildingSMART identifier-registry entry, a freeform IFC4 `IfcMaterial.Name` has no such registry — inventing a resolvable-looking URI for it would misrepresent the material as officially registered. This is a documented, deliberate partial-conformance choice, not a silent gap.

RED test reproduces the drop by parsing a real STEP fixture with an `IfcWall` + `IfcMaterial` + `IfcRelAssociatesMaterial`, exporting to IFCX, and asserting `bsi::ifc::material` is present with the source material's name. A control test pins that an entity with no material association still exports with no `bsi::ifc::material` attribute (proves the emission is conditional, not a blanket addition).

`collectRequiredImports`/`generateUuid`/`stepTypeToClassName` moved to a sibling `ifc5-export-helpers.ts` (pure extraction, no behavior change) to keep `ifc5-exporter.ts` under its zero-headroom module-size budget after the fix.

## Test plan

- [x] `pnpm --filter @ifc-lite/export exec vitest run src/ifc5-exporter.test.ts` — 34 passed, 5 skipped (fixture-gated)
- [x] RED confirmed on unmodified `ifc5-exporter.ts` (git stash), GREEN after the fix
- [x] `pnpm --filter @ifc-lite/export exec vitest run` (excluding the pre-existing, unrelated `lod1-generator.test.ts` wasm-resolution failure — reproduced identically on unmodified `main`) — 1046 passed, 30 skipped
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over 400
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm turbo run typecheck --filter=@ifc-lite/export` — OK
- [x] `node scripts/check-unused-locals.mjs` — no new violations (diff against unmodified `main` is empty)
- [x] Changeset added (`@ifc-lite/export`: minor)
- [x] No public API surface change (`index.ts` unchanged — new helper/material files are internal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436