### PR TITLE
fix(export): preserve GlobalId as the IFCX node path in the Rust IFC5 exporter

### DIFF
--- a/.changeset/fix-ifc5-export-preserve-globalid.md
+++ b/.changeset/fix-ifc5-export-preserve-globalid.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fixed `ifc-lite export --format ifcx` (and any other caller of the Rust IFC5/IFCX exporter) minting a brand-new node path for every product instead of using its IFC `GlobalId`. An element converted from IFC to IFCX lost its original identity — a BCF topic, diff, or any other reference keyed on the source model's GlobalId could no longer find it in the converted file. The exporter now reuses the entity's own GlobalId as its IFCX path when it has one (mirroring the TS exporter, which already did this), falling back to the deterministic synthesized path only for entities with no GlobalId (e.g. the `IfcProject` root).

--- a/rust/export/src/ifc5.rs
+++ b/rust/export/src/ifc5.rs
@@ -55,11 +55,33 @@ impl Default for Ifc5Options {
 }
 
 /// Deterministic UUID-shaped path for an express id (no RNG/clock — wasm-safe).
+/// Fallback only — used when the entity has no `GlobalId` to carry forward
+/// (e.g. the `IfcProject` root, decoded separately from the product rows
+/// `path_for_id` below reads from).
 fn uuid_from_id(id: u32) -> String {
     let a = (id as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0xABCD_EF01_2345_6789;
     let b = (id as u64).wrapping_mul(0xC2B2_AE3D_27D4_EB4F) ^ 0x0F1E_2D3C_4B5A_6978;
     let s = format!("{a:016x}{b:016x}");
     format!("{}-{}-{}-{}-{}", &s[0..8], &s[8..12], &s[12..16], &s[16..20], &s[20..32])
+}
+
+/// IFCX node path for an express id: the entity's own `GlobalId` when it has
+/// one, so a BCF topic / diff / external reference keyed on the source
+/// model's GlobalId still resolves to the same element after IFC→IFCX
+/// conversion; the deterministic fallback otherwise. Mirrors the TS
+/// exporter's `buildEntityMaps` (`packages/export/src/ifc5-exporter.ts`),
+/// which already prefers GlobalId — the Rust port had dropped that and
+/// unconditionally minted a fresh identity for every product, discarding the
+/// original on every `ifc-lite export --format ifcx`.
+fn path_for_id(id: u32, by_id: &HashMap<u32, &EntityRow>) -> String {
+    if let Some(row) = by_id.get(&id) {
+        if let Some(g) = &row.global_id {
+            if !g.is_empty() {
+                return g.clone();
+            }
+        }
+    }
+    uuid_from_id(id)
 }
 
 /// Sanitize a USD prim name (the keys in a node's `children` dict).
@@ -184,7 +206,7 @@ pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
             .cloned()
             .unwrap_or_else(|| (String::new(), "IfcProduct".to_string()));
         let mut node = Map::new();
-        node.insert("path".into(), json!(uuid_from_id(*id)));
+        node.insert("path".into(), json!(path_for_id(*id, &by_id)));
 
         if let Some(ch) = children.get(id) {
             let mut child_map = Map::new();
@@ -193,7 +215,7 @@ pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
                     continue;
                 }
                 let (cname, ctype) = name_of.get(&c).cloned().unwrap_or_default();
-                child_map.insert(prim_name(&cname, &ctype, c), json!(uuid_from_id(c)));
+                child_map.insert(prim_name(&cname, &ctype, c), json!(path_for_id(c, &by_id)));
             }
             if !child_map.is_empty() {
                 node.insert("children".into(), Value::Object(child_map));
@@ -231,86 +253,5 @@ pub fn export_ifc5(content: &[u8], opts: &Ifc5Options) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn duplex_exports_valid_ifcx() {
-        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
-        let v: Value = serde_json::from_str(&s).expect("valid JSON");
-        assert_eq!(v["header"]["ifcxVersion"], IFCX_VERSION);
-        assert_eq!(v["imports"][0]["uri"], IMPORT_CORE);
-
-        let data = v["data"].as_array().expect("data array");
-        assert!(data.len() > 20, "expected a populated node graph, got {}", data.len());
-
-        // Every node has a UUID path; classes are bsi::ifc::*.
-        let paths: HashSet<&str> = data.iter().filter_map(|n| n["path"].as_str()).collect();
-        assert_eq!(paths.len(), data.len(), "paths are unique");
-        for n in data {
-            assert!(n["path"].as_str().unwrap().contains('-'), "uuid-shaped path");
-        }
-
-        // A project root exists and its class is IfcProject.
-        let has_project = data
-            .iter()
-            .any(|n| n["attributes"]["bsi::ifc::class"]["code"] == "IfcProject");
-        assert!(has_project, "project node present");
-
-        // Children dict values reference real node paths (no dangling spatial edges).
-        for n in data {
-            if let Some(ch) = n["children"].as_object() {
-                for (_k, cpath) in ch {
-                    assert!(paths.contains(cpath.as_str().unwrap()), "child path resolves");
-                }
-            }
-        }
-
-        // At least one node carries a known IFC5 property in the bsi::ifc::prop:: namespace.
-        let has_prop = data.iter().any(|n| {
-            n["attributes"].as_object().is_some_and(|a| {
-                a.keys().any(|k| k.starts_with("bsi::ifc::prop::") && k != "bsi::ifc::prop::Name")
-            })
-        });
-        assert!(has_prop, "expected a typed IFC5 property somewhere");
-    }
-
-    /// The header key a READER looks for, which is not the same thing as the
-    /// key this exporter happens to write.
-    ///
-    /// The assertion above was previously `header.version`, mirroring the
-    /// implementation — so it passed while every exported file was rejected by
-    /// `@ifc-lite/ifcx` ("missing or invalid header.ifcxVersion") and did not
-    /// match buildingSMART's own reference files either. Pinning the absence of
-    /// the old key is what makes that regression fail here instead of at the
-    /// other end of a round-trip.
-    #[test]
-    fn header_uses_the_key_readers_look_for() {
-        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
-        let v: Value = serde_json::from_str(&s).expect("valid JSON");
-
-        let header = v["header"].as_object().expect("header object");
-        assert!(
-            header.contains_key("ifcxVersion"),
-            "header must carry ifcxVersion; got keys {:?}",
-            header.keys().collect::<Vec<_>>(),
-        );
-        assert!(
-            !header.contains_key("version"),
-            "the old `version` key is what readers ignore — it must not come back",
-        );
-        // Readers match case-insensitively on the substring "ifcx".
-        assert!(
-            header["ifcxVersion"].as_str().unwrap().to_lowercase().contains("ifcx"),
-            "ifcxVersion must contain 'ifcx'",
-        );
-    }
-
-    #[test]
-    fn unknown_props_filtered_by_default() {
-        let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
-        // 'LoadBearing' / 'Reference' are IFC4 props NOT in the IFC5 known set.
-        assert!(!s.contains("bsi::ifc::prop::LoadBearing"));
-        assert!(!s.contains("bsi::ifc::prop::Reference\""));
-    }
-}
+#[path = "ifc5_tests.rs"]
+mod tests;

