### PR TITLE
fix(export): skip a non-finite mesh in the OBJ exporter instead of writing it

### DIFF
--- a/.changeset/obj-export-skip-nonfinite-mesh.md
+++ b/.changeset/obj-export-skip-nonfinite-mesh.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+The Wavefront OBJ exporter (`export_obj` / `exportObj`) now skips a mesh carrying a non-finite (`NaN`/`Infinity`) position, normal, or per-mesh origin instead of writing it into the `.obj` text verbatim. OBJ's `v`/`vn` tokens have no lexical form for a non-finite number, and because the exporter folds the per-mesh origin into every position, a single non-finite origin poisoned every vertex of that mesh. This mirrors `usd::mesh_emittable`, the sibling from-bytes exporter over the same `process_geometry` source, and the from-meshes `mesh_input::scrub_nonfinite` gate already applied to GLB/COLLADA/KMZ.

--- a/rust/export/src/obj.rs
+++ b/rust/export/src/obj.rs
@@ -56,7 +56,26 @@ fn mesh_visible(mesh: &MeshData, isolated: &[u32], hidden: &[u32]) -> bool {
     if !isolated.is_empty() && !isolated.contains(&mesh.express_id) {
         return false;
     }
-    !mesh.indices.is_empty() && mesh.positions.len() >= 9
+    if mesh.indices.is_empty() || mesh.positions.len() < 9 {
+        return false;
+    }
+    // OBJ's `v`/`vn` tokens have no lexical form for a non-finite number (unlike
+    // `mesh_input::scrub_nonfinite`'s target formats, nothing here even reads
+    // "nan"/"inf" back as a number), and this exporter folds `mesh.origin` into
+    // every position before writing it, so a non-finite origin would poison every
+    // otherwise-good vertex in the mesh. `process_geometry` can hand back such a
+    // value only for a derived quantity like the mid-vertex normal of a
+    // zero-area face (see `usd::fmt::fmt_f32`'s comment on the same source).
+    // Gate the whole mesh out rather than write a token no reader accepts —
+    // mirrors `usd::mesh_emittable`, the sibling from-bytes exporter over the
+    // same `process_geometry` output.
+    if !mesh.origin.iter().all(|v| v.is_finite()) || !mesh.positions.iter().all(|v| v.is_finite()) {
+        return false;
+    }
+    if mesh.normals.len() == mesh.positions.len() && !mesh.normals.iter().all(|v| v.is_finite()) {
+        return false;
+    }
+    true
 }
 
 /// Export the render geometry in `content` (raw IFC/STEP bytes) as a Wavefront OBJ string.
@@ -223,5 +242,61 @@ mod tests {
         // reversal unobservable; assert the fixture is not that degenerate case.
         assert_ne!(tri[1], tri[2], "fixture triangle must distinguish b from c");
         assert_eq!(first_face, expected, "OBJ must emit a, c, b — winding reversed");
+    }
+
+    /// A minimal, otherwise-valid mesh — mirrors the fixture in
+    /// `usd::tests::mesh_emittable_rejects_pathological_meshes`.
+    fn good_mesh() -> MeshData {
+        MeshData {
+            express_id: 1,
+            ifc_type: "IfcWall".into(),
+            global_id: None,
+            name: None,
+            presentation_layer: None,
+            positions: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+            indices: vec![0, 1, 2],
+            color: [0.5, 0.5, 0.5, 1.0],
+            material_name: None,
+            geometry_item_id: None,
+            material_id: None,
+            properties: None,
+            uvs: None,
+            texture: None,
+            geometry_class: 0,
+            origin: [0.0, 0.0, 0.0],
+            instance: None,
+            local_bounds: None,
+            local_to_world: None,
+        }
+    }
+
+    /// `mesh_visible` must reject a mesh carrying a non-finite position, normal, or
+    /// origin — OBJ's `v`/`vn` tokens have no lexical form for `NaN`/`inf`/`-inf`, and
+    /// unlike `mesh_input::scrub_nonfinite` (the from-meshes GLB/COLLADA gate) or
+    /// `usd::mesh_emittable` (the sibling from-bytes exporter), this function let one
+    /// through untouched. Before the fix each of these five cases wrote the offending
+    /// float straight into a `v`/`vn` line (Rust's `Display` renders `NaN`/`inf`/`-inf`,
+    /// none of which OBJ readers accept as a number).
+    #[test]
+    fn mesh_visible_rejects_non_finite_geometry() {
+        let good = good_mesh();
+        assert!(mesh_visible(&good, &[], &[]), "the baseline fixture must itself be visible");
+
+        let mut bad = good.clone();
+        bad.positions[0] = f32::NAN;
+        assert!(!mesh_visible(&bad, &[], &[]), "NaN position must be rejected");
+
+        let mut bad = good.clone();
+        bad.positions[3] = f32::INFINITY;
+        assert!(!mesh_visible(&bad, &[], &[]), "Infinity position must be rejected");
+
+        let mut bad = good.clone();
+        bad.normals[1] = f32::NEG_INFINITY;
+        assert!(!mesh_visible(&bad, &[], &[]), "non-finite normal must be rejected");
+
+        let mut bad = good.clone();
+        bad.origin = [f64::NAN, 0.0, 0.0];
+        assert!(!mesh_visible(&bad, &[], &[]), "non-finite origin must be rejected — it poisons every vertex");
     }
 }


