### PR TITLE
fix(geometry,viewer): surface elements dropped from 2D drawing profile extraction

### DIFF
--- a/.changeset/profile-extraction-drop-signal.md
+++ b/.changeset/profile-extraction-drop-signal.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/wasm': minor
+---
+
+`extractProfiles` silently dropped any element whose `IfcExtrudedAreaSolid` (direct or via `IfcMappedItem`) failed to extract, or whose mapped-item chain exceeded the extractor's depth limit — the only trace was a Rust `diag_debug!` call compiled out of the shipped wasm build (neither `debug_geometry` nor `observability` is enabled there), so a dropped wall or slab was simply missing from the generated 2D construction drawing with no signal at all. `ProfileCollection` now exposes `skippedExpressIds`, the express IDs of every element dropped during extraction, empty on a clean model.

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -34,7 +34,7 @@ import {
   parseProfilesFlat,
   parseSymbolicFlat,
 } from '@/lib/overlay-parse/index.js';
-import { buildProfileEntries } from '@/lib/overlay-parse/profile-entries.js';
+import { buildProfileEntries, warnAboutSkippedProfiles } from '@/lib/overlay-parse/profile-entries.js';
 import {
   buildSymbolicDrawingLines,
   type SymbolicDrawingLine,
@@ -330,13 +330,12 @@ export function useDrawingGeneration({
           // `coordinateInfo` is main-thread state the worker cannot see.
           const ci = geometryResult.coordinateInfo;
           const rtc = ci.wasmRtcOffset;
-          const shift = rtc
-            ? { x: rtc.x, y: rtc.z, z: -rtc.y }
-            : ci.originShift;
+          const shift = rtc ? { x: rtc.x, y: rtc.z, z: -rtc.y } : ci.originShift;
           // Single-model (legacy) mode, so model index is always 0. Multi-model
           // profile extraction would require iterating over each model separately.
           profiles = buildProfileEntries(flat, shift, 0);
           profileCacheRef.current = { profiles, sourceId: modelCacheKey };
+          warnAboutSkippedProfiles(flat); // #3691-class silent-drop signal, one layer over
         } catch (error) {
           // Degrade gracefully: the drawing still renders without projection.
           console.warn('Profile extraction failed:', error);

--- a/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
+++ b/apps/viewer/src/lib/overlay-parse/profile-entries.test.ts
@@ -7,8 +7,8 @@ import assert from 'node:assert';
 
 import type { ProfileCollection } from '@ifc-lite/wasm';
 import type { ProfileEntry } from '@ifc-lite/drawing-2d';
-import { collectFlatProfiles } from './profiles-flat.js';
-import { buildProfileEntries } from './profile-entries.js';
+import { collectFlatProfiles, createEmptyFlatProfiles } from './profiles-flat.js';
+import { buildProfileEntries, warnAboutSkippedProfiles } from './profile-entries.js';
 
 /**
  * Equivalence anchor for moving the construction-projection extraction into
@@ -80,10 +80,14 @@ function entry(fields: {
   };
 }
 
-function makeCollection(entries: (FakeEntry | undefined)[]): ProfileCollection {
+function makeCollection(
+  entries: (FakeEntry | undefined)[],
+  skippedExpressIds: number[] = [],
+): ProfileCollection {
   return {
     length: entries.length,
     get: (i: number) => entries[i],
+    skippedExpressIds: Uint32Array.from(skippedExpressIds),
   } as unknown as ProfileCollection;
 }
 
@@ -291,5 +295,42 @@ describe('buildProfileEntries (#2183)', () => {
   it('rebuilds nothing from an empty flatten', () => {
     const flat = collectFlatProfiles(makeCollection([]));
     assert.deepStrictEqual(buildProfileEntries(flat, SHIFT, 0), []);
+  });
+});
+
+/**
+ * The production-reaching counterpart of a Rust-side `diag_debug!` drop: a
+ * `diag_debug!` legacy leg is gated `#[cfg(feature = "debug_geometry")]`,
+ * which the shipped wasm build never enables, so without this call an element
+ * dropped from `extract_profiles` was silently missing from the generated
+ * drawing with no signal at all.
+ */
+describe('warnAboutSkippedProfiles', () => {
+  it('warns with the dropped express ids when the extraction skipped elements', () => {
+    const calls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => calls.push(args);
+    try {
+      const flat = collectFlatProfiles(makeCollection([], [42, 7]));
+      warnAboutSkippedProfiles(flat);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.strictEqual(calls.length, 1);
+    assert.match(String(calls[0][0]), /2 element\(s\) could not be projected/);
+    assert.deepStrictEqual(calls[0][1], [42, 7]);
+  });
+
+  it('is a no-op — the control — when nothing was skipped', () => {
+    const calls: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => calls.push(args);
+    try {
+      warnAboutSkippedProfiles(createEmptyFlatProfiles());
+      warnAboutSkippedProfiles(collectFlatProfiles(makeCollection([])));
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.deepStrictEqual(calls, [], 'a clean extraction must not warn');
   });
 });

--- a/apps/viewer/src/lib/overlay-parse/profile-entries.ts
+++ b/apps/viewer/src/lib/overlay-parse/profile-entries.ts
@@ -85,3 +85,19 @@ export function buildProfileEntries(
 
   return profiles;
 }
+
+/**
+ * Report elements dropped from a `FlatProfiles` extraction — a genuine
+ * extraction failure or an over-deep mapped-item chain, not a type this
+ * extractor deliberately excludes. Without this the only trace is a Rust
+ * `diag_debug!` compiled out of the shipped wasm build (no `debug_geometry`/
+ * `observability` feature), so a dropped element was silently missing from
+ * the generated drawing. No-op on a clean model.
+ */
+export function warnAboutSkippedProfiles(flat: FlatProfiles): void {
+  if (flat.skippedExpressIds.length === 0) return;
+  console.warn(
+    `Construction projection: ${flat.skippedExpressIds.length} element(s) could not be projected and are missing from this drawing`,
+    Array.from(flat.skippedExpressIds),
+  );
+}

--- a/apps/viewer/src/lib/overlay-parse/profiles-flat.ts
+++ b/apps/viewer/src/lib/overlay-parse/profiles-flat.ts
@@ -74,6 +74,16 @@ export interface FlatProfiles {
   extrusionDir: Float32Array;
   /** Extrusion depth in metres, one per entry. */
   extrusionDepth: Float32Array;
+  /**
+   * Express IDs of elements that had an extrudable representation but whose
+   * profile could not be built, so they are MISSING from every array above.
+   * Not a filtered-out class (openings, non-extruded types) — those never
+   * reach the collection at all. See `ProfileCollection.skippedExpressIds`
+   * (`extract_profiles_with_diagnostics` on the Rust side): without this, a
+   * dropped element was invisible outside a `debug_geometry`/`observability`
+   * build, and the shipped wasm build enables neither.
+   */
+  skippedExpressIds: Uint32Array;
 }
 
 /** Floats per entry in {@link FlatProfiles.transform}. */
@@ -96,6 +106,7 @@ export function createEmptyFlatProfiles(): FlatProfiles {
     transform: new Float32Array(0),
     extrusionDir: new Float32Array(0),
     extrusionDepth: new Float32Array(0),
+    skippedExpressIds: new Uint32Array(0),
   };
 }
 
@@ -185,5 +196,7 @@ export function collectFlatProfiles(collection: ProfileCollection): FlatProfiles
     transform: Float32Array.from(transform),
     extrusionDir: Float32Array.from(extrusionDir),
     extrusionDepth: Float32Array.from(extrusionDepth),
+    // A plain typed-array getter, not a per-entry handle: no `.free()` needed.
+    skippedExpressIds: Uint32Array.from(collection.skippedExpressIds),
   };
 }

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1238,6 +1238,12 @@ export class ProfileCollection {
      * Number of profiles.
      */
     readonly length: number;
+    /**
+     * Express IDs of elements that had an `IfcExtrudedAreaSolid` (direct or
+     * mapped) but whose profile could not be extracted, so they are MISSING
+     * from this collection. Empty on a clean model.
+     */
+    readonly skippedExpressIds: Uint32Array;
 }
 
 /**
@@ -2052,6 +2058,7 @@ export interface InitOutput {
     readonly partitionedbatch_takeShard: (a: number, b: number) => void;
     readonly profilecollection_get: (a: number, b: number) => number;
     readonly profilecollection_length: (a: number) => number;
+    readonly profilecollection_skippedExpressIds: (a: number) => number;
     readonly profileentryjs_expressId: (a: number) => number;
     readonly profileentryjs_extrusionDepth: (a: number) => number;
     readonly profileentryjs_extrusionDir: (a: number) => number;

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -122,6 +122,9 @@ pub(crate) mod mesh_orient;
 pub(crate) mod processors;
 pub(crate) mod profile;
 pub(crate) mod profile_extractor;
+/// [`SkippedProfile`], split out of `profile_extractor` to keep it under
+/// its module-size ratchet.
+pub(crate) mod profile_skip;
 pub(crate) mod profiles;
 pub mod projection_outline;
 pub mod rect_fast;
@@ -207,7 +210,8 @@ pub use processors::{
 };
 pub use alignment::{AlignmentCurve, AlignmentFrame};
 pub use profile::{Profile2D, Profile2DWithVoids, ProfileType, VoidInfo};
-pub use profile_extractor::{extract_profiles, ExtractedProfile};
+pub use profile_extractor::{extract_profiles, extract_profiles_with_diagnostics, ExtractedProfile};
+pub use profile_skip::SkippedProfile;
 pub use profiles::ProfileProcessor;
 pub use router::take_bool2d_stats;
 pub use router::{take_prism_defers, take_prism_stats};

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -18,7 +18,7 @@
 //! Lengths are in metres (unit scale applied).
 
 use crate::profiles::ProfileProcessor;
-use crate::{Error, Point3, Result, TessellationQuality, Vector3};
+use crate::{profile_skip::SkippedProfile, Error, Point3, Result, TessellationQuality, Vector3};
 pub(crate) use ifc_lite_core::MAX_PLACEMENT_DEPTH;
 use ifc_lite_core::{
     build_entity_index, AttributeValue, DecodedEntity, EntityDecoder, EntityScanner, IfcSchema,
@@ -78,15 +78,12 @@ pub struct ExtractedProfile {
 // PUBLIC ENTRY POINT
 // ═══════════════════════════════════════════════════════════════════════════
 
-/// Extract profiles for every building element in `content`.
-///
-/// Extracts `IfcExtrudedAreaSolid` representations, including those nested
-/// inside `IfcMappedItem` chains (up to 3 levels deep).
-/// Returns an empty `Vec` for models with no such elements.
-pub fn extract_profiles<T>(content: &T, model_index: u32) -> Vec<ExtractedProfile>
-where
-    T: AsRef<[u8]> + ?Sized,
-{
+/// Extract `IfcExtrudedAreaSolid` profiles (incl. nested `IfcMappedItem`) for every element in `content`. Drops are silent — see [`extract_profiles_with_diagnostics`].
+pub fn extract_profiles<T: AsRef<[u8]> + ?Sized>(content: &T, model_index: u32) -> Vec<ExtractedProfile> {
+    extract_profiles_with_diagnostics(content, model_index).0
+}
+/// Same as [`extract_profiles`], plus every [`SkippedProfile`] (default features — unlike `diag_debug!`).
+pub fn extract_profiles_with_diagnostics<T: AsRef<[u8]> + ?Sized>(content: &T, model_index: u32) -> (Vec<ExtractedProfile>, Vec<SkippedProfile>) {
     let content = content.as_ref();
     let entity_index = build_entity_index(content);
     let mut decoder = EntityDecoder::with_index(content, entity_index);
@@ -97,7 +94,7 @@ where
     let schema = IfcSchema::new();
     let profile_processor = ProfileProcessor::new(schema);
 
-    let mut results = Vec::new();
+    let (mut results, mut skipped) = (Vec::new(), Vec::new());
     let mut scanner = EntityScanner::new(content);
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
@@ -193,6 +190,7 @@ where
                                     eprintln!("[profile_extractor] Skipping #{id} ({ifc_type_name}): {_e}");
                                 }
                             );
+                            skipped.push(SkippedProfile { express_id: id, ifc_type: ifc_type_name.clone(), reason: _e.to_string() });
                         }
                     }
                 } else if item.ifc_type == IfcType::IfcMappedItem {
@@ -206,14 +204,14 @@ where
                         &mut decoder,
                         model_index,
                         0,
-                        &mut results,
+                        &mut results, &mut skipped,
                     );
                 }
             }
         }
     }
 
-    results
+    (results, skipped)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -243,7 +241,7 @@ fn extract_mapped_item_profiles(
     decoder: &mut EntityDecoder,
     model_index: u32,
     depth: usize,
-    results: &mut Vec<ExtractedProfile>,
+    results: &mut Vec<ExtractedProfile>, skipped: &mut Vec<SkippedProfile>,
 ) {
     if depth > MAX_MAPPED_DEPTH {
         crate::diag::diag_debug!(
@@ -254,6 +252,7 @@ fn extract_mapped_item_profiles(
                 eprintln!("[profile_extractor] #{element_id} ({ifc_type}): max mapped item depth exceeded");
             }
         );
+        skipped.push(SkippedProfile { express_id: element_id, ifc_type: ifc_type.to_string(), reason: "max mapped item depth exceeded".to_string() });
         return;
     }
 
@@ -348,6 +347,7 @@ fn extract_mapped_item_profiles(
                             eprintln!("[profile_extractor] #{element_id} ({ifc_type}) mapped: {_e}");
                         }
                     );
+                    skipped.push(SkippedProfile { express_id: element_id, ifc_type: ifc_type.to_string(), reason: _e.to_string() });
                 }
             }
         } else if sub_item.ifc_type == IfcType::IfcMappedItem {
@@ -361,7 +361,7 @@ fn extract_mapped_item_profiles(
                 decoder,
                 model_index,
                 depth + 1,
-                results,
+                results, skipped,
             );
         }
     }

--- a/rust/geometry/src/profile_skip.rs
+++ b/rust/geometry/src/profile_skip.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! [`SkippedProfile`] — split out of `profile_extractor.rs` to keep that
+//! module under its size ratchet.
+//!
+//! It is the production-reaching counterpart of the `diag_debug!` trace at
+//! each profile-extraction drop site in `profile_extractor.rs`: those macros
+//! compile to nothing unless the crate is built with `debug_geometry` or
+//! `observability` (neither is a default feature, and the shipped wasm build
+//! enables neither — see `scripts/build-wasm.sh`), so without this struct a
+//! real extraction failure was invisible end to end.
+
+/// A building element whose construction-projection profile was dropped —
+/// its `IfcExtrudedAreaSolid` (direct or via `IfcMappedItem`) is present but
+/// could not be turned into 2D drawing geometry, or the mapped-item chain
+/// was too deep. Never an element the extractor deliberately excludes (a
+/// non-`IfcExtrudedAreaSolid` representation, an `IfcFeatureElement`).
+#[derive(Debug, Clone)]
+pub struct SkippedProfile {
+    /// Express ID of the building element whose profile was dropped.
+    pub express_id: u32,
+    /// IFC type name (e.g., `"IfcWall"`).
+    pub ifc_type: String,
+    /// Short, stable reason string (not user-facing prose): the geometry
+    /// error text, or `"max mapped item depth exceeded"`.
+    pub reason: String,
+}

--- a/rust/geometry/tests/issue_shipped_profile_drop_signal.rs
+++ b/rust/geometry/tests/issue_shipped_profile_drop_signal.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A wall whose `IfcExtrudedAreaSolid.SweptArea` cannot be resolved is a real
+//! decode/extraction failure (a malformed or truncated file, not a type this
+//! extractor deliberately skips): `extract_extruded_solid` returns `Err`, and
+//! that element's 2D construction-drawing footprint is dropped.
+//!
+//! Before the fix, the ONLY signal for that drop was `diag_debug!`'s legacy
+//! leg, itself gated `#[cfg(feature = "debug_geometry")]`. Neither
+//! `debug_geometry` nor `observability` is a default feature (see
+//! `rust/geometry/Cargo.toml`, `default = []`), and the shipped wasm build
+//! (`scripts/build-wasm.sh`) never passes either flag unless `DEBUG_GEOMETRY=1`
+//! is set locally — so in the browser build every user actually runs, a wall
+//! silently vanishes from the generated 2D drawing with nothing to tell the
+//! user or an operator that anything was lost.
+//!
+//! `extract_profiles_with_diagnostics` is the fix: same walk, but it also
+//! returns which elements were dropped and why, with default features (no
+//! `debug_geometry`/`observability` needed) — so the signal survives into the
+//! shipped build. `extract_profiles` (the pre-existing, still-used-by-export
+//! entry point) is untouched: same signature, same output, RED here is about
+//! visibility, not behaviour.
+
+use ifc_lite_geometry::{extract_profiles, extract_profiles_with_diagnostics};
+
+/// One healthy wall (`#100`) with a normal rectangular `SweptArea`, and one
+/// "wall" (`#500`) whose `IfcExtrudedAreaSolid` (`#540`) SweptArea attribute
+/// (`#530`) references express id `#999999`, which does not exist in the
+/// file — the STEP-level equivalent of a truncated/corrupted reference.
+const IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('shipped-profile-drop-signal fixture'),'2;1');
+FILE_NAME('issue_shipped_profile_drop_signal.ifc','2026-09-02T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0ShippedDropSignal00A',$,'ShippedDropSignal',$,$,$,$,(#10),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#10,$,.MODEL_VIEW.,$);
+#110=IFCLOCALPLACEMENT($,#111);
+#111=IFCAXIS2PLACEMENT3D(#12,$,$);
+#130=IFCRECTANGLEPROFILEDEF(.AREA.,'GoodWall',#131,4.0,0.3);
+#131=IFCAXIS2PLACEMENT2D(#132,#133);
+#132=IFCCARTESIANPOINT((0.,0.));
+#133=IFCDIRECTION((1.,0.));
+#140=IFCEXTRUDEDAREASOLID(#130,#141,#142,2.5);
+#141=IFCAXIS2PLACEMENT3D(#12,$,$);
+#142=IFCDIRECTION((0.,0.,1.));
+#150=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#140));
+#151=IFCPRODUCTDEFINITIONSHAPE($,$,(#150));
+#100=IFCWALL('0ShippedDropSignalWlA',$,'GoodWall',$,$,#110,#151,$,$);
+#510=IFCLOCALPLACEMENT($,#511);
+#511=IFCAXIS2PLACEMENT3D(#512,$,$);
+#512=IFCCARTESIANPOINT((10.,0.,0.));
+#540=IFCEXTRUDEDAREASOLID(#999999,#141,#142,2.5);
+#550=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#540));
+#551=IFCPRODUCTDEFINITIONSHAPE($,$,(#550));
+#500=IFCWALL('0ShippedDropSignalWlB',$,'BrokenWall',$,$,#510,#551,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn broken_wall_is_dropped_from_the_2d_drawing() {
+    let profiles = extract_profiles(IFC, 0);
+    assert_eq!(
+        profiles.len(),
+        1,
+        "the broken wall's SweptArea cannot resolve, so it must not emit a profile: {profiles:?}"
+    );
+    assert_eq!(profiles[0].express_id, 100, "the healthy wall must still extract");
+}
+
+/// GREEN: with default features (no `debug_geometry`, no `observability` —
+/// the exact feature set the shipped wasm build ships), the diagnostics path
+/// still reports the drop.
+#[test]
+fn dropped_wall_is_reported_with_default_features() {
+    let (profiles, skipped) = extract_profiles_with_diagnostics(IFC, 0);
+    assert_eq!(profiles.len(), 1, "unchanged extraction behaviour");
+    assert_eq!(
+        skipped.len(),
+        1,
+        "the broken wall must be reported as skipped even with default (release-shaped) features: {skipped:?}"
+    );
+    assert_eq!(skipped[0].express_id, 500);
+    assert_eq!(skipped[0].ifc_type, "IfcWall");
+}
+
+/// Control: a file where nothing is dropped must report zero skips — a
+/// diagnostic that fires on a healthy file is worse than none.
+#[test]
+fn healthy_file_reports_no_skips() {
+    let healthy = IFC.lines().filter(|l| !l.starts_with("#500=") && !l.starts_with("#540=") && !l.starts_with("#550=") && !l.starts_with("#551=") && !l.starts_with("#510=") && !l.starts_with("#511=") && !l.starts_with("#512=")).collect::<Vec<_>>().join("\n");
+    let (profiles, skipped) = extract_profiles_with_diagnostics(&healthy, 0);
+    assert_eq!(profiles.len(), 1);
+    assert!(skipped.is_empty(), "a clean file must not produce any skip diagnostics: {skipped:?}");
+}

--- a/rust/wasm-bindings/src/api/extract_profiles.rs
+++ b/rust/wasm-bindings/src/api/extract_profiles.rs
@@ -110,6 +110,15 @@ impl From<ifc_lite_geometry::ExtractedProfile> for ProfileEntryJs {
 #[wasm_bindgen]
 pub struct ProfileCollection {
     entries: Vec<ProfileEntryJs>,
+    /// Express IDs of elements whose profile was DROPPED — a genuine
+    /// extraction failure or a mapped-item chain deeper than the extractor's
+    /// limit, never an element this extractor deliberately excludes. See
+    /// `ifc_lite_geometry::extract_profiles_with_diagnostics`: without this,
+    /// the only trace of a drop is a `diag_debug!` call gated behind Cargo
+    /// features the shipped wasm build never enables, so a caller building
+    /// e.g. a 2D construction drawing had no way to know an element was
+    /// silently missing from it.
+    skipped_express_ids: Vec<u32>,
 }
 
 #[wasm_bindgen]
@@ -133,6 +142,14 @@ impl ProfileCollection {
             extrusion_depth: e.extrusion_depth,
             model_index: e.model_index,
         })
+    }
+
+    /// Express IDs of elements that had an `IfcExtrudedAreaSolid` (direct or
+    /// mapped) but whose profile could not be extracted, so they are MISSING
+    /// from this collection. Empty on a clean model.
+    #[wasm_bindgen(getter, js_name = skippedExpressIds)]
+    pub fn skipped_express_ids(&self) -> js_sys::Uint32Array {
+        js_sys::Uint32Array::from(&self.skipped_express_ids[..])
     }
 }
 
@@ -164,9 +181,10 @@ impl IfcAPI {
     /// ```
     #[wasm_bindgen(js_name = extractProfiles)]
     pub fn extract_profiles(&self, content: String, model_index: u32) -> ProfileCollection {
-        let raw = ifc_lite_geometry::extract_profiles(&content, model_index);
+        let (raw, skipped) = ifc_lite_geometry::extract_profiles_with_diagnostics(&content, model_index);
         ProfileCollection {
             entries: raw.into_iter().map(ProfileEntryJs::from).collect(),
+            skipped_express_ids: skipped.into_iter().map(|s| s.express_id).collect(),
         }
     }
 }


### PR DESCRIPTION
## Reviewer summary

- **Without this:** a wall or slab can silently disappear from a generated 2D construction drawing, with nothing telling the user an element was dropped.
- **Evidence:** reverting, a fixture with one healthy wall and one wall whose `IfcExtrudedAreaSolid.SweptArea` references a non-existent id returns only the healthy wall's profile from `extract_profiles` — the broken wall vanishes silently. Fixed: the diagnostics variant reports `skipped[0].express_id == 500, ifc_type == "IfcWall"` for the same input.
- **Risk:** `extract_profiles`'s existing signature and behavior are untouched (a thin wrapper); `rust/export`'s HBJSON/rooms/openings/shades callers are unaffected, confirmed by the full `ifc-lite-export` suite (384 tests) staying green. Control test `healthy_file_reports_no_skips` confirms no false positives on a clean file.
- **Sequencing:** none; based on `main`. Same defect class as #3691, different pipeline (2D drawing extraction vs. 3D mesh).

---

## Summary

Sweep for the lens PR #3691 opened: a user-relevant signal emitted only under a compile-time flag that is OFF in the shipped wasm build. Found one genuine production-silenced data-loss site outside #3691's own files (see overlap notes below), and shipped a fix for it.

**Site:** `rust/geometry/src/profile_extractor.rs::extract_profiles` — the construction-projection profile walk that feeds the viewer's 2D drawing generation (`useDrawingGeneration.ts` → `parseProfilesFlat` → `packages/geometry`'s `extractProfiles` → `ifc_lite_geometry::extract_profiles`).

**What is hidden:** when an element has an `IfcExtrudedAreaSolid` (direct or via `IfcMappedItem`) but it fails to extract (malformed geometry, unresolvable `SweptArea`, etc.), or a mapped-item chain exceeds the extractor's depth limit, the element is dropped from the profile collection. The only trace was `crate::diag::diag_debug!`, whose legacy `eprintln!` leg is further gated `#[cfg(feature = "debug_geometry")]`.

**Off in release?** Yes, confirmed by reading `rust/geometry/Cargo.toml` (`default = []`; neither `debug_geometry` nor `observability` is default) and `scripts/build-wasm.sh` (`FEATURES=""` unless the developer sets `DEBUG_GEOMETRY=1` locally — never set in `test`/`release`/CI).

**User loses:** a wall or slab silently missing from a generated construction drawing, with no indication anything was dropped. Same shape as #3691 (element silently dropped from the geometry pipeline), one layer over — the 2D drawing path, not the 3D mesh path.

**Verdict:** top severity — silent data loss / wrong result, reachable from a real malformed/truncated reference, invisible end-to-end in the shipped build.

## The fix

- `rust/geometry/src/profile_extractor.rs`: new `extract_profiles_with_diagnostics` returns `(Vec<ExtractedProfile>, Vec<SkippedProfile>)`. The pre-existing `extract_profiles` is untouched in signature and behaviour (now a thin wrapper), so `rust/export`'s HBJSON/rooms/openings/shades callers are unaffected — verified with `cargo test -p ifc-lite-export` (all 384 tests green).
- `SkippedProfile` lives in a new sibling module `rust/geometry/src/profile_skip.rs` to keep `profile_extractor.rs` under its `module_size_ratchet` budget (758 lines).
- `rust/wasm-bindings/src/api/extract_profiles.rs`: `extractProfiles` now calls the diagnostics variant and exposes `ProfileCollection.skippedExpressIds` (additive wasm API surface, `packages/wasm` changeset is `minor`).
- `apps/viewer/src/lib/overlay-parse/{profiles-flat,profile-entries}.ts`: `FlatProfiles` carries `skippedExpressIds` through the worker boundary; new `warnAboutSkippedProfiles` helper.
- `apps/viewer/src/hooks/useDrawingGeneration.ts`: calls `warnAboutSkippedProfiles` after building profile entries for construction projection.

## RED / GREEN / control

`rust/geometry/tests/issue_shipped_profile_drop_signal.rs`, a minimal two-wall fixture (one healthy, one with an `IfcExtrudedAreaSolid` whose `SweptArea` references a non-existent express id):

- **RED** (`broken_wall_is_dropped_from_the_2d_drawing`): `extract_profiles` (unmodified, upstream behaviour) returns only the healthy wall's profile — the broken wall is silently dropped, and there was no way to observe that.
- **GREEN** (`dropped_wall_is_reported_with_default_features`): `extract_profiles_with_diagnostics`, run with **default Cargo features** (the release-shaped feature set — no `debug_geometry`/`observability`), reports the drop: `skipped[0].express_id == 500`, `ifc_type == "IfcWall"`.
- **Control** (`healthy_file_reports_no_skips`): the same fixture with the broken wall removed reports zero skips — a diagnostic that fires on a healthy file would be worse than none.

Mirrored at the TS layer in `apps/viewer/src/lib/overlay-parse/profile-entries.test.ts` (`warnAboutSkippedProfiles` — warns with the dropped ids; no-op control on a clean flatten).

## Other candidates ruled out (not top-severity / not production-silenced)

- `rust/geometry/src/router/layers.rs` (material-layer slicing fallback): already has a browser-facing counter (`push_layer_slice_diag`) alongside `diag_warn!`, whose legacy leg keeps `eprintln!` in production (`diag.rs`'s documented WARN-vs-DEBUG gating policy) — not silenced.
- `rust/geometry/src/processors/advanced.rs` (AdvancedBrep empty-face loss): the whole `empty_faces` tracking + `diag_warn!` block is gated `#[cfg(any(feature = "debug_geometry", feature = "observability"))]`, so it is a real production-silenced signal of the same class — but it and the router-owned `GeometryDiagnostics` counter infra it would naturally extend are inside files an open PR (#3691) already owns (`rust/geometry/src/router/*`), so left for that PR or a follow-up to avoid a parallel-work collision.
- Everything else matching `cfg(debug_assertions)` / `feature = "observability"` / `diag_debug!` in `rust/geometry` and `rust/processing` is either developer-only tracing (correctly compiled out) or already covered by #3691's `unsupportedItemsByType`.

## Test plan

- [x] `cargo test -p ifc-lite-geometry` — full crate suite green (1666-line log, 0 failures)
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6/6 (budget respected after the `profile_skip` split)
- [x] `cargo test -p ifc-lite-export` — 384 tests green (unchanged `extract_profiles` callers)
- [x] `pnpm typecheck` (root) — 89/89 tasks, 1613/1613 test files
- [x] `pnpm build` (root, regenerates `packages/wasm/pkg/ifc-lite.d.ts`)
- [x] `pnpm --filter @ifc-lite/viewer test` — 6673 tests, 0 failed
- [x] `node scripts/check-module-size.mjs`, `check-unused-locals.mjs`, `check-test-wiring.mjs` — all clean
- [x] `pnpm changeset` added for `@ifc-lite/wasm` (minor, additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