--- a/rust/export/src/ifc5_tests.rs
+++ b/rust/export/src/ifc5_tests.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for [`super::ifc5`]. Split out of `ifc5.rs` to keep that module
+//! under the 400-line rule (AGENTS.md), matching the `schema_convert.rs` /
+//! `schema_convert_tests.rs` pattern.
+
+use super::*;
+
+#[test]
+fn duplex_exports_valid_ifcx() {
+    let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
+    let v: Value = serde_json::from_str(&s).expect("valid JSON");
+    assert_eq!(v["header"]["ifcxVersion"], IFCX_VERSION);
+    assert_eq!(v["imports"][0]["uri"], IMPORT_CORE);
+
+    let data = v["data"].as_array().expect("data array");
+    assert!(data.len() > 20, "expected a populated node graph, got {}", data.len());
+
+    // Every node has a non-empty, unique path; classes are bsi::ifc::*.
+    // Paths are the entity's own GlobalId when it has one (see
+    // `globalid_survives_ifc_to_ifcx_conversion` below) or a UUID-shaped
+    // fallback otherwise — not uniformly hyphenated.
+    let paths: HashSet<&str> = data.iter().filter_map(|n| n["path"].as_str()).collect();
+    assert_eq!(paths.len(), data.len(), "paths are unique");
+    for n in data {
+        assert!(!n["path"].as_str().unwrap().is_empty(), "non-empty path");
+    }
+
+    // A project root exists and its class is IfcProject.
+    let has_project = data
+        .iter()
+        .any(|n| n["attributes"]["bsi::ifc::class"]["code"] == "IfcProject");
+    assert!(has_project, "project node present");
+
+    // Children dict values reference real node paths (no dangling spatial edges).
+    for n in data {
+        if let Some(ch) = n["children"].as_object() {
+            for (_k, cpath) in ch {
+                assert!(paths.contains(cpath.as_str().unwrap()), "child path resolves");
+            }
+        }
+    }
+
+    // At least one node carries a known IFC5 property in the bsi::ifc::prop:: namespace.
+    let has_prop = data.iter().any(|n| {
+        n["attributes"].as_object().is_some_and(|a| {
+            a.keys().any(|k| k.starts_with("bsi::ifc::prop::") && k != "bsi::ifc::prop::Name")
+        })
+    });
+    assert!(has_prop, "expected a typed IFC5 property somewhere");
+}
+
+/// The header key a READER looks for, which is not the same thing as the
+/// key this exporter happens to write.
+///
+/// The assertion above was previously `header.version`, mirroring the
+/// implementation — so it passed while every exported file was rejected by
+/// `@ifc-lite/ifcx` ("missing or invalid header.ifcxVersion") and did not
+/// match buildingSMART's own reference files either. Pinning the absence of
+/// the old key is what makes that regression fail here instead of at the
+/// other end of a round-trip.
+#[test]
+fn header_uses_the_key_readers_look_for() {
+    let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
+    let v: Value = serde_json::from_str(&s).expect("valid JSON");
+
+    let header = v["header"].as_object().expect("header object");
+    assert!(
+        header.contains_key("ifcxVersion"),
+        "header must carry ifcxVersion; got keys {:?}",
+        header.keys().collect::<Vec<_>>(),
+    );
+    assert!(
+        !header.contains_key("version"),
+        "the old `version` key is what readers ignore — it must not come back",
+    );
+    // Readers match case-insensitively on the substring "ifcx".
+    assert!(
+        header["ifcxVersion"].as_str().unwrap().to_lowercase().contains("ifcx"),
+        "ifcxVersion must contain 'ifcx'",
+    );
+}
+
+#[test]
+fn unknown_props_filtered_by_default() {
+    let s = export_ifc5(&fixture_or_skip!("ara3d/duplex.ifc"), &Ifc5Options::default());
+    // 'LoadBearing' / 'Reference' are IFC4 props NOT in the IFC5 known set.
+    assert!(!s.contains("bsi::ifc::prop::LoadBearing"));
+    assert!(!s.contains("bsi::ifc::prop::Reference\""));
+}
+
+/// Element identity (RED on unmodified `upstream/main`, GREEN after the fix).
+///
+/// `duplex.ifc`'s products already carry real IFC `GlobalId`s. Converting
+/// to IFCX must not mint a fresh one: the source element's GlobalId is
+/// exactly how a BCF topic, a diff tool, or any other external reference
+/// keyed on the IFC file finds it again after conversion. Before this fix
+/// `path_for_id` didn't exist and every product's path came from
+/// `uuid_from_id(express_id)` — a hash unrelated to the source GlobalId —
+/// so this assertion failed for every element in the fixture.
+#[test]
+fn globalid_survives_ifc_to_ifcx_conversion() {
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
+    let model = build_export_model(&bytes);
+    let wall = model
+        .entities
+        .iter()
+        .find(|e| e.ifc_type == "IfcWall" && e.global_id.as_deref().is_some_and(|g| !g.is_empty()))
+        .expect("fixture has a walled IfcWall with a GlobalId");
+    let source_global_id = wall.global_id.clone().unwrap();
+
+    let s = export_ifc5(&bytes, &Ifc5Options::default());
+    let v: Value = serde_json::from_str(&s).expect("valid JSON");
+    let data = v["data"].as_array().expect("data array");
+
+    let paths: HashSet<&str> = data.iter().filter_map(|n| n["path"].as_str()).collect();
+    assert!(
+        paths.contains(source_global_id.as_str()),
+        "expected the source IfcWall's GlobalId {source_global_id:?} to survive as an \
+         IFCX node path — identity must not be regenerated for an element that already had one",
+    );
+}
+
+/// Control: an entity with no GlobalId to carry (the `IfcProject` root,
+/// decoded outside `model.entities`) still gets a stable, unique,
+/// non-empty path via the deterministic fallback — unaffected by the fix
+/// above, which only changes entities that *have* a GlobalId.
+#[test]
+fn project_root_without_globalid_still_gets_a_stable_path() {
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
+    let s = export_ifc5(&bytes, &Ifc5Options::default());
+    let v: Value = serde_json::from_str(&s).expect("valid JSON");
+    let data = v["data"].as_array().expect("data array");
+
+    let project = data
+        .iter()
+        .find(|n| n["attributes"]["bsi::ifc::class"]["code"] == "IfcProject")
+        .expect("project node present");
+    let path = project["path"].as_str().expect("project has a path");
+    assert!(!path.is_empty(), "project path is non-empty");
+
+    // Re-exporting is deterministic: the same input always yields the
+    // same fallback path (no RNG/clock in `uuid_from_id`).
+    let s2 = export_ifc5(&bytes, &Ifc5Options::default());
+    let v2: Value = serde_json::from_str(&s2).expect("valid JSON");
+    let path2 = v2["data"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|n| n["attributes"]["bsi::ifc::class"]["code"] == "IfcProject")
+        .unwrap()["path"]
+        .as_str()
+        .unwrap();
+    assert_eq!(path, path2, "fallback path is deterministic across runs");
+}


