### PR TITLE
fix(parser): resolve IfcComplexProperty's nested HasProperties in the on-demand STEP path

### DIFF
--- a/.changeset/on-demand-complex-property.md
+++ b/.changeset/on-demand-complex-property.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix `IfcComplexProperty` being silently mis-decoded by the on-demand STEP property extraction path (`extractPropertiesOnDemand`, `extractTypePropertiesOnDemand`, and the material-pset resolver in `on-demand-extractors.ts`).
+
+`IfcComplexProperty`'s EXPRESS attributes are `[Name, Description, UsageName, HasProperties]` — the last a nested list of `IfcProperty` refs. The property-value parser's default branch, written for `IfcPropertySingleValue`, read attribute index 2 as a `NominalValue`; for a complex property that slot is `UsageName`, a label, not a value. So a complex property showed its `UsageName` string as if it were the value, and every nested property in `HasProperties` vanished from the panel/query output with no error.
+
+`resolveComplexPropertyValue` (new, in `property-value-parser.ts`) now walks `HasProperties`, recursing into any further nested `IfcComplexProperty`, and produces a `"Name: value, ..."` display string plus a flat `values` candidate list (mirroring the existing enumerated/list/bounded/table-value handling). `parsePropertyValueWithComplex` dispatches to it for `IfcComplexProperty` and to the existing single-entity parser otherwise; both `columnar-parser.ts`'s `extractPropertiesOnDemand` and `on-demand-extractors.ts`'s pset/material-pset resolvers now call it instead of the single-entity parser directly.

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -14,7 +14,7 @@ import { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
 import { getAttributeNames, getAttributeNamesAcrossSchemas, getInheritanceChain } from './ifc-schema.js';
-import { parsePropertyValue } from './on-demand-extractors.js';
+import { parsePropertyValueWithComplex } from './on-demand-extractors.js';
 import { readQuantitySet } from './quantity-collect.js';
 import { buildCompactEntityIndexAsync } from './compact-entity-index.js';
 import { yieldToEventLoop } from './yield-to-event-loop.js';
@@ -814,7 +814,7 @@ export class ColumnarParser {
                     const propName = typeof propAttrs[0] === 'string' ? propAttrs[0] : '';
                     if (!propName) continue;
 
-                    const parsed = parsePropertyValue(propEntity);
+                    const parsed = parsePropertyValueWithComplex(store, extractor, propEntity);
                     const entry: { name: string; type: number; value: PropertyValue; values?: string[]; dataType?: string } = {
                         name: propName,
                         type: parsed.type,

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -10,11 +10,9 @@
  * rather than pre-building all data upfront during initial parse.
  */
 
-import type { IfcEntity } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import {
     RelationshipType,
-    PropertyValueType,
 } from '@ifc-lite/data';
 import type { PropertyValue } from '@ifc-lite/data';
 import type { IfcDataStore } from './columnar-parser.js';
@@ -110,213 +108,18 @@ export interface MaterialPsetGroup {
 // ============================================================================
 // Property Value Parsing Helpers
 // ============================================================================
+//
+// Moved to ./property-value-parser.ts to stay under the module-size budget;
+// re-exported here so every existing import of this module keeps resolving.
 
-/**
- * Parse a property entity's value based on its IFC type.
- * Handles all 6 IfcProperty subtypes:
- * - IfcPropertySingleValue: direct value
- * - IfcPropertyEnumeratedValue: list of enum values → joined string
- * - IfcPropertyBoundedValue: upper/lower bounds → "value [min – max]"
- * - IfcPropertyListValue: list of values → joined string
- * - IfcPropertyTableValue: defining/defined value pairs → "Table(N rows)"
- * - IfcPropertyReferenceValue: entity reference → "Reference #ID"
- */
-export function parsePropertyValue(propEntity: IfcEntity): { type: number; value: PropertyValue; values?: string[]; dataType?: string } {
-    const attrs = propEntity.attributes || [];
-    const typeUpper = propEntity.type.toUpperCase();
+export {
+    parsePropertyValue,
+    extractNumericValue,
+    resolveComplexPropertyValue,
+    parsePropertyValueWithComplex,
+} from './property-value-parser.js';
+import { parsePropertyValueWithComplex } from './property-value-parser.js';
 
-    switch (typeUpper) {
-        case 'IFCPROPERTYENUMERATEDVALUE': {
-            // [Name, Description, EnumerationValues (list), EnumerationReference]
-            const enumValues = attrs[2];
-            if (Array.isArray(enumValues)) {
-                const values = enumValues.map(v => {
-                    if (Array.isArray(v) && v.length === 2) return String(v[1]); // Typed value
-                    return String(v);
-                }).filter(v => v !== 'null' && v !== 'undefined');
-                // Surface the raw value list separately so IDS facet
-                // checks can iterate "any matching value passes". The
-                // joined display string remains the primary `value`
-                // for visualisation/property-table consumers.
-                return { type: 0, value: values.join(', ') || null, values };
-            }
-            return { type: 0, value: null };
-        }
-
-        case 'IFCPROPERTYBOUNDEDVALUE': {
-            // [Name, Description, UpperBoundValue, LowerBoundValue, Unit, SetPointValue]
-            const upper = extractNumericValue(attrs[2]);
-            const lower = extractNumericValue(attrs[3]);
-            const setPoint = extractNumericValue(attrs[5]);
-            const displayValue = setPoint ?? upper ?? lower;
-            let display = displayValue != null ? String(displayValue) : '';
-            if (lower != null && upper != null) {
-                display += ` [${lower} – ${upper}]`;
-            }
-            // Surface every defined bound as a candidate value — IDS
-            // bounded-property checks pass when ANY of the bounds /
-            // setpoint matches the constraint, per upstream ifctester.
-            const candidates: string[] = [];
-            if (lower != null) candidates.push(String(lower));
-            if (upper != null && upper !== lower) candidates.push(String(upper));
-            if (setPoint != null && setPoint !== lower && setPoint !== upper) {
-                candidates.push(String(setPoint));
-            }
-            // Carry the IFC-declared measure tag so the IDS-side data
-            // type comparison and unit conversion both work.
-            const inferDataType = (attr: unknown): string | undefined => {
-                if (Array.isArray(attr) && attr.length === 2) {
-                    return String(attr[0]).toUpperCase();
-                }
-                return undefined;
-            };
-            const dataType =
-                inferDataType(attrs[5]) ||
-                inferDataType(attrs[2]) ||
-                inferDataType(attrs[3]);
-            return {
-                type: displayValue != null ? 1 : 0,
-                value: display || null,
-                ...(candidates.length > 0 ? { values: candidates } : {}),
-                ...(dataType ? { dataType } : {}),
-            };
-        }
-
-        case 'IFCPROPERTYLISTVALUE': {
-            // [Name, Description, ListValues (list), Unit]
-            const listValues = attrs[2];
-            if (Array.isArray(listValues)) {
-                const values = listValues.map(v => {
-                    if (Array.isArray(v) && v.length === 2) return String(v[1]);
-                    return String(v);
-                }).filter(v => v !== 'null' && v !== 'undefined');
-                return { type: 0, value: values.join(', ') || null, values };
-            }
-            return { type: 0, value: null };
-        }
-
-        case 'IFCPROPERTYTABLEVALUE': {
-            // [Name, Description, DefiningValues, DefinedValues, ...]
-            const definingValues = attrs[2];
-            const definedValues = attrs[3];
-            const rowCount = Array.isArray(definingValues) ? definingValues.length : 0;
-            if (rowCount > 0 && Array.isArray(definedValues) && Array.isArray(definingValues)) {
-                // Surface both defining and defined values as candidate
-                // matches — IDS table-value checks pass when ANY entry
-                // matches the constraint (per upstream ifctester).
-                const stringify = (v: unknown): string => {
-                    if (Array.isArray(v) && v.length === 2) return String(v[1]);
-                    return String(v);
-                };
-                const values = [
-                    ...definingValues.map(stringify),
-                    ...definedValues.map(stringify),
-                ].filter(v => v !== 'null' && v !== 'undefined');
-                // Tables mix types per column (label / length / …),
-                // so we can't surface a single representative
-                // dataType. Leaving it unset lets the IDS check fall
-                // through to a pure value match against any of the
-                // candidates — which is what upstream ifctester does
-                // for table values.
-                return {
-                    type: 0,
-                    value: `Table (${rowCount} rows)`,
-                    values,
-                };
-            }
-            return { type: 0, value: null };
-        }
-
-        case 'IFCPROPERTYREFERENCEVALUE': {
-            // [Name, Description, PropertyReference]
-            const refValue = attrs[2];
-            if (typeof refValue === 'number') {
-                return { type: 0, value: `#${refValue}` };
-            }
-            return { type: 0, value: null };
-        }
-
-        default: {
-            // IfcPropertySingleValue and fallback: [Name, Description, NominalValue, Unit]
-            const nominalValue = attrs[2];
-            let type: number = PropertyValueType.String;
-            let value: PropertyValue = nominalValue as PropertyValue;
-            let dataType: string | undefined;
-
-            // Handle typed values like IFCBOOLEAN(.T.), IFCREAL(1.5)
-            if (Array.isArray(nominalValue) && nominalValue.length === 2) {
-                const innerValue = nominalValue[1];
-                const typeName = String(nominalValue[0]).toUpperCase();
-                dataType = typeName;
-
-                if (typeName.includes('BOOLEAN')) {
-                    type = PropertyValueType.Boolean;
-                    value = innerValue === '.T.' || innerValue === true;
-                } else if (typeName.includes('LOGICAL')) {
-                    type = PropertyValueType.Logical;
-                    // Preserve .U. (unknown) as null; .T./.F. as boolean
-                    if (innerValue === '.U.' || innerValue === '.X.') {
-                        value = null;
-                    } else {
-                        value = innerValue === '.T.' || innerValue === true;
-                    }
-                } else if (typeof innerValue === 'number') {
-                    // Preserve the IFC-declared numeric measure (IFCREAL,
-                    // IFCINTEGER, IFCLENGTHMEASURE, IFCAREAMEASURE, …) —
-                    // the source explicitly tagged the value, so don't
-                    // re-infer from JS number-ness (which would
-                    // misclassify e.g. `IFCREAL(0.0)` as integer).
-                    if (typeName === 'IFCINTEGER' || typeName === 'IFCCOUNTMEASURE') {
-                        type = PropertyValueType.Integer;
-                    } else if (
-                        typeName === 'IFCREAL' ||
-                        typeName.endsWith('MEASURE') ||
-                        typeName.endsWith('RATIO')
-                    ) {
-                        type = PropertyValueType.Real;
-                    } else if (Number.isInteger(innerValue)) {
-                        type = PropertyValueType.Integer;
-                    } else {
-                        type = PropertyValueType.Real;
-                    }
-                    value = innerValue;
-                } else {
-                    type = PropertyValueType.String;
-                    value = String(innerValue);
-                }
-            } else if (typeof nominalValue === 'number') {
-                type = Number.isInteger(nominalValue) ? PropertyValueType.Integer : PropertyValueType.Real;
-            } else if (typeof nominalValue === 'boolean') {
-                type = PropertyValueType.Boolean;
-            } else if (nominalValue !== null && nominalValue !== undefined) {
-                // Normalize untagged STEP enumeration tokens. Conformant IFC wraps
-                // booleans as IFCBOOLEAN(.T.) (handled above), but some authoring
-                // tools emit the bare tokens directly in the NominalValue slot.
-                if (nominalValue === '.T.') {
-                    type = PropertyValueType.Boolean;
-                    value = true;
-                } else if (nominalValue === '.F.') {
-                    type = PropertyValueType.Boolean;
-                    value = false;
-                } else if (nominalValue === '.U.' || nominalValue === '.X.') {
-                    type = PropertyValueType.Logical;
-                    value = null;
-                } else {
-                    value = String(nominalValue);
-                }
-            }
-
-            return { type, value, ...(dataType ? { dataType } : {}) };
-        }
-    }
-}
-
-/** Extract a numeric value from a possibly typed STEP value. */
-export function extractNumericValue(attr: unknown): number | null {
-    if (typeof attr === 'number') return attr;
-    if (Array.isArray(attr) && attr.length === 2 && typeof attr[1] === 'number') return attr[1];
-    return null;
-}
 
 // ============================================================================
 // Property Set Extraction Helpers
@@ -364,7 +167,7 @@ export function extractPsetsFromIds(
                 const propName = typeof propAttrs[0] === 'string' ? propAttrs[0] : '';
                 if (!propName) continue;
 
-                const parsed = parsePropertyValue(propEntity);
+                const parsed = parsePropertyValueWithComplex(store, extractor, propEntity);
                 const entry: { name: string; type: number; value: PropertyValue; values?: string[]; dataType?: string } = {
                     name: propName,
                     type: parsed.type,
@@ -919,7 +722,7 @@ function getMaterialPropertyIndex(store: IfcDataStore): Map<number, MaterialPset
                 const propAttrs = propEntity.attributes || [];
                 const propName = typeof propAttrs[0] === 'string' ? propAttrs[0] : '';
                 if (!propName) continue;
-                const pv = parsePropertyValue(propEntity);
+                const pv = parsePropertyValueWithComplex(store, extractor, propEntity);
                 const entry: MaterialPsetEntry['properties'][number] = {
                     name: propName,
                     type: pv.type,

--- a/packages/parser/src/property-value-parser.ts
+++ b/packages/parser/src/property-value-parser.ts
@@ -1,0 +1,300 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Property VALUE parsing for the on-demand STEP extraction path: decodes a
+ * single `IfcProperty` subtype entity (IfcPropertySingleValue,
+ * IfcPropertyEnumeratedValue, IfcPropertyBoundedValue, IfcPropertyListValue,
+ * IfcPropertyTableValue, IfcPropertyReferenceValue, IfcComplexProperty) into
+ * the `{ type, value, values?, dataType? }` shape the property panel/query
+ * layer consumes. Split out of on-demand-extractors.ts to stay under the
+ * module-size budget.
+ */
+
+import type { IfcEntity } from './types.js';
+import type { EntityExtractor } from './entity-extractor.js';
+import { PropertyValueType } from '@ifc-lite/data';
+import type { PropertyValue } from '@ifc-lite/data';
+import type { IfcDataStore } from './columnar-parser.js';
+
+// ============================================================================
+// Property Value Parsing Helpers
+// ============================================================================
+
+/**
+ * Parse a property entity's value based on its IFC type.
+ * Handles all 6 IfcProperty subtypes:
+ * - IfcPropertySingleValue: direct value
+ * - IfcPropertyEnumeratedValue: list of enum values → joined string
+ * - IfcPropertyBoundedValue: upper/lower bounds → "value [min – max]"
+ * - IfcPropertyListValue: list of values → joined string
+ * - IfcPropertyTableValue: defining/defined value pairs → "Table(N rows)"
+ * - IfcPropertyReferenceValue: entity reference → "Reference #ID"
+ */
+export function parsePropertyValue(propEntity: IfcEntity): { type: number; value: PropertyValue; values?: string[]; dataType?: string } {
+    const attrs = propEntity.attributes || [];
+    const typeUpper = propEntity.type.toUpperCase();
+
+    switch (typeUpper) {
+        case 'IFCPROPERTYENUMERATEDVALUE': {
+            // [Name, Description, EnumerationValues (list), EnumerationReference]
+            const enumValues = attrs[2];
+            if (Array.isArray(enumValues)) {
+                const values = enumValues.map(v => {
+                    if (Array.isArray(v) && v.length === 2) return String(v[1]); // Typed value
+                    return String(v);
+                }).filter(v => v !== 'null' && v !== 'undefined');
+                // Surface the raw value list separately so IDS facet
+                // checks can iterate "any matching value passes". The
+                // joined display string remains the primary `value`
+                // for visualisation/property-table consumers.
+                return { type: 0, value: values.join(', ') || null, values };
+            }
+            return { type: 0, value: null };
+        }
+
+        case 'IFCPROPERTYBOUNDEDVALUE': {
+            // [Name, Description, UpperBoundValue, LowerBoundValue, Unit, SetPointValue]
+            const upper = extractNumericValue(attrs[2]);
+            const lower = extractNumericValue(attrs[3]);
+            const setPoint = extractNumericValue(attrs[5]);
+            const displayValue = setPoint ?? upper ?? lower;
+            let display = displayValue != null ? String(displayValue) : '';
+            if (lower != null && upper != null) {
+                display += ` [${lower} – ${upper}]`;
+            }
+            // Surface every defined bound as a candidate value — IDS
+            // bounded-property checks pass when ANY of the bounds /
+            // setpoint matches the constraint, per upstream ifctester.
+            const candidates: string[] = [];
+            if (lower != null) candidates.push(String(lower));
+            if (upper != null && upper !== lower) candidates.push(String(upper));
+            if (setPoint != null && setPoint !== lower && setPoint !== upper) {
+                candidates.push(String(setPoint));
+            }
+            // Carry the IFC-declared measure tag so the IDS-side data
+            // type comparison and unit conversion both work.
+            const inferDataType = (attr: unknown): string | undefined => {
+                if (Array.isArray(attr) && attr.length === 2) {
+                    return String(attr[0]).toUpperCase();
+                }
+                return undefined;
+            };
+            const dataType =
+                inferDataType(attrs[5]) ||
+                inferDataType(attrs[2]) ||
+                inferDataType(attrs[3]);
+            return {
+                type: displayValue != null ? 1 : 0,
+                value: display || null,
+                ...(candidates.length > 0 ? { values: candidates } : {}),
+                ...(dataType ? { dataType } : {}),
+            };
+        }
+
+        case 'IFCPROPERTYLISTVALUE': {
+            // [Name, Description, ListValues (list), Unit]
+            const listValues = attrs[2];
+            if (Array.isArray(listValues)) {
+                const values = listValues.map(v => {
+                    if (Array.isArray(v) && v.length === 2) return String(v[1]);
+                    return String(v);
+                }).filter(v => v !== 'null' && v !== 'undefined');
+                return { type: 0, value: values.join(', ') || null, values };
+            }
+            return { type: 0, value: null };
+        }
+
+        case 'IFCPROPERTYTABLEVALUE': {
+            // [Name, Description, DefiningValues, DefinedValues, ...]
+            const definingValues = attrs[2];
+            const definedValues = attrs[3];
+            const rowCount = Array.isArray(definingValues) ? definingValues.length : 0;
+            if (rowCount > 0 && Array.isArray(definedValues) && Array.isArray(definingValues)) {
+                // Surface both defining and defined values as candidate
+                // matches — IDS table-value checks pass when ANY entry
+                // matches the constraint (per upstream ifctester).
+                const stringify = (v: unknown): string => {
+                    if (Array.isArray(v) && v.length === 2) return String(v[1]);
+                    return String(v);
+                };
+                const values = [
+                    ...definingValues.map(stringify),
+                    ...definedValues.map(stringify),
+                ].filter(v => v !== 'null' && v !== 'undefined');
+                // Tables mix types per column (label / length / …),
+                // so we can't surface a single representative
+                // dataType. Leaving it unset lets the IDS check fall
+                // through to a pure value match against any of the
+                // candidates — which is what upstream ifctester does
+                // for table values.
+                return {
+                    type: 0,
+                    value: `Table (${rowCount} rows)`,
+                    values,
+                };
+            }
+            return { type: 0, value: null };
+        }
+
+        case 'IFCPROPERTYREFERENCEVALUE': {
+            // [Name, Description, PropertyReference]
+            const refValue = attrs[2];
+            if (typeof refValue === 'number') {
+                return { type: 0, value: `#${refValue}` };
+            }
+            return { type: 0, value: null };
+        }
+
+        default: {
+            // IfcPropertySingleValue and fallback: [Name, Description, NominalValue, Unit]
+            const nominalValue = attrs[2];
+            let type: number = PropertyValueType.String;
+            let value: PropertyValue = nominalValue as PropertyValue;
+            let dataType: string | undefined;
+
+            // Handle typed values like IFCBOOLEAN(.T.), IFCREAL(1.5)
+            if (Array.isArray(nominalValue) && nominalValue.length === 2) {
+                const innerValue = nominalValue[1];
+                const typeName = String(nominalValue[0]).toUpperCase();
+                dataType = typeName;
+
+                if (typeName.includes('BOOLEAN')) {
+                    type = PropertyValueType.Boolean;
+                    value = innerValue === '.T.' || innerValue === true;
+                } else if (typeName.includes('LOGICAL')) {
+                    type = PropertyValueType.Logical;
+                    // Preserve .U. (unknown) as null; .T./.F. as boolean
+                    if (innerValue === '.U.' || innerValue === '.X.') {
+                        value = null;
+                    } else {
+                        value = innerValue === '.T.' || innerValue === true;
+                    }
+                } else if (typeof innerValue === 'number') {
+                    // Preserve the IFC-declared numeric measure (IFCREAL,
+                    // IFCINTEGER, IFCLENGTHMEASURE, IFCAREAMEASURE, …) —
+                    // the source explicitly tagged the value, so don't
+                    // re-infer from JS number-ness (which would
+                    // misclassify e.g. `IFCREAL(0.0)` as integer).
+                    if (typeName === 'IFCINTEGER' || typeName === 'IFCCOUNTMEASURE') {
+                        type = PropertyValueType.Integer;
+                    } else if (
+                        typeName === 'IFCREAL' ||
+                        typeName.endsWith('MEASURE') ||
+                        typeName.endsWith('RATIO')
+                    ) {
+                        type = PropertyValueType.Real;
+                    } else if (Number.isInteger(innerValue)) {
+                        type = PropertyValueType.Integer;
+                    } else {
+                        type = PropertyValueType.Real;
+                    }
+                    value = innerValue;
+                } else {
+                    type = PropertyValueType.String;
+                    value = String(innerValue);
+                }
+            } else if (typeof nominalValue === 'number') {
+                type = Number.isInteger(nominalValue) ? PropertyValueType.Integer : PropertyValueType.Real;
+            } else if (typeof nominalValue === 'boolean') {
+                type = PropertyValueType.Boolean;
+            } else if (nominalValue !== null && nominalValue !== undefined) {
+                // Normalize untagged STEP enumeration tokens. Conformant IFC wraps
+                // booleans as IFCBOOLEAN(.T.) (handled above), but some authoring
+                // tools emit the bare tokens directly in the NominalValue slot.
+                if (nominalValue === '.T.') {
+                    type = PropertyValueType.Boolean;
+                    value = true;
+                } else if (nominalValue === '.F.') {
+                    type = PropertyValueType.Boolean;
+                    value = false;
+                } else if (nominalValue === '.U.' || nominalValue === '.X.') {
+                    type = PropertyValueType.Logical;
+                    value = null;
+                } else {
+                    value = String(nominalValue);
+                }
+            }
+
+            return { type, value, ...(dataType ? { dataType } : {}) };
+        }
+    }
+}
+
+/** Extract a numeric value from a possibly typed STEP value. */
+export function extractNumericValue(attr: unknown): number | null {
+    if (typeof attr === 'number') return attr;
+    if (Array.isArray(attr) && attr.length === 2 && typeof attr[1] === 'number') return attr[1];
+    return null;
+}
+
+/** Guards {@link resolveComplexPropertyValue} against a pathological/cyclic
+ *  HasProperties chain; real IFC nests IfcComplexProperty at most a couple of
+ *  levels deep (e.g. Pset "sub-properties"). */
+const MAX_COMPLEX_PROPERTY_DEPTH = 8;
+
+/**
+ * Resolve an `IfcComplexProperty`'s nested `HasProperties` (EXPRESS:
+ * `[Name, Description, UsageName, HasProperties]`, index 3) into a display
+ * value plus a flat `values` candidate list, recursing into any further
+ * nested `IfcComplexProperty`. Without this, {@link parsePropertyValue}'s
+ * default branch reads attribute index 2 as if it were a `NominalValue`,
+ * which for `IfcComplexProperty` is `UsageName` — a label, not a value — and
+ * every nested property silently vanishes from the panel/query output.
+ */
+export function resolveComplexPropertyValue(
+    store: IfcDataStore,
+    extractor: EntityExtractor,
+    propEntity: IfcEntity,
+    depth = 0
+): { type: number; value: PropertyValue; values?: string[]; dataType?: string } {
+    const attrs = propEntity.attributes || [];
+    const usageName = typeof attrs[2] === 'string' ? attrs[2] : '';
+    const hasProperties = attrs[3];
+
+    if (!Array.isArray(hasProperties) || depth >= MAX_COMPLEX_PROPERTY_DEPTH) {
+        return { type: PropertyValueType.String, value: usageName || null };
+    }
+
+    const parts: string[] = [];
+    const values: string[] = [];
+
+    for (const ref of hasProperties) {
+        if (typeof ref !== 'number') continue;
+        const nestedRef = store.entityIndex.byId.get(ref) ?? store.deferredEntityIndex?.get(ref);
+        if (!nestedRef) continue;
+        const nestedEntity = extractor.extractEntity(nestedRef);
+        if (!nestedEntity) continue;
+
+        const nestedAttrs = nestedEntity.attributes || [];
+        const nestedName = typeof nestedAttrs[0] === 'string' ? nestedAttrs[0] : '';
+        const nestedParsed = nestedEntity.type.toUpperCase() === 'IFCCOMPLEXPROPERTY'
+            ? resolveComplexPropertyValue(store, extractor, nestedEntity, depth + 1)
+            : parsePropertyValue(nestedEntity);
+
+        const display = nestedParsed.value != null ? String(nestedParsed.value) : '';
+        if (!display) continue;
+        parts.push(nestedName ? `${nestedName}: ${display}` : display);
+        values.push(display);
+    }
+
+    return {
+        type: PropertyValueType.String,
+        value: parts.length > 0 ? parts.join(', ') : (usageName || null),
+        ...(values.length > 0 ? { values } : {}),
+    };
+}
+
+/** Dispatch a pset member to {@link resolveComplexPropertyValue} for
+ *  `IfcComplexProperty`, else the single-entity {@link parsePropertyValue}. */
+export function parsePropertyValueWithComplex(
+    store: IfcDataStore,
+    extractor: EntityExtractor,
+    propEntity: IfcEntity
+): { type: number; value: PropertyValue; values?: string[]; dataType?: string } {
+    if (propEntity.type.toUpperCase() === 'IFCCOMPLEXPROPERTY') {
+        return resolveComplexPropertyValue(store, extractor, propEntity);
+    }
+    return parsePropertyValue(propEntity);
+}

--- a/packages/parser/test/on-demand-complex-property.test.ts
+++ b/packages/parser/test/on-demand-complex-property.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser, extractPropertiesOnDemand } from '../src/columnar-parser.js';
+
+describe('parseLite on-demand IfcComplexProperty extraction', () => {
+  it('resolves the nested HasProperties of an IfcComplexProperty instead of showing UsageName as the value', async () => {
+    const ifc = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('Width',$,IFCLENGTHMEASURE(100.0),$);
+#21=IFCPROPERTYSINGLEVALUE('Height',$,IFCLENGTHMEASURE(200.0),$);
+#22=IFCCOMPLEXPROPERTY('Opening','desc','Reference',(#20,#21));
+#30=IFCPROPERTYSET('pset-guid',#1,'Pset_WallOpening',$,(#22));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);`;
+
+    const source = new TextEncoder().encode(ifc);
+    const tokenizer = new StepTokenizer(source);
+    const entityRefs: Array<{
+      expressId: number;
+      type: string;
+      byteOffset: number;
+      byteLength: number;
+      lineNumber: number;
+    }> = [];
+
+    for (const ref of tokenizer.scanEntitiesFast()) {
+      entityRefs.push({
+        expressId: ref.expressId,
+        type: ref.type,
+        byteOffset: ref.offset,
+        byteLength: ref.length,
+        lineNumber: ref.line,
+      });
+    }
+
+    const parser = new ColumnarParser();
+    const store = await parser.parseLite(source.buffer.slice(0), entityRefs, {});
+    const psets = extractPropertiesOnDemand(store, 10);
+
+    expect(psets).toHaveLength(1);
+    expect(psets[0].properties).toHaveLength(1);
+    const complex = psets[0].properties[0];
+    expect(complex.name).toBe('Opening');
+    // The nested Width/Height single-values must survive — not be replaced by
+    // the bare UsageName string with the two child properties silently dropped.
+    expect(complex.values).toEqual(expect.arrayContaining([
+      expect.stringContaining('100'),
+      expect.stringContaining('200'),
+    ]));
+    expect(complex.value).not.toBe('Reference');
+  });
+});


### PR DESCRIPTION
## Summary

Lens: on-demand STEP property/quantity extraction correctness (a scoped hunt, not tied to a queued issue — see `unqueued`).

The on-demand STEP path this targets is `extractPropertiesOnDemand`/`extractTypePropertiesOnDemand`/the material-pset resolver in `packages/parser/src/on-demand-extractors.ts` and `packages/parser/src/columnar-parser.ts` — the resolver every real `.ifc` file's property panel and `ifc-lite query` output goes through (the columnar `PropertyTable`/`QuantityTable` in `packages/data` are built empty for STEP; #3603/#3606 territory, untouched here).

**Verdict table** (per the lens checks):

| Check | Verdict |
|---|---|
| Same-named psets on one entity (IFC4 §4.1.4.4 `IfcRelDefinesByProperties`) | Correct — array entries preserved per set, not collapsed (fixed for `EntityNode` by #3465; the on-demand extractor itself never merged/collapsed) |
| Value fidelity: boolean `.T.`/`.F.`, integer, real, empty string, non-ASCII | Correct — `parsePropertyValue`'s default branch (IFC4 §5.6.3.35 `IfcPropertySingleValue`) decodes each typed NominalValue distinctly; `false`/`0`/`""` are not conflated with absent |
| Property TYPE coverage: `IfcPropertySingleValue`/`Enumerated`/`ListValue`/`BoundedValue` (IFC4 §5.6.3.{2,20,25,35}) | Correct — each has its own switch case |
| **`IfcComplexProperty` (IFC4 §5.6.3.6)** | **Defect — fixed here.** No case existed; it fell through to the `IfcPropertySingleValue` default, which reads attribute index 2 as `NominalValue`. `IfcComplexProperty`'s EXPRESS layout is `[Name, Description, UsageName, HasProperties]` — index 2 is `UsageName`, a label, not a value. So a complex property showed its `UsageName` string as the "value" and every property in its `HasProperties` list (the entire point of the complex-property construct — grouped sub-properties, e.g. layer-set finish detail) silently vanished from the panel/query output with no error. |
| Quantity kinds (`Length`/`Area`/`Volume`/`Count`/`Weight`/`Time`) | Correct — `readQuantitySet` (`quantity-collect.ts`, out of scope here) dispatches per `IfcQuantity` subtype |
| Property with no `NominalValue` (`$`) | Correct — present-but-`null`, not dropped: the property stays in the array with `value: null` |

## The fix

`resolveComplexPropertyValue` (new, `packages/parser/src/property-value-parser.ts`) walks `HasProperties`, recursing into any further nested `IfcComplexProperty`, and produces a `"Name: value, ..."` display string plus a flat `values` candidate list — the same shape the existing Enumerated/List/Bounded/Table-value cases already use for IDS "any value matches" checks. `parsePropertyValueWithComplex` dispatches to it for `IfcComplexProperty`, and to the existing single-entity `parsePropertyValue` otherwise. Both call sites that read a pset's `HasProperties` list now use the dispatcher instead of calling `parsePropertyValue` directly: `columnar-parser.ts`'s `extractPropertiesOnDemand` (the primary on-demand STEP entry point) and `on-demand-extractors.ts`'s `extractPsetsFromIds` (used by type-level property extraction) and the material-pset index builder.

`parsePropertyValue`/`extractNumericValue` and the new functions were split out of `on-demand-extractors.ts` into `property-value-parser.ts` (re-exported, so every existing import keeps resolving) — the file was at 1062 lines against a 1004-line budget after the addition; it's now 797/1004.

## Test plan

- [x] RED on unmodified `upstream/main`: `packages/parser/test/on-demand-complex-property.test.ts` — an `IfcComplexProperty`'s nested `Width`/`Height` single-values (`IFCLENGTHMEASURE(100.0)`/`(200.0)`) were dropped (`complex.values` `undefined`, `complex.value === 'Reference'`, the bare `UsageName`).
- [x] GREEN after the fix — both nested values recovered in `complex.values`, `complex.value` no longer the raw `UsageName`.
- [x] Control: `packages/parser/test/on-demand-properties-regression.test.ts` (a plain single-value `Pset_WallCommon`, unaffected by this change) still passes unchanged.
- [x] `packages/parser` full suite: 86 files, 959 tests pass (2 pre-existing skips, fixture-gated).
- [x] `packages/query`, `packages/cli`, `packages/data` suites (consumers of this path) pass unchanged.
- [x] `pnpm exec tsc --noEmit` clean in `packages/parser`.
- [x] `node scripts/check-module-size.mjs` from repo root — 0 new files over budget; `on-demand-extractors.ts` now 797/1004, new `property-value-parser.ts` 300 lines (under the 400-line default threshold, no allowlist entry needed).
- [x] `node scripts/check-test-wiring.mjs`, `node scripts/check-unused-locals.mjs` — clean for the touched package.
- [x] No public API surface change (`property-value-parser.ts`'s new exports are not re-exported from `packages/parser/src/index.ts`) — no `api-surface.json`/version-bump-level implication beyond the attached `patch` changeset.

Changeset: `.changeset/on-demand-complex-property.md` (`@ifc-lite/parser`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected on-demand parsing of complex IFC properties.
  - Nested property values are now retained and displayed with their names instead of being replaced by a usage label.
  - Improved support for nested complex properties and material property sets.

- **Tests**
  - Added coverage validating extraction of nested complex-property values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->