### PR TITLE
fix(mcp): match bcf_topic_list's status filter case-insensitively

### DIFF
--- a/.changeset/mcp-bcf-status-filter-case.md
+++ b/.changeset/mcp-bcf-status-filter-case.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+Fix `bcf_topic_list`'s `status` filter using an exact, case-sensitive match against `topicStatus`. BCF status strings are conventionally Title Case (`'Open'`, `'Closed'`), but nothing tells a calling agent that, and a differently-cased filter (e.g. `'open'`) silently returned zero topics — indistinguishable from "there really are none". `@ifc-lite/bcf`'s own `computeMarkers3D` already lowercases both sides for its status filter; `bcf_topic_list` now matches that.

--- a/packages/mcp/src/tools/bcf.test.ts
+++ b/packages/mcp/src/tools/bcf.test.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * bcf_topic_list status filter.
+ *
+ * BCF status strings are conventionally Title Case ('Open', 'Closed'), but
+ * nothing in the tool's schema or description tells an agent that, and an
+ * agent has no independent way to check a topic's exact casing before
+ * filtering. An exact `===` match silently returned an empty list for a
+ * differently-cased filter — identical, from the caller's side, to "there
+ * really are no matching topics" (the error-vs-empty distinction this
+ * audit was told is "the whole ballgame"). `@ifc-lite/bcf`'s
+ * `computeMarkers3D` already lowercases both sides for its own status
+ * filter, so this is also a same-repo behavioural inconsistency.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ToolContext } from '../context.js';
+import { DEFAULT_CONFIG, InMemoryModelRegistry, NOOP_PROGRESS, SILENT_LOGGER } from '../context.js';
+import { fullScope } from '../auth/scope.js';
+import { bcfTools } from './bcf.js';
+import type { CallToolResult } from '../protocol/index.js';
+
+function tool(name: string) {
+  const found = bcfTools.find((t) => t.name === name);
+  if (!found) throw new Error(`${name} not registered`);
+  return found;
+}
+
+function makeCtx(): ToolContext {
+  return {
+    registry: new InMemoryModelRegistry(),
+    scope: fullScope(),
+    progress: NOOP_PROGRESS,
+    log: SILENT_LOGGER,
+    signal: new AbortController().signal,
+    config: { ...DEFAULT_CONFIG },
+  };
+}
+
+interface ListShape {
+  count: number;
+  topics: Array<{ guid: string; status?: string }>;
+}
+
+describe('bcf_topic_list status filter', () => {
+  it('matches a status filter case-insensitively', async () => {
+    const ctx = makeCtx();
+    // Default status is 'Open' (Title Case) — see bcf_topic_create's schema default.
+    const created = (await tool('bcf_topic_create').handler({ title: 'Clash on Level 2' }, ctx)) as CallToolResult;
+    expect(created.structuredContent).toBeDefined();
+
+    const lower = (await tool('bcf_topic_list').handler({ status: 'open' }, ctx)) as CallToolResult;
+    const lowerResult = lower.structuredContent as unknown as ListShape;
+    expect(lowerResult.count).toBe(1);
+    expect(lowerResult.topics).toHaveLength(1);
+
+    const exact = (await tool('bcf_topic_list').handler({ status: 'Open' }, ctx)) as CallToolResult;
+    const exactResult = exact.structuredContent as unknown as ListShape;
+    expect(exactResult.count).toBe(1);
+  });
+
+  it('control: an unrelated status still returns nothing', async () => {
+    const ctx = makeCtx();
+    await tool('bcf_topic_create').handler({ title: 'Clash on Level 2' }, ctx);
+
+    const result = (await tool('bcf_topic_list').handler({ status: 'closed' }, ctx)) as CallToolResult;
+    const shape = result.structuredContent as unknown as ListShape;
+    expect(shape.count).toBe(0);
+    expect(shape.topics).toHaveLength(0);
+  });
+});

