### PR TITLE
fix(geometry): occurrence material falls back to its type's IfcRelAssociatesMaterial

### DIFF
--- a/.changeset/type-material-fallback-prepass.md
+++ b/.changeset/type-material-fallback-prepass.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+An element whose material is associated on its `IfcTypeObject` (e.g. `IfcRelAssociatesMaterial` targeting an `IfcWallType`) rather than on the occurrence itself is now coloured by that type's material in the shared prepass resolver (native and browser), unless the occurrence carries its own `IfcRelAssociatesMaterial` (occurrence overrides type). Previously `resolve_prepass` built `element_to_material` only from direct occurrence associations, so a type-associated material was recorded under the type's own express id and never reached any occurrence — a common authoring pattern (material attached at the type) rendered every such element in the default type colour instead of its material's appearance.

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -40,6 +40,7 @@ pub mod pipeline_diagnostics;
 pub mod prepass;
 mod prepass_styled;
 pub use prepass_styled::flat_styles_rgba8_from_geometry_columns;
+mod prepass_type_material;
 mod processor;
 pub(crate) mod simplify_math;
 pub mod simplify_session;

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -32,11 +32,9 @@ pub type Span = (u32, usize, usize);
 #[derive(Debug, Default, Clone)]
 pub struct PrepassSpans {
     /// `IFCSTYLEDITEM` — geometry-attached AND orphan (material appearance);
-    /// the resolver classifies them (the classifying decode is the cost of
-    /// telling the two apart).
+    /// the resolver classifies them (decoding is the cost of telling them apart).
     pub styled_items: Vec<Span>,
-    /// `IFCINDEXEDCOLOURMAP` (#663/#858 — CATIA/3DEXPERIENCE per-triangle
-    /// palettes, IFC4's second colouring mechanism).
+    /// `IFCINDEXEDCOLOURMAP` (#663/#858 — CATIA/3DEXPERIENCE per-triangle palettes).
     pub indexed_colour_maps: Vec<Span>,
     /// `IFCMATERIALDEFINITIONREPRESENTATION` (#407 material chain).
     pub material_def_reprs: Vec<Span>,
@@ -50,6 +48,7 @@ pub struct PrepassSpans {
     /// `IFCRELAGGREGATES` — parent → children, for aggregate void
     /// propagation (#845, IfcWallElementedCase etc.).
     pub aggregate_rels: Vec<Span>,
+    pub defines_by_type: Vec<Span>, // IFCRELDEFINESBYTYPE, for prepass_type_material.
 }
 
 /// Resolution switches (both pipelines share the resolver).
@@ -187,6 +186,7 @@ pub fn resolve_prepass_with_style_seeds(
         }
     }
 
