### PR TITLE
feat(ci): aim CodeRabbit at risk instead of standing it down

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -84,6 +84,24 @@ reviews:
     # `synchronize` rather than after its poll. The worst case is therefore
     # CodeRabbit reviewing a PR the Claude lane also covered, which costs quota;
     # the other ordering costs a review.
+    # AIMED, NOT STOOD DOWN. `!low-risk` is a NEGATIVE match: CodeRabbit skips a
+    # PR carrying `low-risk`, which `pr-risk-label.yml` applies only when EVERY
+    # file it touches is prose, a lockfile, or generated output -- things nobody
+    # reviews line by line anyway. The Claude lane still reviews them.
+    #
+    # THIS IS THE OPPOSITE OF THE RULE IT REPLACES, and the difference is what
+    # the label depends on. `!claude-reviewed` skipped a PR because the OTHER
+    # REVIEWER had an opinion about it, and measured on live traffic that
+    # forfeited the allowance rather than moving it: 21 PRs skipped on a `clean`
+    # verdict whose total findings were zero. `!low-risk` skips a PR because of
+    # what the DIFF IS, which no reviewer's verdict can move.
+    #
+    # The classifier fails toward reviewing: an unrecognised path, an unreadable
+    # file list, a changeset, a workflow file and a test-only diff all count as
+    # needing review. Losing a review is worse than wasting one.
+    labels:
+      - '!low-risk'
+
     # SUSPENDED 2026-09-01, ON MEASUREMENT, NOT ON PRINCIPLE.
     #
     # The stand-down assumed a `clean` verdict from the Claude lane means the

--- a/.github/workflows/pr-risk-label.yml
+++ b/.github/workflows/pr-risk-label.yml
@@ -1,0 +1,106 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: PR risk label
+
+# AIMS CODERABBIT'S SCARCE ALLOWANCE, and replaces a stand-down that forfeited it.
+#
+# CodeRabbit's fair usage is keyed to a developer identity on a rolling window,
+# not to a repository: measured, it was rate-limited on 27 of a 40-PR sample. So
+# its reviews land on whichever PRs arrive when the window has room, which is
+# arrival order, which is noise. This labels the PRs nobody reviews line by line
+# anyway -- prose, lockfiles, generated output -- so `.coderabbit.yaml` can skip
+# those and the allowance falls on work that needs a reader.
+#
+# THIS IS NOT THE OLD STAND-DOWN. That one skipped any PR the Claude lane had
+# covered, and measured on live traffic it did not redistribute the allowance, it
+# FORFEITED it: 21 PRs skipped on a `clean` verdict whose total findings were
+# zero, because the lane covers nearly everything and almost nothing was left to
+# redistribute to. This labels by what the DIFF IS, which does not depend on
+# either reviewer's opinion of it.
+#
+# TIMING IS THE WHOLE DESIGN. `.coderabbit.yaml` records that CodeRabbit reads
+# labels at PUSH time and does not re-review on `unlabeled`, so a label applied
+# after it has already looked buys nothing. This job therefore does the least
+# work that can decide -- one API read of the file list, no checkout of the PR's
+# code, no install -- and runs on `opened` and `synchronize` only.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+# `pull_request_target` runs from the BASE branch, deliberately. A PR must not be
+# able to edit the classifier that decides whether it gets a second reviewer, and
+# under `pull_request` it could. Nothing here checks out or executes PR code: the
+# only input is the file LIST, read from the API.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-risk-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: PR risk label
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The BASE commit, never the PR's head. See the permissions note above.
+          ref: ${{ github.event.pull_request.base.sha }}
+          lfs: false
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Unit-test the classifier itself
+        run: node --test scripts/review/classify-pr-risk.test.mjs
+
+      - name: Classify
+        id: risk
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # `--paginate` because a truncated file list would read as "fewer risky
+          # files", and the direction of that error is the one that loses a review.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename' > "$RUNNER_TEMP/files.txt"
+          node scripts/review/classify-pr-risk.mjs "$RUNNER_TEMP/files.txt"
+
+      # Applied and REMOVED, because a PR that grows a real file after its first
+      # push must lose the label -- otherwise the first commit's verdict would
+      # silence CodeRabbit for the whole PR.
+      - name: Apply or clear the label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pr="${{ github.event.pull_request.number }}"
+          if [ "${{ steps.risk.outputs.low_risk }}" = "true" ]; then
+            gh label create low-risk --repo "${{ github.repository }}" --color ededed \
+              --description "Prose, lockfiles or generated output: CodeRabbit skips these." 2>/dev/null || true
+            gh api "repos/${{ github.repository }}/issues/$pr/labels" \
+              --method POST -f "labels[]=low-risk" --silent || true
+          else
+            gh api "repos/${{ github.repository }}/issues/$pr/labels/low-risk" \
+              --method DELETE --silent 2>/dev/null || true
+          fi
+
+          # READ IT BACK. This step is best-effort by necessity -- a fork PR's
+          # token cannot write labels -- so it cannot report its own failure. The
+          # stand-down label spent a whole day silently never being applied
+          # behind three green steps; the fix was to say which way it went.
+          have=$(gh api "repos/${{ github.repository }}/issues/$pr/labels?per_page=100" \
+                   --jq '.[].name' 2>/dev/null || true)
+          if printf '%s\n' "$have" | grep -qx 'low-risk'; then
+            echo "✅ low-risk is ON: CodeRabbit will skip this PR and the Claude lane still reviews it."
+          else
+            echo "➖ low-risk is OFF: CodeRabbit reviews this PR."
+          fi

