### PR TITLE
feat(ci): a second credential, because the first one is the whole lane

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -194,6 +194,12 @@ jobs:
         working-directory: ${{ runner.temp }}
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # THE FALLBACK, and it is OPTIONAL by design. An unset secret arrives as
+          # an empty string, which `resolveTokens` treats as absent, so this is
+          # inert until a second account's token is actually set. The lane says
+          # which it is on every run rather than leaving a single-credential setup
+          # looking like a redundant one.
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
         run: |
           node "$GITHUB_WORKSPACE/scripts/review/run-reviewer.mjs" \
             --rubric "${{ steps.rubric.outputs.path }}" \

--- a/scripts/review/run-reviewer.mjs
+++ b/scripts/review/run-reviewer.mjs
@@ -283,6 +283,87 @@ function remedyFor(reason) {
   return 'MODEL_ERROR. REMEDY: read the captured stderr below.';
 }
 
+/**
+ * Run the reviewer, falling back to a SECOND credential when the first is the
+ * thing that failed.
+ *
+ * WHY THIS EXISTS. The lane rests on one manually-refreshed subscription token.
+ * It expired once already, and the day it did the lane was dark while every
+ * per-PR check looked like an ordinary transient red. CodeRabbit covers about a
+ * third of this repository's volume, so a single dead credential means most PRs
+ * get no review at all.
+ *
+ * ONLY TWO REASONS RETRY, and the list is deliberately short:
+ *
+ *   AUTH_FAILED    - this credential is dead. A different one may not be.
+ *   QUOTA_DRAINED  - this POOL is empty. A different account has its own pool.
+ *
+ * Everything else -- MODEL_ERROR, EMPTY_RESPONSE, BAD_ENVELOPE -- is a property
+ * of the request or the model, not of the credential, and retrying it on a
+ * second account would burn a second pool to get the same answer. Worse, it
+ * would turn a deterministic failure into an intermittent one, which is harder
+ * to diagnose than the failure itself.
+ *
+ * THE FALLBACK IS OPTIONAL. With no second token configured this behaves exactly
+ * as before, and says so, because a silent single-credential setup that looks
+ * like a redundant one is the failure this whole function is about.
+ *
+ * @param {{ prompt: string, model: string, tokens: {token: string, label: string}[], spawn: Function }} o
+ */
+export function runReviewerWithFailover({ prompt, model, tokens, spawn }) {
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    throw new RunReviewerError('AUTH_MISSING', 'No usable credential was resolved.');
+  }
+  const RETRYABLE = new Set(['AUTH_FAILED', 'QUOTA_DRAINED']);
+  let last;
+  for (const [i, t] of tokens.entries()) {
+    try {
+      const r = runReviewer({ prompt, model, token: t.token, spawn });
+      if (i > 0) console.log(`auth: succeeded on ${t.label} after ${tokens[0].label} failed.`);
+      return r;
+    } catch (err) {
+      last = err;
+      const more = i + 1 < tokens.length;
+      if (!(err instanceof RunReviewerError) || !RETRYABLE.has(err.reason) || !more) throw err;
+      console.log(`auth: ${t.label} failed with ${err.reason}; trying ${tokens[i + 1].label}.`);
+    }
+  }
+  throw last;
+}
+
+/**
+ * Every credential this run may use, in order, with a LABEL that is safe to
+ * print. The value is never logged -- only which slot it came from -- because a
+ * secret in a log is a leaked secret and this repository is public.
+ */
+export function resolveTokens(env) {
+  const out = [];
+  const seen = new Set();
+  for (const [name, label] of [
+    ['CLAUDE_CODE_OAUTH_TOKEN', 'the primary credential'],
+    ['CLAUDE_CODE_OAUTH_TOKEN_2', 'the fallback credential'],
+  ]) {
+    const raw = env[name];
+    if (raw === undefined || String(raw).trim() === '') continue;
+    const { token, note } = checkToken(raw);
+    // THE SAME SECRET IN BOTH SLOTS IS NOT REDUNDANCY, and it is an easy mistake
+    // to make while wiring the second one up. Refused rather than retried,
+    // because a fallback that shares the primary's pool fails at exactly the
+    // moment it is needed while looking like insurance.
+    if (seen.has(token)) {
+      throw new RunReviewerError(
+        'DUPLICATE_CREDENTIAL',
+        `\`${name}\` holds the same value as an earlier slot. Two copies of one credential share ` +
+          'one quota pool and one expiry, so this is not a fallback. REMEDY: set a token from a ' +
+          'different account, or unset it.',
+      );
+    }
+    seen.add(token);
+    out.push({ token, label, note, name });
+  }
+  return out;
+}
+
 function main() {
   const args = { rubric: null, input: null, out: null, model: 'sonnet' };
   const FLAGS = new Map([['--rubric', 'rubric'], ['--input', 'input'], ['--out', 'out'], ['--model', 'model']]);
@@ -302,13 +383,23 @@ function main() {
   const input = JSON.parse(readFileSync(args.input, 'utf8'));
   const prompt = buildPrompt(rubric, input);
 
-  const { token, note } = checkToken(process.env.CLAUDE_CODE_OAUTH_TOKEN);
-  console.log(`auth: ${note}`);
+  const tokens = resolveTokens(process.env);
+  if (tokens.length === 0) {
+    // Unchanged message: `checkToken` owns this diagnosis, and it is the one a
+    // reader has already seen in the logs.
+    checkToken(process.env.CLAUDE_CODE_OAUTH_TOKEN);
+  }
+  console.log(
+    `auth: ${tokens[0].note}` +
+      (tokens.length > 1
+        ? `, plus ${tokens.length - 1} fallback credential(s)`
+        : ', NO fallback configured (set CLAUDE_CODE_OAUTH_TOKEN_2 from a second account)'),
+  );
 
-  const { text, envelope } = runReviewer({
+  const { text, envelope } = runReviewerWithFailover({
     prompt,
     model: args.model,
-    token,
+    tokens,
     spawn: (cmd, a, stdin, env) =>
       spawnSync(cmd, a, { input: stdin, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, env }),
   });

--- a/scripts/review/run-reviewer.test.mjs
+++ b/scripts/review/run-reviewer.test.mjs
@@ -13,8 +13,13 @@
  */
 
 import { test } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
 import assert from 'node:assert/strict';
-import { classify, checkToken, fenceUntrusted, buildPrompt, runReviewer, DISALLOWED_TOOLS } from './run-reviewer.mjs';
+import { classify, checkToken, fenceUntrusted, buildPrompt, runReviewer, runReviewerWithFailover, resolveTokens, DISALLOWED_TOOLS } from './run-reviewer.mjs';
 
 const ok = (result, extra = {}) => () => ({ status: 0, stdout: JSON.stringify({ result, ...extra }), stderr: '' });
 const INPUT = {
@@ -191,4 +196,100 @@ test('the tool surface is pinned: deny-list, empty MCP, one turn', () => {
   assert.ok(seen.includes('--strict-mcp-config'), 'MCP is pinned empty');
   assert.equal(seen[seen.indexOf('--mcp-config') + 1], '{"mcpServers":{}}');
   assert.equal(seen[seen.indexOf('--max-turns') + 1], '1', 'single shot');
+});
+
+// ================================================= the second credential
+
+const TOKENS = [
+  { token: 'sk-ant-oat01-primary', label: 'the primary credential' },
+  { token: 'sk-ant-oat01-fallback', label: 'the fallback credential' },
+];
+const fail = (stderr) => () => ({ status: 1, stdout: '', stderr });
+const okOn = (which) => {
+  let n = 0;
+  return (_c, _a, _stdin, env) => {
+    n += 1;
+    if (n <= which) return { status: 1, stdout: '', stderr: 'Usage limit reached' };
+    return { status: 0, stdout: JSON.stringify({ result: JSON.stringify({ verdict: 'clean' }) }), stderr: '', env };
+  };
+};
+
+test('a DRAINED pool falls through to the second account', () => {
+  // The failure this exists for: one manually-refreshed subscription token, and
+  // the day it lapsed the lane was dark while every per-PR check looked like an
+  // ordinary transient red.
+  const r = runReviewerWithFailover({ prompt: 'p', model: 'sonnet', tokens: TOKENS, spawn: okOn(1) });
+  assert.match(r.text, /clean/);
+});
+
+test('a DEAD credential falls through too', () => {
+  let seen = [];
+  const spawn = (_c, _a, _s, env) => {
+    seen.push(env.CLAUDE_CODE_OAUTH_TOKEN);
+    return seen.length === 1
+      ? { status: 1, stdout: '', stderr: 'invalid api key' }
+      : { status: 0, stdout: JSON.stringify({ result: '{}' }), stderr: '' };
+  };
+  runReviewerWithFailover({ prompt: 'p', model: 'sonnet', tokens: TOKENS, spawn });
+  assert.deepEqual(seen, ['sk-ant-oat01-primary', 'sk-ant-oat01-fallback'], 'the SECOND token is what retried');
+});
+
+test('a MODEL error does NOT retry — it would burn a second pool for the same answer', () => {
+  // The retry list is deliberately two entries. A model or request failure is not
+  // a property of the credential, and retrying it turns a deterministic failure
+  // into an intermittent one, which is harder to diagnose than the failure.
+  let calls = 0;
+  const spawn = () => { calls += 1; return { status: 1, stdout: '', stderr: 'something nobody has seen' }; };
+  assert.throws(
+    () => runReviewerWithFailover({ prompt: 'p', model: 'sonnet', tokens: TOKENS, spawn }),
+    (e) => e.reason === 'MODEL_ERROR',
+  );
+  assert.equal(calls, 1, 'exactly one attempt');
+});
+
+test('with ONE token it behaves exactly as before', () => {
+  let calls = 0;
+  const spawn = () => { calls += 1; return { status: 1, stdout: '', stderr: 'Usage limit reached' }; };
+  assert.throws(
+    () => runReviewerWithFailover({ prompt: 'p', model: 'sonnet', tokens: [TOKENS[0]], spawn }),
+    (e) => e.reason === 'QUOTA_DRAINED',
+  );
+  assert.equal(calls, 1);
+});
+
+test('resolveTokens: the same secret in both slots is REFUSED, not treated as a fallback', () => {
+  // An easy mistake while wiring the second one up, and a fallback that shares
+  // the primary's pool and expiry fails at exactly the moment it is needed while
+  // looking like insurance.
+  assert.throws(
+    () => resolveTokens({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-same', CLAUDE_CODE_OAUTH_TOKEN_2: 'sk-ant-oat01-same' }),
+    (e) => e.reason === 'DUPLICATE_CREDENTIAL',
+  );
+});
+
+test('resolveTokens: an unset or blank fallback is simply absent, not an error', () => {
+  for (const second of [undefined, '', '   ']) {
+    const t = resolveTokens({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-a', CLAUDE_CODE_OAUTH_TOKEN_2: second });
+    assert.equal(t.length, 1, JSON.stringify(second));
+  }
+  const both = resolveTokens({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-a', CLAUDE_CODE_OAUTH_TOKEN_2: 'sk-ant-oat01-b' });
+  assert.equal(both.length, 2);
+});
+
+test('no credential value ever reaches a label or a log line', () => {
+  const t = resolveTokens({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-SUPERSECRET' });
+  assert.doesNotMatch(t[0].label, /SUPERSECRET/);
+  assert.doesNotMatch(t[0].note, /SUPERSECRET/, 'the note reports SHAPE, never the value');
+});
+
+test('THE WIRING: the workflow actually passes the fallback secret', () => {
+  // Without this the failover is dead code that tests green: `resolveTokens`
+  // reads the environment, and the environment is built by the workflow. Static,
+  // because nothing else can reach that step -- it needs a runner and a secret.
+  const wf = readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8');
+  const step = wf.split('- name: Run the reviewer')[1];
+  assert.ok(step, 'the reviewer step must exist');
+  const env = step.split('run:')[0];
+  assert.match(env, /CLAUDE_CODE_OAUTH_TOKEN:\s*\$\{\{\s*secrets\.CLAUDE_CODE_OAUTH_TOKEN\s*\}\}/);
+  assert.match(env, /CLAUDE_CODE_OAUTH_TOKEN_2:\s*\$\{\{\s*secrets\.CLAUDE_CODE_OAUTH_TOKEN_2\s*\}\}/);
 });


### PR DESCRIPTION
The lane rests on **one** manually-refreshed subscription token. It expired yesterday, and the day it did the lane was dark while every per-PR check looked like an ordinary transient red. CodeRabbit covers about a third of this repo's volume, so one dead credential means most PRs get no review at all.

## What retries, and what deliberately does not

`CLAUDE_CODE_OAUTH_TOKEN_2` is tried when — and only when — the **first credential** is what failed:

| reason | why a second account helps |
|---|---|
| `AUTH_FAILED` | this credential is dead; a different one may not be |
| `QUOTA_DRAINED` | this **pool** is empty; a different account has its own |

`MODEL_ERROR`, `EMPTY_RESPONSE` and `BAD_ENVELOPE` do **not** retry. They are properties of the request or the model, not of the credential — a second attempt burns a second pool to get the same answer, and turns a deterministic failure into an intermittent one, which is harder to diagnose than the failure was.

## The same secret in both slots is refused

Not quietly accepted. It is an easy mistake while wiring the second one up, and two copies of one credential share **one quota pool and one expiry** — a fallback that fails at exactly the moment it is needed, while looking like insurance. `DUPLICATE_CREDENTIAL` says so.

## Optional, and it says which

An unset secret arrives as an empty string and is treated as absent, so this is inert until a second account's token is actually set. Every run prints either `plus 1 fallback credential(s)` or `NO fallback configured` — because a single-credential setup that *looks* redundant is the failure this exists to prevent.

## The wiring is asserted

Without it the failover is dead code that tests green: `resolveTokens` reads the environment, and the workflow builds it. A static test reads `claude-review.yml` and fails if either secret stops being passed. Unwiring the second one turns the suite red.

Same reason the alias map and the poll budget are asserted against their own YAML — this repo has shipped that exact defect three times this week.

## Verification

Four mutations turn the suite red: the retry list widened to every error, the loop never reaching the second token, the duplicate guard removed, and the secret unwired.

**To activate:** `claude setup-token` on the second Max account, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN_2`. Until then nothing changes.

27 reviewer tests, 144 across the lane, five repo gates.