### PR TITLE
fix(parser): resolve IfcRelAssignsToGroupByFactor group/zone/system membership

### DIFF
--- a/.changeset/assigns-to-group-by-factor-membership.md
+++ b/.changeset/assigns-to-group-by-factor-membership.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix `IfcRelAssignsToGroupByFactor` (the proportional-factor subtype of `IfcRelAssignsToGroup`) being silently dropped from the relationship graph. It matched none of the parser's relationship-type gates (`RELATIONSHIP_TYPES` / `HIERARCHY_REL_TYPES` / `REL_TYPE_MAP`) or the `extractRelFast` byte scanner, so an element assigned to a zone/system exclusively through this relationship never appeared in that group's members, and the group never appeared in the element's own group list. `extractGroupMembersOnDemand` and `extractRelationshipsOnDemand` now resolve both relationship kinds.

--- a/packages/parser/src/columnar-parser-indexes.ts
+++ b/packages/parser/src/columnar-parser-indexes.ts
@@ -67,7 +67,12 @@ export const RELATIONSHIP_TYPES = new Set([
     'IFCRELCONNECTSPATHELEMENTS', 'IFCRELCONNECTSELEMENTS',
     'IFCRELCONNECTSPORTTOELEMENT', 'IFCRELCONNECTSPORTS',
     'IFCRELSPACEBOUNDARY',
-    'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOPRODUCT',
+    // IfcRelAssignsToGroupByFactor is a subtype of IfcRelAssignsToGroup
+    // (adds a proportional Factor attribute, e.g. zone occupancy share) and
+    // is written to STEP with its own distinct entity keyword — it does not
+    // match the 'IFCRELASSIGNSTOGROUP' string, so it needs its own entry or
+    // every membership assigned through it is silently invisible.
+    'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOGROUPBYFACTOR', 'IFCRELASSIGNSTOPRODUCT',
     'IFCRELREFERENCEDINSPATIALSTRUCTURE',
 ]);
 
@@ -93,6 +98,9 @@ export const REL_TYPE_MAP: Record<string, RelationshipType> = {
     'IFCRELCONNECTSPORTS': RelationshipType.ConnectsPorts,
     'IFCRELSPACEBOUNDARY': RelationshipType.SpaceBoundary,
     'IFCRELASSIGNSTOGROUP': RelationshipType.AssignsToGroup,
+    // Subtype of IfcRelAssignsToGroup (adds a Factor); same RelatingGroup /
+    // RelatedObjects membership semantics, so it shares the same edge type.
+    'IFCRELASSIGNSTOGROUPBYFACTOR': RelationshipType.AssignsToGroup,
     'IFCRELASSIGNSTOPRODUCT': RelationshipType.AssignsToProduct,
     'IFCRELREFERENCEDINSPATIALSTRUCTURE': RelationshipType.ReferencedInSpatialStructure,
 };
@@ -134,7 +142,11 @@ export const HIERARCHY_REL_TYPES = new Set([
     // themselves were parsed.
     'IFCRELCONNECTSPORTTOELEMENT', 'IFCRELCONNECTSPORTS',
     'IFCRELSPACEBOUNDARY',
-    'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOPRODUCT',
+    // IfcRelAssignsToGroupByFactor is a distinct STEP keyword (subtype of
+    // IfcRelAssignsToGroup); omitting it here means it never reaches
+    // relationshipRefs / extractRelFast, so every group/zone/system
+    // membership assigned through it is silently dropped.
+    'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOGROUPBYFACTOR', 'IFCRELASSIGNSTOPRODUCT',
     'IFCRELREFERENCEDINSPATIALSTRUCTURE',
 ]);
 

