### PR TITLE
fix(ci): keep routine workflows off metered runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,8 +27,8 @@ on:
   #
   # Deliberately much narrower than the push paths. Over the last 6 months the
   # push paths matched 447 commits and the Dockerfile alone matched ~6, so
-  # scoping to the Dockerfile is the difference between a Depot build on most
-  # PRs and roughly one a month. Source changes are already covered by
+  # scoping to the Dockerfile is the difference between a build on most PRs
+  # and roughly one a month. Source changes are already covered by
   # test.yml's "Validate Server Binary" jobs plus the post-merge build here;
   # the only unique signal this lane adds is "does the image still build".
   #
@@ -59,7 +59,9 @@ env:
 jobs:
   docker:
     name: Build & Push Docker Image
-    runs-on: depot-ubuntu-24.04-4
+    # Keep recurring image builds out of Depot's metered runner pool. This is
+    # a public repository, so GitHub's standard Ubuntu runner is free.
+    runs-on: ubuntu-latest
     # Cap a stuck "Build and push" so it can't run to GitHub's 6h default.
     # A *cold* build — cargo-chef cooking the whole workspace after a
     # deps-cache miss — is the long pole, and a cold build that gets cancelled
@@ -129,15 +131,9 @@ jobs:
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-          # Cache lives in GHCR (a `:buildcache` tag on the same package), NOT
-          # in the GitHub Actions cache. On a Depot runner `type=gha` is
-          # intercepted by Depot's cache backend and billed per-GB — with
-          # mode=max writing the multi-GB cargo-chef layer set on ~1/3 of main
-          # pushes, that was the single largest contributor to Depot's uncapped
-          # cache bill. `type=registry` writes straight to GHCR instead, which
-          # is free + unlimited for public packages, so the cache cost drops to
-          # $0 while warm builds stay fast. Trade: pushing the cache to GHCR
-          # adds ~1-3 min of network per build vs Depot's local cache.
+          # Cache lives in GHCR (a `:buildcache` tag on the same package), not
+          # in the GitHub Actions cache. `type=registry` is free for this public
+          # package and preserves the cargo-chef layers across standard runners.
           cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache
           # mode=max keeps the cargo-chef "cooked deps" stage in the cache —
           # that layer is what makes warm builds finish in minutes instead of
@@ -160,7 +156,6 @@ jobs:
           # Build arm64 only for actual releases (distribution images). On the
           # frequent push-to-main builds (~1/3 of commits touch rust/** and
           # trigger this workflow) we build amd64 only — the arm64 leg runs
