### PR TITLE
fix(export): map IfcDoorType/IfcWindowType to IfcDoorStyle/IfcWindowStyle in the Rust IFC4→IFC2X3 converter (mirrors #3653)

### DIFF
--- a/.changeset/fix-rust-schema-convert-door-window-type-proxy.md
+++ b/.changeset/fix-rust-schema-convert-door-window-type-proxy.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Fix `ifc-lite export --format step` (and `ifc-lite convert --schema IFC2X3`, both backed by the Rust `wasm` export path) silently corrupting every `IfcDoorType`/`IfcWindowType` on an IFC4/IFC4X3 → IFC2X3 downgrade instead of mapping it to its real IFC2X3 target.
+
+`schema_convert.rs`'s `map_4_to_2x3` had no entry for `IFCDOORTYPE`/`IFCWINDOWTYPE`, so `convert_entity_type` left the type name unchanged and the line was emitted as an unrecognized `IFCDOORTYPE`/`IFCWINDOWTYPE` in an IFC2X3-schema file — invalid STEP, and losing the fact that IFC2X3 has a real target for both: `IfcDoorStyle`/`IfcWindowStyle`. This is the Rust twin of the TS `packages/export/src/schema-converter.ts` fix (#3653); the two converters previously disagreed on this case.
+
+`map_4_to_2x3` now maps `IFCDOORTYPE`/`IFCWINDOWTYPE` to `IFCDOORSTYLE`/`IFCWINDOWSTYLE`. Their attribute lists only partially overlap by name (IFC4 inserted `ElementType`/`PredefinedType` ahead of the attributes it kept), so a new `by_name_attr_remap_names` + `remap_attrs_by_name` pair reconciles them by attribute NAME rather than the generic positional trim, preserving `GlobalId`/`Name`/`Description`/`HasPropertySets`/`RepresentationMaps`/`Tag`/`OperationType`/`ParameterTakesPrecedence` and `$`-ing out only the attributes IFC2X3's `IfcDoorStyle`/`IfcWindowStyle` genuinely don't carry under that name. This is a deliberately narrow allowlist scoped to exactly these two types; every other rename in `map_4_to_2x3` keeps its existing positional trim/pass-through behavior unchanged.

--- a/rust/export/src/schema_convert.rs
+++ b/rust/export/src/schema_convert.rs
@@ -41,8 +41,70 @@ fn map_4_to_2x3(t: &str) -> Option<&'static str> {
         "IFCFACILITY" | "IFCBRIDGE" | "IFCROAD" | "IFCRAILWAY" | "IFCMARINEFACILITY" => "IFCBUILDING",
         "IFCFACILITYPART" | "IFCFACILITYPARTCOMMON" | "IFCBRIDGEPART" | "IFCROADPART"
         | "IFCRAILWAYPART" | "IFCMARINEPART" => "IFCBUILDINGSTOREY",
+        // IFC4 renamed the IFC2X3 door/window type objects. Left unmapped,
+        // `should_skip_entity`-adjacent proxy fallback below treated them as
+        // having no IFC2X3 representation and replaced every one with an
+        // IFCPROXY carrying a freshly minted GlobalId (mirrors TS #3653).
+        // `BY_NAME_ATTR_REMAP_TYPES` reconciles their attribute lists by
+        // name since IFC4 inserted ElementType/PredefinedType mid-list.
+        "IFCDOORTYPE" => "IFCDOORSTYLE",
+        "IFCWINDOWTYPE" => "IFCWINDOWSTYLE",
         _ => return None,
     })
