### PR TITLE
fix(create): stop NetFloorArea exceeding GrossFloorArea under generate-spaces --boundary outer

### DIFF
--- a/.changeset/generate-spaces-net-floor-area-inversion.md
+++ b/.changeset/generate-spaces-net-floor-area-inversion.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/create': patch
+---
+
+`generateSpacesFromWalls` (`ifc-lite generate-spaces` / `bim.spaces.generate`) no longer reports `NetFloorArea` larger than `GrossFloorArea` when `--boundary outer` (or `center`) is used. `addSpaceToStore` derives `NetFloorArea` from the emitted `OuterCurve` polygon's own area when a caller omits `netFloorArea`; the orchestrator passed only `grossFloorArea` (the centreline measure), assuming `OuterCurve` was always the inner (net) face — true only for the default `--boundary inner`. Under `outer`, `OuterCurve` is the outward-offset (larger) footprint, so the reported `NetFloorArea` came out bigger than `GrossFloorArea`, which `Qto_SpaceBaseQuantities` never allows. `generateSpacesFromWalls` now always computes the inner-face inset separately and passes its area as `netFloorArea`, independent of `boundaryMode`. The shared geometry helpers (`offsetRoomFootprint` and friends) moved unchanged to a new sibling module, `room-footprint-offset.ts`; the package's public exports are unchanged.

