### PR TITLE
fix(query): stop a non-finite quantity value poisoning --sum/--avg/--min/--max

### DIFF
--- a/.changeset/cli-query-sum-infinite-poisoning.md
+++ b/.changeset/cli-query-sum-infinite-poisoning.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Stop a single non-finite quantity value (Infinity/-Infinity, reachable from a STEP REAL literal with an extreme exponent such as `1.0E400`, which parses without erroring at the decode boundary) from poisoning `ifc-lite query`'s `--sum`, `--avg`, `--min`, and `--max` aggregates for every other matched entity. The value is now treated the same as the existing present-but-unparseable case: substituted with 0 instead of propagating.

--- a/packages/cli/src/commands/query-aggregation.test.ts
+++ b/packages/cli/src/commands/query-aggregation.test.ts
@@ -71,6 +71,26 @@ describe('getQuantityValue', () => {
     expect(value).toBe(0);
     expect(Number.isNaN(value)).toBe(false);
   });
+
+  // A STEP REAL literal with an extreme exponent (e.g. 1.0E400) parses to
+  // f64::INFINITY without erroring in the decoder (see
+  // rust/export/src/json.rs's finite_json_number and its test), so a
+  // present-but-infinite quantity value is reachable from real files, not
+  // just from a computed/synthetic one. `Number(Infinity) || 0` evaluates
+  // to `Infinity` (Infinity is truthy), so the existing `|| 0` guard — built
+  // to turn an unparseable string into a safe 0 — does not catch it.
+  it('answers 0, not Infinity, for a present-but-non-finite value', () => {
+    const infBim = fakeBim({
+      3: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: Infinity }] }],
+      4: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: -Infinity }] }],
+    });
+    const pos = getQuantityValue(infBim, 3, 'Length');
+    const neg = getQuantityValue(infBim, 4, 'Length');
+    expect(pos).toBe(0);
+    expect(neg).toBe(0);
+    expect(Number.isFinite(pos)).toBe(true);
+    expect(Number.isFinite(neg)).toBe(true);
+  });
 });
 
 describe('sortEntities — quantity sort', () => {

--- a/packages/cli/src/commands/query-aggregation.ts
+++ b/packages/cli/src/commands/query-aggregation.ts
@@ -65,7 +65,18 @@ export function getQuantityValue(bim: any, ref: any, quantityName: string): numb
   const qsets = bim.quantities(ref);
   for (const qset of qsets) {
     for (const q of qset.quantities) {
-      if (q.name === quantityName) return Number(q.value) || 0;
+      if (q.name === quantityName) {
+        // `Number(x) || 0` only catches NaN (an unparseable value): an
+        // extreme STEP REAL literal (e.g. 1.0E400) parses to Infinity
+        // without erroring at the decode boundary, and `Number(Infinity) ||
+        // 0` stays Infinity because Infinity is truthy. Left uncaught, that
+        // one entity poisons every downstream sum/avg/min/max over the
+        // whole result set. Number.isFinite catches NaN and both infinities
+        // alike, so a present-but-non-finite value is treated the same as
+        // the existing present-but-unparseable case: substituted with 0.
+        const n = Number(q.value);
+        return Number.isFinite(n) ? n : 0;
+      }
     }
   }
   return null;

--- a/packages/cli/src/commands/query-output.test.ts
+++ b/packages/cli/src/commands/query-output.test.ts
@@ -116,6 +116,40 @@ describe('outputSum', () => {
    * (contains "area" but not "surface") stops being flagged as a possible
    * mix-up for a `--sum Area` query, silently dropping the warning.
    */
+  // Oracle test: compare the engine's --sum output against a plain loop
+  // over the same fixture. A STEP REAL literal with an extreme exponent
+  // (e.g. 1.0E400) parses to f64::INFINITY without erroring at the parse
+  // boundary, so an Infinity quantity value is reachable from a real file.
+  // `Number(q.value) || 0` in outputSum's own accumulation loop does not
+  // catch Infinity (it is truthy), so one bad entity poisons the total for
+  // every other entity in the query — a silent wrong number, not a crash.
+  it('does not let one non-finite quantity value poison the sum for every other entity', () => {
+    const bimWithInfinity = fakeBim({
+      quantities: {
+        1: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 10 }] }],
+        2: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: Infinity }] }],
+        3: [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', value: 5 }] }],
+      },
+    });
+    const entities = [{ ref: 1 }, { ref: 2 }, { ref: 3 }] as FakeEntity[];
+
+    // Direct-loop oracle: a non-finite value should not dominate the
+    // aggregate — it is treated the same as the existing, already-tested
+    // "present but unparseable" case (substituted with 0), not skipped and
+    // not propagated.
+    const oracleTotal = entities.reduce((sum, e) => {
+      const raw = bimWithInfinity.quantities(e.ref)[0]?.quantities[0]?.value;
+      const n = Number(raw);
+      return sum + (Number.isFinite(n) ? n : 0);
+    }, 0);
+    expect(oracleTotal).toBe(15);
+
+    const out = captureStdout();
+    outputSum(entities, 'NetVolume', bimWithInfinity, false);
+    out.spy.mockRestore();
+    expect(out.chunks.join('')).toBe(`${oracleTotal}\n`);
+  });
+
   it('warns about a similarly-named quantity that was not summed', () => {
     const bimWithAmbiguity = fakeBim({
       quantities: {

--- a/packages/cli/src/commands/query-output.ts
+++ b/packages/cli/src/commands/query-output.ts
@@ -42,7 +42,12 @@ export function outputSum(entities: any[], quantityName: string, bim: any, jsonO
           allQuantityNames.set(key, { qsetName: qset.name, count: 1 });
         }
         if (q.name === quantityName) {
-          total += Number(q.value) || 0;
+          // Mirrors getQuantityValue in query-aggregation.ts: `Number(x) ||
+          // 0` lets a present-but-Infinite value through (Infinity is
+          // truthy), which would poison `total` for every other entity in
+          // the sum. Number.isFinite catches NaN and both infinities.
+          const n = Number(q.value);
+          total += Number.isFinite(n) ? n : 0;
           matched++;
           matchedQsets.add(qset.name);
         }


### PR DESCRIPTION
## Summary

Hunted `ifc-lite query`'s aggregation surface (`--sum`/`--avg`/`--min`/`--max`/`--group-by`) against a direct-loop oracle. `packages/query/src` itself has no SUM/AVG/MIN/MAX/GROUP BY implementation (only `.count()`, plus DuckDB SQL registration where real aggregation is delegated to DuckDB, not custom JS); the actual aggregate surface lives in `packages/cli/src/commands/query-aggregation.ts` and `query-output.ts`, which every mode (`ifc-lite query --sum/--avg/--min/--max/--group-by`) goes through. That's where this fix landed.

**Oracle matrix** (engine result vs. a plain loop over the fixture):

| Case | Result |
|---|---|
| missing property (entity has no matching quantity) | skipped (returns `null`) — matches loop |
| present but unparseable value (e.g. `"not a number"`) | `0` (existing, already-tested, deliberate) — matches loop |
| empty input / empty group | `--sum` reports `0` with an error; `--avg` divide-by-zero guarded (`matched === 0` short-circuits) — matches loop |
| **present but non-finite value (`Infinity`/`-Infinity`)** | **BUG: propagated as `Infinity`, poisoning the whole aggregate** — did not match loop |
| same-named psets (any-match, #3541 territory) | out of scope here — untouched by this change |

**Top finding — silently wrong aggregate value:** A STEP `REAL` literal with an extreme exponent (e.g. `1.0E400`) parses to `f64::INFINITY` without erroring at the decode boundary (see `rust/export/src/json.rs`'s `finite_json_number` and its test, already on `main`), so a present-but-Infinite quantity value is reachable from a real, if adversarial, IFC file — not only from computed data.

`getQuantityValue` (`packages/cli/src/commands/query-aggregation.ts`) and `outputSum`'s own inline accumulation (`packages/cli/src/commands/query-output.ts`, which does not go through `getQuantityValue`) each guarded an unparseable value with `Number(x) || 0`. That only catches `NaN` — `Infinity` is truthy, so `Number(Infinity) || 0` stays `Infinity`. One Infinite quantity on any matched entity silently turned `--sum`'s total, and `--avg`/`--min`/`--max`'s aggregate, into `Infinity` for the *entire* result set — a wrong answer with no error, not a crash.

**Fix:** `Number.isFinite(n) ? n : 0` in both places, catching `NaN` and both infinities alike, consistent with the existing (already-tested) present-but-unparseable → `0` behavior.

## RED / GREEN

- RED on unmodified `upstream/main`: `getQuantityValue(bim, ref, 'Length')` with a present `Infinity` value returned `Infinity`, not `0`; `outputSum` over a 3-entity fixture (`10`, `Infinity`, `5`) printed `Infinity`, not the oracle's `15`.
- GREEN after the fix: both return `0`/`15` respectively.
- Control: the existing `answers 0, not NaN, for a present-but-unparseable value` test (documented, deliberate NaN→0 behavior) still passes unchanged.

## Test plan
- [x] `pnpm --filter @ifc-lite/cli exec vitest run` — 578/578 passing
- [x] `pnpm --filter @ifc-lite/cli exec tsc --noEmit` — clean
- [x] `node scripts/check-module-size.mjs` — OK (2044 files measured, 305 allowlisted, 0 new over 400)
- [x] `pnpm run check:vitest-timeout-audit` — no regex-literal violations introduced
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] Changeset added for `@ifc-lite/cli` (patch)
- [x] No `index.ts` export changes — `scripts/api-surface.json` untouched

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
