### PR TITLE
fix(bcf-api): narrow with Array.isArray so extensionsFromApi typechecks

### DIFF
--- a/packages/bcf-api/src/mapping.ts
+++ b/packages/bcf-api/src/mapping.ts
@@ -250,6 +250,10 @@ export function extensionsFromApi(dto: BcfExtensionsDto): BCFExtensions | undefi
     users: orUndefined(dto.user_id_type),
     stages: orUndefined(dto.stage),
   };
-  const hasAny = Object.values(extensions).some((list) => list && list.length > 0);
+  // Array.isArray, not a truthiness check: each value is string[] | undefined,
+  // and truthiness does not narrow it, so .length is read off {} and the
+  // Typecheck lane fails. This shipped in #3288 because a fork PR's workflows
+  // need maintainer approval, so that lane never ran on it.
+  const hasAny = Object.values(extensions).some((list) => Array.isArray(list) && list.length > 0);
   return hasAny ? extensions : undefined;
 }


### PR DESCRIPTION
Follow-up to #3288, landed immediately after it.

```
packages/bcf-api/src/mapping.ts(253,72):
  error TS2339: Property 'length' does not exist on type '{}'
```

`Object.values(extensions).some((list) => list && list.length > 0)` reads `.length` off `{}` — each value is `string[] | undefined` and a truthiness check does not narrow that. `Array.isArray` does, and is semantically identical here since every value is an array or `undefined`.

## Why it reached main

#3288 came from a fork, and a fork PR's workflows sit at `action_required` until a maintainer approves them. All four of its workflows did. So the Typecheck lane — and every other real lane — **never ran** on a 37-file, +5,269-line feature. It had 5 checks where a same-repo PR gets 32, and the only visible red was Vercel refusing to build preview deploys from a fork.

The contributor asked twice whether anything more was needed. There wasn't, except a click nobody made.

Running the repo's gates locally against a merge of that branch into `main` is what surfaced this. Worth stating what else that found, because it was almost all good: it merges clean despite being 90 commits behind, all six repo gates pass, its own 53 tests pass across 4 files, the changeset carries the right bump, `api-surface.json` is updated, PKCE is implemented and `clientSecret` is optional so the public-client OAuth flow is the correct shape. This one line was the only thing that would have gone red.

Merged and fixed forward rather than sending a week-old external contribution back for another round trip.

## Verification

- `TS2339` errors: 0 after the change.
- `packages/bcf-api`: 53 tests pass across 4 files.
- `check-test-wiring` passes; oxlint clean over `packages/bcf-api/src`.

## Worth a separate look

`apps/viewer/src/services/bcf-server-config.ts` persists `accessToken`, `refreshToken` and `clientSecret` to `localStorage`. PKCE is implemented and the secret is optional, so this is defensible for a confidential-client deployment — but a secret in web storage is reachable by any XSS and survives the session. Not a blocker and not this PR's to change; flagging it for a decision rather than fixing it silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of extension data when processing API responses.
  * Ensured extension lists are recognized only when provided as valid arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->