### PR TITLE
feat(ci): a daily canary, because a dark review lane looks exactly like a blip

### DIFF
--- a/.github/workflows/review-lane-canary.yml
+++ b/.github/workflows/review-lane-canary.yml
@@ -1,0 +1,115 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Review lane canary
+
+# THE LANE'S ONLY AGGREGATE SIGNAL.
+#
+# Every other check on the reviewer is PER-PR, and `Review posted` is not a
+# required check, so a dark lane renders exactly like a transient blip. The token
+# expired once already and the failure was invisible: individual reds that nobody
+# reads as "the reviewer has been gone since Tuesday". CodeRabbit covers roughly a
+# third of this repo's volume, so a dark lane means most PRs get no review while
+# every check still looks normal.
+#
+# So this runs on a clock, on ONE frozen input with a known answer, and opens an
+# issue when it fails. Daily rather than hourly: the failures it catches (an
+# expired token, a drained pool, a rubric regression) last hours or days, and an
+# hourly canary would spend subscription quota to find them a few hours sooner.
+on:
+  schedule:
+    # 06:20 UTC, before the working day here, so a dead lane is known before the
+    # day's PRs are opened rather than after they have merged.
+    - cron: '20 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # To open and update the ops issue. Nothing else.
+  issues: write
+
+concurrency:
+  group: review-lane-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: Review lane canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # The judge is exercised before it judges. A canary whose own logic has
+      # regressed would otherwise report a healthy lane, which is the failure
+      # mode this whole repository exists to refuse.
+      - name: Unit-test the canary itself
+        run: node --test scripts/review/lane-canary.test.mjs
+
+      - name: Install the reviewer CLI
+        run: npm install -g @anthropic-ai/claude-code@2.0.76
+
+      - name: Ask the reviewer for a known answer
+        id: canary
+        continue-on-error: true
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set +e
+          node scripts/review/lane-canary.mjs 2>&1 | tee "$RUNNER_TEMP/canary.log"
+          echo "rc=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      # AN ISSUE, NOT A RED RUN. A failed scheduled workflow is a row in a tab
+      # nobody opens; the point of this canary is to reach a human. The issue is
+      # updated in place rather than duplicated, so a week of failures is one
+      # thread and the close is the all-clear.
+      - name: Raise or update the ops issue
+        if: steps.canary.outputs.rc != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          body="$(printf 'The review lane failed its liveness canary at %s.\n\n```\n%s\n```\n\nThe canary runs one frozen diff with a known defect and requires the reviewer to find it. A failure here is NOT a per-PR blip: it means most PRs are currently getting no substantive review, because CodeRabbit covers only about a third of this volume.\n\nCheck, in order: the `CLAUDE_CODE_OAUTH_TOKEN` secret, the subscription pool, and any recent change to `rubric.md` or `run-reviewer.mjs`.\n\nThis issue is updated in place by each failing run, and closing it is the all-clear.\n' "$(date -u +%FT%TZ)" "$(tail -40 "$RUNNER_TEMP/canary.log")")"
+          existing="$(gh issue list --repo "${{ github.repository }}" --state open \
+            --label review-lane-down --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" --body "$body"
+          else
+            gh label create review-lane-down --repo "${{ github.repository }}" \
+              --color b60205 --description "The review lane failed its liveness canary." 2>/dev/null || true
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Review lane is not reviewing (canary failed)" \
+              --label review-lane-down --body "$body"
+          fi
+
+      # Closing the loop: a canary that only ever shouts is one people mute. When
+      # it passes and an issue is open, say so and close it.
+      - name: All clear
+        if: steps.canary.outputs.rc == '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --repo "${{ github.repository }}" --state open \
+            --label review-lane-down --limit 1 --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --repo "${{ github.repository }}" \
+              --comment "Canary passed at $(date -u +%FT%TZ): the reviewer found the planted defect again."
+          fi
+
+      # The job's own verdict, AFTER the issue is filed. Ordered this way so a
+      # failure still reaches a human even if this step is what someone later
+      # decides to make non-blocking.
+      - name: Fail the run if the lane is down
+        if: steps.canary.outputs.rc != '0'
+        run: |
+          echo "The lane canary failed; see the review-lane-down issue."
+          exit 1