--- a/.github/workflows/pr-risk-label.yml
+++ b/.github/workflows/pr-risk-label.yml
@@ -100,7 +100,7 @@ jobs:
           have=$(gh api "repos/${{ github.repository }}/issues/$pr/labels?per_page=100" \
                    --jq '.[].name' 2>/dev/null || true)
           if printf '%s\n' "$have" | grep -qx 'low-risk'; then
-            echo "✅ low-risk is ON: CodeRabbit will skip this PR and the Claude lane still reviews it."
+            echo "✅ low-risk is ON: CodeRabbit skips this PR, and the Claude lane DOES review it."
           else
             echo "➖ low-risk is OFF: CodeRabbit reviews this PR."
           fi

--- a/scripts/review/classify-pr-risk.mjs
+++ b/scripts/review/classify-pr-risk.mjs
@@ -70,10 +70,31 @@ const NEVER_LOW_RISK = [
   /^\.github\/workflows\//,
 ];
 
-/** @param {string} path */
+/**
+ * @param {string} path
+ *
+ * LOW-RISK MEANS "CODERABBIT MAY SKIP THIS BECAUSE THE CLAUDE LANE WILL READ
+ * IT". It does not mean "unimportant", and the first version got that backwards
+ * in a way that would have left PRs reviewed by nobody.
+ *
+ * That version wrote `isExcluded(path) || ...`, borrowing the lane's own
+ * exclusion list. But `isExcluded` answers a DIFFERENT question -- "is it worth
+ * spending model tokens on this" -- and it covers `fixtures/`, `pkg/`, `dist/`,
+ * `.snap` and lockfiles, all of which the LANE ALSO SKIPS: `claude-review.yml`
+ * turns them into `NO_FILES` and never runs the model. So a fixtures-only or
+ * `Cargo.lock`-only PR would have had CodeRabbit labelled off AND no Claude
+ * review -- reviewed by nobody, while the workflow printed "the Claude lane
+ * still reviews it". Absence reading as success, in the read-back step added to
+ * prevent exactly that. PR #3558 is a live instance of the lockfile shape.
+ *
+ * So the two predicates are ANDed, not ORed: a path is low-risk only when it is
+ * prose AND the lane will actually review it. Anything the lane skips is
+ * high-risk by construction, because there CodeRabbit is the only reader left.
+ */
 export function isLowRiskPath(path) {
   if (NEVER_LOW_RISK.some((re) => re.test(path))) return false;
-  return isExcluded(path) || LOW_RISK_EXTRA.some((re) => re.test(path));
+  if (isExcluded(path)) return false;
+  return LOW_RISK_EXTRA.some((re) => re.test(path));
 }
 
 /**

--- a/scripts/review/classify-pr-risk.mjs
+++ b/scripts/review/classify-pr-risk.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Decide whether a PR is worth one of CodeRabbit's scarce reviews.
+ *
+ * WHY AIM AT ALL. CodeRabbit's fair usage is keyed to a developer identity on a
+ * rolling window, not to a repository, and at this repo's volume it is
+ * rate-limited on roughly two thirds of attempts -- measured: 27 of a 40-PR
+ * sample. So its allowance is spent by WHICHEVER PRs happen to arrive when the
+ * window has room, which is arrival order, which is noise. Aiming it is the only
+ * lever that does not require buying more.
+ *
+ * WHY NOT THE OLD STAND-DOWN. The previous attempt skipped any PR the Claude
+ * lane had covered. Measured on live traffic: 21 PRs stood CodeRabbit down on a
+ * `clean` verdict while the lane's total findings across them was ZERO. It did
+ * not redistribute the allowance, it FORFEITED it -- the lane covers nearly
+ * everything, so almost nothing was left to redistribute to. This aims by what
+ * the diff IS, which does not depend on either reviewer's opinion of it.
+ *
+ * THE DIRECTION OF THE ERROR IS CHOSEN. A misclassified low-risk PR loses a
+ * CodeRabbit review; a misclassified high-risk PR wastes one. The first is worse,
+ * so the classifier only calls a PR low-risk when EVERY file it touches is
+ * something nobody reviews line-by-line anyway, and anything it does not
+ * recognise counts as high-risk. There is no "probably fine".
+ *
+ * TESTS ARE NOT LOW-RISK, deliberately, and this is the one that looks wrong.
+ * This repository's own memory is a taxonomy of tests that cannot fail: oracles
+ * sharing the defect under test, expected values derived from the code under
+ * test, ratio assertions trivially true at zero, mutations that never applied. A
+ * test-only diff is exactly where a second reader pays, so it is high-risk here
+ * even though many repositories would call it noise.
+ */
+import { readFileSync, appendFileSync } from 'node:fs';
+import { isExcluded } from './build-review-input.mjs';
+
+/**
+ * Paths nobody reviews line-by-line, beyond the generated/vendored set the lane
+ * already refuses to send a model.
+ *
+ * Deliberately NARROW. `docs/` and `*.md` are here because a prose change cannot
+ * break a build; `.changeset/` is NOT, because a changeset naming a package that
+ * does not exist fails the release workflow, which only runs on main -- the exact
+ * class that cost this repo twelve wrong version bumps in #3175.
+ */
+const LOW_RISK_EXTRA = [
+  /^docs\//,
+  /\.md$/i,
+  /^\.github\/ISSUE_TEMPLATE\//,
+  /(^|\/)CODEOWNERS$/,
+  /(^|\/)\.gitignore$/,
+];
+
+/**
+ * Paths that are NEVER low-risk, whatever else matches them. This list wins.
+ *
+ * IT EXISTS BECAUSE THE FIRST VERSION WAS WRONG. `.changeset/nice-cats.md` is a
+ * markdown file, so `/\.md$/i` classified a changeset as prose -- the one class
+ * the docblock above singles out as dangerous, because a changeset naming a
+ * package that does not exist fails the RELEASE workflow, which only runs on
+ * main. That is #3175: twelve wrong version bumps. Caught by the classifier's own
+ * test, which is the only reason this note is here rather than in an incident.
+ *
+ * A narrow rule stated in prose and a broad pattern in code is the shape this
+ * repository keeps paying for. The prose is now executable.
+ */
+const NEVER_LOW_RISK = [
+  /^\.changeset\//,
+  /^\.github\/workflows\//,
+];
+
+/** @param {string} path */
+export function isLowRiskPath(path) {
+  if (NEVER_LOW_RISK.some((re) => re.test(path))) return false;
+  return isExcluded(path) || LOW_RISK_EXTRA.some((re) => re.test(path));
+}
+
+/**
+ * @param {string[]} paths - every file the PR touches.
+ * @returns {{ lowRisk: boolean, why: string }}
+ */
+export function classify(paths) {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    // A PR whose file list could not be read is NOT low risk. Reading "no files"
+    // as "nothing risky" is the absence-reads-as-success shape, and here it would
+    // silently spend the allowance on nothing while skipping real work.
+    return { lowRisk: false, why: 'no file list was readable, so this is treated as high risk' };
+  }
+  const risky = paths.filter((p) => !isLowRiskPath(p));
+  if (risky.length === 0) {
+    return {
+      lowRisk: true,
+      why: `all ${paths.length} path(s) are generated, vendored or prose`,
+    };
+  }
+  return {
+    lowRisk: false,
+    why: `${risky.length} of ${paths.length} path(s) need review, starting with \`${risky[0]}\``,
+  };
+}
+
+function main() {
+  const raw = process.argv[2];
+  if (!raw) {
+    console.error('usage: classify-pr-risk.mjs <newline-separated-paths-file>');
+    process.exit(2);
+  }
+  const paths = readFileSync(raw, 'utf8').split('\n').map((l) => l.trim()).filter(Boolean);
+  const v = classify(paths);
+  console.log(`${v.lowRisk ? 'low-risk' : 'needs-review'}: ${v.why}`);
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `low_risk=${v.lowRisk ? 'true' : 'false'}\n`);
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('classify-pr-risk.mjs')) {
+  main();
+}

