### PR TITLE
fix(ci): give the review-lane canary a valid synthetic head SHA

### DIFF
--- a/scripts/review/build-review-input.mjs
+++ b/scripts/review/build-review-input.mjs
@@ -114,25 +114,45 @@ export function isExcluded(path) {
 }
 
 /**
- * Line ranges the PR ADDED, from the hunk headers. A finding may only anchor
- * inside one of these: a comment on a line the PR did not touch is noise at
- * best, and a line number the model invented at worst.
+ * Walk a patch and classify every line, numbering it AS IT WILL BE IN THE NEW FILE.
+ *
+ * This is the single counter. `addedLineRanges` is built on it, and so is the
+ * canary's check that its fixture's quote sits on the line the fixture claims,
+ * because a second hand-rolled counter is how an off-by-one gets certified: it
+ * agrees with this one on the easy patch it was written against and diverges on
+ * a hunk that does not start at line 1, on a second hunk, and on a file with no
+ * trailing newline.
+ *
+ * Match a quote against `text` for `added` lines only. That is STRICTER than
+ * `quotableLines` in validate-findings, which also accepts removed lines and
+ * `diff --git` lines; the two are not the same gate.
+ *
+ * Splits on /\r?\n/, where the older walker split on '\n', so `text` carries no
+ * trailing `\r`. That is what makes it comparable to `quotableLines`.
+ *
+ * KNOWN, PRE-EXISTING, NOT FIXED HERE (see #3634): neither the `-`/`---` nor
+ * the `+`/`+++` test can tell a file header from content that starts the same
+ * way, and the two halves fail DIFFERENTLY, so a fix must cover both:
+ *
+ *   deleting a markdown `---` rule gives `----`, read as context, which
+ *     advances the counter and numbers every later line in that hunk too high;
+ *   adding `++i;` gives `+++i;`, which is dropped from the ranges, so
+ *     `lineIsAdded` refuses a CORRECT finding on a line the PR really added.
+ *
+ * `addedLineRanges` behaves exactly as it does on origin/main; the commit
+ * message carries the differential evidence.
  *
  * @param {string} patch a unified diff for ONE file
- * @returns {[number, number][]}
+ * @returns {{line: number, text: string, kind: 'added'|'context'|'removed'|'hunk'}[]}
  */
