### PR TITLE
fix(review): the lane could not review a comment-only diff

### DIFF
--- a/scripts/review/rubric.md
+++ b/scripts/review/rubric.md
@@ -138,6 +138,21 @@ commentary before or after:
 
 `files_reviewed` must list every file you were given. `riskiest_change` is
 required even when `verdict` is `clean` — it is how a review that did not read
-the diff is told apart from one that read it and found nothing. `end` must be the
+the diff is told apart from one that read it and found nothing.
+
+**`riskiest_change` is required even when NOTHING in the diff is risky.** A diff
+of pure comments, documentation or configuration still has a most-substantive
+line: quote it. "Riskiest" is relative to the diff you were given, never an
+absolute claim that the line is dangerous — a comment-only change has a riskiest
+line in exactly the sense that a still pond has a deepest point. Omitting the
+field, or setting it to null, fails the review outright and posts nothing, so a
+diff you consider entirely safe is precisely where refusing to nominate one does
+the most damage.
+
+MEASURED: this happened. A pull request whose every added line was a YAML
+comment got `SCHEMA_INVALID: riskiest_change must be an object with non-empty
+path and quoted_line strings`, twice, deterministically — so the lane could not
+review config-only or docs-only changes at all, and those go to CodeRabbit or to
+nobody. `end` must be the
 last key and must be exactly `ifc-lite-review-v1`; without it the response is
 treated as truncated.


### PR DESCRIPTION
Measured on live traffic. PR #3613 changed `.coderabbit.yaml` and nothing else — **31 added lines, every one a YAML comment**. The lane failed:

```
❌ SCHEMA_INVALID: `riskiest_change` must be an object with non-empty
   `path` and `quoted_line` strings.
```

It failed again identically on a re-run. This is the contract, not model variance: the reviewer was asked to nominate the *riskiest* change in a diff containing no change at all, and declined. Defensible reading of the question; total failure of the lane.

## The validator is not what changes

`riskiest_change` is fatal by design, for a good reason: it is the proof-of-work standing between this system and `claude-code-action` #1644, where a review exits successfully having read nothing. Making it optional would trade the anti-#1644 guarantee for the ability to review comments — the wrong trade in a repo whose premise is that absence must not read as success.

So the **prompt** changes instead. "Riskiest" is relative to the diff you were given, never an absolute claim the line is dangerous: a comment-only change has a riskiest line in the sense that a still pond has a deepest point. The rubric now says so, and says what omitting it costs — the review fails outright and posts nothing, so a diff the model considers entirely safe is exactly where refusing to nominate one does the most damage.

## The coverage hole this closes

Config-only and docs-only PRs are common here and were getting **no Claude review at all**. They fell to CodeRabbit, rate-limited on two-thirds of attempts, or to nobody — the same 174-unreviewed-merges problem arriving through a schema field.

## Not verified pre-merge, and that is structural

`claude-review.yml` fetches the rubric from the **base branch** at run time so a PR cannot weaken the rules that judge it. Correct — and it means a rubric change cannot be exercised on its own PR. The token is a repository secret and cannot be read back, so a local A/B is unavailable.

Verification is a specific post-merge prediction: **the next comment-only PR should pass `Claude review` where #3613 failed twice.**

Six repo gates, 136 review tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review guidance to require identifying the riskiest change for every diff, including documentation, comment, and configuration updates.
  * Added instructions for selecting and quoting the most substantive added line.
  * Documented schema failures that occur when this information is omitted or left blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->