--- a/scripts/review/lane-canary-fixture.json
+++ b/scripts/review/lane-canary-fixture.json
@@ -1,0 +1,29 @@
+{
+  "$comment": [
+    "GROUND TRUTH FOR THE LANE CANARY. A diff carrying a defect this repository has",
+    "actually paid for, in a shape the rubric explicitly lists. If the reviewer cannot",
+    "find THIS, it is not reviewing.",
+    "",
+    "The defect: a numeric bound guarded at ONE end. `timeoutMs > 0` passes for NaN?",
+    "No -- NaN loses every comparison, so NaN takes the ELSE branch and the code falls",
+    "through to the destructive default. That is feedback_numeric_config_needs_both_ends,",
+    "a class this repo has shipped and fixed before, and rubric.md names it verbatim:",
+    "'A numeric bound guarded at one end. NaN loses every comparison, so it falls",
+    "through to whichever branch the author did not intend.'",
+    "",
+    "WHY A FIXTURE AND NOT A REAL PR. A canary must have a KNOWN answer that does not",
+    "move. Replaying a real PR would re-measure a diff whose findings depend on what",
+    "else changed around it; this input is frozen, so a failure means the REVIEWER",
+    "changed, never the input."
+  ],
+  "headSha": "canary00000000000000000000000000000000ca",
+  "files": [
+    {
+      "path": "src/session-timeout.ts",
+      "patch": "@@ -1,6 +1,14 @@\n export function resolveTimeout(raw: string | undefined): number {\n-  return DEFAULT_TIMEOUT_MS;\n+  const timeoutMs = Number(raw);\n+  if (timeoutMs > 0) {\n+    return timeoutMs;\n+  }\n+  // Anything else falls back to closing the session immediately.\n+  return 0;\n }",
+      "addedLineRanges": [[2, 8]]
+    }
+  ],
+  "unreviewable": [],
+  "excluded": []
+}