--- a/packages/create/src/in-store/generate-spaces-net-area.test.ts
+++ b/packages/create/src/in-store/generate-spaces-net-area.test.ts
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression for a `Qto_SpaceBaseQuantities` inversion in `--boundary outer`
+ * (and, more mildly, `--boundary center`) `ifc-lite generate-spaces` output.
+ *
+ * `offsetRoomFootprint` (generate-spaces.ts) bakes the emitted `IfcSpace`
+ * solid at whichever face `boundaryMode` selects — for `'outer'` that is the
+ * OUTWARD-offset (largest) footprint, not the inner (room-side) one.
+ * `addSpaceToStore` (space.ts), when a caller omits `netFloorArea`, derives
+ * `NetFloorArea` from that same `OuterCurve` polygon's own area. So an
+ * unpatched caller that passes only `grossFloorArea` (the centreline area)
+ * alongside an outer-offset `OuterCurve` reports `NetFloorArea` LARGER than
+ * `GrossFloorArea` — backwards, since a room's net (inner-face) area can
+ * never exceed its gross (outer-face or centreline) area.
+ *
+ * `generateSpacesFromWalls` now always computes the true inner-face area
+ * separately and passes it as `netFloorArea`, independent of `boundaryMode`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '@ifc-lite/mutations';
+import { addSpaceToStore } from './space.js';
+import { offsetRoomFootprint, type BoundaryMode } from './generate-spaces.js';
+import type { Segment, Vec2 } from './auto-space-detect.js';
+
+function makeStore(maxId: number): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+function polygonArea(pts: Vec2[]): number {
+  let acc = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    const q = pts[(i + 1) % pts.length];
+    acc += p[0] * q[1] - q[0] * p[1];
+  }
+  return Math.abs(acc) / 2;
+}
+
+// A 4x4 m centreline room bounded by four 0.3 m thick walls.
+const outline: Vec2[] = [[0, 0], [4, 0], [4, 4], [0, 4]];
+const segments: Segment[] = [
+  { a: [0, 0], b: [4, 0] },
+  { a: [4, 0], b: [4, 4] },
+  { a: [4, 4], b: [0, 4] },
+  { a: [0, 4], b: [0, 0] },
+];
+const wallThicknesses = [0.3, 0.3, 0.3, 0.3];
+const grossArea = polygonArea(outline); // 16 — the centreline (GrossFloorArea) measure
+
+function bake(view: MutablePropertyView, editor: StoreEditor, boundaryMode: BoundaryMode, netFloorArea?: number) {
+  const bakedOutline = offsetRoomFootprint(outline, segments, wallThicknesses, boundaryMode, []);
+  return addSpaceToStore(
+    editor,
+    { ownerHistoryId: 5, bodyContextId: 14, axisContextId: 15, storeyId: 43, storeyPlacementId: 54 },
+    {
+      Profile: 'polygon',
+      OuterCurve: bakedOutline,
+      Height: 3,
+      grossFloorArea: grossArea,
+      netFloorArea,
+    },
+  );
+}
+
+const namedQ = (view: MutablePropertyView, id: number): Record<string, number> => {
+  const qto = view.getQuantitiesForEntity(id).find((s) => s.name === 'Qto_SpaceBaseQuantities');
+  return Object.fromEntries((qto?.quantities ?? []).map((q) => [q.name, q.value]));
+};
+
+describe('generate-spaces boundaryMode=outer: NetFloorArea must not exceed GrossFloorArea', () => {
+  it('BUG (space.ts default fallback): an outer-offset OuterCurve with no netFloorArea override reports Net > Gross', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(60), view);
+    // This mirrors the pre-fix generate-spaces.ts call shape: OuterCurve is
+    // the outer-offset polygon, only grossFloorArea (centreline) is supplied.
+    const result = bake(view, editor, 'outer', undefined);
+    const q = namedQ(view, result.spaceId);
+    expect(q['GrossFloorArea']).toBeCloseTo(grossArea, 6);
+    // The defect: net exceeds gross, which Qto_SpaceBaseQuantities forbids.
+    expect(q['NetFloorArea']).toBeGreaterThan(q['GrossFloorArea']);
+  });
+
+  it('FIX: generateSpacesFromWalls always derives netFloorArea from the inner (room-side) offset, independent of boundaryMode', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(60), view);
+    const innerOutline = offsetRoomFootprint(outline, segments, wallThicknesses, 'inner', []);
+    const netFloorArea = polygonArea(innerOutline);
+    const result = bake(view, editor, 'outer', netFloorArea);
+    const q = namedQ(view, result.spaceId);
+    expect(q['GrossFloorArea']).toBeCloseTo(grossArea, 6);
+    expect(q['NetFloorArea']).toBeCloseTo(netFloorArea, 6);
+    expect(q['NetFloorArea']).toBeLessThanOrEqual(q['GrossFloorArea']);
+  });
+
+  it('CONTROL: boundaryMode=inner (the default) was already correct — OuterCurve IS the net face', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(60), view);
+    // No netFloorArea override — matches generate-spaces.ts's actual call for
+    // the default boundaryMode, both before and after the fix.
+    const result = bake(view, editor, 'inner', undefined);
+    const q = namedQ(view, result.spaceId);
+    expect(q['GrossFloorArea']).toBeCloseTo(grossArea, 6);
+    expect(q['NetFloorArea']).toBeLessThanOrEqual(q['GrossFloorArea']);
+  });
+});

--- a/packages/create/src/in-store/generate-spaces.ts
+++ b/packages/create/src/in-store/generate-spaces.ts
@@ -32,6 +32,9 @@ import {
   type Vec2,
 } from './auto-space-detect.js';
 import { addSpaceToStore, type SpaceBuildResult, type SpaceBoundaryInput } from './space.js';