### PR DESCRIPTION
## Format + spec clause

Wavefront OBJ (no ISO spec, but every parser — Blender, MeshLab, Assimp — reads `v`/`vn` values as IEEE numeric tokens): a `v`/`vn` line has no lexical form for `NaN`/`Infinity`/`-Infinity`. Rust's `Display` writes `NaN`/`inf`/`-inf` for those, none of which any OBJ reader accepts as a coordinate.

This PR is a hunt task (COLLADA/OBJ mesh-export geometry-fidelity lens), no `ready` issue to close — `unqueued` applied.

## Geometry-fidelity verdict (rust/export/src/obj.rs, `export_obj`)

| aspect | emitted vs correct |
|---|---|
| axis (declared frame vs coordinates) | correct — header states the Y-up renderer frame; `frame::yup_f64`/`yup_f32` convert `process_geometry`'s Z-up output `(x,y,z) -> (x,z,-y)` before every `v`/`vn` line, applied identically to positions and normals |
| unit | correct — header states metres, matching `process_geometry`'s native units |
| index integrity | correct — 1-based, offset by a running `vert_base`; pinned by the existing `duplex_exports_well_formed_obj` test (every `f` index in range) and `obj_faces_reverse_the_source_mesh_winding` (winding pinned against the source mesh, not a second copy of the same conversion) |
| transform application | correct — `mesh.origin` (world/RTC offset) is folded into every position before the axis swap, so a placed element is not emitted at the local origin |
| structural validity | **defect, fixed here** — `mesh_visible` had no finiteness gate. A non-finite position/normal/origin from `process_geometry` (reachable only for a derived quantity like the mid-vertex normal of a zero-area face, per `usd::fmt::fmt_f32`'s comment on the same producer) was written straight into `v`/`vn` lines, and because the origin is folded into every position, a single non-finite origin poisoned every vertex of that mesh |

COLLADA (`collada.rs`) was checked too and found correct/deliberate: `<up_axis>Z_UP</up_axis>` matches its `to_zup` conversion, `<unit meter="1"/>` matches emitted magnitudes, indices are validated by `collada_conformance_tests.rs` (id uniqueness, `count`/accessor/`<p>` agreement, symbol/material binding), the documented AABB XY re-centring is deliberate (KMZ `<Location>` convention, #1427), and it already scrubs non-finite input via `mesh_input::scrub_nonfinite` (added in #3329). No further finding there.

## The fix

`mesh_visible` (`rust/export/src/obj.rs`) now rejects a mesh whose `origin`, any `position`, or any `normal` (when normals are present) is non-finite — gating the whole mesh out rather than writing a token no reader accepts. This mirrors `usd::mesh_emittable`, the sibling from-bytes exporter over the same `process_geometry` source, and the from-meshes `mesh_input::scrub_nonfinite` gate `#3329` already applied to GLB/COLLADA/KMZ (that PR's scope was explicitly "the three exporters that take the viewer's flattened `MeshData`" — the from-bytes OBJ/GLB paths were out of scope there).

### RED/GREEN

New test `mesh_visible_rejects_non_finite_geometry` constructs a minimal valid `MeshData` (mirrors the existing `usd::tests` fixture) and five variants with a NaN/±Infinity position, normal, or origin.

- **RED** (`mesh_visible` reverted to its unmodified `main` body, test kept): fails immediately — `NaN position must be rejected` panics, confirming the unmodified function accepts the non-finite mesh.
- **GREEN** (fix restored): all 5 cases pass; the pre-existing `duplex_exports_well_formed_obj` and `obj_faces_reverse_the_source_mesh_winding` tests (control — an already-correct, all-finite fixture) are unchanged and still pass.

### Reachability

Exercised via `ifc_lite_export::export_obj`/`export_obj_with_stats`, called from the CLI (`ifc-lite export --format obj`), the from-bytes wasm binding `IfcAPI::exportObj` (`rust/wasm-bindings/src/api/export_obj.rs`), and any SDK/MCP consumer of the OBJ export path — all of which route through the same `mesh_visible` gate now fixed.

## Verification

- `cargo test -p ifc-lite-export` — all green (351 passed, no failures)
- `cargo test -p ifc-lite-processing` — all green
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — green
- `cargo clippy -p ifc-lite-export --all-targets` — clean
- `node scripts/check-module-size.mjs` — OK, 0 new over budget
- `node scripts/check-test-wiring.mjs`, `node scripts/check-unused-locals.mjs`, `pnpm run check:vitest-timeout-audit` — clean (no TS changed)
- No public API/signature change; no `pkg/ifc-lite.d.ts` regeneration needed; changeset added for `@ifc-lite/wasm` (patch — the wasm `exportObj` binding calls this function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436