### PR TITLE
fix(create): schema-conditional trailing attributes for quantities, wall/column/beam, IfcRelSequence

### DIFF
--- a/.changeset/create-quantity-formula-attribute.md
+++ b/.changeset/create-quantity-formula-attribute.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/create': patch
+---
+
+`addIfcElementQuantity` wrote `IfcQuantityLength`/`Area`/`Volume`/`Weight`/`Count` records with only 4 attributes (`Name`, `Description`, `Unit`, `<Value>`) instead of the 5 the schema declares — `IfcPhysicalSimpleQuantity`'s trailing `Formula` attribute was omitted entirely rather than written as an unset `$`. STEP part 21 requires every declared attribute position to be present (`$` for unset), so the emitted record was one field short of what `IfcQuantityLength`/etc. need; a strict reader can reject the entity outright. Every quantity attached via the public `addIfcElementQuantity` API now writes the trailing `$` for `Formula`.

--- a/.changeset/create-quantity-formula-attribute.md
+++ b/.changeset/create-quantity-formula-attribute.md
@@ -2,4 +2,9 @@
 '@ifc-lite/create': patch
 ---
 
-`addIfcElementQuantity` wrote `IfcQuantityLength`/`Area`/`Volume`/`Weight`/`Count` records with only 4 attributes (`Name`, `Description`, `Unit`, `<Value>`) instead of the 5 the schema declares — `IfcPhysicalSimpleQuantity`'s trailing `Formula` attribute was omitted entirely rather than written as an unset `$`. STEP part 21 requires every declared attribute position to be present (`$` for unset), so the emitted record was one field short of what `IfcQuantityLength`/etc. need; a strict reader can reject the entity outright. Every quantity attached via the public `addIfcElementQuantity` API now writes the trailing `$` for `Formula`.
+Several `IfcCreator` element/relationship writers wrote an attribute count that only matched the IFC4/IFC4X3 schema, not IFC2X3, for entities whose trailing attribute list genuinely differs between schema versions:
+
+- `addIfcElementQuantity` omitted `IfcQuantityLength`/`Area`/`Volume`/`Weight`/`Count`'s trailing `Formula` attribute entirely (added in IFC4) instead of writing it as an unset `$` — every quantity record was one attribute short of the IFC4/IFC4X3 declaration.
+- `addIfcWall`/`addIfcColumn`/`addIfcBeam` and `addIfcRelSequence` always wrote a trailing `PredefinedType`/`UserDefinedSequenceType` value, an attribute IFC2X3 does not declare at all — so a creator targeting `Schema: 'IFC2X3'` emitted one attribute too *many* for those entities, which is exactly as invalid as writing too few.
+
+STEP part 21 requires an explicit slot for every attribute a schema version declares — no more, no fewer. The trailing attribute is now written only for schemas that declare it (IFC4/IFC4X3), driven off the creator's own `Schema` field, and omitted for IFC2X3.