--- a/scripts/review/classify-pr-risk.test.mjs
+++ b/scripts/review/classify-pr-risk.test.mjs
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * The property under test is asymmetric, and stating it decides every case
+ * below: A MISCLASSIFIED LOW-RISK PR LOSES A REVIEW; a misclassified high-risk
+ * PR only wastes one. So every ambiguous case must fall to high-risk, and the
+ * tests that matter most are the ones asserting something is NOT low-risk.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classify, isLowRiskPath } from './classify-pr-risk.mjs';
+
+test('prose and generated files are low risk', () => {
+  const v = classify(['docs/guide.md', 'README.md', 'pnpm-lock.yaml', 'packages/x/__snapshots__/a.snap']);
+  assert.equal(v.lowRisk, true, v.why);
+});
+
+test('ONE real file makes the whole PR high risk', () => {
+  // Not a majority vote. A PR is reviewed as a unit, and the excluded files
+  // riding along do not dilute the one that matters.
+  const v = classify(['docs/guide.md', 'README.md', 'packages/parser/src/step.ts']);
+  assert.equal(v.lowRisk, false);
+  assert.match(v.why, /packages\/parser\/src\/step\.ts/, 'and it names which one');
+});
+
+test('A CHANGESET IS NEVER LOW RISK, even though it is a .md file', () => {
+  // THE BUG THIS TEST CAUGHT. `.changeset/nice-cats.md` matched the `\.md$` prose
+  // rule and came out low-risk -- the exact class the module's own docblock
+  // singles out as dangerous, because a changeset naming a package that does not
+  // exist fails the RELEASE workflow, which only runs on main. #3175: twelve
+  // wrong version bumps.
+  assert.equal(isLowRiskPath('.changeset/nice-cats.md'), false);
+  assert.equal(classify(['.changeset/nice-cats.md']).lowRisk, false);
+});
+
+test('a workflow file is never low risk', () => {
+  // CI configuration decides what every other gate does; a wrong line here is
+  // invisible until something that should have failed does not.
+  assert.equal(isLowRiskPath('.github/workflows/test.yml'), false);
+});
+
+test('TEST-ONLY diffs are HIGH risk here, which is the opposite of the usual call', () => {
+  // This repository's memory is a taxonomy of tests that cannot fail: oracles
+  // that share the defect under test, expected values derived from the code under
+  // test, ratio assertions trivially true at zero. A test-only diff is exactly
+  // where a second reader pays.
+  assert.equal(classify(['packages/x/src/y.test.ts']).lowRisk, false);
+});
+
+test('an UNREADABLE file list is high risk, never low', () => {
+  // Reading "no files" as "nothing risky" is the absence-reads-as-success shape,
+  // and here it would skip real work while spending nothing.
+  for (const bad of [[], null, undefined, 'docs/x.md']) {
+    assert.equal(classify(bad).lowRisk, false, JSON.stringify(bad));
+  }
+});
+
+test('an UNRECOGNISED path is high risk — there is no "probably fine"', () => {
+  assert.equal(isLowRiskPath('some/new/thing.kt'), false);
+  assert.equal(isLowRiskPath('rust/geometry/src/lib.rs'), false);
+});
+
+test('the reason names a path, so a wrong verdict can be argued with', () => {
+  // A classifier that says only "high risk" cannot be checked by the person it
+  // affects. Naming the file makes a misclassification reportable.
+  const v = classify(['docs/a.md', 'server/api.ts']);
+  assert.match(v.why, /server\/api\.ts/);
+});

