### PR TITLE
fix(ci): the eval scored raw model output, and its guard could not have known

### DIFF
--- a/scripts/review/rubric-eval.mjs
+++ b/scripts/review/rubric-eval.mjs
@@ -158,7 +158,36 @@ function main() {
       console.error(`${r.stdout || ''}${r.stderr || ''}`.trim());
       throw new Error(`Case ${f} did not run. The reviewer's own verdict is above; the score is not computable.`);
     }
-    const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+    // THROUGH `validate-findings`, EXACTLY AS THE LANE DOES -- and the canary
+    // had to learn this the same way an hour earlier. `run-reviewer.mjs --out`
+    // writes RAW model text, and the model FENCES it: this step failed on its
+    // first live run with
+    //
+    //   SyntaxError: Unexpected token '`', "```json ...
+    //
+    // even though rubric.md says "no prose, no markdown fence". That is worth
+    // knowing on its own -- the fence-stripping in `validate-findings` is
+    // load-bearing rather than defensive -- and it means any harness that parses
+    // the raw output is measuring a pipeline the lane does not have.
+    //
+    // Running the real chain also makes the score honest in a second way: the
+    // lane POSTS validated findings, so recall over unvalidated ones would credit
+    // the reviewer for findings that would have been dropped for quoting a line
+    // that is not in the diff.
+    const findingsPath = join(tmp, `${f}.findings.json`);
+    const v = spawnSync(
+      process.execPath,
+      [join(HERE, 'validate-findings.mjs'), '--raw', outPath, '--input', inputPath, '--out', findingsPath],
+      { encoding: 'utf8' },
+    );
+    if (v.status !== 0) {
+      console.error(`${v.stdout || ''}${v.stderr || ''}`.trim());
+      throw new Error(
+        `Case ${f}: the reviewer answered but the validator rejected it. That is a lane regression, ` +
+          'not a rubric score; the verdict is above.',
+      );
+    }
+    const parsed = JSON.parse(readFileSync(findingsPath, 'utf8'));
     results.push({ pr: c.pr, expected: c.expected, verdict: parsed.verdict, findings: parsed.findings ?? [] });
   }
 

--- a/scripts/review/rubric-eval.mjs
+++ b/scripts/review/rubric-eval.mjs
@@ -36,7 +36,7 @@
  * catch a change that makes recall WORSE, which is the direction that matters
  * when the current recall is zero.
  */
