### PR TITLE
fix(ci): suspend the CodeRabbit stand-down — it was forfeiting the better reviewer

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,8 +84,37 @@ reviews:
     # `synchronize` rather than after its poll. The worst case is therefore
     # CodeRabbit reviewing a PR the Claude lane also covered, which costs quota;
     # the other ordering costs a review.
-    labels:
-      - '!claude-reviewed'
+    # SUSPENDED 2026-09-01, ON MEASUREMENT, NOT ON PRINCIPLE.
+    #
+    # The stand-down assumed a `clean` verdict from the Claude lane means the
+    # diff is fine, so CodeRabbit could skip it and save quota. Measured on live
+    # traffic the day it went on:
+    #
+    #   21 open PRs carried `claude-reviewed`, so CodeRabbit skipped them.
+    #   The lane's verdict on all 21: `clean`. Total findings it produced: ZERO.
+    #   On six PRs where both reviewers ran, CodeRabbit produced ELEVEN findings
+    #   and the lane produced none -- including one Major defect that reopened a
+    #   hole, and one where the lane's own author had mis-described the design.
+    #
+    # So the label was suppressing the reviewer that finds things, in favour of
+    # one that had found nothing, on ~70% of new PRs. That is not a saving, it is
+    # review getting WORSE than before this system existed, compounding at
+    # several PRs an hour.
+    #
+    # The lane's rubric buys precision with recall deliberately, and that trade
+    # may be right for a repo whose PRs are already reviewed. It is the wrong
+    # trade here, where the alternative to a finding is often NO review: 174 PRs
+    # merged unreviewed in August, which is the problem this whole system exists
+    # to fix.
+    #
+    # WHAT IS NOT SUSPENDED: the lane still runs and still posts a marker, and
+    # `check-review-posted.mjs` still verifies a review reached each head. Only
+    # the stand-down is off, so both reviewers now see every PR. Re-enable it
+    # when the lane demonstrates recall worth trading for -- the marker's
+    # `count=` field is the measurement, and it currently reads 0 everywhere.
+    #
+    # labels:
+    #   - '!claude-reviewed'
     # NO `ignore_usernames`, DELIBERATELY. Excluding dependabot was tried and
     # reverted: it saves ~21 PRs/month of allowance and buys a silent blind spot.
     # An ignored author gets no CodeRabbit CONTEXT at all, and nothing detects


### PR DESCRIPTION
Measured on live traffic, the day the label started working.

```
21 open PRs carried `claude-reviewed`, so CodeRabbit skipped them.
The Claude lane's verdict on all 21:  clean
Findings the lane produced across them:  ZERO
10 of the 14 newest PRs:  "Review skipped: excluded by label configuration"
```

On the six PRs where **both** reviewers ran, CodeRabbit produced **11 findings** and the lane produced **none** — including a Major defect that reopened a hole this work had just closed, and one where the lane's own author had mis-described his own design.

So the label was suppressing the reviewer that finds things, in favour of one that had found nothing, on most new PRs. That is not a quota saving. It is review getting **worse than before this system existed**, compounding at several PRs an hour.

## It does not even save the quota it costs

The stand-down was meant to redistribute CodeRabbit's scarce allowance to PRs the lane had not covered. But the lane covers every non-draft same-repo PR, so there is almost nothing left to redistribute *to*. The allowance is **forfeited, not moved**: the scarce high-recall reviewer idles while the abundant low-recall one certifies everything.

## Why the lane finds nothing

Its rubric opens: *"You are the last reviewer, not the first... anything the other gates can catch, they will."*

That is false here. **174 PRs merged in August with no review of any kind**, and CodeRabbit is rate-limited on two-thirds of attempts. The precision-over-recall trade it makes is calibrated for a reader whose twenty minutes a false positive wastes. This repo's reader triages a finding in seconds, and a missed Major merges within hours. The rubric is optimising the wrong asymmetry — that is a separate change, gated on an eval built from the 11 known findings as ground truth.

## What is not suspended

The lane still runs, still posts a marker, and `check-review-posted.mjs` still verifies a review reached each head. **Only the stand-down is off**, so both reviewers see every PR again.

The re-enable condition is written into the file and is a measurement rather than a judgement: the marker's `count=` field, which currently reads `0` everywhere.

Two lines commented out. Reversible in one line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflows so all configured review checks run consistently, including for changes marked as already reviewed.
  * Existing review gating and verification steps remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->