### PR TITLE
fix(ci): module-size gate was TS-only, so 208 .mjs files were outside the rule it reported OK for (#3672)

### DIFF
--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -4,8 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Module-size ratchet for TypeScript — the TS half of the rule that
- * `rust/processing/tests/module_size_ratchet.rs` already enforces for Rust.
+ * Module-size ratchet for TypeScript and Node scripts — the non-Rust half of
+ * the rule that `rust/processing/tests/module_size_ratchet.rs` already
+ * enforces for Rust.
  *
  * WHY THIS EXISTS: the Rust gate's `collect_rs_files` filters on
  * `extension == "rs"`, and the allowlist it reads is Rust-only, so the
@@ -17,9 +18,9 @@
  * the new shape.
  *
  * The gate has two teeth, identical to the Rust one:
- *  1. A NEW non-generated, non-test TS/TSX file that crosses 400 lines and has
- *     no allowlist row fails. This is the load-bearing guarantee: no new god
- *     files.
+ *  1. A NEW non-generated, non-test TS/TSX/MJS/CJS file that crosses 400 lines
+ *     and has no allowlist row fails. This is the load-bearing guarantee: no
+ *     new god files.
  *  2. An allowlisted file that GROWS past its recorded budget fails. Existing
  *     debt is frozen; a listed file may stay flat or shrink, never grow.
  *
@@ -63,8 +64,9 @@
  * Neither is licence to raise a budget for growth the PR itself introduced,
  * which is why the regeneration command refuses a raise unless asked twice.
  *
- * What the step breaks on afterwards, by design: any PR adding a TS/TSX file
- * over 400 lines, any PR growing a listed file past its recorded budget, and
+ * What the step breaks on afterwards, by design: any PR adding a TS/TSX/MJS/
+ * CJS file over 400 lines, any PR growing a listed file past its recorded
+ * budget, and
  * any PR editing the allowlist without moving that scope's ALLOWLIST_DIGESTS
  * entry — including a
  * rebase that lands after someone else's shrink, which requires recomputing
@@ -73,9 +75,18 @@
  *
  * WHAT THIS GATE CANNOT SEE: it counts lines, nothing else. A 400-line file
  * doing five jobs passes; a cohesive 900-line table fails. It does not look at
- * .js/.mjs/.cjs, at anything outside packages/ and apps/, at generated,
- * declaration or test files, or at whether a "split" merely moved lines into a
- * sibling file. Freezing a size is not the same as enforcing a design.
+ * plain .js (four hand-written ones under scripts/ at last count — #3672 left
+ * them out deliberately), at anything outside packages/, apps/ and scripts/
+ * (tools/ holds ~26 more .mjs), at generated, declaration or test files, or at
+ * whether a "split" merely moved lines into a sibling file. Freezing a size is
+ * not the same as enforcing a design.
+ *
+ * .mjs/.cjs became part of the population in #3672: this script's own header
+ * describes the "extension filter hides a whole tree" defect it was written to
+ * close for TypeScript, and it then reported `OK (2084 files measured)` while
+ * 208 non-test .mjs files — several over 1,000 lines, this tree's CI gates
+ * among them — were invisible to it. Same shape as #3639/#3662
+ * (check-source-text-assertions).
  *
  * Run: node scripts/check-module-size.mjs
  * Regenerate: pnpm lint:module-size-baseline   (node scripts/check-module-size.mjs --update)
@@ -138,8 +149,12 @@ import {
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPTS_DIR, '..');
 
-/** Trees walked. `apps/server` is a Rust crate and contributes no TS files. */
-const SEARCH_DIRS = ['packages', 'apps'];
+/**
+ * Trees walked. `apps/server` is a Rust crate and contributes no TS files.
+ * `scripts` is almost entirely .mjs and is where the CI gates themselves live,
+ * which is why it joined the walk in #3672.
+ */
+const SEARCH_DIRS = ['packages', 'apps', 'scripts'];
 
 /** Build output, vendored code and caches — never hand-written modules. */
 const SKIP_DIRS = new Set([
@@ -154,7 +169,7 @@ const SKIP_DIRS = new Set([
   '.git',
 ]);
 
-const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
+const SOURCE_RE = /\.(ts|tsx|mts|cts|mjs|cjs)$/;
 
 /**
  * Digest of every `(path, budget)` pair in the allowlist, pinned HERE rather
@@ -237,6 +252,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/source-dalux': '11927553717016520308',
   'packages/source-dropbox': '13897585807232807340',
   'packages/viewer': '17290688824834287099',
+  'scripts': '7432628421945259767',
 };
 
 function parseArgs(argv) {
@@ -454,7 +470,7 @@ const files = paths
 
 if (files.length === 0) {
   fail(
-    `no TypeScript files matched under ${SEARCH_DIRS.join(', ')} in ${args.root}. ` +
+    `no TypeScript or Node-script files matched under ${SEARCH_DIRS.join(', ')} in ${args.root}. ` +
       'Exiting 0 here would certify a tree nobody looked at.',
   );
 }
@@ -638,7 +654,7 @@ const { newOffenders, grew, shrunk, missing, slack } = evaluate(files, allowlist
 if (newOffenders.length > 0) {
   failed = true;
   console.error(`
-New TypeScript file(s) over ${LIMIT} lines with no allowlist row:\n
+New source file(s) over ${LIMIT} lines with no allowlist row:\n
 ${newOffenders.join('\n')}
 
 Split them (AGENTS.md house rule), or — only with a written justification in

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -58,7 +58,7 @@ function writeSource(dir, rel, lines) {
 function makeTree(files) {
   const dir = mkdtempSync(join(tmpdir(), 'module-size-'));
   for (const [rel, lines] of Object.entries(files)) writeSource(dir, rel, lines);
-  for (const d of ['packages', 'apps']) mkdirSync(join(dir, d), { recursive: true });
+  for (const d of ['packages', 'apps', 'scripts']) mkdirSync(join(dir, d), { recursive: true });
   return dir;
 }
 
@@ -130,8 +130,33 @@ test('a new file over the limit fails', () => {
   const dir = tree({ 'packages/a/big.ts': 500, 'apps/v/new_god.tsx': 401 });
   const { code, out } = run(dir, '500 packages/a/big.ts\n');
   assert.equal(code, 1, out);
-  assert.match(out, /New TypeScript file\(s\) over 400 lines with no allowlist row/);
+  assert.match(out, /New source file\(s\) over 400 lines with no allowlist row/);
   assert.match(out, /apps\/v\/new_god\.tsx: 401 lines/);
+});
+
+test('a new .mjs file over the limit fails too (#3672)', () => {
+  // The defect this gate itself shipped: SOURCE_RE was TS/TSX-only, so 208
+  // .mjs files — the tree the CI gates live in — were outside the population
+  // it printed OK for. Same shape as #3639 in check-source-text-assertions.
+  const dir = tree({ 'packages/a/big.ts': 500, 'scripts/god-gate.mjs': 401 });
+  const { code, out } = run(dir, '500 packages/a/big.ts\n');
+  assert.equal(code, 1, out);
+  assert.match(out, /scripts\/god-gate\.mjs: 401 lines/);
+});
+
+test('a .test.mjs file of any size is exempt, and .cjs is in the population', () => {
+  // One case, both carve-out edges: the test-file exemption must match the new
+  // extensions (or seeding day one would have swept ~70 *.test.mjs files into
+  // the allowlist), while a plain .cjs module is measured like any other.
+  const dir = tree({
+    'packages/a/big.ts': 500,
+    'scripts/god-gate.test.mjs': 900,
+    'scripts/legacy.cjs': 401,
+  });
+  const { code, out } = run(dir, '500 packages/a/big.ts\n');
+  assert.equal(code, 1, out);
+  assert.match(out, /scripts\/legacy\.cjs: 401 lines/);
+  assert.doesNotMatch(out, /god-gate\.test\.mjs/);
 });
 
 test('exactly 400 lines is not over the limit', () => {
@@ -197,7 +222,7 @@ test('VACUOUS: no TypeScript files at all fails', () => {
   const dir = tree({ 'packages/a/readme.md': 3 });
   const { code, out } = run(dir, '500 packages/a/big.ts\n');
   assert.equal(code, 1, out);
-  assert.match(out, /no TypeScript files matched/);
+  assert.match(out, /no TypeScript or Node-script files matched/);
   assert.match(out, /Exiting 0 here would certify a tree nobody looked at/);
 });
 
@@ -208,10 +233,11 @@ test('VACUOUS: only exempt TypeScript files fails', () => {
     'packages/a/x.test.ts': 900,
     'packages/a/x.d.ts': 900,
     'packages/a/generated/y.ts': 900,
+    'scripts/x.test.mjs': 900,
   });
   const { code, out } = run(dir, '500 packages/a/big.ts\n');
   assert.equal(code, 1, out);
-  assert.match(out, /no TypeScript files matched/);
+  assert.match(out, /no TypeScript or Node-script files matched/);
 });
 
 test('VACUOUS: a missing search root fails instead of scanning nothing', () => {
@@ -585,7 +611,7 @@ test('--update refuses a --root that is not the top of its worktree', () => {
   const nested = join(dir, 'nested');
   writeSource(nested, 'packages/a/big.ts', 500);
   writeSource(nested, 'packages/b/slack.ts', 450);
-  mkdirSync(join(nested, 'apps'), { recursive: true });
+  for (const d of ['apps', 'scripts']) mkdirSync(join(nested, d), { recursive: true });
 
   const { code, out, allowlistPath } = run(nested, SCOPED_BEFORE, { extra: ['--update'] });
   assert.equal(code, 1, out);

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -47,12 +47,16 @@ export function countLines(source) {
  *    e2e|fixtures` directories: test code, matching the Rust gate's `/tests/`,
  *    `/examples/`, `/benches/`, `/fuzz/` and `*_test.rs` exemptions. A long
  *    table-driven test is not the debt this rule targets.
+ *
+ * The suffix regexes carry `.mjs`/`.cjs` since #3672 brought Node scripts into
+ * the walk; a `*.test.mjs` that stayed non-exempt would have seeded ~70 test
+ * files into the allowlist on day one.
  */
 export function isExempt(rel) {
   return (
     /(^|\/)generated\//.test(rel) ||
     /\.d\.(ts|tsx|mts|cts)$/.test(rel) ||
-    /\.(test|spec|bench)\.(ts|tsx|mts|cts)$/.test(rel) ||
+    /\.(test|spec|bench)\.(ts|tsx|mts|cts|mjs|cjs)$/.test(rel) ||
     /(^|\/)(test|tests|__tests__|__mocks__|e2e|fixtures)\//.test(rel)
   );
 }

--- a/scripts/lib/module-size-ratchet.test.mjs
+++ b/scripts/lib/module-size-ratchet.test.mjs
@@ -68,12 +68,20 @@ test('isExempt covers generated, declaration and test files only', () => {
     'apps/viewer/src/__mocks__/x.ts',
     'tests/e2e/x.ts',
     'packages/x/fixtures/model.ts',
+    // The .mjs/.cjs population joined in #3672, and its test files must be as
+    // exempt as TS ones — scripts/ alone holds ~70 *.test.mjs.
+    'scripts/check-module-size.test.mjs',
+    'scripts/lib/pr-review-signal.spec.cjs',
+    'scripts/fixtures/sample.mjs',
   ]) {
     assert.equal(isExempt(rel), true, rel);
   }
   for (const rel of [
     'packages/export/src/step-exporter.ts',
     'apps/viewer/src/components/viewer/Viewport.tsx',
+    // A non-test .mjs module is measured like any other source file (#3672).
+    'scripts/check-module-size.mjs',
+    'scripts/space-dcel-e2e.cjs',
     // "generated" must be a path SEGMENT, not a substring: a module that
     // generates something is production code.
     'apps/viewer/src/components/viewer/schedule/generate-schedule.ts',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -1,8 +1,9 @@
-# Module-size ratchet allowlist for TypeScript (see scripts/check-module-size.mjs).
-# The TS twin of rust/processing/tests/module_size_allowlist.txt.
+# Module-size ratchet allowlist for TypeScript and Node scripts
+# (see scripts/check-module-size.mjs).
+# The non-Rust twin of rust/processing/tests/module_size_allowlist.txt.
 #
-# Non-generated, non-test .ts/.tsx files currently over the ~400-line house
-# rule (AGENTS.md). Each line is '<budget> <path>'; the budget is the line
+# Non-generated, non-test .ts/.tsx/.mts/.cts/.mjs/.cjs files currently over the
+# ~400-line house rule (AGENTS.md). Each line is '<budget> <path>'; the budget is the line
 # count at the moment it was recorded. The gate fails if any of these grows
 # PAST its budget, or if a NEW file crosses 400 without an entry.
 #
@@ -336,3 +337,56 @@
    432 packages/source-dropbox/src/provider.ts
    415 packages/viewer/src/server.ts
   1486 packages/viewer/src/viewer-html.ts
+   501 scripts/check-agents-md-size.mjs
+   680 scripts/check-changeset-bump.mjs
+   523 scripts/check-ci-path-coverage.mjs
+   574 scripts/check-collab-room-model-target.mjs
+   529 scripts/check-generated.mjs
+   430 scripts/check-git-lfs.mjs
+   598 scripts/check-isolate-expansion-routing.mjs
+   957 scripts/check-issue-queue.mjs
+   448 scripts/check-legacy-entity-coverage.mjs
+  1145 scripts/check-loader-hook-specifier-match.mjs
+   694 scripts/check-module-size.mjs
+   951 scripts/check-pr-review-signal.mjs
+   771 scripts/check-review-posted.mjs
+   423 scripts/check-test-glob-coverage.mjs
+   612 scripts/check-test-revert-oracle.mjs
+   703 scripts/check-test-wiring.mjs
+   488 scripts/check-wasm-disposal.mjs
+   506 scripts/generate-bim-globals.mjs
+   423 scripts/generate-epsg-index.ts
+   403 scripts/lib/ci-path-coverage.mjs
+   472 scripts/lib/pr-green-sweep.mjs
+  1077 scripts/lib/pr-review-signal.mjs
+   443 scripts/lib/prepass-class-boundary.mjs
+   734 scripts/lib/refwalk-classify.mjs
+   518 scripts/lib/revert-oracle.mjs
+   494 scripts/lib/rust-source-text-detect.mjs
+  1165 scripts/lib/vitest-timeout-audit.mjs
+  1304 scripts/moonshot/b45-m1-midterm/run.mjs
+   422 scripts/moonshot/b51-real-merge-traces/identifier-guard.mjs
+   617 scripts/moonshot/b51-real-merge-traces/run.mjs
+   790 scripts/moonshot/b52-foreign-ifc/build-scorecard.mjs
+   605 scripts/moonshot/b55-scan-to-parametric/extract-rooms.mjs
+   889 scripts/moonshot/ci/assert-b35-golden.mjs
+   402 scripts/moonshot/ci/b55-pipeline-regression.mjs
+  1363 scripts/moonshot/ci/check-report-numerals.mjs
+   408 scripts/moonshot/diff-spike/trajectory.mjs
+   511 scripts/moonshot/g0-certificate-demo.mjs
+   533 scripts/moonshot/g1-memoized-recompute.mjs
+   465 scripts/moonshot/g2-footprint-tightness.mjs
+   515 scripts/moonshot/g2-merge-soundness.mjs
+   807 scripts/moonshot/gpu-predicates/b25-page-main.mjs
+   626 scripts/moonshot/gpu-predicates/harness.mjs
+   415 scripts/moonshot/m5-constrained-decoding/dsl.mjs
+   621 scripts/moonshot/m5-constrained-decoding/run-tier2.mjs
+   980 scripts/moonshot/m5-constrained-decoding/tasks-tier2.mjs
+   733 scripts/review/post-review.mjs
+   427 scripts/review/run-reviewer.mjs
+   892 scripts/review/validate-findings.mjs
+   688 scripts/source-text-assertion-detect.mjs
+   504 scripts/test-geometry-regression.mjs
+  2196 scripts/test-wasm-contract.mjs
+   678 scripts/typecheck-tests.mjs
+   467 scripts/xmatch/score.mjs


### PR DESCRIPTION
Closes #3672.

## The gate reported OK for a tree it never read

`check-module-size.mjs` enforced the AGENTS.md "~400 non-generated lines" rule
for `.ts`/`.tsx` only. Every `.mjs` file was invisible to it — 208 non-test
source files, several over 1,000 lines, one at **2,196** — while the gate
printed `OK (2084 files measured, 0 new over 400)`.

`scripts/` is almost entirely `.mjs`, and that tree is where the CI gates
themselves live. The script's own header says it exists to close exactly this
hole for TypeScript; it closed it for one extension.

A gate that reports OK over a population it never looked at is worse than no
gate, because the OK is read as evidence. This is the third instance of an
extension filter silently excluding a whole tree (#3639 was the same shape in
`check-source-text-assertions`).

## A second blind spot, inside the first

The test-file exemption regex was `\.(test|spec|bench)\.(ts|tsx|mts|cts)$` — it
does **not** match `*.test.mjs`. Without fixing that, extending the walk would
have seeded ~70 test files into the allowlist as if they were god files.
Verified, not assumed.

## Shape

`.mjs` and `.cjs` are both included (`.cjs` closes the rename escape hatch), and
`scripts/` joins the search dirs. 53 rows are seeded at their current measured
counts, so the ratchet holds the line going forward without demanding a refactor
now — exactly what the TS half already does with its 305 rows. No existing row
is touched.

Deliberately out of scope, and recorded in the docstring: four hand-written
`.js` under `scripts/` (one at 436 lines) and ~26 `.mjs` under `tools/`.

## Mutation-checked, both directions

With the fix, appending 4 lines to `scripts/test-wasm-contract.mjs` → **exit 1**,
`2200 lines, budget 2196`. With the fix reverted, the same grown file → **exit
0**. The gate now catches a growing `.mjs`; before, it certifiably did not.

## Merge-order note

All 53 rows land in one **new** allowlist scope (`scripts`), so no existing
digest line and no existing row moves — that is deliberate, given #3289/#3291
recording that a repo-wide digest serialises the PR queue. It still conflicts
with any open PR that edits the adjacent `packages/viewer` pin line, appends at
the allowlist tail, or edits the header. Land it early or rebase it last with
`pnpm lint:module-size-baseline`; either way the fix is one line.

63/63 tests pass. `check-module-size` now measures 2,286 files (was 2,084).
