### PR TITLE
fix(core): resolve a chained IfcConversionBasedUnit UnitComponent

### DIFF
--- a/.changeset/conversion-based-unit-chained-component.md
+++ b/.changeset/conversion-based-unit-chained-component.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Fix `ProjectUnits` resolving a conversion-based unit whose `ConversionFactor.UnitComponent` is itself a conversion-based unit (a real-world chain, e.g. `YARD` defined as 3 `FOOT` where `FOOT` is 0.3048 metre) or a derived unit, rather than a bare/prefixed `IfcSIUnit`.
+
+`IfcMeasureWithUnit.UnitComponent` is typed `IfcUnit` — any `IfcNamedUnit` or `IfcDerivedUnit`, not just `IfcSIUnit` — but `conversion_factor_scale` (`rust/core/src/project_units/mod.rs`) only recognised a plain `IFCSIUNIT` component and silently fell back to a component scale of `1.0` for anything else. For the YARD/FOOT chain this resolved `si_scale` to `3.0` instead of the spec-correct `0.9144`, a ~3.3x error with no error reported — the unit still resolved, just to the wrong magnitude. The fix resolves the `UnitComponent` through the same recursive `resolve_unit_by_ref_depth` dispatcher already used for `IFCDERIVEDUNIT` elements, so a chained conversion-based (or derived) component composes correctly; the existing SI and prefixed-SI-component cases are unchanged (both already covered by tests).
+
+This is `ifc-lite-core`'s `ProjectUnits` resolver, exported from the crate for `@ifc-lite/wasm` consumers; it has no in-tree Rust caller yet (no CLI/server path wires it up today). The parallel TypeScript resolver (`packages/parser/src/project-units.ts`) has the identical gap but is out of scope here — it is the target file of two other in-flight PRs.

--- a/rust/core/src/project_units/mod.rs
+++ b/rust/core/src/project_units/mod.rs
@@ -176,7 +176,7 @@ fn resolve_unit_by_ref_depth(
             let symbol = conversion_unit_symbol(name);
             let conv_ref = entity.get_ref(3);
             let scale = conv_ref
-                .and_then(|r| conversion_factor_scale(decoder, r))
+                .and_then(|r| conversion_factor_scale(decoder, r, depth))
                 .unwrap_or(1.0);
             Some((unit_type, ResolvedUnit::new(symbol, scale), false))
         }
@@ -234,9 +234,13 @@ fn resolve_derived_element(
 }
 
 /// The SI scale of an `IFCCONVERSIONBASEDUNIT.ConversionFactor`