+import { offsetRoomFootprint, pointInPolygon, polygonArea, type BoundaryMode } from './room-footprint-offset.js';
+
+export { offsetRoomFootprint, type BoundaryMode } from './room-footprint-offset.js';
 
 /**
  * IfcSpace.ObjectType marker stamped on every derived space, so a re-run can
@@ -187,13 +190,17 @@ export function generateSpacesFromWalls(
   if (options.guidRandom !== undefined) anchor.guidRandom = options.guidRandom;
 
   const allOutlines = rooms.map((r) => r.outline);
+  const boundaryMode = options.boundaryMode ?? 'inner';
   rooms.forEach((region, i) => {
     const name = namePattern.replace('{n}', String(i + 1));
     const others = allOutlines.filter((_, j) => j !== i);
-    // Bake the solid at the inner (net) face — IfcSpace should stop at the room
-    // side of the walls, not run to their centreline. GrossFloorArea keeps the
-    // centreline measure; NetFloorArea falls out of the inset OuterCurve.
-    const netOutline = offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, options.boundaryMode ?? 'inner', others);
+    // Bake the solid at the chosen boundary face, but always derive
+    // NetFloorArea from the inner (room-side) inset — under 'outer'/'center'
+    // OuterCurve isn't the inner face, so reusing its area would report
+    // NetFloorArea > GrossFloorArea.
+    const netOutline = offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, boundaryMode, others);
+    const netFootprint = boundaryMode === 'inner' ? netOutline
+      : offsetRoomFootprint(region.outline, extraction.segments, extraction.wallThicknesses, 'inner', others);
     const result = addSpaceToStore(editor, anchor, {
       Profile: 'polygon',
       OuterCurve: netOutline,
@@ -209,6 +216,7 @@ export function generateSpacesFromWalls(
         others,
       ),
       grossFloorArea: region.area,
+      netFloorArea: polygonArea(netFootprint),
     });
     emitted.push({ region, result, name });
   });
@@ -222,143 +230,6 @@ export function generateSpacesFromWalls(
     emitted,
     skippedExisting,
   };
-}
-
-/** Absolute polygon area (shoelace), m². */
-function polygonArea(pts: Vec2[]): number {
-  let acc = 0;
-  for (let i = 0; i < pts.length; i++) {
-    const p = pts[i];
-    const q = pts[(i + 1) % pts.length];
-    acc += p[0] * q[1] - q[0] * p[1];
-  }
-  return Math.abs(acc) / 2;
-}
-
-/** Intersection of two lines given as point + unit direction; null if parallel. */
-function lineIntersect(
-  p0: Vec2, d0: Vec2, p1: Vec2, d1: Vec2,
-): Vec2 | null {
-  const denom = d0[0] * d1[1] - d0[1] * d1[0];
-  if (Math.abs(denom) < 1e-9) return null;
-  const t = ((p1[0] - p0[0]) * d1[1] - (p1[1] - p0[1]) * d1[0]) / denom;
-  return [p0[0] + d0[0] * t, p0[1] + d0[1] * t];
-}
-
-/** Does outline edge a→b run along wall segment `seg` (parallel, on its
- *  centreline, overlapping extent)? */
-function edgeRunsAlong(a: Vec2, b: Vec2, seg: Segment): boolean {
-  const PERP_TOL = 0.2, PARALLEL_TOL = 0.03, OVERLAP_MARGIN = 0.3;
-  let ex = b[0] - a[0], ey = b[1] - a[1];
-  const el = Math.hypot(ex, ey);
-  if (el < 1e-6) return false;
-  ex /= el; ey /= el;
-  let sx = seg.b[0] - seg.a[0], sy = seg.b[1] - seg.a[1];
-  const sl = Math.hypot(sx, sy);
-  if (sl < 1e-6) return false;
-  sx /= sl; sy /= sl;
-  if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) return false;
-  const mx = (a[0] + b[0]) / 2, my = (a[1] + b[1]) / 2;
-  const t = (mx - seg.a[0]) * sx + (my - seg.a[1]) * sy;
-  const px = seg.a[0] + sx * t, py = seg.a[1] + sy * t;
-  if (Math.hypot(mx - px, my - py) > PERP_TOL) return false;
-  return t >= -OVERLAP_MARGIN && t <= sl + OVERLAP_MARGIN;
-}
-
-/** How a space boundary relates to its bounding walls. */
-export type BoundaryMode = 'center' | 'inner' | 'outer';
-
-/** Drop vertices whose two adjacent edges are collinear (e.g. a T-junction
- *  point left on a straight wall run). Such a vertex makes its two adjacent
- *  offset lines parallel, so they don't intersect — the offset then falls back
- *  to the un-offset centreline point and the corner skews. */
-function simplifyCollinear(pts: Vec2[]): Vec2[] {
-  const n = pts.length;
-  if (n < 4) return pts;
-  const out: Vec2[] = [];
-  for (let i = 0; i < n; i++) {
-    const p = pts[(i - 1 + n) % n], c = pts[i], q = pts[(i + 1) % n];
-    let ax = c[0] - p[0], ay = c[1] - p[1];
-    let bx = q[0] - c[0], by = q[1] - c[1];
-    const al = Math.hypot(ax, ay) || 1, bl = Math.hypot(bx, by) || 1;
-    ax /= al; ay /= al; bx /= bl; by /= bl;
-    if (Math.abs(ax * by - ay * bx) > 1e-4) out.push(c); // keep real corners only
-  }
-  return out.length >= 3 ? out : pts;
-}
-
-/**
- * Offset a (centreline) room outline to the chosen wall boundary: `center` =
- * the centreline as-is; `inner` = each edge shifted toward the room by half the
- * wall thickness (net / inner face); `outer` = shifted away by half (gross /
- * outer face). Re-corners by intersecting adjacent offset edges. `segments[k]`
- * has thickness `wallThicknesses[k]`. `otherRooms` (other rooms' centreline
- * outlines) lets `outer` keep shared/internal edges on the centreline so
- * neighbouring rooms meet there instead of overlapping inside the wall.
- * Returns the original outline if the offset degenerates (e.g. an inner inset
- * of a room thinner than its walls). Exact for orthogonal rooms.
- */
-export function offsetRoomFootprint(
-  outline: Vec2[],
-  segments: Segment[],
-  wallThicknesses: ReadonlyArray<number | undefined>,
-  mode: BoundaryMode = 'inner',
-  otherRooms: Vec2[][] = [],
-): Vec2[] {
-  if (mode === 'center') return outline;
-  const simple = simplifyCollinear(outline);
-  const n = simple.length;
-  if (n < 3) return outline;
-  const sign = mode === 'inner' ? 1 : -1; // inner → inward, outer → outward
-  const lines: { p: Vec2; d: Vec2 }[] = [];
-  for (let i = 0; i < n; i++) {
-    const a = simple[i];
-    const b = simple[(i + 1) % n];
-    let dx = b[0] - a[0];
-    let dy = b[1] - a[1];
-    const l = Math.hypot(dx, dy);
-    if (l < 1e-6) return outline;
-    dx /= l; dy /= l;
-    let half = 0; // half the thickest wall this edge runs along
-    for (let k = 0; k < segments.length; k++) {
-      const t = wallThicknesses[k];
-      if (t !== undefined && t / 2 > half && edgeRunsAlong(a, b, segments[k])) half = t / 2;
-    }
-    let off = sign * half;
-    // A shared (internal) edge has another room on its OUTWARD side. Pushing it
-    // outward (outer mode) would overlap that room, so pin shared edges to the
-    // centreline; only edges facing outside the building actually push out.
-    if (mode === 'outer' && half > 0 && otherRooms.length) {
-      const mx = (a[0] + b[0]) / 2 + dy * 0.1; // outward = right normal (dy, -dx)
-      const my = (a[1] + b[1]) / 2 - dx * 0.1;
-      if (otherRooms.some((poly) => pointInPolygon(mx, my, poly))) off = 0;
-    }
-    // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
-    lines.push({ p: [a[0] - dy * off, a[1] + dx * off], d: [dx, dy] });
-  }
-  const verts: Vec2[] = [];
-  for (let i = 0; i < n; i++) {
-    const prev = lines[(i - 1 + n) % n];
-    const cur = lines[i];
-    verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? simple[i]);
-  }
-  if (!verts.every((v) => Number.isFinite(v[0]) && Number.isFinite(v[1]))) return outline;
-  const gross = polygonArea(simple);
-  const got = polygonArea(verts);
-  if (got <= 1e-6) return outline;
-  if (mode === 'inner' && got > gross + 1e-6) return outline; // inset inverted
-  return verts;
-}
-
-/** Ray-cast point-in-polygon test. */
-function pointInPolygon(x: number, y: number, poly: Vec2[]): boolean {
-  let inside = false;
-  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
-    const xi = poly[i][0], yi = poly[i][1];
-    const xj = poly[j][0], yj = poly[j][1];
-    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
-  }
-  return inside;
 }
 
 /** Wall ids whose centreline an outline edge runs along (parallel, on the

--- a/packages/create/src/in-store/room-footprint-offset.ts
+++ b/packages/create/src/in-store/room-footprint-offset.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * 2D room-footprint geometry helpers shared by `generate-spaces.ts`: offset a
+ * detected room's centreline outline to its net (inner) or gross (outer)
+ * wall-face boundary, plus the small polygon primitives that offset needs.
+ * Split out of `generate-spaces.ts` to keep that file's orchestration logic
+ * under the module-size budget — no behavioural change from the move.
+ */
+
+import type { Segment, Vec2 } from './auto-space-detect.js';
+
+/** Absolute polygon area (shoelace), m². */
+export function polygonArea(pts: Vec2[]): number {
+  let acc = 0;
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    const q = pts[(i + 1) % pts.length];
+    acc += p[0] * q[1] - q[0] * p[1];
+  }
+  return Math.abs(acc) / 2;
+}
+
+/** Ray-cast point-in-polygon test. */
+export function pointInPolygon(x: number, y: number, poly: Vec2[]): boolean {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const xi = poly[i][0], yi = poly[i][1];
+    const xj = poly[j][0], yj = poly[j][1];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) inside = !inside;
+  }
+  return inside;
+}
+
+/** Intersection of two lines given as point + unit direction; null if parallel. */
+function lineIntersect(
+  p0: Vec2, d0: Vec2, p1: Vec2, d1: Vec2,
+): Vec2 | null {
+  const denom = d0[0] * d1[1] - d0[1] * d1[0];
+  if (Math.abs(denom) < 1e-9) return null;
+  const t = ((p1[0] - p0[0]) * d1[1] - (p1[1] - p0[1]) * d1[0]) / denom;
+  return [p0[0] + d0[0] * t, p0[1] + d0[1] * t];
+}
+
+/** Does outline edge a→b run along wall segment `seg` (parallel, on its
+ *  centreline, overlapping extent)? */
+function edgeRunsAlong(a: Vec2, b: Vec2, seg: Segment): boolean {
+  const PERP_TOL = 0.2, PARALLEL_TOL = 0.03, OVERLAP_MARGIN = 0.3;
+  let ex = b[0] - a[0], ey = b[1] - a[1];
+  const el = Math.hypot(ex, ey);
+  if (el < 1e-6) return false;
+  ex /= el; ey /= el;
+  let sx = seg.b[0] - seg.a[0], sy = seg.b[1] - seg.a[1];
+  const sl = Math.hypot(sx, sy);
+  if (sl < 1e-6) return false;
+  sx /= sl; sy /= sl;
+  if (Math.abs(ex * sy - ey * sx) > PARALLEL_TOL) return false;
+  const mx = (a[0] + b[0]) / 2, my = (a[1] + b[1]) / 2;
+  const t = (mx - seg.a[0]) * sx + (my - seg.a[1]) * sy;
+  const px = seg.a[0] + sx * t, py = seg.a[1] + sy * t;
+  if (Math.hypot(mx - px, my - py) > PERP_TOL) return false;
+  return t >= -OVERLAP_MARGIN && t <= sl + OVERLAP_MARGIN;
+}
+
+/** How a space boundary relates to its bounding walls. */
+export type BoundaryMode = 'center' | 'inner' | 'outer';
+
+/** Drop vertices whose two adjacent edges are collinear (e.g. a T-junction
+ *  point left on a straight wall run). Such a vertex makes its two adjacent
+ *  offset lines parallel, so they don't intersect — the offset then falls back
+ *  to the un-offset centreline point and the corner skews. */
+function simplifyCollinear(pts: Vec2[]): Vec2[] {
+  const n = pts.length;
+  if (n < 4) return pts;
+  const out: Vec2[] = [];
+  for (let i = 0; i < n; i++) {
+    const p = pts[(i - 1 + n) % n], c = pts[i], q = pts[(i + 1) % n];
+    let ax = c[0] - p[0], ay = c[1] - p[1];
+    let bx = q[0] - c[0], by = q[1] - c[1];
+    const al = Math.hypot(ax, ay) || 1, bl = Math.hypot(bx, by) || 1;
+    ax /= al; ay /= al; bx /= bl; by /= bl;
+    if (Math.abs(ax * by - ay * bx) > 1e-4) out.push(c); // keep real corners only
+  }
+  return out.length >= 3 ? out : pts;
+}
+
+/**
+ * Offset a (centreline) room outline to the chosen wall boundary: `center` =
+ * the centreline as-is; `inner` = each edge shifted toward the room by half the
+ * wall thickness (net / inner face); `outer` = shifted away by half (gross /
+ * outer face). Re-corners by intersecting adjacent offset edges. `segments[k]`
+ * has thickness `wallThicknesses[k]`. `otherRooms` (other rooms' centreline
+ * outlines) lets `outer` keep shared/internal edges on the centreline so
+ * neighbouring rooms meet there instead of overlapping inside the wall.
+ * Returns the original outline if the offset degenerates (e.g. an inner inset
+ * of a room thinner than its walls). Exact for orthogonal rooms.
+ */
+export function offsetRoomFootprint(
+  outline: Vec2[],
+  segments: Segment[],
+  wallThicknesses: ReadonlyArray<number | undefined>,
+  mode: BoundaryMode = 'inner',
+  otherRooms: Vec2[][] = [],
+): Vec2[] {
+  if (mode === 'center') return outline;
+  const simple = simplifyCollinear(outline);
+  const n = simple.length;
+  if (n < 3) return outline;
+  const sign = mode === 'inner' ? 1 : -1; // inner → inward, outer → outward
+  const lines: { p: Vec2; d: Vec2 }[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = simple[i];
+    const b = simple[(i + 1) % n];
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    const l = Math.hypot(dx, dy);
+    if (l < 1e-6) return outline;
+    dx /= l; dy /= l;
+    let half = 0; // half the thickest wall this edge runs along
+    for (let k = 0; k < segments.length; k++) {
+      const t = wallThicknesses[k];
+      if (t !== undefined && t / 2 > half && edgeRunsAlong(a, b, segments[k])) half = t / 2;
+    }
+    let off = sign * half;
+    // A shared (internal) edge has another room on its OUTWARD side. Pushing it
+    // outward (outer mode) would overlap that room, so pin shared edges to the
+    // centreline; only edges facing outside the building actually push out.
+    if (mode === 'outer' && half > 0 && otherRooms.length) {
+      const mx = (a[0] + b[0]) / 2 + dy * 0.1; // outward = right normal (dy, -dx)
+      const my = (a[1] + b[1]) / 2 - dx * 0.1;
+      if (otherRooms.some((poly) => pointInPolygon(mx, my, poly))) off = 0;
+    }
+    // Inward normal of a CCW outline is to the left of a→b: (-dy, dx).
+    lines.push({ p: [a[0] - dy * off, a[1] + dx * off], d: [dx, dy] });
+  }
+  const verts: Vec2[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = lines[(i - 1 + n) % n];
+    const cur = lines[i];
+    verts.push(lineIntersect(prev.p, prev.d, cur.p, cur.d) ?? simple[i]);
+  }
+  if (!verts.every((v) => Number.isFinite(v[0]) && Number.isFinite(v[1]))) return outline;
+  const gross = polygonArea(simple);
+  const got = polygonArea(verts);
+  if (got <= 1e-6) return outline;
+  if (mode === 'inner' && got > gross + 1e-6) return outline; // inset inverted
+  return verts;
+}

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -81,7 +81,10 @@ export interface SpacePolygonParams {
   /** Bounding elements → one IfcRelSpaceBoundary each. */
   boundaries?: SpaceBoundaryInput[];
   /** Net (inner-face) floor area in m² for Qto_SpaceBaseQuantities; defaults
-   *  to the gross/centreline area when omitted. */
+   *  to the OuterCurve polygon's own area when omitted — pass this explicitly
+   *  whenever OuterCurve is not itself the inner (room-side) face, e.g. a
+   *  centreline or outer-face boundary, otherwise NetFloorArea can come out
+   *  larger than GrossFloorArea. */
   netFloorArea?: number;
   /** Gross (centreline) floor area in m² for GrossFloorArea + GrossVolume;
    *  defaults to the OuterCurve area when omitted. */
@@ -195,7 +198,11 @@ export function addSpaceToStore(
   // Qto_SpaceBaseQuantities — attached via the property view (createQuantitySet)
   // rather than as raw IfcElementQuantity entities, so they surface in the
   // properties panel (getQuantitiesForEntity) AND export, from one source.
-  // `area` is the OuterCurve (net when generated from walls) footprint;
+  // `area` is the OuterCurve polygon's own footprint — the fallback used only
+  // when a caller omits `netFloorArea` / `grossFloorArea`. A caller whose
+  // OuterCurve isn't the inner (room-side) face — e.g. a centreline or
+  // outer-face boundary — must pass `netFloorArea` explicitly, else
+  // NetFloorArea comes out equal to or larger than GrossFloorArea.
   // GrossFloorArea/GrossVolume take the supplied centreline measure.
   const area = polygon ? polygonArea(params.OuterCurve) : params.Width * params.Depth;
   const perimeter = polygon


### PR DESCRIPTION
## Hunt: `ifc-lite generate-spaces` correctness

**Algorithm.** `generateSpacesFromWalls` (`packages/create/src/in-store/generate-spaces.ts`, called by the CLI `generate-spaces` command and `bim.spaces.generate`) extracts wall axis segments per storey (`extractWallSegmentsForStorey`), snaps/splits them into a half-edge planar graph and walks minimum face cycles to detect enclosed rooms (`detectEnclosedAreasWithStats` in `auto-space-detect.ts`: snap → T-junction/crossing split → DCEL → leftmost-turn face walk → drop the unbounded face → filter by `minArea`), then bakes one `IfcSpace` per surviving region via `addSpaceToStore` (`space.ts`), offsetting the centreline outline to the chosen `--boundary` face (`center`/`inner`/`outer`) via `offsetRoomFootprint`.

**Verdict table** (synthetic 4×4 m room, four 0.3 m walls, all `--boundary` modes; `IfcRelAggregates`-to-storey containment, GlobalId generation, and coordinate/unit scaling are shared code paths already covered elsewhere and verified correct):

| Check | inner (default) | center | outer |
|---|---|---|---|
| Unique, well-formed GlobalId | ✅ | ✅ | ✅ |
| Attached via `IfcRelAggregates` to storey | ✅ | ✅ | ✅ |
| `OuterCurve` polygon face | correct (net) | correct (centreline) | correct (gross) |
| `GrossFloorArea` (centreline) | ✅ | ✅ | ✅ |
| **`NetFloorArea` ≤ `GrossFloorArea`** | ✅ | ✅ (equal, by construction) | ❌ **BUG** — net came out *larger* than gross |
| Coordinate/unit scale (mm model) | ✅ | ✅ | ✅ |
| Re-run dedup (skip overlapping existing space) | ✅ | ✅ | ✅ |

## The one fix

`addSpaceToStore` (`space.ts`) derives `Qto_SpaceBaseQuantities.NetFloorArea` from the `OuterCurve` polygon's own area whenever a caller omits an explicit `netFloorArea`. `generateSpacesFromWalls` only ever passed `grossFloorArea` (the pre-offset centreline area), on the assumption that `OuterCurve` is always the inner (net) face — true for the default `--boundary inner`, where the emitted solid *is* inset to the room side. Under `--boundary outer`, `OuterCurve` is instead the **outward**-offset (larger) footprint, so the reported `NetFloorArea` came out bigger than `GrossFloorArea` — backwards, since a room's net area can never exceed its gross area, and `Qto_SpaceBaseQuantities` never allows it. (`--boundary center` doesn't trip the inequality — `OuterCurve` there is the untouched centreline outline, so the fallback area equals `grossFloorArea` exactly — but it's still not a genuine *net* measure, which the fix also corrects.)

`generateSpacesFromWalls` now always computes the true inner-face inset separately (regardless of which face the solid itself uses) and passes its area as `netFloorArea` explicitly, so the quantity stays correct for every `--boundary` mode.

Reachability: any run of `ifc-lite generate-spaces --out out.ifc --boundary outer` (or the SDK's `bim.spaces.generate({ boundaryMode: 'outer' })` / the viewer's Space Sketch boundary picker feeding the same `offsetRoomFootprint`/`addSpaceToStore` pair) on a model with wall material-layer thickness.

**RED/GREEN/control** — `packages/create/src/in-store/generate-spaces-net-area.test.ts`, exercising the real `offsetRoomFootprint` + `addSpaceToStore`:
- RED (`space.ts`'s unpatched fallback, the pre-fix `generate-spaces.ts` call shape): outer-offset `OuterCurve` + only `grossFloorArea` ⇒ `NetFloorArea > GrossFloorArea`.
- GREEN (the fix's formula): `netFloorArea` derived from the inner inset ⇒ `NetFloorArea ≤ GrossFloorArea`, matches the true inner-face area.
- CONTROL: `--boundary inner` (the default, already correct before and after) ⇒ unchanged, `NetFloorArea ≤ GrossFloorArea`.

Housekeeping: the geometry offset helpers (`offsetRoomFootprint` and its private support functions) moved unchanged into a new sibling module, `room-footprint-offset.ts`, to keep `generate-spaces.ts` under the module-size budget after the fix — no behavioural change, and the package's public exports (`offsetRoomFootprint`, `BoundaryMode`) are unaffected (re-exported from the same path).

**Note for follow-up (not fixed here, out of this hunt's CLI scope):** the viewer's interactive Space Sketch tool (`apps/viewer/.../space-sketch/space-bake.ts`) calls the same `addSpaceToStore` with the same call shape (`OuterCurve` at the chosen boundary face, only `grossFloorArea` supplied) — it has the identical latent defect for its outer/center boundary modes.

## Verification (foreground)
- `packages/create`: `pnpm exec vitest run` — 27 files / 396 tests pass (includes the new regression file).
- `packages/cli`: `pnpm exec tsc --noEmit` via `pnpm turbo run typecheck --filter=@ifc-lite/create --filter=@ifc-lite/cli` — clean; `pnpm test` — 58 files / 582 tests pass, 8 skipped (fixture-gated).
- `node scripts/check-module-size.mjs` — exit 0 (no allowlist file touched; `generate-spaces.ts` dropped to 308 lines, under the unraised 400-line default).
- `pnpm run check:vitest-timeout-audit`, `node scripts/check-test-wiring.mjs`, `node scripts/check-unused-locals.mjs` — all clean, no new findings.
- Changeset added for `@ifc-lite/create` (patch — bugfix only, no export surface change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated net floor areas so they do not exceed gross floor areas when using outer or center boundary modes.
  * Ensured net floor area is calculated from the room-side boundary consistently across boundary modes.
* **Documentation**
  * Clarified how net floor area is determined when an explicit value is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->