### PR TITLE
fix(viewer): sheet title block prints the requested scale, not the actual one, on a fit-clamped drawing

### DIFF
--- a/.changeset/sheet-title-block-scale-field-not-clamped.md
+++ b/.changeset/sheet-title-block-scale-field-not-clamped.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a Drawing Sheet's title block printing the requested scale ratio instead of the actual one when the viewport fit shrinks the drawing.
+
+`sheet-types.ts`'s `calculateDrawingTransform` (`fitScale = min(scaleX, scaleY, 1)`) can shrink a drawing below its requested named scale to fit the sheet's fixed viewport. The scale bar already accounted for this — `generateSheetSVG` passes the actual `scaleFactor` to `renderTitleBlock` as `effectiveScaleFactor` — but the title block's "Scale" text field is plain static content, written once (by `sheetSlice.ts`'s `autoPopulateTitleBlock`) from the requested `sheet.scale.factor`, and was never corrected the same way. A sheet whose drawing had to be shrunk to fit the page could print e.g. "Scale: 1:100" next to a bar and a drawing both actually rendered at a materially different ratio — a silently wrong deliverable, the same defect class PR #2131 fixed for the plain (non-sheet) SVG exporter's title block.
+
+`generateSheetSVG` (`useDrawingExport.ts`) now runs the title block through `titleBlockWithEffectiveScale` (new `apps/viewer/src/hooks/titleBlockScaleField.ts`), which replaces the "scale" field's value with the actual rendered ratio whenever the fit clamp changed it, and leaves the title block untouched otherwise.

--- a/apps/viewer/src/hooks/titleBlockScaleField.ts
+++ b/apps/viewer/src/hooks/titleBlockScaleField.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { formatScaleFactorLabel, type TitleBlockConfig } from '@ifc-lite/drawing-2d';
+
+/**
+ * Correct the title block's "Scale" text field for a fit-clamped sheet.
+ *
+ * The field is plain static content: it was written once, by
+ * `sheetSlice.ts`'s `autoPopulateTitleBlock`, from the REQUESTED
+ * `sheet.scale.factor`. `calculateDrawingTransform`'s
+ * `fitScale = min(scaleX, scaleY, 1)` (`sheet-types.ts`) can shrink the
+ * drawing below that requested scale to fit the sheet's fixed viewport, and
+ * when it does, `effectiveScaleFactor` (already fed to the scale BAR as
+ * `TitleBlockExtras.effectiveScaleFactor` in `useDrawingExport.ts`) is the
+ * actual mm-per-metre the drawing was placed at. Left uncorrected, the field
+ * would keep printing the requested ratio next to a bar and a drawing
+ * rendered at a materially different one — a silently wrong deliverable, the
+ * same defect class PR #2131 fixed for the plain (non-sheet) SVG exporter's
+ * title block.
+ *
+ * Returns `titleBlock` unchanged when the drawing was not clamped (the
+ * common path incurs no allocation and never regresses a user-edited field
+ * on the un-clamped path), and a shallow copy with only the 'scale' field's
+ * `value` replaced otherwise.
+ */
+export function titleBlockWithEffectiveScale(
+  titleBlock: TitleBlockConfig,
+  requestedScaleFactor: number,
+  effectiveScaleFactor: number
+): TitleBlockConfig {
+  const nominalScaleFactor = 1000 / requestedScaleFactor;
+  if (Math.abs(effectiveScaleFactor - nominalScaleFactor) <= 1e-9) {
+    return titleBlock;
+  }
+  return {
+    ...titleBlock,
+    fields: titleBlock.fields.map((field) =>
+      field.id === 'scale'
+        ? { ...field, value: `1:${formatScaleFactorLabel(1000 / effectiveScaleFactor)}` }
+        : field
+    ),
+  };
+}

--- a/apps/viewer/src/hooks/useDrawingExport.pdfSheet.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingExport.pdfSheet.test.tsx
@@ -54,6 +54,7 @@ import {
   calculateViewportBounds,
   calculateOptimalScaleBarLength,
   calculateDrawingTransformForAxis,
+  formatScaleFactorLabel,
   type Drawing2D,
   type DrawingSheet,
 } from '@ifc-lite/drawing-2d';
@@ -676,5 +677,88 @@ describe('generateSheetSVG — pinned placement, shared with the preview', () =>
       cached: { ...held },
     });
     assert.deepEqual(after, held, 'the export path must not overwrite an existing cache entry');