-/// (`IFCMEASUREWITHUNIT`): the value component expressed in the (possibly
-/// prefixed) SI unit component.
-fn conversion_factor_scale(decoder: &mut EntityDecoder, measure_ref: u32) -> Option<f64> {
+/// (`IFCMEASUREWITHUNIT`): the value component expressed in its `UnitComponent`,
+/// which per `IfcMeasureWithUnit` is any `IfcUnit` — a (possibly prefixed)
+/// `IfcSIUnit`, an `IfcDerivedUnit`, or *another* `IfcConversionBasedUnit`
+/// (a real-world chain, e.g. YARD defined as 3 FOOT where FOOT is itself
+/// conversion-based). Resolving through the shared dispatcher folds in every
+/// case uniformly instead of silently treating a non-SI component as scale 1.0.
+fn conversion_factor_scale(decoder: &mut EntityDecoder, measure_ref: u32, depth: u32) -> Option<f64> {
     let measure = decoder.decode_by_id(measure_ref).ok()?;
     if measure.ifc_type.as_str() != "IFCMEASUREWITHUNIT" {
         return None;
@@ -246,19 +250,10 @@ fn conversion_factor_scale(decoder: &mut EntityDecoder, measure_ref: u32) -> Opt
     if !(value.is_finite() && value > 0.0) {
         return None;
     }
-    // Fold the unit component's own SI scale (e.g. a value stated in millimetres).
     let component_scale = measure
         .get_ref(1)
-        .and_then(|r| {
-            let comp = decoder.decode_by_id(r).ok()?;
-            if comp.ifc_type.as_str() == "IFCSIUNIT" {
-                let name = comp.get(3).and_then(|a| a.as_enum())?;
-                let prefix = comp.get(2).filter(|a| !a.is_null()).and_then(|a| a.as_enum());
-                si_unit_symbol_and_scale(name, prefix).map(|(_, s)| s)
-            } else {
-                None
-            }
-        })
+        .and_then(|r| resolve_unit_by_ref_depth(decoder, r, depth + 1))
+        .map(|(_, resolved, _)| resolved.si_scale)
         .unwrap_or(1.0);
     Some(value * component_scale)
 }

--- a/rust/core/src/project_units/tests.rs
+++ b/rust/core/src/project_units/tests.rs
@@ -129,6 +129,40 @@ END-ISO-10303-21;
     assert!((len.si_scale - 0.0254).abs() < 1e-12, "expected 0.0254, got {}", len.si_scale);
 }
 
+/// `IFCMEASUREWITHUNIT.UnitComponent` (`IfcUnit`) is not restricted to
+/// `IfcSIUnit` — the spec allows any `IfcNamedUnit`, so a conversion-based unit
+/// can be defined relative to *another* conversion-based unit (a real-world
+/// chain: YARD = 3 FOOT, FOOT = 0.3048 METRE). `conversion_factor_scale` must
+/// resolve that chain, not just fold in a bare/prefixed SI component — else the
+/// derived unit's si_scale silently drops the FOOT factor entirely (3.0 instead
+/// of 0.9144, a ~3.3x error) rather than being flagged as unresolved.
+#[test]
+fn conversion_based_unit_resolves_chained_conversion_component() {
+    let ifc = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#3=IFCUNITASSIGNMENT((#20));
+#5=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#6=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(0.3048),#5);
+#7=IFCCONVERSIONBASEDUNIT(#11,.LENGTHUNIT.,'FOOT',#6);
+#9=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(3.0),#7);
+#20=IFCCONVERSIONBASEDUNIT(#11,.LENGTHUNIT.,'YARD',#9);
+#11=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let units = units_of(ifc);
+    let len = units.unit_for_measure("IfcLengthMeasure").unwrap();
+    // 1 YARD = 3 FOOT = 3 * 0.3048 m = 0.9144 m, NOT 3.0 m (chained
+    // conversion-based UnitComponent dropped to scale 1.0).
+    assert!((len.si_scale - 0.9144).abs() < 1e-12, "expected 0.9144, got {}", len.si_scale);
+}
+
 #[test]
 fn kilogram_mass_unit() {
     let ifc = r#"ISO-10303-21;


### PR DESCRIPTION
## Unit kind
`IfcConversionBasedUnit` — specifically the `ConversionFactor : IfcMeasureWithUnit` -> `UnitComponent : IfcUnit` link (IFC4 clause 8.7.3.15 `IfcMeasureWithUnit`; `IfcConversionBasedUnit` 8.7.3.9).

## Scope
This lens targets `IfcConversionBasedUnit` / `IfcDerivedUnit` scale composition, explicitly staying out of the `IfcSIUnit` prefix path already owned by #3549 and #3555 (neither touches `rust/core/src/project_units/`, so there is no overlap).

## Verdict table

| Case | Rust (`rust/core/src/project_units/mod.rs`) | Verdict |
|---|---|---|
| INCH, factor 0.0254 against a bare SI metre `UnitComponent` | resolves correctly | already correct (control) |
| INCH, factor 25.4 against a `MILLI.METRE` `UnitComponent` | resolves correctly (folds prefix scale) — pinned by `conversion_based_unit_folds_prefixed_component_scale` | already correct (control) |
| `IfcDerivedUnit` with a negative exponent (`m³·s⁻¹`) and one with exponent 3 (`m³`) | resolves correctly — `scale *= unit_scale.powi(exponent)` composes both, pinned by existing `resolves_vzt_flow_rate_as_derived_m3_per_s` / mass-density tests | already correct (control) |
| `IfcConversionBasedUnit.UnitComponent` is **another** `IfcConversionBasedUnit` (a real-world chain: YARD = 3 FOOT, FOOT = 0.3048 m) | `conversion_factor_scale` only matched a bare `IFCSIUNIT` component and silently fell back to scale `1.0` for anything else | **bug — fixed** |
| An unresolvable unit ref (bad/missing entity) | `resolve_unit_by_ref_depth` returns `None`, callers `unwrap_or(1.0)` treat it as SI (a pre-existing, narrower, already-flagged-in-code fallback) | unchanged, out of scope (lower-ranked per the lens's own priority order) |

## The fix

`IfcMeasureWithUnit.UnitComponent` is typed `IfcUnit` (any `IfcNamedUnit` or `IfcDerivedUnit`), not just `IfcSIUnit`. `conversion_factor_scale` hand-checked only for `"IFCSIUNIT"` and used `unwrap_or(1.0)` for every other component type — including another conversion-based unit. For a YARD/FOOT chain this silently resolved `si_scale` to `3.0` instead of the spec-correct `0.9144` (~3.3x wrong), with no error surfaced — the unit still "resolved", just to the wrong magnitude, ranking above an unresolved-unit fallback per the hunt's own priority order.

Fixed by resolving `UnitComponent` through the same recursive `resolve_unit_by_ref_depth` dispatcher already used for `IFCDERIVEDUNITELEMENT.Unit`, so a chained conversion-based (or derived) component composes correctly instead of being dropped to `1.0`.

### RED (on unmodified `upstream/main`)
```
thread 'project_units::tests::conversion_based_unit_resolves_chained_conversion_component' panicked:
expected 0.9144, got 3
```

### GREEN (after the fix)
All 26 `project_units::` unit tests pass, including the new chained-component test and every existing control case (bare-SI INCH, prefixed-SI-component INCH, derived-unit exponents, kilogram, monetary, degree).

### Control
- The already-correct SI-metre / prefixed-SI-component and derived-unit-exponent cases are unchanged (same tests, still green).
- `IfcSIUnit` prefix handling itself is untouched — this PR does not modify `si_unit_symbol_and_scale` or any file in #3549/#3555's diff.

## Reachability (honest)
`ProjectUnits`/`resolve_unit_by_ref` is `pub use`d from `ifc-lite-core` (published surface for `@ifc-lite/wasm` consumers) but has **no in-tree Rust caller** today — no CLI/server path currently wires it into an output. The parallel TypeScript resolver, `packages/parser/src/project-units.ts`'s `conversionFactorScale`, is the one actually wired to the viewer/CLI/quantity display and has the identical `IFCSIUNIT`-only gap, but that exact file is the target of two other in-flight PRs (#3549, #3555), so it is intentionally left untouched here — noted for whichever of those lands last to pick up.

## Verification (foreground)
- `cargo test -p ifc-lite-core project_units::` — 26 passed
- `cargo test -p ifc-lite-core` (full crate) — all passed
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6 passed
- `node scripts/check-module-size.mjs` — OK
- `pnpm run check:vitest-timeout-audit` — OK (no TS changed)
- `node scripts/check-test-wiring.mjs` — OK
- `node scripts/check-unused-locals.mjs` — OK (no TS changed)
- No TS/`index.ts` export changed — `tsc`/api-surface untouched
- Changeset added: `.changeset/conversion-based-unit-chained-component.md` (`@ifc-lite/wasm`: patch)