### PR TITLE
fix(renderer): reserve overlay headroom in FederationRegistry offsets

### DIFF
--- a/.changeset/federation-registry-overlay-headroom.md
+++ b/.changeset/federation-registry-overlay-headroom.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+`FederationRegistry` now reserves headroom after every federated model's own id range, so a mutation-overlay entity added to a non-last model (AddElement tool, IDS auto-fix, a script) can no longer collide with the next model's already-assigned, real entity ids. `StoreEditor.addEntity` (`@ifc-lite/mutations`) allocates new local expressIds from a per-model watermark that starts right after that model's own `maxExpressId`; with the previous bare `+1` gap between models, the very first entity added to a non-last model produced a global id that landed on the next model's real entity `#0` (and the second addition on its real `#1`, and so on) — the new entity silently resolved as a genuine, unrelated entity in the other model wherever a global id is looked up (annotation placement, storey inference for smart element placement, BCF markup id resolution). The registry now packs a 1,000,000-id reserved block after each model's range before the next model's offset begins, making that collision unreachable for any realistic number of overlay-added entities per model.

--- a/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.test.ts
@@ -240,7 +240,7 @@ describe('buildTreeData', () => {
     assert.ok(spaceNode);
     assert.strictEqual(spaceNode.type, 'IfcSpace');
     assert.deepStrictEqual(spaceNode.expressIds, [5]);
-    assert.deepStrictEqual(spaceNode.globalIds, [105]);
+    assert.deepStrictEqual(spaceNode.globalIds, [1_000_105]);
     assert.strictEqual(spaceNode.elementCount, 1);
     assert.strictEqual(spaceNode.hasChildren, true);
 
@@ -249,7 +249,7 @@ describe('buildTreeData', () => {
     assert.strictEqual(windowNode.type, 'element');
     assert.strictEqual(windowNode.ifcType, 'IfcWindow');
     assert.deepStrictEqual(windowNode.expressIds, [7]);
-    assert.deepStrictEqual(windowNode.globalIds, [107]);
+    assert.deepStrictEqual(windowNode.globalIds, [1_000_107]);
     assert.strictEqual(windowNode.name, 'IfcWindow #7');
 
     assert.strictEqual(nodes.filter((node) => node.id === 'element-model-1-6').length, 1);

--- a/apps/viewer/src/hooks/federationMeshIdInvariant.test.ts
+++ b/apps/viewer/src/hooks/federationMeshIdInvariant.test.ts
@@ -83,7 +83,9 @@ beforeEach(() => {
   secondaryOffset = store.registerModelOffset('secondary', SECONDARY_MAX_EXPRESS_ID);
   assert.equal(
     secondaryOffset,
-    PRIMARY_MAX_EXPRESS_ID + 1,
+    // +1 gap, plus FederationRegistry's OVERLAY_ID_HEADROOM (1_000_000)
+    // reserved after every model's own range.
+    PRIMARY_MAX_EXPRESS_ID + 1 + 1_000_000,
     'sanity: the secondary must start after the primary\'s range — if this changes, the '
     + '"unshifted id lands in the primary" premise below is no longer set up',
   );

--- a/apps/viewer/src/hooks/useIfcLoader.federatedIdOffset.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.federatedIdOffset.test.tsx
@@ -271,8 +271,8 @@ describe('useIfcLoader — the federation id-offset WRITE side (producer half of
     assert.equal(seededOffset, 0, 'sanity: the seed must be the FIRST registration, or the offset below is not the one this test controls');
 
     // Chosen so `local`, `local + offset`, and `local + 2*offset` are three
-    // unambiguous numbers: offset will be 1001 (seed's maxExpressId 1000 + 1
-    // gap), local is 42, so correct = 1043, doubled-defect = 2044, unshifted = 42.
+    // unambiguous numbers: offset will be 1_001_001 (seed's maxExpressId 1000
+    // + 1 gap + OVERLAY_ID_HEADROOM 1_000_000), local is 42.
     const localExpressId = 42;
     const file = glbFile('federated-fixture.glb', localExpressId);
 
@@ -290,7 +290,7 @@ describe('useIfcLoader — the federation id-offset WRITE side (producer half of
 
     const mesh = model.geometryResult!.meshes[0]!;
 
-    assert.equal(model.idOffset, 1001, 'the registered offset itself must be 1001 (seed maxExpressId 1000 + 1 gap) — if this fails, the seed setup changed, not the code under test');
+    assert.equal(model.idOffset, 1_001_001, 'the registered offset itself must be 1_001_001 (seed maxExpressId 1000 + 1 gap + OVERLAY_ID_HEADROOM 1_000_000) — if this fails, the seed setup changed, not the code under test');
 
     // The three-direction discrimination this file exists to provide:
     assert.equal(

--- a/apps/viewer/src/store/clearAllModels-overlay-stale.test.ts
+++ b/apps/viewer/src/store/clearAllModels-overlay-stale.test.ts
@@ -50,14 +50,14 @@ function model(id: string, idOffset: number, maxExpressId: number): FederatedMod
 }
 
 /** Mirrors what `useConstructionSequence.ts` registers for a PAUSED
- *  animation frame: local product id 42 in model 'B' (offset 1000),
- *  translated to global id 1042 at registration time. */
+ *  animation frame: local product id 42 in model 'B' (offset 1_001_000),
+ *  translated to global id 1_001_042 at registration time. */
 function seedPausedAnimationLayer(): OverlayLayer {
   return {
     id: 'animation',
     priority: 100,
-    hiddenIds: new Set([1042]),
-    colorOverrides: new Map([[1042, [1, 0, 0, 1]]]),
+    hiddenIds: new Set([1_001_042]),
+    colorOverrides: new Map([[1_001_042, [1, 0, 0, 1]]]),
   };
 }
 
@@ -69,7 +69,7 @@ describe('overlaySlice.overlayLayers survives clearAllModels as a dangling — a
     useViewerStore.setState({
       models: new Map([
         ['A', model('A', 0, 100)],
-        ['B', model('B', 1000, 1100)],
+        ['B', model('B', 1_001_000, 1_001_100)],
       ]),
       activeModelId: 'A',
     });
@@ -89,15 +89,15 @@ describe('overlaySlice.overlayLayers survives clearAllModels as a dangling — a
   it('misresolution: a stale animation layer left behind lands its hide+colour on a reloaded, unrelated model\'s LIVE entity', () => {
     // Same repro shape as removeModel-compare-stale.test.ts: clearAllModels()
     // resets the offset counter, so the very first model registered
-    // afterward can land on offset 1000 again — the exact number the stale
-    // layer's global id 1042 was computed against.
+    // afterward can land on offset 1_001_000 again — the exact number the
+    // stale layer's global id 1_001_042 was computed against.
     federationRegistry.clear();
     federationRegistry.registerModel('A', 100);
     federationRegistry.registerModel('B', 100);
     useViewerStore.setState({
       models: new Map([
         ['A', model('A', 0, 100)],
-        ['B', model('B', 1000, 1100)],
+        ['B', model('B', 1_001_000, 1_001_100)],
       ]),
       activeModelId: 'A',
     });
@@ -106,37 +106,37 @@ describe('overlaySlice.overlayLayers survives clearAllModels as a dangling — a
     useViewerStore.getState().clearAllModels();
 
     // Reload: two fresh, UNRELATED models — offset space was reset, so the
-    // second one can land on 1000 again, same as `newOffsetC === 0` in
+    // second one can land on 1_001_000 again, same as `newOffsetC === 0` in
     // removeModel-compare-stale.test.ts.
     const offsetX = federationRegistry.registerModel('X', 999);
     const offsetC = federationRegistry.registerModel('C', 50);
-    assert.strictEqual(offsetC, 1000, 'offset space is not burned across a full clear — confirms the hazard is real');
+    assert.strictEqual(offsetC, 1_001_000, 'offset space is not burned across a full clear — confirms the hazard is real');
     useViewerStore.getState().addModel(model('X', offsetX, 999));
     useViewerStore.getState().addModel(model('C', offsetC, 50));
 
     const afterReload = useViewerStore.getState();
     // If the fix did its job the layer is gone and there is nothing left to
-    // misresolve. If it did not, the layer (and its stale global id 1042)
-    // is still sitting in the registry, and the compositor
+    // misresolve. If it did not, the layer (and its stale global id
+    // 1_001_042) is still sitting in the registry, and the compositor
     // (`useOverlayCompositor.ts`) would apply it verbatim.
     const stillRegistered = afterReload.overlayLayers.get('animation');
     if (stillRegistered) {
       const { hiddenIds, colorOverrides } = afterReload.computeCompositeOverlay();
-      assert.ok(hiddenIds.has(1042), 'sanity: composite still carries the stale global id');
-      // Resolve global id 1042 against the RELOADED federation — this is
+      assert.ok(hiddenIds.has(1_001_042), 'sanity: composite still carries the stale global id');
+      // Resolve global id 1_001_042 against the RELOADED federation — this is
       // exactly what a global-id-keyed hide/colour channel means once
       // applied to the renderer.
-      const resolved = fromGlobalIdFromModels(afterReload.models, 1042);
-      console.log('global id 1042 resolves, post-reload, to:', resolved);
+      const resolved = fromGlobalIdFromModels(afterReload.models, 1_001_042);
+      console.log('global id 1_001_042 resolves, post-reload, to:', resolved);
       assert.deepStrictEqual(
         resolved,
         { modelId: 'C', expressId: 42 },
-        'global id 1042 now names a LIVE entity in the reloaded model C — a task from the pre-clear schedule ' +
+        'global id 1_001_042 now names a LIVE entity in the reloaded model C — a task from the pre-clear schedule ' +
           'would hide/tint an entity that has nothing to do with it',
       );
-      assert.ok(colorOverrides.has(1042), 'and the stale RED colour override would land on that same live entity');
+      assert.ok(colorOverrides.has(1_001_042), 'and the stale RED colour override would land on that same live entity');
       assert.fail(
-        'DEFECT: clearAllModels left the animation overlay layer registered; its stale global id 1042 now ' +
+        'DEFECT: clearAllModels left the animation overlay layer registered; its stale global id 1_001_042 now ' +
           'misresolves onto model C\'s live entity 42 — same shape as the compareResult/lens defects fixed in #2854',
       );
     }
@@ -151,7 +151,7 @@ describe('overlaySlice.overlayLayers survives clearAllModels as a dangling — a
     useViewerStore.setState({
       models: new Map([
         ['A', model('A', 0, 100)],
-        ['B', model('B', 1000, 1100)],
+        ['B', model('B', 1_001_000, 1_001_100)],
       ]),
       activeModelId: 'A',
     });
@@ -169,11 +169,11 @@ describe('overlaySlice.overlayLayers survives clearAllModels as a dangling — a
     );
 
     // Prove the "cannot misresolve" half: register a brand new model and
-    // confirm the federation never hands out offset 1000 again.
+    // confirm the federation never hands out offset 1_001_000 again.
     const offsetC = federationRegistry.registerModel('C', 50);
     assert.notStrictEqual(
       offsetC,
-      1000,
+      1_001_000,
       'unregisterModel burns the offset space — a new model can never be handed the range the removed model owned, ' +
         'so the still-registered stale layer names a global id no live model can ever claim again',
     );

--- a/packages/renderer/src/federation-registry.test.ts
+++ b/packages/renderer/src/federation-registry.test.ts
@@ -8,14 +8,15 @@ import assert from 'node:assert';
 import { FederationRegistry } from './federation-registry.js';
 
 describe('FederationRegistry - offset assignment', () => {
-  it('registers models with non-overlapping offsets and a +1 gap', () => {
+  it('registers models with non-overlapping offsets, a +1 gap, and overlay headroom', () => {
     const reg = new FederationRegistry();
     const offsetA = reg.registerModel('modelA', 100);
     const offsetB = reg.registerModel('modelB', 50);
 
     assert.equal(offsetA, 0);
-    // Next model starts after modelA's range (maxExpressId 100) + 1 gap
-    assert.equal(offsetB, 101);
+    // Next model starts after modelA's range (maxExpressId 100) + 1 gap +
+    // OVERLAY_ID_HEADROOM (1_000_000) reserved for mutation-added entities.
+    assert.equal(offsetB, 1_000_101);
   });
 
   it('re-registering the same model returns the existing offset (no duplicate range)', () => {
@@ -30,7 +31,7 @@ describe('FederationRegistry - offset assignment', () => {
   it('unregisterModel removes the model but does NOT reclaim offset space (#federation gap)', () => {
     const reg = new FederationRegistry();
     reg.registerModel('modelA', 100); // offset 0..100
-    const offsetB = reg.registerModel('modelB', 50); // offset 101
+    const offsetB = reg.registerModel('modelB', 50); // offset 1_000_101
 
     reg.unregisterModel('modelA');
     assert.equal(reg.hasModel('modelA'), false);
@@ -54,10 +55,10 @@ describe('FederationRegistry - offset assignment', () => {
     // only crossing it must throw. Testing only far past the limit (as the
     // test above does) cannot tell `>` apart from `>=` at the boundary.
     const reg = new FederationRegistry();
-    reg.registerModel('modelA', 0); // offset 0, nextOffset -> 1
-    // sum = nextOffset(1) + maxExpressId(1_999_999_999) = 2_000_000_000 exactly.
-    assert.doesNotThrow(() => reg.registerModel('modelB', 1_999_999_999));
-    // nextOffset is now 2_000_000_001; any further model overflows by exactly 1.
+    reg.registerModel('modelA', 0); // offset 0, nextOffset -> 1 + OVERLAY_ID_HEADROOM = 1_000_001
+    // sum = nextOffset(1_000_001) + maxExpressId(1_998_999_999) = 2_000_000_000 exactly.
+    assert.doesNotThrow(() => reg.registerModel('modelB', 1_998_999_999));
+    // nextOffset now overflows MAX_SAFE_OFFSET; any further model throws.
     assert.throws(() => reg.registerModel('modelC', 0), /exceed safe ID limit/);
   });
 });
@@ -66,7 +67,7 @@ describe('FederationRegistry - toGlobalId / fromGlobalId round-trip', () => {
   it('round-trips expressId -> globalId -> {modelId, expressId} across multiple models', () => {
     const reg = new FederationRegistry();
     reg.registerModel('modelA', 100); // offset 0
-    reg.registerModel('modelB', 200); // offset 101
+    reg.registerModel('modelB', 200); // offset 1_000_101
 
     const globalA = reg.toGlobalId('modelA', 42);
     const globalB = reg.toGlobalId('modelB', 42);
@@ -109,42 +110,71 @@ describe('FederationRegistry - fromGlobalId binary search (N=0, N=1, N=many, gap
   it('N=many: resolves the correct model at each range boundary across several models', () => {
     const reg = new FederationRegistry();
     reg.registerModel('modelA', 100); // range [0, 100]
-    reg.registerModel('modelB', 50); // offset 101, range [101, 151]
-    reg.registerModel('modelC', 30); // offset 152, range [152, 182]
+    reg.registerModel('modelB', 50); // offset 1_000_101, range [1_000_101, 1_000_151]
+    reg.registerModel('modelC', 30); // offset 2_000_152, range [2_000_152, 2_000_182]
 
     assert.deepEqual(reg.fromGlobalId(0), { modelId: 'modelA', expressId: 0 });
     assert.deepEqual(reg.fromGlobalId(100), { modelId: 'modelA', expressId: 100 });
-    assert.deepEqual(reg.fromGlobalId(101), { modelId: 'modelB', expressId: 0 });
-    assert.deepEqual(reg.fromGlobalId(151), { modelId: 'modelB', expressId: 50 });
-    assert.deepEqual(reg.fromGlobalId(152), { modelId: 'modelC', expressId: 0 });
-    assert.deepEqual(reg.fromGlobalId(182), { modelId: 'modelC', expressId: 30 });
+    assert.deepEqual(reg.fromGlobalId(1_000_101), { modelId: 'modelB', expressId: 0 });
+    assert.deepEqual(reg.fromGlobalId(1_000_151), { modelId: 'modelB', expressId: 50 });
+    assert.deepEqual(reg.fromGlobalId(2_000_152), { modelId: 'modelC', expressId: 0 });
+    assert.deepEqual(reg.fromGlobalId(2_000_182), { modelId: 'modelC', expressId: 30 });
   });
 
   it('N=many with a gap: unregistering a middle model leaves a dead zone that resolves to null', () => {
     const reg = new FederationRegistry();
     reg.registerModel('modelA', 100); // range [0, 100]
-    reg.registerModel('modelB', 50); // offset 101, range [101, 151]
-    reg.registerModel('modelC', 30); // offset 152, range [152, 182]
+    reg.registerModel('modelB', 50); // offset 1_000_101, range [1_000_101, 1_000_151]
+    reg.registerModel('modelC', 30); // offset 2_000_152, range [2_000_152, 2_000_182]
 
     reg.unregisterModel('modelB');
 
     // A globalId that used to belong to modelB now lands in the gap between
     // modelA's and modelC's ranges - this is the exact collision-prevention
     // mechanism under test: it must resolve to null, never to a wrong model.
-    assert.equal(reg.fromGlobalId(120), null);
+    assert.equal(reg.fromGlobalId(1_000_120), null);
 
     // The surrounding models are unaffected.
     assert.deepEqual(reg.fromGlobalId(50), { modelId: 'modelA', expressId: 50 });
-    assert.deepEqual(reg.fromGlobalId(160), { modelId: 'modelC', expressId: 8 });
+    assert.deepEqual(reg.fromGlobalId(2_000_160), { modelId: 'modelC', expressId: 8 });
   });
 
   it('globalId landing before the very first range resolves to null', () => {
     const reg = new FederationRegistry();
     reg.registerModel('modelA', 10); // offset 0, so nothing is "before" it here
-    reg.registerModel('modelB', 10); // offset 11
+    reg.registerModel('modelB', 10); // offset 1_000_011
 
     reg.unregisterModel('modelA');
-    // Now the only remaining range starts at offset 0 is gone; sortedRanges = [modelB @11]
+    // Now the only remaining range starts at offset 0 is gone; sortedRanges = [modelB @1_000_011]
     assert.equal(reg.fromGlobalId(5), null, 'below the first remaining range -> null, not a wrong match');
+  });
+});
+
+describe('FederationRegistry - mutation-overlay id collision with the next model', () => {
+  it('an overlay-allocated id in a non-last model must not resolve to a real entity in the next model', () => {
+    // StoreEditor.addEntity() (packages/mutations/src/store-editor.ts) allocates
+    // new entity expressIds from a per-model watermark starting at
+    // maxExistingId + 1 — it has no knowledge of the FederationRegistry's global
+    // offset scheme. If the registry packs the next model's offset directly at
+    // modelA.maxExpressId + 1 (a bare +1 gap), then adding even a SINGLE new
+    // entity to modelA (via the AddElement tool, IDS auto-fix, etc.) produces a
+    // local expressId that, once offset to a globalId, lands exactly on modelB's
+    // real entity #0 — a silent misattribution to a genuine, unrelated entity.
+    const reg = new FederationRegistry();
+    reg.registerModel('modelA', 100); // modelA real entities occupy local ids [0, 100]
+    reg.registerModel('modelB', 50);  // modelB real entities occupy local ids [0, 50]
+
+    // Simulate StoreEditor's watermark allocation: the first entity added to
+    // modelA after load gets local expressId 101 (maxExistingId + 1).
+    const overlayLocalId = 101;
+    const overlayGlobalId = reg.toGlobalId('modelA', overlayLocalId);
+
+    const resolved = reg.fromGlobalId(overlayGlobalId);
+
+    // It must NEVER resolve as modelB's real, pre-existing entity #0 — that is
+    // a completely different element silently standing in for the newly added
+    // one (annotations, BCF markup, and storey inference would all target the
+    // wrong entity with no error surfaced).
+    assert.notDeepEqual(resolved, { modelId: 'modelB', expressId: 0 });
   });
 });

--- a/packages/renderer/src/federation-registry.ts
+++ b/packages/renderer/src/federation-registry.ts
@@ -28,6 +28,22 @@ export interface GlobalIdLookup {
 // WebGPU picking uses r32uint (max 4,294,967,295)
 const MAX_SAFE_OFFSET = 2_000_000_000;
 
+// Reserved headroom appended after every model's own maxExpressId, on top of
+// the +1 gap, before the next model's offset begins.
+//
+// StoreEditor.addEntity() (packages/mutations/src/store-editor.ts) allocates
+// new overlay entity ids from a per-model watermark that starts at that
+// model's OWN maxExpressId + 1 — it has no knowledge of this registry's
+// global offset packing. With only a bare +1 gap between models, adding even
+// a single new entity (AddElement tool, IDS auto-fix, a script) to a
+// non-last federated model produces a globalId that lands exactly inside the
+// NEXT model's already-assigned real-entity range: the new entity silently
+// resolves as a genuine, unrelated entity in that other model (annotations,
+// BCF markup, and storey inference all target the wrong element with no
+// error surfaced). This headroom makes that collision structurally
+// unreachable for any realistic number of overlay-added entities per model.
+const OVERLAY_ID_HEADROOM = 1_000_000;
+
 /**
  * Central registry for multi-model federation
  * Manages ID offsets and provides O(1) to-global / O(log N) from-global transformations
@@ -78,8 +94,10 @@ export class FederationRegistry {
     // Keep sorted by offset for binary search
     this.sortedRanges.sort((a, b) => a.offset - b.offset);
 
-    // Next model starts after this model's range (+1 gap for safety)
-    this.nextOffset = offset + maxExpressId + 1;
+    // Next model starts after this model's range (+1 gap for safety), plus
+    // reserved headroom for mutation-overlay ids allocated into this model's
+    // own space after load (see OVERLAY_ID_HEADROOM above).
+    this.nextOffset = offset + maxExpressId + 1 + OVERLAY_ID_HEADROOM;
 
     return offset;
   }


### PR DESCRIPTION
## Federation lens summary

Scope covered: `apps/viewer`'s in-session multi-model federation (`FederationRegistry` + the `useIfcFederation`/`modelSlice` id-resolution stack), not `ifc-lite merge`/`MergedExporter` — that CLI/export path currently has open PRs against the exact files (#3550, #3551, #3586, #3554/#3552 already merged), so this hunt moved to the viewer's federation loader per the lens's "(and/or the federation loader)" scope.

Verdict table (scenario → resolved-model result):

| Scenario | Before | After |
|---|---|---|
| Express-id remap across two loaded models (real, parsed entities) | Correct — non-overlapping ranges, round-trips | Unchanged, correct |
| GlobalId collision between two models | Out of scope by design (renderer ids are per-session express-id offsets, not IFC `GlobalId` dedup) | Unchanged — documented deliberate, not a bug |
| Coordinate frame (georef alignment across CRSs) | Handled by `federationAlign.ts`'s CRS-aware transform/reprojection | Unchanged, not touched |
| **Mutation-overlay entity added to a non-last model** | **Silently resolves as a different, real entity in the NEXT model** | **Fixed — collision structurally unreachable** |
| Units | Handled by the georef/scale pipeline | Unchanged, not touched |

## Invariant violated

`FederationRegistry.registerModel` packs each model's global-id offset directly at `previous model's maxExpressId + 1` (`packages/renderer/src/federation-registry.ts`). That packing only reserves room for the model's ids **as parsed at load time**. It has no visibility into `StoreEditor.addEntity` (`packages/mutations/src/store-editor.ts`), which allocates a new overlay entity's local expressId from that SAME model's own watermark, starting at `maxExistingId + 1` — i.e. exactly the first id the registry gave to the **next** model.

So: add one entity (AddElement tool, IDS auto-fix, a script) to a non-last federated model, and its globalId lands on the next model's real, pre-existing entity `#0`. Add a second, it lands on that model's real `#1`. And so on. This is silent corruption of the express-id → entity mapping (lens item 1): every code path that resolves a renderer globalId back to `(model, expressId)` — annotation pin placement, "place new element in the same storey as the one I clicked" inference, BCF markup id resolution — targets a completely different, unrelated, pre-existing entity, with no error.

Traced through: `apps/viewer/src/components/viewer/selectionHandlers.ts` (`fromGlobalIdFromModels`, annotate-tool model/entity lookup and `inferStoreyForGlobalId`), `apps/viewer/src/hooks/bcfIdLookup.ts` / `useBCF.ts`, and the store's own "canonical" resolver `apps/viewer/src/store/slices/modelSlice.ts#resolveGlobalIdFromModels` (its mutation-view fallback pass never runs for this case either, because the FIRST pass — the plain offset-range check — already matches the wrong model before the overlay-aware pass gets a chance).

## Reproduction (RED on unmodified `upstream/main`)

`packages/renderer/src/federation-registry.test.ts`, new suite `FederationRegistry - mutation-overlay id collision with the next model`:

```ts
const reg = new FederationRegistry();
reg.registerModel('modelA', 100); // modelA real entities occupy local ids [0, 100]
reg.registerModel('modelB', 50);  // modelB real entities occupy local ids [0, 50]

// StoreEditor.addEntity's watermark: the first entity added to modelA
// after load gets local expressId 101 (maxExistingId + 1).
const overlayGlobalId = reg.toGlobalId('modelA', 101);
const resolved = reg.fromGlobalId(overlayGlobalId);

assert.notDeepEqual(resolved, { modelId: 'modelB', expressId: 0 });
```

On unmodified `upstream/main` this **fails**: `resolved` is exactly `{ modelId: 'modelB', expressId: 0 }` — the brand-new entity in `modelA` resolves as `modelB`'s real, pre-existing entity `#0`.

## Fix

`registerModel` now reserves `OVERLAY_ID_HEADROOM` (1,000,000) ids after every model's own `maxExpressId + 1` gap before handing out the next model's offset. Since overlay-allocated ids in a model grow from that model's own watermark, and 1,000,000 sequential UI/script additions to one federated model is not a realistic session, the next model's real range can no longer be reached by an overlay id. This is a single, root-cause fix in the one place (`FederationRegistry.registerModel`) that every id-resolution path (`fromGlobalId`, `toGlobalId`, the app's parallel `globalId.ts` helpers, and `modelSlice.resolveGlobalIdFromModels`, all of which read `idOffset` from what this method returns) ultimately depends on — rather than patching each resolver's ambiguity individually, which can't fully disambiguate post hoc once a real entity and an overlay id land on the same number.

## Verification

- `packages/renderer`: `npx tsx --test src/federation-registry.test.ts` — 14/14 passed (new suite included; RED confirmed failing on unmodified `upstream/main`, GREEN after the fix). `npx tsc --noEmit` — clean.
- `apps/viewer`: `npx tsc --noEmit` — clean. Full suite (`pnpm --filter @ifc-lite/viewer test`) — 6611 passed, 0 failed, 6 skipped (fixture-gated), including the federation-specific suites (`federationMeshIdInvariant.test.ts`, `useIfcLoader.federatedIdOffset.test.tsx`, `useIfcLoader.primaryGlbFederationOffset.test.tsx`, `clearAllModels-overlay-stale.test.ts`, `removeModel-compare-stale.test.ts`, `removeModel-lens-stale.test.ts`, `treeDataBuilder.test.ts`, all the `useClash.*` federation-offset suites, `useLens.model-removal.test.tsx`).
- `packages/collab`: `npx vitest run test/federation-bridge.test.ts` — 2/2 passed.
- Updated the handful of tests whose fixtures hardcoded the old exact `+1`-gap offset arithmetic (`federation-registry.test.ts`'s existing suites, `federationMeshIdInvariant.test.ts`, `useIfcLoader.federatedIdOffset.test.tsx`, `treeDataBuilder.test.ts`, `clearAllModels-overlay-stale.test.ts`) to the new headroom-based numbers — same invariants, same assertions, just the new packing constant.
- `node scripts/check-module-size.mjs` — OK, 0 new over 400 (no allowlist touched).
- `node scripts/check-test-wiring.mjs` — OK.
- `node scripts/check-unused-locals.mjs` — OK (0 new).
- `pnpm run check:vitest-timeout-audit` — no regression (informational, not a gate).
- No public API surface change (`OVERLAY_ID_HEADROOM` is a private module constant; no export added/removed/renamed) — `scripts/api-surface.json` unaffected.
- Changeset added: `@ifc-lite/renderer` patch.

## Control (unaffected)

Express-id resolution for real, parsed entities across N models (N=0/1/many, including the unregister-leaves-a-dead-zone and offset-reuse-after-clear cases) is unchanged — only the numeric spacing between models grew, not the resolution logic; every existing round-trip/boundary test in `federation-registry.test.ts` still passes with updated (not removed or weakened) assertions. GlobalId collision handling and coordinate-frame/unit reconciliation are untouched — this PR is scoped to the id-offset packing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented entities added to one federated model from being mistaken for real entities in another model.
  * Improved global ID resolution for spatial, element, and overlay entities across federated models.
  * Preserved correct stale-overlay cleanup and reload behavior when models use expanded ID ranges.

* **Tests**
  * Updated federation and viewer coverage to validate expanded ID offsets and collision prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->