### PR TITLE
docs(export): pin the TS/Rust BOS Parquet export table-set gap with a test

### DIFF
--- a/rust/export/src/parquet_bos.rs
+++ b/rust/export/src/parquet_bos.rs
@@ -3,6 +3,17 @@
 //! `packages/export/src/parquet-exporter.ts` (BIM Open Schema): Entities / Properties /
 //! Quantities + optional geometry (VertexBuffer / IndexBuffer / Meshes) + Metadata.json.
 //!
+//! **Known gap vs. the TS twin (unverified whether intentional):** on the same
+//! fixture (`tests/models/ara3d/duplex.ifc`), `ParquetExporter.exportBOS()` in
+//! `packages/export/src/parquet-exporter.ts` additionally writes
+//! `Relationships.parquet`, `Strings.parquet`, and — when the source store carries
+//! one — `SpatialHierarchy.parquet`. Those three tables are not produced here, so
+//! a `.bos` archive produced through the CLI/native path (this file) is missing
+//! relationship, string-dedup, and spatial-hierarchy data that a browser export of
+//! the identical model would contain. See `duplex_exports_valid_bos` below, which
+//! asserts the current (narrower) table set explicitly so this gap can't widen
+//! further without a test failure.
+//!
 //! Native-only (feature `parquet-bos`): parquet's native compression and the zip writer
 //! don't target wasm32 cleanly, and `.bos` isn't a browser-exposed format, so this stays
 //! out of the wasm bundle. Server / CLI builds opt in.
@@ -315,6 +326,20 @@ mod tests {
             "Metadata.json",
         ] {
             assert!(names.iter().any(|n| n == expected), "missing {expected}");
+        }
+
+        // TS/Rust BOS parity check: running the same `ara3d/duplex.ifc` fixture
+        // through `packages/export/src/parquet-exporter.ts` also produces
+        // `Relationships.parquet`, `Strings.parquet`, and `SpatialHierarchy.parquet`.
+        // This crate does not yet write those three tables — pin that explicitly
+        // so a future silent narrowing (or widening) of the gap fails a test
+        // instead of going unnoticed.
+        for not_yet_ported in ["Relationships.parquet", "Strings.parquet", "SpatialHierarchy.parquet"] {
+            assert!(
+                !names.iter().any(|n| n == not_yet_ported),
+                "{not_yet_ported} is now written here — the TS/Rust BOS parity gap noted \
+                 in this file's module doc comment has narrowed; update the doc comment"
+            );
         }
 
         // Each parquet entry starts + ends with the PAR1 magic.


### PR DESCRIPTION
## Summary

Hunt for untested TS/Rust behaviour twins (per the running parity-hunt lens). `rust/export/src/parquet_bos.rs` explicitly documents itself as porting `packages/export/src/parquet-exporter.ts` (the ara3d BOS/Parquet exporter). Running the same fixture through both confirms they actually diverge, and nothing tracked that.

**Executed, not inferred:** parsed `tests/models/ara3d/duplex.ifc` with `IfcParser.parseColumnar` and ran it through `ParquetExporter.exportBOS()`, and separately ran the existing `duplex_exports_valid_bos` Rust test (`export_bos()`) on the same fixture. Zip entries:

- TS (`packages/export/src/parquet-exporter.ts`): `Entities.parquet`, `Metadata.json`, `Properties.parquet`, `Quantities.parquet`, `Relationships.parquet`, `SpatialHierarchy.parquet`, `Strings.parquet`
- Rust (`rust/export/src/parquet_bos.rs`): `Entities.parquet`, `Properties.parquet`, `Quantities.parquet`, `VertexBuffer.parquet`, `IndexBuffer.parquet`, `Meshes.parquet`, `Metadata.json`

The Rust `.bos` path is missing `Relationships.parquet`, `Strings.parquet`, and `SpatialHierarchy.parquet` — a `.bos` archive exported through the CLI/native path silently drops relationship, string-dedup, and spatial-hierarchy data that a browser export of the identical model would carry. I could not find a comment or test marking this as deliberate, so it reads as an incomplete port rather than an intentional scope cut.

Implementing the three missing tables is a real feature addition (new Arrow schemas, more decoding), too large for this pass, so this PR documents the gap and locks it down with a test instead of silently letting it drift further:

- Module doc comment on `parquet_bos.rs` now states the gap explicitly, naming the fixture and the missing tables.
- `duplex_exports_valid_bos` now also asserts the three tables are absent, with a comment pointing at the doc comment — so if someone starts writing one of them, a test forces the doc comment to be updated (and, more importantly, someone notices the current call site's silent gap while it still doesn't).

No behavior change. Follow-up: port `Relationships.parquet` / `Strings.parquet` / `SpatialHierarchy.parquet` to `parquet_bos.rs`, or, if the omission turns out to be deliberate, replace this test with one that says so.

## Test plan
- [x] `cargo test --features parquet-bos --lib parquet_bos` (new assertions pass)
- [x] `cargo test --features parquet-bos` in `rust/export` (83 passed)
- [x] `cargo test --test module_size_ratchet -p ifc-lite-processing` (unaffected)
- [x] Manually ran `ParquetExporter.exportBOS()` on `tests/models/ara3d/duplex.ifc` via a scratch vitest test (not committed) to enumerate the TS-side table set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Rust-based exports do not currently include `Relationships.parquet`, `Strings.parquet`, or `SpatialHierarchy.parquet`.

- **Tests**
  - Added validation to ensure these three tables remain absent from Rust exports unless the behavior changes intentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->