### PR TITLE
fix(export): emit the schema-required uri key on bsi::ifc::material

### DIFF
--- a/.changeset/ifc5-material-required-uri.md
+++ b/.changeset/ifc5-material-required-uri.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+`Ifc5Exporter` emitted `bsi::ifc::material` as `{ code }`, omitting the `uri` key. The vendored buildingSMART schema (`packages/export/src/__fixtures__/schemas/ifc@v5a.ifcx`) declares `bsi::ifc::material` as an Object with both `code` and `uri` required — neither key is marked `optional`, the same convention `bsi::ifc::class` uses right next to it, and that attribute already emits both. The real buildingSMART reference sample committed at `apps/viewer/public/samples/hello-wall.ifcx` confirms a registry exists for materials too: every `bsi::ifc::material` value there carries a `uri` resolving into buildingSMART's `midas-materials` identifier registry. `uri` is now always present, emitted as an empty string when the material name cannot be resolved into a real registry entry (this package has no lookup service for arbitrary IFC4 material names), rather than omitted outright — so IFC5 output for any element with a material association now matches the required shape of the schema it is imported against.

--- a/packages/export/src/ifc5-exporter.test.ts
+++ b/packages/export/src/ifc5-exporter.test.ts
@@ -715,12 +715,14 @@ END-ISO-10303-21;`;
           && n.attributes?.['bsi::ifc::prop::Name']?.startsWith('Basic Wall:Holz Aussenwand'),
       );
       expect(wallNode).toBeDefined();
-      expect(wallNode.attributes['bsi::ifc::material']).toEqual({ code: 'Concrete' });
+      // `uri` is a required key per the official schema (same convention as
+      // `bsi::ifc::class` right above), but an arbitrary IFC4 material name
+      // cannot be resolved into a real buildingSMART `midas-materials`
+      // registry entry, so it is emitted empty rather than fabricated — see
+      // `ifc5-material.ts` and `ifc5-material.test.ts` for the full schema
+      // conformance check via `validateValue`.
+      expect(wallNode.attributes['bsi::ifc::material']).toEqual({ code: 'Concrete', uri: '' });
 
-      // `code` matches the official schema's `String` restriction — `uri` is
-      // deliberately omitted rather than fabricated, since arbitrary IFC4
-      // material names have no buildingSMART identifier registry (unlike
-      // IFC classes, which resolve to a real one — see bsi::ifc::class above).
       const schema = ALL_OFFICIAL_SCHEMAS['bsi::ifc::material'];
       expect(schema.value.objectRestrictions?.values.code.dataType).toBe('String');
     });

--- a/packages/export/src/ifc5-material.test.ts
+++ b/packages/export/src/ifc5-material.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `buildMaterialAttribute` builds the `bsi::ifc::material` payload emitted by
+ * {@link Ifc5Exporter} for an `IfcRelAssociatesMaterial` association. The
+ * shape it must produce is defined by the vendored buildingSMART schema
+ * (`packages/export/src/__fixtures__/schemas/ifc@v5a.ifcx`), which declares
+ * `bsi::ifc::material` as an Object requiring both `code` and `uri` (neither
+ * key is marked `optional`, the same convention `bsi::ifc::class` uses right
+ * next to it in the same file — and `bsi::ifc::class` emits both).
+ *
+ * The real buildingSMART reference sample committed at
+ * `apps/viewer/public/samples/hello-wall.ifcx` confirms this reading: every
+ * `bsi::ifc::material` value it contains carries a `uri` resolving into
+ * buildingSMART's own `midas-materials` identifier registry, e.g.
+ * `https://identifier.buildingsmart.org/uri/fish/midas-materials/26/class/CONCRETE`.
+ * So a registry for material identifiers exists — contrary to this file's own
+ * prior comment, which said "a freeform IFC4 `IfcMaterial.Name` has no such
+ * registry" and used that as the reason to omit `uri` outright.
+ *
+ * `buildMaterialAttribute` returned `{ code }` with no `uri` key at all,
+ * which `validateValue` (the same helper `ifc5-exporter.test.ts` uses for
+ * every other IFC5 attribute) flags as "Missing required key uri" against
+ * the vendored schema.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { buildMaterialAttribute } from './ifc5-material.js';
+import { ALL_OFFICIAL_SCHEMAS, validateValue } from './__fixtures__/ifc5-official-schemas.js';
+
+const enc = (s: string): ArrayBuffer => new TextEncoder().encode(s).buffer as ArrayBuffer;
+
+async function parse(model: string): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(enc(model));
+}
+
+const guid = (n: number): string => `0GUID${String(n).padStart(17, '0')}`;
+
+/** Wall #5 associated with material "Concrete" (#9) via `IfcRelAssociatesMaterial` #27. */
+const FIXTURE_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('ifc5-material-fixture.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('${guid(1)}',$,'Project',$,$,$,$,$,$);
+#5=IFCWALL('${guid(5)}',$,'Wall A',$,$,$,$,$);
+#9=IFCMATERIAL('Concrete');
+#27=IFCRELASSOCIATESMATERIAL('${guid(27)}',$,$,$,(#5),#9);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('buildMaterialAttribute — conformance to the vendored bsi::ifc::material schema', () => {
+  it('emits a value that satisfies every required key of the official schema', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const attr = buildMaterialAttribute(store, 5);
+
+    expect(attr).toBeDefined();
+    expect(attr?.code).toBe('Concrete');
+
+    const schema = ALL_OFFICIAL_SCHEMAS['bsi::ifc::material'];
+    const errors = validateValue(attr, schema.value, 'bsi::ifc::material');
+    expect(errors).toEqual([]);
+  });
+
+  // Control: an entity with no material association still yields `undefined`
+  // — proves the fix does not fabricate a material out of nothing.
+  it('control: returns undefined when the entity has no material association', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const attr = buildMaterialAttribute(store, 1);
+    expect(attr).toBeUndefined();
+  });
+});

