### PR TITLE
fix(ci): the source-text ratchet never scanned scripts/, behind two separate barriers

### DIFF
--- a/scripts/check-rust-source-text-assertions.mjs
+++ b/scripts/check-rust-source-text-assertions.mjs
@@ -8,9 +8,11 @@
  * unenforced across the whole `rust/` tree.
  *
  * `scripts/check-source-text-assertions.mjs` enforces that rule for `packages/`
- * and `apps/`, and says so in its own header -- "SCAN SCOPE is packages/ and
- * apps/ test files only". `grep -c rust` over that file returns 0. The
- * maintainer demonstrated the consequence rather than inferring it: a genuine
+ * and `apps/`. It also covers `scripts/` since #3639, but never Rust: its
+ * detector parses JavaScript, so a Rust test is invisible to it whatever the
+ * scan scope says.
+ *
+ * The maintainer demonstrated the consequence rather than inferring it: a genuine
  * source-text assertion (`fs::read_to_string("src/api/space_plate_input.rs")`
  * plus a `contains`) planted in a real Rust test left the gate exiting 0
  * without naming the file (#3129).

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -67,12 +67,20 @@
  * longer stand in for one, and a marker is read from comment trivia, so a
  * string can no longer forge one.
  *
- * SCAN SCOPE is packages/ and apps/ test files only; scripts/*.test.mjs are not
- * scanned. That is a deliberate limit, not an oversight: those files run gates
- * against real repo inputs through indirect mutator callbacks, and the taint
- * analysis has to fail closed there, so bringing them in scope would demand
- * markers on assertions that are about a gate's output rather than about source
- * text. Widening the scope means paying that down first.
+ * SCAN SCOPE is packages/, apps/ and scripts/ test files. `scripts/` came in
+ * with #3639. Before that this paragraph called its exclusion "a deliberate
+ * limit, not an oversight" -- it was an oversight, and a total one: TWO
+ * independent barriers hid the tree (scripts/ absent from SEARCH_DIRS, .mjs
+ * absent from TEST_FILE_RE), so the whole review lane sat behind both while
+ * this gate reported OK. The old paragraph's concern was real, though, and is
+ * why the 14 files went to the allowlist rather than being converted: several
+ * assert on a gate's OUTPUT through indirect mutator callbacks, where the taint
+ * analysis fails closed and a marker would be about output, not source text.
+ *
+ * `tests/` and `tools/` remain outside. All eight tracked test files there were
+ * clean when scripts/ was brought in, so nothing is hidden today -- but it is
+ * the same shape of hole, and `tools/**` would also need a row in the frontend
+ * CI path filter before a gate there could run.
  */
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
@@ -81,9 +89,20 @@ import { fileURLToPath } from 'node:url';
 import { analyze } from './source-text-assertion-detect.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SEARCH_DIRS = ['packages', 'apps'];
+// TWO independent barriers hid the same tree, and fixing either alone changes
+// nothing: `scripts/` was never walked, AND `.mjs` was not a test extension.
+// Adding the extension first made this guard report the newly-allowlisted files
+// as stale entries -- it still could not see them -- which is how the second
+// barrier surfaced.
+const SEARCH_DIRS = ['packages', 'apps', 'scripts'];
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'generated']);
-const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts)$/;
+// `.mjs` was absent until #3639, and its absence was total: every test under
+// scripts/ is `.test.mjs`, so the entire tree -- the whole review lane included
+// -- had never been scanned by this guard. It reported "OK (8 allowlisted, 0
+// new)" while its own detector flagged 14 files it never opened. A prohibited
+// source-text assertion landed in #3633 and survived eight rounds of hardening
+// underneath that green.
+const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|mjs)$/;
 
 const ALLOWLIST_PATH = join(ROOT, 'scripts', 'source-text-assertion-allowlist.txt');
 
