### PR TITLE
fix(export): rescue IfcPresentationLayerAssignment in subset STEP export

### DIFF
--- a/.changeset/style-closure-hidden-product-leak.md
+++ b/.changeset/style-closure-hidden-product-leak.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+A `visibleOnly` STEP export could ship a hidden product's geometry through a shared `IfcPresentationLayerAssignment` (or `IfcStyledItem`/`IfcStyledRepresentation`). These entities reference geometry the closure walk cannot reach on its own, so the export rescues one whenever it names an already-visible item — but the rescue then walked ALL of that entity's references unconditionally, with no check for whether the other item(s) it named belonged to a hidden product. One CAD layer naming every wall's shape representation is a routine real-world shape, so hiding one wall that shared a layer with a visible wall pulled the hidden wall's own geometry back into the export. The forward walk now refuses to add a representation/geometry id that was not already independently visible, and the rescued entity's own output line is narrowed (or withheld) the same way a relationship's is, so it no longer ships a dangling reference to the geometry it can no longer name.

--- a/.changeset/subset-export-layer-assignment-rescue.md
+++ b/.changeset/subset-export-layer-assignment-rescue.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/export': patch
+---
+
+A `visibleOnly`/subset STEP export (viewer hide/isolate export, the anonymize-export subset path, and `MergedExporter`) dropped `IfcPresentationLayerAssignment` (and its `IfcPresentationLayerWithStyle` subtype) whenever the export included the layer's assigned geometry — the same reference-direction gap already fixed for georeferencing (#3696) and styled items: `IfcPresentationLayerAssignment.AssignedItems` points AT the representation/items it names, but nothing in the file points back at the layer assignment, so the forward closure walk from the visible roots never reached it.
+
+`collectStyleEntities` (`packages/export/src/reference-collector.ts`) now also runs its reverse pass over `IFCPRESENTATIONLAYERASSIGNMENT`/`IFCPRESENTATIONLAYERWITHSTYLE`, alongside the `IFCSTYLEDITEM`/`IFCSTYLEDREPRESENTATION` pass it already did: a layer assignment naming an item already in the closure is rescued in. Both `StepExporter` (`visibleOnly` and `subsetEntityIds`) and `MergedExporter` share this function, so both paths are fixed by the one change. A layer assignment naming only entities excluded from the export (a hidden product, or the anonymize-export privacy scrub) is still correctly left out.

--- a/packages/export/src/index.ts
+++ b/packages/export/src/index.ts
@@ -27,7 +27,8 @@ export type {
   AnonymizeResult,
 } from './anonymize-types.js';
 export { MergedExporter, type MergeModelInput, type MergeExportOptions, type MergeExportResult, type MergeBlobExportResult, type ExportProgress } from './merged-exporter.js';
