### PR TITLE
fix(ci): the canary tested a pipeline the lane does not have

### DIFF
--- a/scripts/review/lane-canary.mjs
+++ b/scripts/review/lane-canary.mjs
@@ -123,14 +123,41 @@ function main() {
     throw new CanaryError('LANE_DOWN', 'The reviewer did not complete. Its own verdict is above.');
   }
 
+  // THROUGH `validate-findings`, EXACTLY AS THE LANE DOES. The first version
+  // JSON.parsed the reviewer's RAW output and failed on its first live run with
+  // BAD_OUTPUT -- because `run-reviewer.mjs --out` writes raw model text, and it
+  // is `validate-findings.mjs` that parses it, strips fencing, checks the quotes
+  // against the diff and drops anything unanchored. So the canary was not merely
+  // failing to parse: it was testing a pipeline the lane does not have, and a
+  // canary that exercises a different path from the thing it watches is worth
+  // less than no canary.
+  //
+  // Running the real chain means the canary now also covers the validator: a
+  // regression that rejects every finding shows up here as "found nothing",
+  // which is the same red as a dead reviewer and wants the same look.
+  const findingsPath = join(dirname(out), 'findings.json');
+  const v = spawnSync(
+    process.execPath,
+    [join(HERE, 'validate-findings.mjs'), '--raw', out, '--input', fixture, '--out', findingsPath],
+    { encoding: 'utf8' },
+  );
+  if (v.status !== 0) {
+    console.error(`${v.stdout || ''}${v.stderr || ''}`.trim());
+    throw new CanaryError(
+      'VALIDATION_FAILED',
+      'The reviewer answered but the validator rejected it. Its verdict is above -- that is a lane ' +
+        'regression even though the reviewer itself exited 0.',
+    );
+  }
+
   let parsed;
   try {
-    parsed = JSON.parse(readFileSync(out, 'utf8'));
+    parsed = JSON.parse(readFileSync(findingsPath, 'utf8'));
   } catch {
     throw new CanaryError(
       'BAD_OUTPUT',
-      'The reviewer completed but its output is not JSON this canary can read. That is a lane ' +
-        'regression even though the job exited 0.',
+      'The validator exited 0 but wrote findings this canary cannot read, which should be impossible ' +
+        'and is a defect in the validator rather than in the review.',
     );
   }
 

--- a/scripts/review/lane-canary.test.mjs
+++ b/scripts/review/lane-canary.test.mjs
@@ -100,3 +100,27 @@ test('the added-line ranges cover the defect, or the validator would reject the 
   const [[lo, hi]] = f.files[0].addedLineRanges;
   assert.ok(lo <= 4 && 4 <= hi, `the guard is on line 4; ranges are ${lo}..${hi}`);
 });
+
+test('THE CANARY RUNS THE LANE\'S REAL PIPELINE, not a shortcut past it', () => {
+  // Its first live run failed BAD_OUTPUT because it JSON.parsed the reviewer's
+  // RAW text. `run-reviewer.mjs --out` writes raw model output; it is
+  // `validate-findings.mjs` that parses it, strips fencing, checks quotes
+  // against the diff and drops unanchored findings.
+  //
+  // So the canary was exercising a pipeline the lane does not have. A canary on
+  // a different path from the thing it watches is worth less than none, and this
+  // asserts the two stay the same shape. Static, because the alternative is a
+  // live model call per test run.
+  // COMMENTS STRIPPED FIRST. The first version of this assertion matched the
+  // string anywhere in the file, and the docblock above DISCUSSES
+  // `validate-findings.mjs` -- so deleting the actual call left the test green.
+  // A check satisfied by prose about the thing, rather than the thing, is the
+  // defect this repository has now paid for four times in one day.
+  const strip = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*(\/\/|#).*$/gm, '');
+  const canary = strip(readFileSync(join(HERE, 'lane-canary.mjs'), 'utf8'));
+  const lane = strip(readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8'));
+  for (const stage of ['run-reviewer.mjs', 'validate-findings.mjs']) {
+    assert.ok(lane.includes(stage), `the lane must still use ${stage}`);
+    assert.ok(canary.includes(stage), `the canary must RUN ${stage}, not merely mention it`);
+  }
+});


### PR DESCRIPTION
The canary's first live run failed:

```
❌ BAD_OUTPUT: The reviewer completed but its output is not JSON this canary can read.
```

That was the **canary's** bug, not the lane's — and the shape of it matters more than the fix.

`run-reviewer.mjs --out` writes **raw model text**. It is `validate-findings.mjs` that parses it, strips fencing, checks every quote against the diff and drops anything unanchored. The lane runs both stages. The canary ran only the first, then `JSON.parse`d the result.

So it was not merely failing to parse — **it was exercising a pipeline that does not exist.** A canary on a different path from the thing it watches is worth less than no canary: its green means nothing and its red points at the wrong component. This one at least failed loudly. The dangerous version of the same mistake is the one that passes.

## What running the real chain buys

Beyond correctness, it widens coverage: a validator regression that rejects every finding now shows up as "found nothing" — the same red as a dead reviewer, and it wants the same investigation.

## The test for this was wrong too

It asserted both stage names appear in the canary's source. The docblock **discusses** `validate-findings.mjs`, so deleting the actual call left the suite green.

That is the fourth time in this repo today that a check was satisfied by prose *about* the thing rather than the thing — the same shape as a regex matching a YAML comment, and a `REMEDY:` filter matching a docblock. Comments are stripped before the check now, so it matches the **call**. Removing the stage turns it red.

9 canary tests, four repo gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review canary results are now validated before being parsed.
  - Clearer failure reporting is provided when validation fails or produces malformed output.

- **Tests**
  - Added regression coverage to verify that review workflows invoke both review generation and findings validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->