### PR TITLE
fix(review): PROOF_OF_WORK_FAILED offered a remedy the model could not perform

### DIFF
--- a/scripts/review/rubric.md
+++ b/scripts/review/rubric.md
@@ -140,6 +140,19 @@ commentary before or after:
 required even when `verdict` is `clean` — it is how a review that did not read
 the diff is told apart from one that read it and found nothing.
 
+**Nominate a `riskiest_change.quoted_line` you can reproduce EXACTLY.** It is
+checked character for character against the patch, and a line long enough that
+you would truncate it will fail that check however many times the review is
+re-run. "Riskiest" is relative, so if the line you would otherwise nominate is
+too long to reproduce, nominate a different line **from the same file** — a
+shorter one you can quote verbatim, though still a substantive one of a dozen
+characters or more, not `});` or `return;`. Any real line of the diff proves you
+read it, which is the whole job of this field. Do not truncate, and do not quote
+a fragment from the middle of a line.
+
+This applies to `riskiest_change` only. A finding's `quote` anchors an inline
+comment to a specific line, so it must be that line, exactly.
+
 **`riskiest_change` is required even when NOTHING in the diff is risky.** A diff
 of pure comments, documentation or configuration still has a most-substantive
 line: quote it. "Riskiest" is relative to the diff you were given, never an

--- a/scripts/review/validate-findings.mjs
+++ b/scripts/review/validate-findings.mjs
@@ -622,7 +622,9 @@ function checkProofOfWork({ response, input }) {
       `\`riskiest_change.quoted_line\` is not a line of \`${rc.path}\`'s patch (or is shorter than ` +
         `${MIN_PROOF_QUOTE_CHARS} characters, which would not be evidence of anything): ` +
         `${JSON.stringify(String(rc.quoted_line).slice(0, 120))}. This is the one thing a model that ` +
-        'quit early cannot fake. REMEDY: re-run; quote a WHOLE line, not a fragment.',
+        'quit early cannot fake. REMEDY: re-run. Quote a WHOLE line, not a fragment; and if the ' +
+        'line you nominated is too long to reproduce exactly, nominate a SHORTER line from the ' +
+        'same file instead -- any real line of the diff proves you read it.',
     );
   }
 }

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -41,6 +41,7 @@ import {
   sanitizeLabel,
   stripFence,
   REASONS,
+  validate,
 } from './validate-findings.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -870,4 +871,44 @@ test('REASONS covers EVERY raise site in this file, and names nothing that is no
 
   const phantom = [...REASONS].filter((r) => !seen.has(r));
   assert.deepEqual(phantom, [], 'these are in REASONS but are never raised');
+});
+
+test('PROOF_OF_WORK_FAILED names a remedy the model can actually carry out', () => {
+  // #3597 was blocked permanently, not transiently. Its riskiest line is 216
+  // characters; the model reproduced about 120 and the message said "quote a
+  // WHOLE line" -- which it cannot do, so `re-run` looped forever.
+  //
+  // The guard is unchanged: a truncated quote is still refused, because
+  // accepting a prefix turned out to be guessable from boilerplate (a standard
+  // XML namespace opening in the .ids corpus clears 40 characters with the diff
+  // unread). What changed is that the model is now told it may nominate a
+  // SHORTER line instead, which is always available and proves the same thing.
+  // The `${...}` sequences are literal source text copied from the PR, not
+  // interpolation -- that is the whole point of the fixture.
+  // oxlint-disable-next-line no-template-curly-in-string
+  const long = "      svg += `    <path d=\"${pathData}\" fill=\"${escapeXml(fillColor)}\" fill-opacity=\"${opacity.toFixed(2)}\" fill-rule=\"evenodd\" data-entity-id=\"${polygon.entityId}\" data-ifc-type=\"${escapeXml(polygon.ifcType)}\"/>\\n`;";
+  const patch = ['@@ -1,3 +1,4 @@', ' const before = 1;', '+const shortEnough = 2;', `+${long}`].join('\n');
+  const input = {
+    headSha: 'a'.repeat(40),
+    files: new Map([['src/a.ts', { path: 'src/a.ts', patch, addedLineRanges: [[2, 3]] }]]),
+    unreviewable: [],
+  };
+  const truncated = {
+    verdict: 'clean',
+    files_reviewed: ['src/a.ts'],
+    riskiest_change: { path: 'src/a.ts', quoted_line: long.trim().slice(0, 120) },
+    findings: [],
+    end: 'ifc-lite-review-v1',
+  };
+  let err;
+  assert.throws(() => validate({ response: truncated, input }), (e) => { err = e; return e.reason === 'PROOF_OF_WORK_FAILED'; });
+  assert.match(err.message, /SHORTER line/, 'the remedy must offer an achievable alternative');
+
+  // And that alternative genuinely works on this same patch.
+  const shorter = {
+    ...truncated,
+    // A shorter ADDED line -- what the rubric actually steers the model toward.
+    riskiest_change: { path: 'src/a.ts', quoted_line: 'const shortEnough = 2;' },
+  };
+  assert.doesNotThrow(() => validate({ response: shorter, input }));
 });