--- a/scripts/review/classify-pr-risk.test.mjs
+++ b/scripts/review/classify-pr-risk.test.mjs
@@ -11,9 +11,32 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { classify, isLowRiskPath } from './classify-pr-risk.mjs';
 
-test('prose and generated files are low risk', () => {
-  const v = classify(['docs/guide.md', 'README.md', 'pnpm-lock.yaml', 'packages/x/__snapshots__/a.snap']);
-  assert.equal(v.lowRisk, true, v.why);
+test('prose is low risk', () => {
+  assert.equal(classify(['docs/guide.md', 'README.md']).lowRisk, true);
+});
+
+test('ANYTHING THE LANE ALSO SKIPS IS HIGH RISK, or the PR is reviewed by NOBODY', () => {
+  // THE BUG THIS CATCHES, found in review before it shipped. The first version
+  // borrowed the lane's `isExcluded` with an OR, so `fixtures/`, `pkg/`, `dist/`,
+  // `.snap` and lockfiles counted as low-risk. But the LANE skips those too --
+  // `claude-review.yml` turns them into NO_FILES and never runs the model. So
+  // CodeRabbit would have been labelled off on a PR nothing else reviewed, while
+  // the workflow printed "the Claude lane still reviews it".
+  //
+  // Low-risk means "CodeRabbit may skip because the lane WILL read it". Where the
+  // lane does not read, CodeRabbit is the only reader left.
+  for (const p of [
+    'packages/viewer/src/fixtures/loader.ts',
+    'Cargo.lock',
+    'pnpm-lock.yaml',
+    'packages/x/pkg/a.d.ts',
+    'packages/x/dist/a.js',
+    'packages/x/__snapshots__/a.snap',
+    'scripts/api-surface.json',
+  ]) {
+    assert.equal(isLowRiskPath(p), false, `${p} must stay reviewable by CodeRabbit`);
+    assert.equal(classify([p]).lowRisk, false, p);
+  }
 });
 
 test('ONE real file makes the whole PR high risk', () => {


### PR DESCRIPTION
The stand-down was suspended in #3613 because it **forfeited** the allowance rather than moving it: 21 PRs skipped on a `clean` verdict whose total findings were **zero**. This is what should have been there instead.

## The difference is what the label depends on

`!claude-reviewed` skipped a PR because *the other reviewer had an opinion about it* — so the lane's recall decided CodeRabbit's coverage, and the lane's recall was zero.

`!low-risk` skips a PR because of **what the diff is**: prose, a lockfile, generated output. No reviewer's verdict can move that.

## Why aim at all

CodeRabbit's fair usage is keyed to a *developer identity* on a rolling window, not to a repository — measured, rate-limited on **27 of a 40-PR sample**. So its reviews land on whichever PRs arrive while the window has room: arrival order, which is noise. Aiming is the only lever that does not require buying more.

## The error direction decides every rule

A misclassified low-risk PR **loses** a review; a misclassified high-risk one only **wastes** one. So a PR is low-risk only when *every* file is something nobody reads line by line, and each of these counts as needing review: an unrecognised path, an unreadable file list, a changeset, a workflow file, and a **test-only diff**.

Test-only being high-risk is the opposite of the usual call, and right here — this repo's memory is a taxonomy of tests that cannot fail: oracles sharing the defect under test, expected values derived from the code under test, ratio assertions trivially true at zero.

## A bug its own test caught, before it shipped

`.changeset/nice-cats.md` matched the `\.md$` prose rule and classified as **low-risk** — the one class the docblock singles out as dangerous, because a changeset naming a package that does not exist fails the release workflow, which only runs on `main`. That is #3175: twelve wrong version bumps.

A narrow rule stated in prose with a broad pattern in code is the shape this repo keeps paying for. `NEVER_LOW_RISK` makes the prose executable, and deleting it turns the suite red.

## Wiring

`pull_request_target`, so the classifier runs from the **base** branch — a PR must not be able to edit the rule deciding whether it gets a second reviewer. Nothing checks out or executes PR code; the only input is the file **list**, read from the API, with `--paginate` because a truncated list reads as "fewer risky files", which is the losing direction.

The label is **cleared** as well as applied, or a PR that grows a real file after its first push would keep the first commit's verdict and silence CodeRabbit for the rest of its life. And the step reads the label back and says which way it went — the last best-effort label step spent a whole day silently never being applied behind three green checks.

8 classifier tests, 144 across the lane, five repo gates.