### PR DESCRIPTION
## Lens
GlobalId identity census (hunt task, no tracked issue — flagging `unqueued`). Scope: sites that generate, parse, compare, remap, or truncate an IFC `GlobalId`, judged for whether identity survives.

## Census

| Site | Generates / parses / compares / remaps | Identity survives? |
|---|---|---|
| `packages/encoding/src/guid.ts` (`uuidToIfcGuid`/`ifcGuidToUuid`, buildingSMART alphabet) | Encoding | Yes — round-trips losslessly; correct alphabet, not standard base64 |
| `packages/parser/src/deterministic-global-id.ts` | Generates (schedule tasks/sequences only, not IFC products) | Yes — used only where no upstream GlobalId exists to begin with; not reachable on any path that already has an identity |
| `packages/create/src/ifc-creator.ts`, `in-store/*` (walls/beams/columns/slabs/spaces) | Generates (new elements) | Yes — `generateIfcGuid`/`crypto.randomUUID`-backed, correct guardrail case (new element, new identity) |
| `rust/export/src/csv.rs`, `parquet_bos.rs`, `gltf.rs`, `model.rs` | Passes through `EntityRow.global_id` | Yes — untouched pass-through to output columns/extras |
| `packages/export/src/ifc5-exporter.ts` (TS IFC5/IFCX exporter) | Remaps (IFC → IFCX node path) | Yes — already prefers `GlobalId` as the path, falls back to a generated UUID only when absent |
| `rust/export/src/ifc5.rs` (Rust IFC5/IFCX exporter, backs `ifc-lite export --format ifcx`) | Remaps (IFC → IFCX node path) | **No, before this fix** — every product got a deterministic hash of its express id as its path; the real GlobalId was discarded and appeared nowhere in the output |
| `packages/ifcx/src/entity-extractor.ts` | Parses (IFCX → internal EntityTable, uses `node.path` as GlobalId) | By design for native IFC5 files (path IS identity in IFC5); downstream of the writer bug above for any IFC→IFCX→IFC round trip. Owned by open PR #3677 — out of scope here |
| `packages/ifcx/src/writer.ts` (TS `IfcxWriter`/`exportToIfcx`, published `@ifc-lite/ifcx` API) | Remaps (IFC → IFCX node path) | **No** — fetches `entities.globalId[i]` and never uses it; same defect class as the Rust exporter, but currently unreachable from any wired CLI/viewer path (CLI's `ifcx` export goes through the Rust wasm binding, not this writer). Flagging for a maintainer follow-up; out of scope for this PR (different package, different reachability story) |
| `packages/export/src/schema-converter.ts` / `schema-converter-attr-remap.ts` (schema up/downgrade) | Remaps (attribute list to target schema) | Yes — `GlobalId` is attribute 0 of every rooted entity and is carried by position in both the direct and by-name remap paths; #3653/#3655 already fixed the IfcDoorType/IfcWindowType→proxy identity loss in this family |
| `packages/query`/`PropertyTable`/diff (comparison) | Compares GlobalId | Yes — exact string comparison, no case-folding or trimming found on either side |
| Federation (`packages/renderer/src/federation-registry.ts`) | Remaps (renderer-local id ↔ GlobalId per model) | Yes — already fixed for the overlay-collision class in #3651 |

## The one fix

`rust/export/src/ifc5.rs`'s `export_ifc5` built every node's `path` from `uuid_from_id(express_id)` — a deterministic hash with no relationship to the source entity's `GlobalId`. `EntityRow.global_id` was available (used elsewhere in the same crate for CSV/Parquet/glTF output) but never read here. This is the exact defect class called out by the lens: an element that *already had* an identity got a new one minted for it, silently, on the production `ifc-lite export --format ifcx` path. Any external reference (a BCF topic, a diff, an asset register keyed on the source model's GlobalId) would no longer resolve after conversion.