--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -336,14 +336,62 @@ describe('IfcCreator', () => {
     expect(result.content).toContain("'Qto_SlabBaseQuantities'");
 
     // IfcPhysicalSimpleQuantity subtypes (IfcQuantityArea/Volume/…) declare
-    // 5 attributes: Name, Description, Unit, <Value>, Formula. Formula is
-    // trailing-optional but STEP still requires an explicit `$` slot for
-    // it — a record with only 4 fields is one attribute short of what the
-    // schema declares (packages/data/src/ifc-schema/generated/entities-ifc4.ts).
+    // 5 attributes from IFC4 on: Name, Description, Unit, <Value>, Formula.
+    // Formula is trailing-optional but STEP still requires an explicit `$`
+    // slot for it — a record with only 4 fields is one attribute short of
+    // what the default IFC4 schema declares
+    // (packages/data/src/ifc-schema/generated/entities-ifc4.ts).
     const areaLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYAREA('));
     const volumeLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYVOLUME('));
     expect(areaLine).toMatch(/^#\d+=IFCQUANTITYAREA\('GrossArea',\$,\$,80\.,\$\);$/);
     expect(volumeLine).toMatch(/^#\d+=IFCQUANTITYVOLUME\('GrossVolume',\$,\$,24\.,\$\);$/);
+  });
+
+  it('attaches quantity sets in IFC2X3 without the Formula attribute', () => {
+    // entities-ifc2x3.ts declares only 4 attributes for IfcQuantityArea/
+    // Volume/…: Name, Description, Unit, <Value> — no Formula (added in
+    // IFC4). A creator targeting IFC2X3 must NOT write the trailing `$`
+    // the IFC4 branch needs, or the record has one attribute too many.
+    const creator = new IfcCreator({ Schema: 'IFC2X3' });
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    const slabId = creator.addIfcSlab(storey, {
+      Position: [0, 0, 0], Thickness: 0.3, Width: 10, Depth: 8,
+    });
+
+    creator.addIfcElementQuantity(slabId, {
+      Name: 'Qto_SlabBaseQuantities',
+      Quantities: [
+        { Name: 'GrossArea', Value: 80, Kind: 'IfcQuantityArea' },
+        { Name: 'GrossVolume', Value: 24, Kind: 'IfcQuantityVolume' },
+      ],
+    });
+
+    const result = creator.toIfc();
+    const areaLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYAREA('));
+    const volumeLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYVOLUME('));
+    expect(areaLine).toMatch(/^#\d+=IFCQUANTITYAREA\('GrossArea',\$,\$,80\.\);$/);
+    expect(volumeLine).toMatch(/^#\d+=IFCQUANTITYVOLUME\('GrossVolume',\$,\$,24\.\);$/);
+  });
+
+  it('drops the trailing IFC4-only attribute for IfcWall/Column/Beam/RelSequence in IFC2X3', () => {
+    // entities-ifc2x3.ts gives IfcWall/IfcColumn/IfcBeam 8 attributes (no
+    // PredefinedType) and IfcRelSequence 8 (no UserDefinedSequenceType) —
+    // all four gained one trailing attribute only from IFC4 on.
+    const creator = new IfcCreator({ Schema: 'IFC2X3' });
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    creator.addIfcWall(storey, { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3 });
+    creator.addIfcColumn(storey, { Position: [0, 0, 0], Width: 0.3, Depth: 0.3, Height: 3 });
+    creator.addIfcBeam(storey, { Start: [0, 0, 0], End: [3, 0, 0], Width: 0.2, Height: 0.4 });
+    const t1 = creator.addIfcTask({ Name: 'T1' });
+    const t2 = creator.addIfcTask({ Name: 'T2' });
+    creator.addIfcRelSequence(t1, t2, { UserDefinedSequenceType: 'custom' });
+
+    const result = creator.toIfc();
+    const find = (tag: string) => result.content.split('\n').find(l => l.includes(`${tag}(`));
+    expect(find('IFCWALL')).toMatch(/,\$\);$/);
+    expect(find('IFCCOLUMN')).toMatch(/,\$\);$/);
+    expect(find('IFCBEAM')).toMatch(/,\$\);$/);
+    expect(find('IFCRELSEQUENCE')).toMatch(/,\.FINISH_START\.\);$/);
   });
 
   it('attaches a simple material via IfcRelAssociatesMaterial', () => {

--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -334,6 +334,16 @@ describe('IfcCreator', () => {
     expect(result.content).toContain('IFCQUANTITYAREA');
     expect(result.content).toContain('IFCQUANTITYVOLUME');
     expect(result.content).toContain("'Qto_SlabBaseQuantities'");
+
+    // IfcPhysicalSimpleQuantity subtypes (IfcQuantityArea/Volume/…) declare
+    // 5 attributes: Name, Description, Unit, <Value>, Formula. Formula is
+    // trailing-optional but STEP still requires an explicit `$` slot for
+    // it — a record with only 4 fields is one attribute short of what the
+    // schema declares (packages/data/src/ifc-schema/generated/entities-ifc4.ts).
+    const areaLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYAREA('));
+    const volumeLine = result.content.split('\n').find(l => l.includes('IFCQUANTITYVOLUME('));
+    expect(areaLine).toMatch(/^#\d+=IFCQUANTITYAREA\('GrossArea',\$,\$,80\.,\$\);$/);
+    expect(volumeLine).toMatch(/^#\d+=IFCQUANTITYVOLUME\('GrossVolume',\$,\$,24\.,\$\);$/);
   });
 
   it('attaches a simple material via IfcRelAssociatesMaterial', () => {

--- a/packages/create/src/ifc-creator.ts
+++ b/packages/create/src/ifc-creator.ts
@@ -275,7 +275,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(wallId, 'IFCWALL',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.STANDARD.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.STANDARD.')}`);
 
     this.elementSolids.set(wallId, [solidId]);
     this.trackElement(storeyId, wallId);
@@ -390,7 +390,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(colId, 'IFCCOLUMN',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.COLUMN.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.COLUMN.')}`);
 
     this.elementSolids.set(colId, [solidId]);
     this.trackElement(storeyId, colId);
@@ -433,7 +433,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(beamId, 'IFCBEAM',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.BEAM.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.BEAM.')}`);
 
     this.elementSolids.set(beamId, [solidId]);
     this.trackElement(storeyId, beamId);
@@ -1234,7 +1234,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(colId, 'IFCCOLUMN',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.COLUMN.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.COLUMN.')}`);
 
     this.elementSolids.set(colId, [solidId]);
     this.trackElement(storeyId, colId);
@@ -1291,7 +1291,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(beamId, 'IFCBEAM',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.BEAM.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.BEAM.')}`);
 
     this.elementSolids.set(beamId, [solidId]);
     this.trackElement(storeyId, beamId);
@@ -1489,7 +1489,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(colId, 'IFCCOLUMN',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.COLUMN.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.COLUMN.')}`);
 
     this.elementSolids.set(colId, [solidId]);
     this.trackElement(storeyId, colId);
@@ -1545,7 +1545,7 @@ export class IfcCreator {
     const tag = params.Tag ? `'${esc(params.Tag)}'` : '$';
 
     this.line(beamId, 'IFCBEAM',
-      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag},.BEAM.`);
+      `'${globalId}',#${this.ownerHistoryId},'${esc(name)}',${desc},${objType},#${placementId},#${prodShapeId},${tag}${this.ifc4Only('.BEAM.')}`);
 
     this.elementSolids.set(beamId, [solidId]);
     this.trackElement(storeyId, beamId);
@@ -1590,9 +1590,8 @@ export class IfcCreator {
     for (const qty of qset.Quantities) {
       const qtyId = this.id();
       const valueField = this.quantityValueField(qty);
-      // Trailing Formula attribute needs an explicit `$`, not omission.
       this.line(qtyId, qty.Kind.toUpperCase(),
-        `'${esc(qty.Name)}',$,${valueField},$`);
+        `'${esc(qty.Name)}',$,${valueField}${this.ifc4Only('$')}`);
       qtyIds.push(qtyId);
     }
 
@@ -1798,7 +1797,7 @@ export class IfcCreator {
     }
 
     this.line(relId, 'IFCRELSEQUENCE',
-      `'${globalId}',#${this.ownerHistoryId},$,$,#${predecessorTaskId},#${successorTaskId},${lagRef},${seqType},${userDef}`);
+      `'${globalId}',#${this.ownerHistoryId},$,$,#${predecessorTaskId},#${successorTaskId},${lagRef},${seqType}${this.ifc4Only(userDef)}`);
     return relId;
   }
 
@@ -2732,6 +2731,7 @@ ENDSEC;
     return '$';
   }
 
+  private ifc4Only(v: string): string { return this.schema === 'IFC2X3' ? '' : `,${v}`; } // trailing IFC4/4X3-only attribute
   private quantityValueField(qty: QuantityDef): string {
     switch (qty.Kind) {
       case 'IfcQuantityLength':

--- a/packages/create/src/ifc-creator.ts
+++ b/packages/create/src/ifc-creator.ts
@@ -1590,8 +1590,9 @@ export class IfcCreator {
     for (const qty of qset.Quantities) {
       const qtyId = this.id();
       const valueField = this.quantityValueField(qty);
+      // Trailing Formula attribute needs an explicit `$`, not omission.
       this.line(qtyId, qty.Kind.toUpperCase(),
-        `'${esc(qty.Name)}',$,${valueField}`);
+        `'${esc(qty.Name)}',$,${valueField},$`);
       qtyIds.push(qtyId);
     }
 

--- a/scripts/moonshot/b35-demo/demo-report.json
+++ b/scripts/moonshot/b35-demo/demo-report.json
@@ -15,9 +15,9 @@
           "seed": 20260724,
           "family": "office",
           "entityCount": 548,
-          "fileSize": 28008,
+          "fileSize": 28208,
           "storeyCount": 1,
-          "sha256": "7fdb6b6032c6333baf071d6bb5d37a308b53debffdc4fad36d70119cea3f450e",
+          "sha256": "0754b4686d5f77a6fb7bac98e0bff9d12d1b038b765b6922a2b7f9289c262877",
           "groundTruthTotals": {
             "slabCount": 1,
             "slabGrossArea": 214.212816,
@@ -83,7 +83,7 @@
           "spotlight": {
             "seed": 20260725,
             "family": "office",
-            "sha256": "6f3865669ffdde9fcb339d731c3f1c713842c1bd8351d20e1fe3eb0863a70f9e",
+            "sha256": "da572549bf32d4615ab528f321632b09f6af9fbc773e009e4f68d2b6bf9e8dbc",
             "plantedDefects": [
               {
                 "type": "duplicate-globalid",
@@ -391,25 +391,25 @@
   },
   "volatile": {
     "note": "ONLY this block differs between runs: wall clocks and the timestamp. Everything under `deterministic` is a pure function of the master seed.",
-    "generatedAt": "2026-08-29T21:07:30.298Z",
-    "nodeVersion": "v22.14.0",
-    "totalWallClockMs": 6235,
+    "generatedAt": "2026-09-02T16:15:26.331Z",
+    "nodeVersion": "v22.13.1",
+    "totalWallClockMs": 6926,
     "actWallClockMs": {
-      "act1": 32,
-      "act2": 55,
-      "act3": 244,
-      "act4": 2287,
-      "act5": 3615
+      "act1": 38,
+      "act2": 91,
+      "act3": 287,
+      "act4": 2512,
+      "act5": 3998
     },
     "actVolatile": {
       "act2": {
-        "verifyMs": 2.897,
-        "tamperVerifyMs": 2.15
+        "verifyMs": 3.04,
+        "tamperVerifyMs": 2.451
       },
       "act4": {
-        "batteryElapsedMs": 2279.123958
+        "batteryElapsedMs": 2502.463167
       }
     },
-    "artifactDir": "/var/folders/nv/01qd6gt17wzcc99yqf12gr940000gn/T/ifc-lite-b35-demo"
+    "artifactDir": "/var/folders/pf/_t1ndxkx1sv0nmyhtcsfr_lr0000gn/T/ifc-lite-b35-demo"
   }
 }

--- a/scripts/moonshot/b35-demo/demo-report.md
+++ b/scripts/moonshot/b35-demo/demo-report.md
@@ -17,9 +17,9 @@ seed: rerun the command and the hashes, scores and counts reproduce exactly.
 ## Act 1 -- BIRTH (M2 world-gym)
 
 Seed 20260724 deterministically births an **office** building: 548
-entities, 1 storey(s), 28008 bytes.
+entities, 1 storey(s), 28208 bytes.
 
-- model sha256: `7fdb6b6032c6333baf071d6bb5d37a308b53debffdc4fad36d70119cea3f450e` (regenerable from the seed alone)
+- model sha256: `0754b4686d5f77a6fb7bac98e0bff9d12d1b038b765b6922a2b7f9289c262877` (regenerable from the seed alone)
 - schema: valid=true (0 errors, 0 warnings); clashes: 0
 - ground-truth totals (m3 / m2): slabCount=1, slabGrossArea=214.212816, slabGrossVolume=62.550142, wallCount=4, wallGrossSideArea=427.1124, wallGrossVolume=68.594251, partitionWallCount=6, roomCount=16, roomNetFloorArea=214.212816, roomNetVolume=617.361336
 - reward channels: schemaValidity=1, clashScore=1, determinismHashMatch=1, quantityAccuracy=1, defectDetection=1
@@ -90,8 +90,8 @@ differentiable building with exact dual-number gradients:
 
 Wall clocks and the timestamp below change run to run; nothing above does.
 
-- generated at: 2026-08-29T21:07:30.298Z (node v22.14.0)
-- total wall clock: 6.2s
-- per act: act1=0.0s, act2=0.1s, act3=0.2s, act4=2.3s, act5=3.6s
-- artifacts (outside the repo): /var/folders/nv/01qd6gt17wzcc99yqf12gr940000gn/T/ifc-lite-b35-demo
+- generated at: 2026-09-02T16:15:26.331Z (node v22.13.1)
+- total wall clock: 6.9s
+- per act: act1=0.0s, act2=0.1s, act3=0.3s, act4=2.5s, act5=4.0s
+- artifacts (outside the repo): /var/folders/pf/_t1ndxkx1sv0nmyhtcsfr_lr0000gn/T/ifc-lite-b35-demo
 

--- a/scripts/moonshot/ci/b35-golden.json
+++ b/scripts/moonshot/ci/b35-golden.json
@@ -11,9 +11,9 @@
         "seed": 20260724,
         "family": "office",
         "entityCount": 548,
-        "fileSize": 28008,
+        "fileSize": 28208,
         "storeyCount": 1,
-        "sha256": "7fdb6b6032c6333baf071d6bb5d37a308b53debffdc4fad36d70119cea3f450e",
+        "sha256": "0754b4686d5f77a6fb7bac98e0bff9d12d1b038b765b6922a2b7f9289c262877",
         "groundTruthTotals": {
           "slabCount": 1,
           "slabGrossArea": 214.212816,
@@ -79,7 +79,7 @@
         "spotlight": {
           "seed": 20260725,
           "family": "office",
-          "sha256": "6f3865669ffdde9fcb339d731c3f1c713842c1bd8351d20e1fe3eb0863a70f9e",
+          "sha256": "da572549bf32d4615ab528f321632b09f6af9fbc773e009e4f68d2b6bf9e8dbc",
           "plantedDefects": [
             {
               "type": "duplicate-globalid",


### PR DESCRIPTION
## Reviewer summary

- **Without this:** IFC files ifc-lite creates can be schema-invalid — wrong attribute count for the target schema — which risks rejection or misparse by other tools that validate strictly.
- **Evidence:** reverting to this PR's own first (unconditional) attempt produced a 9-attribute IFC2X3 wall (`IFCWALL(...,$,.STANDARD.);`) where the schema declares 8 attributes — caught in review before merge, now fixed schema-conditionally.
- **Risk:** confined to the handful of entities (quantities, wall/column/beam `PredefinedType`, `IfcRelSequence`) with a single trailing IFC4-only attribute; every other entity in the original conformance table (`IfcSlab`, psets, `IfcProject`, etc.) is confirmed unchanged. Two-schema test coverage (IFC2X3 4-slot vs IFC4 5-slot) guards against regressing either direction again.
- **Sequencing:** none; based on `main`.

---

## Summary

Audit lens: is the IFC ifc-lite **creates** actually schema-valid (sibling question to #3674's exporter audit, for `packages/create`)?

`IfcCreator.addIfcElementQuantity` (`packages/create/src/ifc-creator.ts`) writes `IfcQuantityLength`/`Area`/`Volume`/`Weight`/`Count` records via `quantityValueField` + a hand-built parameter string. `IfcPhysicalSimpleQuantity`'s trailing `Formula` attribute — declared from IFC4 on — was omitted from the parameter list entirely instead of written as an unset `$`, leaving every quantity record one attribute short of the IFC4/IFC4X3 declaration.

**The first version of this fix appended the trailing `$` unconditionally**, which broke IFC2X3 in the opposite direction: `entities-ifc2x3.ts` gives those same quantity entities only **4** attributes — `Formula` doesn't exist in IFC2X3 at all, not even as optional — so an unconditional `$` produced a 5-slot record against a 4-attribute declaration, exactly as invalid as the 4-slot record this PR started from. Caught in review before merge.

The fix is now schema-conditional, driven off `IfcCreator`'s own `Schema: 'IFC2X3' | 'IFC4' | 'IFC4X3'` field (already stamped into `FILE_SCHEMA`) via a shared `ifc4Only()` helper, rather than a hardcoded `,$`.

While auditing whether the same schema-version question applies elsewhere in the original conformance table, **three more emission sites turned out to have the identical one-line shape** (a single trailing attribute IFC4/IFC4X3 declare that IFC2X3 does not, everything else byte-identical) and are fixed here too, through the same helper:

- `IfcWall`/`IfcColumn`/`IfcBeam`: IFC4 adds a trailing `PredefinedType` (9 attrs vs IFC2X3's 8). All 7 emission sites (1 wall, 3 column-profile variants, 3 beam-profile variants) now go through `ifc4Only()`.
- `IfcRelSequence`: IFC4 adds a trailing `UserDefinedSequenceType` (9 attrs vs IFC2X3's 8).

## Cross-schema check on the rest of the conformance table (§3)

Every entity from the original table was diffed IFC4-vs-IFC2X3. Fixed above are the ones with a genuine single-trailing-attribute shape. **Not fixed here** — the divergence is bigger than one attribute and needs separate scoping:

| Entity | IFC2X3 vs IFC4 divergence | Why not a one-line fix |
|---|---|---|
| `IfcDoor`/`IfcWindow` | IFC2X3 ends at `OverallWidth` (10 attrs); IFC4 adds **three** trailing attrs at once (`PredefinedType`, `OperationType`/`PartitioningType`, `UserDefinedOperationType`/`UserDefinedPartitioningType`) | The creator always writes concrete enum values for the first two rather than `$` — a design question (what's the IFC2X3-equivalent default?), not a mechanical drop |
| `IfcRoof` | IFC2X3's trailing attribute is `ShapeType`; IFC4's is `PredefinedType` | A renamed attribute with a different value domain at the same position, not an added/removed slot |
| `IfcTask` | IFC2X3: `TaskId` + 4 attrs (10 total). IFC4: `Identification`/`LongDescription`/`TaskTime`/`PredefinedType` (13 total) | Attribute sets differ throughout, not just at the tail |
| `IfcTaskTime`/`IfcLagTime` | **Absent from IFC2X3's generated table entirely** | `addIfcTask`/`addIfcRelSequence` would emit `IFCTASKTIME`/`IFCLAGTIME` records for entities that don't exist in an IFC2X3 file — a deeper problem than attribute shape |
| `IfcWorkSchedule`/`IfcWorkPlan` | IFC2X3 has **15** attrs vs IFC4's 14 | `Identification`/`PredefinedType` are renamed to `Identifier`/`WorkControlType` at the same positions, and IFC2X3 additionally adds a trailing `UserDefinedControlType` IFC4 doesn't have — a rename plus more attributes, not fewer |

Unchanged from the original audit (schema-identical between IFC2X3 and IFC4 for every attribute checked): `IfcSlab`, `IfcPropertySet`, `IfcPropertySingleValue`, `IfcRelDefinesByProperties`, `IfcElementQuantity` (the container, not its quantities), `IfcOwnerHistory`, `IfcProject`, `IfcSite`, `IfcBuilding`.

## RED/GREEN

Two-schema coverage — a single assertion against the IFC4 default cannot catch this class of error, which is exactly how the first version of this fix got through:

- **RED** (this PR's own prior commit, the unconditional `,$`): `IFCQUANTITYAREA('GrossArea',$,$,80.,$);` in IFC2X3 (5 slots against a 4-attribute schema) and `IFCWALL(...,$,.STANDARD.);` in IFC2X3 (9 slots against an 8-attribute schema).
- **GREEN** (this commit): IFC2X3 → `IFCQUANTITYAREA('GrossArea',$,$,80.);` (4 slots) and `IFCWALL(...,#41,$);` (8 slots, no trailing `.STANDARD.`). IFC4 default unchanged: `IFCQUANTITYAREA('GrossArea',$,$,80.,$);` (5 slots) and `IFCWALL(...,$,.STANDARD.);` (9 slots).
- **Control**: `IfcSlab` and every other checked entity in the original conformance table is unchanged.

`packages/create/src/ifc-creator.test.ts` now has both an IFC4 quantity test (5-slot) and an IFC2X3 quantity test (4-slot), plus a new test asserting `IfcWall`/`IfcColumn`/`IfcBeam`/`IfcRelSequence` drop their trailing attribute in IFC2X3.

## Test plan

- [x] `pnpm typecheck` (turbo, `@ifc-lite/create` + `@ifc-lite/data`)
- [x] `pnpm test` (turbo, `@ifc-lite/create`) — 27 files, 398 tests pass
- [x] `node scripts/check-module-size.mjs` — `ifc-creator.ts` at 2843/2843 budget (no allowlist change; the shared `ifc4Only()` helper was added specifically to stay within budget across 8 call sites)
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — no new unprotected tests added
- [x] Changeset updated to describe the schema-conditional behavior

Base SHA worked from: `fa0624bc0` (`upstream/main`, confirmed via `git fetch upstream` + `git log --oneline -1 upstream/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IFC file generation to match schema-specific attribute requirements.
  * Fixed quantity, relationship, and building-element records for IFC2X3, IFC4, and IFC4X3 formats.
  * Prevented invalid trailing attributes from appearing in IFC2X3 output.
  * Ensured optional IFC4/IFC4X3 attributes are included correctly, including quantity formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