--- a/packages/mcp/src/tools/bcf.ts
+++ b/packages/mcp/src/tools/bcf.ts
@@ -59,8 +59,17 @@ const bcfTopicList: Tool = {
   handler(input, ctx) {
     const project = getProject(ctx.registry);
     const filter = input.status as string | undefined;
+    // Case-insensitive: BCF status strings are conventionally Title Case
+    // ('Open', 'In Progress', 'Closed'), but an agent has no way to know
+    // the exact casing a topic was created with. An exact `===` match here
+    // (the previous behaviour) silently returned an empty list for a
+    // differently-cased filter — indistinguishable from "no matching
+    // topics" — instead of the topics that actually matched. Mirrors the
+    // case-insensitive statusFilter already used for BCF markers in
+    // `@ifc-lite/bcf`'s `computeMarkers3D`.
+    const filterLower = filter?.toLowerCase();
     const topics = Array.from(project.topics.values())
-      .filter((t) => !filter || t.topicStatus === filter)
+      .filter((t) => !filterLower || (t.topicStatus ?? '').toLowerCase() === filterLower)
       .map((t) => ({ guid: t.guid, title: t.title, status: t.topicStatus, type: t.topicType, priority: t.priority, comments: t.comments.length }));
     return okResult(`${topics.length} topic(s).`, { count: topics.length, topics });
   },


### PR DESCRIPTION
## Reviewer summary

- **Without this:** an MCP agent filtering BCF topics by status with different casing than the file uses (e.g. `'open'` vs. the on-disk `'Open'`) gets an empty list back — indistinguishable from "no matching topics," with no human looking at a 3D view to catch the false negative.
- **Evidence:** on the unmodified tool, filtering `status: 'open'` against a topic created with the default `'Open'` status returned 0 topics; after the fix, it returns 1.
- **Risk:** narrow, single-comparison change, matching a lowercasing convention `@ifc-lite/bcf`'s own `computeMarkers3D` already uses elsewhere in the repo. Control: `status: 'closed'` against the same fixture still correctly returns 0 — the fix isn't just returning everything.
- **Sequencing:** none; based on `main`.

---

## Summary

- `bcf_topic_list`'s `status` filter did an exact, case-sensitive `===` match against `topicStatus`. BCF status strings are conventionally Title Case (`'Open'`, `'Closed'`), the `bcf_topic_create` schema even defaults `status` to `'Open'`, but nothing tells a calling agent the exact casing to use. A differently-cased filter (e.g. `status: 'open'`) silently returned an empty list — indistinguishable, from the caller's side, from "there really are no matching topics".
- `@ifc-lite/bcf`'s own `computeMarkers3D` already lowercases both sides for its equivalent status filter, so this was also a same-repo behavioural inconsistency, not just an isolated bug.
- Fix: lowercase both sides before comparing, matching the existing `computeMarkers3D` convention.

## Context

Found auditing the MCP tool surface (the set of tools an AI agent calls to answer questions about an IFC model, with no human looking at a 3D view to sanity-check the answer) for tools that can return a confidently wrong or misleadingly-empty result. `bcf_topic_list` had no test coverage at all prior to this PR.

## Test plan

- [x] `packages/mcp/src/tools/bcf.test.ts` (new): RED on unmodified `bcf.ts` — `status: 'open'` against a topic created with the default `'Open'` status returned 0 topics; GREEN after the fix — returns 1. A control case (`status: 'closed'` against the same fixture) still correctly returns 0, proving the fix doesn't just return everything.
- [x] `pnpm --filter @ifc-lite/mcp test` — 36 files / 351 tests pass.
- [x] `pnpm --filter @ifc-lite/mcp exec tsc --noEmit` — clean.
- [x] `node scripts/check-module-size.mjs`, `node scripts/check-test-wiring.mjs`, `node scripts/check-unused-locals.mjs`, `pnpm run check:vitest-timeout-audit` — no new findings for the touched files.
- [x] Changeset added for `@ifc-lite/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