@@ -135,7 +154,11 @@ const ALLOWLIST_PATH = join(ROOT, 'scripts', 'source-text-assertion-allowlist.tx
  * than shipped for the convenience of one file.
  * Raised in the same commit as the row, which is what this constant forces.
  */
-const ALLOWLIST_CEILING = 8;
+// 8 -> 22. The jump is not new debt: it is 14 files that were always in
+// violation and are only now visible, grandfathered in the same commit that
+// makes them visible, which is exactly what this constant exists to force. The
+// list still only ratchets DOWN from here.
+const ALLOWLIST_CEILING = 22;
 
 function walk(dir, found = []) {
   // Fail closed. Swallowing an unreadable directory would let this guard

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -818,8 +818,9 @@ test('REASONS covers EVERY raise site in this file, and names nothing that is no
   // form of that question -- driving all fifteen would mean constructing fifteen
   // failure inputs, several unreachable on purpose (OUT_UNWRITABLE). What it
   // guards is a data structure, not a call.
-  // NOTE: the ratchet does not scan `.test.mjs` at all (#3639), so this marker
-  // documents intent rather than recording an approval that was granted.
+  // The ratchet scans this file as of #3639, so this marker is enforced, not
+  // decorative: strip its reason text and CI fails on "markers that excuse
+  // nothing".
   // @source-text-assertion-ok inventory of raise sites against the REASONS export
   for (let i = src.indexOf(NEEDLE); i !== -1; i = src.indexOf(NEEDLE, i + 1)) {
     sites += 1;
@@ -864,7 +865,7 @@ test('REASONS covers EVERY raise site in this file, and names nothing that is no
   for (const r of REASONS) {
     // `r` comes from the imported REASONS constant, not from the file read
     // above; this pins a naming convention on that constant.
-    // Marker documents intent; the ratchet cannot see this file (#3639).
+    // Enforced by the ratchet as of #3639, not decorative.
     // @source-text-assertion-ok naming convention on an imported constant
     assert.match(r, /^[A-Z][A-Z0-9_]*$/, `${r} is outside the alphabet validatorReason parses`);
   }

--- a/scripts/source-text-assertion-allowlist.txt
+++ b/scripts/source-text-assertion-allowlist.txt
@@ -45,3 +45,32 @@ apps/viewer/src/utils/aggregation.test.ts                                   # TW
 # assert on it".
 apps/viewer/src/components/viewer/toolbar-parity.test.ts                    # every assertion is on the TypeScript AST. The surviving hits are PATH checks (`spec.startsWith('@/')`, `base.endsWith('.js')`) and an array-key `.startsWith`, on names the flat taint set reaches from an unrelated read -- no assertion reads source text.
 packages/create-ifc-lite/test/config-fixers.test.ts                         # asserts on the `vite.config.ts` the scaffolder writes into a temp dir, i.e. on its OUTPUT. Nothing here reads a production source file.
+
+# --- Added by #3639, when TEST_FILE_RE finally included .mjs ---
+# These 14 were never scanned, because scripts/ was outside SEARCH_DIRS and
+# .mjs was outside TEST_FILE_RE. They are grandfathered so the widened scan can
+# land without 268 rewrites in one commit; the ceiling moved 8 -> 22 to match.
+#
+# NOT historical debt. Every one of these files was created AFTER this gate
+# landed on 2026-08-10 -- checked with `git log --diff-filter=A` -- and five of
+# the review/ rows were written in the 48 hours before the widening, one of them
+# the same day. 106 of the 268 hits come from files two days old. The gate was
+# blind for its whole life, so the debt accumulated behind it rather than
+# predating it, and the review/ rows are the ones to convert first.
+#
+# Each row carries its hit count at the time of widening. Nothing enforces the
+# count, so treat it as a size hint for whoever converts the file, not a fact.
+scripts/check-clash-degenerate-reason-parity.test.mjs  # 14 hits
+scripts/check-collab-room-model-target.test.mjs  # 6 hits
+scripts/check-legacy-entity-coverage.test.mjs  # 35 hits
+scripts/check-module-size.test.mjs  # 56 hits
+scripts/check-server-bin-targets.test.mjs  # 16 hits
+scripts/ci-wasm-prebuilt-eligible.test.mjs  # 1 hit
+scripts/docs/check-doc-samples.test.mjs  # 4 hits
+scripts/generate-server-attr-indices.test.mjs  # 12 hits
+scripts/lib/module-size-ratchet.test.mjs  # 3 hits
+scripts/review/build-review-input.test.mjs  # 5 hits
+scripts/review/lane-canary.test.mjs  # 7 hits
+scripts/review/post-review.test.mjs  # 60 hits
+scripts/review/run-reviewer.test.mjs  # 3 hits
+scripts/review/validate-findings.test.mjs  # 46 hits


### PR DESCRIPTION
Closes #3639.

`check-source-text-assertions` stops a test reading its subject's source and asserting on the text (#2434). It has never looked at `scripts/` — so the review lane, the thing that reviews everything else, was outside it.

## Two independent barriers, and fixing either alone changes nothing

```
SEARCH_DIRS = ['packages', 'apps']              scripts/ is never walked
TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts)$/   .mjs is not a test file
```

Every test under `scripts/` is `.test.mjs`, so it needed both to be wrong, and both were. The gate reported `OK (8 allowlisted, 0 new)` while its own detector, pointed at the tree by hand, flagged **14 files it had never opened**.

That is how a prohibited source-text assertion landed in #3633 and survived eight rounds of my own hardening: I kept making the assertion better at answering a question about text, and no gate ever said the question was wrong.

I fixed the extension first, and **the guard caught the incomplete fix** — it reported the newly-allowlisted files as *stale entries*, because it still could not see them. That is what surfaced the second barrier.

## The ceiling raise, stated accurately

8 → 22. The 14 are grandfathered so the widened scan can land without 268 rewrites in one commit.

They are **not historical debt**, and my first draft of this PR said they were. Checked with `git log --diff-filter=A`: all fourteen were created *after* this gate landed on 2026-08-10. Five of the `review/` rows were written in the 48 hours before the widening, one the same day, and 106 of the 268 hits come from files two days old. The gate was blind for its entire life, so the debt accumulated behind it rather than predating it. The `review/` rows are the ones to convert first.

## Mutation-tested, and the first attempt did not apply

A hand-written probe file went unflagged — not because the gate was blind, but because it was not the detector's shape. That proves nothing, so I used a file the detector is known to flag:

| mutation | result |
|---|---|
| drop `scripts/review/lane-canary.test.mjs` from the allowlist | **fails**, naming five sites with file:line |
| revert `SEARCH_DIRS` to `['packages','apps']` | **fails** (14 stale entries) |
| revert `TEST_FILE_RE` to exclude `.mjs` | **fails** (14 stale entries) |

The last two matter most: the allowlist now pins both barriers open, so neither can be quietly closed again.

## Also fixed, from review

- The `SCAN SCOPE` docblock still called the old limit "a deliberate limit, not an oversight" — the opposite of this change, in the file whose thesis is that a comment is a claim to test. Its concern was real though, and is now recorded as the *reason* the 14 were allowlisted rather than converted: several assert on a gate's **output** through indirect mutator callbacks, where the taint analysis fails closed.
- Two markers in `validate-findings.test.mjs` said the ratchet "cannot see this file". True this morning, false now, and actively dangerous: a reader who believes a marker is decorative and trims its reason text turns CI red, because the gate errors on markers that excuse nothing.
- The Rust sibling gate quoted this file's header verbatim as its justification for existing; that sentence no longer exists. Rewritten to the durable reason — its detector parses JavaScript, so Rust is invisible whatever the scan scope says.
- `tests/` and `tools/` remain outside `SEARCH_DIRS`. All eight tracked test files there are clean today, so nothing is hidden, but it is the same shape of hole and the docblock now says so.

## Verification

259 tests pass across the touched suites; both source-text gates green; oxlint clean over `scripts/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded source-text assertion checks to cover script directories and `.test.mjs`/`.spec.mjs` files.
  * Updated validation comments and allowlist entries to accurately reflect newly scanned test files.
  * Increased the permitted baseline to account for existing assertions discovered by the broader scan.

* **Documentation**
  * Clarified which file types and directories are inspected by the assertion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->