### PR TITLE
fix(ifcx): stop fabricating a Name from the node path

### DIFF
--- a/.changeset/ifcx-no-fabricated-name-from-path.md
+++ b/.changeset/ifcx-no-fabricated-name-from-path.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/ifcx': patch
+---
+
+An IFCX entity or spatial node with no `Name` (no `bsi::ifc::name`, `prop::Name`, `prop::TypeName`/`prop::ObjectName`, or usable incoming edge name) decoded with a fabricated name: an 8-character slice of its internal IFCX path (e.g. `4f9c1a3e`). That reads as a plausible short name or code no source data backs, indistinguishable from an authored one, and it pre-empted the viewer's own "Name absent" fallback (`getName(id) || '<Type> #<id>'` in the entity tree, `<Type>` alone in the hierarchy panel) since that only fires on a falsy name. Both extractors (`entity-extractor.ts`'s `EntityTable.name`, `hierarchy-builder.ts`'s `SpatialNode.name`) now leave the name `''` when the source genuinely has none, matching the STEP parser's own convention and letting the existing UI fallback show a clearly-synthetic placeholder instead.

--- a/packages/ifcx/src/entity-extractor.test.ts
+++ b/packages/ifcx/src/entity-extractor.test.ts
@@ -155,4 +155,26 @@ describe('extractEntities', () => {
     assert.strictEqual(entities.getName(wallId), 'Wall-01');
     assert.strictEqual(entities.getObjectType(wallId), 'Basic Wall:Generic 200mm');
   });
+
+  it('does not fabricate Name from the node path when the source has none', () => {
+    // `extractName` returning null (no bsi::ifc::name / prop::Name /
+    // prop::TypeName / prop::ObjectName, and no usable incoming edge name)
+    // used to fall back to `node.path.slice(0, 8)` — an 8-char slice of the
+    // IFCX path that reads as a plausible short name/code no source
+    // attribute backs, indistinguishable from an authored one. Worse: it
+    // pre-empts the viewer's own "Name absent" convention
+    // (`getName(id) || '${typeName} #${expressId}'` in treeDataBuilder.ts),
+    // which never fires because getName() no longer returns '' here. Name
+    // must stay '' — the STEP parser's own convention for a missing Name
+    // (`columnar-parser.ts`) — like ObjectType/Description above.
+    const wall = createNode('4f9c1a3e-unnamed-wall-node-path');
+    wall.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+
+    const strings = new StringTable();
+    const { entities, pathToId } = extractEntities(new Map([[wall.path, wall]]), strings);
+
+    const wallId = pathToId.get(wall.path);
+    assert.ok(wallId !== undefined);
+    assert.strictEqual(entities.getName(wallId), '');
+  });
 });

