### PR TITLE
fix(bcf): refuse an out-of-range BCF 3.0 FieldOfView instead of writing it

### DIFF
--- a/.changeset/bcf-writer-fieldofview-range.md
+++ b/.changeset/bcf-writer-fieldofview-range.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Refuse to write a BCF 3.0 `PerspectiveCamera/FieldOfView` outside `visinfo.xsd`'s `(0, 180)` exclusive facet, instead of emitting a finite-but-invalid archive.
+
+`FieldOfView` is `xs:double` with `minExclusive="0"` and `maxExclusive="180"` in BCF 3.0's `visinfo.xsd`. The writer's only guard on write-side numbers, `xsdDouble`, checks finiteness — it says nothing about a value that is out of range but perfectly finite, so `0`, a negative number, or `180` and above walked straight through it and were written as-is. Every existing test that touched this field validated the *schema's* rejection of a hand-mutated string, never the writer's own behavior on an out-of-range `fieldOfView` in the input `BCFProject`; `AspectRatio`, the sibling 3.0-only facet-bearing field, already had this guard and `FieldOfView` did not.
+
+`writeBCF` now throws for a 3.0 camera whose `fieldOfView` is `<= 0` or `>= 180`, naming the viewpoint, the same policy `requireAspectRatioElement` and the `Topic/@TopicType`/`Topic/@TopicStatus` checks already apply: no safe value to invent, and no invalid archive handed back silently. BCF 2.1's own `FieldOfView` facet (`[45, 60]`) is deliberately left unenforced — its schema annotation says that limitation will be dropped and viewers should expect values outside it.

