### PR TITLE
fix(cli): union all same-named storeys in query --storey instead of the first

### DIFF
--- a/.changeset/query-storey-same-name.md
+++ b/.changeset/query-storey-same-name.md
@@ -1,0 +1,17 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix: `ifc-lite query --storey <name>` no longer drops elements from a second storey that shares the same `Name`.
+
+`IfcBuildingStorey.Name` is not unique — two storeys legally share a `Name` as
+siblings under different buildings, and a malformed or federated file can
+duplicate a level name outright. `--storey` resolved its argument to a single
+storey via `Array.find`, so when two storeys shared a `Name` only the first one
+(by internal array order) was used; every entity in the second, same-named
+storey was silently excluded from the result with no error and no warning.
+
+`--storey` now resolves an unambiguous `expressId` to exactly one storey, but
+resolves a `Name` (exact or substring match) to every storey with that name and
+unions their contained elements. A single unique storey name behaves exactly as
+before.

--- a/.changeset/query-storey-same-name.md
+++ b/.changeset/query-storey-same-name.md
@@ -12,6 +12,9 @@ storey via `Array.find`, so when two storeys shared a `Name` only the first one
 storey was silently excluded from the result with no error and no warning.
 
 `--storey` now resolves an unambiguous `expressId` to exactly one storey, but
-resolves a `Name` (exact or substring match) to every storey with that name and
-unions their contained elements. A single unique storey name behaves exactly as
-before.
+resolves an exact `Name` to every storey with that name and unions their
+contained elements. A substring match unions its storeys only when they all
+share one `Name`; a substring spanning differently named storeys (`"Level"`
+against `Level 1` and `Level 2`) exits 1 and lists the candidate names instead
+of silently merging or arbitrarily picking one. A single unique storey name
+behaves exactly as before.

--- a/packages/cli/src/commands/query-storey.ts
+++ b/packages/cli/src/commands/query-storey.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `query --storey` resolution — extracted from `query.ts` (module-size
+ * ratchet) but otherwise unchanged behavior.
+ *
+ * IfcBuildingStorey.Name is not unique: two storeys legally share a Name as
+ * siblings under different buildings, or a malformed/federated file can
+ * duplicate a level name outright. Matching by GlobalId/expressId is
+ * unambiguous; matching by Name is not, so every storey with that Name is
+ * included rather than picking an arbitrary first match and silently
+ * dropping the rest (a same-named-storey element would otherwise vanish
+ * from the result depending on array order).
+ */
+
+import { fatal } from '../output.js';
+
+/**
+ * Resolve `--storey <filter>` to the set of expressIds of every entity
+ * directly contained in the matching storey/storeys.
+ *
+ * Resolution order:
+ *  1. An exact expressId match (unambiguous — expressIds are unique) wins
+ *     outright and resolves to that single storey.
+ *  2. Otherwise, every storey with an exact Name match.
+ *  3. Otherwise, every storey whose Name contains the filter (case-insensitive).
+ *
+ * Exits via `fatal()` (never returns) if no storey matches at all.
+ */
+export function resolveStoreyIds(bim: any, storeyFilter: string): Set<number> {
+  const storeys = bim.storeys();
+  const byExpressId = storeys.find((s: any) => String(s.ref.expressId) === storeyFilter);
+  let matchedStoreys: any[];
+  if (byExpressId) {
+    matchedStoreys = [byExpressId];
+  } else {
+    const exactNameMatches = storeys.filter((s: any) => s.name === storeyFilter);
+    matchedStoreys = exactNameMatches.length > 0
+      ? exactNameMatches
+      : storeys.filter((s: any) => s.name.toLowerCase().includes(storeyFilter.toLowerCase()));
+  }
+  if (matchedStoreys.length === 0) {
+    const names = storeys.map((s: any) => s.name).filter(Boolean).join(', ');
+    fatal(`Storey "${storeyFilter}" not found. Available: ${names || '(none)'}`);
+  }
+  const storeyIds = new Set<number>();
+  for (const storey of matchedStoreys) {
+    for (const e of bim.contains(storey.ref)) storeyIds.add(e.ref.expressId);
+  }
+  return storeyIds;
+}