+  });
+});
+
+/** The title block's "Scale" field text, read out of the rendered
+ *  `title-block-fields` group. The field's `<text>` label ("Scale") is
+ *  immediately followed by its value `<text>` — see
+ *  `title-block-renderer.ts`'s `renderTitleBlockFields`. */
+function parseTitleBlockScaleFieldText(svg: string): string {
+  const match = svg.match(/fill="#666666">Scale<\/text>\s*<text[^>]*>([^<]*)<\/text>/);
+  assert.ok(match, `expected a "Scale" title-block field in the exported sheet svg; got:\n${svg.slice(0, 2000)}`);
+  return match[1];
+}
+
+/** A drawing 1000m wide — far beyond what any sheet viewport can hold at a
+ *  requested named scale, so `calculateDrawingTransform`'s
+ *  `fitScale = min(scaleX, scaleY, 1)` (sheet-types.ts) must shrink it well
+ *  below the requested ratio to fit the fixed viewport. */
+function buildOversizedDrawing(): Drawing2D {
+  return {
+    ...buildDrawing(),
+    bounds: { min: { x: 0, y: 0 }, max: { x: 1000, y: 0 } },
+  };
+}
+
+/** `buildSheet()` reuses `DEFAULT_TITLE_BLOCK_FIELDS` verbatim, whose
+ *  'scale' field carries the hardcoded placeholder value `'1:100'`
+ *  (title-block-types.ts). Production sheets instead carry whatever
+ *  `sheetSlice.ts`'s `autoPopulateTitleBlock` wrote (`1:${scale.factor}`,
+ *  called when a project loads) — reproduce that here so the fixture
+ *  matches what a real sheet's title block actually holds, rather than
+ *  coincidentally matching (or missing) the '1:100' placeholder. */
+function withPopulatedScaleField(sheet: DrawingSheet): DrawingSheet {
+  return {
+    ...sheet,
+    titleBlock: {
+      ...sheet.titleBlock,
+      fields: sheet.titleBlock.fields.map((f) =>
+        f.id === 'scale' ? { ...f, value: `1:${sheet.scale.factor}` } : f
+      ),
+    },
+  };
+}
+
+describe('generateSheetSVG — title block "Scale" field vs. a fit-clamped drawing', () => {
+  it('prints the ACTUAL rendered ratio, not the requested one, when the viewport fit shrinks the drawing', async () => {
+    // Requested 1:100 on A3 landscape cannot hold a 1000m-wide drawing —
+    // `calculateDrawingTransform`'s fit clamp shrinks it. The scale BAR
+    // (`renderScaleBarInTitleBlock`, fed `effectiveScaleFactor`) already
+    // reflects that shrink; the field text populated once by
+    // `sheetSlice.ts`'s `autoPopulateTitleBlock` (`1:${scale.factor}`) does
+    // not — it is static content passed straight through to
+    // `renderTitleBlock`, unrelated to the transform actually used.
+    const sheet = withPopulatedScaleField(buildSheet('A3_LANDSCAPE', 100, '1:100'));
+    const drawing = buildOversizedDrawing();
+    const { svg } = await exportPdfForSheet(sheet, drawing);
+
+    const expected = calculateDrawingTransformForAxis(
+      { minX: drawing.bounds.min.x, minY: drawing.bounds.min.y, maxX: drawing.bounds.max.x, maxY: drawing.bounds.max.y },
+      sheet.viewportBounds,
+      sheet.scale,
+      false,
+    );
+    // Sanity: the fixture actually triggers the clamp this test targets.
+    const nominalScaleFactor = 1000 / sheet.scale.factor;
+    assert.ok(
+      expected.scaleFactor < nominalScaleFactor * 0.5,
+      `fixture does not exercise the fit clamp (effective ${expected.scaleFactor} vs nominal ${nominalScaleFactor} mm/m) — strengthen it`,
+    );
+    const expectedLabel = `1:${formatScaleFactorLabel(1000 / expected.scaleFactor)}`;
+
+    const printed = parseTitleBlockScaleFieldText(svg);
+    assert.equal(
+      printed,
+      expectedLabel,
+      `title block prints "${printed}" but the drawing was actually rendered at ${expectedLabel} — a silently wrong scale on the sheet`,
+    );
+    assert.notEqual(printed, sheet.scale.name, 'the requested (unclamped) label must not survive onto a clamped sheet');
+  });
+
+  it('control: prints the requested scale unchanged when the drawing fits without clamping', async () => {
+    const sheet = withPopulatedScaleField(buildSheet('A3_LANDSCAPE', 50, '1:50'));
+    const { svg } = await exportPdfForSheet(sheet); // buildDrawing()'s default 4m span fits comfortably
+    assert.equal(parseTitleBlockScaleFieldText(svg), '1:50');
   });
 });

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -39,6 +39,7 @@ import { downloadDxf } from '@/hooks/dxfDownload';
 import { DEFAULT_SCAN_SVG_CAP, type ScanBandPoint } from '@/hooks/scanSectionMath';
 import { computeSvgExportViewport, svgExportMmToWorld } from '@/hooks/svgExportViewport';
 import { makePropertiesGetter } from '@/hooks/drawingElementProperties';
