### PR TITLE
fix(export): blank FILE_DESCRIPTION in exportAnonymizedSubset instead of carrying the source header verbatim

### DIFF
--- a/.changeset/anonymize-header-description-leak.md
+++ b/.changeset/anonymize-header-description-leak.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+`exportAnonymizedSubset` blanks the STEP header's `author`/`organization`/`authorization` fields outright, but left `FILE_DESCRIPTION` unset — which falls through to `buildStepHeader`'s own default of carrying the SOURCE file's description items verbatim when no explicit value is given. An authoring tool's free-text `Comment [...]` item there (a project or client name, a contact address) survived every anonymized export unscrubbed, alongside the header fields right next to it that were already blanked. `description` is now blanked the same unconditional way as the other header identity fields.

--- a/packages/export/src/anonymize-export.test.ts
+++ b/packages/export/src/anonymize-export.test.ts
@@ -357,6 +357,26 @@ describe('exportAnonymizedSubset — full-subset export invariants (#2934 A6)', 
     expect(parseSourceHeader(result.content)!.originatingSystem).toBe('Source Originating System');
   });
 
+  it('blanks header FILE_DESCRIPTION instead of carrying the source items verbatim', async () => {
+    // Same fixture, only the header's FILE_DESCRIPTION swapped for one
+    // carrying identifying free text — the shape an authoring tool's
+    // "Comment" field actually takes (project/client name, a contact
+    // address), same class of signal as the author/organization/
+    // authorization fields the sibling test above already proves blanked.
+    const identifyingDescriptionModel = FIXTURE_MODEL.replace(
+      "FILE_DESCRIPTION((''),'2;1');",
+      "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]',"
+        + "'Comment [Property of Umbriel Nyx, contact nyx.umbriel@example-fictitious.test]'),'2;1');",
+    );
+    const store = await parse(identifyingDescriptionModel);
+    const result = exportAnonymizedSubset(store, FULL_INCLUDED_IDS, { guidRandom: seededRandom(7) });
+    const out = parseSourceHeader(result.content);
+    expect(out).not.toBeNull();
+    const description = out!.description.join(' ');
+    expect(description).not.toContain('Umbriel Nyx');
+    expect(description).not.toContain('nyx.umbriel@example-fictitious.test');
+  });
+
   it('is deterministic and byte-identical across two independent runs with the same seed', async () => {
     const opts: AnonymizeOptions = { guidRandom: seededRandom(42), timeStamp: '2024-01-01T00:00:00' };
     const storeA = await parse(FIXTURE_MODEL);

--- a/packages/export/src/anonymize-export.ts
+++ b/packages/export/src/anonymize-export.ts
@@ -281,13 +281,21 @@ export function exportAnonymizedSubset(
     // Header scrub per the decision doc: author/organization/authorization
     // blanked outright (never inherited from the source header — an empty
     // string is a deliberate override, not "no override", per
-    // `step-header.ts`'s `??` wiring). `originating_system` is blanked under
-    // `scrubOwnerHistory` (a vendor build string such as `26.0.0 NOR FULL`
-    // encodes the licence region); `preprocessor_version` comes from
-    // `application`, left unset here (defaults to 'ifc-lite').
+    // `step-header.ts`'s `??` wiring). `description` gets the same
+    // unconditional override: `buildStepHeader` falls through to the SOURCE
+    // FILE_DESCRIPTION items verbatim whenever this orchestrator leaves
+    // `description` undefined — an authoring tool's free-text
+    // "Comment [...]" item there is exactly as identifying as the
+    // author/organization fields beside it, so it is blanked the same way,
+    // not merely left to whatever the source happened to carry.
+    // `originating_system` is blanked under `scrubOwnerHistory` (a
+    // vendor build string such as `26.0.0 NOR FULL` encodes the licence
+    // region); `preprocessor_version` comes from `application`, left unset
+    // here (defaults to 'ifc-lite').
     author: '',
     organization: '',
     authorization: '',
+    description: '',
     ...((options.scrubOwnerHistory ?? true) ? { originatingSystem: '' } : {}),
     timeStamp: options.timeStamp,
     guidRandom: options.guidRandom,


### PR DESCRIPTION
## Anonymize completeness lens

Coverage check of `exportAnonymizedSubset` (`packages/export/src/anonymize-export.ts` and the modules it calls) against every PII-bearing field the feature's own doc comments claim to scrub:

| Field | Scrubbed? |
|---|---|
| `IfcPerson` (FamilyName/GivenName/MiddleNames/PrefixTitles/SuffixTitles/Roles/Addresses) | Yes — `scrubPerson`, whole model, not just `includedIds` |
| `IfcOrganization` (Name/Description/Roles/Addresses) | Yes — `scrubOrganization`, whole model |
| `IfcPersonAndOrganization.Roles` | Yes |
| `IfcOwnerHistory` (CreationDate/LastModifiedDate) | Yes |
| `IfcApplication.Version` | Yes (Name/Identifier kept by design — debugging signal) |
| `IfcPostalAddress` / `IfcTelecomAddress` | Yes — unconditionally excluded from the export closure (`IDENTIFYING_TYPES`), not merely reference-nulled |
| `IfcSite`/`IfcBuilding` georeferencing + address slots | Yes |
| `IfcMapConversion`/`IfcProjectedCRS`/`IfcGeographicCRS` | Yes |
| `IfcActorRole` | Yes |
| Product `Name`/`Description`/`LongName`/`Tag`/`ObjectType`/etc. | Yes — `pseudonymizeNames`/`pseudonymizeAllNames` |
| `GlobalId` | Yes — regenerated by default, mapping returned out-of-band |
| `IfcMonetaryUnit.Currency` | Yes — neutralized to USD |
| STEP header `author`/`organization`/`authorization` | Yes |
| STEP header `originating_system` (build string) | Yes, under `scrubOwnerHistory` |
| **STEP header `FILE_DESCRIPTION`** | **No — this PR** |
| Property/quantity values | Deliberately out of scope — psets are dropped entirely by default (`keepPropertySets: false`); the doc comment states values are "unscrubbed by design" when kept |

## The one fix

`buildStepHeader` (`packages/export/src/step-header.ts`) falls through to the SOURCE file's `FILE_DESCRIPTION` items verbatim whenever the caller leaves `description` unset:

```ts
const description: string[] =
  options.description !== undefined
    ? [options.description]
    : sourceHeader && sourceHeader.description.length > 0
      ? [...sourceHeader.description]
      : ['Exported from ifc-lite'];
```

`exportAnonymizedSubset` blanks `author`/`organization`/`authorization` outright for exactly this reason (the decision-doc comment right above the call site), but never set `description`. Some authoring tools put free text in `FILE_DESCRIPTION`'s "Comment [...]" item — a project or client name, a contact address — carrying the same class of identifying signal as the fields right next to it that were already scrubbed. That text survived every anonymized export unmodified.

**RED** (on unmodified `upstream/main`): new test in `anonymize-export.test.ts` builds a fixture whose `FILE_DESCRIPTION` carries `'Comment [Property of Umbriel Nyx, contact nyx.umbriel@example-fictitious.test]'` and asserts the anonymized output's header does not contain that text — fails, header round-trips it byte-for-byte.

**GREEN**: `exportAnonymizedSubset` now passes `description: ''` to `StepExporter.export()` alongside `author`/`organization`/`authorization`, the same unconditional-override treatment.

**Control**: the existing header test (`'blanks header author/organization/authorization, keeps originating_system...'`) and the rest of the `anonymize-export.test.ts` / `anonymize-scrub.test.ts` / `anonymize-placement.test.ts` suites (54 tests) still pass unchanged — already-anonymized fields stay anonymized, and geometry/relationship data the feature preserves is untouched.

Reachable via `ifc-lite anonymize <file> --out F` (the CLI command) and the viewer's anonymized-export dialog, both thin wrappers over `exportAnonymizedSubset`.

## Verification (foreground)
- `packages/export`: `vitest run` — 1057 passed, 34 skipped (1 pre-existing unrelated wasm-resolution failure in `lod1-generator.test.ts`, reproduces on clean `upstream/main`)
- `packages/cli`: `vitest run` — 570 passed, 8 skipped
- `pnpm exec tsc --noEmit -p packages/export/tsconfig.json` — clean
- `pnpm exec tsc --noEmit -p packages/cli/tsconfig.json` — clean
- `typecheck-tests.mjs` (packages/export) — OK
- `node scripts/check-module-size.mjs` — OK, no new files over budget
- `pnpm run check:vitest-timeout-audit` — no regressions
- `node scripts/check-test-wiring.mjs` — OK
- `node scripts/check-unused-locals.mjs` — pre-existing failures (apps/viewer, apps/viewer-embed, packages/embed-sdk, packages/source-*) reproduce identically on clean `upstream/main`; unrelated to this change
- No `@ifc-lite/export` index export changed — no api-surface bump needed
- Changeset added: `.changeset/anonymize-header-description-leak.md` (patch, `@ifc-lite/export`)

`unqueued` — hunt-originated (anonymize completeness lens), not tied to a specific `ready` issue.