### PR TITLE
docs(review): a comment claim in the builder's test is measurably false

### DIFF
--- a/scripts/review/build-review-input.mjs
+++ b/scripts/review/build-review-input.mjs
@@ -123,9 +123,33 @@ export function isExcluded(path) {
  * a hunk that does not start at line 1, on a second hunk, and on a file with no
  * trailing newline.
  *
- * Match a quote against `text` for `added` lines only. That is STRICTER than
- * `quotableLines` in validate-findings, which also accepts removed lines and
- * `diff --git` lines; the two are not the same gate.
+ * Match a quote against `text` for `added` lines only, and TRIM BOTH SIDES.
+ * That GATE is strictly stricter than `quotableLines` in validate-findings:
+ * every NON-EMPTY quote it accepts, `quotableLines` accepts too, and not the
+ * reverse. The exception is the one rule `quotableLines` has that the gate does
+ * not -- it drops what trims to empty -- so a blank added line gives a quote the
+ * gate accepts and the validator refuses.
+ *
+ * The two FUNCTIONS still differ, which matters the moment you read `text` for
+ * any other kind. `quotableLines` works on the RAW diff line: it discards
+ * anything beginning `@@`, `+++ `, `--- ` or `\`, strips one leading `+`, `-`
+ * or space from what is left, trims, and drops what is then empty.
+ * `newFileLines` classifies the line first and strips only a space from a
+ * context line. Measured on this commit:
+ *
+ *   raw          newFileLines   quotableLines
+ *   "---x"       "---x"         "--x"       strip rules differ
+ *   "--- x"      "--- x"        dropped     read as a file header
+ *   "+++i;"      "+++i;"        "++i;"      strip rules differ
+ *   "+++ i;"     "+++ i;"       dropped     read as a file header
+ *   "+--foo"     "--foo"        "--foo"     agree
+ *   "-++i;"      "++i;"         "++i;"      agree
+ *   "     deep"  "    deep"     "deep"      trimmed
+ *   " "          ""             dropped     blank
+ *
+ * A deleted `-- drop old table` becomes the raw line `--- drop old table`, and
+ * `quotableLines` refuses it outright -- worth knowing before reusing it to
+ * match anything that is not an added line.
  *
  * Splits on /\r?\n/, where the older walker split on '\n', so `text` carries no
  * trailing `\r`. That is what makes it comparable to `quotableLines`.
@@ -170,10 +194,8 @@ export function newFileLines(patch) {
       // A removed line does not advance the new-file counter.
       out.push({ line: newLine, text: line.slice(1), kind: 'removed' });
     } else {
-      // Strip only a leading SPACE, which is the marker a context line has.
-      // NOT the same rule as `quotableLines`, which also strips a leading `+`
-      // or `-` -- so on the ambiguous lines below the two disagree, and a
-      // consumer must not assume otherwise.
+      // Strip only a leading SPACE, the marker a context line carries. Not
+      // `quotableLines`' rule; see the divergences listed above.
       out.push({ line: newLine, text: line.startsWith(' ') ? line.slice(1) : line, kind: 'context' });
       newLine += 1;
     }

--- a/scripts/review/build-review-input.test.mjs
+++ b/scripts/review/build-review-input.test.mjs
@@ -206,8 +206,11 @@ test('newFileLines pins the kind contract, since the JSDoc now promises one', ()
   const got = newFileLines(patch);
   assert.deepEqual(got.map((l) => l.kind), ['context', 'hunk', 'context', 'removed', 'added']);
 
-  // Only a real diff marker is stripped, the way `quotableLines` does it, so a
-  // line that never had one keeps its first character.
+  // Only a leading SPACE is stripped, so a line that never carried a diff
+  // marker keeps its first character. This fixture cannot tell that apart from
+  // `quotableLines`' rule, which also strips `+` and `-`: no line here begins
+  // with `+` or `-` while being classified as context, and that is the only
+  // place the two strip rules can disagree.
   assert.equal(got[0].text, 'diff --git a/x.md b/x.md');
   assert.equal(got[1].text, '@@ -1,2 +1,2 @@');
   assert.equal(got[2].text, 'ctx');


### PR DESCRIPTION
Follow-up to #3635. **Comment-only: zero non-comment lines change.**

## The defect

`build-review-input.test.mjs` says the marker strip works "the way `quotableLines` does it". It does not. `quotableLines` strips a leading `+`, `-` or space; `newFileLines` strips only a space from a context line.

The test's own fixture cannot tell them apart, because `diff --git` starts with `d` and is the one input where both rules agree. So a false claim about the contract sits in the file a reader consults for it, asserted by a test that shares its blind spot.

## Four attempts at the JSDoc half were themselves wrong

Each was caught by review, by measurement:

| claim | why it was false |
|---|---|
| "accepts every removed line" | a deleted `-- drop old table` becomes raw `--- drop old table`, which `quotableLines` refuses outright |
| "accepts every context line" | false for a blank one, contradicting "drops blanks" four lines below it |
| "each rejects things the other keeps" | false, and it **replaced a true sentence** — the gate is a strict subset |
| "every quote it accepts, `quotableLines` accepts too" | false for an empty quote; my own sweep missed it because real quotes are never blank |

Every one was an unqualified quantifier about a gate whose behaviour is case-by-case. That is the shape of the fix: the prose now asserts only the relation `main` already had right — the gate is strictly stricter — plus the mechanism, and everything specific is a table with each row executed against this commit.

```
raw          newFileLines   quotableLines
"---x"       "---x"         "--x"       strip rules differ
"--- x"      "--- x"        dropped     read as a file header
"+++i;"      "+++i;"        "++i;"      strip rules differ
"+++ i;"     "+++ i;"       dropped     read as a file header
"+--foo"     "--foo"        "--foo"     agree
"-++i;"      "++i;"         "++i;"      agree
"     deep"  "    deep"     "deep"      trimmed
" "          ""             dropped     blank
```

The subset claim is now qualified and re-measured with blanks in the alphabet: **0** non-empty counterexamples, **2** blank ones, which the sentence names as the exception. The blank case is the interesting one — a patch that adds an empty line produces a quote the gate accepts and the validator refuses, so a consumer treating "my gate passed it" as a guarantee fails exactly when the model emits an empty quote.

Also corrected: the JSDoc pointed at "the ambiguous lines below", which are above it.

## Verification

- Comment-only, checked mechanically: every changed line is inside a `/** */` or `//` block.
- 176 review-pipeline tests pass.
- Every table row, the `-- drop old table` example, and the `quotableLines` mechanism description were each run against this commit rather than reasoned about.