-export function addedLineRanges(patch) {
-  const ranges = [];
+export function newFileLines(patch) {
+  const out = [];
   let newLine = 0;
-  let start = null;
-  for (const line of String(patch).split('\n')) {
+  for (const line of String(patch).split(/\r?\n/)) {
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line);
     if (hunk) {
-      if (start !== null) {
-        ranges.push([start, newLine - 1]);
-        start = null;
-      }
       newLine = Number(hunk[1]);
+      out.push({ line: newLine, text: line, kind: 'hunk' });
       continue;
     }
     // `\ No newline at end of file` is diff METADATA, not a context line. Counting
@@ -144,23 +164,48 @@ export function addedLineRanges(patch) {
     // already skipped it, so the two halves disagreed about the same diff.
     if (line.startsWith('\\')) continue;
     if (line.startsWith('+') && !line.startsWith('+++')) {
-      if (start === null) start = newLine;
+      out.push({ line: newLine, text: line.slice(1), kind: 'added' });
       newLine += 1;
     } else if (line.startsWith('-') && !line.startsWith('---')) {
       // A removed line does not advance the new-file counter.
-      if (start !== null) {
-        ranges.push([start, newLine - 1]);
-        start = null;
-      }
+      out.push({ line: newLine, text: line.slice(1), kind: 'removed' });
     } else {
-      if (start !== null) {
-        ranges.push([start, newLine - 1]);
-        start = null;
-      }
+      // Strip only a leading SPACE, which is the marker a context line has.
+      // NOT the same rule as `quotableLines`, which also strips a leading `+`
+      // or `-` -- so on the ambiguous lines below the two disagree, and a
+      // consumer must not assume otherwise.
+      out.push({ line: newLine, text: line.startsWith(' ') ? line.slice(1) : line, kind: 'context' });
       newLine += 1;
     }
   }
-  if (start !== null) ranges.push([start, newLine - 1]);
+  return out;
+}
+
+/**
+ * Line ranges the PR ADDED, in NEW-FILE numbering.
+ *
+ * A run of added lines is broken by ANYTHING that is not an added line -- a
+ * removed line, a context line, a header, a hunk boundary -- which is what makes
+ * this exactly what it was before `newFileLines` was factored out of it. Merging
+ * runs across a removed line would be invisible to `lineIsAdded`, the only
+ * consumer, since that is a membership test; it would not be invisible to a
+ * caller that counts or serialises ranges, and there is no reason to leave that
+ * difference lying around.
+ *
+ * @param {string} patch a unified diff for ONE file
+ * @returns {[number, number][]}
+ */
+export function addedLineRanges(patch) {
+  const ranges = [];
+  let open = null;
+  for (const { line, kind } of newFileLines(patch)) {
+    if (kind !== 'added') {
+      open = null;
+      continue;
+    }
+    if (open) open[1] = line;
+    else ranges.push((open = [line, line]));
+  }
   return ranges;
 }
 

--- a/scripts/review/build-review-input.test.mjs
+++ b/scripts/review/build-review-input.test.mjs
@@ -18,7 +18,7 @@ import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { addedLineRanges, buildInput, isExcluded, MAX_PATCH_BYTES } from './build-review-input.mjs';
+import { addedLineRanges, newFileLines, buildInput, isExcluded, MAX_PATCH_BYTES } from './build-review-input.mjs';
 import { pageAll as pageFiles } from '../check-review-posted.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -191,4 +191,29 @@ test('the emitted input carries exactly what the reviewer may see', () => {
   // they are not in the shape at all rather than being sanitised later.
   assert.equal(r.result.title, undefined);
   assert.equal(r.result.body, undefined);
+});
+
+test('newFileLines pins the kind contract, since the JSDoc now promises one', () => {
+  // Nothing exercised `removed` or `hunk`, so a tidy-up of the walker would
+  // leave every test green and the documented contract false.
+  const patch = [
+    'diff --git a/x.md b/x.md',
+    '@@ -1,2 +1,2 @@',
+    ' ctx',
+    '-gone',
+    '+added',
+  ].join('\n');
+  const got = newFileLines(patch);
+  assert.deepEqual(got.map((l) => l.kind), ['context', 'hunk', 'context', 'removed', 'added']);
+
+  // Only a real diff marker is stripped, the way `quotableLines` does it, so a
+  // line that never had one keeps its first character.
+  assert.equal(got[0].text, 'diff --git a/x.md b/x.md');
+  assert.equal(got[1].text, '@@ -1,2 +1,2 @@');
+  assert.equal(got[2].text, 'ctx');
+
+  // A removed line carries the NEXT new-file line number, because it occupies no
+  // line in the new file at all. Reading it as a position is a trap.
+  assert.equal(got[3].line, got[4].line);
+  assert.deepEqual(addedLineRanges(patch), [[2, 2]]);
 });

--- a/scripts/review/lane-canary-fixture.json
+++ b/scripts/review/lane-canary-fixture.json
@@ -16,12 +16,12 @@
     "else changed around it; this input is frozen, so a failure means the REVIEWER",
     "changed, never the input."
   ],