--- a/packages/parser/src/columnar-parser-relationships.ts
+++ b/packages/parser/src/columnar-parser-relationships.ts
@@ -43,7 +43,14 @@ export function extractRelFast(
         const [relating, _] = readRefId(buffer, pos, end);
         if (relating < 0 || related.length === 0) return null;
         return { relatingObject: relating, relatedObjects: related };
-    } else if (typeUpper === 'IFCRELASSIGNSTOGROUP' || typeUpper === 'IFCRELASSIGNSTOPRODUCT') {
+    } else if (
+        typeUpper === 'IFCRELASSIGNSTOGROUP'
+        // Subtype of IfcRelAssignsToGroup: same attr[4]=RelatedObjects,
+        // attr[5]=RelatedObjectsType, attr[6]=RelatingGroup layout, plus a
+        // trailing Factor we don't need to read.
+        || typeUpper === 'IFCRELASSIGNSTOGROUPBYFACTOR'
+        || typeUpper === 'IFCRELASSIGNSTOPRODUCT'
+    ) {
         const [related, rp] = readRefList(buffer, pos, end);
         // `readRefList` returns `rp` pointing AT the closing `)` of
         // the list. `skipCommas` tracks paren depth, so leaving `rp`

--- a/packages/parser/test/group-membership-by-factor.test.ts
+++ b/packages/parser/test/group-membership-by-factor.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import {
+  ColumnarParser,
+  extractRelationshipsOnDemand,
+  extractGroupMembersOnDemand,
+} from '../src/columnar-parser.js';
+
+// IfcRelAssignsToGroupByFactor (IFC2X3/IFC4/IFC4X3) is a SUBTYPE of
+// IfcRelAssignsToGroup — same RelatingGroup/RelatedObjects membership
+// semantics, plus a proportional Factor attribute — but it is written to
+// STEP under its own distinct entity keyword. `HIERARCHY_REL_TYPES` /
+// `RELATIONSHIP_TYPES` / `REL_TYPE_MAP` (columnar-parser-indexes.ts) and the
+// `extractRelFast` byte scanner (columnar-parser-relationships.ts) matched
+// only the literal 'IFCRELASSIGNSTOGROUP' string, so a ByFactor relationship
+// never reached the categorized `relationshipRefs` bucket: it fell through
+// to CAT_RELEVANT (its keyword starts with 'IFCREL') and was parsed only for
+// GlobalId/Name, never turned into a graph edge. Any element assigned to a
+// zone/system exclusively through IfcRelAssignsToGroupByFactor was silently
+// invisible to both "members of this group" and "groups of this element".
+const IFC = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALL('wall-1',#1,'Wall A',$,$,$,$,$);
+#11=IFCWALL('wall-2',#1,'Wall B',$,$,$,$,$);
+#12=IFCWALL('wall-3',#1,'Wall C',$,$,$,$,$);
+#30=IFCSYSTEM('sys-1',#1,'HVAC System',$,'HVAC');
+#31=IFCZONE('zone-1',#1,'Thermal Zone',$,$,$);
+// wall-1 -> sys-1 via the plain (non-factor) relationship: control.
+#40=IFCRELASSIGNSTOGROUP('rel-plain',#1,$,$,(#10),$,#30);
+// wall-2 -> sys-1 EXCLUSIVELY via IfcRelAssignsToGroupByFactor.
+#41=IFCRELASSIGNSTOGROUPBYFACTOR('rel-factor',#1,$,$,(#11),$,#30,0.5);
+// wall-3 -> zone-1 via factor AND independently assigned into sys-1 via the
+// plain relationship (multiple membership across both relationship kinds).
+#42=IFCRELASSIGNSTOGROUPBYFACTOR('rel-factor-2',#1,$,$,(#12),$,#31,0.75);
+#43=IFCRELASSIGNSTOGROUP('rel-plain-2',#1,$,$,(#12),$,#30);`;
+
+async function parse() {
+  const source = new TextEncoder().encode(IFC.split('\n').filter(l => !l.trim().startsWith('//')).join('\n'));
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs = Array.from(tokenizer.scanEntitiesFast()).map((ref) => ({
+    expressId: ref.expressId,
+    type: ref.type,
+    byteOffset: ref.offset,
+    byteLength: ref.length,
+    lineNumber: ref.line,
+  }));
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+describe('IfcRelAssignsToGroupByFactor membership', () => {
+  it('resolves group -> members through the ByFactor relationship, not just the plain one', async () => {
+    const store = await parse();
+    const sysMembers = extractGroupMembersOnDemand(store, 30).map(m => m.id).sort((a, b) => a - b);
+    // wall-1 (plain) + wall-3 (plain) are the control; wall-2 is assigned
+    // EXCLUSIVELY via IfcRelAssignsToGroupByFactor — the regression is that
+    // it used to be dropped entirely from this list.
+    expect(sysMembers).toEqual([10, 11, 12]);
+
+    const zoneMembers = extractGroupMembersOnDemand(store, 31).map(m => m.id);
+    expect(zoneMembers).toEqual([12]);
+  });
+
+  it('resolves element -> groups for an element assigned only via ByFactor', async () => {
+    const store = await parse();
+    const wall2Groups = extractRelationshipsOnDemand(store, 11).groups.map(g => g.id);
+    expect(wall2Groups).toEqual([30]);
+  });
+
+  it('keeps multiple membership: an element in two distinct groups via two different relationship kinds', async () => {
+    const store = await parse();
+    const wall3Groups = extractRelationshipsOnDemand(store, 12).groups.map(g => g.id).sort();
+    expect(wall3Groups).toEqual([30, 31]);
+  });
+
+  it('bidirectional consistency: every group->member edge has a matching member->group edge', async () => {
+    const store = await parse();
+    for (const groupId of [30, 31]) {
+      for (const member of extractGroupMembersOnDemand(store, groupId)) {
+        const memberGroups = extractRelationshipsOnDemand(store, member.id).groups.map(g => g.id);
+        expect(memberGroups).toContain(groupId);
+      }
+    }
+  });
+
+  it('control: a plain-only group membership is unaffected', async () => {
+    const store = await parse();
+    const wall1Groups = extractRelationshipsOnDemand(store, 10).groups.map(g => g.id);
+    expect(wall1Groups).toEqual([30]);
+  });
+});


### PR DESCRIPTION
## How group membership is resolved

`IfcRelAssignsToGroup` edges (`RelatingGroup` → `RelatedObjects`) are collected during the columnar parse into a bidirectional CSR `RelationshipGraph` keyed by numeric entity id (`packages/data/src/relationship-graph.ts`). Two on-demand readers consume it (`packages/parser/src/on-demand-extractors.ts`):

- `extractGroupMembersOnDemand(store, groupId)` — forward edges (group → members), used by the viewer hierarchy panel to isolate a zone/system's contents.
- `extractRelationshipsOnDemand(store, entityId).groups` — inverse edges (element → its groups), used by the properties panel.

Both walk the *same* graph, so a group's members and a member's groups agree by construction (bidirectional consistency and multiple membership — an element in N groups — both fall out of the CSR structure, which stores every edge, not a single-value map). Groups are distinguished by their own numeric entity id everywhere, so two `IfcZone`/`IfcSystem` sharing a `Name` never collapse into one bucket.

The gap was earlier in the pipeline: which STEP entity keywords ever become a graph edge at all. That's gated three times in `packages/parser/src`: `RELATIONSHIP_TYPES` / `HIERARCHY_REL_TYPES` (categorization — `columnar-parser-indexes.ts`) and the attribute-layout branch in `extractRelFast` (`columnar-parser-relationships.ts`). All three matched the literal string `'IFCRELASSIGNSTOGROUP'` only.

`IfcRelAssignsToGroupByFactor` is a distinct STEP entity keyword — a subtype of `IfcRelAssignsToGroup` that adds a proportional `Factor` attribute (IFC2X3 through IFC4X3), same `RelatingGroup`/`RelatedObjects` semantics otherwise. Because its keyword didn't match, `getCategory()` fell through to `CAT_RELEVANT` (it starts with `IFCREL`) instead of `CAT_HIERARCHY_REL`, so it was parsed only for `GlobalId`/`Name` and never reached `extractRelFast` or the relationship graph at all.

## Verdict table

| Model assignment | Resolved membership before | Resolved membership after |
|---|---|---|
| wall-1 → sys-1 via plain `IfcRelAssignsToGroup` (control) | ✅ in `sys-1` members, `sys-1` in wall-1's groups | ✅ unchanged |
| wall-2 → sys-1 **exclusively** via `IfcRelAssignsToGroupByFactor` | ❌ absent from `sys-1` members; wall-2 reports zero groups | ✅ in `sys-1` members; wall-2 reports `sys-1` |
| wall-3 → sys-1 (plain) **and** → zone-1 (ByFactor) — multiple membership across both relationship kinds | ❌ only the plain edge visible | ✅ both groups visible |
| Bidirectional consistency (every group→member edge has a matching member→group edge) | ❌ broken for any ByFactor-only edge | ✅ holds for both kinds |

## The fix

Added `'IFCRELASSIGNSTOGROUPBYFACTOR'` alongside `'IFCRELASSIGNSTOGROUP'` in all three gates it needs to pass:
- `RELATIONSHIP_TYPES` and `HIERARCHY_REL_TYPES` (`packages/parser/src/columnar-parser-indexes.ts`) — so the entity is categorized `CAT_HIERARCHY_REL` and reaches `extractRelFast`.
- `REL_TYPE_MAP` — mapped to the same `RelationshipType.AssignsToGroup` edge bucket as the plain relationship.
- `extractRelFast` (`packages/parser/src/columnar-parser-relationships.ts`) — added to the branch that reads `attr[4]=RelatedObjects`, `attr[5]=RelatedObjectsType`, `attr[6]=RelatingGroup` (the trailing `Factor` attribute isn't needed for membership resolution).

## RED/GREEN and reachability

`packages/parser/test/group-membership-by-factor.test.ts` — a synthetic fixture with one `IfcSystem`, one `IfcZone`, and three walls assigned via a mix of the plain and ByFactor relationships (plus a control-only-plain case). On unmodified `upstream/main`, 3 of 5 assertions fail (ByFactor-only element absent from group members, absent from the element's own group list, multiple-membership across kinds broken); the control (plain-only) case and one property already pass unmodified, ruling out an unrelated break. All 5 pass after the fix.

Reachability: `extractGroupMembersOnDemand`/`extractRelationshipsOnDemand` are the functions the viewer's hierarchy panel (`apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts`) and properties panel (`apps/viewer/src/components/viewer/properties/RelationshipsCard.tsx`) call to answer "what's in this zone/system" and "what groups is this element in" — any real-world IFC file using `IfcRelAssignsToGroupByFactor` (a legal, if less common, assignment relationship across IFC2X3/IFC4/IFC4X3) hit this gap.

## Verification (foreground)

- `packages/parser`: targeted test file + the two existing group/relationship regression suites, all green (16/16).
- `node scripts/check-module-size.mjs` — OK, 0 new over 400.
- `pnpm exec tsc --noEmit` in `packages/parser` — clean.
- `node scripts/check-test-wiring.mjs` — OK.
- No index-export changes, so no api-surface update needed.
- Changeset added (`@ifc-lite/parser`, patch).