+}
+
+/// Source (IFC4) and target (IFC2X3) EXPRESS attribute names for the two
+/// door/window-type renames above, in the order STEP encodes them. Neither
+/// list is a positional prefix of the other (IFC4 inserted `ElementType`/
+/// `PredefinedType` ahead of the attributes it kept), so
+/// `convert_step_line` reconciles them by NAME rather than trimming a
+/// positional suffix like every other IFC2X3-downgrade rename.
+fn by_name_attr_remap_names(entity_type: &str) -> Option<(&'static [&'static str], &'static [&'static str])> {
+    match entity_type {
+        "IFCDOORTYPE" => Some((
+            &[
+                "GlobalId", "OwnerHistory", "Name", "Description", "ApplicableOccurrence",
+                "HasPropertySets", "RepresentationMaps", "Tag", "ElementType", "PredefinedType",
+                "OperationType", "ParameterTakesPrecedence", "UserDefinedOperationType",
+            ],
+            &[
+                "GlobalId", "OwnerHistory", "Name", "Description", "ApplicableOccurrence",
+                "HasPropertySets", "RepresentationMaps", "Tag", "OperationType", "ConstructionType",
+                "ParameterTakesPrecedence", "Sizeable",
+            ],
+        )),
+        "IFCWINDOWTYPE" => Some((
+            &[
+                "GlobalId", "OwnerHistory", "Name", "Description", "ApplicableOccurrence",
+                "HasPropertySets", "RepresentationMaps", "Tag", "ElementType", "PredefinedType",
+                "PartitioningType", "ParameterTakesPrecedence", "UserDefinedPartitioningType",
+            ],
+            &[
+                "GlobalId", "OwnerHistory", "Name", "Description", "ApplicableOccurrence",
+                "HasPropertySets", "RepresentationMaps", "Tag", "ConstructionType", "OperationType",
+                "ParameterTakesPrecedence", "Sizeable",
+            ],
+        )),
+        _ => None,
+    }
+}
+
+/// Reconcile a renamed entity's attribute list by matching attribute NAMES
+/// between the source and target schema tables, rather than by position.
+/// A target attribute with no same-named source attribute becomes `$`
+/// (unknown); a source attribute with no same-named target slot is dropped.
+/// Mirrors TS `schema-converter-attr-remap.ts`'s `remapRenamedAttributesByName`.
+fn remap_attrs_by_name(attrs: &str, src_names: &[&str], tgt_names: &[&str]) -> String {
+    let values = split_top_level(attrs);
+    let mut by_name: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for (name, value) in src_names.iter().zip(values.iter()) {
+        by_name.insert(*name, value.as_str());
+    }
+    tgt_names
+        .iter()
+        .map(|name| by_name.get(name).copied().unwrap_or("$"))
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn map_4x3_to_4(t: &str) -> Option<&'static str> {
@@ -134,10 +196,13 @@ pub(crate) fn placeholder_guid(id: u32) -> String {
     String::from_utf8(s.to_vec()).unwrap()
 }
 
-/// Trim a STEP attribute list to `max_count` top-level attributes (STEP-nesting aware).
-fn trim_attributes(attrs: &str, max_count: usize) -> String {
+/// Split a raw STEP attribute list into its top-level (comma-separated)
+/// value strings, respecting nested parentheses and single-quoted strings.
+/// Empty list -> `[]`. Shared by `trim_attributes` (positional truncation)
+/// and `remap_attrs_by_name` (by-name reconciliation).
+fn split_top_level(attrs: &str) -> Vec<String> {
     if attrs.trim().is_empty() {
-        return attrs.to_string();
+        return Vec::new();
     }
     let bytes = attrs.as_bytes();
     let mut out: Vec<String> = Vec::new();
@@ -168,15 +233,21 @@ fn trim_attributes(attrs: &str, max_count: usize) -> String {
             current.push(ch);
         } else if ch == ',' && depth == 0 {
             out.push(std::mem::take(&mut current));
-            if out.len() >= max_count {
-                return out.join(",");
-            }
         } else {
             current.push(ch);
         }
         i += 1;
     }
     out.push(current);
+    out
+}
+
+/// Trim a STEP attribute list to `max_count` top-level attributes (STEP-nesting aware).
+fn trim_attributes(attrs: &str, max_count: usize) -> String {
+    if attrs.trim().is_empty() {
+        return attrs.to_string();
+    }
+    let out = split_top_level(attrs);
     if out.len() > max_count {
         out[..max_count].join(",")
     } else {
@@ -233,7 +304,22 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
         );
     }
 
-    let mut final_attrs = if cto == "IFC2X3" {
+    // IFCDOORTYPE/IFCWINDOWTYPE -> IFCDOORSTYLE/IFCWINDOWSTYLE: neither
+    // attribute list is a positional prefix of the other (IFC4 inserted
+    // ElementType/PredefinedType mid-list), so reconcile by name instead of
+    // the generic positional trim below.
+    let mut final_attrs = if new_type != entity_type {
+        if let Some((src_names, tgt_names)) = by_name_attr_remap_names(&entity_type) {
+            remap_attrs_by_name(attrs, src_names, tgt_names)
+        } else if cto == "IFC2X3" {
+            match ifc2x3_attr_count(&new_type) {
+                Some(max) => trim_attributes(attrs, max),
+                None => attrs.to_string(),
+            }
+        } else {
+            attrs.to_string()
+        }
+    } else if cto == "IFC2X3" {
         match ifc2x3_attr_count(&new_type) {
             Some(max) => trim_attributes(attrs, max),
             None => attrs.to_string(),

--- a/rust/export/src/schema_convert_tests.rs
+++ b/rust/export/src/schema_convert_tests.rs
@@ -2,6 +2,19 @@
 //! Tests for [`super::schema_convert`]. Split out of `schema_convert.rs` to
 //! keep that module under the 400-line rule (AGENTS.md), matching the
 //! `schema_helpers.rs` / `schema_helpers_tests.rs` pattern.
+//!
+//! Includes the Rust twin of TS PR #3653
+//! (`schema-converter-door-window-type.test.ts`): `ifc-lite export --format
+//! step` on an IFC4 model downgraded to IFC2X3 silently destroyed every
+//! IfcDoorType/IfcWindowType. `map_4_to_2x3` had no entry for either, so
+//! `convert_entity_type` left the type name unchanged, `should_skip_entity`
+//! never matched it either, and the un-renamed type sailed through
+//! `convert_step_line` as an unrecognized IFC2X3 type name — producing an
+//! invalid `IFCDOORTYPE(...)` line in an IFC2X3 file (the TS side
+//! additionally fell through to an IFCPROXY substitution via a different
+//! code path, `resolveUnrepresentedEntity`; the net defect is the same: the
+//! door/window type's own identity is not carried into IFC2X3 as
+//! `IfcDoorStyle`/`IfcWindowStyle`).
 
 use super::*;
 
@@ -133,4 +146,67 @@ fn no_conversion_is_identity() {
     assert_eq!(convert_step_line(line, "IFC4", "IFC4", 1), line);
     assert!(!needs_conversion("IFC4", "IFC4"));
     assert!(needs_conversion("IFC2X3", "IFC4"));
+}
+
+#[test]
+fn ifcdoortype_maps_to_ifcdoorstyle_preserving_globalid_and_name() {
+    // IfcDoorType(IFC4) attrs: GlobalId,OwnerHistory,Name,Description,
+    // ApplicableOccurrence,HasPropertySets,RepresentationMaps,Tag,
+    // ElementType,PredefinedType,OperationType,ParameterTakesPrecedence,
+    // UserDefinedOperationType
+    let line = "#1=IFCDOORTYPE('1mW6gHB0W7lxCAqIKVEzia',#2,'Door Type',$,$,(#3),(#4),'tag',\
+                $,.DOOR.,.SINGLE_SWING_LEFT.,.T.,$);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 1);
+
+    assert!(!out.contains("IFCPROXY"), "must not fall back to a proxy: {out}");
+    assert!(out.starts_with("#1=IFCDOORSTYLE("), "renamed to IfcDoorStyle: {out}");
+    // GlobalId, Name, HasPropertySets, RepresentationMaps, Tag all survive.
+    assert!(out.contains("'1mW6gHB0W7lxCAqIKVEzia'"), "GlobalId preserved: {out}");
+    assert!(out.contains("'Door Type'"), "Name preserved: {out}");
+    assert!(out.contains("(#3)"), "HasPropertySets preserved: {out}");
+    assert!(out.contains("(#4)"), "RepresentationMaps preserved: {out}");
+    assert!(out.contains("'tag'"), "Tag preserved: {out}");
+    // IfcDoorStyle(IFC2X3) attrs: GlobalId,OwnerHistory,Name,Description,
+    // ApplicableOccurrence,HasPropertySets,RepresentationMaps,Tag,
+    // OperationType,ConstructionType,ParameterTakesPrecedence,Sizeable
+    assert_eq!(
+        out,
+        "#1=IFCDOORSTYLE('1mW6gHB0W7lxCAqIKVEzia',#2,'Door Type',$,$,(#3),(#4),'tag',\
+         .SINGLE_SWING_LEFT.,$,.T.,$);"
+    );
+}
+
+#[test]
+fn ifcwindowtype_maps_to_ifcwindowstyle_preserving_globalid_and_name() {
+    // IfcWindowType(IFC4) attrs: …,Tag,ElementType,PredefinedType,
+    // PartitioningType,ParameterTakesPrecedence,UserDefinedPartitioningType
+    let line = "#1=IFCWINDOWTYPE('3Vnz8SzMO$_GklsTTZo$zj',#2,'Window Type',$,$,$,$,'tag',\
+                $,.WINDOW.,.SINGLE_PANEL.,.T.,$);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 1);
+
+    assert!(!out.contains("IFCPROXY"), "must not fall back to a proxy: {out}");
+    assert!(out.starts_with("#1=IFCWINDOWSTYLE("), "renamed to IfcWindowStyle: {out}");
+    assert!(out.contains("'3Vnz8SzMO$_GklsTTZo$zj'"), "GlobalId preserved: {out}");
+    assert!(out.contains("'Window Type'"), "Name preserved: {out}");
+}
+
+#[test]
+fn ifcdoorstyle_upgrade_leg_is_a_pure_pass_through() {
+    // IfcDoorStyle is valid (deprecated) in IFC4 too, so IFC2X3 -> IFC4 was
+    // never the buggy direction: no rename entry, no attribute remap.
+    let line = "#1=IFCDOORSTYLE('1mW6gHB0W7lxCAqIKVEzia',#2,'Door Style',$,$,$,$,$,\
+                .SINGLE_SWING_LEFT.,$,.T.,$);";
+    let out = convert_step_line(line, "IFC2X3", "IFC4", 1);
+    assert_eq!(out, line, "upgrade leg is untouched: {out}");
+}
+
+#[test]
+fn other_ifc2x3_downgrade_renames_still_use_positional_trim() {
+    // Control: the by-name remap is scoped to exactly IFCDOORTYPE/
+    // IFCWINDOWTYPE, not applied to every IFC4->IFC2X3 rename.
+    let line = "#5=IFCCHIMNEY('g',$,'C1',$,$,#6,#7,'tag',.USERDEFINED.);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 5);
+    assert!(out.starts_with("#5=IFCBUILDINGELEMENTPROXY("), "renamed via positional path: {out}");
+    // IfcBuildingElementProxy caps at 9 IFC2X3 attrs; this line has exactly 9, so nothing trims.
+    assert!(out.contains(".USERDEFINED."), "positional trim/pass-through unaffected: {out}");
 }


### PR DESCRIPTION
## Summary

Rust twin of #3653 (which fixed the TS `packages/export/src/schema-converter.ts`). `rust/export/src/schema_convert.rs` — which backs `ifc-lite export --format step` / `ifc-lite convert --schema IFC2X3` — had the identical gap: `map_4_to_2x3` had no entry for `IFCDOORTYPE`/`IFCWINDOWTYPE`, so an IFC4/IFC4X3 → IFC2X3 downgrade left the type name unmodified, emitting an unrecognized `IFCDOORTYPE`/`IFCWINDOWTYPE` line inside an IFC2X3-schema file rather than mapping it to IFC2X3's real target: `IfcDoorStyle`/`IfcWindowStyle`.

- `map_4_to_2x3` now maps `IFCDOORTYPE` → `IFCDOORSTYLE` and `IFCWINDOWTYPE` → `IFCWINDOWSTYLE`.
- Their attribute lists only partially overlap by name (IFC4 inserted `ElementType`/`PredefinedType` ahead of the attributes it kept from IFC2X3's `IfcTypeProduct` lineage), so neither list is a positional prefix of the other — the generic trim/pad logic (`ifc2x3_attr_count` + `trim_attributes`) would misalign values. A new `by_name_attr_remap_names` + `remap_attrs_by_name` pair reconciles the two attribute lists by NAME instead, mirroring the TS side's `schema-converter-attr-remap.ts`: a target attribute with no same-named source becomes `$`, a source attribute with no same-named target slot is dropped.
- Scoped to exactly these two types via an allowlist match in `by_name_attr_remap_names`; every other rename in `map_4_to_2x3` is untouched and still uses the existing positional trim/pass-through path.
- The IFC2X3 → IFC4 upgrade leg is unaffected (no rename entry — `IfcDoorStyle`/`IfcWindowStyle` are valid, if deprecated, in IFC4 too), matching the TS fix's scope.

Landing this alongside #3653 keeps the TS and Rust schema converters in agreement on this case.

## Test plan

- [x] New test `rust/export/src/schema_convert_tests.rs` (ratchet-exempt `_tests.rs` sibling, wired via `#[path]` from `schema_convert.rs`): asserts an `IFCDOORTYPE`/`IFCWINDOWTYPE` line converts to a well-formed `IFCDOORSTYLE`/`IFCWINDOWSTYLE` with GlobalId and Name preserved (not a proxy or an un-renamed line), plus control cases for the IFC2X3→IFC4 pass-through and an unrelated rename's unaffected positional trim.
- [x] RED verified: temporarily removed the two `map_4_to_2x3` rename entries — the new door/window tests failed as expected.
- [x] GREEN: restored the fix, all `schema_convert` tests pass.
- [x] `cargo test -p ifc-lite-export` — 86 passed, 0 failed.
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` — 4 passed, 0 failed (new file kept under budget via the `_tests.rs` sibling).
- [x] Changeset added (`@ifc-lite/wasm: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436