### PR DESCRIPTION
Closes #3652.

`riskiest_change.quoted_line` must appear verbatim in the patch. A failure exits non-zero, the lane posts no marker, and the evidence gate correctly goes red. That is right for a model that quit early.

It was wrong for #3597, whose riskiest line is **216 characters**. The model reproduced about 120 of them, and the message said `REMEDY: re-run; quote a WHOLE line, not a fragment` — which it cannot do. The remedy looped, and any PR whose riskiest line was long enough was permanently unreviewable.

## The guard is unchanged

`git diff origin/main -- scripts/review/validate-findings.mjs` is four lines, all inside the failure message. `quoteAppearsIn`, `quotableLines` and `MIN_PROOF_QUOTE_CHARS` are untouched.

That is the second attempt. **The first one relaxed the guard to accept a 40-character prefix of a real line, and two independent reviews rejected it — correctly.** My justifying measurement counted prefix *collision* when the threat is prefix *guessability*: `packages/ids/src/__corpus__/` is not excluded from review, its files open with a standard XML namespace declaration over 160 characters, and a model that read nothing but the file path can type 40 characters of it from world knowledge and pass. Restricting the relaxation to long lines did not help, because the guessable lines are themselves long. The same review found the rubric paragraph I had added was unscoped and read onto findings' `quote`, where truncation is still fatal — so the fix would have opened the identical permanent block one field over, via `VALIDATION_EMPTY`.

## What changed instead

`riskiest_change` exists to tell a review that read the diff from one that did not, and the rubric already says "riskiest" is relative rather than an absolute claim about danger. Nothing requires the *longest* line.

So the model is now told to nominate a line it can reproduce exactly, and to pick a shorter one from the same file when the obvious candidate is too long — still substantive, not `});`. The paragraph names `riskiest_change` explicitly and states that a finding's `quote` must still be that line exactly, because a finding anchors an inline comment. The error message carries the same alternative, so a failure is recoverable rather than terminal.

## Verification

- A truncated 216-character quote **still** throws `PROOF_OF_WORK_FAILED` — the test asserts this, so the rejected relaxation is now actively pinned against.
- The message names the shorter-line alternative, and quoting a shorter *added* line from the same patch validates.
- Mutation-tested: reverting the message wording reddens. Swapping in `origin/main`'s validator fails the test.
- 184 review-pipeline tests pass; `check-test-wiring`, `check-module-size`, `check-source-text-assertions` green.

## Honest limit

The lane fetches `rubric.md` from the **base** sha, so this PR's own review runs the old rubric — the rubric half cannot be measured in-lane before merge. The validator half is measured. After merge I will re-run the lane on #3585 and #3597, which are red on exactly this, and report whether they clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified review requirements for selecting exact, sufficiently long quoted lines from patches.
  * Added guidance for handling truncated or non-substantive lines.

* **Bug Fixes**
  * Improved validation feedback when quoted lines are too long, recommending a shorter complete line from the same file.

* **Tests**
  * Added coverage confirming overlong quotes fail with actionable guidance and valid shorter quotes pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->