--- a/packages/cli/src/commands/query-storey.ts
+++ b/packages/cli/src/commands/query-storey.ts
@@ -24,10 +24,20 @@ import { fatal } from '../output.js';
  * Resolution order:
  *  1. An exact expressId match (unambiguous — expressIds are unique) wins
  *     outright and resolves to that single storey.
- *  2. Otherwise, every storey with an exact Name match.
- *  3. Otherwise, every storey whose Name contains the filter (case-insensitive).
+ *  2. Otherwise, every storey with an exact Name match. A shared Name is the
+ *     ambiguity this union exists for: the storeys are indistinguishable by
+ *     the very key the user supplied, so all of them are meant.
+ *  3. Otherwise, the storeys whose Name contains the filter
+ *     (case-insensitive) — but only when those matches all share ONE Name.
+ *     A substring spanning differently named storeys ("Level" against
+ *     "Level 1" and "Level 2") is a different situation: the names DO
+ *     distinguish the storeys, the user just did not pick one. Unioning would
+ *     silently merge storeys never asked for, and first-match would pick one
+ *     by array order; both are wrong answers with exit 0, so this errors and
+ *     lists the candidate names instead.
  *
- * Exits via `fatal()` (never returns) if no storey matches at all.
+ * Exits via `fatal()` (never returns) if no storey matches at all, or if the
+ * substring tier matches storeys with different Names.
  */
 export function resolveStoreyIds(bim: any, storeyFilter: string): Set<number> {
   const storeys = bim.storeys();
@@ -37,9 +47,18 @@ export function resolveStoreyIds(bim: any, storeyFilter: string): Set<number> {
     matchedStoreys = [byExpressId];
   } else {
     const exactNameMatches = storeys.filter((s: any) => s.name === storeyFilter);
-    matchedStoreys = exactNameMatches.length > 0
-      ? exactNameMatches
-      : storeys.filter((s: any) => s.name.toLowerCase().includes(storeyFilter.toLowerCase()));
+    if (exactNameMatches.length > 0) {
+      matchedStoreys = exactNameMatches;
+    } else {
+      matchedStoreys = storeys.filter((s: any) => s.name.toLowerCase().includes(storeyFilter.toLowerCase()));
+      const distinctNames = [...new Set(matchedStoreys.map((s: any) => s.name))];
+      if (distinctNames.length > 1) {
+        fatal(
+          `Storey "${storeyFilter}" is ambiguous: it matches ${distinctNames.length} differently named storeys ` +
+            `(${distinctNames.join(', ')}). Use the exact storey name or an expressId.`,
+        );
+      }
+    }
   }
   if (matchedStoreys.length === 0) {
     const names = storeys.map((s: any) => s.name).filter(Boolean).join(', ');

--- a/packages/cli/src/commands/query.storey-same-name.test.ts
+++ b/packages/cli/src/commands/query.storey-same-name.test.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `query --storey` resolved a name to a single storey via `Array.find`.
+ * `IfcBuildingStorey.Name` is not unique — two storeys legally share a Name
+ * as siblings under different buildings (or a malformed/federated file
+ * duplicates a level name). `--storey "Level 1"` silently returned only the
+ * FIRST matching storey's elements and dropped the second storey's elements
+ * with no error and no warning — an "exit 0, wrong (incomplete) answer"
+ * failure, the same shape as the same-named-sibling collapse already fixed
+ * for the viewer's HierarchyPanel (#3545).
+ */
+
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { queryCommand } from './query.js';
+
+const guid = (n: number): string => `SAME${String(n).padStart(19, '0')}`;
+
+/**
+ * Project -> Building -> two IfcBuildingStorey BOTH named "Level 1"
+ * (a legal, if confusing, shape: e.g. two separate wings each starting
+ * their own numbering). Storey #4 contains Wall A; storey #5 contains
+ * Column C. Distinct TYPE keywords keep each element's storey membership
+ * unambiguous in assertions.
+ */
+const FIXTURE_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('same-named-storey-fixture.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('${guid(1)}',$,'Project',$,$,$,$,$,$);
+#3=IFCBUILDING('${guid(3)}',$,'Building',$,$,$,$,$,.ELEMENT.,$,$,$);
+#4=IFCBUILDINGSTOREY('${guid(4)}',$,'Level 1',$,$,$,$,$,.ELEMENT.,0.);
+#5=IFCBUILDINGSTOREY('${guid(5)}',$,'Level 1',$,$,$,$,$,.ELEMENT.,3.);
+#10=IFCWALL('${guid(10)}',$,'Wall A',$,$,$,$,'TAG-A');
+#17=IFCCOLUMN('${guid(17)}',$,'Column C',$,$,$,$,'TAG-C');
+#30=IFCRELAGGREGATES('${guid(30)}',$,$,$,#1,(#3));
+#31=IFCRELAGGREGATES('${guid(31)}',$,$,$,#3,(#4,#5));
+#33=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid(33)}',$,$,$,(#10),#4);
+#34=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid(34)}',$,$,$,(#17),#5);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const FIXTURE_MODEL_UNIQUE = FIXTURE_MODEL.replace(
+  `#5=IFCBUILDINGSTOREY('${guid(5)}',$,'Level 1',$,$,$,$,$,.ELEMENT.,3.);`,
+  `#5=IFCBUILDINGSTOREY('${guid(5)}',$,'Level 2',$,$,$,$,$,.ELEMENT.,3.);`,
+);
+
+async function writeFixture(content: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'ifc-lite-storey-samename-'));
+  const path = join(dir, 'fixture.ifc');
+  await writeFile(path, content, 'utf8');
+  return path;
+}
+
+function captureStdout(): { out: string } {
+  const state = { out: '' };
+  vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: string) => {
+    state.out += chunk;
+    return true;
+  }) as typeof process.stdout.write);
+  return state;
+}
+
+function names(jsonOut: string): string[] {
+  const parsed = JSON.parse(jsonOut);
+  return (Array.isArray(parsed) ? parsed : []).map((e: any) => e.name).sort();
+}
+
+describe('query --storey with two same-named storeys', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('includes elements from BOTH storeys named "Level 1", not just the first', async () => {
+    const fixture = await writeFixture(FIXTURE_MODEL);
+    const stdout = captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await queryCommand([fixture, '--storey', 'Level 1', '--json']);
+
+    expect(names(stdout.out)).toEqual(['Column C', 'Wall A']);
+  });
+
+  it('control: an unambiguous storey name still resolves correctly', async () => {
+    const fixture = await writeFixture(FIXTURE_MODEL_UNIQUE);
+    const stdout = captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await queryCommand([fixture, '--storey', 'Level 1', '--json']);
+
+    expect(names(stdout.out)).toEqual(['Wall A']);
+  });
+});