--- a/packages/ifcx/src/entity-extractor.ts
+++ b/packages/ifcx/src/entity-extractor.ts
@@ -79,8 +79,15 @@ export function extractEntities(
     pathToId.set(node.path, expressId);
     idToPath.set(expressId, node.path);
 
-    // Extract name from attributes
-    const name = extractName(node, incomingEdgeNames.get(node.path) ?? []) ?? node.path.slice(0, 8);
+    // Extract name from attributes. No source attribute and no usable
+    // incoming edge name means the entity genuinely has no Name — stay
+    // '' (the STEP parser's own convention for a missing Name, see
+    // `columnar-parser.ts`'s `addEntityBatch`) rather than fabricating one
+    // from a slice of the internal IFCX path, which reads as a plausible
+    // short name/code no source data backs and pre-empts the viewer's own
+    // "Name absent" display convention (`getName(id) || '${type} #${id}'`
+    // in treeDataBuilder.ts).
+    const name = extractName(node, incomingEdgeNames.get(node.path) ?? []) ?? '';
 
     // Extract description from attributes (writer.ts writes it to the same
     // `bsi::ifc::prop::Description` attribute it writes name to under

--- a/packages/ifcx/src/hierarchy-builder-synthetic.test.ts
+++ b/packages/ifcx/src/hierarchy-builder-synthetic.test.ts
@@ -256,6 +256,22 @@ describe('buildHierarchy — synthetic (no fixture required)', () => {
       assert.strictEqual(hierarchy.project.name, 'Type Name');
     });
 
+    it('does not fabricate a name from the node path when the source has none', () => {
+      // `extractName` returning null used to fall back to
+      // `node.path.slice(0, 8)` — an 8-char slice of the IFCX path that
+      // reads as a plausible short name/code no source attribute backs,
+      // indistinguishable from an authored one in the hierarchy panel.
+      // Worse: it pre-empts treeDataBuilder.ts's own "Name absent"
+      // convention (`(spatialNode.name && ... !== 'unknown') ? ... :
+      // nodeType`), which never fires because name is never falsy here.
+      // Name must stay '' so that convention decides what the user sees.
+      const project = node('4f9c1a3e-unnamed-project-node-path', 'IfcProject');
+      const composed = new Map([[project.path, project]]);
+      const pathToId = new Map([[project.path, 1]]);
+      const hierarchy = buildHierarchy(composed, pathToId);
+      assert.strictEqual(hierarchy.project.name, '');
+    });
+
     it('keeps LongName as a distinct descriptor when it differs from the resolved name', () => {
       const project = node('project', 'IfcProject', {
         'bsi::ifc::prop::Name': '01',

--- a/packages/ifcx/src/hierarchy-builder.ts
+++ b/packages/ifcx/src/hierarchy-builder.ts
@@ -142,7 +142,12 @@ function buildSpatialNode(
   const typeEnum = IfcTypeEnumFromString(ifcClass?.code ?? '');
   const elementIds = new Set<number>();
 
-  const name = extractName(node) ?? node.path.slice(0, 8);
+  // No source attribute means the spatial node genuinely has no Name —
+  // stay '' rather than fabricating one from a slice of the internal IFCX
+  // path (a plausible-looking short name no source data backs, which also
+  // pre-empts treeDataBuilder.ts's own "Name absent" fallback to the type,
+  // e.g. "IfcBuildingStorey", since that only fires on a falsy name).
+  const name = extractName(node) ?? '';
   // Keep LongName as a distinct descriptor (Name "01" / LongName "Main
   // Residence") so the hierarchy panel can show both (issue #1634); drop it when
   // it just duplicates the primary label.


### PR DESCRIPTION
## Summary

Hunt PR (per the "invented data" lens: #3574/#3571/#3572's shape — absent/unknown data replaced by a plausible-looking concrete value the consumer cannot distinguish from real data).

An IFCX entity or spatial node with no `Name` attribute (no `bsi::ifc::name`, `prop::Name`, `prop::TypeName`/`prop::ObjectName`, and no usable incoming edge name) decoded with a **fabricated** name: an 8-character slice of its internal IFCX path (e.g. `4f9c1a3e`). That reads as a plausible short name or code no source data backs — indistinguishable from an authored one — and it pre-empted the viewer's own "Name absent" display convention:
- `treeDataBuilder.ts`: `dataStore.entities.getName(id) || \`${typeName} #${id}\`` (element rows)
- `treeDataBuilder.ts`: `(spatialNode.name && spatialNode.name.toLowerCase() !== 'unknown') ? spatialNode.name : nodeType` (spatial/hierarchy rows)

Both conventions only fire on a falsy name, so a genuinely-unnamed IFCX entity or spatial node (Storey, Site, …) showed a garbled path-prefix string instead of the established, clearly-synthetic `"<Type> #<id>"` / `"<Type>"` placeholder a STEP-loaded model with the same missing-Name condition gets. Same real-world condition, two different loaders, two different (one actively misleading) outcomes.

This mirrors an already-accepted fix in this same file for `ObjectType` ("does not fabricate ObjectType from the IFC class code" — see the existing test a few lines above the one this PR adds), just not yet applied to `Name`.

## Fix

`packages/ifcx/src/entity-extractor.ts` (`EntityTable.name`) and `packages/ifcx/src/hierarchy-builder.ts` (`SpatialNode.name`): when the extracted name is `null`, fall back to `''` — the STEP parser's own convention for a missing `Name` (`columnar-parser.ts`) — instead of `node.path.slice(0, 8)`. This lets the existing, already-correct viewer fallbacks decide what the user sees.

## Test plan

- [x] RED on unmodified `upstream/main`: added tests assert `entities.getName(id) === ''` / `hierarchy.project.name === ''` for a node with no Name attributes; both failed, returning the fabricated 8-char path slice instead.
- [x] GREEN after the fix: both new tests pass.
- [x] Control (unchanged): existing tests in both files assert a genuinely-present `Name`/`prop::Name`/`prop::TypeName`/`prop::LongName` still round-trips unchanged.
- [x] Full package suite: `packages/ifcx` — 189/189 passing (`npx tsx --test src/*.test.ts`).
- [x] `packages/ifcx`: `tsc --noEmit` clean.
- [x] `node scripts/check-module-size.mjs`, `node scripts/check-unused-locals.mjs`, `node scripts/check-test-wiring.mjs` — no findings for the touched files.
- [x] Changeset added (`@ifc-lite/ifcx`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436