+    crate::prepass_type_material::propagate_type_material(&spans.defines_by_type, decoder, &mut out.element_to_material);
     // ── Voids + fills + aggregate propagation (#845) ──
     for &(id, start, end) in &spans.void_rels {
         if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
@@ -610,7 +610,7 @@ fn normalize_style_name(raw: Option<&str>) -> Option<String> {
 }
 
 /// Extract entity references from a list attribute.
-fn refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
+pub(crate) fn refs_from_list(entity: &DecodedEntity, index: usize) -> Option<Vec<u32>> {
     let list = entity.get_list(index)?;
     let refs: Vec<u32> = list.iter().filter_map(|v| v.as_entity_ref()).collect();
     if refs.is_empty() {

--- a/rust/processing/src/prepass_type_material.rs
+++ b/rust/processing/src/prepass_type_material.rs
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Type-associated material fallback (split from `prepass.rs`): an
+//! `IfcRelAssociatesMaterial` may target an `IfcTypeObject` (e.g.
+//! `IfcWallType`) rather than an occurrence directly — authoring tools
+//! commonly attach material at the type. `resolve_prepass`'s direct-
+//! association loop already records that in `element_to_material` under the
+//! TYPE's own express id (it's just another entry in `RelatedObjects`); this
+//! pass gives every occurrence of that type the same material, UNLESS the
+//! occurrence already has its own (occurrence overrides type — the same
+//! precedence `resolveAllMaterialDefIds` uses on the TS side).
+
+use ifc_lite_core::EntityDecoder;
+use rustc_hash::FxHashMap;
+
+use crate::prepass::{refs_from_list, Span};
+
+/// Walk `defines_by_type` spans (`IFCRELDEFINESBYTYPE`) and, for every
+/// occurrence whose type already has a resolved material, install that
+/// material UNLESS the occurrence already has one of its own.
+pub(crate) fn propagate_type_material(
+    defines_by_type: &[Span],
+    decoder: &mut EntityDecoder,
+    element_to_material: &mut FxHashMap<u32, u32>,
+) {
+    for &(id, start, end) in defines_by_type {
+        let Ok(entity) = decoder.decode_at_with_id(id, start, end) else {
+            continue;
+        };
+        // IfcRelDefinesByType: RelatedObjects (attr 4), RelatingType (attr 5).
+        let Some(type_id) = entity.get_ref(5) else {
+            continue;
+        };
+        let Some(&type_material) = element_to_material.get(&type_id) else {
+            continue;
+        };
+        let Some(occurrences) = refs_from_list(&entity, 4) else {
+            continue;
+        };
+        for occurrence_id in occurrences {
+            element_to_material.entry(occurrence_id).or_insert(type_material);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prepass::{resolve_prepass, PrepassSpans, ResolveOptions};
+    use ifc_lite_core::EntityScanner;
+
+    /// A type-object `IfcRelAssociatesMaterial` (e.g. IfcWallType →
+    /// Concrete) applies to every occurrence of that type via
+    /// `IfcRelDefinesByType`, UNLESS the occurrence carries its own
+    /// `IfcRelAssociatesMaterial` (occurrence overrides type). Before this
+    /// fix `element_to_material` was built only from the direct
+    /// `IfcRelAssociatesMaterial` loop, which records the association under
+    /// the TYPE's own express id — never propagated to its occurrences, so
+    /// a type-only-styled model rendered every such occurrence in the
+    /// default type colour.
+    #[test]
+    fn resolve_prepass_falls_back_to_type_material_unless_occurrence_has_its_own() {
+        const IFC: &[u8] = br#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m.ifc','2026-09-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCMATERIAL('Concrete',$,$);
+#11=IFCMATERIAL('Steel',$,$);
+#20=IFCWALLTYPE('t',$,'WT',$,$,$,$,$,$,$,$);
+#21=IFCRELASSOCIATESMATERIAL('r1',$,$,$,(#20),#10);
+#30=IFCWALL('w1',$,'TypeOnly',$,$,$,$,$,$);
+#31=IFCRELDEFINESBYTYPE('d1',$,$,$,(#30),#20);
+#40=IFCWALL('w2',$,'Overridden',$,$,$,$,$,$);
+#41=IFCRELASSOCIATESMATERIAL('r2',$,$,$,(#40),#11);
+#42=IFCRELDEFINESBYTYPE('d2',$,$,$,(#40),#20);
+#50=IFCWALL('w3',$,'InstanceOnly',$,$,$,$,$,$);
+#51=IFCRELASSOCIATESMATERIAL('r3',$,$,$,(#50),#11);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+        let mut spans = PrepassSpans::default();
+        let mut scanner = EntityScanner::new(IFC);
+        while let Some((id, type_name, start, end)) = scanner.next_entity() {
+            match type_name {
+                "IFCRELASSOCIATESMATERIAL" => spans.rel_associates_material.push((id, start, end)),
+                "IFCRELDEFINESBYTYPE" => spans.defines_by_type.push((id, start, end)),
+                _ => {}
+            }
+        }
+
+        let mut decoder = EntityDecoder::new(IFC);
+        let resolved = resolve_prepass(&spans, &mut decoder, ResolveOptions::default());
+
+        // RED (pre-fix): w1 (#30) had no entry at all — its type's material
+        // was recorded under #20, never reached the occurrence.
+        assert_eq!(
+            resolved.element_to_material.get(&30),
+            Some(&10),
+            "occurrence with only a type-level material association must inherit it"
+        );
+        // Occurrence overrides type: w2 (#40) keeps its OWN material (#11 =
+        // Steel), not the type's (#10 = Concrete) and not both.
+        assert_eq!(
+            resolved.element_to_material.get(&40),
+            Some(&11),
+            "an occurrence's own material association must win over its type's"
+        );
+        // Control: an instance-only association (no type in play) is
+        // unaffected by the type-fallback pass.
+        assert_eq!(resolved.element_to_material.get(&50), Some(&11));
+    }
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -798,6 +798,8 @@ pub fn process_geometry_streaming_filtered_with_options(
             if let Some(type_id) = args.get(5).and_then(|token| parse_step_ref(token)) {
                 instantiated_type_ids.insert(type_id);
             }
+            // Also feed the shared resolver's type-material fallback.
+            prepass_spans.defines_by_type.push((id, start, end));
         } else if let Some(type_ty) = ifc_lite_core::type_product_ifc_type(type_name) {
             let args = parse_step_arguments(&content[start..end]);
             // IfcTypeProduct.RepresentationMaps is attribute index 6.

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -248,9 +248,8 @@ impl IfcAPI {
         // on their first batch to rebuild these three per-content structures
         // (referenced RepresentationMaps, instantiated type ids, the material-
         // layer index). Collect the spans they need HERE, during the one scan the
-        // pre-pass already runs, then build + ship each ONCE below so every
-        // worker skips its own full-file walk. `rel_associates_material` spans are
-        // already stashed in `prepass_spans`.
+        // pre-pass already runs, then build + ship each ONCE below (`rel_associates_material`
+        // spans are already stashed in `prepass_spans`).
         let mut mapped_item_spans: Vec<(u32, usize, usize)> = Vec::new();
         let mut rel_defines_by_type_spans: Vec<(u32, usize, usize)> = Vec::new();
         // #957/#962: IfcTypeProduct candidates (id, span, resolved type), stashed
@@ -376,6 +375,7 @@ impl IfcAPI {
                 }
                 "IFCRELDEFINESBYTYPE" => {
                     rel_defines_by_type_spans.push((id, start, end));
+                    prepass_spans.defines_by_type.push((id, start, end)); // material type-fallback
                 }
                 "IFCMATERIALLAYERSET" | "IFCMATERIALLAYERSETUSAGE" => {
                     has_layer_set = true;

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery.rs
@@ -124,6 +124,10 @@ pub(super) fn discover_from_columns(
             }
             c if c == p::PREPASS_CLASS_REL_DEFINES_BY_TYPE => {
                 d.rel_defines_by_type_spans.push((id, start, end));
+                // Also feed the shared resolver's material type-fallback
+                // (an occurrence with no material of its own inherits its
+                // type's IfcRelAssociatesMaterial).
+                d.prepass_spans.defines_by_type.push((id, start, end));
                 continue;
             }
             _ => {}

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs
@@ -276,6 +276,11 @@ impl IfcAPI {
             void_rels: triples(void_spans),
             fills_rels: triples(fills_spans),
             aggregate_rels: triples(aggregate_spans),
+            // Not plumbed across this wasm_bindgen boundary (no
+            // rel-defines-by-type span param here yet): occurrences merged
+            // via this sharded-finalize path get no type-material fallback.
+            // The serial and columns-discovery paths (the common case) do.
+            defines_by_type: Vec::new(),
         };
         let index = {
             let slot = self

--- a/rust/wasm-bindings/src/api/styling/prepass.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass.rs
@@ -56,6 +56,7 @@ pub(crate) fn combined_pre_pass(
             "IFCRELVOIDSELEMENT" => spans.void_rels.push((id, start, end)),
             "IFCRELFILLSELEMENT" => spans.fills_rels.push((id, start, end)),
             "IFCRELAGGREGATES" => spans.aggregate_rels.push((id, start, end)),
+            "IFCRELDEFINESBYTYPE" => spans.defines_by_type.push((id, start, end)),
             "IFCPROJECT" => {
                 if project_id.is_none() {
                     project_id = Some(id);


### PR DESCRIPTION
## Summary

Coverage question from the type-object-association-inheritance hunt: property sets on an `IfcTypeObject` are already inherited by its occurrences via `IfcRelDefinesByType` (#3621 owns that). This PR checks whether **material** and **classification** associations get the same inheritance.

**Classification** (`packages/parser/src/classification-resolver.ts`, `extractClassificationsOnDemand`): already walks `IfcRelDefinesByType` to the type and includes the type's `IfcRelAssociatesClassification` alongside the instance's own. Correct — no fix needed there.

**Material, TS side** (`packages/parser/src/material-resolver.ts`, `resolveAllMaterialDefIds`): already falls back to the type's `IfcRelAssociatesMaterial` when the occurrence has none, with occurrence-overrides-type precedence. Correct.

**Material, the viewer/server geometry-colouring pipeline (Rust) — the defect.** `resolve_prepass` (`rust/processing/src/prepass.rs`), the single shared post-scan resolver both the native/server pipeline (`processor/mod.rs`) and the browser wasm pipeline (`wasm-bindings`) run, built `element_to_material` **only** from direct occurrence-level `IfcRelAssociatesMaterial` (`RelatingMaterial` ← `RelatedObjects`). When a material is associated to an `IfcTypeObject` (e.g. `IfcWallType`) instead of the occurrence — a common authoring pattern — the association is recorded under the *type's own* express id and is never reached by `build_element_material_colors`, which only iterates `element_to_material` keyed by occurrence ids. Every occurrence of that type rendered in the default type colour instead of its material's appearance (issue #407/#913 material-chain colouring), in **both** the native/server and browser pipelines, since they share this resolver.

## Fix

`resolve_prepass` now walks `IfcRelDefinesByType` (a new `PrepassSpans::defines_by_type` span list, fed by all four scan sites: native `processor/mod.rs`, and the wasm `styling::prepass::combined_pre_pass`, `gpu_meshes::prepass` serial scan, and `gpu_meshes::prepass_discovery` columns-discovery path) and, for each occurrence whose type already resolved a material, installs it on the occurrence — `.entry(...).or_insert(...)`, so an occurrence with its own `IfcRelAssociatesMaterial` keeps it (occurrence overrides type), matching the precedence `resolveAllMaterialDefIds` already uses on the TS side.

The propagation logic lives in a new sibling module, `rust/processing/src/prepass_type_material.rs` (`prepass.rs` was at its exact module-size budget with zero headroom).

**Known gap, left as-is:** the sharded wasm "finalize" merge path (`gpu_meshes/prepass_sharded.rs::finalizePrepassStyles`, used for very large files split across workers) doesn't carry `defines_by_type` spans across its `wasm_bindgen` boundary — adding a new span parameter there would need new wasm API surface and a `pkg/ifc-lite.d.ts` regen, out of scope for this fix. Occurrences merged via that path get no type-material fallback; the serial and columns-discovery paths (used below the sharding threshold) do.

## Resolution verdict table

| Association | Instance | Type | Resolved (before) | Resolved (after) | Spec-correct |
|---|---|---|---|---|---|
| Material | none | Concrete | *(none — default colour)* | Concrete | Concrete |
| Material | Steel | Concrete | Steel | Steel | Steel (instance overrides) |
| Material | Steel | none | Steel | Steel | Steel (control, unchanged) |
| Classification | none | System X | System X (already worked) | System X | System X |

## RED/GREEN

`rust/processing/src/prepass_type_material.rs::tests::resolve_prepass_falls_back_to_type_material_unless_occurrence_has_its_own`:
- RED (verified by temporarily removing the propagation call): an occurrence with only a type-level material association resolved to `None` in `element_to_material`.
- GREEN: the same occurrence resolves to the type's material; an occurrence with its own material keeps its own (not the type's, not both); a control instance-only association is unaffected.

Reachability: `resolve_prepass` is called from `rust/processing/src/processor/mod.rs` (native/server geometry pipeline — every element mesh's colour) and from `rust/wasm-bindings/src/api/styling/prepass.rs` / `rust/wasm-bindings/src/api/gpu_meshes/prepass.rs` (browser viewer's material-based colouring), so this reaches the viewer's 3D rendering and the server's mesh export colouring for any type-associated-material model below the sharding size threshold.

## Test plan
- [x] `cargo test -p ifc-lite-processing` — 133 passed
- [x] `cargo test -p ifc-lite-wasm` — 135 passed
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6 passed
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget (touched Rust files re-measured at/under their ratchet budget)
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — unchanged baseline (no TS touched)
- [x] Changeset added for `@ifc-lite/wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Elements now correctly display materials assigned to their associated type.
  * Materials assigned directly to an individual element continue to override type-level materials.
  * Prevents affected elements from incorrectly rendering with the default appearance.

* **Tests**
  * Added coverage for type-level material inheritance, direct-material overrides, and instance-only materials across supported processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->