New `path_for_id(id, by_id)` reuses the entity's own `GlobalId` as its IFCX path when it has one, falling back to `uuid_from_id` only when the entity has none (currently just the `IfcProject` root, which is decoded outside the product-row model). This mirrors the TS sibling exporter (`packages/export/src/ifc5-exporter.ts`), which already did this — the Rust port had silently dropped it.

### RED / GREEN
`rust/export/src/ifc5_tests.rs`, new test `globalid_survives_ifc_to_ifcx_conversion`: exports `duplex.ifc`, picks a real `IfcWall`'s GlobalId (`2O2Fr$t4X7Zf8NOew3FKau`), and asserts it appears as a node path in the exported IFCX.
- On unmodified `upstream/main`: **RED** — panics with `expected the source IfcWall's GlobalId "2O2Fr$t4X7Zf8NOew3FKau" to survive as an IFCX node path` (verified by reverting `path_for_id` back to `uuid_from_id` and re-running).
- After the fix: **GREEN**.

**Control** (`project_root_without_globalid_still_gets_a_stable_path`): the `IfcProject` root, which never had a GlobalId to preserve, keeps its existing deterministic fallback path — unaffected, still unique and stable across runs. The existing `duplex_exports_valid_ifcx` test's uniqueness/well-formedness assertions still pass (its "uuid-shaped" path assertion was loosened to "non-empty," since paths are correctly non-hyphenated GlobalIds now, not uniformly synthesized UUIDs).

