### PR TITLE
fix(drawing-2d): mirror DXF underlay placement offset/rotation to match SVG/viewer

### DIFF
--- a/.changeset/dxf-underlay-placement-mirrored.md
+++ b/.changeset/dxf-underlay-placement-mirrored.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/drawing-2d': patch
+---
+
+Fix `DXFExporter`'s `underlays` option applying a `DxfPlacement`'s offset/rotation with the opposite sign from every other consumer of the same type.
+
+`DxfPlacement` is documented as drawing space (+Y down): "Offset in metres (drawing space)", "counter-clockwise as seen on a plan view". `svg-exporter.ts`'s underlay mapping and the viewer's `dxfUnderlayMath.ts` (`worldToDrawing`, driving the 2D canvas and the 3D reference overlay) both negate Y before calling `applyDxfPlacement`, then negate back for a world-space output — so the same placement value produces the same visual result everywhere. `dxf-exporter.ts`'s `writeUnderlay` called `applyDxfPlacement` directly on world-space (+Y up) points, skipping that round trip: a placed underlay with a non-zero `offsetY` shifted north instead of south, and a non-zero `rotationDeg` spun clockwise instead of counter-clockwise — a silently mirrored underlay in the exported DXF, diverging from what the SVG export and the viewer itself show for the identical placement.
+
+Not reachable through the current viewer UI — its DXF export explicitly does not embed underlays yet (see `useDrawingExport.ts`'s `handleExportDXF`) — but `DXFExporter.export`'s `underlays` option is documented and exercised by the package's own README example and test suite, and is public API for any direct consumer of `@ifc-lite/drawing-2d`.

--- a/packages/drawing-2d/src/dxf-exporter.test.ts
+++ b/packages/drawing-2d/src/dxf-exporter.test.ts
@@ -202,16 +202,69 @@ describe('DXFExporter', () => {
     expect(texts[0].text).toBe('A');
     expect(texts[0].x).toBeCloseTo(0);
     expect(texts[0].y).toBeCloseTo(0);
-    // Local second-line anchor (0, -2.6), scaled by 2 then rotated 90deg
-    // clockwise (applyDxfPlacement: x' = x c + y s, y' = -x s + y c):
-    // (0, -5.2) -> (-5.2, 0). The old output-space offset would have put it
-    // at (0, -2.6).
+    // `DxfPlacement.rotationDeg` is documented as "counter-clockwise as seen
+    // on a plan view" (drawing/screen space, +Y down) — the same convention
+    // `applyDxfPlacement` implements directly and every OTHER consumer
+    // (svg-exporter.ts's underlay mapping, dxfUnderlayMath.ts's
+    // worldToDrawing) applies by negating Y, calling `applyDxfPlacement`,
+    // then negating back for a world-space (+Y up) output. Local
+    // second-line anchor (0, -2.6): negate Y -> (0, 2.6), scale by 2 ->
+    // (0, 5.2), rotate 90 deg CCW-as-seen-on-plan (applyDxfPlacement:
+    // x' = x c + y s, y' = -x s + y c) -> (5.2, 0), negate Y back -> (5.2, 0).
     expect(texts[1].text).toBe('B');
-    expect(texts[1].x).toBeCloseTo(-5.2);
+    expect(texts[1].x).toBeCloseTo(5.2);
     expect(texts[1].y).toBeCloseTo(0);
     // Glyph height follows the placement scale, like the SVG exporter.
     expect(texts[0].height).toBeCloseTo(4);
     expect(texts[1].height).toBeCloseTo(4);
+  });
+
+  it('applies underlay placement offset/rotation in the same sense as every other DxfPlacement consumer (world Y-up, not mirrored)', () => {
+    // `DxfPlacement` is documented as drawing space (+Y down): "Offset in
+    // metres (drawing space)" / "counter-clockwise as seen on a plan view".
+    // `svg-exporter.ts` and `dxfUnderlayMath.ts`'s `worldToDrawing` both
+    // negate Y before calling `applyDxfPlacement` (world +Y-up -> drawing
+    // +Y-down) so the SAME placement value produces the SAME visual result
+    // in the 2D canvas, the 3D overlay, and SVG export. The DXF exporter
+    // must match: it stays in world space (+Y up, no final flip — see the
+    // module docs), so it needs the negate/placement/negate-back round trip.
+    const offsetOnly = underlay();
+    offsetOnly.layers[0].texts = [];
+    offsetOnly.layers[0].paths = [{ points: [{ x: 0, y: 0 }, { x: 1, y: 0 }], closed: false }];
+    const offsetDxf = exportToDXF(emptyDrawing(), {
+      underlays: [{
+        underlay: offsetOnly,
+        placement: { offsetX: 0, offsetY: 10, rotationDeg: 0, scale: 1 },
+      }],
+    });
+    const offsetLine = parseDxf(offsetDxf).entities.find(
+      (e): e is DxfPolylineEntity => e.kind === 'polyline',
+    )!;
+    // A drawing-space offsetY of +10 shifts the underlay SOUTH (world -Y),
+    // matching worldToDrawing's `y: -(world.y - shiftY)` sign convention —
+    // not north (+Y), which is what applying the placement to the raw
+    // world point without the Y round trip would produce.
+    expect(offsetLine.vertices[0].y).toBeCloseTo(-10);
+    expect(offsetLine.vertices[1].y).toBeCloseTo(-10);
+
+    const rotateOnly = underlay();
+    rotateOnly.layers[0].texts = [];
+    // A single east-pointing (+X) segment.
+    rotateOnly.layers[0].paths = [{ points: [{ x: 0, y: 0 }, { x: 1, y: 0 }], closed: false }];
+    const rotateDxf = exportToDXF(emptyDrawing(), {
+      underlays: [{
+        underlay: rotateOnly,
+        placement: { offsetX: 0, offsetY: 0, rotationDeg: 90, scale: 1 },
+      }],
+    });
+    const rotatedLine = parseDxf(rotateDxf).entities.find(
+      (e): e is DxfPolylineEntity => e.kind === 'polyline',
+    )!;
+    // A 90-degree "counter-clockwise as seen on a plan view" rotation turns
+    // an east-pointing (+X) segment to point north (+Y) — not south (-Y),
+    // which a mirrored (clockwise) rotation would produce.
+    expect(rotatedLine.vertices[1].x).toBeCloseTo(0, 5);
+    expect(rotatedLine.vertices[1].y).toBeCloseTo(1);
   });
 
   it('honours underlay per-layer visibility overrides', () => {

--- a/packages/drawing-2d/src/dxf-exporter.ts
+++ b/packages/drawing-2d/src/dxf-exporter.ts
@@ -167,9 +167,23 @@ export class DXFExporter {
   ): void {
     const { underlay, placement = DEFAULT_DXF_PLACEMENT, layerVisibility = {} } = options;
     // Underlay points are already in world plan coordinates (metres, +Y
-    // north) — the same convention DXF itself uses, so (unlike SVG, which
-    // is +Y down) no sign flip is needed before the placement transform.
-    const mapPoint = (p: Point2D): Point2D => map(applyDxfPlacement(p, placement));
+    // north) — the same convention DXF itself uses, so unlike SVG (+Y
+    // down), the FINAL output needs no sign flip relative to world space.
+    // But `applyDxfPlacement` itself is defined in DRAWING space (+Y down —
+    // see `DxfPlacement`'s docs: "Offset in metres (drawing space)",
+    // "counter-clockwise as seen on a plan view"): every other consumer
+    // (`svg-exporter.ts`'s underlay mapping, `dxfUnderlayMath.ts`'s
+    // `worldToDrawing`) negates Y, applies the placement, and — for
+    // consumers that stay in world space — negates Y back. Calling
+    // `applyDxfPlacement` directly on a world-space (+Y up) point skips
+    // that round trip, so a non-zero `offsetY` lands with the opposite
+    // sign and a non-zero `rotationDeg` spins the opposite direction from
+    // what the same `placement` produces everywhere else (2D canvas, 3D
+    // overlay, SVG export) — a silently mirrored underlay in the DXF.
+    const mapPoint = (p: Point2D): Point2D => {
+      const drawingSpace = applyDxfPlacement({ x: p.x, y: -p.y }, placement);
+      return map({ x: drawingSpace.x, y: -drawingSpace.y });
+    };
     const underlayPrefix = `DXF_${underlay.name}`;
 
     for (const dxfLayer of underlay.layers) {


### PR DESCRIPTION
## Summary

`DXFExporter`'s `underlays` export option placed a `DxfPlacement` (offset/rotation) with the opposite sign from every other consumer of that same type — a silently mirrored underlay in the exported DXF for any non-zero `offsetY` or `rotationDeg`.

## Verdict table

| Scenario | Emitted (before) | Spec/convention-correct |
|---|---|---|
| DXF is well-formed (SECTION/ENDSEC pairs, EOF, group codes) | Correct | Correct — no defect found |
| Coordinates, no `NaN`/`Infinity`, `.` decimal, no locale comma | Correct (`fmt()` guards non-finite -> `0.0`, `toFixed(6)`) | Correct — no defect found |
| Layers (group 8) declared in TABLES, hidden lines on dashed layer | Correct | Correct — no defect found |
| TEXT escaping / non-ASCII (R12 `$DWGCODEPAGE ANSI_1252`) | Correct — fixed in #3570 | Correct |
| Main drawing geometry Y-orientation (`drawing.lines`/`cutPolygons`) | Correct — `Drawing2D` is native Y-up, matching DXF; no flip needed (verified against `svg-transform.ts`'s explicit flip for the *screen* path) | Correct — no defect found |
| **Underlay placement (`offsetY`, `rotationDeg`) on `DXFExportOptions.underlays`** | **`offsetY=10` shifts the underlay NORTH (+Y); `rotationDeg=90` rotates CLOCKWISE** | **Per `DxfPlacement`'s own docs ("drawing space", "CCW as seen on a plan view") and every other consumer, `offsetY=10` must shift SOUTH (-Y); `rotationDeg=90` must rotate CCW** |

## Root cause

`DxfPlacement` is documented as drawing space (+Y down): "Offset in metres (drawing space)", "Rotation in degrees, counter-clockwise as seen on a plan view." `applyDxfPlacement`'s own rotation formula is built for that convention (its docstring: "the transposed rotation matrix" because "drawing space renders with +y downward on screen").

Every consumer that needs a *world-space* (+Y up) result negates Y before calling `applyDxfPlacement`, then negates back:
- `svg-exporter.ts` (underlay mapping): `applyDxfPlacement({ x: p.x, y: -p.y }, placement)`
- `apps/viewer/src/hooks/dxfUnderlayMath.ts`'s `worldToDrawing` (drives the 2D canvas and the 3D reference overlay): negates Y before `applyDxfPlacement`

`packages/drawing-2d/src/dxf-exporter.ts`'s `writeUnderlay` called `applyDxfPlacement(p, placement)` directly on the underlay's raw world-space (+Y north) points — skipping that round trip. The comment above it reasoned only about the *final* output convention (DXF, like world space, needs no flip vs. SVG's screen space) and missed that `applyDxfPlacement` itself is Y-down internally.

Confirmed analytically and by test: for `placement = { offsetY: 10, rotationDeg: 0 }`, a world point `(0,0)` came out at `(0, 10)` (shifted north) instead of `(0, -10)` (south, matching every other consumer). For `rotationDeg: 90`, an east-pointing `(1,0)` segment came out pointing south `(0,-1)` instead of north `(0,1)` (CCW as documented).

## Fix

`writeUnderlay`'s `mapPoint` now negates Y, applies the placement, and negates back — the same pattern `svg-exporter.ts` and `dxfUnderlayMath.ts` already use.

## RED/GREEN

- **RED** (unmodified `upstream/main`): the new tests, and the existing rotated multi-line-text test (which had enshrined the mirrored math as "expected"), fail — `offsetY=10` case: expected `-10`, got `10`; rotation case: expected the segment tip at `(0,1)`, got `(0,-1)`.
- **GREEN**: all 14 tests in `dxf-exporter.test.ts` pass (one test split into two assertions); full `packages/drawing-2d` suite (551 tests) passes; `tsc --noEmit` clean.
- **Control**: a valid, unplaced underlay (identity placement) and non-underlay geometry (drawing lines/cut-polygon hatching) are byte-identical before/after — only the placement math path changed.

## Reachability (honest)

Not reachable through the current viewer UI: `apps/viewer/src/hooks/useDrawingExport.ts`'s `handleExportDXF` explicitly does not pass `underlays` to `exportToDXF` ("DXF reference underlays are not embedded in this export; see PR notes"). It IS reachable through `@ifc-lite/drawing-2d`'s public, documented API — `DXFExporter.export`'s `underlays` option, shown in the package README's usage example, and exercised by the package's own test suite (which is what caught it, after correcting the test's own wrong expectation).

## Test plan
- [x] `packages/drawing-2d`: `npx vitest run` — 43 files, 551 tests pass
- [x] `packages/drawing-2d`: `npx tsc --noEmit` — clean
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — no regression
- [x] `node scripts/check-unused-locals.mjs` — drawing-2d compiles standalone, no regression
- [x] Changeset added (`@ifc-lite/drawing-2d`, patch)