-          # under slow QEMU emulation and roughly doubled build time (and, when
-          # the cache was on Depot, the cache bill too). The `latest`/sha main
+          # under slow QEMU emulation and roughly doubled build time. The `latest`/sha main
           # images stay amd64; multi-arch manifests ship on release.
           platforms: ${{ github.event_name == 'release' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,8 @@ jobs:
     # Free GitHub-hosted runner. ifc-lite is a PUBLIC repo, so standard
     # `ubuntu-latest` runners are free + unlimited (GitHub only bills public
     # repos for *larger* runners). Light jobs — path filter, lint, the gate —
-    # don't need Depot's paid cores; only the Rust/WASM-compile jobs do.
+    # don't need a larger runner; Rust/WASM compilation also stays on the
+    # standard runner so routine CI remains within the Depot Developer tier.
     # See scripts/README-vercel-cost.md for the full runner-cost rationale.
     runs-on: ubuntu-latest
     outputs:
@@ -61,9 +62,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       agents_md: ${{ steps.filter.outputs.agents_md }}
       # `true` when the WASM source is byte-identical to the published release
-      # tag, so `build` can fetch the prebuilt bundle and run on a FREE runner
-      # instead of compiling wasm32 on a paid Depot runner. See the `build`
-      # job and scripts/ci-wasm-prebuilt-eligible.sh.
+      # tag, so `build` can fetch the prebuilt bundle instead of compiling
+      # wasm32. See the `build` job and scripts/ci-wasm-prebuilt-eligible.sh.
       wasm_prebuilt: ${{ steps.wasm.outputs.eligible }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -174,10 +174,8 @@ jobs:
               # `test.yml` are subsumed by this glob; test.yml stays named
               # individually in the OTHER filters below, which this does not
               # cover. COST: a workflow-only PR now runs the JS lane. Every job
-              # it adds is on a FREE ubuntu-latest runner except `build`, which
-              # only reaches Depot when the WASM source has drifted from the
-              # published release tag -- the same condition every frontend PR
-              # already pays. Workflow-only PRs are rare (dependabot bumps).
+              # it adds is on a FREE ubuntu-latest runner. Workflow-only PRs
+              # are rare (dependabot bumps).
               - '.github/workflows/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
@@ -201,7 +199,7 @@ jobs:
               # Same trap this block warns about for `apps/`, `examples/` and
               # `.oxlintrc.json` above. It goes here rather than under `rust:`
               # because the gate is a Node step and `rust:` would additionally
-              # spin the paid Depot compile lane for a one-line JSON edit
+              # spin the WASM compile lane for a one-line JSON edit
               # (scripts/README-vercel-cost.md).
               - 'rust-major-offset.json'
               - 'tests/models/manifest.json'
@@ -246,8 +244,8 @@ jobs:
       # Decide whether `build` can skip the from-source wasm32 compile. The
       # probe emits `true` only when the WASM source is byte-identical to the
       # `@ifc-lite/wasm@<version>` release tag that produced the published
-      # bundle; any doubt emits `false` → build from source on Depot (unchanged
-      # behaviour). It can never green-light a stale bundle.
+      # bundle; any doubt emits `false` → build from source. It can never
+      # green-light a stale bundle.
       - name: Resolve prebuilt-WASM eligibility
         id: wasm
         run: echo "eligible=$(bash scripts/ci-wasm-prebuilt-eligible.sh)" >> "$GITHUB_OUTPUT"
@@ -259,16 +257,11 @@ jobs:
     name: Build packages + WASM
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
-    # Runner is chosen by whether we can skip the wasm32 compile. When the WASM
-    # source is byte-identical to the published release tag (the common case on
-    # frontend-only PRs), we fetch the prebuilt @ifc-lite/wasm bundle and run on
-    # a FREE ubuntu-latest runner — no Rust toolchain, no wasm-pack, no Swatinem
-    # rust-cache write to Depot. When Rust changed we compile from source on the
-    # paid Depot runner (needs the cores + the uncapped cargo cache), exactly as
-    # before. This is the CI twin of the scripts/vercel-install.sh fast path and
-    # attacks the single largest Depot line — the wasm32 compile on ~2/3 of PRs.
-    runs-on: ${{ needs.changes.outputs.wasm_prebuilt == 'true' && 'ubuntu-latest' || 'depot-ubuntu-24.04-4' }}
-    timeout-minutes: 20
+    # Keep all routine CI on GitHub's free standard runner. This public repo's
+    # previous 4-vCPU Depot path consumed the Developer plan's included minutes
+    # in a few days; the prebuilt bundle remains a speed optimization only.
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -294,9 +287,7 @@ jobs:
       # Rust + wasm-pack for the wasm32 build (pure-Rust CSG kernel — no
       # C++ toolchain needed since M9). Single-sourced in
       # .github/actions/setup-wasm-build so the four wasm-building
-      # workflows stay in lock-step. Skipped on the prebuilt fast path — that's
-      # where the Depot minutes AND the `ci-build` Swatinem rust-cache write to
-      # Depot both disappear.
+      # workflows stay in lock-step. Skipped on the prebuilt fast path.
       - name: Setup WASM build toolchain
         if: needs.changes.outputs.wasm_prebuilt != 'true'
         uses: ./.github/actions/setup-wasm-build
@@ -1307,13 +1298,10 @@ jobs:
     name: Rust tests
     needs: changes
     if: needs.changes.outputs.rust == 'true'
-    # Stays on Depot for the uncapped, fast cargo cache (GitHub's free cache
-    # is 10 GB LRU and would thrash the Rust target dir). Right-sized 8→4
-    # cores: Depot bills minutes × (vCPU/2), so -8 is 4× and -4 is 2× the
-    # base rate — halving per-minute cost for ~1.5× wall-clock. Timeout
-    # bumped to absorb the slower wall-clock.
-    runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 28
+    # Standard GitHub runners keep routine Rust validation out of Depot's
+    # metered pool. The longer cap accommodates a cold GitHub cache restore.
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -1418,8 +1406,9 @@ jobs:
     needs: changes
     # PR-only — see viewer-e2e.
     if: needs.changes.outputs.geometry == 'true' && github.event_name == 'pull_request'
-    runs-on: depot-ubuntu-24.04-4
-    timeout-minutes: 45
+    # This high-volume PR gate must not consume metered runner minutes.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary
- move routine Docker, WASM, Rust, and geometry CI jobs to GitHub standard Ubuntu runners
- raise cold-cache timeouts for the standard runner
- remove all executable Depot runner labels from workflows

## Verification
- YAML parse and runner-label audit pass
- pnpm test:e2e:ci: 3 passed; 2 fixture-dependent smoke tests skipped
- root pnpm test is running locally

This prevents routine GitHub Actions runner usage from exceeding the Depot Developer plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build and test workflows to use standard GitHub-hosted runners.
  - Extended workflow time limits to improve reliability for longer-running builds and tests.
  - Continued using registry-backed caching to help maintain efficient build performance.
  - Clarified release-only architecture build behavior, including arm64 builds.

- **Documentation**
  - Updated workflow guidance to describe standard runners as the default for routine checks.
  - Clarified that prebuilt WebAssembly artifacts are an optional speed optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->