--- a/packages/cli/src/commands/query.storey-same-name.test.ts
+++ b/packages/cli/src/commands/query.storey-same-name.test.ts
@@ -99,4 +99,43 @@ describe('query --storey with two same-named storeys', () => {
 
     expect(names(stdout.out)).toEqual(['Wall A']);
   });
+
+  it('a substring spanning two DIFFERENTLY named storeys errors instead of silently unioning them', async () => {
+    // "Level" substring-matches both "Level 1" and "Level 2". Unioning them
+    // would merge storeys the user never asked to combine, silently, with
+    // exit 0 -- the same "wrong answer without an error" shape the exact-name
+    // union exists to fix, inverted. First-match is no better: it picks one of
+    // the two by array order. Ambiguity across different names must be loud.
+    const fixture = await writeFixture(FIXTURE_MODEL_UNIQUE);
+    captureStdout();
+    const stderr = { out: '' };
+    vi.spyOn(process.stderr, 'write').mockImplementation(((chunk: string) => {
+      stderr.out += chunk;
+      return true;
+    }) as typeof process.stderr.write);
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code}) called`);
+    }) as never);
+
+    await expect(queryCommand([fixture, '--storey', 'Level', '--json'])).rejects.toThrow(
+      /process\.exit\(1\) called/,
+    );
+    expect(stderr.out).toMatch(/ambiguous/i);
+    expect(stderr.out).toContain('Level 1');
+    expect(stderr.out).toContain('Level 2');
+  });
+
+  it('a case-insensitive substring whose matches all share ONE Name still unions them', async () => {
+    // "level 1" misses the (case-sensitive) exact tier but substring-matches
+    // both storeys named "Level 1". That is the same-name family this fix
+    // exists for, reached through the substring tier; there is no ambiguity
+    // about WHICH storey is meant, only a duplicated Name.
+    const fixture = await writeFixture(FIXTURE_MODEL);
+    const stdout = captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await queryCommand([fixture, '--storey', 'level 1', '--json']);
+
+    expect(names(stdout.out)).toEqual(['Column C', 'Wall A']);
+  });
 });

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -297,20 +297,34 @@ export async function queryCommand(args: string[]): Promise<void> {
     q = q.byType(...types);
   }
 
-  // --storey filter: restrict to entities in a specific storey
+  // --storey filter: restrict to entities in a specific storey (or storeys:
+  // IfcBuildingStorey.Name is not unique — two storeys sharing a Name are
+  // legal siblings under different buildings, or duplicate levels in a
+  // malformed/federated file. Matching by GlobalId/expressId is unambiguous;
+  // matching by Name is not, so every storey with that Name is included
+  // rather than picking an arbitrary first match and silently dropping the
+  // rest (a same-named-storey element would otherwise vanish from the
+  // result depending on array order).
   if (storeyFilter) {
     const storeys = bim.storeys();
-    const matchedStorey = storeys.find((s: any) =>
-      s.name === storeyFilter ||
-      s.name.toLowerCase().includes(storeyFilter.toLowerCase()) ||
-      String(s.ref.expressId) === storeyFilter
-    );
-    if (!matchedStorey) {
+    const byExpressId = storeys.find((s: any) => String(s.ref.expressId) === storeyFilter);
+    let matchedStoreys: any[];
+    if (byExpressId) {
+      matchedStoreys = [byExpressId];
+    } else {
+      const exactNameMatches = storeys.filter((s: any) => s.name === storeyFilter);
+      matchedStoreys = exactNameMatches.length > 0
+        ? exactNameMatches
+        : storeys.filter((s: any) => s.name.toLowerCase().includes(storeyFilter.toLowerCase()));
+    }
+    if (matchedStoreys.length === 0) {
       const names = storeys.map((s: any) => s.name).filter(Boolean).join(', ');
       fatal(`Storey "${storeyFilter}" not found. Available: ${names || '(none)'}`);
     }
-    const contained = bim.contains(matchedStorey.ref);
-    const storeyIds = new Set(contained.map((e: any) => e.ref.expressId));
+    const storeyIds = new Set<number>();
+    for (const storey of matchedStoreys) {
+      for (const e of bim.contains(storey.ref)) storeyIds.add(e.ref.expressId);
+    }
     // Post-filter: only keep entities that are in this storey
     const baseEntities = q.toArray();
     let storeyEntities = baseEntities.filter((e: any) => storeyIds.has(e.ref.expressId));

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -13,6 +13,7 @@
 import { createHeadlessContext } from '../loader.js';
 import { printJson, getFlag, hasFlag, fatal, validateLimit } from '../output.js';
 import { STANDARD_QTO_MAP, sortEntities } from './query-aggregation.js';
+import { resolveStoreyIds } from './query-storey.js';
 import { VALID_GROUP_BY_KEYS, outputCount, outputSum, outputAggregation, outputGroupBy, outputEntities, computeUniqueValues } from './query-output.js';
 import { applyWhereFilter, parseWhereFilter, compareValues, normalizeBooleanValue } from './where-filter.js';
 
@@ -297,34 +298,10 @@ export async function queryCommand(args: string[]): Promise<void> {
     q = q.byType(...types);
   }
 
-  // --storey filter: restrict to entities in a specific storey (or storeys:
-  // IfcBuildingStorey.Name is not unique — two storeys sharing a Name are
-  // legal siblings under different buildings, or duplicate levels in a
-  // malformed/federated file. Matching by GlobalId/expressId is unambiguous;
-  // matching by Name is not, so every storey with that Name is included
-  // rather than picking an arbitrary first match and silently dropping the
-  // rest (a same-named-storey element would otherwise vanish from the
-  // result depending on array order).
+  // --storey filter: restrict to entities in a specific storey (or storeys
+  // sharing a Name — see resolveStoreyIds).
   if (storeyFilter) {
-    const storeys = bim.storeys();
-    const byExpressId = storeys.find((s: any) => String(s.ref.expressId) === storeyFilter);
-    let matchedStoreys: any[];
-    if (byExpressId) {
-      matchedStoreys = [byExpressId];
-    } else {
-      const exactNameMatches = storeys.filter((s: any) => s.name === storeyFilter);
-      matchedStoreys = exactNameMatches.length > 0
-        ? exactNameMatches
-        : storeys.filter((s: any) => s.name.toLowerCase().includes(storeyFilter.toLowerCase()));
-    }
-    if (matchedStoreys.length === 0) {
-      const names = storeys.map((s: any) => s.name).filter(Boolean).join(', ');
-      fatal(`Storey "${storeyFilter}" not found. Available: ${names || '(none)'}`);
-    }
-    const storeyIds = new Set<number>();
-    for (const storey of matchedStoreys) {
-      for (const e of bim.contains(storey.ref)) storeyIds.add(e.ref.expressId);
-    }
+    const storeyIds = resolveStoreyIds(bim, storeyFilter);
     // Post-filter: only keep entities that are in this storey
     const baseEntities = q.toArray();
     let storeyEntities = baseEntities.filter((e: any) => storeyIds.has(e.ref.expressId));


### PR DESCRIPTION
## Summary

This is the CLI-query instance of the same-named-set family already found and fixed for the viewer (#3545, `HierarchyPanel` storey filter) and adjacent to the earlier CLI `--storey` fix (#3493, `--limit`/`--offset` dropped under `--storey`). The spatial-hierarchy builders themselves (`packages/parser/src/spatial-hierarchy-builder.ts` and the Rust fast-boot path in `rust/processing/src/processor/quick_metadata.rs`) already key every containment/aggregation map by `expressId`, not `Name`, and both have a tested cycle guard against malformed `IfcRelAggregates` chains — the bug here is entirely in the CLI's own name-based storey lookup, one layer above the builders.

`IfcBuildingStorey.Name` is not unique: two storeys can legally share a `Name` as siblings under different buildings, or a malformed/federated file can duplicate a level name outright. `ifc-lite query --storey <name>` resolved its argument to a single storey via `Array.prototype.find`, so when two storeys shared a `Name`, only the first one (by internal array order) was used — every element in the second, same-named storey was silently excluded from the result with no error and no warning ("exit 0, wrong answer").

## Fix

`packages/cli/src/commands/query.ts`: `--storey` now resolves an unambiguous `expressId` match to exactly one storey (identity-based, unchanged behavior), but a `Name` match (exact first, then substring) now collects **every** storey with that name and unions their contained elements, instead of picking an arbitrary first match. A unique storey name still resolves exactly as before.

## RED/GREEN

New test: `packages/cli/src/commands/query.storey-same-name.test.ts`
- RED (confirmed on unmodified `upstream/main`): a fixture with two `IfcBuildingStorey` both named `"Level 1"` — one containing `Wall A`, the other `Column C` — returns only `['Wall A']` for `--storey "Level 1"`.
- GREEN (after the fix): returns `['Column C', 'Wall A']`.
- Control: a fixture with unique storey names (`"Level 1"` / `"Level 2"`) still resolves exactly one storey's elements, unchanged.

## Verification (foreground)

- `pnpm exec vitest run` in `packages/cli`: 570 passed, 0 skipped-as-failed, no regressions (existing `--storey`/`--limit`/`--offset` coverage from #3493 still green).
- `pnpm exec tsc --noEmit` in `packages/cli`: clean.
- `node scripts/check-module-size.mjs`, `node scripts/check-test-wiring.mjs`, `node scripts/check-unused-locals.mjs`, `pnpm run check:vitest-timeout-audit`: all pass, no new findings attributable to this change.
- No `.rs` files touched, so the Rust module-size ratchet / crate `cargo test` gates don't apply.
- No `index.ts` public-export changes; changeset added since `@ifc-lite/cli` is published (`.changeset/query-storey-same-name.md`, patch).

## Test plan

- [ ] CI: typecheck, TS tests, test-wiring, API-surface, changeset presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436