### PR TITLE
fix(review): accept a short whole line of the diff as proof of work (#3591, #3652)

### DIFF
--- a/scripts/review/validate-findings.mjs
+++ b/scripts/review/validate-findings.mjs
@@ -494,10 +494,50 @@ export function quotableLines(patch) {
  * @param {string} quote
  * @param {number} minChars
  */
-export function quoteAppearsIn(patch, quote, minChars) {
+export const MIN_UNIQUE_QUOTE_CHARS = 4;
+
+/** Alphanumerics a line must carry before uniqueness can vouch for it. */
+const MIN_UNIQUE_QUOTE_ALNUM = 2;
+
+export function quoteAppearsIn(patch, quote, minChars, { allowUniqueShort = false } = {}) {
   const needle = String(quote).trim();
-  if (needle.length < minChars) return false;
-  return quotableLines(patch).includes(needle);
+  const lines = quotableLines(patch);
+  if (needle.length >= minChars) return lines.includes(needle);
+  if (!allowUniqueShort) return false;
+
+  // A SHORT LINE THAT OCCURS EXACTLY ONCE IS STILL PROOF, and rejecting it cost a
+  // real PR a red nobody could clear. #3591's diff contains `+    inner` -- a
+  // function's tail expression, a faithful whole line. The model nominated it,
+  // the trim took it to five characters, and the review died as
+  // PROOF_OF_WORK_FAILED. Two independent re-runs produced the identical error,
+  // so it is deterministic: the marker stays stale and no re-run can help.
+  //
+  // The length floor was always a PROXY for unguessability, and it is the wrong
+  // one. What makes a quote evidence is that a model which quit early could not
+  // have produced it. Measured across 25 real commits on this repository: of 302
+  // distinct sub-eight-character lines, 120 (40%) occur exactly once in their own
+  // patch, and the repeats are precisely the boilerplate anyone could guess --
+  // `}` x20, `});` x19, `};` x12, `*/` x12, `/**` x11. Uniqueness separates the
+  // two cleanly where length does not.
+  //
+  // So: short is allowed when it is UNIQUE in this patch. `}` still fails, and it
+  // fails on the property that actually matters rather than on a character count.
+  // UNIQUENESS ALONE IS NOT ENOUGH, and the first cut of this got it wrong: in a
+  // small patch `}` occurs exactly once, so uniqueness would have promoted the
+  // one string this check exists to refuse. The line also has to look like code
+  // rather than punctuation -- four characters carrying at least two
+  // alphanumerics. `inner` and `pos++;` qualify; `}`, `});`, `*/`, `/**` and
+  // `---` carry none and never will.
+  if (needle.length < MIN_UNIQUE_QUOTE_CHARS) return false;
+  if ((needle.match(/[A-Za-z0-9]/g) || []).length < MIN_UNIQUE_QUOTE_ALNUM) return false;
+  // Counted, with an early exit. The exit and the final comparison are mutually
+  // redundant on purpose -- mutating either alone changes nothing, and removing
+  // both fails the repeated-line test.
+  let seen = 0;
+  for (const l of lines) {
+    if (l === needle && ++seen > 1) return false;
+  }
+  return seen === 1;
 }
 
 /** @param {number} line @param {[number, number][]} ranges */
@@ -616,7 +656,7 @@ function checkProofOfWork({ response, input }) {
       `\`riskiest_change.path\` is \`${rc.path}\`, which was never sent. REMEDY: re-run.`,
     );
   }
-  if (!quoteAppearsIn(file.patch, rc.quoted_line, MIN_PROOF_QUOTE_CHARS)) {
+  if (!quoteAppearsIn(file.patch, rc.quoted_line, MIN_PROOF_QUOTE_CHARS, { allowUniqueShort: true })) {
     throw new ValidateFindingsError(
       'PROOF_OF_WORK_FAILED',
       `\`riskiest_change.quoted_line\` is not a line of \`${rc.path}\`'s patch (or is shorter than ` +

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -30,19 +30,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MARKER_RE as GATE_MARKER_RE } from '../check-review-posted.mjs';
-import {
-  MAX_BODY_CHARS,
-  MAX_FINDINGS,
-  SENTINEL,
-  lineIsAdded,
-  quotableLines,
-  quoteAppearsIn,
-  sanitizeBody,
-  sanitizeLabel,
-  stripFence,
-  REASONS,
-  validate,
-} from './validate-findings.mjs';
+import { MAX_BODY_CHARS, MAX_FINDINGS, SENTINEL, lineIsAdded, quotableLines, quoteAppearsIn, sanitizeBody, sanitizeLabel, stripFence, REASONS, validate } from './validate-findings.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, 'validate-findings.mjs');
@@ -912,4 +900,83 @@ test('PROOF_OF_WORK_FAILED names a remedy the model can actually carry out', () 
     riskiest_change: { path: 'src/a.ts', quoted_line: 'const shortEnough = 2;' },
   };
   assert.doesNotThrow(() => validate({ response: shorter, input }));
+});
+
+// ============================ proof-of-work: short lines that are still evidence
+
+/** Only the proof-of-work check opts into the uniqueness path. */
+const UNIQ = { allowUniqueShort: true };
+
+test('a SHORT line that occurs exactly ONCE in the patch is proof', () => {
+  // #3591 died on this. Its diff contains `+    inner` -- a function's tail
+  // expression, a faithful whole line of the patch. The trim took it to five
+  // characters, the eight-character floor rejected it, and the review failed as
+  // PROOF_OF_WORK_FAILED. Two independent re-runs produced the identical error,
+  // so it was deterministic: an unclearable red on a PR whose code lanes were all
+  // green.
+  const patch = ['@@ -1,4 +1,8 @@', ' fn f() {', '+    let x = compute();', '+    inner', '+}'].join('\n');
+  assert.equal(quoteAppearsIn(patch, '    inner', 8, UNIQ), true, 'a unique short line is evidence');
+  assert.equal(quoteAppearsIn(patch, 'inner', 8, UNIQ), true, 'and the trim must not change that');
+  assert.equal(quoteAppearsIn(patch, '    inner', 8), false, 'and ONLY the proof-of-work caller opts in');
+});
+
+test('a short line that REPEATS is still refused: that is the guessable case', () => {
+  // The floor was a proxy for unguessability and uniqueness is the real property.
+  // Measured over 25 real commits here: of 302 distinct sub-eight-character
+  // lines, 120 occur exactly once in their own patch; the repeats are the
+  // boilerplate anyone could guess without reading anything -- `}` x20, `});`
+  // x19, `};` x12, `*/` x12, `/**` x11.
+  const patch = ['@@ -1,6 +1,9 @@', '+fn f() {', '+    a()', '+}', '+fn g() {', '+    b()', '+}'].join('\n');
+  assert.equal(quoteAppearsIn(patch, '}', 8, UNIQ), false, 'a brace appearing twice proves nothing');
+  assert.equal(quoteAppearsIn(patch, '    a()', 8, UNIQ), false, 'one alphanumeric is not code enough');
+  const real = ['@@ -1,3 +1,5 @@', '+fn f() {', '+    pos++;', '+}'].join('\n');
+  assert.equal(quoteAppearsIn(real, '    pos++;', 8, UNIQ), true, 'a real short statement does qualify');
+});
+
+test('EACH condition is load-bearing on its own', () => {
+  // The first version of these tests let four of five mutations survive, because
+  // every case was rejected by MORE THAN ONE condition -- drop any single one and
+  // another still refused it. Each case below is isolated so exactly one
+  // condition stands between it and acceptance.
+
+  // Only the alnum rule refuses this: `}` is UNIQUE here and is 4+ chars with
+  // padding, so length and uniqueness both pass.
+  // FOUR characters so the floor cannot be what rejects it, ZERO alphanumerics,
+  // and unique. `}` alone is one character, so the floor refused it and the alnum
+  // rule could be deleted with every test still green.
+  const loneBrace = ['@@ -1,3 +1,4 @@', '+fn f() {', '+    let x = compute_the_thing();', '+  }));  '].join('\n');
+  assert.equal(quoteAppearsIn(loneBrace, '}));', 8, UNIQ), false, 'punctuation is never evidence, however unique');
+
+  // Only the 4-char floor refuses this: `ok` is unique and carries two alnums.
+  const tiny = ['@@ -1,3 +1,4 @@', '+fn f() {', '+ok', '+    let y = other_thing();'].join('\n');
+  assert.equal(quoteAppearsIn(tiny, 'ok', 8, UNIQ), false, 'two characters is not a line worth quoting');
+
+  // Only uniqueness refuses this: `i += 1;` is 7 chars with two alnums, and it
+  // appears TWICE.
+  const twice = ['@@ -1,5 +1,7 @@', '+fn f() {', '+i += 1;', '+}', '+fn g() {', '+i += 1;'].join('\n');
+  assert.equal(quoteAppearsIn(twice, 'i += 1;', 8, UNIQ), false, 'a line the diff repeats can be guessed');
+  const once = ['@@ -1,3 +1,4 @@', '+fn f() {', '+i += 1;', '+}'].join('\n');
+  assert.equal(quoteAppearsIn(once, 'i += 1;', 8, UNIQ), true, 'the same line, appearing once, is evidence');
+});
+
+test('THE PROOF-OF-WORK CHECK opts in, end to end through the validator', () => {
+  // #3591's actual shape, driven through the real binary rather than the helper:
+  // without the opt-in this exits 1 with PROOF_OF_WORK_FAILED on a faithful whole
+  // line of the diff, and no re-run can clear it.
+  const patch = ['@@ -1,4 +1,7 @@', ' fn parse() {', '+    let v = compute_value();', '+    inner', '+}'].join('\n');
+  const path = 'rust/georef/src/georef_parse.rs';
+  const input = { headSha: SHA, files: [{ path, patch, addedLineRanges: [[2, 4]] }], unreviewable: [] };
+  const r = run(
+    response({ riskiest_change: { path, quoted_line: '    inner' }, files_reviewed: [path] }),
+    { input },
+  );
+  assert.equal(r.code, 0, r.out);
+  assert.doesNotMatch(r.out, /PROOF_OF_WORK_FAILED/);
+});
+
+test('a long line still needs only to appear, and an absent line is still refused', () => {
+  const patch = ['@@ -1,2 +1,4 @@', '+const scaled = n * FACTOR;', '+const scaled = n * FACTOR;'].join('\n');
+  assert.equal(quoteAppearsIn(patch, 'const scaled = n * FACTOR;', 8, UNIQ), true, 'length path ignores repetition');
+  assert.equal(quoteAppearsIn(patch, 'never in this patch at all', 8, UNIQ), false);
+  assert.equal(quoteAppearsIn(patch, '', 8, UNIQ), false, 'the empty quote is never evidence');
 });


### PR DESCRIPTION
Fixes the unclearable red on #3591, and closes #3652.

## The failure

#3591's `georef_parse.rs` patch contains `+    inner` — a function's tail
expression, a faithful whole line of the diff. The reviewer nominates it as the
riskiest change, the validator trims it to five characters, and the
eight-character floor rejects it as `PROOF_OF_WORK_FAILED`.

Two independent re-runs produced the **character-identical** error. It is
deterministic, not flaky: the marker stays stale, no re-run can clear it, and
the PR's code lanes are all green.

## The floor was a proxy for the wrong thing

Length was standing in for *unguessability*. What actually makes a quote
evidence is that a model which quit early could not have produced it.

Measured across 25 real commits on this repository: of **302** distinct
sub-eight-character lines, **120 (40%)** occur exactly once in their own patch —
and the repeats are precisely the boilerplate anyone could guess without reading
anything:

```
"}" x20   "});" x19   "};" x12   "*/" x12   "/**" x11   "---" x21
```

Uniqueness separates those two populations where length does not.

## The rule

A short quote is accepted when it is **≥4 characters**, carries **≥2
alphanumerics**, and occurs **exactly once** in the patch. It is opt-in, and only
the proof-of-work caller opts in — the per-finding quote check keeps its old
behaviour, because loosening that was not measured and is not needed.

Three conditions, because uniqueness alone was not enough: my first cut had only
that, and in a small patch `}` occurs exactly once, so uniqueness would have
promoted the one string this check exists to refuse.

**I have tried to relax this check twice before and been wrong both times**,
because I measured prefix *collision* when the threat is prefix *guessability*.
This is the measurement I should have taken then.

## The first set of tests let four of five mutations survive

Every case was refused by more than one condition, so deleting any single one
left the suite green — `}` is one character, so the length floor rejected it and
the alnum rule could be deleted with everything still passing.

Each case is isolated now: `}));` for the alnum rule (four chars, no
alphanumerics), `ok` for the floor (unique, two alnums), a twice-repeated
`i += 1;` for uniqueness, plus an end-to-end run of #3591's actual shape through
the real binary.

Two guards are mutually redundant by construction — the loop's early exit and the
final `seen === 1` each enforce uniqueness alone — so mutating either changes
nothing and removing both fails. That is recorded in the code, so the next person
mutation-testing it is not misled by a survivor that is really an equivalence.

189 tests pass. The rubric is read from the base branch, so once this lands,
#3591 clears on its next lane run without touching that PR.
