### PR TITLE
fix(export): resolve attribute mutation slot against source entity's own schema

### DIFF
--- a/.changeset/step-attribute-mutation-source-schema.md
+++ b/.changeset/step-attribute-mutation-source-schema.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/export': patch
+---
+
+Fix `setAttribute` on a source-backed IFC2X3/IFC4X3 entity resolving its STEP positional slot against a fixed IFC4-pinned attribute order, writing the new value into a different, unrelated attribute of the record instead of the one named.
+
+`applySourceLineMutations`'s named-attribute pass (`step-attribute-mutations.ts`) resolved a mutation's `attrName` to a positional slot via `getAttributeNamesAcrossSchemas`, which tries the parser's IFC4-pinned codegen registry first regardless of the entity's actual schema. An entity's attribute order can differ between IFC2X3, IFC4 and IFC4X3 for a shared attribute name — e.g. `IfcTask.Status` sits at slot 6 in IFC2X3, but IFC4 inserts `Identification`/`LongDescription` ahead of it, pushing `Status` to slot 7 — so editing `Status` on an IFC2X3 `IfcTask` silently overwrote `WorkMethod` instead, leaving `Status` itself unchanged and no error raised. This is the write-side counterpart of the read-side fix `subset-entity-reader.ts`'s `attrIndex`/`stepSourceSchema` already applied for `anonymize-scrub.ts` (#3309), and had been called out there as a known, unfixed pitfall on this exact function.
+
+`applyAttributeMutations` now resolves each name through `attrIndex(entityType, attrName, stepSourceSchema(schemaVersion))` — the source entity's own bundled schema table first, falling back to the pinned-then-union resolver only for a type that schema's table doesn't know.

--- a/packages/export/src/step-attribute-mutations.ts
+++ b/packages/export/src/step-attribute-mutations.ts
@@ -19,7 +19,7 @@
 import { splitTopLevelArgs } from './step-argument-parser.js';
 import { getRealTypedSlots } from './attribute-real-slots.js';
 import { retypeStepLine } from './retype.js';
-import { getAttributeNamesAcrossSchemas } from '@ifc-lite/parser';
+import { attrIndex, stepSourceSchema } from './subset-entity-reader.js';
 import type { IfcAttributeValue } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { IfcSchemaVersion } from './schema-converter.js';
@@ -148,16 +148,6 @@ function applyAttributeMutations(
     return entityText;
   }
 
-  // Cross-schema, not the IFC4 pin: an IFC4X3-only class (IfcCourse, IfcRoad,
-  // IfcBridge, …) resolves no slots under the pin, so every named edit on one
-  // was silently discarded here too. Identical for the 755 pinned classes
-  // that declare attributes — `attribute-slot-types.test.ts` measures that —
-  // so no IFC4 export changes; this only stops dropping edits it used to drop.
-  const attrNames = getAttributeNamesAcrossSchemas(entityType);
-  if (attrNames.length === 0) {
-    return entityText;
-  }
-
   const args = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
   // A source line NEVER pads (unlike the overlay-created path): a short
   // argument list here means the file speaks a different schema, and growing
@@ -165,8 +155,20 @@ function applyAttributeMutations(
   let changed = false;
   const realSlots = getRealTypedSlots(entityType, schemaVersion);
 
+  // Resolve each name against THIS record's own schema first (`attrIndex`,
+  // `subset-entity-reader.ts`) — the bundled schemas do not always agree on a
+  // class's attribute order (IFC2X3's `IfcTask.Status` sits at slot 6; IFC4
+  // inserts `Identification`/`LongDescription` ahead of it, pushing `Status`
+  // to slot 7). Resolving against a fixed IFC4-pinned order regardless of
+  // `schemaVersion` writes the new value into a DIFFERENT, unrelated
+  // attribute of the true record: silent corruption, not a dropped edit —
+  // exactly the write-side pitfall `attrIndex`'s own doc comment warned this
+  // function used to fall into (fixed here). Falls back to the pinned-first
+  // cross-schema union (via `attrIndex`'s own fallback) only when the source
+  // schema's own table doesn't know the type at all.
+  const sourceSchema = stepSourceSchema(schemaVersion);
   for (const [attrName, value] of attributeMutations) {
-    const index = attrNames.indexOf(attrName);
+    const index = attrIndex(entityType, attrName, sourceSchema);
     if (index < 0 || index >= args.length) continue;
     // The source path shares every `$`-slot hole with the overlay-created
     // path, because a source record has plenty of `$` slots of its own. Both

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -212,6 +212,39 @@ describe('StepExporter', () => {
     expect(result.stats.modifiedEntityCount).toBe(1);
   });
 
+  // `IfcTask`'s attribute order DIFFERS between IFC2X3 and IFC4: IFC2X3 has
+  // `Status` at index 6 (GlobalId,OwnerHistory,Name,Description,ObjectType,
+  // TaskId,Status,WorkMethod,IsMilestone,Priority — verified against
+  // `entities-ifc2x3.ts`); IFC4 inserts `Identification`/`LongDescription`
+  // ahead of it, pushing `Status` to index 7 (`entities-ifc4.ts`). A named
+  // attribute override resolved against a fixed IFC4-pinned order — rather
+  // than the SOURCE entity's own `dataStore.schemaVersion` — writes the new
+  // value into `WorkMethod`'s slot instead: silent corruption of an
+  // unrelated attribute, not a dropped edit and not a visible error.
+  it('resolves a named attribute override against the source entity\'s own schema version (IFC2X3 IfcTask)', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCTASK', "#1=IFCTASK('g',$,'Old Name','Old Desc','Type','TASK-1','OLD-STATUS','OLD-METHOD',.F.,5);"],
+    ]);
+    (dataStore as unknown as { schemaVersion: string }).schemaVersion = 'IFC2X3';
+    const mutationView = new LiveMutablePropertyView(null, 'model-1');
+    mutationView.setAttribute(1, 'Status', 'NEW-STATUS');
+
+    const exporter = new StepExporter(dataStore, mutationView);
+    const result = exporter.export({
+      schema: 'IFC2X3',
+      includeGeometry: true,
+      includeProperties: true,
+      includeQuantities: true,
+      includeRelationships: true,
+      applyMutations: true,
+    });
+
+    const content = decode(result.content);
+    expect(content).toContain(
+      "#1=IFCTASK('g',$,'Old Name','Old Desc','Type','TASK-1','NEW-STATUS','OLD-METHOD',.F.,5);",
+    );
+  });
+
   it('rejects georeferencing edits for IFC2X3 export', async () => {
     const parser = new IfcParser();
     const store = await parser.parseColumnar(new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC).buffer);

--- a/packages/export/src/subset-entity-reader.ts
+++ b/packages/export/src/subset-entity-reader.ts
@@ -129,15 +129,16 @@ export function stepSourceSchema(schemaVersion: string | undefined): SourceStepS
  * `anonymize-placement.ts` and `anonymize-scrub.ts` do exactly that, each
  * noting at the call site why its type is fixed rather than caller-supplied.
  *
- * WRITE-SIDE PITFALL a caller resolving a slot via this function must not
- * fall into: `MutablePropertyView.setAttribute(id, name, value)` re-resolves
- * `name` to a slot by ITS OWN lookup at STEP-serialize time
- * (`step-attribute-mutations.ts`'s `applyAttributeMutations`), which is not
- * schema-aware — so an edit queued that way can still land on the wrong slot
- * even after reading the right one here. Write with
- * `MutablePropertyView.setPositionalAttribute(id, index, value)` and this
- * function's resolved `index` instead; `anonymize-scrub.ts` does exactly
- * that for every slot it resolves through a `schema` argument (#3309).
+ * `MutablePropertyView.setAttribute(id, name, value)` re-resolves `name` to a
+ * slot by its own lookup at STEP-serialize time
+ * (`step-attribute-mutations.ts`'s `applyAttributeMutations`), which now
+ * calls THIS function with the source entity's own `stepSourceSchema` too —
+ * so a `setAttribute` edit resolves the same slot this function would report
+ * for the same type/schema. `anonymize-scrub.ts` still writes through
+ * `MutablePropertyView.setPositionalAttribute(id, index, value)` with an
+ * `index` resolved here directly (#3309); that path needs no re-resolution
+ * at serialize time at all, so it stays the more direct choice for a caller
+ * that already has the index in hand.
  */
 export function attrIndex(type: string, name: string, schema?: SourceStepSchema): number {
   if (schema) {


### PR DESCRIPTION
## Summary

- `applySourceLineMutations`'s named-attribute pass (`step-attribute-mutations.ts`) resolved a `setAttribute(id, name, value)` edit's STEP positional slot via `getAttributeNamesAcrossSchemas`, which tries the parser's IFC4-pinned registry first regardless of the entity's actual schema.
- An entity's attribute order can differ between IFC2X3, IFC4 and IFC4X3 for a shared attribute name — e.g. `IfcTask.Status` sits at slot 6 in IFC2X3 (`GlobalId,OwnerHistory,Name,Description,ObjectType,TaskId,Status,WorkMethod,IsMilestone,Priority`), but IFC4 inserts `Identification`/`LongDescription` ahead of it, pushing `Status` to slot 7. Editing `Status` on an IFC2X3 `IfcTask` therefore silently overwrote `WorkMethod` instead — `Status` itself stayed unchanged, and no error was raised.
- This is the write-side counterpart of the read-side fix `subset-entity-reader.ts`'s `attrIndex`/`stepSourceSchema` already applied for `anonymize-scrub.ts` (#3309) — whose own doc comment named this exact function as a known, unfixed pitfall ("WRITE-SIDE PITFALL a caller resolving a slot via this function must not fall into: `MutablePropertyView.setAttribute` ... is not schema-aware"). `applyAttributeMutations` now resolves each name through `attrIndex(entityType, attrName, stepSourceSchema(schemaVersion))` — the source entity's own bundled schema table first, falling back to the pinned-then-union resolver only for a type that schema's table doesn't know — and the stale doc comment on `attrIndex` is updated to say so.

## Test plan

- [x] Added `step-exporter.test.ts`: `resolves a named attribute override against the source entity's own schema version (IFC2X3 IfcTask)` — RED on unmodified `main` (asserted `#1=IFCTASK(...,'OLD-STATUS','NEW-STATUS',...)`, i.e. the new value landing in `WorkMethod`'s slot instead of `Status`'s), GREEN after the fix.
- [x] Existing `packages/export` suite (1062 tests, including the IFC4 control case and the IFC2X3 `IfcRelAggregates`/`IfcRelAssociates*` tests that deliberately picked schema-identical classes to dodge this exact bug) stays green.
- [x] `tsc --noEmit` clean for `packages/export`.
- [x] `node scripts/check-module-size.mjs`, `node scripts/check-test-wiring.mjs`, `pnpm run check:vitest-timeout-audit` — no violations for touched files.
- [x] Changeset added for `@ifc-lite/export`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed named attribute updates for source-backed IFC entities across different schema versions.
  - Updates now modify the intended attribute while preserving neighboring values, including IFC2X3 `IfcTask.Status` records.

- **Documentation**
  - Clarified how attribute names are resolved when editing source-backed entity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->