### PR TITLE
fix(ids): stop an ObjectType attribute requirement reading the PredefinedType enum

### DIFF
--- a/.changeset/ids-attribute-facet-objecttype-predefinedtype-shadow.md
+++ b/.changeset/ids-attribute-facet-objecttype-predefinedtype-shadow.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/ids': patch
+---
+
+Fix an IDS `<attribute><name>ObjectType</name></attribute>` requirement reading the wrong IFC attribute when the entity's `PredefinedType` is a concrete, non-`USERDEFINED`, non-`NOTDEFINED` enum token.
+
+`checkAttributeFacet`'s `ObjectType` lookup went through `accessor.getObjectType`, the helper `matchPredefinedType` uses to resolve the USERDEFINED-name fallback (its own doc: "entity object type (predefined type)"). For an entity like `IfcWall` with `PredefinedType = STANDARD` and its own, unrelated `ObjectType = 'Steel I-Beam 200x100'`, that helper short-circuits on the `PredefinedType` enum and never looks at the entity's actual `ObjectType` attribute — so a required-and-present `ObjectType` value requirement was checked against `'STANDARD'` instead, and failed. The bridge's generic `getAttribute('ObjectType', …)` had the same conflation.
+
+`ObjectType` now routes through the plain attribute path (the same one `Tag`, `LongName`, and every other named attribute uses), which reads the entity's real attribute value; `PredefinedType` requirement checks are unaffected. Same root cause as #2316 (`getAncestors` sourcing a partOf parent's predefined-type match from `getObjectType` instead of the raw enum), here on the plain attribute-facet path instead of `partOf`.

--- a/packages/ids/src/bridge/attribute-facet-objecttype-shadow.test.ts
+++ b/packages/ids/src/bridge/attribute-facet-objecttype-shadow.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IDS `<attribute><name>ObjectType</name></attribute>` requirement,
+ * checked against a REAL parsed store (not the mock accessor
+ * `facets.test.ts` uses — that mock hands `ObjectType` to the checker
+ * through a dedicated `objectType` field, so it cannot see a bug in how
+ * the bridge POPULATES that value from the raw entity).
+ *
+ * `checkAttributeFacet`'s `getAttributeValue('objecttype', …)` reads
+ * `accessor.getObjectType(expressId)`, which is `resolveObjectType` —
+ * a helper built for the *PredefinedType* USERDEFINED-fallback lookup
+ * (`matchPredefinedType`'s `userDefinedType` argument), documented in
+ * `IFCDataAccessor.getObjectType` as "entity object type (predefined
+ * type)". For an entity whose raw `PredefinedType` is a concrete,
+ * non-`USERDEFINED`, non-`NOTDEFINED` enum token (e.g. `STANDARD`),
+ * `resolveObjectType` returns that enum token immediately — it never
+ * looks at the entity's actual `ObjectType` *attribute* at all. So an
+ * IDS spec checking the real `ObjectType` attribute value on such an
+ * entity is silently checked against the `PredefinedType` enum instead
+ * — two distinct IFC attributes conflated into one, exactly the shape
+ * `partof-predefined-type.test.ts` already pinned for `getAncestors`
+ * (#2316) but here for the plain attribute-facet path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer, ColumnarParser } from '@ifc-lite/parser';
+import type { EntityRef } from '@ifc-lite/parser';
+import { createDataAccessor } from './data-accessor.js';
+import { checkAttributeFacet } from '../facets/attribute-facet.js';
+import type { IDSAttributeFacet, IDSSimpleValue } from '../types.js';
+
+const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
+
+async function parse(ifc: string) {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: EntityRef[] = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0) as ArrayBuffer, entityRefs, {});
+}
+
+// A wall with a concrete PredefinedType enum (STANDARD — not USERDEFINED,
+// not NOTDEFINED) AND its own, unrelated ObjectType free-text value.
+// Attribute order (IFC4 IfcWall): GlobalId, OwnerHistory, Name,
+// Description, ObjectType, ObjectPlacement, Representation, Tag,
+// PredefinedType.
+const IFC = `#100=IFCWALL('0Wall00000000000000001',$,'Wall_001',$,'Steel I-Beam 200x100',$,$,$,.STANDARD.);`;
+
+describe('IDS attribute facet — ObjectType must not read the PredefinedType enum', () => {
+  it('reads the real ObjectType attribute, not the concrete PredefinedType token, for a required-and-present value check', async () => {
+    const store = await parse(IFC);
+    const accessor = createDataAccessor(store);
+
+    const facet: IDSAttributeFacet = {
+      type: 'attribute',
+      name: sv('ObjectType'),
+      value: sv('Steel I-Beam 200x100'),
+    };
+    const result = checkAttributeFacet(facet, 100, accessor);
+
+    expect(result.passed).toBe(true);
+    expect(result.actualValue).toBe('Steel I-Beam 200x100');
+  });
+
+  it('control: an unrelated required-and-present attribute (Name) still passes', async () => {
+    const store = await parse(IFC);
+    const accessor = createDataAccessor(store);
+
+    const facet: IDSAttributeFacet = {
+      type: 'attribute',
+      name: sv('Name'),
+      value: sv('Wall_001'),
+    };
+    const result = checkAttributeFacet(facet, 100, accessor);
+
+    expect(result.passed).toBe(true);
+  });
+});