--- a/scripts/review/lane-canary.mjs
+++ b/scripts/review/lane-canary.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * THE LANE'S LIVENESS CANARY. Runs the real reviewer over a frozen diff whose
+ * answer is known, and fails when it cannot find it.
+ *
+ * WHY THIS EXISTS. The lane's credential is a manually-refreshed subscription
+ * token. It expired once already, and the day it did the failure was invisible:
+ * `Review posted` went red on individual PRs, which is a NON-REQUIRED check that
+ * looks exactly like every other transient red. Nothing aggregated it, so
+ * "the reviewer has been dark for a week" and "this PR had a blip" render the
+ * same. Meanwhile CodeRabbit's ceiling is roughly a third of this repo's volume,
+ * so a dark lane means most PRs get no review while every check still looks
+ * normal.
+ *
+ * WHAT IT ASSERTS, and why it is not just a token ping. A ping proves the
+ * credential authenticates. It does not prove the reviewer still REVIEWS: a
+ * rubric edit, a model change, a truncated prompt or a validator regression can
+ * all leave a lane that authenticates fine and finds nothing. So the canary
+ * demands a FINDING on an input that contains one:
+ *
+ *   verdict=findings, and the finding must name the added line it is about.
+ *
+ * A `clean` verdict here is a FAILURE. That is the whole point -- it is the one
+ * assertion that separates "reviewing" from "answering".
+ *
+ * THE INPUT IS FROZEN, DELIBERATELY. Replaying a real PR would re-measure a diff
+ * whose findings shift with everything around it, so a red would be ambiguous
+ * between "the reviewer broke" and "the diff changed". This fixture cannot
+ * change, so a red means the reviewer changed.
+ *
+ * NO SUBDIRECTORY, DELIBERATELY. `test.yml`'s catch-all runs
+ * `scripts/review/*.test.mjs` and is per-DIRECTORY -- its own comment says it
+ * "goes blind on the next subdirectory anyone adds". A `canary/` folder was the
+ * next subdirectory, and `check-test-glob-coverage` did not catch it (it audits
+ * packages). So this lives flat, where the existing glob reaches it.
+ *
+ * STATED HOLE: one fixture measures one defect class. It answers "is the lane
+ * alive and still finding things", NOT "is the lane's recall good" -- that is a
+ * different instrument (an eval over many known findings) and it belongs in a
+ * different file. Do not let a green canary be read as a recall measurement.
+ */
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..');
+
+/** Thrown for every fail-closed condition; `reason` is the machine-readable tag. */
+export class CanaryError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'CanaryError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Does this review actually find the planted defect?
+ *
+ * TWO CONDITIONS, and the second is what stops a lucky pass. A model that
+ * answers `findings` with a finding about something else has not found THIS
+ * defect, and a canary satisfied by any non-empty list would go green on a
+ * reviewer that had started hallucinating.
+ *
+ * @param {object} parsed - the reviewer's JSON output.
+ * @param {string[]} mustMention - substrings the finding has to name.
+ * @returns {{ ok: boolean, why: string }}
+ */
+export function judge(parsed, mustMention) {
+  if (parsed === null || typeof parsed !== 'object') {
+    return { ok: false, why: 'the reviewer returned something that is not an object' };
+  }
+  if (parsed.verdict !== 'findings') {
+    return {
+      ok: false,
+      why:
+        `verdict=${JSON.stringify(parsed.verdict)}, expected "findings". The canary diff contains a ` +
+        'numeric bound guarded at one end -- `Number(raw)` of a non-number is NaN, NaN loses every ' +
+        'comparison, so it takes the else branch and returns 0, closing the session immediately. ' +
+        'A reviewer that calls this clean is answering, not reviewing.',
+    };
+  }
+  const list = Array.isArray(parsed.findings) ? parsed.findings : [];
+  if (list.length === 0) {
+    return { ok: false, why: 'verdict=findings with an EMPTY findings list, which contradicts itself' };
+  }
+  const blob = JSON.stringify(list).toLowerCase();
+  const missing = mustMention.filter((m) => !blob.includes(m.toLowerCase()));
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      why:
+        `${list.length} finding(s), but none names ${missing.map((m) => JSON.stringify(m)).join(' or ')}. ` +
+        'Findings about something else do not show this defect was found.',
+    };
+  }
+  return { ok: true, why: `${list.length} finding(s), naming the planted defect` };
+}
+
+function main() {
+  const fixture = join(HERE, 'lane-canary-fixture.json');
+  const rubric = join(HERE, 'rubric.md');
+  const out = join(mkdtempSync(join(tmpdir(), 'canary-')), 'raw.txt');
+
+  const r = spawnSync(
+    process.execPath,
+    [join(HERE, 'run-reviewer.mjs'),
+     '--rubric', rubric, '--input', fixture, '--out', out, '--model', process.env.CANARY_MODEL || 'sonnet'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const log = `${r.stdout || ''}${r.stderr || ''}`;
+  if (r.status !== 0) {
+    // The reviewer's own error classes already name the remedy; do not restate
+    // them, forward them. AUTH_FAILED and QUOTA_DRAINED are the two this canary
+    // exists to surface, and they are exactly the ones that go unnoticed per-PR.
+    console.error(log.trim());
+    throw new CanaryError('LANE_DOWN', 'The reviewer did not complete. Its own verdict is above.');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(out, 'utf8'));
+  } catch {
+    throw new CanaryError(
+      'BAD_OUTPUT',
+      'The reviewer completed but its output is not JSON this canary can read. That is a lane ' +
+        'regression even though the job exited 0.',
+    );
+  }
+
+  const verdict = judge(parsed, ['session-timeout', 'timeoutMs']);
+  if (!verdict.ok) {
+    throw new CanaryError(
+      'LANE_NOT_REVIEWING',
+      `The reviewer answered but did not find the planted defect: ${verdict.why}\n` +
+        '   REMEDY: this is not a per-PR blip. Check, in order: the token, the subscription pool, ' +
+        'and any recent change to rubric.md or run-reviewer.mjs. Until it is green, assume most ' +
+        'PRs are getting no substantive review and consider `mode: advisory` on review-posted.',
+    );
+  }
+  console.log(`Lane canary OK: ${verdict.why}.`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('lane-canary.mjs')) {
+  try {
+    main();
+  } catch (err) {
+    if (err instanceof CanaryError) {
+      console.error(`❌ ${err.reason}: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/review/lane-canary.test.mjs
+++ b/scripts/review/lane-canary.test.mjs
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * The property under test: THIS CANARY MUST NOT GO GREEN ON A LANE THAT IS NOT
+ * REVIEWING. Every case below is a way a broken or lazy reviewer could look fine
+ * to a weaker judge -- an empty findings list, a `clean` verdict, findings about
+ * something else entirely.
+ *
+ * The canary is itself an instrument, and an instrument nobody checks is the
+ * thing this repository keeps paying for. So it is exercised in BOTH directions:
+ * the passing case is here too, or every assertion below would be satisfied by a
+ * judge that always fails.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { judge } from './lane-canary.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MUST = ['session-timeout', 'timeoutMs'];
+const finding = (extra = {}) => ({
+  path: 'src/session-timeout.ts',
+  line: 4,
+  quote: '  if (timeoutMs > 0) {',
+  body: 'Number(undefined) is NaN and NaN > 0 is false, so this returns 0 and closes the session.',
+  class: 'numeric-bound',
+  ...extra,
+});
+
+test('THE PASSING CASE: findings that name the planted defect', () => {
+  const v = judge({ verdict: 'findings', findings: [finding()] }, MUST);
+  assert.equal(v.ok, true, v.why);
+});
+
+test('a CLEAN verdict is a FAILURE — that is the whole point of the canary', () => {
+  // A token ping proves authentication. It does not prove the reviewer still
+  // reviews: a rubric edit or a truncated prompt leaves a lane that answers
+  // cleanly and finds nothing, and every per-PR check still looks normal.
+  const v = judge({ verdict: 'clean', findings: [] }, MUST);
+  assert.equal(v.ok, false);
+  assert.match(v.why, /answering, not reviewing/);
+});
+
+test('`findings` with an EMPTY list contradicts itself and fails', () => {
+  const v = judge({ verdict: 'findings', findings: [] }, MUST);
+  assert.equal(v.ok, false);
+  assert.match(v.why, /EMPTY findings list/);
+});
+
+test('findings about something ELSE do not count as finding THIS one', () => {
+  // Without this, a reviewer that had started hallucinating would keep the
+  // canary green: any non-empty list would pass.
+  const v = judge(
+    { verdict: 'findings', findings: [finding({ path: 'src/unrelated.ts', quote: 'const x = 1;', body: 'nit' })] },
+    MUST,
+  );
+  assert.equal(v.ok, false);
+  assert.match(v.why, /none names/);
+});
+
+test('a PARTIAL match still fails: naming the file is not naming the defect', () => {
+  const v = judge(
+    { verdict: 'findings', findings: [{ path: 'src/session-timeout.ts', body: 'looks fine to me' }] },
+    MUST,
+  );
+  assert.equal(v.ok, false, 'mentions the file but never the symbol the defect is in');
+});
+
+test('a non-object response fails rather than throwing', () => {
+  for (const bad of [null, 'clean', 42, undefined]) {
+    assert.equal(judge(bad, MUST).ok, false, JSON.stringify(bad));
+  }
+});
+
+// ============================================== the fixture is the ground truth
+
+test('THE FIXTURE ACTUALLY CONTAINS THE DEFECT the canary demands be found', () => {
+  // If the fixture were ever edited to remove the bug, the canary would demand a
+  // finding that is not there and go permanently red -- a false alarm that would
+  // then be "fixed" by weakening the judge. Pin the input, not just the output.
+  const f = JSON.parse(readFileSync(join(HERE, 'lane-canary-fixture.json'), 'utf8'));
+  const patch = f.files[0].patch;
+  assert.match(patch, /Number\(raw\)/, 'the NaN source');
+  assert.match(patch, /timeoutMs > 0/, 'the one-ended bound');
+  assert.match(patch, /return 0;/, 'the destructive fall-through');
+  assert.equal(f.files[0].path, 'src/session-timeout.ts');
+  // And the strings the judge requires must be present in the diff, or the
+  // canary is asking for something the reviewer could not say.
+  for (const m of MUST) assert.ok(JSON.stringify(f).includes(m), `fixture must contain ${m}`);
+});
+
+test('the added-line ranges cover the defect, or the validator would reject the finding', () => {
+  // `validate-findings.mjs` refuses any finding whose line falls outside an added
+  // range. A fixture whose ranges miss the defect would make a CORRECT review
+  // fail validation, and the canary would blame the reviewer.
+  const f = JSON.parse(readFileSync(join(HERE, 'lane-canary-fixture.json'), 'utf8'));
+  const [[lo, hi]] = f.files[0].addedLineRanges;
+  assert.ok(lo <= 4 && 4 <= hi, `the guard is on line 4; ranges are ${lo}..${hi}`);
+});


### PR DESCRIPTION
The failure this exists for **already happened**. The lane's OAuth token expired yesterday. Every signal was per-PR: `Review posted` went red on individual pull requests, a **non-required** check that renders identically to any transient failure. Nothing aggregated it, so *"the reviewer has been dark since Tuesday"* and *"this PR had a blip"* look the same. CodeRabbit covers roughly a third of this repo's volume, so a dark lane means most PRs get no review while every check still looks normal.

## Why it demands a finding rather than pinging the token

A ping proves the credential authenticates. It does **not** prove the reviewer still reviews — a rubric edit, a model change, a truncated prompt or a validator regression each leave a lane that authenticates fine and finds nothing.

This session measured exactly that shape: **21 PRs stood CodeRabbit down on a `clean` verdict while the lane's total findings across them was zero.**

So the canary runs one frozen diff whose answer is known and requires the reviewer to find it. **A `clean` verdict here is a failure** — that single assertion is what separates "reviewing" from "answering".

## A fixture, not a replayed PR

A real PR's findings shift with everything around it, so a red would be ambiguous between "the reviewer broke" and "the diff changed". This input cannot change, so a red means the reviewer changed.

The planted defect is a numeric bound guarded at one end — `Number(raw)` of a non-number is NaN, NaN loses every comparison, so it takes the else branch and returns 0. A class this repo has shipped, paid for, and names in the rubric verbatim.

## The judge is tested before it judges

In its own workflow step. A canary whose logic has regressed would report a healthy lane — the exact failure this repo exists to refuse. Three mutations die: accepting `clean`, accepting an empty findings list, and dropping the must-mention check that stops a hallucinating reviewer passing on findings about something else.

The **fixture** is pinned too. If it were edited to remove the bug, the canary would demand a finding that is not there, go permanently red, and get "fixed" by weakening the judge. So a test asserts the diff still contains the defect, and that its added-line ranges cover it — otherwise a correct review would fail validation and the canary would blame the reviewer.

## It opens an issue, not just a red run

A failed scheduled workflow is a row in a tab nobody opens. The issue is updated in place, so a week of failures is one thread, and a passing canary **closes** it — an alarm that only ever shouts is one people mute.

## No subdirectory, and that is not tidiness

`test.yml`'s catch-all runs `scripts/review/*.test.mjs` and is per-**directory**; its own comment warns it *"goes blind on the next subdirectory anyone adds"*. A `canary/` folder was that subdirectory, and `check-test-glob-coverage` did **not** catch it — it audits packages, and reported OK while the new test would never have run in CI. Flat, where the glob reaches it: **144 tests now run there, up from 136.**

Daily at 06:20 UTC rather than hourly: the failures it catches last hours or days, and an hourly canary would spend subscription quota to find them slightly sooner.

8 tests, six repo gates.