-  "headSha": "canary00000000000000000000000000000000ca",
+  "headSha": "ca11ab1e00000000000000000000000000000000",
   "files": [
     {
       "path": "src/session-timeout.ts",
-      "patch": "@@ -1,6 +1,14 @@\n export function resolveTimeout(raw: string | undefined): number {\n-  return DEFAULT_TIMEOUT_MS;\n+  const timeoutMs = Number(raw);\n+  if (timeoutMs > 0) {\n+    return timeoutMs;\n+  }\n+  // Anything else falls back to closing the session immediately.\n+  return 0;\n }",
-      "addedLineRanges": [[2, 8]]
+      "patch": "@@ -1,3 +1,8 @@\n export function resolveTimeout(raw: string | undefined): number {\n-  return DEFAULT_TIMEOUT_MS;\n+  const timeoutMs = Number(raw);\n+  if (timeoutMs > 0) {\n+    return timeoutMs;\n+  }\n+  // Anything else falls back to closing the session immediately.\n+  return 0;\n }",
+      "addedLineRanges": [[2, 7]]
     }
   ],
   "unreviewable": [],

--- a/scripts/review/lane-canary.test.mjs
+++ b/scripts/review/lane-canary.test.mjs
@@ -14,16 +14,22 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { judge } from './lane-canary.mjs';
+import { readInput, quotableLines } from './validate-findings.mjs';
+import { addedLineRanges, newFileLines } from './build-review-input.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MUST = ['session-timeout', 'timeoutMs'];
+// One path, read fresh per test: a second literal is a second thing to drift.
+const FIXTURE = join(HERE, 'lane-canary-fixture.json');
+const fixture = () => JSON.parse(readFileSync(FIXTURE, 'utf8'));
 const finding = (extra = {}) => ({
   path: 'src/session-timeout.ts',
-  line: 4,
+  line: 3,
   quote: '  if (timeoutMs > 0) {',
   body: 'Number(undefined) is NaN and NaN > 0 is false, so this returns 0 and closes the session.',
   class: 'numeric-bound',
@@ -81,7 +87,7 @@ test('THE FIXTURE ACTUALLY CONTAINS THE DEFECT the canary demands be found', () 
   // If the fixture were ever edited to remove the bug, the canary would demand a
   // finding that is not there and go permanently red -- a false alarm that would
   // then be "fixed" by weakening the judge. Pin the input, not just the output.
-  const f = JSON.parse(readFileSync(join(HERE, 'lane-canary-fixture.json'), 'utf8'));
+  const f = fixture();
   const patch = f.files[0].patch;
   assert.match(patch, /Number\(raw\)/, 'the NaN source');
   assert.match(patch, /timeoutMs > 0/, 'the one-ended bound');
@@ -92,13 +98,44 @@ test('THE FIXTURE ACTUALLY CONTAINS THE DEFECT the canary demands be found', () 
   for (const m of MUST) assert.ok(JSON.stringify(f).includes(m), `fixture must contain ${m}`);
 });
 
-test('the added-line ranges cover the defect, or the validator would reject the finding', () => {
+test('the fixture\'s ranges are what the BUILDER emits, and the quote is where it says', () => {
   // `validate-findings.mjs` refuses any finding whose line falls outside an added
-  // range. A fixture whose ranges miss the defect would make a CORRECT review
-  // fail validation, and the canary would blame the reviewer.
-  const f = JSON.parse(readFileSync(join(HERE, 'lane-canary-fixture.json'), 'utf8'));
-  const [[lo, hi]] = f.files[0].addedLineRanges;
-  assert.ok(lo <= 4 && 4 <= hi, `the guard is on line 4; ranges are ${lo}..${hi}`);
+  // range, so a fixture whose ranges miss the defect makes a CORRECT review fail
+  // validation and the canary blames the reviewer.
+  //
+  // Both numbers are DERIVED, and derived from the LANE'S OWN counter. Written
+  // down by hand they were both wrong and nothing noticed: the ranges said
+  // `[[2, 8]]` where the builder emits `[[2, 7]]` -- new-file line 8 is the
+  // trailing `}`, a context line -- so the frozen fixture was LOOSER than any
+  // real review input and would have certified a finding on a line the PR never
+  // added. The quote's line was written as 4 in two places; it is 3.
+  //
+  // The first repair walked the patch here instead, which was the same mistake
+  // one level up: a second counter agrees with the builder on the easy patch it
+  // was written against and diverges on a hunk that does not start at line 1, on
+  // a second hunk, and on a file with no trailing newline -- and in each case
+  // lands INSIDE a valid range, so both assertions pass while certifying an
+  // off-by-one. `newFileLines` is now the one counter that `addedLineRanges` is
+  // itself built on.
+  const f = fixture();
+  const patch = f.files[0].patch;
+  assert.deepEqual(
+    f.files[0].addedLineRanges,
+    addedLineRanges(patch),
+    'the fixture must be a shape the builder can actually produce',
+  );
+
+  // Matched the way the LANE matches: `quotableLines` compares trimmed text and
+  // ignores diff metadata. Exact untrimmed equality here would be stricter than
+  // the gate it mirrors, so a trailing space or a CRLF fixture would redden this
+  // test while the real canary run stayed green -- a false alarm on the
+  // instrument whose whole purpose is that a fixture the pipeline refuses must
+  // not be mistaken for a reviewer that stopped working.
+  const want = finding().quote.trim();
+  const hits = newFileLines(patch).filter((l) => l.kind === 'added' && l.text.trim() === want);
+  assert.equal(hits.length, 1, 'the quote must identify exactly one ADDED line, or its position is ambiguous');
+  assert.equal(hits[0].line, finding().line, 'the finding\'s line must be where its quote actually is');
+  assert.ok(quotableLines(patch).includes(want), 'and the lane\'s own matcher must accept it');
 });
 
 test('THE CANARY RUNS THE LANE\'S REAL PIPELINE, not a shortcut past it', () => {
@@ -123,4 +160,27 @@ test('THE CANARY RUNS THE LANE\'S REAL PIPELINE, not a shortcut past it', () => 
     assert.ok(lane.includes(stage), `the lane must still use ${stage}`);
     assert.ok(canary.includes(stage), `the canary must RUN ${stage}, not merely mention it`);
   }
+});
+
+test('THE FIXTURE PASSES THE VALIDATOR THE LANE ACTUALLY RUNS, and it can still refuse', () => {
+  // The canary's third failure was a fixture the pipeline refused before the
+  // reviewer's verdict could be judged: `headSha` was `canary000...ca`, which
+  // reads well and is not hex. A fixture that cannot pass the pipeline it is fed
+  // to makes the canary permanently red for a reason that has nothing to do with
+  // the reviewer, which is how an alarm gets muted.
+  //
+  // `readInput` is called rather than re-checking the sha with a copied regex, so
+  // the assertion cannot drift from what the lane enforces. On THIS fixture the
+  // rules with teeth are the sha, non-empty `files`, and range shape; the
+  // duplicate-path and files/unreviewable-overlap rules are vacuous here because
+  // there is one file and `unreviewable` is empty. It is exercised in both
+  // directions, because an assertion that only ever sees a pass would stay green
+  // if `readInput` stopped refusing anything at all.
+  assert.doesNotThrow(() => readInput(FIXTURE));
+
+  const bad = fixture();
+  bad.headSha = 'canary00000000000000000000000000000000ca';
+  const tmp = join(mkdtempSync(join(tmpdir(), 'canary-fx-')), 'bad.json');
+  writeFileSync(tmp, JSON.stringify(bad));
+  assert.throws(() => readInput(tmp), (e) => e.reason === 'INPUT_INVALID');
 });


### PR DESCRIPTION
## Fix

#3631 made the canary run the reviewer’s real pipeline, but its frozen fixture supplied a non-hex synthetic `headSha`. The input validator therefore rejected it before the reviewer answer could be judged, making the liveness canary fail deterministically.

The fixture now uses a full 40-hex synthetic SHA. Its hunk range and quoted finding coordinate are derived from the review-input builder, and the canary tests call the real input reader for both the accepted fixture and a deliberately invalid SHA.

## Validation

- `node --test scripts/review/lane-canary.test.mjs` — 10 passing
- actual fixture accepted by `readInput`
- `git diff --check` — pass

The live incident (#3630) remains open until a dispatched canary succeeds on merged `main`.