### PR TITLE
fix(ci): make the review-lane timeout budget executable

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,11 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # Verify the shared producer/consumer time-budget invariant before asking
-      # the reviewer to start its potentially twenty-minute run.
-      - name: Verify review-lane time budget
-        run: node -e "import('./scripts/review-lane-budget.mjs').then(({ assertReviewLaneBudget }) => assertReviewLaneBudget())"
-
       # The SCRIPTS come from the PR so a change to the lane is exercised by its
       # own PR. The RUBRIC comes from the base branch below, because it is the
       # thing worth editing to weaken the review that judges you. Same split, and
@@ -78,13 +73,19 @@ jobs:
         with:
           node-version: 22
 
+      # The runner has no repository checkout before actions/checkout.  Verify
+      # the shared producer/consumer invariant from the same PR ref whose lane
+      # it governs, before asking the reviewer to start its twenty-minute run.
+      - name: Verify review-lane time budget
+        run: node --input-type=module --eval 'import { assertReviewLaneBudget } from "./scripts/review-lane-budget.mjs"; assertReviewLaneBudget();'
+
       # NO SETTLE SLEEP. Correctness is already owned three times over:
       # `cancel-in-progress` allows one live run per PR, the head check below
       # exits a superseded run, and post-review re-reads the head immediately
       # before posting. A sleep would buy only occasional model-quota insurance,
       # and it is charged three ways -- runner minutes, time-to-green, and three
-      # EXTRA poll ticks on the sibling gate, which polls every 30s while this
-      # lane naps, against a repository-wide 1,000/hour API budget.
+      # EXTRA poll work on the sibling gate while this lane naps, against a
+      # repository-wide 1,000/hour API budget.
       #
       # If the head moved, the newer event owns it. Exit rather
       # than review a dead commit: a marker for a superseded head is one the gate

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -47,6 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # Verify the shared producer/consumer time-budget invariant before asking
+      # the reviewer to start its potentially twenty-minute run.
+      - name: Verify review-lane time budget
+        run: node -e "import('./scripts/review-lane-budget.mjs').then(({ assertReviewLaneBudget }) => assertReviewLaneBudget())"
+
       # The SCRIPTS come from the PR so a change to the lane is exercised by its
       # own PR. The RUBRIC comes from the base branch below, because it is the
       # thing worth editing to weaken the review that judges you. Same split, and

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -73,19 +73,13 @@ jobs:
         with:
           node-version: 22
 
-      # The runner has no repository checkout before actions/checkout.  Verify
-      # the shared producer/consumer invariant from the same PR ref whose lane
-      # it governs, before asking the reviewer to start its twenty-minute run.
-      - name: Verify review-lane time budget
-        run: node --input-type=module --eval 'import { assertReviewLaneBudget } from "./scripts/review-lane-budget.mjs"; assertReviewLaneBudget();'
-
       # NO SETTLE SLEEP. Correctness is already owned three times over:
       # `cancel-in-progress` allows one live run per PR, the head check below
       # exits a superseded run, and post-review re-reads the head immediately
       # before posting. A sleep would buy only occasional model-quota insurance,
       # and it is charged three ways -- runner minutes, time-to-green, and three
-      # EXTRA poll work on the sibling gate while this lane naps, against a
-      # repository-wide 1,000/hour API budget.
+      # EXTRA poll ticks on the sibling gate, which polls every 30s while this
+      # lane naps, against a repository-wide 1,000/hour API budget.
       #
       # If the head moved, the newer event owns it. Exit rather
       # than review a dead commit: a marker for a superseded head is one the gate

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -166,11 +166,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          poll_seconds="$(
+            node --input-type=module --eval \
+              'import { pollSecondsArgument } from "./scripts/review-lane-budget.mjs"; console.log(pollSecondsArgument());'
+          )"
           node scripts/check-review-posted.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}" \
             --config "${{ steps.cfg.outputs.config }}" \
-            --timeout-seconds "$(node -e \"import('./scripts/review-lane-budget.mjs').then(({ pollSecondsArgument }) => console.log(pollSecondsArgument()))\")"
+            --timeout-seconds "$poll_seconds"
 
       # ADDS ONLY. The clearing half runs up front, above.
       #

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -56,7 +56,8 @@ jobs:
   review-posted:
     name: Review posted
     runs-on: ubuntu-latest
-    # ABOVE the gate's poll budget (1500s), deliberately, so a run that exhausts
+    # ABOVE the gate's poll budget (REVIEW_POSTED_POLL_SECONDS in
+    # scripts/review-lane-budget.mjs), deliberately, so a run that exhausts
     # the budget still gets to PRINT its verdict rather than being killed
     # mid-wait with no output and no `covered` value. The sibling gate states the
     # same rule at pr-review-signal.yml (a job cap comfortably over its own poll

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -56,7 +56,7 @@ jobs:
   review-posted:
     name: Review posted
     runs-on: ubuntu-latest
-    # ABOVE the gate's poll budget (600s), deliberately, so a run that exhausts
+    # ABOVE the gate's poll budget (1500s), deliberately, so a run that exhausts
     # the budget still gets to PRINT its verdict rather than being killed
     # mid-wait with no output and no `covered` value. The sibling gate states the
     # same rule at pr-review-signal.yml (a job cap comfortably over its own poll
@@ -170,7 +170,7 @@ jobs:
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}" \
             --config "${{ steps.cfg.outputs.config }}" \
-            --timeout-seconds 1500
+            --timeout-seconds "$(node -e \"import('./scripts/review-lane-budget.mjs').then(({ pollSecondsArgument }) => console.log(pollSecondsArgument()))\")"
 
       # ADDS ONLY. The clearing half runs up front, above.
       #

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -167,10 +167,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
-          poll_seconds="$(
-            node --input-type=module --eval \
-              'import { pollSecondsArgument } from "./scripts/review-lane-budget.mjs"; console.log(pollSecondsArgument());'
-          )"
+          poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"
           node scripts/check-review-posted.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}" \

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -608,8 +608,9 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
   // returns its own input, and stays green through any constant change. 1500 s
   // is the budget the two workflow caps below (20 min lane, 30 min job) were
   // chosen against, so changing it must be acknowledged here.
