### PR TITLE
fix(deps): repair the bcf-api vitest snapshot reference that broke every CI job

### DIFF
--- a/packages/bcf-api/package.json
+++ b/packages/bcf-api/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   },
   "license": "MPL-2.0",
   "author": "Louis True",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,7 +655,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.4.0)(happy-dom@20.11.6)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.4.0)(happy-dom@20.11.12)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/cache:
     dependencies:


### PR DESCRIPTION
**`main` is red.** `pnpm install --frozen-lockfile` is the first step of both `test.yml` and `release.yml`, and it fails:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'vitest@4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.4.0)(happy-dom@20.11.6)(vite@8.2.2(...))'
```

The `packages/bcf-api` importer references a snapshot keyed on `happy-dom@20.11.6`. The only `vitest@4.1.11` snapshot in the lockfile is keyed on `happy-dom@20.11.12` — one patch apart, referenced from exactly that one place.

## Reproduced, not inferred

| commit | command | result |
|---|---|---|
| `9ce6dd2f` (main) | `pnpm install --frozen-lockfile` | `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` |
| `5f44fec2` (parent) | same command, same pnpm 10.8.1 | exit 0, "Done in 675ms" |

Regenerated with `pnpm install --no-frozen-lockfile`; the lockfile diff is **one line**. `--frozen-lockfile` now succeeds.

Also aligned `packages/bcf-api`'s `vitest` specifier from `^4.1.10` to `^4.1.11`, which every sibling uses. pnpm 10.8.1 does not gate on that drift — mutation-tested, `^9.9.9` still printed "Lockfile is up to date" — so it was silent.

## How it reached main, stated plainly

It came in with #3288's last commit, *"point bcf-api vitest at the lockfile snapshot that exists after the main merge"* — a hand-edited snapshot suffix that guessed the version. Self-consistent when written, stale by the time it merged.

#3288 was a fork PR, so its workflows sat at `action_required` and **no lane ever ran on it**. I verified the merge locally before landing it — six repo gates, its own 53 tests, a clean merge into main — but I never ran `pnpm install --frozen-lockfile`. That is the one step every job begins with and the only one that reads the lockfile; local `node --test` runs against an already-installed tree and cannot see it. That gap is mine.

## Urgency

The `Release` run queued on `9ce6dd2f` dies at the same step. It fails **before** "Build Packages" and before "Create Release PR or Publish", so it blocks the release rather than half-publishing — but nothing releases until this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the testing tool dependency to a newer patch version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->