### PR TITLE
fix(mutations): stop a non-finite quantity value collapsing to 0 across exportMutations/importMutations

### DIFF
--- a/.changeset/mutations-nonfinite-quantity-roundtrip.md
+++ b/.changeset/mutations-nonfinite-quantity-roundtrip.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mutations': patch
+---
+
+`MutablePropertyView.exportMutations()` no longer lets a non-finite quantity value (`NaN`/`Infinity`/`-Infinity`) collapse to `0` across `importMutations()`. `JSON.stringify` maps a non-finite number to `null`, and the quantity replay path (`applyMutations`) did `Number(mutation.newValue)`, where `Number(null)` is `0` — so a serialize→deserialize round trip silently changed the value, even though applying the same mutations directly (no serialization in between) preserved it exactly. `exportMutations`/`importMutations` now wrap a non-finite `newValue`/`oldValue`/whole-set member `value` in a JSON-safe marker and restore it on import; an ordinary finite value is unaffected, and a string property value is never mistaken for the marker.

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -15,6 +15,7 @@
 import type { PropertyTable, PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
 import { findQuantityInBaseSets } from './base-qset-lookup.js';
 import { computeSetClaims, mutatedMembersForInstance } from './same-name-set-claims.js';
+import { encodeNonFiniteNumbers, decodeNonFiniteNumbers } from './nonfinite-json.js';
 import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 import type { IfcAttributeValue, PropertyValue, PropertyMutation, QuantityMutation, AttributeMutation, EntityTypeMutation, Mutation, NewEntity, EffectiveChange } from './types.js';
 import { propertyKey, quantityKey, attributeKey, generateMutationId } from './types.js';
@@ -2064,7 +2065,7 @@ export class MutablePropertyView {
       modelId: this.modelId,
       mutations: this.mutationHistory,
       exportedAt: Date.now(),
-    }, null, 2);
+    }, encodeNonFiniteNumbers, 2);
   }
 
   /**
@@ -2087,7 +2088,7 @@ export class MutablePropertyView {
    * fires.
    */
   importMutations(json: string): void {
-    const data = JSON.parse(json);
+    const data = JSON.parse(json, decodeNonFiniteNumbers);
     if (data.mutations && Array.isArray(data.mutations)) {
       this.applyMutations(data.mutations);
     }

--- a/packages/mutations/src/nonfinite-json.ts
+++ b/packages/mutations/src/nonfinite-json.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `JSON.stringify`/`JSON.parse` replacer+reviver pair that preserves a
+ * non-finite number (`NaN`/`Infinity`/`-Infinity`) inside a `Mutation`'s
+ * `newValue`/`oldValue`, or a `value` inside a whole-set `newValue` array
+ * (`createPropertySet`/`createQuantitySet`'s per-member payload).
+ *
+ * JSON has no non-finite numeric literal (RFC 8259); `JSON.stringify` silently
+ * maps `NaN`/`Infinity`/`-Infinity` to `null`, indistinguishable from the value
+ * being absent. `MutablePropertyView.applyMutations`' quantity replay then
+ * does `Number(mutation.newValue)`, and `Number(null)` is `0` — so an
+ * out-of-range quantity (e.g. a computed volume that overflowed, or a CSV
+ * cell parsed to `NaN`) silently became `0` across `exportMutations()` →
+ * `importMutations()`, even though direct application (no serialization in
+ * between) preserves it exactly. Mirrors the sibling fix for the JSON/JSON-LD
+ * export path (`finite_json_number` in `rust/export/src/json.rs`, #3596) and
+ * the query aggregation guard (#3611) — this repo's recurring non-finite-value
+ * shape.
+ */
+const NON_FINITE_NUMBER_KEYS = new Set(['newValue', 'oldValue', 'value']);
+
+interface NonFiniteNumberMarker {
+  __nonFiniteNumber: 'NaN' | 'Infinity' | '-Infinity';
+}
+
+function isNonFiniteNumberMarker(value: unknown): value is NonFiniteNumberMarker {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { __nonFiniteNumber?: unknown }).__nonFiniteNumber === 'string'
+  );
+}
+
+/** `JSON.stringify` replacer for `MutablePropertyView.exportMutations()`. */
+export function encodeNonFiniteNumbers(key: string, value: unknown): unknown {
+  if (NON_FINITE_NUMBER_KEYS.has(key) && typeof value === 'number' && !Number.isFinite(value)) {
+    const token: NonFiniteNumberMarker['__nonFiniteNumber'] = Number.isNaN(value)
+      ? 'NaN'
+      : value > 0
+        ? 'Infinity'
+        : '-Infinity';
+    return { __nonFiniteNumber: token } satisfies NonFiniteNumberMarker;
+  }
+  return value;
+}
+
+/**
+ * `JSON.parse` reviver for `MutablePropertyView.importMutations()`; inverse
+ * of {@link encodeNonFiniteNumbers}.
+ */
+export function decodeNonFiniteNumbers(key: string, value: unknown): unknown {
+  if (NON_FINITE_NUMBER_KEYS.has(key) && isNonFiniteNumberMarker(value)) {
+    switch (value.__nonFiniteNumber) {
+      case 'NaN':
+        return NaN;
+      case 'Infinity':
+        return Infinity;
+      case '-Infinity':
+        return -Infinity;
+    }
+  }
+  return value;
+}

--- a/packages/mutations/test/nonfinite-quantity-roundtrip.test.ts
+++ b/packages/mutations/test/nonfinite-quantity-roundtrip.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { MutablePropertyView } from '../src/index.js';
+import { QuantityType } from '@ifc-lite/data';
+
+describe('MutablePropertyView non-finite quantity round trip (#3596/#3611 shape)', () => {
+  it('a non-finite per-quantity value survives exportMutations -> importMutations', () => {
+    // `JSON.stringify` maps NaN/Infinity/-Infinity to `null` (RFC 8259 has no
+    // non-finite numeric literal). `applyMutations`' quantity replay then does
+    // `Number(mutation.newValue)`, and `Number(null)` is `0` — so an
+    // out-of-range quantity silently became 0 across the round trip even
+    // though direct application (no serialization in between) preserves it.
+    for (const value of [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, NaN]) {
+      const a = new MutablePropertyView(null, 'm1');
+      a.setQuantity(42, 'Qto_WallBaseQuantities', 'NetVolume', value, QuantityType.Volume);
+
+      const json = a.exportMutations();
+      const b = new MutablePropertyView(null, 'm1');
+      b.importMutations(json);
+
+      expect(b.getQuantitiesForEntity(42)).toEqual(a.getQuantitiesForEntity(42));
+    }
+  });
+
+  it('a non-finite value in a whole-set CREATE_QUANTITY payload survives the round trip', () => {
+    const a = new MutablePropertyView(null, 'm1');
+    a.createQuantitySet(42, 'Qto_WallBaseQuantities', [
+      { name: 'NetVolume', value: Number.POSITIVE_INFINITY, quantityType: QuantityType.Volume },
+      { name: 'GrossArea', value: 12, quantityType: QuantityType.Area },
+    ]);
+
+    const json = a.exportMutations();
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    expect(b.getQuantitiesForEntity(42)).toEqual(a.getQuantitiesForEntity(42));
+  });
+
+  it('control: an ordinary finite quantity value still round-trips unchanged', () => {
+    const a = new MutablePropertyView(null, 'm1');
+    a.setQuantity(42, 'Qto_WallBaseQuantities', 'NetVolume', 3.5, QuantityType.Volume);
+
+    const json = a.exportMutations();
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    expect(b.getQuantitiesForEntity(42)).toEqual(a.getQuantitiesForEntity(42));
+    expect(json).not.toContain('__nonFiniteNumber');
+  });
+
+  it('control: a literal string property value is never mistaken for a non-finite-number marker', () => {
+    // Guards the replacer/reviver scoping: only a raw *number* newValue/oldValue/
+    // value is ever wrapped, so a string property whose text happens to be
+    // "Infinity" must round-trip as that exact string, not as a number.
+    const a = new MutablePropertyView(null, 'm1');
+    a.setProperty(7, 'Pset_Custom', 'Note', 'Infinity');
+
+    const json = a.exportMutations();
+    const b = new MutablePropertyView(null, 'm1');
+    b.importMutations(json);
+
+    const value = b.getForEntity(7)
+      .find(p => p.name === 'Pset_Custom')
+      ?.properties.find(p => p.name === 'Note')?.value;
+    expect(value).toBe('Infinity');
+  });
+});


### PR DESCRIPTION
## Summary

`MutablePropertyView.exportMutations()` serializes `mutationHistory` with plain `JSON.stringify`, which maps a non-finite number (`NaN`/`Infinity`/`-Infinity`) to `null` (RFC 8259 has no non-finite numeric literal). `applyMutations()`'s quantity replay then does `Number(mutation.newValue)`, and `Number(null)` is `0` — so a quantity carrying a non-finite value silently became `0` across a serialize → deserialize → apply round trip, even though applying the same mutations directly (no serialization in between) preserves the value exactly.

This is the mutation-serialization sibling of two PRs already open on the same non-finite-value shape: `finite_json_number` in `rust/export/src/json.rs` (#3596, JSON/JSON-LD export) and the CLI aggregation guard (#3611).

## Fix

`encodeNonFiniteNumbers`/`decodeNonFiniteNumbers` (new sibling module `packages/mutations/src/nonfinite-json.ts`, kept separate to stay under the module-size budget) wrap a non-finite `newValue`/`oldValue`/whole-set member `value` in a JSON-safe marker on export and restore it on import. The check is scoped to exactly those keys and to `typeof value === 'number'`, so a legitimate string property value — even one whose text happens to read `"Infinity"` — is never mistaken for the marker (covered by a control test).

## Mutation-type round-trip fidelity (spot-checked this session)

| Mutation shape | Round-trips via exportMutations/importMutations? |
|---|---|
| Per-quantity SET with a non-finite value (`NaN`/`±Infinity`) | **Was broken → fixed here.** Collapsed to `0`. |
| Whole-set `CREATE_QUANTITY` payload with a non-finite member value | **Was broken → fixed here.** |
| Property SET with falsy value (`false`/`0`/`''`) | Survives — every replay branch guards with `!== undefined`, not truthiness. |
| Property SET with `null` (present-but-unset, e.g. bSDD boolean, #1107) | Survives — `null` is distinguished from absent throughout. |
| DELETE_PROPERTY / DELETE_PROPERTY_SET / DELETE_QUANTITY_SET | Survive (existing coverage, `retype.test.ts`/`effective-changes.test.ts`). |
| Ordinary finite numeric quantity (control) | Unaffected by this change. |
| String property value equal to `"Infinity"` (control) | Unaffected — not mistaken for the marker. |
| Duplicate/replayed `CREATE_ENTITY` without a restored payload | Already handled: `applyMutations` logs and drops it plus dependents, by design (documented on `importMutations`). |
| `DELETE_QUANTITY` (single quantity inside a set, distinct from `DELETE_QUANTITY_SET`) | **No producer exists anywhere in the codebase** — the type is declared in `MutationType` and handled in `change-set-to-ops.ts`'s separate layer-publish path, but `MutablePropertyView` has no `deleteQuantity()` method that emits it, so it's currently unreachable through `applyMutations`. Left as-is (documented gap, not exercised by any real workflow); flagging here rather than papering over it with an untested branch. |

## Test plan
- [x] New regression test (`packages/mutations/test/nonfinite-quantity-roundtrip.test.ts`): RED before the fix (`Infinity` → `0`), GREEN after, plus a whole-set-payload case, a finite-value control, and a string-value-that-reads-"Infinity" control.
- [x] `pnpm exec vitest run` in `packages/mutations`: 238 passed, 10 skipped (fixture-gated), 0 failed.
- [x] `pnpm exec tsc --noEmit` in `packages/mutations`: clean.
- [x] `node scripts/check-module-size.mjs`: clean (`mutable-property-view.ts` 2096/2121; the new logic lives in a fresh sibling module).
- [x] `pnpm run check:vitest-timeout-audit`: no new unprotected/parenthesized-regex findings.
- [x] `node scripts/check-test-wiring.mjs`: OK.
- [x] Changeset added (`@ifc-lite/mutations`: patch — no public API surface change, `nonfinite-json.ts` helpers are internal).

Claude-Session: https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `NaN`, `Infinity`, and `-Infinity` quantity values when exporting and importing mutations.
  * Prevented non-finite values from being converted to zero during serialization round trips.
  * Confirmed finite quantities and string values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->