--- a/packages/bcf/src/schema-validation.test.ts
+++ b/packages/bcf/src/schema-validation.test.ts
@@ -407,6 +407,57 @@ describe('BCF 3.0 AspectRatio', () => {
 });
 
 /**
+ * `FieldOfView` is a facet-bearing simple type in BOTH versions -- v3_0/visinfo.xsd
+ * restricts it to `(0, 180)` exclusive -- yet, unlike `AspectRatio` right above,
+ * nothing on the write side ever checked the facet. "rejects a value outside a
+ * schema facet range" above only proves xmllint itself enforces the range on
+ * hand-mutated XML; it never asks the writer to refuse the value in the first
+ * place, so `writeBCF` happily emitted `<FieldOfView>0</FieldOfView>` or
+ * `<FieldOfView>200</FieldOfView>` -- a finite, well-formed `xs:double` that
+ * every other guard in this file (`xsdDouble`, the non-finite sweep) waves
+ * through, and that a 3.0 archive fails schema validation for. Same policy as
+ * `requireAspectRatioElement`: refuse rather than silently emit an archive a
+ * conforming BCF 3.0 reader may reject.
+ */
+describe('BCF 3.0 FieldOfView range', () => {
+  it('refuses a non-positive or >=180 FieldOfView rather than emitting an invalid archive', async () => {
+    for (const bad of [0, -10, 180, 200]) {
+      const topic = maximalTopic();
+      topic.viewpoints[0].perspectiveCamera!.fieldOfView = bad;
+      const project: BCFProject = { version: '3.0', topics: new Map([[TOPIC_GUID, topic]]) };
+      await expect(writeBCF(project)).rejects.toThrow(/FieldOfView/);
+    }
+  });
+
+  it('accepts the open interval boundaries a real fixture would sit just inside', async () => {
+    for (const good of [0.001, 90, 179.999]) {
+      const topic = maximalTopic();
+      topic.viewpoints[0].perspectiveCamera!.fieldOfView = good;
+      const project: BCFProject = { version: '3.0', topics: new Map([[TOPIC_GUID, topic]]) };
+      const entries = await writeAndUnzip(project);
+      const xml = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+      const { valid, messages } = await validate('3.0', 'visinfo.xsd', xml);
+      expect(messages.join('\n')).toBe('');
+      expect(valid).toBe(true);
+    }
+  });
+
+  it('does not restrict BCF 2.1, whose [45,60] facet the schema itself says will be dropped', async () => {
+    // v2_1/visinfo.xsd's own annotation on FieldOfView: "This limitation will
+    // be dropped in the next release and viewers should expect values outside
+    // this range in current implementations." Enforcing it here would reject
+    // legitimate 2.1 input the schema authors themselves disclaim.
+    const topic = maximalTopic();
+    topic.viewpoints[0].perspectiveCamera!.fieldOfView = 90;
+    const project: BCFProject = { version: '2.1', topics: new Map([[TOPIC_GUID, topic]]) };
+    const entries = await writeAndUnzip(project);
+    expect(entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)).toContain(
+      '<FieldOfView>90</FieldOfView>'
+    );
+  });
+});
+
+/**
  * FINITENESS is the property, not sign and not schema-conformance.
  *
  * `AspectRatio` was guarded with `!(aspectRatio > 0)`, and `Infinity > 0` is

--- a/packages/bcf/src/writer-camera.ts
+++ b/packages/bcf/src/writer-camera.ts
@@ -85,6 +85,35 @@ function requireAspectRatioElement(aspectRatio: number | undefined, viewpointGui
 }
 
 /**
+ * Require a FINITE FieldOfView within BCF 3.0's `(0, 180)` exclusive facet and
+ * return the text `xsdDouble` will accept for it.
+ *
+ * v3_0/visinfo.xsd's `FieldOfView` simpleType is `xs:double` with
+ * `minExclusive value="0"` and `maxExclusive value="180"`. `xsdDouble` alone
+ * only rejects non-finite values (Infinity/-Infinity/NaN); it says nothing
+ * about a finite value that is merely out of range, so `0`, a negative number,
+ * or `180` and above walked straight through it and were emitted as-is --
+ * schema-invalid the same way an unset `AspectRatio` was before
+ * {@link requireAspectRatioElement} started refusing it. 2.1's own
+ * `FieldOfView` facet (`[45, 60]` inclusive) is deliberately NOT enforced
+ * here: its own schema annotation says "This limitation will be dropped in
+ * the next release and viewers should expect values outside this range in
+ * current implementations", so treating it as a hard constraint would reject
+ * legitimate 2.1 input the schema authors themselves disclaim.
+ */
+function requireFieldOfViewElement(fieldOfView: number, viewpointGuid: string): string {
+  const where = `viewpoint "${viewpointGuid}"`;
+  if (!(fieldOfView > 0 && fieldOfView < 180)) {
+    throw new Error(
+      `BCF 3.0 requires PerspectiveCamera/FieldOfView in (0, 180) exclusive (${where} has ` +
+        `${fieldOfView}). visinfo.xsd's FieldOfView simpleType declares minExclusive="0" and ` +
+        `maxExclusive="180"; set a value inside that range before writing a 3.0 file.`
+    );
+  }
+  return xsdDouble(fieldOfView, 'PerspectiveCamera/FieldOfView', where);
+}
+
+/**
  * Write perspective camera XML
  */
 export function writePerspectiveCamera(
@@ -94,8 +123,12 @@ export function writePerspectiveCamera(
 ): string {
   const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
   const where = `viewpoint "${viewpointGuid}"`;
+  const fieldOfView =
+    version === '3.0'
+      ? requireFieldOfViewElement(camera.fieldOfView, viewpointGuid)
+      : xsdDouble(camera.fieldOfView, 'PerspectiveCamera/FieldOfView', where);
   return `\n  <PerspectiveCamera>${cameraVectors(camera, where)}
-    <FieldOfView>${xsdDouble(camera.fieldOfView, 'PerspectiveCamera/FieldOfView', where)}</FieldOfView>${aspectRatioElement}
+    <FieldOfView>${fieldOfView}</FieldOfView>${aspectRatioElement}
   </PerspectiveCamera>`;
 }
 


### PR DESCRIPTION
## BCF version targeted
Both 2.1 and 3.0 (`packages/bcf/src/writer-camera.ts`), lens applied against the vendored `__fixtures__/schemas/v2_1/visinfo.xsd` and `v3_0/visinfo.xsd` — writer OUTPUT checked against the OASIS BCF-XML schema, not against our own reader.

## Spec clause
`visinfo.xsd`'s `FieldOfView` simpleType:
- BCF 3.0: `xs:double` with `minExclusive value="0"` and `maxExclusive value="180"`.
- BCF 2.1: `xs:double` with `minInclusive="45"`/`maxInclusive="60"`, but the schema's own annotation states "This limitation will be dropped in the next release and viewers should expect values outside this range in current implementations" — so this PR deliberately does not enforce the 2.1 facet, matching the schema authors' own guidance.

## Verdict table (writer output vs. spec, camera-related fields)

| Field | Spec-conformant before this PR? |
|---|---|
| Camera choice/cardinality (2.1 order, 3.0 xs:choice) | Yes (already enforced, `requireCameraChoice`) |
| `AspectRatio` (3.0, `PositiveDouble`) | Yes (already enforced, `requireAspectRatioElement`) |
| Camera vector coordinates (`xs:double`, finiteness) | Yes (already enforced, `xsdDouble`) |
| `ViewToWorldScale` (`xs:double`, finiteness) | Yes (already enforced) |
| **`FieldOfView` (3.0, `(0, 180)` exclusive)** | **No — the gap this PR closes** |

`xsdDouble`, the writer's one shared numeric guard, checks finiteness only (rejects `Infinity`/`-Infinity`/`NaN`). It says nothing about a value that is finite but out of a type's facet range. `AspectRatio` already had its own extra guard (`requireAspectRatioElement`) for exactly this reason — `PositiveDouble`'s `minExclusive`. `FieldOfView` never got the equivalent guard, so a `BCFProject` (from the public writer API, or from re-exporting a file read via `readBCF`, which never validates `FieldOfView`'s range either) carrying `fieldOfView <= 0` or `fieldOfView >= 180` was written straight into a BCF 3.0 `.bcfv` as `<FieldOfView>0</FieldOfView>` or `<FieldOfView>200</FieldOfView>` — schema-invalid, and a conforming reader can reject the whole viewpoint.

