### PR TITLE
fix(viewer): Lists Area/Volume falls back to LENGTHUNIT²/³ when no explicit AREAUNIT/VOLUMEUNIT

### DIFF
--- a/apps/viewer/src/lib/units/list-column-units.test.ts
+++ b/apps/viewer/src/lib/units/list-column-units.test.ts
@@ -196,6 +196,29 @@ describe('resolveListColumnUnits (issue #1573 follow-up)', () => {
     assert.ok(Math.abs((ftFirst.convertCell(0, 1000, 'mmModel') as number) - 3.280839895013123) < 1e-9); // 1000mm -> ft
   });
 
+  it('converts an Area quantity column when the file declares no explicit AREAUNIT (falls back to LENGTHUNIT²)', () => {
+    // MM_MODEL declares only LENGTHUNIT (millimetre) — no explicit AREAUNIT.
+    // Per IFC convention (and `quantitySiScale`/`resolveMeasureScales`'s
+    // documented fallback), an undeclared AREAUNIT derives from the length
+    // unit SQUARED: 1,000,000 mm² is stored as the raw value 1e6 and must
+    // read back as 1 m².
+    const columns: ColumnDefinition[] = [
+      { id: 'area', source: 'quantity', psetName: 'Qto', propertyName: 'Area', quantityType: QuantityType.Area },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), {});
+    assert.strictEqual(resolver.unitSymbol(0), 'm²');
+    assert.ok(Math.abs((resolver.convertCell(0, 1_000_000, 'm1') as number) - 1) < 1e-9);
+  });
+
+  it('converts a Volume quantity column when the file declares no explicit VOLUMEUNIT (falls back to LENGTHUNIT³)', () => {
+    const columns: ColumnDefinition[] = [
+      { id: 'vol', source: 'quantity', psetName: 'Qto', propertyName: 'Volume', quantityType: QuantityType.Volume },
+    ];
+    const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), {});
+    assert.strictEqual(resolver.unitSymbol(0), 'm³');
+    assert.ok(Math.abs((resolver.convertCell(0, 1_000_000_000, 'm1') as number) - 1) < 1e-9);
+  });
+
   it('unitSymbol returns null for a non-convertible column', () => {
     const columns: ColumnDefinition[] = [{ id: 'name', source: 'attribute', propertyName: 'Name' }];
     const resolver = resolveListColumnUnits(columns, new Map([['m1', MM_MODEL]]), {});

--- a/apps/viewer/src/lib/units/list-column-units.ts
+++ b/apps/viewer/src/lib/units/list-column-units.ts
@@ -15,7 +15,7 @@
  */
 
 import type { CellValue, ColumnDefinition } from '@ifc-lite/lists';
-import { measureUnit, type ProjectUnits, type ResolvedUnit } from '@ifc-lite/parser';
+import { measureUnit, type ProjectUnits } from '@ifc-lite/parser';
 import { alternativesForUnitType } from './alternatives.js';
 import { convertValue, resolveFromUnit, type LinearUnit } from './convert.js';
 import { QUANTITY_TYPE_UNIT } from './display.js';
@@ -40,6 +40,45 @@ function columnUnitKind(col: ColumnDefinition): ColumnUnitKind | undefined {
     if (m?.kind === 'typed') return { unitType: m.unitType, defaultSymbol: m.defaultSymbol };
   }
   return undefined;
+}
+
+/** IFC lets a project declare no explicit `AREAUNIT`/`VOLUMEUNIT` at all —
+ *  the file then means "derive it from `LENGTHUNIT`", squared for area and
+ *  cubed for volume (a millimetre-authored 1 m² is stored raw as `1e6`, not
+ *  `1e3`). Same fallback `quantitySiScale` (`@ifc-lite/parser`) and IDS's
+ *  `resolveMeasureScales` already implement; kept in sync by
+ *  `AREA_VOLUME_POWER`'s two entries rather than a general power lookup. */
+const AREA_VOLUME_POWER: Record<string, number> = { AREAUNIT: 2, VOLUMEUNIT: 3 };
+
+/**
+ * A model's SOURCE unit for `kind.unitType`, as a `LinearUnit`: its explicit
+ * declaration (through {@link resolveFromUnit}, so a curated affine unit like
+ * DEGREE_CELSIUS keeps its offset) when present, else — for AREAUNIT/VOLUMEUNIT
+ * only — the length unit's scale raised to the matching power. `undefined`
+ * when the model declares neither.
+ *
+ * The length-derived branch is built directly as `{scale, offset: 0}`
+ * rather than round-tripped through `resolveFromUnit` (unlike the declared
+ * branch): area/volume units are never affine, and `resolveFromUnit` picks a
+ * curated alternative by SYMBOL — `kind.defaultSymbol` ('m²'/'m³') collides
+ * with the real SI m²/m³ alternative (scale 1), which would silently discard
+ * the derived scale and read every row as already-SI. Not to be used for the
+ * TARGET side: `resolveTarget` intentionally treats "no model declares this
+ * unit-type" as "fall to the SI default", not "adopt the first model's
+ * implied unit" — the target is one fixed unit for the whole column, and its
+ * own SI-default branch already gives it a well-defined scale of 1.
+ */
+function sourceUnitFor(pu: ProjectUnits, kind: ColumnUnitKind): (LinearUnit & { symbol: string }) | undefined {
+  const declared = pu.resolvedForUnitType(kind.unitType);
+  if (declared) {
+    const lin = resolveFromUnit(kind.unitType, declared);
+    return { scale: lin.scale, offset: lin.offset, symbol: declared.symbol };
+  }
+  const power = AREA_VOLUME_POWER[kind.unitType];
+  if (power === undefined) return undefined;
+  const length = pu.unitForMeasure('IfcLengthMeasure');
+  if (!length) return undefined;
+  return { scale: length.siScale ** power, offset: 0, symbol: kind.defaultSymbol };
 }
 
 interface TargetUnit extends LinearUnit {
@@ -83,8 +122,7 @@ export function resolveListColumnUnits(
       if (typeof rawValue !== 'number' || !Number.isFinite(rawValue)) return rawValue;
       const pu = modelUnits.get(modelId);
       if (!pu) return rawValue; // unrecognized model — can't resolve its source unit safely
-      const fileUnit: ResolvedUnit = pu.resolvedForUnitType(kind.unitType) ?? { symbol: kind.defaultSymbol, siScale: 1 };
-      const from = resolveFromUnit(kind.unitType, fileUnit);
+      const from: LinearUnit = sourceUnitFor(pu, kind) ?? resolveFromUnit(kind.unitType, { symbol: kind.defaultSymbol, siScale: 1 });
       // Identity short-circuit: when the row's declared unit already equals the
       // target (single model, no override — the common case), skip the round
       // trip. `v * s / s` is NOT an FP identity for non-power-of-two scales


### PR DESCRIPTION
## Summary

Unit-scale hunt (no ready issue queued; labeled `unqueued`).

`resolveListColumnUnits` (`apps/viewer/src/lib/units/list-column-units.ts`), the single resolver shared by the Lists on-screen table and its XLSX/CSV export, resolved a row's SOURCE unit for an Area/Volume column by reading the model's declared `AREAUNIT`/`VOLUMEUNIT` directly and falling back to `siScale: 1` when the file declared neither.

IFC does not require `AREAUNIT`/`VOLUMEUNIT` to be declared at all — a project that declares only a `LENGTHUNIT` (common) implicitly means the area/volume unit is the length unit squared/cubed. Three other places in the codebase already implement this fallback deliberately: `quantitySiScale` (`packages/parser/src/quantity-collect.ts`), IDS's `resolveMeasureScales` (`packages/ids/src/bridge/units.ts`), and `MergedExporter.resolveDerivedUnitScale`. `list-column-units.ts` was the one boundary that didn't.

**RED (unmodified `upstream/main`)**: a model declaring `LENGTHUNIT = MILLIMETRE` and no explicit `AREAUNIT`, with a Qto_ Area quantity raw value of `1,000,000` (i.e. 1,000,000 mm² = 1 m²) — Lists shows/exports `1,000,000` labeled `"m²"`. A 1,000,000× overstatement under the label shown (Volume: `1,000,000,000` mm³ shown as `1,000,000,000 m³`, a 1e9× overstatement).

**GREEN (fixed)**: the same input converts to `1 m²` / `1 m³`.

**Control**: Length columns, an explicit-unit measure property (m³/s → m³/h), the °C affine-offset case, and federated mm+ft columns are all unchanged (existing tests still pass) — the fix only touches the AREAUNIT/VOLUMEUNIT-undeclared source-side path.

The fix adds `sourceUnitFor`, used only on the per-row SOURCE side of `convertCell`; the TARGET side keeps the existing "no model declares this unit-type → fall to the SI default" rule unchanged (this matters for federation: the target must stay a single fixed unit for the whole column, not silently adopt whichever model happens to iterate first).

## Test plan
- [x] `apps/viewer/src/lib/units/list-column-units.test.ts`: 2 new tests (Area/Volume fallback), 10 existing tests unchanged — 12/12 pass
- [x] `pnpm typecheck --filter @ifc-lite/viewer` (turbo) — clean
- [x] `node scripts/check-module-size.mjs` — no new violation
- [x] `node scripts/check-unused-locals.mjs` — no new violation (pre-existing unrelated `embed-sdk` compile note)
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — no change in baseline
- [x] `apps/viewer` is a private (unpublished) package — no changeset needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436