--- a/packages/ids/src/bridge/data-accessor.ts
+++ b/packages/ids/src/bridge/data-accessor.ts
@@ -301,7 +301,13 @@ export function createDataAccessor(store: IfcDataStore): IFCDataAccessor {
           return accessor.getDescription(expressId);
         case 'globalid':
           return accessor.getGlobalId(expressId);
-        case 'objecttype':
+        // `predefinedtype` deliberately resolves through
+        // `getObjectType` (the PredefinedType/USERDEFINED-name helper) —
+        // but `objecttype` must NOT: that would shadow the entity's
+        // actual `ObjectType` attribute with the PredefinedType enum
+        // whenever PredefinedType is a concrete, non-USERDEFINED,
+        // non-NOTDEFINED token. Let it fall through to the raw
+        // attribute extraction below, same as any other named attribute.
         case 'predefinedtype':
           return accessor.getObjectType(expressId);
         default: {

--- a/packages/ids/src/facets/attribute-facet.ts
+++ b/packages/ids/src/facets/attribute-facet.ts
@@ -205,10 +205,18 @@ function getAttributeValue(
       return accessor.getEntityName(expressId);
     case 'description':
       return accessor.getDescription(expressId);
-    case 'objecttype':
-      return accessor.getObjectType(expressId);
     case 'globalid':
       return accessor.getGlobalId(expressId);
+    // Deliberately NOT `case 'objecttype'`: `accessor.getObjectType` is the
+    // PredefinedType USERDEFINED-fallback helper (its own doc: "entity
+    // object type (predefined type)"), not the literal IFC `ObjectType`
+    // attribute. For an entity whose raw PredefinedType is a concrete,
+    // non-USERDEFINED, non-NOTDEFINED enum token (e.g. `STANDARD`), that
+    // helper returns the enum token — never the entity's actual ObjectType
+    // text — so an `<attribute><name>ObjectType</name></attribute>`
+    // requirement was silently checked against the wrong IFC attribute.
+    // Route it through the generic accessor instead, same as any other
+    // named attribute.
     default:
       // Try generic attribute access
       return accessor.getAttribute(expressId, attrName);


### PR DESCRIPTION
## What

`checkAttributeFacet`'s `ObjectType` lookup went through `accessor.getObjectType`, which is the helper `matchPredefinedType` uses to resolve the `USERDEFINED`-name fallback for `<entity predefinedType="…">`/`<partOf>` matching (see its own doc: "entity object type (predefined type)").

For an entity whose raw `PredefinedType` is a concrete, non-`USERDEFINED`, non-`NOTDEFINED` enum token (e.g. `IfcWall` with `PredefinedType = STANDARD`) and its own, unrelated `ObjectType` attribute value, that helper short-circuits on the `PredefinedType` enum and never reads the entity's actual `ObjectType` attribute at all. So:

```
<attribute>
  <name><simpleValue>ObjectType</simpleValue></name>
  <value><simpleValue>Steel I-Beam 200x100</simpleValue></value>
</attribute>
```

checked against `IfcWall(PredefinedType=STANDARD, ObjectType='Steel I-Beam 200x100')` was silently checked against `'STANDARD'` instead — a **required-and-present** requirement, wrong per IDS clause `ids:attributeType` (a plain, literal check of the named IFC attribute), reported **FAIL**. `packages/ids/src/bridge/data-accessor.ts`'s generic `getAttribute('ObjectType', …)` fallback had the identical conflation.

## Verdict table

| Entity | Spec (attribute facet) | Engine verdict (before) | Spec-correct verdict | Engine verdict (after) |
|---|---|---|---|---|
| `IfcWall` `PredefinedType=STANDARD`, `ObjectType='Steel I-Beam 200x100'` | `ObjectType == 'Steel I-Beam 200x100'` | FAIL (checked against `'STANDARD'`) | PASS | PASS |
| same entity | `Name == 'Wall_001'` (control) | PASS | PASS | PASS |

## Fix

`ObjectType` now routes through the same plain-attribute path every other named attribute uses (`Tag`, `LongName`, …), which reads the entity's real attribute value via the schema-driven extractor. `PredefinedType` requirement checks (which legitimately want the USERDEFINED-name substitution) are untouched — only the `objecttype` case was removed from both switches.

Same root cause as #2316 (`getAncestors` sourcing a `partOf` parent's predefined-type match from `getObjectType` instead of the raw enum token) — here on the plain attribute-facet path instead of `partOf`.

## Test plan

- [x] RED: `packages/ids/src/bridge/attribute-facet-objecttype-shadow.test.ts`, run against unmodified `upstream/main` — fails with `actualValue: 'STANDARD'` instead of the real `ObjectType` text.
- [x] GREEN after the fix; control assertion (`Name` check) passes throughout.
- [x] `packages/ids` full suite: 831/831 passing.
- [x] `tsc --noEmit` clean for `packages/ids`.
- [x] `node scripts/check-module-size.mjs`, `node scripts/check-test-wiring.mjs` — no new findings.
- [x] Changeset added (`@ifc-lite/ids`, patch).
- [x] No `.rs` files touched. No `xml-parser.ts`/`digit-facets.ts` (PR #3601's area) or spatial-containment files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IDS validation for `ObjectType` attributes to read the entity’s actual value.
  * Preserved existing `PredefinedType` handling, including USERDEFINED fallback behavior.
  * Improved validation accuracy when `ObjectType` and `PredefinedType` contain different values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->