## Verification (foreground)
- `cargo test -p ifc-lite-export` — 356/356 passed (fixture copied in manually since `pnpm fixtures` wasn't run in this worktree; `tests/models/ara3d/duplex.ifc` is gitignored and not committed).
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6/6 passed; `ifc5.rs` split into `ifc5_tests.rs` (matching the `schema_convert.rs`/`schema_convert_tests.rs` precedent) to stay under the 400-line budget after the new tests (406 lines pre-split → 257 post-split).
- `cargo check -p ifc-lite-wasm` — clean (confirms the downstream wasm-bindings crate that exposes `exportIfcx` to the CLI still compiles).
- `node scripts/check-module-size.mjs` — OK, 0 new over budget.
- `node scripts/check-unused-locals.mjs` — OK, no new offenders (Rust-only change).
- `node scripts/check-test-wiring.mjs` — OK.
- Changeset added: `@ifc-lite/wasm` patch (this is a Rust change surfaced through the wasm binding that backs `ifc-lite export --format ifcx`).

## Overlap / not touched
`rust/export/src/ifc5.rs` had no open-PR overlap (checked via the repo's PR-file-overlap script). `packages/export/src/ifc5-exporter.ts` (TS sibling, already correct) is owned by #3608/#3676 — not touched. `packages/ifcx/src/entity-extractor.ts` is owned by #3677 — not touched. The `packages/ifcx/src/writer.ts` GlobalId-drop noted in the census table above is a separate, currently-unreachable defect in a different package; flagging for a maintainer follow-up rather than bundling into this PR.