-  assert.equal(pollSecondsArgument(), '1500');
-  assert.equal(REVIEW_POSTED_POLL_SECONDS, 1500);
+  const REMEDY = 'the poll budget is a contract with the two workflow caps below: restore 1500, or change the constant, this pin and both caps together';
+  assert.equal(pollSecondsArgument(), '1500', REMEDY);
+  assert.equal(REVIEW_POSTED_POLL_SECONDS, 1500, REMEDY);
 
   assert.throws(
     () => assertReviewLaneBudget({ pollSeconds: REVIEW_LANE_TIMEOUT_SECONDS }),

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -603,7 +603,13 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
   // The shared executable contract is used by both lanes. THE COPIES below
   // pins it to the two workflow literals it cannot read at run time.
   assert.doesNotThrow(assertReviewLaneBudget);
-  assert.equal(pollSecondsArgument(), String(REVIEW_POSTED_POLL_SECONDS));
+  // THE CONCRETE NUMBER, not `String(REVIEW_POSTED_POLL_SECONDS)`: deriving the
+  // expectation from the thing under test asserts only that the function
+  // returns its own input, and stays green through any constant change. 1500 s
+  // is the budget the two workflow caps below (20 min lane, 30 min job) were
+  // chosen against, so changing it must be acknowledged here.
+  assert.equal(pollSecondsArgument(), '1500');
+  assert.equal(REVIEW_POSTED_POLL_SECONDS, 1500);
 
   assert.throws(
     () => assertReviewLaneBudget({ pollSeconds: REVIEW_LANE_TIMEOUT_SECONDS }),
@@ -633,9 +639,53 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
 // the duplication the design cannot remove, not a restatement of the module.
 const GATE_STEP = 'Check a review was actually posted for this head';
 
-/** The wiring the gate step's shell must actually execute. */
-const WIRED_POLL =
-  /poll_seconds="\$\([\s\S]*?review-lane-budget\.mjs[\s\S]*?\)"[\s\S]*?--timeout-seconds "\$poll_seconds"/;
+const BUDGET_CLI = join(HERE, 'review-lane-budget.mjs');
+const budgetCli = (...args) => {
+  const r = spawnSync(process.execPath, [BUDGET_CLI, ...args], { encoding: 'utf8' });
+  return { code: r.status, out: r.stdout.trim(), err: r.stderr.trim() };
+};
+
+/**
+ * THE COMMAND LINE, not the exported function. Every other test here imports
+ * `pollSecondsArgument()`, and all of them stayed green while the module had no
+ * CLI at all: `node scripts/review-lane-budget.mjs --poll-seconds` printed
+ * NOTHING and exited 0, so the workflow's command substitution would have set an
+ * empty `poll_seconds` and the gate would have exited BAD_ARGS on every PR. The
+ * wiring pin cannot see that -- it reads the workflow's text, and the text was
+ * right. Only spawning the thing catches it. Raised by /simplify on PR #3610.
+ */
+test('THE CLI: the spelling the workflow runs prints the poll budget', () => {
+  const ok = budgetCli('--poll-seconds');
+  assert.equal(ok.code, 0, ok.err);
+  assert.equal(ok.out, '1500', 'the workflow captures stdout; an empty capture is BAD_ARGS on every PR');
+  assert.equal(ok.out, String(REVIEW_POSTED_POLL_SECONDS), 'the CLI and the constant are one number');
+});
+
+test('THE CLI: an argument it does not implement FAILS rather than printing nothing', () => {
+  // The silent-exit-0 shape is the whole defect: with `set -e` a non-zero exit
+  // stops the step loudly, while an empty stdout travels on and misconfigures
+  // the gate. Both an unknown flag and no flag at all must take the loud path.
+  for (const args of [['--bogus'], [], ['--poll-seconds', 'extra']]) {
+    const r = budgetCli(...args);
+    assert.notEqual(r.code, 0, `\`${args.join(' ')}\` must not exit 0: ${r.out}`);
+    assert.equal(r.out, '', 'nothing may reach stdout on the failure path');
+    assert.match(r.err, /usage: node scripts\/review-lane-budget\.mjs --poll-seconds/);
+  }
+});
+
+
+/**
+ * The wiring the gate step's shell must actually execute, pinned to the EXACT
+ * spelling that ships. A loose `[\s\S]*?` between the halves let any invocation
+ * of the module count -- including the `node --input-type=module --eval` form
+ * this replaced, and including a `--poll-seconds` flag the module does not
+ * implement. There is one command line CI runs; this is it.
+ */
+const WIRED_ASSIGNMENT = 'poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"';
+const WIRED_PASS = '--timeout-seconds "$poll_seconds"';
+const WIRED_POLL = new RegExp(
+  `${WIRED_ASSIGNMENT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${WIRED_PASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+);
 
 /**
  * The EXECUTED shell of one workflow step: its `run:` block scalar with comment
@@ -672,8 +722,8 @@ test('THE COPIES: a COMMENT naming the module cannot satisfy the wiring pin', ()
     '    steps:',
     `      - name: ${GATE_STEP}`,
     '        run: |',
-    '          # poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"',
-    '          # node scripts/check-review-posted.mjs --timeout-seconds "$poll_seconds"',
+    `          # ${WIRED_ASSIGNMENT}`,
+    `          # node scripts/check-review-posted.mjs ${WIRED_PASS}`,
     '          node scripts/check-review-posted.mjs --timeout-seconds 600',
     '      - name: something after',
     '        run: echo done',
@@ -747,9 +797,9 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
     runScript,
     WIRED_POLL,
     `the '${GATE_STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
-      'from review-lane-budget.mjs. REMEDY: inside that one step, set ' +
-      '`poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"` and pass ' +
-      '`--timeout-seconds "$poll_seconds"`. IN THAT SAME STEP is the whole point: a shell ' +
+      `from review-lane-budget.mjs. REMEDY: inside that one step, set \`${WIRED_ASSIGNMENT}\` ` +
+      `and pass \`${WIRED_PASS}\`. THE REMEDY IS BUILT FROM THE MATCHER, so it cannot ` +
+      'describe a spelling the pin would reject. IN THAT SAME STEP is the whole point: a shell ' +
       'variable does not survive across steps, so splitting them expands to empty and the ' +
       'gate exits BAD_ARGS on every PR while still looking wired.',
   );

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -20,6 +20,14 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pageAll } from './check-review-posted.mjs';
+import {
+  REVIEW_LANE_TIMEOUT_SECONDS,
+  REVIEW_POSTED_JOB_TIMEOUT_SECONDS,
+  REVIEW_POSTED_MINIMUM_GRACE_SECONDS,
+  REVIEW_POSTED_POLL_SECONDS,
+  assertReviewLaneBudget,
+  pollSecondsArgument,
+} from './review-lane-budget.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GATE = join(HERE, 'check-review-posted.mjs');
@@ -579,7 +587,7 @@ test('FAIL CLOSED: the fork check REFUSES when no repository was resolved', () =
 
 // ============================ the gate must outwait the lane it is waiting FOR
 
-test('THE RACE: the gate\'s poll budget exceeds the LANE\'s own job timeout', () => {
+test('THE RACE: the shared producer/consumer budget rejects either side shrinking', () => {
   // MEASURED, on PR #3593, with the gate already enforcing:
   //
   //   gate gave up after 600 s   05:12:43
@@ -592,31 +600,33 @@ test('THE RACE: the gate\'s poll budget exceeds the LANE\'s own job timeout', ()
   // the gate was always going to lose eventually; observed lane runs that
   // actually reviewed took 525 s and 676 s, either side of it.
   //
-  // The relationship lives in TWO FILES and nothing connected them, which is the
-  // matched-pair shape this repository keeps paying for. Connected here.
-  const here = dirname(fileURLToPath(import.meta.url));
-  const wf = (n) => readFileSync(join(here, '..', '.github/workflows', n), 'utf8');
+  // The shared executable contract is used by both lanes; this tests the
+  // producer/consumer behaviour rather than parsing either workflow's text.
+  assert.doesNotThrow(assertReviewLaneBudget);
+  assert.equal(pollSecondsArgument(), String(REVIEW_POSTED_POLL_SECONDS));
 
-  const laneCap = /^[ \t]*timeout-minutes:[ \t]*(\d+)/m.exec(wf('claude-review.yml'));
-  assert.ok(laneCap, 'claude-review.yml must carry a job timeout');
-
-  const gateText = wf('review-posted.yml');
-  const budget = /^[ \t]*--timeout-seconds[ \t]+(\d+)/m.exec(gateText);
-  const gateCap = /^[ \t]*timeout-minutes:[ \t]*(\d+)/m.exec(gateText);
-  assert.ok(budget && gateCap, 'review-posted.yml must carry both an explicit budget and a job cap');
-
-  const laneSeconds = Number(laneCap[1]) * 60;
-  const budgetSeconds = Number(budget[1]);
-  assert.ok(
-    budgetSeconds > laneSeconds,
-    `the gate waits ${budgetSeconds}s but the lane may run ${laneSeconds}s: the gate can give up ` +
-      'while the reviewer is still legitimately working, and report NOT_POSTED on a good PR',
+  assert.throws(
+    () => assertReviewLaneBudget({ pollSeconds: REVIEW_LANE_TIMEOUT_SECONDS }),
+    /may run/,
+    'equal budgets reproduce the race',
   );
-  // And the gate's own job must outlive its poll, or it is killed mid-wait and
-  // reports `cancelled` with no verdict at all.
-  assert.ok(
-    Number(gateCap[1]) * 60 - budgetSeconds >= 300,
-    `job cap ${gateCap[1]}min leaves ${Number(gateCap[1]) * 60 - budgetSeconds}s over a ${budgetSeconds}s budget`,
+  assert.throws(
+    () => assertReviewLaneBudget({ laneTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS }),
+    /may run/,
+    'raising the producer cap alone reproduces the race',
+  );
+  assert.throws(
+    () =>
+      assertReviewLaneBudget({
+        gateJobTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS + REVIEW_POSTED_MINIMUM_GRACE_SECONDS - 1,
+      }),
+    /needs at least/,
+    'the gate cannot be killed before it prints its verdict',
+  );
+  assert.equal(
+    REVIEW_POSTED_JOB_TIMEOUT_SECONDS - REVIEW_POSTED_POLL_SECONDS,
+    REVIEW_POSTED_MINIMUM_GRACE_SECONDS,
+    'the shipped gate retains its promised grace period',
   );
 });
 

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -607,12 +607,12 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
 
   assert.throws(
     () => assertReviewLaneBudget({ pollSeconds: REVIEW_LANE_TIMEOUT_SECONDS }),
-    /may run/,
+    /raise the poll budget above/,
     'equal budgets reproduce the race',
   );
   assert.throws(
     () => assertReviewLaneBudget({ laneTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS }),
-    /may run/,
+    /raise the poll budget above/,
     'raising the producer cap alone reproduces the race',
   );
   assert.throws(
@@ -620,13 +620,57 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
       assertReviewLaneBudget({
         gateJobTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS + REVIEW_POSTED_MINIMUM_GRACE_SECONDS - 1,
       }),
-    /needs at least/,
+    /raise .*timeout-minutes.* or lower the poll budget/,
     'the gate cannot be killed before it prints its verdict',
   );
   assert.equal(
     REVIEW_POSTED_JOB_TIMEOUT_SECONDS - REVIEW_POSTED_POLL_SECONDS,
     REVIEW_POSTED_MINIMUM_GRACE_SECONDS,
     'the shipped gate retains its promised grace period',
+  );
+});
+
+// The constants above are the AUTHORITY, but `timeout-minutes:` is evaluated by
+// GitHub before any step runs, so no workflow can read them at run time. That
+// leaves a copy in each YAML, and a copy held together only by prose drifts:
+// the very race this module exists to prevent comes back the moment someone
+// edits one number. Bind the copies to the authority here -- this is a gate on
+// the duplication the design cannot remove, not a restatement of the module.
+test('THE COPIES: both workflows carry the job caps the budget module assumes', () => {
+  const jobTimeoutSeconds = (workflow) => {
+    const text = readFileSync(join(HERE, '..', '.github/workflows', workflow), 'utf8');
+    const found = [...text.matchAll(/^[ \t]*timeout-minutes:[ \t]*(\d+)/gm)];
+    assert.equal(found.length, 1, `${workflow} must declare exactly one job timeout`);
+    return Number(found[0][1]) * 60;
+  };
+
+  assert.equal(
+    jobTimeoutSeconds('claude-review.yml'),
+    REVIEW_LANE_TIMEOUT_SECONDS,
+    'claude-review.yml timeout-minutes drifted from REVIEW_LANE_TIMEOUT_SECONDS: the gate ' +
+      'sizes its poll against that constant, so change both or the gate can give up while ' +
+      'the reviewer is still legitimately working',
+  );
+  assert.equal(
+    jobTimeoutSeconds('review-posted.yml'),
+    REVIEW_POSTED_JOB_TIMEOUT_SECONDS,
+    'review-posted.yml timeout-minutes drifted from REVIEW_POSTED_JOB_TIMEOUT_SECONDS: the ' +
+      'job would be killed mid-poll and report no verdict at all, so change both',
+  );
+
+  // The gate reads its poll budget from the module rather than from a literal.
+  // If that wiring is ever replaced by a hardcoded number, the module stops
+  // governing anything, so pin the wiring itself.
+  const gateText = readFileSync(join(HERE, '..', '.github/workflows/review-posted.yml'), 'utf8');
+  assert.match(
+    gateText,
+    /--timeout-seconds "\$poll_seconds"/,
+    'review-posted.yml must pass the poll budget it read from review-lane-budget.mjs',
+  );
+  assert.match(
+    gateText,
+    /pollSecondsArgument.*review-lane-budget\.mjs|review-lane-budget\.mjs.*pollSecondsArgument/s,
+    'review-posted.yml must source its poll budget from review-lane-budget.mjs',
   );
 });
 

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -600,8 +600,8 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
   // the gate was always going to lose eventually; observed lane runs that
   // actually reviewed took 525 s and 676 s, either side of it.
   //
-  // The shared executable contract is used by both lanes; this tests the
-  // producer/consumer behaviour rather than parsing either workflow's text.
+  // The shared executable contract is used by both lanes. THE COPIES below
+  // pins it to the two workflow literals it cannot read at run time.
   assert.doesNotThrow(assertReviewLaneBudget);
   assert.equal(pollSecondsArgument(), String(REVIEW_POSTED_POLL_SECONDS));
 
@@ -611,7 +611,7 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
     'equal budgets reproduce the race',
   );
   assert.throws(
-    () => assertReviewLaneBudget({ laneTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS }),
+    () => assertReviewLaneBudget({ laneTimeoutSeconds: REVIEW_POSTED_POLL_SECONDS + 1 }),
     /raise the poll budget above/,
     'raising the producer cap alone reproduces the race',
   );
@@ -623,11 +623,6 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
     /raise .*timeout-minutes.* or lower the poll budget/,
     'the gate cannot be killed before it prints its verdict',
   );
-  assert.equal(
-    REVIEW_POSTED_JOB_TIMEOUT_SECONDS - REVIEW_POSTED_POLL_SECONDS,
-    REVIEW_POSTED_MINIMUM_GRACE_SECONDS,
-    'the shipped gate retains its promised grace period',
-  );
 });
 
 // The constants above are the AUTHORITY, but `timeout-minutes:` is evaluated by
@@ -637,40 +632,49 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
 // edits one number. Bind the copies to the authority here -- this is a gate on
 // the duplication the design cannot remove, not a restatement of the module.
 test('THE COPIES: both workflows carry the job caps the budget module assumes', () => {
-  const jobTimeoutSeconds = (workflow) => {
-    const text = readFileSync(join(HERE, '..', '.github/workflows', workflow), 'utf8');
-    const found = [...text.matchAll(/^[ \t]*timeout-minutes:[ \t]*(\d+)/gm)];
-    assert.equal(found.length, 1, `${workflow} must declare exactly one job timeout`);
+  const workflow = (name) => readFileSync(join(HERE, '..', '.github/workflows', name), 'utf8');
+  const jobTimeoutSeconds = (name, text) => {
+    // Job keys sit at 4-space indent, step keys at 8: anchoring to the job
+    // level lets a step carry its own timeout-minutes without a false red.
+    const found = [...text.matchAll(/^ {4}timeout-minutes:[ \t]*(\d+)/gm)];
+    assert.equal(found.length, 1, `${name} must declare exactly one JOB timeout`);
     return Number(found[0][1]) * 60;
   };
+  const gateText = workflow('review-posted.yml');
 
   assert.equal(
-    jobTimeoutSeconds('claude-review.yml'),
+    jobTimeoutSeconds('claude-review.yml', workflow('claude-review.yml')),
     REVIEW_LANE_TIMEOUT_SECONDS,
     'claude-review.yml timeout-minutes drifted from REVIEW_LANE_TIMEOUT_SECONDS: the gate ' +
       'sizes its poll against that constant, so change both or the gate can give up while ' +
       'the reviewer is still legitimately working',
   );
   assert.equal(
-    jobTimeoutSeconds('review-posted.yml'),
+    jobTimeoutSeconds('review-posted.yml', gateText),
     REVIEW_POSTED_JOB_TIMEOUT_SECONDS,
     'review-posted.yml timeout-minutes drifted from REVIEW_POSTED_JOB_TIMEOUT_SECONDS: the ' +
       'job would be killed mid-poll and report no verdict at all, so change both',
   );
 
   // The gate reads its poll budget from the module rather than from a literal.
-  // If that wiring is ever replaced by a hardcoded number, the module stops
-  // governing anything, so pin the wiring itself.
-  const gateText = readFileSync(join(HERE, '..', '.github/workflows/review-posted.yml'), 'utf8');
+  // Pin PRODUCER TO CONSUMER, and pin them WITHIN ONE STEP. Both weaker forms
+  // were shown green against a broken workflow: asserting the two halves
+  // separately passed with the module fully unwired (`poll_seconds=1500` plus a
+  // comment naming both symbols), and a whole-file match passed with the
+  // substitution moved into its own preceding step -- where a shell variable
+  // does not survive, so `$poll_seconds` expands to empty and the gate exits
+  // BAD_ARGS on every PR.
+  const STEP = 'Check a review was actually posted for this head';
+  const start = gateText.indexOf(`- name: ${STEP}`);
+  assert.notEqual(start, -1, `review-posted.yml must carry the step '${STEP}'`);
+  const after = gateText.slice(start + 1);
+  const nextStep = after.search(/\n {6}- /);
+  const step = nextStep === -1 ? after : after.slice(0, nextStep);
   assert.match(
-    gateText,
-    /--timeout-seconds "\$poll_seconds"/,
-    'review-posted.yml must pass the poll budget it read from review-lane-budget.mjs',
-  );
-  assert.match(
-    gateText,
-    /pollSecondsArgument.*review-lane-budget\.mjs|review-lane-budget\.mjs.*pollSecondsArgument/s,
-    'review-posted.yml must source its poll budget from review-lane-budget.mjs',
+    step,
+    /poll_seconds="\$\([\s\S]*?review-lane-budget\.mjs[\s\S]*?\)"[\s\S]*?--timeout-seconds "\$poll_seconds"/,
+    `the '${STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
+      'from review-lane-budget.mjs',
   );
 });
 

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -637,7 +637,15 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
     // Job keys sit at 4-space indent, step keys at 8: anchoring to the job
     // level lets a step carry its own timeout-minutes without a false red.
     const found = [...text.matchAll(/^ {4}timeout-minutes:[ \t]*(\d+)/gm)];
-    assert.equal(found.length, 1, `${name} must declare exactly one JOB timeout`);
+    assert.equal(
+      found.length,
+      1,
+      `${name} must declare exactly one JOB timeout, found ${found.length}. ` +
+        'REMEDY: keep exactly one 4-space-indented `timeout-minutes:` in that workflow. ' +
+        'A step-level cap belongs at 8-space indent and is not what the budget module reads; ' +
+        'two job-level caps make "the job timeout" ambiguous and this module would pick one ' +
+        'arbitrarily.',
+    );
     return Number(found[0][1]) * 60;
   };
   const gateText = workflow('review-posted.yml');
@@ -666,7 +674,13 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
   // BAD_ARGS on every PR.
   const STEP = 'Check a review was actually posted for this head';
   const start = gateText.indexOf(`- name: ${STEP}`);
-  assert.notEqual(start, -1, `review-posted.yml must carry the step '${STEP}'`);
+  assert.notEqual(
+    start,
+    -1,
+    `review-posted.yml must carry the step '${STEP}'. REMEDY: restore that step by name. ` +
+      'The budget contract is asserted against THAT step, so renaming it silently detaches ' +
+      'the contract from the thing it governs rather than failing loudly.',
+  );
   const after = gateText.slice(start + 1);
   const nextStep = after.search(/\n {6}- /);
   const step = nextStep === -1 ? after : after.slice(0, nextStep);
@@ -674,7 +688,11 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
     step,
     /poll_seconds="\$\([\s\S]*?review-lane-budget\.mjs[\s\S]*?\)"[\s\S]*?--timeout-seconds "\$poll_seconds"/,
     `the '${STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
-      'from review-lane-budget.mjs',
+      'from review-lane-budget.mjs. REMEDY: inside that one step, set ' +
+      '`poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"` and pass ' +
+      '`--timeout-seconds "$poll_seconds"`. IN THAT SAME STEP is the whole point: a shell ' +
+      'variable does not survive across steps, so splitting them expands to empty and the ' +
+      'gate exits BAD_ARGS on every PR while still looking wired.',
   );
 });
 

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -658,7 +658,6 @@ test('THE CLI: the spelling the workflow runs prints the poll budget', () => {
   const ok = budgetCli('--poll-seconds');
   assert.equal(ok.code, 0, ok.err);
   assert.equal(ok.out, '1500', 'the workflow captures stdout; an empty capture is BAD_ARGS on every PR');
-  assert.equal(ok.out, String(REVIEW_POSTED_POLL_SECONDS), 'the CLI and the constant are one number');
 });
 
 test('THE CLI: an argument it does not implement FAILS rather than printing nothing', () => {
@@ -673,19 +672,26 @@ test('THE CLI: an argument it does not implement FAILS rather than printing noth
   }
 });
 
-
 /**
  * The wiring the gate step's shell must actually execute, pinned to the EXACT
  * spelling that ships. A loose `[\s\S]*?` between the halves let any invocation
  * of the module count -- including the `node --input-type=module --eval` form
  * this replaced, and including a `--poll-seconds` flag the module does not
  * implement. There is one command line CI runs; this is it.
+ *
+ * Both halves are literal shell, so this is ORDERED SUBSTRING CONTAINMENT, not
+ * a pattern: `$`, `(` and `"` are all regex metacharacters, and escaping them
+ * by hand to ask a question `indexOf` already answers is how the loose bridge
+ * got there in the first place.
  */
 const WIRED_ASSIGNMENT = 'poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"';
 const WIRED_PASS = '--timeout-seconds "$poll_seconds"';
-const WIRED_POLL = new RegExp(
-  `${WIRED_ASSIGNMENT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${WIRED_PASS.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
-);
+
+/** Does this shell set `poll_seconds` from the module and then pass it on, in that order? */
+function isWiredPoll(script) {
+  const assigned = script.indexOf(WIRED_ASSIGNMENT);
+  return assigned !== -1 && script.indexOf(WIRED_PASS, assigned + WIRED_ASSIGNMENT.length) !== -1;
+}
 
 /**
  * The EXECUTED shell of one workflow step: its `run:` block scalar with comment
@@ -730,15 +736,15 @@ test('THE COPIES: a COMMENT naming the module cannot satisfy the wiring pin', ()
     '',
   ].join('\n');
 
-  assert.doesNotMatch(
-    stepRunScript(unwired, GATE_STEP),
-    WIRED_POLL,
+  assert.equal(
+    isWiredPoll(stepRunScript(unwired, GATE_STEP)),
+    false,
     'a hard-coded --timeout-seconds must stay red however faithfully a COMMENT describes ' +
       'the wiring: a comment is not what CI runs',
   );
   // The same file with those two lines uncommented IS wired, so the assertion
   // above fails on the comments and not on some unrelated difference.
-  assert.match(stepRunScript(unwired.replaceAll('          # ', '          '), GATE_STEP), WIRED_POLL);
+  assert.ok(isWiredPoll(stepRunScript(unwired.replaceAll('          # ', '          '), GATE_STEP)));
   assert.equal(stepRunScript(unwired, 'a step that is not there'), null);
 });
 
@@ -793,9 +799,8 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
       'The budget contract is asserted against THAT step, so renaming it silently detaches ' +
       'the contract from the thing it governs rather than failing loudly.',
   );
-  assert.match(
-    runScript,
-    WIRED_POLL,
+  assert.ok(
+    isWiredPoll(runScript),
     `the '${GATE_STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
       `from review-lane-budget.mjs. REMEDY: inside that one step, set \`${WIRED_ASSIGNMENT}\` ` +
       `and pass \`${WIRED_PASS}\`. THE REMEDY IS BUILT FROM THE MATCHER, so it cannot ` +

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -631,6 +631,67 @@ test('THE RACE: the shared producer/consumer budget rejects either side shrinkin
 // the very race this module exists to prevent comes back the moment someone
 // edits one number. Bind the copies to the authority here -- this is a gate on
 // the duplication the design cannot remove, not a restatement of the module.
+const GATE_STEP = 'Check a review was actually posted for this head';
+
+/** The wiring the gate step's shell must actually execute. */
+const WIRED_POLL =
+  /poll_seconds="\$\([\s\S]*?review-lane-budget\.mjs[\s\S]*?\)"[\s\S]*?--timeout-seconds "\$poll_seconds"/;
+
+/**
+ * The EXECUTED shell of one workflow step: its `run:` block scalar with comment
+ * lines removed. `null` when the step is absent, `''` when it has no `run:`.
+ *
+ * Matching the raw YAML of the step instead let COMMENT TEXT satisfy the pin --
+ * a step hard-coding `--timeout-seconds 600` passes as long as some comment
+ * above it happens to name the module and the variable. Raised by CodeRabbit on
+ * PR #3610; the fixture below is that exact shape.
+ */
+function stepRunScript(text, stepName) {
+  const start = text.indexOf(`- name: ${stepName}`);
+  if (start === -1) return null;
+  const after = text.slice(start + 1);
+  const nextStep = after.search(/\n {6}- /);
+  const step = nextStep === -1 ? after : after.slice(0, nextStep);
+  const lines = step.split('\n');
+  const runAt = lines.findIndex((line) => /^ {8}run: \|/.test(line));
+  if (runAt === -1) return '';
+  return lines
+    .slice(runAt + 1)
+    .filter((line) => !/^\s*#/.test(line))
+    .join('\n');
+}
+
+// Anti-vacuity for the pin below: prove the matcher reads the SHELL, not the
+// prose around it. Without this the strengthening is untested, and the weaker
+// raw-YAML form it replaces would pass every assertion in THE COPIES.
+test('THE COPIES: a COMMENT naming the module cannot satisfy the wiring pin', () => {
+  const unwired = [
+    'jobs:',
+    '  gate:',
+    '    timeout-minutes: 30',
+    '    steps:',
+    `      - name: ${GATE_STEP}`,
+    '        run: |',
+    '          # poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"',
+    '          # node scripts/check-review-posted.mjs --timeout-seconds "$poll_seconds"',
+    '          node scripts/check-review-posted.mjs --timeout-seconds 600',
+    '      - name: something after',
+    '        run: echo done',
+    '',
+  ].join('\n');
+
+  assert.doesNotMatch(
+    stepRunScript(unwired, GATE_STEP),
+    WIRED_POLL,
+    'a hard-coded --timeout-seconds must stay red however faithfully a COMMENT describes ' +
+      'the wiring: a comment is not what CI runs',
+  );
+  // The same file with those two lines uncommented IS wired, so the assertion
+  // above fails on the comments and not on some unrelated difference.
+  assert.match(stepRunScript(unwired.replaceAll('          # ', '          '), GATE_STEP), WIRED_POLL);
+  assert.equal(stepRunScript(unwired, 'a step that is not there'), null);
+});
+
 test('THE COPIES: both workflows carry the job caps the budget module assumes', () => {
   const workflow = (name) => readFileSync(join(HERE, '..', '.github/workflows', name), 'utf8');
   const jobTimeoutSeconds = (name, text) => {
@@ -665,29 +726,27 @@ test('THE COPIES: both workflows carry the job caps the budget module assumes', 
   );
 
   // The gate reads its poll budget from the module rather than from a literal.
-  // Pin PRODUCER TO CONSUMER, and pin them WITHIN ONE STEP. Both weaker forms
-  // were shown green against a broken workflow: asserting the two halves
-  // separately passed with the module fully unwired (`poll_seconds=1500` plus a
-  // comment naming both symbols), and a whole-file match passed with the
-  // substitution moved into its own preceding step -- where a shell variable
-  // does not survive, so `$poll_seconds` expands to empty and the gate exits
-  // BAD_ARGS on every PR.
-  const STEP = 'Check a review was actually posted for this head';
-  const start = gateText.indexOf(`- name: ${STEP}`);
+  // Pin PRODUCER TO CONSUMER, and pin them WITHIN ONE STEP, and pin them in the
+  // EXECUTED shell. All three weaker forms were shown green against a broken
+  // workflow: asserting the two halves separately passed with the module fully
+  // unwired (`poll_seconds=1500` plus a comment naming both symbols); a
+  // whole-file match passed with the substitution moved into its own preceding
+  // step -- where a shell variable does not survive, so `$poll_seconds` expands
+  // to empty and the gate exits BAD_ARGS on every PR; and matching the raw YAML
+  // of the step passed on COMMENT TEXT alone, next to a hard-coded
+  // `--timeout-seconds 600`. The third is why `stepRunScript` strips comments.
+  const runScript = stepRunScript(gateText, GATE_STEP);
   assert.notEqual(
-    start,
-    -1,
-    `review-posted.yml must carry the step '${STEP}'. REMEDY: restore that step by name. ` +
+    runScript,
+    null,
+    `review-posted.yml must carry the step '${GATE_STEP}'. REMEDY: restore that step by name. ` +
       'The budget contract is asserted against THAT step, so renaming it silently detaches ' +
       'the contract from the thing it governs rather than failing loudly.',
   );
-  const after = gateText.slice(start + 1);
-  const nextStep = after.search(/\n {6}- /);
-  const step = nextStep === -1 ? after : after.slice(0, nextStep);
   assert.match(
-    step,
-    /poll_seconds="\$\([\s\S]*?review-lane-budget\.mjs[\s\S]*?\)"[\s\S]*?--timeout-seconds "\$poll_seconds"/,
-    `the '${STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
+    runScript,
+    WIRED_POLL,
+    `the '${GATE_STEP}' step must pass --timeout-seconds the value it read, in that same step, ` +
       'from review-lane-budget.mjs. REMEDY: inside that one step, set ' +
       '`poll_seconds="$(node scripts/review-lane-budget.mjs --poll-seconds)"` and pass ' +
       '`--timeout-seconds "$poll_seconds"`. IN THAT SAME STEP is the whole point: a shell ' +

--- a/scripts/review-lane-budget.mjs
+++ b/scripts/review-lane-budget.mjs
@@ -23,13 +23,18 @@ export function assertReviewLaneBudget({
 } = {}) {
   if (pollSeconds <= laneTimeoutSeconds) {
     throw new Error(
-      `Review-posted polls for ${pollSeconds}s, but the review lane may run for ${laneTimeoutSeconds}s.`,
+      `Review-posted polls for ${pollSeconds}s, but the review lane may run for ${laneTimeoutSeconds}s, ` +
+        'so the gate can give up while the reviewer is still working and report NOT_POSTED on a ' +
+        `good PR. Remedy: raise the poll budget above ${laneTimeoutSeconds}s (REVIEW_POSTED_POLL_SECONDS), ` +
+        'or lower claude-review.yml timeout-minutes and REVIEW_LANE_TIMEOUT_SECONDS together.',
     );
   }
   if (gateJobTimeoutSeconds - pollSeconds < minimumGraceSeconds) {
     throw new Error(
       `Review-posted job leaves ${gateJobTimeoutSeconds - pollSeconds}s after its ${pollSeconds}s poll; ` +
-        `it needs at least ${minimumGraceSeconds}s to print a verdict.`,
+        `it needs at least ${minimumGraceSeconds}s to print a verdict, or it is killed mid-wait with ` +
+        'no verdict at all. Remedy: raise review-posted.yml timeout-minutes and ' +
+        'REVIEW_POSTED_JOB_TIMEOUT_SECONDS together, or lower the poll budget.',
     );
   }
 }

--- a/scripts/review-lane-budget.mjs
+++ b/scripts/review-lane-budget.mjs
@@ -6,9 +6,15 @@
  * The Claude lane may run for twenty minutes. The review-posted gate must wait
  * longer than that, and its job must leave enough time to print a verdict.
  *
- * Keep this as executable policy rather than a test that inspects workflow
- * text: workflow layout is an implementation detail, while these are the
- * behaviour limits the two lanes promise one another.
+ * These are the behaviour limits the two lanes promise one another, kept as
+ * executable policy so the gate can DERIVE its `--timeout-seconds` from them.
+ *
+ * The two `timeout-minutes:` values are still copies, unavoidably: GitHub
+ * evaluates them before any step runs, so no workflow can read this module for
+ * them. `THE COPIES`, in scripts/check-review-posted.test.mjs, parses both out
+ * of the YAML and fails when either drifts from the constant here. That test is
+ * load-bearing -- deleting it silently reopens the 600s-vs-1200s race this
+ * module exists to close.
  */
 export const REVIEW_LANE_TIMEOUT_SECONDS = 20 * 60;
 export const REVIEW_POSTED_POLL_SECONDS = 25 * 60;

--- a/scripts/review-lane-budget.mjs
+++ b/scripts/review-lane-budget.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { isMainEntry } from './lib/is-main-entry.mjs';
+
 /**
  * The Claude lane may run for twenty minutes. The review-posted gate must wait
  * longer than that, and its job must leave enough time to print a verdict.
@@ -15,6 +17,10 @@
  * of the YAML and fails when either drifts from the constant here. That test is
  * load-bearing -- deleting it silently reopens the 600s-vs-1200s race this
  * module exists to close.
+ *
+ * The sibling `pr-review-signal` lane is deliberately NOT covered by
+ * `assertReviewLaneBudget` yet: it reads a verdict rather than waiting on one,
+ * so it has no poll budget to reconcile. Bringing it in is separate work.
  */
 export const REVIEW_LANE_TIMEOUT_SECONDS = 20 * 60;
 export const REVIEW_POSTED_POLL_SECONDS = 25 * 60;
@@ -48,4 +54,36 @@ export function assertReviewLaneBudget({
 export function pollSecondsArgument() {
   assertReviewLaneBudget();
   return String(REVIEW_POSTED_POLL_SECONDS);
+}
+
+const USAGE = 'usage: node scripts/review-lane-budget.mjs --poll-seconds';
+
+/**
+ * THE CLI IS THE WORKFLOW'S ONLY DOOR IN, so it must never exit 0 saying
+ * nothing. `poll_seconds="$(node scripts/review-lane-budget.mjs ...)"` captures
+ * stdout; an unrecognised flag that fell through silently would set an EMPTY
+ * variable, and the gate would then be handed `--timeout-seconds ""` and exit
+ * BAD_ARGS on every PR -- while every test here stayed green, because they all
+ * call the module's functions rather than the command line CI actually runs.
+ * That is exactly the shape this module was written to prevent, so: print, or
+ * fail loudly.
+ */
+export function runCli(argv) {
+  if (argv.length !== 1 || argv[0] !== '--poll-seconds') {
+    console.error(`${USAGE} (got: ${argv.join(' ') || 'no arguments'})`);
+    return 2;
+  }
+  console.log(pollSecondsArgument());
+  return 0;
+}
+
+if (isMainEntry(import.meta.url)) {
+  try {
+    process.exitCode = runCli(process.argv.slice(2));
+  } catch (err) {
+    // A budget violation must reach the operator as text, not as a stack trace
+    // swallowed by command substitution.
+    console.error(`❌ ${err.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/review-lane-budget.mjs
+++ b/scripts/review-lane-budget.mjs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Claude lane may run for twenty minutes. The review-posted gate must wait
+ * longer than that, and its job must leave enough time to print a verdict.
+ *
+ * Keep this as executable policy rather than a test that inspects workflow
+ * text: workflow layout is an implementation detail, while these are the
+ * behaviour limits the two lanes promise one another.
+ */
+export const REVIEW_LANE_TIMEOUT_SECONDS = 20 * 60;
+export const REVIEW_POSTED_POLL_SECONDS = 25 * 60;
+export const REVIEW_POSTED_JOB_TIMEOUT_SECONDS = 30 * 60;
+export const REVIEW_POSTED_MINIMUM_GRACE_SECONDS = 5 * 60;
+
+export function assertReviewLaneBudget({
+  laneTimeoutSeconds = REVIEW_LANE_TIMEOUT_SECONDS,
+  pollSeconds = REVIEW_POSTED_POLL_SECONDS,
+  gateJobTimeoutSeconds = REVIEW_POSTED_JOB_TIMEOUT_SECONDS,
+  minimumGraceSeconds = REVIEW_POSTED_MINIMUM_GRACE_SECONDS,
+} = {}) {
+  if (pollSeconds <= laneTimeoutSeconds) {
+    throw new Error(
+      `Review-posted polls for ${pollSeconds}s, but the review lane may run for ${laneTimeoutSeconds}s.`,
+    );
+  }
+  if (gateJobTimeoutSeconds - pollSeconds < minimumGraceSeconds) {
+    throw new Error(
+      `Review-posted job leaves ${gateJobTimeoutSeconds - pollSeconds}s after its ${pollSeconds}s poll; ` +
+        `it needs at least ${minimumGraceSeconds}s to print a verdict.`,
+    );
+  }
+}
+
+export function pollSecondsArgument() {
+  assertReviewLaneBudget();
+  return String(REVIEW_POSTED_POLL_SECONDS);
+}

--- a/scripts/review-lane-budget.mjs
+++ b/scripts/review-lane-budget.mjs
@@ -68,7 +68,7 @@ const USAGE = 'usage: node scripts/review-lane-budget.mjs --poll-seconds';
  * That is exactly the shape this module was written to prevent, so: print, or
  * fail loudly.
  */
-export function runCli(argv) {
+function runCli(argv) {
   if (argv.length !== 1 || argv[0] !== '--poll-seconds') {
     console.error(`${USAGE} (got: ${argv.join(' ') || 'no arguments'})`);
     return 2;


### PR DESCRIPTION
## Fix

#3594’s timeout regression now uses an executable shared budget contract instead of reading workflow source text. The reviewer validates that contract after checking out the PR, and the review-posted workflow derives its 1,500-second poll through a shell-safe module invocation.

The contract requires the poll to outwait the reviewer and leaves gate-job grace. Its behavioral mutations cover equal budgets, a longer producer, and insufficient grace.

## Validation

`node --test scripts/check-review-posted.test.mjs` — 46 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated review checks with consistent polling and timeout budgets.
  - Reduced the risk of checks expiring before results are posted or displayed.
  - Added safeguards to preserve sufficient time for final verdict output.
  - Added validation for invalid or conflicting review timing settings.

- **Tests**
  - Expanded coverage for review timing, timeout safety, polling configuration, command-line behavior, and workflow consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->