### PR TITLE
fix(diff): stop a non-finite property value hashing the same as null

### DIFF
--- a/.changeset/diff-fingerprint-nonfinite-collapse-to-null.md
+++ b/.changeset/diff-fingerprint-nonfinite-collapse-to-null.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/diff': patch
+---
+
+`buildDataFingerprint`/`buildComponentFingerprints` no longer hash a non-finite property/quantity value (`NaN`/`Infinity`/`-Infinity` — reachable from a STEP `IfcReal` with an extreme exponent, e.g. `1.0E400`) the same as that value being absent. `JSON.stringify`, which both functions feed into, has no non-finite numeric literal (RFC 8259) and silently maps all three to `null`; `normalizeValue` now stringifies a non-finite number first, so it survives as a distinct token instead of colliding with a genuinely `null` property. Left unfixed, that collision let `matchUnpairedByContent` retire a real `added`/`deleted` pair as one "unchanged" match whenever the only difference was a corrupt-but-present value versus an absent one.

--- a/packages/diff/src/fingerprint.test.ts
+++ b/packages/diff/src/fingerprint.test.ts
@@ -46,6 +46,73 @@ describe('normalizeValue', () => {
     expect(normalizeValue(true)).toBe(true);
     expect(normalizeValue({ a: 1 })).toBe('{"a":1}');
   });