The existing `schema-validation.test.ts` > "rejects a value outside a schema facet range" test only proved that xmllint itself flags an out-of-range value after hand-mutating already-written XML — it never asked the writer to refuse the value on the way in.

## The fix

`requireFieldOfViewElement` in `packages/bcf/src/writer-camera.ts`, gated to BCF 3.0 only (mirrors `requireAspectRatioElement`'s pattern and its 3.0-only scope), throwing a descriptive error naming the viewpoint when `fieldOfView` is not strictly inside `(0, 180)`.

### RED
On unmodified `upstream/main`, `writeBCF` with a BCF 3.0 project whose `perspectiveCamera.fieldOfView` is `0`, `-10`, `180`, or `200` resolves successfully and produces an archive whose `.bcfv` fails `visinfo.xsd`'s `FieldOfView` facet.

### GREEN
Same input now rejects with `/FieldOfView/` in the error, before any bytes are written. Values just inside the open interval (`0.001`, `90`, `179.999`) are unaffected and validate against `visinfo.xsd` via `xmllint-wasm` (schema-validation.test.ts's real validator, not our own reader). A BCF 2.1 fixture with `fieldOfView = 90` (outside 2.1's disclaimed `[45, 60]` facet) still writes it verbatim — the 2.1 facet is intentionally not enforced.

Tests added: `packages/bcf/src/schema-validation.test.ts` > `BCF 3.0 FieldOfView range` (3 cases: refuses out-of-range, accepts near-boundary values validated against the real XSD, leaves 2.1 unrestricted).

## Scope note
Stays out of #3599 (`project.bcfp`'s `ProjectId` XML-escaping) — this PR touches only `writer-camera.ts` and its test file, no overlap.

## Verification run (foreground)
- `packages/bcf`: `vitest run` — 322/322 passed (was 319 before the new tests; net +3).
- `packages/bcf`: `pnpm exec tsc` (build) and `typecheck-tests.mjs` — clean.
- `node scripts/check-module-size.mjs` — OK (writer-camera.ts is 168 lines).
- `node scripts/check-test-wiring.mjs` — OK.
- `node scripts/check-unused-locals.mjs` — pre-existing environment gap unrelated to this change: several packages (not `bcf`) fail to "compile standalone" in this worktree because their siblings' `dist/` aren't built (no repo-wide `turbo build` was run per house rules); `packages/bcf` is not among them.
- `pnpm run check:vitest-timeout-audit` — no new unprotected timeouts introduced.
- `oxlint` on the two touched files — clean.
- No `.rs` touched — Rust ratchet test not applicable.
- No `index.ts` export changed — `scripts/api-surface.json` unaffected (the check itself needs a full `pnpm build`, not run here per the no-repo-wide-build house rule).
- Changeset added: `.changeset/bcf-writer-fieldofview-range.md` (patch, matching the bump level of the sibling `AspectRatio` fix).