### PR TITLE
fix(viewer): correct Space Sketch NetFloorArea (twin of #3656)

### DIFF
--- a/.changeset/space-sketch-net-floor-area-inversion.md
+++ b/.changeset/space-sketch-net-floor-area-inversion.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Space Sketch no longer inverts `NetFloorArea` above `GrossFloorArea` when the "outer" boundary is emitted (twin of #3656). Confirming a drawn room only ever passed `grossFloorArea` (the wall-centreline area) to `addSpaceToStore`, leaving `NetFloorArea` to default to the emitted `OuterCurve`'s own area — the outer-face outline when the user picked "outer" in the boundary popover, which is larger than the centreline. `Qto_SpaceBaseQuantities.NetFloorArea` now always measures the room's inner-face outline, independent of which boundary the user chose to draw/emit, so it never exceeds `GrossFloorArea`.

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.test.ts
@@ -18,9 +18,11 @@ function square(x: number, y: number, size: number): Pt[] {
   return [[x, y], [x + size, y], [x + size, y + size], [x, y + size]];
 }
 
-/** A draft room whose emit boundary is inset from its centreline outline. */
-function room(outline: Pt[], boundary: Pt[] = outline): DraftRoom {
-  return { outline, boundary };
+/** A draft room whose emit boundary is inset from its centreline outline.
+ *  `inner` (the net face used for NetFloorArea) defaults to the outline
+ *  itself, matching a room with no wall-thickness data. */
+function room(outline: Pt[], boundary: Pt[] = outline, inner: Pt[] = outline): DraftRoom {
+  return { outline, boundary, inner };
 }
 
 describe('floorToFloorHeight', () => {
@@ -78,6 +80,21 @@ describe('planStoreySpaces', () => {
     const { planned } = planStoreySpaces([room(outline, boundary)], [], 3);
     assert.deepEqual(planned[0].OuterCurve, boundary, 'the inset face is what gets created');
     assert.equal(planned[0].grossFloorArea, 16, 'the area stays on the centreline');
+  });
+
+  it('measures NetFloorArea on the INNER face, never the emitted OUTER boundary', () => {
+    // Emitting the "outer" boundary as OuterCurve must not make NetFloorArea
+    // the outer-face area — that would put NetFloorArea above GrossFloorArea,
+    // an area a space physically cannot have (twin of #3656's inversion bug).
+    const outline = square(0, 0, 4);          // 16 m² on the centreline (gross)
+    const outerFace = square(-0.1, -0.1, 4.2); // 17.64 m² outer face (what gets emitted)
+    const innerFace = square(0.1, 0.1, 3.8);   // 14.44 m² inner face (net)
+    const rooms = [{ outline, boundary: outerFace, inner: innerFace }];
+    const { planned } = planStoreySpaces(rooms, [], 3);
+    assert.deepEqual(planned[0].OuterCurve, outerFace, 'the outer face is what gets created');
+    assert.equal(planned[0].grossFloorArea, 16);
+    assert.equal(planned[0].netFloorArea, 14.44, 'net stays on the inner face');
+    assert.ok(planned[0].netFloorArea < planned[0].grossFloorArea, 'net must not exceed gross');
   });
 
   it('skips a room whose centroid sits inside an already-authored space', () => {

--- a/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/space-bake.ts
@@ -10,10 +10,13 @@
  * failure stories are all decisions rather than plumbing: a room emitted on top
  * of an authored space (duplicate rooms in the file), a floor-to-floor taken
  * from a storey list that is unsorted or has a nonsense gap (spaces a hundred
- * metres tall, or the wall band the derive reads collapsing to nothing), and
- * gross floor area measured off the wrong outline (the display boundary rather
- * than the centreline, which would make the quantity describe the wall face).
- * Those are the decisions this module owns; `useSpaceBake` owns the emitting.
+ * metres tall, or the wall band the derive reads collapsing to nothing), gross
+ * floor area measured off the wrong outline (the display boundary rather than
+ * the centreline, which would make the quantity describe the wall face), and
+ * net floor area tracking the display boundary too closely — a user emitting
+ * the "outer" boundary as `OuterCurve` would otherwise make NetFloorArea the
+ * outer-face area, larger than GrossFloorArea. Those are the decisions this
+ * module owns; `useSpaceBake` owns the emitting.
  */
 
 import { centroid, pointInPoly, polyArea, type Pt } from '@/lib/space-sketch-geometry';
@@ -51,11 +54,15 @@ export function floorToFloorHeight(storeys: StoreyElevation[], sid: number): num
 
 /**
  * One drafted room as the bake sees it: the topology outline (always the wall
- * centreline) and the display/emit boundary at the user's chosen boundary mode.
+ * centreline), the display/emit boundary at the user's chosen boundary mode,
+ * and the inner-face outline (always net, regardless of that choice).
  */
 export interface DraftRoom {
   outline: Pt[];
   boundary: Pt[];
+  /** The room's inner-face outline — independent of `boundary`'s mode, so
+   *  NetFloorArea stays net even when the user draws/emits at "outer". */
+  inner: Pt[];
 }
 
 /** An IfcSpace footprint the caller is cleared to create. */
@@ -65,6 +72,10 @@ export interface PlannedSpace {
   Height: number;
   /** Measured on the CENTRELINE outline, so the quantity is the room. */
   grossFloorArea: number;
+  /** Measured on the INNER-FACE outline, so the quantity never exceeds
+   *  `grossFloorArea` — even when the user emits the "outer" boundary as
+   *  `OuterCurve`, which is larger than the centreline. */
+  netFloorArea: number;
 }
 
 /**
@@ -91,6 +102,7 @@ export function planStoreySpaces(
       OuterCurve: room.boundary,
       Height: height,
       grossFloorArea: polyArea(room.outline),
+      netFloorArea: polyArea(room.inner),
     });
   }
   return { planned, skipped };

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceBake.ts
@@ -101,7 +101,8 @@ export function useSpaceBake({
     let error: string | null = null;
     for (const space of planned) {
       // `OuterCurve` is the engine's net/gross/centre outline; gross area stays
-      // on the centreline so the quantity reflects the room, not the wall face.
+      // on the centreline and net area stays on the inner face, so neither
+      // quantity is at the mercy of which boundary the user chose to emit.
       // The name counts SUCCESSFUL emissions, so a failed space does not leave
       // a gap in the numbering the user can see.
       const res = addSpace(sketchModelId, sid, {
@@ -111,6 +112,7 @@ export function useSpaceBake({
         Name: `Space ${newIds.length + 1}`,
         ObjectType: GENERATED_SPACE_OBJECTTYPE,
         grossFloorArea: space.grossFloorArea,
+        netFloorArea: space.netFloorArea,
       });
       if (res && 'expressId' in res) newIds.push(res.expressId);
       else error ??= (res && 'error' in res ? res.error : 'unknown error');
@@ -144,6 +146,10 @@ export function useSpaceBake({
       const rooms = session.rooms().map((r) => ({
         outline: r.outline,
         boundary: session.boundaryOutline(r.face, boundaryMode),
+        // Always the inner face, independent of `boundaryMode` — so
+        // NetFloorArea stays net even when the user emits "outer" as the
+        // room's OuterCurve.
+        inner: session.boundaryOutline(r.face, 'inner'),
       }));
       const res = createSpacesForStorey(sid, rooms, authoredMap.get(sid) ?? []);
       emitted += res.emitted;


### PR DESCRIPTION
## Summary

- #3656 fixed the CLI's `generate-spaces` so `Qto_SpaceBaseQuantities.NetFloorArea` is always the inner-face area instead of defaulting to the `OuterCurve` area (which could be larger than `GrossFloorArea` in `--boundary outer` mode).
- The viewer's Space Sketch tool has the same shape of call (`addSpaceToStore` receiving `grossFloorArea` but not `netFloorArea`), and the boundary popover lets a user pick `outer` as the emitted boundary. In that mode, `NetFloorArea` defaulted to the outer-face outline's area — larger than `GrossFloorArea` (the centreline area) — the same inversion #3656 fixed for the CLI.
- `space-bake.ts`'s `planStoreySpaces` now always measures `netFloorArea` from the room's inner-face outline (requested independently of the display `boundaryMode`), and `useSpaceBake.ts` passes it through to `addSpaceToStore`.

Verified concretely for a room whose centreline is a 4×4 m square (16 m² gross): with `boundaryMode: 'outer'`, the previous code emitted `NetFloorArea` = area of the ~4.2×4.2 m outer face (~17.64 m²) > `GrossFloorArea` = 16 m². The fix measures `NetFloorArea` off the inner face (~3.8×3.8 m ≈ 14.44 m²), which is always ≤ `GrossFloorArea`.

## Test plan

- [x] `space-bake.test.ts` — added a RED→GREEN test asserting `NetFloorArea` is measured on the inner face and never exceeds `GrossFloorArea` even when `OuterCurve` is the outer boundary; all 18 tests in `space-bake.test.ts` + `useSpaceBake.test.tsx` pass.
- [x] `pnpm --filter @ifc-lite/viewer exec tsc --noEmit` — clean.
- [x] `node scripts/check-module-size.mjs` — OK, no new files over budget.
- [x] `node scripts/check-test-wiring.mjs` — OK.
- [x] `pnpm run check:vitest-timeout-audit` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)