+import { titleBlockWithEffectiveScale } from '@/hooks/titleBlockScaleField';
 
 /** Map a DXF vertical justification onto an SVG dominant-baseline. */
 function dxfValignToBaseline(valign: 'baseline' | 'bottom' | 'middle' | 'top'): string {
@@ -947,8 +948,10 @@ function useDrawingExport({
       scale: activeSheet.scale,
       effectiveScaleFactor: scaleFactor,
     };
+    // Correct the "Scale" field for a viewport-fit-clamped sheet (#2131's
+    // defect class; see titleBlockScaleField.ts).
     const titleBlockResult = renderTitleBlock(
-      activeSheet.titleBlock,
+      titleBlockWithEffectiveScale(activeSheet.titleBlock, activeSheet.scale.factor, scaleFactor),
       frameResult.innerBounds,
       activeSheet.revisions,
       titleBlockExtras


### PR DESCRIPTION
## Sheet-composition verdict (drawing-2d lens)

| Check | Verdict |
|---|---|
| Scale bar vs. viewport transform | Correct — `renderScaleBarInTitleBlock` is fed `effectiveScaleFactor` (the actual `scaleFactor` from `resolveSheetTransform`/`calculateDrawingTransform`), so the drawn bar always matches the real transform. |
| Scale-bar division lengths (`scale-stamp.ts` / `title-block-renderer.ts`) | Correct — reviewed, already covered by extensive existing tests (`scale-stamp.ts`, `title-block-scale-bar.test.ts`). |
| **Title block "Scale" text field vs. actual rendered ratio** | **Wrong** — printed the *requested* ratio unconditionally; see fix below. |
| Coordinate/unit handling (mm/m authoring) | Correct — `computeTransform`/`calculateDrawingTransform` derive `worldToMm`/`scaleFactor` uniformly from metres; no unit-scale defect found. |
| SVG escaping (title block, DXF underlay text) | Correct — `escapeXml` applied to every text run. |
| Non-finite coordinates | Correct — `finiteOr0`/`svgNum` already guard both the plain SVG exporter and the sheet path. |
| Frame/margins per paper size | Correct — pinned by `sheet-types.test.ts` / `paper-sizes.test.ts` across the ISO 216 table. |
| Y-axis / orientation, per-axis flip (down/front/side) | Correct — `calculateDrawingTransformForAxis`, exercised for all three axes in `useDrawingExport.pdfSheet.test.tsx`. |

## The one fix

`sheet-types.ts`'s `calculateDrawingTransform` (`fitScale = min(scaleX, scaleY, 1)`) can shrink a drawing below its **requested** named scale to fit the sheet's fixed viewport — this is a documented, deliberate behaviour (see the file's own comments) that exists precisely so a to-scale sheet is never silently wrong.

The scale **bar** already accounts for this: `generateSheetSVG` (`useDrawingExport.ts`) passes the transform's actual `scaleFactor` into `renderTitleBlock` as `TitleBlockExtras.effectiveScaleFactor`, and `renderScaleBarInTitleBlock` draws from it.

The title block's **"Scale" text field**, however, is plain static content — written once by `sheetSlice.ts`'s `autoPopulateTitleBlock` (`value: \`1:${scale.factor}\``) from the *requested* scale — and `generateSheetSVG` passed it straight through to `renderTitleBlock` unmodified. When the fit clamp fires, the printed field kept saying e.g. "Scale: 1:100" next to a bar (and a drawing) both actually rendered at a materially different ratio — the same silently-wrong-deliverable defect class PR #2131 already fixed for the plain (non-sheet) SVG exporter's title block.

**Fix**: `generateSheetSVG` now runs the title block through a new `titleBlockWithEffectiveScale` helper (`apps/viewer/src/hooks/titleBlockScaleField.ts`), which replaces the `'scale'` field's value with the actual rendered ratio (`formatScaleFactorLabel`) whenever the fit clamp changed it, and returns the title block untouched on the common (non-clamped) path.

### RED / GREEN

Added to `useDrawingExport.pdfSheet.test.tsx` (exercises the real `handleExportPDF` → `generateSheetSVG` → `renderTitleBlock` path, the same production path SVG/Print/PDF sheet export all share):

- **RED** (on `upstream/main`): a 1000m-wide drawing on an A3/1:100 sheet forces the fit clamp to an effective ~1:2845 — the field still printed `"1:100"`.
- **GREEN**: the field now prints `"1:2844.95"` (the real ratio the drawing was placed at).
- **Control**: an un-clamped sheet (drawing comfortably fits at 1:50) still prints the requested `"1:50"` unchanged — no regression on the common path.

### Reachability

Every consumer of `generateSheetSVG` (SVG export, Print, and the vector-free "Drawing Sheet" PDF path in `handleExportPDF`) goes through this one function, so the fix applies uniformly. The defect is real whenever a section/plan's extent exceeds what the sheet's fixed viewport can hold at the user's chosen named scale — not a contrived edge case; any oversized section on a small paper size at a "round" scale reaches it.

### Verification (foreground)

- `node scripts/check-module-size.mjs` — clean (extracted the fix into a sibling module, `titleBlockScaleField.ts`, to stay under `useDrawingExport.ts`'s allowlisted budget)
- `pnpm run check:vitest-timeout-audit` — clean
- `node scripts/check-test-wiring.mjs` — clean
- `node scripts/check-unused-locals.mjs` — clean
- `pnpm typecheck` — clean (87/87 tasks)
- `pnpm --filter @ifc-lite/drawing-2d test` — 550/550 passing (untouched)
- `useDrawingExport.pdfSheet.test.tsx` + 3 sibling `useDrawingExport.*.test.tsx` files — 28/28 passing
- Changeset added for `@ifc-lite/viewer` (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