+
+  it('stringifies a non-finite number instead of letting it collapse to null', () => {
+    // RED on the unfixed code: normalizeValue returned NaN/Infinity/-Infinity
+    // as-is, and JSON.stringify (in buildDataFingerprint) silently maps every
+    // one of them to `null` (RFC 8259 has no non-finite literal) — the same
+    // token an absent property serializes to. GREEN requires each non-finite
+    // value to survive as a distinct, non-null token.
+    expect(normalizeValue(NaN)).toBe('NaN');
+    expect(normalizeValue(Infinity)).toBe('Infinity');
+    expect(normalizeValue(-Infinity)).toBe('-Infinity');
+    expect(normalizeValue(NaN)).not.toBeNull();
+  });
+});
+
+describe('buildDataFingerprint — non-finite property value', () => {
+  const base: DataFingerprintInput = {
+    ifcType: 'IfcWall',
+    name: 'W1',
+    propertySets: [{ name: 'Pset_A', properties: [{ name: 'x', value: null }] }],
+  };
+
+  it('does not hash the same as a genuinely absent (null) property value', () => {
+    // A property whose value is Infinity (reachable from a STEP IfcReal with
+    // an extreme exponent, e.g. "1.0E400") must not fingerprint identically
+    // to the same entity with that property entirely null — collapsing the
+    // two lets matchUnpairedByContent retire a real added/deleted pair as
+    // "unchanged" on an unrelated dataHash coincidence.
+    const withNull = base;
+    const withInfinity: DataFingerprintInput = {
+      ...base,
+      propertySets: [{ name: 'Pset_A', properties: [{ name: 'x', value: Infinity }] }],
+    };
+    const withNaN: DataFingerprintInput = {
+      ...base,
+      propertySets: [{ name: 'Pset_A', properties: [{ name: 'x', value: NaN }] }],
+    };
+
+    const hashNull = buildDataFingerprint(withNull);
+    const hashInfinity = buildDataFingerprint(withInfinity);
+    const hashNaN = buildDataFingerprint(withNaN);
+
+    expect(hashInfinity).not.toBe(hashNull);
+    expect(hashNaN).not.toBe(hashNull);
+    expect(hashInfinity).not.toBe(hashNaN);
+  });
+
+  it('control: a finite value fingerprints as before (unaffected by the guard)', () => {
+    const withFinite: DataFingerprintInput = {
+      ...base,
+      propertySets: [{ name: 'Pset_A', properties: [{ name: 'x', value: 42 }] }],
+    };
+    expect(buildDataFingerprint(withFinite)).toBe(
+      stableHash(
+        JSON.stringify({
+          Type: 'IfcWall',
+          Name: 'W1',
+          Description: '',
+          ObjectType: '',
+          PredefinedType: '',
+          Tag: '',
+          TypeAssignments: [],
+          PropertySets: [{ name: 'Pset_A', properties: [{ name: 'x', value: 42 }] }],
+          QuantitySets: [],
+        }),
+      ),
+    );
+  });
 });
 
 describe('buildDataFingerprint', () => {

--- a/packages/diff/src/fingerprint.ts
+++ b/packages/diff/src/fingerprint.ts
@@ -10,6 +10,7 @@
  * have and hash it here, so the base and head adapters (CLI, viewer) produce
  * byte-identical fingerprints for an unchanged entity.
  */
+import { stringifyIfNonFinite } from './nonfinite-value.js';
 
 export interface PropertyEntryInput {
   name: string;
@@ -168,15 +169,13 @@ function stableSerialize(value: unknown): string {
   return `{${keys.map((key) => `${JSON.stringify(key)}:${stableSerialize(record[key])}`).join(',')}}`;
 }
 
-/**
- * Normalize a property/quantity value to a stable scalar so that structurally
- * equal values hash identically regardless of object identity or key order.
- */
+/** Normalize a property/quantity value to a stable scalar (numbers route
+ * through {@link stringifyIfNonFinite}) so structurally equal values hash
+ * identically regardless of object identity or key order. */
 export function normalizeValue(value: unknown): string | number | boolean | null {
   if (value == null) return null;
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return value;
-  }
+  if (typeof value === 'number') return stringifyIfNonFinite(value);
+  if (typeof value === 'string' || typeof value === 'boolean') return value;
   try {
     return stableSerialize(value);
   } catch (error) {

--- a/packages/diff/src/nonfinite-value.ts
+++ b/packages/diff/src/nonfinite-value.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Represent a non-finite number (`NaN`/`Infinity`/`-Infinity`) as a distinct
+ * string token instead of letting it reach `JSON.stringify`.
+ *
+ * `fingerprint.ts`'s `normalizeValue` feeds its result into `JSON.stringify`
+ * (via `buildDataFingerprint`/`buildComponentFingerprints`), and `JSON` (RFC
+ * 8259) has no non-finite numeric literal: `JSON.stringify` silently maps
+ * `NaN`/`Infinity`/`-Infinity` to `null` — the same token an absent property
+ * serializes to. An `Infinity` property value (reachable from a STEP
+ * `IfcReal` with an extreme exponent, e.g. `1.0E400`) would then hash
+ * identically to that property being entirely absent, and
+ * `matchUnpairedByContent` treats equal `dataHash` as content identity — so
+ * the collision can retire a genuine `added`/`deleted` pair as "unchanged".
+ * Mirrors `finite_json_number` (`rust/export/src/json.rs`, #3596) and
+ * `packages/mutations`' `encodeNonFiniteNumbers` — this repo's recurring
+ * non-finite-value shape, applied to the diff content hash.
+ */
+export function stringifyIfNonFinite(value: number): string | number {
+  return Number.isFinite(value) ? value : String(value);
+}


### PR DESCRIPTION
## The sink

`normalizeValue` (`packages/diff/src/fingerprint.ts`) passes a property/quantity value straight through into an object that `buildDataFingerprint`/`buildComponentFingerprints` then hand to `JSON.stringify`. JSON (RFC 8259) has no non-finite numeric literal, so `JSON.stringify` silently maps `NaN`, `Infinity` and `-Infinity` to `null` — the exact token a genuinely absent property serializes to:

```
> JSON.stringify({ a: NaN })
'{"a":null}'
> JSON.stringify({ a: null })
'{"a":null}'
```

## Reachability

A property's stored value can be `Infinity`/`NaN` from a STEP `IfcReal`/measure with an extreme exponent (e.g. `1.0E400` overflows to `Infinity` on parse) or from a degenerate upstream computation. That value flows unchanged through `normalizeValue` into the fingerprinted object.

## Why it's wrong

`buildDataFingerprint`'s `dataHash` is used as content **identity**: `diffModels(..., { matchUnpairedByContent: true })` retires a real `added` and a real `deleted` entry as one "unchanged" match whenever their `dataHash` (and component sub-hashes) agree. Before this fix, an entity carrying a property valued `Infinity` fingerprinted **identically** to the same entity with that property entirely `null` — so a base/head pair that genuinely differ (present-but-corrupt value vs. absent) could be silently matched as unchanged, hiding the real difference.

This is a different bug from #3644 (which scales a measure's *unit* before hashing, so a genuinely equal value in a different unit space hashes the same) — this one is about the sink never distinguishing a non-finite number from `null` at all, regardless of units.

## The fix

`normalizeValue` now routes a non-finite number through a new sibling helper, `stringifyIfNonFinite` (`packages/diff/src/nonfinite-value.ts`), which stringifies it (`"NaN"` / `"Infinity"` / `"-Infinity"`) before it ever reaches `JSON.stringify`. This mirrors the convention this session already established for the same value class: `finite_json_number` in `rust/export/src/json.rs` (#3596) and `encodeNonFiniteNumbers` in `packages/mutations`.

The helper lives in a sibling file rather than inline because `fingerprint.ts` was already at its `check-module-size.mjs` line budget with zero headroom (per house rules, the allowlist itself is never touched — only the sibling extraction).

## RED / GREEN

- **RED** (on unfixed `normalizeValue`): `buildDataFingerprint` of an entity with a property valued `Infinity` (or `NaN`) equals the fingerprint of the same entity with that property `null`.
- **GREEN**: the two now differ, and `Infinity` vs `NaN` also differ from each other.
- **Control**: a finite value's fingerprint is byte-identical to what it was before (asserted against the exact pre-fix `JSON.stringify`/`stableHash` construction).

New tests: `packages/diff/src/fingerprint.test.ts` — `normalizeValue > stringifies a non-finite number...` and `buildDataFingerprint — non-finite property value`.

## Other unguarded sinks noted, not fixed (out of scope for this PR)

- `packages/ids/src/constraints/comparators.ts`'s `compareNumeric`: an `Infinity` `actual` value against a finite `expected` correctly returns `false` (fails safe, not silently wrong), so left alone — flagging in case a future IDS facet wants it treated differently.
- The HBJSON exporter's geometry predicates (`rust/export/src/geom.rs` `face_ok`/`polygon_area`/`min_edge`) are not explicitly `.is_finite()`-guarded, but a NaN/Infinite coordinate already fails their `>=`/`>`/`<=` comparisons (NaN comparisons are always false), so a degenerate/non-finite face is rejected as expected rather than emitted — noting for visibility, not filing as a defect.

## Verification (foreground)

- `pnpm test` in `packages/diff`: 15 files / 305 tests passed (before AND after confirming RED on the unfixed code via `git stash`).
- `pnpm exec tsc --noEmit` in `packages/diff`: clean.
- `node scripts/check-module-size.mjs`: OK, 0 new files over 400 (`fingerprint.ts` stayed within its existing 440-line budget by extracting the new logic to `nonfinite-value.ts`).
- `node scripts/check-test-wiring.mjs`: OK.
- `pnpm run check:vitest-timeout-audit`: unaffected (repo-wide summary line, no new failures attributable to this change).
- `node scripts/check-unused-locals.mjs`: pre-existing broad "does not compile standalone" failures across many packages are present identically before and after this change (confirmed via `git stash` diff) — environmental, not introduced here. `packages/diff` itself is not in that failure list.
- Changeset added (`@ifc-lite/diff`, patch). No public export added (`nonfinite-value.ts` is not re-exported from `index.ts`), so no api-surface update needed.

Not a merge/close request — flagging for review per repo convention.