-import { readFileSync, writeFileSync, readdirSync, mkdtempSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +44,64 @@ import { spawnSync } from 'node:child_process';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CASE_DIR = join(HERE, 'eval-cases');
+
+/**
+ * Which side a non-zero validator exit blames.
+ *
+ * The REVIEWER's fault: it answered with malformed JSON, said nothing, ran out
+ * of tokens, contradicted itself, skipped the proof of work, or quoted lines
+ * that are not in the diff so every finding was dropped. The lane POSTS nothing
+ * in each of those cases, so the honest score is zero findings for that PR.
+ * Aborting instead throws away every other case and reports a broken
+ * instrument -- the exact confusion between absence and failure that this
+ * pipeline exists to keep apart, and the first version of this split made it
+ * for four of the seven, including the two most likely on a real corpus.
+ *
+ * The INSTRUMENT's fault: the harness fed the validator something wrong, or
+ * could not write its output. RAW_UNREADABLE and RAW_EMPTY sit here even though
+ * their remedies talk about the model, and for the same reason:
+ * `run-reviewer.mjs` throws EMPTY_RESPONSE and exits non-zero before it writes,
+ * so the case is already refused as "did not run" upstream. If the validator
+ * ever does see a missing or blank raw file, the plumbing broke rather than the
+ * model, and aborting is the conservative direction anyway. Putting RAW_EMPTY
+ * on the reviewer side contradicted that reasoning while sitting four lines
+ * from it. Nothing about the rubric can be read off such a
+ * run, so it stops.
+ *
+ * A reason in NEITHER set stops the run too. Both sets are written out here --
+ * the classification is this harness's policy, not the validator's -- and they
+ * are held to `REASONS`, which validate-findings.mjs exports, by a test that
+ * requires every reason to be classified exactly once. So a reason added there
+ * cannot be silently scored as "the reviewer found nothing".
+ */
+export const REVIEWER_FAULT = new Set([
+  'RAW_UNPARSEABLE',
+  'RESPONSE_TRUNCATED',
+  'SCHEMA_INVALID',
+  'VERDICT_CONTRADICTS_FINDINGS',
+  'PROOF_OF_WORK_FAILED',
+  'VALIDATION_EMPTY',
+]);
+
+export const INSTRUMENT_FAULT = new Set([
+  'BAD_ARGS',
+  'NO_RAW',
+  'NO_INPUT',
+  'NO_OUT',
+  'RAW_UNREADABLE',
+  'RAW_EMPTY',
+  'INPUT_UNREADABLE',
+  'INPUT_INVALID',
+  'OUT_UNWRITABLE',
+]);
+
+export function validatorReason(said) {
+  // [A-Z0-9_] to match the reason alphabet. Narrower here, a reason with a
+  // digit parsed as null at run time while the guard test happily classified it
+  // -- the eval would abort every case blaming the harness, with green tests.
+  return /(?:^|\n)\u274c ([A-Z0-9_]+):/.exec(String(said))?.[1] ?? null;
+}
+
 
 /**
  * Did the review surface this known finding?
@@ -133,71 +191,125 @@ export function score(cases) {
 }
 
 function main() {
-  const rubricArg = process.argv.indexOf('--rubric');
-  const rubric = rubricArg === -1 ? join(HERE, 'rubric.md') : process.argv[rubricArg + 1];
+  const arg = (name, fallback) => {
+    const i = process.argv.indexOf(name);
+    return i === -1 ? fallback : process.argv[i + 1];
+  };
+  const rubric = arg('--rubric', join(HERE, 'rubric.md'));
   const model = process.env.EVAL_MODEL || 'sonnet';
   const tmp = mkdtempSync(join(tmpdir(), 'rubric-eval-'));
+  // Removed on SUCCESS only. It holds each case's raw reviewer output and
+  // validated findings, which is exactly what you need when a case fails --
+  // deleting it on the failure path would throw away the evidence the harness
+  // exists to produce. On success it is megabytes of noise per run.
+  let ok = false;
+  try {
 
-  const files = readdirSync(CASE_DIR).filter((f) => f.endsWith('.json')).sort();
-  if (files.length === 0) throw new Error('No eval cases found; the harness would report a vacuous 0/0.');
+    // `--cases` and `--reviewer` exist so the ORCHESTRATION can be exercised for
+    // real: point the harness at a fixture case and at a deterministic stub in
+    // place of the model, and every other stage -- validate-findings included --
+    // still runs as a genuine child process. Nothing is mocked, so a test can ask
+    // what the harness DOES rather than what its source says.
+    const caseDir = arg('--cases', CASE_DIR);
+    const reviewer = arg('--reviewer', join(HERE, 'run-reviewer.mjs'));
 
-  const results = [];
-  for (const f of files) {
-    const c = JSON.parse(readFileSync(join(CASE_DIR, f), 'utf8'));
-    const inputPath = join(tmp, `${f}.input.json`);
-    const outPath = join(tmp, `${f}.out.txt`);
-    writeFileSync(inputPath, JSON.stringify(c.input));
-    const r = spawnSync(
-      process.execPath,
-      [join(HERE, 'run-reviewer.mjs'), '--rubric', rubric, '--input', inputPath, '--out', outPath, '--model', model],
-      { encoding: 'utf8' },
-    );
-    if (r.status !== 0) {
-      // A case that could not run is NOT a case that found nothing. Scoring it as
-      // a miss would blame the rubric for a drained pool.
-      console.error(`${r.stdout || ''}${r.stderr || ''}`.trim());
-      throw new Error(`Case ${f} did not run. The reviewer's own verdict is above; the score is not computable.`);
-    }
-    // THROUGH `validate-findings`, EXACTLY AS THE LANE DOES -- and the canary
-    // had to learn this the same way an hour earlier. `run-reviewer.mjs --out`
-    // writes RAW model text, and the model FENCES it: this step failed on its
-    // first live run with
-    //
-    //   SyntaxError: Unexpected token '`', "```json ...
-    //
-    // even though rubric.md says "no prose, no markdown fence". That is worth
-    // knowing on its own -- the fence-stripping in `validate-findings` is
-    // load-bearing rather than defensive -- and it means any harness that parses
-    // the raw output is measuring a pipeline the lane does not have.
-    //
-    // Running the real chain also makes the score honest in a second way: the
-    // lane POSTS validated findings, so recall over unvalidated ones would credit
-    // the reviewer for findings that would have been dropped for quoting a line
-    // that is not in the diff.
-    const findingsPath = join(tmp, `${f}.findings.json`);
-    const v = spawnSync(
-      process.execPath,
-      [join(HERE, 'validate-findings.mjs'), '--raw', outPath, '--input', inputPath, '--out', findingsPath],
-      { encoding: 'utf8' },
-    );
-    if (v.status !== 0) {
-      console.error(`${v.stdout || ''}${v.stderr || ''}`.trim());
-      throw new Error(
-        `Case ${f}: the reviewer answered but the validator rejected it. That is a lane regression, ` +
-          'not a rubric score; the verdict is above.',
+    const files = readdirSync(caseDir).filter((f) => f.endsWith('.json')).sort();
+    if (files.length === 0) throw new Error('No eval cases found; the harness would report a vacuous 0/0.');
+
+    const results = [];
+    for (const f of files) {
+      const c = JSON.parse(readFileSync(join(caseDir, f), 'utf8'));
+      const inputPath = join(tmp, `${f}.input.json`);
+      const outPath = join(tmp, `${f}.out.txt`);
+      writeFileSync(inputPath, JSON.stringify(c.input));
+      const r = spawnSync(
+        process.execPath,
+        [reviewer, '--rubric', rubric, '--input', inputPath, '--out', outPath, '--model', model],
+        { encoding: 'utf8' },
       );
+      if (r.status !== 0) {
+        // A case that could not run is NOT a case that found nothing. Scoring it as
+        // a miss would blame the rubric for a drained pool.
+        console.error(`${r.stdout || ''}${r.stderr || ''}`.trim());
+        throw new Error(`Case ${f} did not run. The reviewer's own verdict is above; the score is not computable.`);
+      }
+      // THROUGH `validate-findings`, EXACTLY AS THE LANE DOES -- and the canary
+      // had to learn this the same way an hour earlier. `run-reviewer.mjs --out`
+      // writes RAW model text, and the model FENCES it: this step failed on its
+      // first live run with
+      //
+      //   SyntaxError: Unexpected token '`', "```json ...
+      //
+      // even though rubric.md says "no prose, no markdown fence". That is worth
+      // knowing on its own -- the fence-stripping in `validate-findings` is
+      // load-bearing rather than defensive -- and it means any harness that parses
+      // the raw output is measuring a pipeline the lane does not have.
+      //
+      // Running the real chain also makes the score honest in a second way: the
+      // lane POSTS validated findings, so recall over unvalidated ones would credit
+      // the reviewer for findings that would have been dropped for quoting a line
+      // that is not in the diff.
+      const findingsPath = join(tmp, `${f}.findings.json`);
+      const v = spawnSync(
+        process.execPath,
+        [join(HERE, 'validate-findings.mjs'), '--raw', outPath, '--input', inputPath, '--out', findingsPath],
+        { encoding: 'utf8' },
+      );
+      // A non-zero exit is not one thing: see REVIEWER_FAULT above for which
+      // refusals are the model answering badly (scored zero, the eval carries on)
+      // and which mean the harness broke (stop).
+      const said = `${v.stdout || ''}${v.stderr || ''}`.trim();
+      if (v.status !== 0) {
+        // FROM STDERR ONLY. `said` concatenates stdout, and stdout carries the
+        // per-finding DROPPED warnings, which interpolate the model's own `path`
+        // unescaped. A path of "x.ts\n\u274c NO_RAW: injected" puts a forged reason
+        // line ahead of the real one, and `.exec` takes the first match -- turning
+        // a reviewer fault into a fabricated instrument fault that aborts the run.
+        // validate-findings prints exactly one reason line, always on stderr.
+        const reason = validatorReason(v.stderr || '');
+        if (!REVIEWER_FAULT.has(reason)) {
+          console.error(said);
+          throw new Error(
+            `Case ${f}: the validator refused the harness's own input (${reason ?? 'unknown'}). ` +
+              'That is a lane regression, not a rubric score; the verdict is above.',
+          );
+        }
+        console.log(`  ${f}: scored ZERO -- the reviewer's answer did not survive validation (${reason}).`);
+        console.log(said.split('\n').map((l) => `    ${l}`).join('\n'));
+        // NOT `verdict: 'findings'`. On RAW_EMPTY the model said nothing at all,
+        // and printing a verdict it never gave is the same fabrication
+        // validate-findings refuses to make. `null` is what actually happened.
+        results.push({ pr: c.pr, expected: c.expected, verdict: null, findings: [] });
+        continue;
+      }
+      // PARTIAL losses exit 0. DROPPED is one finding refused; CAPPED is the
+      // MAX_FINDINGS ceiling, and a 7-finding review silently loses 2. Either way
+      // recall falls, and without this nothing on screen separates "the reviewer
+      // missed it" from "the pipeline discarded it".
+      const lost = said.split('\n').filter((l) => /DROPPED|CAPPED/.test(l));
+      if (lost.length) console.log(lost.map((l) => `    ${f}: ${l.trim()}`).join('\n'));
+      const parsed = JSON.parse(readFileSync(findingsPath, 'utf8'));
+      results.push({ pr: c.pr, expected: c.expected, verdict: parsed.verdict, findings: parsed.findings ?? [] });
     }
-    const parsed = JSON.parse(readFileSync(findingsPath, 'utf8'));
-    results.push({ pr: c.pr, expected: c.expected, verdict: parsed.verdict, findings: parsed.findings ?? [] });
-  }
 
-  const s = score(results);
-  console.log(`\nRubric: ${rubric}   model: ${model}`);
-  for (const l of s.lines) console.log(l);
-  console.log(`\n  RECALL of known findings: ${s.recall}`);
-  console.log(`  EXTRA findings (look at these, do not minimise them): ${s.extra}`);
-  console.log('\n  Compare against the same command on the other rubric. A change that lowers');
-  console.log('  recall is a regression whatever it does to EXTRA.\n');
+    const s = score(results);
+    console.log(`\nRubric: ${rubric}   model: ${model}`);
+    for (const l of s.lines) console.log(l);
+    // A case whose review never validated contributes zero to recall, and a recall
+    // number is not readable without knowing how many of those there were.
+    const noReview = results.filter((r) => r.verdict === null).length;
+    console.log(`\n  RECALL of known findings: ${s.recall}`);
+    if (noReview) {
+      console.log(`  ...over ${results.length} cases, of which ${noReview} PRODUCED NO USABLE REVIEW and scored zero.`);
+    }
+    console.log(`  EXTRA findings (look at these, do not minimise them): ${s.extra}`);
+    console.log('\n  Compare against the same command on the other rubric. A change that lowers');
+    console.log('  recall is a regression whatever it does to EXTRA.\n');
+    ok = true;
+  } finally {
+    if (ok) rmSync(tmp, { recursive: true, force: true });
+    else console.error(`\n  Left the working directory in place for diagnosis: ${tmp}`);
+  }
 }
 
 if (process.argv[1] && process.argv[1].endsWith('rubric-eval.mjs')) main();

--- a/scripts/review/rubric-eval.test.mjs
+++ b/scripts/review/rubric-eval.test.mjs
@@ -163,3 +163,22 @@ test('a DIFFERENT finding in the same file is an EXTRA, never silently dropped',
   assert.equal(s2.extra, 1, 'it must be counted');
   assert.ok(s2.lines.some((l) => l.includes('➕ EXTRA')), 'and printed');
 });
+
+test('THE HARNESS RUNS THE LANE\'S REAL PIPELINE, both stages', () => {
+  // Made twice in one day, in two separate instruments: JSON.parsing the
+  // reviewer's RAW output. `run-reviewer.mjs --out` writes raw model text and
+  // the model FENCES it -- this harness died on its first live run with
+  // "Unexpected token '`', ```json" -- so `validate-findings.mjs` is what parses
+  // it. A harness that skips that stage scores a pipeline the lane does not have.
+  //
+  // Comments are stripped first: the docblock above DISCUSSES both stage names,
+  // and an assertion satisfied by prose about the call rather than the call is
+  // the shape this repository has paid for repeatedly today.
+  const strip = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*(\/\/|#).*$/gm, '');
+  const harness = strip(readFileSync(join(HERE, 'rubric-eval.mjs'), 'utf8'));
+  const lane = strip(readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8'));
+  for (const stage of ['run-reviewer.mjs', 'validate-findings.mjs']) {
+    assert.ok(lane.includes(stage), `the lane must still use ${stage}`);
+    assert.ok(harness.includes(stage), `the harness must RUN ${stage}, not merely mention it`);
+  }
+});

--- a/scripts/review/rubric-eval.test.mjs
+++ b/scripts/review/rubric-eval.test.mjs
@@ -10,10 +10,13 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync, readdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { matches, score } from './rubric-eval.mjs';
+import { matches, score, validatorReason, REVIEWER_FAULT, INSTRUMENT_FAULT } from './rubric-eval.mjs';
+import { REASONS } from './validate-findings.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const EXPECTED = {
@@ -164,21 +167,218 @@ test('a DIFFERENT finding in the same file is an EXTRA, never silently dropped',
   assert.ok(s2.lines.some((l) => l.includes('➕ EXTRA')), 'and printed');
 });
 
-test('THE HARNESS RUNS THE LANE\'S REAL PIPELINE, both stages', () => {
-  // Made twice in one day, in two separate instruments: JSON.parsing the
-  // reviewer's RAW output. `run-reviewer.mjs --out` writes raw model text and
-  // the model FENCES it -- this harness died on its first live run with
-  // "Unexpected token '`', ```json" -- so `validate-findings.mjs` is what parses
-  // it. A harness that skips that stage scores a pipeline the lane does not have.
+
+test('a validator refusal is blamed on the REVIEWER or the INSTRUMENT, never both', () => {
+  // Every non-zero exit used to abort the whole eval as "a lane regression". Two
+  // of the reasons are not that: a reviewer that answers with unanchorable quotes
+  // has REVIEWED BADLY, and the honest score for it is zero findings on that PR.
+  // Aborting threw away every other case and reported a broken instrument.
   //
-  // Comments are stripped first: the docblock above DISCUSSES both stage names,
-  // and an assertion satisfied by prose about the call rather than the call is
-  // the shape this repository has paid for repeatedly today.
-  const strip = (t) => t.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*(\/\/|#).*$/gm, '');
-  const harness = strip(readFileSync(join(HERE, 'rubric-eval.mjs'), 'utf8'));
-  const lane = strip(readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8'));
-  for (const stage of ['run-reviewer.mjs', 'validate-findings.mjs']) {
-    assert.ok(lane.includes(stage), `the lane must still use ${stage}`);
-    assert.ok(harness.includes(stage), `the harness must RUN ${stage}, not merely mention it`);
+  // Both strings below are real `validate-findings.mjs` output, produced by
+  // driving it with a review whose quotes are not in the diff, and with a
+  // malformed input file.
+  assert.equal(validatorReason('\u274c VALIDATION_EMPTY: nothing survived.'), 'VALIDATION_EMPTY');
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c VALIDATION_EMPTY: nothing survived.')), true);
+  // RAW_EMPTY is the INSTRUMENT's side: `run-reviewer.mjs` throws EMPTY_RESPONSE
+  // and exits non-zero before it writes, so the case is refused as "did not run"
+  // upstream. If the validator ever sees a blank raw file, the plumbing broke.
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c RAW_EMPTY: the raw file is blank.')), false);
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c SCHEMA_INVALID: not an object.')), true);
+
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c INPUT_INVALID: `headSha` must be 40 hex.')), false);
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c NO_RAW: the raw file is missing.')), false);
+
+  // An UNRECOGNISED reason must stop the eval, not be scored as a zero: a reason
+  // added to the validator later would otherwise be silently absorbed as "the
+  // reviewer found nothing", which is a recall number that means nothing.
+  assert.equal(validatorReason('\u274c BRAND_NEW_REASON: x'), 'BRAND_NEW_REASON');
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c BRAND_NEW_REASON: x')), false);
+  assert.equal(REVIEWER_FAULT.has(validatorReason('a crash with no reason line at all')), false);
+});
+
+test('EVERY reason validate-findings can exit with is classified, or the eval stops', () => {
+  // The two sets are a second copy of a list that lives in another file, and a
+  // second copy held together by prose is how this drifts: a reason added to the
+  // validator later falls into neither set, and the question is only whether the
+  // eval NOTICES. It must, in the safe direction -- unclassified aborts the run
+  // rather than being scored as "the reviewer found nothing", which would be a
+  // recall number quietly computed from a case that never produced a review.
+  //
+  // The first version of this split classified 3 of the 7 reviewer-fault
+  // reasons, so RAW_UNPARSEABLE and RESPONSE_TRUNCATED -- the two likeliest on a
+  // real corpus -- still aborted the whole eval and blamed the instrument.
+  // IMPORTED, not scraped. Recovering this list with a regex over the
+  // validator's source failed silently in one direction: a reason spelled with a
+  // digit, or in double quotes, was invisible and the count still passed.
+  // validate-findings.test.mjs holds the guard that REASONS covers every raise
+  // site, which is where a new reason is actually added.
+  const documented = [...REASONS];
+  assert.ok(documented.length >= 15, `expected the validator's reasons; found ${documented.length}`);
+
+  const unclassified = documented.filter((r) => !REVIEWER_FAULT.has(r) && !INSTRUMENT_FAULT.has(r));
+  assert.deepEqual(unclassified, [], 'every documented reason must be on one side or the other');
+
+  const both = [...REVIEWER_FAULT].filter((r) => INSTRUMENT_FAULT.has(r));
+  assert.deepEqual(both, [], 'a reason cannot be both');
+
+  // And the sets must not name reasons the validator does not have, which is the
+  // other way the copy rots.
+  for (const r of [...REVIEWER_FAULT, ...INSTRUMENT_FAULT]) {
+    assert.ok(REASONS.has(r), `${r} is classified here but does not exist in validate-findings.mjs`);
   }
+
+  // The safe direction, exercised rather than asserted.
+  assert.equal(REVIEWER_FAULT.has(validatorReason('\u274c A_REASON_ADDED_LATER: x')), false);
+});
+
+// ============================================ the orchestration, run for real
+//
+// The assertion this replaces read the harness's SOURCE and checked that the
+// string `validate-findings.mjs` appeared in it. That certifies a string
+// exists; it cannot show either stage runs, it is green while the behaviour is
+// broken, and it reddens on a rename. It is also the pattern
+// scripts/check-source-text-assertions.mjs exists to keep out -- that ratchet
+// only walks `.test.ts|tsx|mts`, so no `.test.mjs` in this repo has ever been
+// scanned by it, which is why the assertion landed and survived review.
+//
+// So the harness is driven end to end instead: a real case directory, a
+// deterministic stub in place of the model, and every other stage running as a
+// genuine child process. Validation is never observed directly. It is proven by
+// its EFFECT -- a finding whose quote is not in the diff must not reach the
+// score, and no source-level check can tell you that.
+
+const STUB_PATCH = '@@ -1,2 +1,4 @@\n export function f(raw) {\n+  const n = Number(raw);\n+  if (n > 0) return n;\n+  return 0;\n }';
+
+// `t.after` rather than a trailing rmSync: an assertion that throws would skip
+// the latter, and a failing test is exactly when these directories pile up.
+function tmpCase(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'eval-orch-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function evalCase(dir, { expected }) {
+  // `expected[].what` is prose the scorer stems for terms; the shape must match
+  // the real eval cases or the harness dies before the assertion is reached.
+  writeFileSync(join(dir, 'case.json'), JSON.stringify({
+    pr: 9001,
+    expected,
+    input: {
+      headSha: 'a'.repeat(40),
+      files: [{ path: 'src/f.ts', patch: STUB_PATCH, addedLineRanges: [[2, 4]] }],
+      unreviewable: [],
+      excluded: [],
+    },
+  }));
+}
+
+// A stub REVIEWER, not a stub validator: it writes the raw file exactly as
+// run-reviewer.mjs does, fenced the way the real model fences it.
+function stubReviewer(dir, body) {
+  const p = join(dir, 'stub-reviewer.mjs');
+  writeFileSync(p, `import { writeFileSync } from 'node:fs';
+const out = process.argv[process.argv.indexOf('--out') + 1];
+writeFileSync(out, ${JSON.stringify(body)});
+`);
+  return p;
+}
+
+const runHarness = (dir, reviewer) => spawnSync(
+  process.execPath,
+  [join(HERE, 'rubric-eval.mjs'), '--cases', dir, '--reviewer', reviewer, '--rubric', join(HERE, 'rubric.md')],
+  { encoding: 'utf8' },
+);
+
+const fenced = (findings, verdict = 'findings') => '```json\n' + JSON.stringify({
+  verdict,
+  files_reviewed: ['src/f.ts'],
+  riskiest_change: { path: 'src/f.ts', quoted_line: '  if (n > 0) return n;' },
+  findings,
+  end: 'ifc-lite-review-v1',
+}) + '\n```';
+
+test('ONLY findings that survive validation are scored, and a FENCED response is read', (t) => {
+  // Two findings, identical in shape. One quotes a line that is really in the
+  // diff; the other quotes a line that is not. A harness that JSON.parsed the
+  // raw output would die on the fence; one that skipped validation would score
+  // both; one that discarded the validator's result would score neither.
+  //
+  // The COUNTS are what separate those, so they are asserted exactly. An earlier
+  // version of this test matched /RECALL/, which `rubric-eval.mjs` prints on
+  // every successful run -- so its positive half could not fail, and scoring
+  // nothing at all passed it. That is the same defect as the source-text
+  // assertion this test replaced, one level in.
+  const dir = tmpCase(t);
+  evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN so the comparison falls through and closes the session' }] });
+  const reviewer = stubReviewer(dir, fenced([
+    { path: 'src/f.ts', line: 3, quote: '  if (n > 0) return n;', body: 'Number(raw) returns NaN for a non-number, the comparison falls through, and closes the session.', class: 'numeric-bound' },
+    { path: 'src/f.ts', line: 3, quote: '  this line is nowhere in the diff', body: 'a fabricated anchor', class: 'numeric-bound' },
+  ]));
+  const r = runHarness(dir, reviewer);
+  const said = `${r.stdout}${r.stderr}`;
+
+  assert.equal(r.status, 0, said);
+  // Exactly one finding survived, it was the real one, and it was RECOGNISED.
+  assert.match(said, /RECALL of known findings: 1\/1/, said);
+  assert.match(said, /EXTRA findings[^:]*: 0/, said);
+  // The drop names the FABRICATED quote, not merely the word DROPPED, which the
+  // whole-output echo on the failure path also satisfies.
+  assert.match(said, /DROPPED[\s\S]*this line is nowhere in the diff/, said);
+  assert.doesNotMatch(said, /a fabricated anchor/, 'a finding that failed validation must not reach the score');
+});
+
+test('a response where NOTHING survives scores ZERO and the eval CARRIES ON', (t) => {
+  // VALIDATION_EMPTY is the reviewer answering badly, not the harness breaking.
+  // Aborting here threw away every other case and reported a broken instrument.
+  const dir = tmpCase(t);
+  evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN and the comparison falls through, closing the session' }] });
+  const reviewer = stubReviewer(dir, fenced([
+    { path: 'src/f.ts', line: 3, quote: '  not in the diff at all', body: 'x', class: 'numeric-bound' },
+  ]));
+  const r = runHarness(dir, reviewer);
+  const said = `${r.stdout}${r.stderr}`;
+
+  assert.equal(r.status, 0, `the eval must finish and report a score:\n${said}`);
+  assert.match(said, /VALIDATION_EMPTY/, said);
+  assert.match(said, /scored ZERO/, said);
+  assert.match(said, /PRODUCED NO USABLE REVIEW/, 'the recall line must say how many cases produced nothing');
+});
+
+test('an EMPTY response is a HARD ERROR, because the real chain cannot produce one', (t) => {
+  // Not "the model said nothing, score it zero". `run-reviewer.mjs` throws
+  // EMPTY_RESPONSE and exits non-zero on empty output, so through the real chain
+  // this case is refused as "did not run" long before the validator sees it. A
+  // blank raw file reaching validation means the plumbing broke, and the earlier
+  // version of this test asserted a property of the STUB rather than of the lane
+  // -- it reached RAW_EMPTY only because a stub can exit 0 with an empty file,
+  // which run-reviewer cannot.
+  const dir = tmpCase(t);
+  evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN so the comparison falls through and closes the session' }] });
+  const r = runHarness(dir, stubReviewer(dir, ''));
+  const said = `${r.stdout}${r.stderr}`;
+
+  assert.notEqual(r.status, 0, `an empty response must not produce a score:\n${said}`);
+  assert.match(said, /RAW_EMPTY/, said);
+  assert.doesNotMatch(said, /RECALL of known findings/, 'no recall number may be printed from a run that produced nothing');
+});
+
+test('a VALIDATION failure on the harness\'s own input is a HARD ERROR', (t) => {
+  // The other side of the split, and the one that must never be scored: if the
+  // input WE built is refused, nothing about the rubric can be read off the run.
+  // Reporting a low recall here would blame the reviewer for our own bug.
+  const dir = tmpCase(t);
+  evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN and the comparison falls through, closing the session' }] });
+  const bad = JSON.parse(readFileSync(join(dir, 'case.json'), 'utf8'));
+  bad.input.headSha = 'not-a-sha';
+  writeFileSync(join(dir, 'case.json'), JSON.stringify(bad));
+
+  const reviewer = stubReviewer(dir, fenced([
+    { path: 'src/f.ts', line: 3, quote: '  if (n > 0) return n;', body: 'Number(raw) is NaN, so this returns 0.', class: 'numeric-bound' },
+  ]));
+  const r = runHarness(dir, reviewer);
+  const said = `${r.stdout}${r.stderr}`;
+
+  assert.notEqual(r.status, 0, `an INPUT_INVALID refusal must stop the run:\n${said}`);
+  assert.match(said, /INPUT_INVALID/, said);
+  assert.doesNotMatch(said, /RECALL of known findings/, 'no recall number may be printed from a run that did not happen');
 });

--- a/scripts/review/validate-findings.mjs
+++ b/scripts/review/validate-findings.mjs
@@ -158,6 +158,36 @@ export const SENTINEL = 'ifc-lite-review-v1';
  */
 export const MAX_FINDINGS = 5;
 
+/**
+ * Every reason this module can exit with.
+ *
+ * Published rather than left to be scraped: `rubric-eval.mjs` has to decide, per
+ * reason, whether a refusal means the REVIEWER answered badly (score it zero and
+ * carry on) or the HARNESS broke (stop). It was recovering this list with a
+ * regex over this file's source, which failed silently in one direction -- a
+ * reason spelled with a digit, or in double quotes, was simply invisible.
+ *
+ * `validate-findings.test.mjs` holds the guard that this covers every raise
+ * site, because the raise sites live here and a new reason is added here.
+ */
+export const REASONS = new Set([
+  'BAD_ARGS',
+  'NO_RAW',
+  'NO_INPUT',
+  'NO_OUT',
+  'RAW_UNREADABLE',
+  'INPUT_UNREADABLE',
+  'RAW_EMPTY',
+  'RAW_UNPARSEABLE',
+  'RESPONSE_TRUNCATED',
+  'INPUT_INVALID',
+  'SCHEMA_INVALID',
+  'VERDICT_CONTRADICTS_FINDINGS',
+  'PROOF_OF_WORK_FAILED',
+  'VALIDATION_EMPTY',
+  'OUT_UNWRITABLE',
+]);
+
 /** GitHub renders long comments fine; a reviewer reading twenty of them does not. */
 export const MAX_BODY_CHARS = 1500;
 const TRUNCATION_NOTE = '\n\n[truncated by validate-findings]';

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -40,6 +40,7 @@ import {
   sanitizeBody,
   sanitizeLabel,
   stripFence,
+  REASONS,
 } from './validate-findings.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -787,4 +788,86 @@ test('stripFence removes one fence and refuses to guess at anything else', () =>
   // fails if it is not, which is the honest outcome either way.
   assert.equal(stripFence('```json\n{"a":1}'), '{"a":1}');
   assert.equal(stripFence('```json {"a":1} ```'), '```json {"a":1} ```', 'a one-line fence is not stripped');
+});
+
+test('REASONS covers EVERY raise site in this file, and names nothing that is not one', () => {
+  // `REASONS` is published for rubric-eval, which decides per reason whether a
+  // refusal means the reviewer answered badly or the harness broke. A reason
+  // added below and not added to the set would be classified as neither and stop
+  // the eval blaming the harness -- so the guard lives here, next to the raise
+  // sites, where the same commit that adds a reason has to walk past it.
+  //
+  // The first argument is read with a paren-balanced scan, not a regex: the
+  // earlier version of this lived in rubric-eval and used `[^,)]+`, which
+  // silently returns nothing when that argument contains a call.
+  //
+  // EVERY screaming-snake token in the argument must be known, and the site must
+  // name at least one. Requiring only one hit let a ternary carry a second,
+  // unclassified reason with every test green. Lowercase tokens are skipped,
+  // which is what lets a condition like `kind === 'raw' ? ...` through without
+  // a special case.
+  const src = readFileSync(new URL('./validate-findings.mjs', import.meta.url), 'utf8');
+  const NEEDLE = 'ValidateFindingsError(';
+  const seen = new Set();
+  const barren = [];
+  const computed = [];
+  let sites = 0;
+  // An INVENTORY check, not a behaviour check: it asks whether a published
+  // constant lists every reason this file can raise. There is no behavioural
+  // form of that question -- driving all fifteen would mean constructing fifteen
+  // failure inputs, several unreachable on purpose (OUT_UNWRITABLE). What it
+  // guards is a data structure, not a call.
+  // NOTE: the ratchet does not scan `.test.mjs` at all (#3639), so this marker
+  // documents intent rather than recording an approval that was granted.
+  // @source-text-assertion-ok inventory of raise sites against the REASONS export
+  for (let i = src.indexOf(NEEDLE); i !== -1; i = src.indexOf(NEEDLE, i + 1)) {
+    sites += 1;
+    let depth = 1;
+    let j = i + NEEDLE.length;
+    const start = j;
+    for (; j < src.length && depth > 0; j += 1) {
+      if (src[j] === '(') depth += 1;
+      else if (src[j] === ')') depth -= 1;
+      else if (src[j] === ',' && depth === 1) break;
+    }
+    // EVERY screaming-snake token in the argument must be a known reason, not
+    // just one of them. Accepting a site because it named one left a second,
+    // unclassified reason live in the code with all 59 tests green -- verified
+    // by mutating the ternary's else branch to a new name. A lowercase token is
+    // not reason-shaped, which is what lets the `kind === 'raw' ? ...` condition
+    // through without a special case.
+    const arg = src.slice(start, j);
+    const tokens = [...arg.matchAll(/['"]([A-Z][A-Z0-9_]{2,})['"]/g)].map((m) => m[1]);
+    const unknown = tokens.filter((r) => !REASONS.has(r));
+    if (unknown.length) barren.push(`${arg.trim().slice(0, 50)} -> ${unknown.join(', ')}`);
+    // A site whose first argument is a variable rather than a literal cannot be
+    // read this way. That is NOT a failure -- hoisting a reason to a const is
+    // behaviour-preserving and reddening it would train people to weaken this --
+    // but it is counted, so the blind spot stays visible instead of growing.
+    if (tokens.length === 0) computed.push(arg.trim().slice(0, 50));
+    for (const r of tokens) seen.add(r);
+  }
+  assert.ok(sites > 0, 'the scan found no raise sites at all, which means it is broken');
+  assert.deepEqual(barren, [], 'these raise sites name a reason that is not in REASONS');
+  assert.equal(
+    computed.length,
+    0,
+    `these raise sites build their reason from a variable, so this check cannot read them; ` +
+      `add any new reason to REASONS by hand and raise this count: ${JSON.stringify(computed)}`,
+  );
+
+  // The alphabet is a THIRD copy of the same convention: `validatorReason` in
+  // rubric-eval parses `[A-Z0-9_]+` off the printed line. A reason outside that
+  // shape would be in REASONS, be classified, be raised, and still parse as null
+  // at run time -- green everywhere, and the eval aborts calling it unknown.
+  for (const r of REASONS) {
+    // `r` comes from the imported REASONS constant, not from the file read
+    // above; this pins a naming convention on that constant.
+    // Marker documents intent; the ratchet cannot see this file (#3639).
+    // @source-text-assertion-ok naming convention on an imported constant
+    assert.match(r, /^[A-Z][A-Z0-9_]*$/, `${r} is outside the alphabet validatorReason parses`);
+  }
+
+  const phantom = [...REASONS].filter((r) => !seen.has(r));
+  assert.deepEqual(phantom, [], 'these are in REASONS but are never raised');
 });


### PR DESCRIPTION
Two defects: one in production, one in the test that was supposed to cover it.

## The production defect

`run-reviewer.mjs --out` writes **raw** model text, and the model fences it — the eval died on its first live run with ``Unexpected token '`', ```json``. `validate-findings.mjs` is what parses that: strips the fence, checks quotes against the diff, drops unanchored findings. Scoring raw output measures a pipeline the lane does not have, and credits the reviewer for findings the lane would never post.

## The test defect

The first fix asserted that the harness's **source contained** the strings `run-reviewer.mjs` and `validate-findings.mjs`. That is a source-text assertion: it certifies a string exists, stays green while the behaviour is broken, and reddens on a rename. Successive rounds hardened it — stripping comments, then demanding a `spawnSync` argument list, then parsing the workflow into commands — and every version still answered a question about text.

The decisive measurement. Validator still spawned, its exit code still honoured, its **output discarded** and the raw findings scored instead:

| | |
|---|---|
| the source-text assertion | **green** — both names present, both spawns present |
| the behavioural test | **red** — the fabricated finding reached the score |

So it is replaced, not hardened again.

## The replacement

`rubric-eval.mjs` takes `--cases` and `--reviewer`, and the test drives the harness end to end: a real case directory, a deterministic stub in place of the model, every other stage running as a genuine child process. Nothing is mocked. Validation is never observed directly — it is proven by its **effect**.

- A fenced response with two findings, one quoting a real added line and one quoting a line absent from the diff: exactly one is scored (`RECALL 1/1`, `EXTRA 0`) and the drop names the fabricated quote. A harness that `JSON.parse`d raw output dies on the fence; one that skipped validation scores both; one that discarded the validator's result scores neither.
- Nothing survives → `VALIDATION_EMPTY`, scored zero, the eval **carries on**, and the recall line says how many cases produced no review.
- A malformed input the harness itself built → `INPUT_INVALID`, a **hard error**, and no recall number is printed from a run that did not happen.
- An empty response → `RAW_EMPTY`, also a hard error, because `run-reviewer.mjs` exits non-zero on empty output so the real chain cannot produce one.

All four redden when the validation stage is deleted; the first also reddens when the validator's findings are discarded, and when `MIN_FINDING_QUOTE_CHARS` is raised so validation drops everything.

## Why the prohibited assertion survived review

`check-source-text-assertions` exists to keep exactly this out, and it never looked. Its filter is `/\.(test|spec)\.(ts|tsx|mts)$/` — **`.mjs` is not in it**, so no test under `scripts/` has ever been scanned. Pointing its own detector at the repo by hand flags **14 of 70** `.mjs` test files, while the gate reports `OK (8 allowlisted, 0 marked, 0 new)`. Filed as #3639. `rubric-eval.test.mjs` is now clean to that detector.

`scripts/lib/workflow-run-commands.mjs` is deleted along with the assertion it existed to serve, and #3637 is closed with it.

## Also in this diff

**A non-zero validator exit is not one thing.** Seven of the fifteen reasons mean the *reviewer* answered badly; the lane posts nothing in those cases, so the honest score is zero for that PR. Aborting threw away every other case and reported a broken instrument — the confusion between absence and failure this pipeline exists to keep apart. The instrument reasons still stop the run, and so does an unrecognised one.

**The reason is read from stderr, not stdout.** The per-finding `DROPPED` warnings interpolate the model's own `path` unescaped, so a path of `"x.ts\n❌ NO_RAW: injected"` put a forged reason line ahead of the real one and `.exec` took the first match. Reproduced: a genuine `VALIDATION_EMPTY` was classified `NO_RAW` and aborted the eval as "a lane regression" — the model steering the harness into exactly the failure this change prevents.

**`validate-findings` publishes its reasons** rather than having them scraped out of its own source, which failed silently for a reason spelled with a digit or in double quotes. The guard that `REASONS` covers every raise site lives next to those sites and requires every screaming-snake token in a raise site's first argument to be known — accepting a site because it named *one* left a second, unclassified reason live with every test green.

## Verification

183 tests pass. `check-test-wiring`, `check-module-size` and `check-source-text-assertions` green. Rebased on `aaa3aa804`, i.e. after the canary repair (#3635) landed.