-export { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
+export { collectReferencedEntityIds, getVisibleEntityIds } from './reference-collector.js';
+export { collectStyleEntities } from './style-closure.js';
 export { convertEntityType, convertStepLine, needsConversion, describeConversion, type IfcSchemaVersion } from './schema-converter.js';
 export { Ifc5Exporter, IFC5_KNOWN_PROP_NAMES, type Ifc5ExportOptions, type Ifc5ExportResult } from './ifc5-exporter.js';
 

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -288,6 +288,47 @@ describe('MergedExporter', () => {
     expect(findDanglingRefs(content)).toEqual([]);
   });
 
+  // Same shape as `step-exporter.test.ts`'s "does not leak a hidden
+  // product's geometry through a layer assignment it shares with a visible
+  // one" — `MergedExporter.computeIncludedEntityIds` has its OWN
+  // `collectStyleEntities` call site (`style-closure.ts`), and `renderEntity`
+  // has its OWN dangling-ref line filter, both independent of
+  // `StepExporter`'s. A shared `IFCPRESENTATIONLAYERASSIGNMENT` naming a
+  // visible and a hidden wall's shape representations must not resurrect the
+  // hidden wall's geometry, nor ship a dangling `#N` on the assignment's own
+  // line, through this path either.
+  it('does not leak a hidden product’s geometry through a shared layer assignment in a merged export', () => {
+    const model1 = buildModel('m1', 'Arch', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('g2',$,'VisibleWall',$,$,$,$,#10);"],
+      [3, 'IFCWALL', "#3=IFCWALL('g3',$,'HiddenWall',$,$,$,$,#99);"],
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID($,$,$,3.);'],
+      [99, 'IFCSHAPEREPRESENTATION', "#99=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#98));"],
+      [98, 'IFCEXTRUDEDAREASOLID', '#98=IFCEXTRUDEDAREASOLID($,$,$,3.);'],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#99),$);"],
+    ]);
+
+    const exporter = new MergedExporter([model1]);
+    const result = exporter.export({
+      schema: 'IFC4',
+      projectStrategy: 'keep-first',
+      visibleOnly: true,
+      hiddenEntityIdsByModel: new Map([['m1', new Set([3])]]), // Hide wall #3
+    });
+
+    const content = decode(result.content);
+    expect(content).not.toContain('HiddenWall');
+    expect(content).toContain('IFCPRESENTATIONLAYERASSIGNMENT');
+    expect(content).toContain('#10=IFCSHAPEREPRESENTATION');
+    expect(content).toContain('#11=IFCEXTRUDEDAREASOLID');
+    expect(content).not.toContain('#99=IFCSHAPEREPRESENTATION');
+    expect(content).not.toContain('#98=IFCEXTRUDEDAREASOLID');
+    const layerLine = content.split('\n').find((line) => line.includes('IFCPRESENTATIONLAYERASSIGNMENT'));
+    expect(layerLine).not.toContain('#99');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
   it('should unify single site and remap spatial chain', () => {
     // Model1: Project#1 → Site#2 (via RelAgg#3)
     const model1 = buildModel('m1', 'Arch', [

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -21,9 +21,9 @@ import type { MutablePropertyView } from '@ifc-lite/mutations';
 import {
   collectReferencedEntityIds,
   getVisibleEntityIds,
-  collectStyleEntities,
   filterHiddenRefsFromRelationshipLine,
 } from './reference-collector.js';
+import { collectStyleEntities, STYLE_RESCUE_TYPES } from './style-closure.js';
 import { collectGeoreferencingEntities } from './georef-closure.js';
 import { convertStepLine, needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { assembleStepBytes, assembleStepBlob } from './step-file-assembly.js';
@@ -536,7 +536,7 @@ export class MergedExporter {
         if (plan.skipEntityIds.has(expressId)) continue;
         const line = this.renderEntity(
           expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, mode,
-          visibility?.hiddenProductIds ?? null, completeIndex,
+          visibility?.hiddenProductIds ?? null, completeIndex, visibility?.included ?? null,
         );
         if (line !== null) allEntityLines.push(line);
       }
@@ -674,7 +674,7 @@ export class MergedExporter {
 
         const line = this.renderEntity(
           expressId, entityRef, source, offset, plan, sourceSchema, schema, guidToFinalId, mode,
-          visibility?.hiddenProductIds ?? null, completeIndex,
+          visibility?.hiddenProductIds ?? null, completeIndex, visibility?.included ?? null,
         );
         if (line !== null) allEntityLines.push(line);
 
@@ -1059,11 +1059,11 @@ export class MergedExporter {
     const isolatedIds = options.isolatedEntityIdsByModel?.get(model.id) ?? null;
     const { roots, hiddenProductIds } = getVisibleEntityIds(model.dataStore, hiddenIds, isolatedIds);
     const included = collectReferencedEntityIds(roots, source, completeIndex, hiddenProductIds);
-    // Second pass: collect style entities that reference included geometry.
+    // Second pass: style entities referencing included geometry (see style-closure.ts).
     collectStyleEntities(included, source, {
       byId: completeIndex,
       byType: model.dataStore.entityIndex.byType,
-    });
+    }, hiddenProductIds);
     // Third pass: rescue IFCMAPCONVERSION/IFCPROJECTEDCRS — see georef-closure.ts.
     collectGeoreferencingEntities(
       included, source,
@@ -1189,30 +1189,37 @@ export class MergedExporter {
     mode: ModelMode,
     hiddenProductIds: ReadonlySet<number> | null,
     completeIndex: CompleteEntityIndex,
+    includedIds: ReadonlySet<number> | null,
   ): string | null {
     let entityText = decodeRange(source, entityRef.byteOffset, entityRef.byteOffset + entityRef.byteLength);
 
     // A `visibleOnly` export must narrow — or entirely withhold — a
-    // relationship's own OUTPUT line the same way `StepExporter` does
-    // (`isOmittedFromOutput`, consumed at its two
-    // `filterHiddenRefsFromRelationshipLine` call sites — named rather than
-    // cited by line number, which went stale the first time either file moved).
-    // NOTE the predicates are not identical: `StepExporter`'s also answers for
-    // an unreadable source ref and a geometry exclusion, which this one — a
-    // hidden product or an id absent from the complete index — does not.
+    // relationship's (and, below, a rescued style/layer entity's) own OUTPUT
+    // line the same way `StepExporter` does (`isOmittedFromOutput`, its two
+    // `filterHiddenRefsFromRelationshipLine` call sites). NOTE the predicates
+    // are not identical: `StepExporter`'s also answers for an unreadable
+    // source ref and a geometry exclusion, which these do not.
     // `collectReferencedEntityIds` already refuses to WALK INTO a relationship
     // whose sole subject is hidden (#2548), but a root's own bytes are still
     // copied to the output verbatim unless narrowed here too — without this,
-    // a hidden id survived as a dangling `#N` with no `#N=` line (the #2398
-    // shape), which is exactly what closing the #2548 closure leak would
-    // otherwise have traded it for. Runs in LOCAL id space, before the remap
-    // below, because `hiddenProductIds` and `completeIndex` are both local to
-    // this model.
-    if (hiddenProductIds !== null && isRelationshipType(entityRef.type.toUpperCase())) {
-      const isExcluded = (id: number): boolean => hiddenProductIds.has(id) || !completeIndex.has(id);
-      const filtered = filterHiddenRefsFromRelationshipLine(entityText, isExcluded);
-      if (filtered === null) return null;
-      entityText = filtered;
+    // a hidden id survives as a dangling `#N` with no `#N=` line (#2398).
+    // Runs in LOCAL id space, before the remap below.
+    if (hiddenProductIds !== null) {
+      const entityTypeUpper = entityRef.type.toUpperCase();
+      // Same narrowing for a rescued style/layer entity (`STYLE_RESCUE_TYPES`,
+      // `style-closure.ts`): its line can name a kept AND an excluded id (a
+      // shared CAD layer) — `hiddenProductIds` misses that id (exclusively-
+      // owned geometry, not a hidden PRODUCT), so this arm uses `includedIds`.
+      const isExcluded: ((id: number) => boolean) | null = isRelationshipType(entityTypeUpper)
+        ? (id) => hiddenProductIds.has(id) || !completeIndex.has(id)
+        : STYLE_RESCUE_TYPES.has(entityTypeUpper) && includedIds !== null
+          ? (id) => !includedIds.has(id) || !completeIndex.has(id)
+          : null;
+      if (isExcluded) {
+        const filtered = filterHiddenRefsFromRelationshipLine(entityText, isExcluded);
+        if (filtered === null) return null;
+        entityText = filtered;
+      }
     }
 
     // A dropped empty spatial container (#3643) is never written, so any line

--- a/packages/export/src/reference-collector.equivalence.test.ts
+++ b/packages/export/src/reference-collector.equivalence.test.ts
@@ -62,8 +62,8 @@ import { asSourceBytes, scanIfcEntities, type IfcSourceBytes } from '@ifc-lite/p
 import {
   collectReferencedEntityIds,
   collectRefsInByteRange,
-  collectStyleEntities,
 } from './reference-collector.js';
+import { collectStyleEntities } from './style-closure.js';
 
 /** Fixture, relative to `tests/models`. Fixtures are NOT committed (AGENTS.md). */
 const FIXTURE_RELPATH = 'ara3d/AC20-FZK-Haus.ifc';

--- a/packages/export/src/reference-collector.test.ts
+++ b/packages/export/src/reference-collector.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 import {
   PRODUCT_TYPES,
   collectReferencedEntityIds,
+  collectStyleEntities,
   getVisibleEntityIds,
 } from './reference-collector.js';
 import { EMPTY_SOURCE_BYTES, type IfcDataStore } from '@ifc-lite/parser';
@@ -708,5 +709,76 @@ describe('product-type classification vs the generated IFC schema', () => {
     expect(hidden.roots.has(3)).toBe(false);
     expect(hidden.hiddenProductIds.has(3)).toBe(true);
     expect(hidden.roots.has(4)).toBe(true);
+  });
+});
+
+describe('collectStyleEntities rescues IFCPRESENTATIONLAYERASSIGNMENT', () => {
+  /**
+   * A subset-export closure the forward walk from a product cannot reach:
+   * IfcPresentationLayerAssignment.AssignedItems (#20 -> #10, the shape
+   * representation already in the closure) is the only reference between the
+   * two, and it points the wrong direction for a forward walk to find —
+   * exactly the shape #3696 fixed for IfcMapConversion, this time for a
+   * non-`IFCREL*` entity `getVisibleEntityIds` cannot root unconditionally.
+   */
+  function buildIndex(entries: Array<[number, string, string]>) {
+    const { source, entityIndex } = buildTestData(entries);
+    const byType = new Map<string, number[]>();
+    for (const [id, type] of entries) {
+      const list = byType.get(type);
+      if (list) list.push(id);
+      else byType.set(type, [id]);
+    }
+    return { source, byId: entityIndex, byType };
+  }
+
+  it('rescues IFCPRESENTATIONLAYERASSIGNMENT referencing a shape already in the closure', () => {
+    const entries: Array<[number, string, string]> = [
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10),$);"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+
+    // RED: the closure has the shape but not the layer assignment naming it —
+    // nothing in the closure points back at #20.
+    const closure = new Set([10, 11]);
+    expect(closure.has(20)).toBe(false);
+
+    collectStyleEntities(closure, source, { byId, byType });
+
+    // GREEN: rescued by the reverse pass.
+    expect(closure.has(20)).toBe(true);
+  });
+
+  it('rescues the IFCPRESENTATIONLAYERWITHSTYLE subtype the same way', () => {
+    const entries: Array<[number, string, string]> = [
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [21, 'IFCPRESENTATIONLAYERWITHSTYLE', "#21=IFCPRESENTATIONLAYERWITHSTYLE('Layer_Styled',$,(#10),$,.T.,.F.,.F.,$);"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+    const closure = new Set([10, 11]);
+
+    collectStyleEntities(closure, source, { byId, byType });
+
+    expect(closure.has(21)).toBe(true);
+  });
+
+  it('does not rescue a layer assignment naming only entities outside the closure (control)', () => {
+    const entries: Array<[number, string, string]> = [
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [99, 'IFCSHAPEREPRESENTATION', "#99=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#98));"],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Elsewhere',$,(#99),$);"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+    // Closure excludes #99 — the layer assignment names only entities
+    // that never made it into this export's closure, so it must stay out too.
+    const closure = new Set([10, 11]);
+
+    collectStyleEntities(closure, source, { byId, byType });
+
+    expect(closure.has(20)).toBe(false);
   });
 });

--- a/packages/export/src/reference-collector.test.ts
+++ b/packages/export/src/reference-collector.test.ts
@@ -6,9 +6,9 @@ import { describe, it, expect } from 'vitest';
 import {
   PRODUCT_TYPES,
   collectReferencedEntityIds,
-  collectStyleEntities,
   getVisibleEntityIds,
 } from './reference-collector.js';
+import { collectStyleEntities } from './style-closure.js';
 import { EMPTY_SOURCE_BYTES, type IfcDataStore } from '@ifc-lite/parser';
 import type { EffectiveEntityIndex } from './effective-index.js';
 import {
@@ -780,5 +780,94 @@ describe('collectStyleEntities rescues IFCPRESENTATIONLAYERASSIGNMENT', () => {
     collectStyleEntities(closure, source, { byId, byType });
 
     expect(closure.has(20)).toBe(false);
+  });
+
+  // RED (PR #3698 follow-up): the "control" case above only covers a layer
+  // assignment naming EITHER an included item OR only excluded ones — never
+  // one spanning BOTH, which is the realistic shape (one CAD layer naming
+  // every wall's shape representation). `#20` is rescued correctly — #10 is
+  // visible — but the pre-fix forward walk pulled in #99 unconditionally too,
+  // because #99 exists in `entityIndex` and nothing checked whether it was
+  // ever independently visible.
+  it('does not resurrect an excluded item a rescued layer assignment ALSO names, alongside a visible one (#3698 follow-up)', () => {
+    const entries: Array<[number, string, string]> = [
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      // #99 is a real entity (exists in entityIndex) but was never reached by
+      // the main closure walk — the shape representation of a HIDDEN wall.
+      [99, 'IFCSHAPEREPRESENTATION', "#99=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#98));"],
+      [98, 'IFCEXTRUDEDAREASOLID', '#98=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#99),$);"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+    const closure = new Set([10, 11]);
+
+    collectStyleEntities(closure, source, { byId, byType });
+
+    // GREEN: rescued via the visible member.
+    expect(closure.has(20)).toBe(true);
+    // RED before the fix: closure ended up [10, 11, 20, 99] — the hidden
+    // wall's own shape representation, and transitively its solid, riding
+    // in on the unconditional forward walk from #20.
+    expect(closure.has(99)).toBe(false);
+    expect(closure.has(98)).toBe(false);
+  });
+
+  // The task that motivated this fix flags IFCSTYLEDITEM/IFCSTYLEDREPRESENTATION
+  // as sharing the SAME unguarded-forward-walk root cause (it predates #3698,
+  // which only made it practically triggerable via layer assignments). Verify
+  // rather than assume: an IFCSTYLEDREPRESENTATION.Items list can itself mix a
+  // styled item over VISIBLE geometry with one over geometry belonging to a
+  // HIDDEN product — schema allows an arbitrary IfcStyledItem per product to
+  // be gathered under one shared IfcStyledRepresentation.
+  it('does not resurrect a hidden product’s styled item via a shared IFCSTYLEDREPRESENTATION', () => {
+    const entries: Array<[number, string, string]> = [
+      // Visible geometry + its styled item.
+      [10, 'IFCEXTRUDEDAREASOLID', '#10=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [30, 'IFCSTYLEDITEM', '#30=IFCSTYLEDITEM(#10,$,$);'],
+      // Hidden product's OWN geometry + its OWN styled item — never reached
+      // by the main closure walk (#99 is not in `closure` below).
+      [99, 'IFCEXTRUDEDAREASOLID', '#99=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [31, 'IFCSTYLEDITEM', '#31=IFCSTYLEDITEM(#99,$,$);'],
+      // One shared IFCSTYLEDREPRESENTATION gathering both styled items —
+      // analogous to one CAD layer naming both walls' geometry.
+      [50, 'IFCSTYLEDREPRESENTATION', "#50=IFCSTYLEDREPRESENTATION(#1,'Style','Style',(#30,#31));"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+    const closure = new Set([10]);
+
+    collectStyleEntities(closure, source, { byId, byType });
+
+    // GREEN: rescued via the visible styled item.
+    expect(closure.has(30)).toBe(true);
+    expect(closure.has(50)).toBe(true);
+    // The hidden product's OWN styled item (and, transitively, ITS geometry)
+    // must stay out — it is reachable from #50 only alongside #30, the same
+    // shape as the layer-assignment case above.
+    expect(closure.has(31)).toBe(false);
+    expect(closure.has(99)).toBe(false);
+  });
+
+  // `excludeIds` is threaded through independently of the geometry-type
+  // guard above (matching `collectGeoreferencingEntities`'s shape) — this
+  // pins that it does real work of its own, for a referenced id the
+  // geometry-type check alone would not catch (a non-geometry-classified
+  // type, e.g. a directly-excluded id that is not representation geometry).
+  it('honours excludeIds directly in the forward walk, independent of the geometry-type guard', () => {
+    const entries: Array<[number, string, string]> = [
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#1,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      // #77 is NOT geometry-classified (IFCPROPERTYSET), so the geometry-type
+      // guard alone would happily add it — only `excludeIds` stops it here.
+      [77, 'IFCPROPERTYSET', "#77=IFCPROPERTYSET('g',$,'P',$,());"],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#77),$);"],
+    ];
+    const { source, byId, byType } = buildIndex(entries);
+    const closure = new Set([10, 11]);
+
+    collectStyleEntities(closure, source, { byId, byType }, new Set([77]));
+
+    expect(closure.has(20)).toBe(true);
+    expect(closure.has(77)).toBe(false);
   });
 });

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -950,106 +950,12 @@ function propagateOpeningExclusions(
 }
 
 // ---------------------------------------------------------------------------
-// Style / layer entity collection (reverse pass)
+// Style / layer entity collection (reverse pass) — moved to style-closure.ts
 // ---------------------------------------------------------------------------
 
-/**
- * Collect style and presentation-layer entities (IFCSTYLEDITEM,
- * IFCSTYLEDREPRESENTATION, IFCPRESENTATIONLAYERASSIGNMENT) that reference
- * geometry already in the closure, then transitively follow their own
- * references.
- *
- * In IFC STEP, IFCSTYLEDITEM references a geometry RepresentationItem, but
- * nothing references the StyledItem back — and IFCPRESENTATIONLAYERASSIGNMENT
- * is the same shape: it names the representation/items assigned to a layer
- * (`AssignedItems`) but nothing points back at the assignment itself. So the
- * forward closure walk misses both entirely. This function does one reverse
- * pass using the byType index: for each candidate, check if any referenced ID
- * is in the closure. If yes, add it and walk its own reference chain in.
- *
- * Uses byType for O(candidates) instead of O(allEntities), and byte-level
- * scanning for #ID extraction.
- *
- * Must be called AFTER collectReferencedEntityIds so the closure is complete.
- *
- * @param closure - The existing closure set (mutated in place)
- * @param source - The original STEP file source buffer
- * @param entityIndex - Full entity index with type info and byType lookup
- */
-export function collectStyleEntities(
-  closure: Set<number>,
-  source: Uint8Array | IfcSourceBytes,
-  entityIndex: {
-    byId: {
-      get(expressId: number): { type: string; byteOffset: number; byteLength: number } | undefined;
-      has(expressId: number): boolean;
-      refsOf?(expressId: number): readonly number[] | undefined;
-    };
-    byType: Map<string, number[]>;
-  },
-): void {
-  const src = asSourceBytes(source);
-  const queue: number[] = [];
-  const refs: number[] = [];
-  const refsInto = (expressId: number, ref: { byteOffset: number; byteLength: number }): void => {
-    refs.length = 0;
-    const authored = entityIndex.byId.refsOf?.(expressId);
-    if (authored) refs.push(...authored);
-    else {
-      const span = src.slice(ref.byteOffset, ref.byteOffset + ref.byteLength);
-      extractRefsFromBytes(span, 0, span.length, refs);
-    }
-  };
-
-  // Use byType index for direct lookup — O(candidates) not O(allEntities)
-  const styledItemIds = entityIndex.byType.get('IFCSTYLEDITEM') ?? [];
-  const styledRepIds = entityIndex.byType.get('IFCSTYLEDREPRESENTATION') ?? [];
-  const layerAssignmentIds = entityIndex.byType.get('IFCPRESENTATIONLAYERASSIGNMENT') ?? [];
-  // IFCPRESENTATIONLAYERWITHSTYLE is a subtype (adds LayerOn/LayerFrozen/
-  // LayerBlocked/LayerStyles) indexed under its own STEP type name, not
-  // IFCPRESENTATIONLAYERASSIGNMENT's — a separate byType lookup, same rescue.
-  const layerWithStyleIds = entityIndex.byType.get('IFCPRESENTATIONLAYERWITHSTYLE') ?? [];
-
-  for (const ids of [styledItemIds, styledRepIds, layerAssignmentIds, layerWithStyleIds]) {
-    for (const expressId of ids) {
-      if (closure.has(expressId)) continue;
-
-      const entityRef = entityIndex.byId.get(expressId);
-      if (!entityRef) continue;
-
-      // Check if any referenced ID is in the closure
-      refsInto(expressId, entityRef);
-
-      let referencesClosureEntity = false;
-      for (let i = 0; i < refs.length; i++) {
-        if (closure.has(refs[i])) {
-          referencesClosureEntity = true;
-          break;
-        }
-      }
-
-      if (referencesClosureEntity) {
-        closure.add(expressId);
-        queue.push(expressId);
-      }
-    }
-  }
-
-  // Walk forward from newly added style entities to pull in their style chain
-  // (IfcPresentationStyleAssignment → IfcSurfaceStyle → IfcSurfaceStyleRendering → IfcColourRgb)
-  while (queue.length > 0) {
-    const entityId = queue.pop()!;
-    const ref = entityIndex.byId.get(entityId);
-    if (!ref) continue;
-
-    refsInto(entityId, ref);
-
-    for (let i = 0; i < refs.length; i++) {
-      const referencedId = refs[i];
-      if (!closure.has(referencedId) && entityIndex.byId.has(referencedId)) {
-        closure.add(referencedId);
-        queue.push(referencedId);
-      }
-    }
-  }
-}
+// `collectStyleEntities` (IFCSTYLEDITEM / IFCSTYLEDREPRESENTATION /
+// IFCPRESENTATIONLAYERASSIGNMENT / IFCPRESENTATIONLAYERWITHSTYLE rescue) now
+// lives in `style-closure.ts`, split out for the same reason
+// `collectGeoreferencingEntities` was: this file was already at its module
+// size budget. It still uses `collectRefsInByteRange` (above) for its byte
+// scan.

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -950,20 +950,24 @@ function propagateOpeningExclusions(
 }
 
 // ---------------------------------------------------------------------------
-// Style entity collection (reverse pass)
+// Style / layer entity collection (reverse pass)
 // ---------------------------------------------------------------------------
 
 /**
- * Collect style entities (IFCSTYLEDITEM, etc.) that reference geometry already
- * in the closure, then transitively follow their style references.
+ * Collect style and presentation-layer entities (IFCSTYLEDITEM,
+ * IFCSTYLEDREPRESENTATION, IFCPRESENTATIONLAYERASSIGNMENT) that reference
+ * geometry already in the closure, then transitively follow their own
+ * references.
  *
  * In IFC STEP, IFCSTYLEDITEM references a geometry RepresentationItem, but
- * nothing references the StyledItem back. So the forward closure walk misses
- * them entirely. This function does a reverse pass using the byType index:
- * for each styled item, check if any referenced ID is in the closure. If yes,
- * add the styled item and walk its style chain into the closure.
+ * nothing references the StyledItem back — and IFCPRESENTATIONLAYERASSIGNMENT
+ * is the same shape: it names the representation/items assigned to a layer
+ * (`AssignedItems`) but nothing points back at the assignment itself. So the
+ * forward closure walk misses both entirely. This function does one reverse
+ * pass using the byType index: for each candidate, check if any referenced ID
+ * is in the closure. If yes, add it and walk its own reference chain in.
  *
- * Uses byType for O(styledItems) instead of O(allEntities), and byte-level
+ * Uses byType for O(candidates) instead of O(allEntities), and byte-level
  * scanning for #ID extraction.
  *
  * Must be called AFTER collectReferencedEntityIds so the closure is complete.
@@ -997,11 +1001,16 @@ export function collectStyleEntities(
     }
   };
 
-  // Use byType index for direct lookup — O(styledItems) not O(allEntities)
+  // Use byType index for direct lookup — O(candidates) not O(allEntities)
   const styledItemIds = entityIndex.byType.get('IFCSTYLEDITEM') ?? [];
   const styledRepIds = entityIndex.byType.get('IFCSTYLEDREPRESENTATION') ?? [];
+  const layerAssignmentIds = entityIndex.byType.get('IFCPRESENTATIONLAYERASSIGNMENT') ?? [];
+  // IFCPRESENTATIONLAYERWITHSTYLE is a subtype (adds LayerOn/LayerFrozen/
+  // LayerBlocked/LayerStyles) indexed under its own STEP type name, not
+  // IFCPRESENTATIONLAYERASSIGNMENT's — a separate byType lookup, same rescue.
+  const layerWithStyleIds = entityIndex.byType.get('IFCPRESENTATIONLAYERWITHSTYLE') ?? [];
 
-  for (const ids of [styledItemIds, styledRepIds]) {
+  for (const ids of [styledItemIds, styledRepIds, layerAssignmentIds, layerWithStyleIds]) {
     for (const expressId of ids) {
       if (closure.has(expressId)) continue;
 

--- a/packages/export/src/step-collection.ts
+++ b/packages/export/src/step-collection.ts
@@ -29,7 +29,8 @@
 
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
-import { collectReferencedEntityIds, getVisibleEntityIds, collectStyleEntities } from './reference-collector.js';
+import { collectReferencedEntityIds, getVisibleEntityIds } from './reference-collector.js';
+import { collectStyleEntities } from './style-closure.js';
 import { collectGeoreferencingEntities } from './georef-closure.js';
 import { getSubsetEntityIds } from './subset-roots.js';
 import { buildRelDefinesByPropertiesIndex } from './step-property-set-index.js';
@@ -234,13 +235,17 @@ function applyExportClosure(
     excludeIds,
     pass.isRefExcludedDuringClosureWalk,
   );
-  // Second pass: collect IFCSTYLEDITEM entities that reference included
-  // geometry. Styled items reference geometry items but nothing references
-  // them back, so the forward closure misses them.
+  // Second pass: collect IFCSTYLEDITEM/layer-assignment entities that
+  // reference included geometry. These reference geometry items but nothing
+  // references them back, so the forward closure misses them. `excludeIds`
+  // is passed through — see `style-closure.ts` for why a shared
+  // IFCPRESENTATIONLAYERASSIGNMENT (one CAD layer naming both a visible and
+  // a hidden product's geometry) needs it, not just the styled-item case.
   collectStyleEntities(
     pass.allowedEntityIds,
     ctx.dataStore.source,
     { byId: pass.effective, byType: pass.effective.byType },
+    excludeIds,
   );
   // Third pass: collect IFCMAPCONVERSION (+ its IFCPROJECTEDCRS) when the
   // context it converts is already in the closure. IfcMapConversion.SourceCRS

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -216,6 +216,18 @@ export const relationshipWithheldWarning = (expressId: number, type: string): st
   `Relationship #${expressId} (${type}) was withheld from the export: it names at least one entity that has no line in this export, in a slot with no spelling for an omitted reference (a single-valued attribute, or a set whose every member is omitted). Anything else that relationship associated is no longer associated in the output.`;
 
 /**
+ * Same withholding, for a rescued `IFCSTYLEDITEM` / `IFCSTYLEDREPRESENTATION`
+ * / `IFCPRESENTATIONLAYERASSIGNMENT` / `IFCPRESENTATIONLAYERWITHSTYLE`
+ * (`style-closure.ts`'s `collectStyleEntities`) rather than an `IFCREL*`
+ * line — a distinct message rather than reusing {@link relationshipWithheldWarning}
+ * verbatim because that one says "Relationship", which these are not; the
+ * dangling-ref shape it withholds against is identical (a single-valued
+ * attribute, e.g. `IfcStyledItem.Item`, naming an entity this export omits).
+ */
+export const styleEntityWithheldWarning = (expressId: number, type: string): string =>
+  `Entity #${expressId} (${type}) was withheld from the export: it names at least one entity that has no line in this export, in a slot with no spelling for an omitted reference (a single-valued attribute, or a set whose every member is omitted).`;
+
+/**
  * What `step-attribute-mutations.ts`'s `applySourceLineMutations` produced: the rewritten
  * line, plus which edit kinds that rewrite actually delivered. The delivery
  * half is {@link SourceLineDelivery} rather than three loose booleans so that

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -492,6 +492,116 @@ describe('StepExporter', () => {
     expect(findDanglingRefs(content)).toEqual([]);
   });
 
+  // The fifth route, and PR #3698's own follow-up: `collectStyleEntities`
+  // (`style-closure.ts`) rescues an `IFCPRESENTATIONLAYERASSIGNMENT` into the
+  // closure when ANY of its `AssignedItems` is already visible — but a layer
+  // assignment routinely spans MANY products (one CAD layer naming every
+  // wall's shape representation), so a layer shared by a visible and a
+  // hidden wall must not drag the hidden wall's geometry back in with it.
+  it('does not leak a hidden product’s geometry through a layer assignment it shares with a visible one', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('1ys5Xwuxz8gPJk6N$NGhA1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('1ys5Xwuxz8gPJk6N$NGhA2',$,'VisibleWall',$,$,$,$,#10);"],
+      [3, 'IFCWALL', "#3=IFCWALL('1ys5Xwuxz8gPJk6N$NGhA3',$,'HiddenWall',$,$,$,$,#99);"],
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      [12, 'IFCARBITRARYCLOSEDPROFILEDEF', "#12=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#15);"],
+      [13, 'IFCAXIS2PLACEMENT3D', '#13=IFCAXIS2PLACEMENT3D($,$,$);'],
+      [14, 'IFCDIRECTION', '#14=IFCDIRECTION((0.,0.,1.));'],
+      [15, 'IFCPOLYLINE', '#15=IFCPOLYLINE((#16,#17));'],
+      [16, 'IFCCARTESIANPOINT', '#16=IFCCARTESIANPOINT((0.,0.));'],
+      [17, 'IFCCARTESIANPOINT', '#17=IFCCARTESIANPOINT((1.,1.));'],
+      // #99/#98 belong exclusively to the HIDDEN wall — never reachable from
+      // any visible root except through the shared layer assignment below.
+      [99, 'IFCSHAPEREPRESENTATION', "#99=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#98));"],
+      [98, 'IFCEXTRUDEDAREASOLID', '#98=IFCEXTRUDEDAREASOLID(#12,#13,#14,3.);'],
+      // One CAD layer naming BOTH walls' shape representations.
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#99),$);"],
+    ]);
+
+    const result = new StepExporter(dataStore, liveView(dataStore)).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([3]),
+    });
+    const content = decode(result.content);
+
+    // The hidden wall's own line is correctly omitted (pre-existing behaviour).
+    expect(content).not.toContain('HiddenWall');
+    // The shared layer assignment is still rescued — that is PR #3698's
+    // whole purpose — and the VISIBLE wall's geometry survives intact.
+    expect(content).toContain('IFCPRESENTATIONLAYERASSIGNMENT');
+    expect(content).toContain('#10=IFCSHAPEREPRESENTATION');
+    expect(content).toContain('#11=IFCEXTRUDEDAREASOLID');
+    // RED before the fix: the forward walk from the rescued #20 pulled in
+    // the HIDDEN wall's own shape representation and solid too.
+    expect(content).not.toContain('#99=IFCSHAPEREPRESENTATION');
+    expect(content).not.toContain('#98=IFCEXTRUDEDAREASOLID');
+    // The rescued layer assignment's OWN line must not keep naming #99 now
+    // that #99 has no defining line — `filterHiddenRefsFromRelationshipLine`
+    // narrows AssignedItems down to the surviving member instead of shipping
+    // a dangling `#99` (step-source-iteration.ts's new STYLE_RESCUE_TYPES arm).
+    const layerLine = content.split('\n').find((line) => line.startsWith('#20='));
+    expect(layerLine).toContain('#10');
+    expect(layerLine).not.toContain('#99');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  // Control: a layer assignment naming ONLY visible items must still be
+  // rescued with its FULL closure — nothing in the fix should make the
+  // rescue itself more conservative than PR #3698 intended.
+  it('control: a layer assignment naming only visible items keeps its full closure', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('1ys5Xwuxz8gPJk6N$NGhA1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('1ys5Xwuxz8gPJk6N$NGhA2',$,'VisibleWall',$,$,$,$,#10);"],
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID($,$,$,3.);'],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10),$);"],
+    ]);
+
+    const result = new StepExporter(dataStore, liveView(dataStore)).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set<number>(),
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain('#20=IFCPRESENTATIONLAYERASSIGNMENT');
+    expect(content).toContain('#10=IFCSHAPEREPRESENTATION');
+    expect(content).toContain('#11=IFCEXTRUDEDAREASOLID');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  // Control: a normal FULL export (no `visibleOnly`) is completely
+  // unaffected — `mayNameOmittedRefs` is false with no hidden ids, an
+  // overlay, geometry exclusion or unreadable ref in play, so the new
+  // STYLE_RESCUE_TYPES writer branch never even runs, and `collectStyleEntities`
+  // is never called at all (`pass.allowedEntityIds` stays null).
+  it('control: a full export with a shared layer assignment is unaffected by the visibleOnly fix', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('1ys5Xwuxz8gPJk6N$NGhA1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCWALL', "#2=IFCWALL('1ys5Xwuxz8gPJk6N$NGhA2',$,'VisibleWall',$,$,$,$,#10);"],
+      [3, 'IFCWALL', "#3=IFCWALL('1ys5Xwuxz8gPJk6N$NGhA3',$,'OtherWall',$,$,$,$,#99);"],
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#11));"],
+      [11, 'IFCEXTRUDEDAREASOLID', '#11=IFCEXTRUDEDAREASOLID($,$,$,3.);'],
+      [99, 'IFCSHAPEREPRESENTATION', "#99=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#98));"],
+      [98, 'IFCEXTRUDEDAREASOLID', '#98=IFCEXTRUDEDAREASOLID($,$,$,3.);'],
+      [20, 'IFCPRESENTATIONLAYERASSIGNMENT', "#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#99),$);"],
+    ]);
+
+    const result = new StepExporter(dataStore, liveView(dataStore)).export({ schema: 'IFC4' });
+    const content = decode(result.content);
+
+    // Nothing is hidden under a plain full export — every entity ships,
+    // including BOTH walls' geometry, byte-identical to the source records.
+    expect(content).toContain('VisibleWall');
+    expect(content).toContain('OtherWall');
+    expect(content).toContain('#99=IFCSHAPEREPRESENTATION');
+    expect(content).toContain('#98=IFCEXTRUDEDAREASOLID');
+    expect(content).toContain("#20=IFCPRESENTATIONLAYERASSIGNMENT('Layer_Walls',$,(#10,#99),$);");
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
   // #2548: the closure-walk fix that stops a HIDDEN product's pset from
   // riding along on the relationship that named it (see
   // `visible-only-dangling-refs.test.ts`) has to recognise a DELETED subject

--- a/packages/export/src/step-source-iteration.ts
+++ b/packages/export/src/step-source-iteration.ts
@@ -54,6 +54,8 @@
 
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { filterHiddenRefsFromRelationshipLine } from './reference-collector.js';
+import { STYLE_RESCUE_TYPES } from './style-closure.js';
+import { styleEntityWithheldWarning } from './step-export-types.js';
 import { convertStepLine, type IfcSchemaVersion } from './schema-converter.js';
 import { nominateDeliveredInPlaceEdits } from './in-place-nomination.js';
 import { decodeRange } from './source-ref-bounds.js';
@@ -260,6 +262,24 @@ export function writeSourceEntityLines(
         const filtered = filterHiddenRefsFromRelationshipLine(nextEntityText, isOmittedFromOutput);
         if (filtered === null) {
           pass.warnings.push(ctx.relationshipWithheldWarning(expressId, effectiveRelType));
+          continue;
+        }
+        nextEntityText = filtered;
+      } else if (mayNameOmittedRefs && STYLE_RESCUE_TYPES.has(effectiveRelType)) {
+        // A rescued IFCSTYLEDITEM/IFCSTYLEDREPRESENTATION/
+        // IFCPRESENTATIONLAYERASSIGNMENT/IFCPRESENTATIONLAYERWITHSTYLE
+        // (`style-closure.ts`) can legitimately name BOTH a kept item and one
+        // this export omits — e.g. a layer assignment shared by a visible and
+        // a hidden product's geometry, rescued because the visible one is in
+        // the closure. Unlike `IFCREL*`, these lines are otherwise never
+        // touched (`step-omission-predicates.ts` documents that as a general
+        // gap for non-relationship lines), so left alone this would ship the
+        // exact #2398 dangling-`#N` shape on a line the rescue itself just
+        // introduced into the closure. Same filter, same withhold-vs-narrow
+        // rule, applied to this line for the same reason.
+        const filtered = filterHiddenRefsFromRelationshipLine(nextEntityText, isOmittedFromOutput);
+        if (filtered === null) {
+          pass.warnings.push(styleEntityWithheldWarning(expressId, effectiveRelType));
           continue;
         }
         nextEntityText = filtered;

--- a/packages/export/src/style-closure.ts
+++ b/packages/export/src/style-closure.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Rescue `IFCSTYLEDITEM` / `IFCSTYLEDREPRESENTATION` /
+ * `IFCPRESENTATIONLAYERASSIGNMENT` / `IFCPRESENTATIONLAYERWITHSTYLE` into a
+ * STEP export closure that otherwise never reaches them.
+ *
+ * Split out of `reference-collector.ts` (which already sits at its module
+ * size budget) rather than grown in place — same reason `georef-closure.ts`
+ * was split out: `collectReferencedEntityIds` only walks FORWARD from a
+ * product, but a styled item / layer assignment references geometry the
+ * OTHER way (item -> style, layer -> assigned item), so nothing reaches it
+ * from a product root. This file's `collectStyleEntities` does one reverse
+ * pass over the byType index instead: for each candidate, check if any
+ * referenced id is already in the closure, and if so rescue it.
+ */
+
+import type { IfcSourceBytes } from '@ifc-lite/parser';
+import { collectRefsInByteRange } from './reference-collector.js';
+import { isGeometryEntity } from './step-geometry-types.js';
+
+/**
+ * The four entity classes `collectStyleEntities` rescues. Exported so
+ * `step-source-iteration.ts` can apply the SAME dangling-ref-safe line
+ * filter (`filterHiddenRefsFromRelationshipLine`) to a rescued entity's own
+ * output line as it already does for `IFCREL*` — a rescued
+ * `IFCPRESENTATIONLAYERASSIGNMENT` can legitimately end up naming both a
+ * kept item and an excluded one (see `collectStyleEntities`'s own doc), and
+ * without that filter its `AssignedItems` line would ship a dangling `#N`.
+ */
+export const STYLE_RESCUE_TYPES: ReadonlySet<string> = new Set([
+  'IFCSTYLEDITEM',
+  'IFCSTYLEDREPRESENTATION',
+  'IFCPRESENTATIONLAYERASSIGNMENT',
+  'IFCPRESENTATIONLAYERWITHSTYLE',
+]);
+
+/**
+ * Presentation RESOURCE types (colours, surface styles, the assignment that
+ * glues a style to an item) that `isGeometryEntity` also classifies as
+ * "geometry" for the unrelated `includeGeometry: false` feature, but that
+ * are never exclusively owned by one product the way an
+ * `IfcShapeRepresentation` or `IfcExtrudedAreaSolid` is: they are shared
+ * presentation data, referenced BY styled items rather than referencing a
+ * product's geometry themselves. `IFCSTYLEDITEM` is deliberately NOT in this
+ * set — a `IfcStyledRepresentation.Items` list can itself mix a rescued
+ * (visible) styled item with one reachable only through a hidden product's
+ * OWN styled item (each product can carry its own styling), so it gets the
+ * same "must already be in the closure" treatment as any other geometry
+ * candidate.
+ */
+const STYLE_RESOURCE_EXEMPT_TYPES: ReadonlySet<string> = new Set([
+  'IFCPRESENTATIONSTYLEASSIGNMENT',
+  'IFCSURFACESTYLE',
+  'IFCSURFACESTYLERENDERING',
+  'IFCCOLOURRGB',
+]);
+
+/**
+ * Collect style and presentation-layer entities (IFCSTYLEDITEM,
+ * IFCSTYLEDREPRESENTATION, IFCPRESENTATIONLAYERASSIGNMENT,
+ * IFCPRESENTATIONLAYERWITHSTYLE) that reference geometry already in the
+ * closure, then transitively follow their own references.
+ *
+ * In IFC STEP, IFCSTYLEDITEM references a geometry RepresentationItem, but
+ * nothing references the StyledItem back — and IFCPRESENTATIONLAYERASSIGNMENT
+ * is the same shape: it names the representation/items assigned to a layer
+ * (`AssignedItems`) but nothing points back at the assignment itself. So the
+ * forward closure walk misses both entirely. This function does one reverse
+ * pass using the byType index: for each candidate, check if any referenced ID
+ * is in the closure. If yes, add it and walk its own reference chain in.
+ *
+ * ## Why the forward walk needs more than `excludeIds`
+ *
+ * `excludeIds` (`hiddenProductIds`) only ever holds PRODUCT ids, never the
+ * geometry those products exclusively own. `IfcPresentationLayerAssignment.
+ * AssignedItems` routinely names REPRESENTATION-level ids directly (one CAD
+ * layer naming every wall's `IfcShapeRepresentation`), so a shared layer
+ * assignment can legitimately be rescued by a VISIBLE wall's representation
+ * while also naming a HIDDEN wall's — an id nowhere in `excludeIds`. A plain
+ * `excludeIds.has(id)` check (the shape `collectGeoreferencingEntities` uses)
+ * would miss that id entirely and resurrect the hidden wall's geometry.
+ *
+ * The fix relies on an invariant this function's own contract already
+ * guarantees: it runs strictly AFTER `collectReferencedEntityIds`, which has
+ * already walked the FULL forward closure from every visible root. So any
+ * geometry/representation-classified entity (`isGeometryEntity`) that is
+ * NOT already in `closure` by the time this pass starts has no other path to
+ * visibility — it is either exclusively owned by an excluded product, or
+ * genuinely unreferenced by any visible root — and must not be resurrected
+ * just because it happens to sit in the same `AssignedItems`/`Item` list as
+ * something that IS visible. Presentation RESOURCE types (colours, surface
+ * styles — see `STYLE_RESOURCE_EXEMPT_TYPES`) are the one exception: they are
+ * shared data, never product-exclusive, so the pre-existing "pull in the
+ * style chain" behaviour for them is preserved unconditionally.
+ *
+ * `excludeIds` is still threaded through and checked directly (matching
+ * `collectGeoreferencingEntities`'s shape) as a second, cheap guard — e.g. if
+ * a future entity ever names an excluded id that is not geometry-classified.
+ *
+ * Uses byType for O(candidates) instead of O(allEntities), and byte-level
+ * scanning for #ID extraction.
+ *
+ * Must be called AFTER collectReferencedEntityIds so the closure is complete.
+ *
+ * @param closure - The existing closure set (mutated in place)
+ * @param source - The original STEP file source buffer
+ * @param entityIndex - Full entity index with type info and byType lookup
+ * @param excludeIds - Entity IDs to never add, even if they reference the
+ *   closure (e.g. `pass.hiddenProductIds` / a subset export's `excludedIds`)
+ */
+export function collectStyleEntities(
+  closure: Set<number>,
+  source: Uint8Array | IfcSourceBytes,
+  entityIndex: {
+    byId: {
+      get(expressId: number): { type: string; byteOffset: number; byteLength: number } | undefined;
+      has(expressId: number): boolean;
+      refsOf?(expressId: number): readonly number[] | undefined;
+    };
+    byType: Map<string, number[]>;
+  },
+  excludeIds?: ReadonlySet<number>,
+): void {
+  const queue: number[] = [];
+  const refsOf = (expressId: number, ref: { byteOffset: number; byteLength: number }): number[] => {
+    const authored = entityIndex.byId.refsOf?.(expressId);
+    if (authored) return authored.slice();
+    return collectRefsInByteRange(source, ref.byteOffset, ref.byteLength);
+  };
+
+  // Use byType index for direct lookup — O(candidates) not O(allEntities)
+  const styledItemIds = entityIndex.byType.get('IFCSTYLEDITEM') ?? [];
+  const styledRepIds = entityIndex.byType.get('IFCSTYLEDREPRESENTATION') ?? [];
+  const layerAssignmentIds = entityIndex.byType.get('IFCPRESENTATIONLAYERASSIGNMENT') ?? [];
+  // IFCPRESENTATIONLAYERWITHSTYLE is a subtype (adds LayerOn/LayerFrozen/
+  // LayerBlocked/LayerStyles) indexed under its own STEP type name, not
+  // IFCPRESENTATIONLAYERASSIGNMENT's — a separate byType lookup, same rescue.
+  const layerWithStyleIds = entityIndex.byType.get('IFCPRESENTATIONLAYERWITHSTYLE') ?? [];
+
+  for (const ids of [styledItemIds, styledRepIds, layerAssignmentIds, layerWithStyleIds]) {
+    for (const expressId of ids) {
+      if (closure.has(expressId)) continue;
+
+      const entityRef = entityIndex.byId.get(expressId);
+      if (!entityRef) continue;
+
+      // Check if any referenced ID is in the closure
+      const refs = refsOf(expressId, entityRef);
+
+      let referencesClosureEntity = false;
+      for (let i = 0; i < refs.length; i++) {
+        if (closure.has(refs[i])) {
+          referencesClosureEntity = true;
+          break;
+        }
+      }
+
+      if (referencesClosureEntity) {
+        closure.add(expressId);
+        queue.push(expressId);
+      }
+    }
+  }
+
+  // Walk forward from newly added style entities to pull in their style chain
+  // (IfcPresentationStyleAssignment → IfcSurfaceStyle → IfcSurfaceStyleRendering → IfcColourRgb)
+  // — but see the function doc for why a geometry-classified id not already
+  // in the closure is refused here rather than resurrected.
+  while (queue.length > 0) {
+    const entityId = queue.pop()!;
+    const ref = entityIndex.byId.get(entityId);
+    if (!ref) continue;
+
+    const refs = refsOf(entityId, ref);
+
+    for (let i = 0; i < refs.length; i++) {
+      const referencedId = refs[i];
+      if (closure.has(referencedId)) continue;
+      if (excludeIds?.has(referencedId)) continue;
+
+      const targetRef = entityIndex.byId.get(referencedId);
+      if (!targetRef) continue;
+
+      const targetType = targetRef.type.toUpperCase();
+      if (isGeometryEntity(targetType) && !STYLE_RESOURCE_EXEMPT_TYPES.has(targetType)) {
+        // A representation/geometry id this pass has not already proven
+        // visible — refusing it is what stops a shared layer assignment or
+        // styled representation from resurrecting a hidden product's
+        // exclusively-owned geometry (see function doc).
+        continue;
+      }
+
+      closure.add(referencedId);
+      queue.push(referencedId);
+    }
+  }
+}

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -246,7 +246,7 @@
    888 packages/export/src/ifc5-exporter.ts
   1585 packages/export/src/merged-exporter.ts
    639 packages/export/src/parquet-exporter.ts
-  1062 packages/export/src/reference-collector.ts
+   961 packages/export/src/reference-collector.ts
    524 packages/export/src/schema-converter.ts
    437 packages/extensions/src/testing/runner.ts
    625 packages/geometry/src/coordinate-handler.ts


### PR DESCRIPTION
## Reviewer summary

- **Without this:** presentation-layer assignments (CAD-layer metadata) are silently dropped from every hide/isolate/subset STEP export, the one non-`IFCREL*`-prefixed entity in this defect class still falling through the closure walk after #3696 closed the georeferencing and #3691-era style-entity gaps.
- **Evidence:** reverting the fix, the two new assertions in `reference-collector.test.ts` fail as expected — an `IFCPRESENTATIONLAYERASSIGNMENT` referencing an entity already in the export closure is left out of the export.
- **Risk:** confined to `collectStyleEntities`, the same reverse-rescue-pass function #3696 already extended; a control test confirms a layer assignment naming only excluded entities is still correctly left out (no over-inclusion). Both export call sites (`step-collection.ts`, `merged-exporter.ts`) share this one function, so the fix covers all subset-export paths identically.
- **Sequencing:** stacked on #3696 (`fix-georef-visible-export-drops-mapconversion`) — merge that first.

---

## Stacked on #3696

This PR targets `fix-georef-visible-export-drops-mapconversion` (#3696), not `main` — it extends the exact reverse-rescue-pass shape #3696 introduced (`collectStyleEntities`), on the same file, to close a sibling gap in the same defect class. Should be reviewed/merged after #3696.

## Summary

Hunt for the "subset export drops an entity nothing points back at" defect class (already found and fixed three times: styles, georeferencing/anonymize, georeferencing/visibleOnly in #3696). Built one fixture covering psets, quantities, material, classification, group membership, an opening+filling, spatial containment, `IfcRelConnectsPathElements`, and a presentation-layer assignment, and ran it through the real `StepExporter.export({ visibleOnly: true })` path.

**Survival table** (visibleOnly export, one product hidden as control, nothing isolated):

| Entity | Carried by | Survives? |
|---|---|---|
| `IfcPropertySet` / `IfcRelDefinesByProperties` | `IFCREL*` unconditional root | yes |
| `IfcElementQuantity` / `IfcRelDefinesByProperties` | `IFCREL*` unconditional root | yes |
| `IfcMaterial` / `IfcRelAssociatesMaterial` | `IFCREL*` unconditional root | yes |
| `IfcClassification(Reference)` / `IfcRelAssociatesClassification` | `IFCREL*` unconditional root | yes |
| `IfcGroup` / `IfcRelAssignsToGroup` | `IFCREL*` unconditional root | yes |
| `IfcOpeningElement` + `IfcDoor` / `IfcRelVoidsElement` + `IfcRelFillsElement` | `IFCREL*` unconditional root | yes |
| Spatial chain (`IfcRelAggregates`, `IfcRelContainedInSpatialStructure`) | `IFCREL*` unconditional root | yes |
| `IfcRelConnectsPathElements` | `IFCREL*` unconditional root | yes |
| `IfcStyledItem` | reverse pass (`collectStyleEntities`) | yes (already fixed) |
| `IfcMapConversion`/`IfcProjectedCRS` | reverse pass (`collectGeoreferencingEntities`, #3696) | yes |
| **`IfcPresentationLayerAssignment`** | **nothing — dropped** | **no (this PR)** |

`getVisibleEntityIds` makes every `IFCREL*`-prefixed entity an unconditional root, so every relationship-mediated case above was already correctly rescued going into this hunt — that's the encouraging negative result. `IfcPresentationLayerAssignment` is the one entity in scope that is *not* `IFCREL*`-prefixed and, like `IfcStyledItem`, only points forward (`AssignedItems` → representation items) with nothing pointing back — so it fell through the same gap `IfcStyledItem` was already rescued from, and `IfcMapConversion` was rescued from in #3696.

Verified no path divergence: `step-collection.ts`'s `applyExportClosure` (shared by `visibleOnly` and `subsetEntityIds`) and `merged-exporter.ts`'s `computeIncludedEntityIds` both call the same `collectStyleEntities`, so this one fix covers all three subset-export paths identically.

**Deliberate omissions found, not bugs:** with `isolatedEntityIds` active (isolate mode, not just hide), an isolated wall's own opening/filling-door are excluded unless also isolated — isolation is "show only these ids", and voids/fillings aren't currently implied members of an isolated set. That's a product-semantics question, not this defect class (nothing points back at anything here — the opening genuinely isn't a root under isolation), so left alone.

## Fix

Extends `collectStyleEntities` (`packages/export/src/reference-collector.ts`) — already the reverse-pass home for `IFCSTYLEDITEM`/`IFCSTYLEDREPRESENTATION` — to also scan `IFCPRESENTATIONLAYERASSIGNMENT` and its `IFCPRESENTATIONLAYERWITHSTYLE` subtype: same rule, "rescue it if it references something already in the closure." No new sibling file needed since both call sites (`step-collection.ts`, `merged-exporter.ts`) already call `collectStyleEntities` — zero changes required in either near-budget file (`merged-exporter.ts` had 1 line of `check-module-size.mjs` headroom).

RED/GREEN pinned in `reference-collector.test.ts` (`collectStyleEntities rescues IFCPRESENTATIONLAYERASSIGNMENT`): reverted the fix locally and confirmed the two new assertions fail exactly as expected; a third control test confirms a layer assignment naming only excluded entities is correctly left out.

## Test plan

- [x] `pnpm typecheck` (full workspace, 89/89 tasks) — clean
- [x] `pnpm --filter @ifc-lite/export exec vitest run` — 1065 passed (1 unrelated suite fails: `lod1-generator.test.ts` needs a built `@ifc-lite/wasm`, not touched by this change, not run per house rule against `cargo`)
- [x] `node scripts/check-module-size.mjs` — `reference-collector.ts` 1055/1062 lines, still under budget; no `--update`/`--allow-raise` used
- [x] `node scripts/check-unused-locals.mjs` — clean
- [x] `node scripts/check-test-wiring.mjs` — clean
- [x] `pnpm run check:vitest-timeout-audit` — no new violations
- [x] Changeset added for `@ifc-lite/export`
- [x] RED confirmed by reverting the source change and rerunning the new tests

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


Closes #3875