--- a/packages/export/src/ifc5-material.ts
+++ b/packages/export/src/ifc5-material.ts
@@ -19,16 +19,29 @@ import { extractMaterialsOnDemand } from '@ifc-lite/parser';
  * Build the `bsi::ifc::material` attribute value for an entity, or
  * `undefined` when it has no material association.
  *
- * `uri` is deliberately omitted rather than fabricated: unlike an IFC class
- * name (`bsi::ifc::class`, which resolves to a real buildingSMART identifier
- * registry entry), a freeform IFC4 `IfcMaterial.Name` has no such registry —
- * inventing a resolvable-looking URI for it would misrepresent the material
- * as officially registered.
+ * The vendored buildingSMART schema
+ * (`packages/export/src/__fixtures__/schemas/ifc@v5a.ifcx`) declares
+ * `bsi::ifc::material` as an Object with both `code` and `uri` required
+ * (neither key carries `optional: true` — the same convention `bsi::ifc::class`
+ * uses right next to it, and that attribute emits both). The real
+ * buildingSMART reference sample committed at
+ * `apps/viewer/public/samples/hello-wall.ifcx` confirms a registry exists:
+ * every `bsi::ifc::material` value there carries a `uri` resolving into
+ * buildingSMART's `midas-materials` identifier registry (e.g.
+ * `.../uri/fish/midas-materials/26/class/CONCRETE`).
+ *
+ * We cannot resolve an arbitrary IFC4 `IfcMaterial.Name` (freeform text, not
+ * a midas-materials catalog code) into a real registry entry without a
+ * lookup service this package does not have, so `uri` is emitted as an empty
+ * string rather than a fabricated URL that would misrepresent the material
+ * as officially matched to a registry entry it was never checked against.
+ * An empty string still satisfies the schema's declared shape (`uri` present,
+ * typed `String`), unlike omitting the key outright.
  */
 export function buildMaterialAttribute(
   dataStore: IfcDataStore,
   expressId: number,
-): { code: string } | undefined {
+): { code: string; uri: string } | undefined {
   const material = extractMaterialsOnDemand(dataStore, expressId);
-  return material?.name ? { code: material.name } : undefined;
+  return material?.name ? { code: material.name, uri: '' } : undefined;
 }


### PR DESCRIPTION
## Summary

- Applied the same authority-conformance check the recent BCF/IDS hunts used, to IFC5/ifcx: validated `Ifc5Exporter`'s output against the buildingSMART schema vendored under `packages/export/src/__fixtures__/schemas/` (`ifc@v5a.ifcx`, `prop@v5a.ifcx`) via the existing `validateValue` helper.
- `bsi::ifc::material` is declared as an Object with both `code` and `uri` required (neither key carries `optional: true`) — the identical shape and convention as `bsi::ifc::class` right next to it in the same schema file, which already emits both keys. `buildMaterialAttribute` (`packages/export/src/ifc5-material.ts`) emitted only `{ code }`, which `validateValue` flags as `Missing required key "uri"`.
- The prior comment justified omitting `uri` by claiming "a freeform IFC4 `IfcMaterial.Name` has no such registry." The real buildingSMART reference sample committed at `apps/viewer/public/samples/hello-wall.ifcx` contradicts that: every `bsi::ifc::material` value there carries a `uri` resolving into buildingSMART's own `midas-materials` identifier registry (e.g. `.../uri/fish/midas-materials/26/class/CONCRETE`).
- Fix: `uri` is now always present. Since this package has no lookup service to resolve an arbitrary IFC4 material name into a real `midas-materials` catalog entry, it is emitted as an empty string rather than fabricated — satisfying the schema's declared shape (key present, typed `String`) without misrepresenting the material as officially registry-matched.
- Added `packages/export/src/ifc5-material.test.ts` (RED on unmodified `upstream/main`: `validateValue` reports the missing key; GREEN after the fix) plus a control asserting no material association still yields `undefined`. Updated the one pre-existing assertion in `ifc5-exporter.test.ts` that pinned the old `{ code }`-only shape.

## Authority used

Vendored buildingSMART IFC5 schema files under `packages/export/src/__fixtures__/schemas/` (loaded and diffed against at test time via `packages/export/src/__fixtures__/ifc5-official-schemas.ts`, source: `github.com/buildingSMART/ifcx.dev`), cross-checked against the real buildingSMART reference sample `apps/viewer/public/samples/hello-wall.ifcx`. Both packages/ifcx's own writer/reader pair (`writer.ts` / `entity-extractor.ts`) were reviewed for read/write asymmetry against the same authority and found already well-hardened by recent prior fixes (GlobalId-as-path, ObjectType fabrication, etc.) — no new asymmetry found there.

## Test plan

- [x] `packages/export/src/ifc5-material.test.ts` — RED on unmodified `upstream/main`, GREEN after the fix
- [x] `pnpm --filter @ifc-lite/export exec tsc --noEmit` — clean
- [x] `pnpm --filter @ifc-lite/export test` (vitest) — 1063 passed, 34 skipped
- [x] `pnpm --filter @ifc-lite/ifcx exec tsc --noEmit` / `pnpm --filter @ifc-lite/ifcx test` (tsx --test) — unaffected, 187 passed
- [x] `node scripts/check-module-size.mjs` — OK
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — no new unprotected files
- [x] Changeset added for `@ifc-lite/export`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436