### PR TITLE
feat(lists): report World Coordinates as sortable X/Y/Z columns

### DIFF
--- a/.changeset/lists-world-coordinate-columns.md
+++ b/.changeset/lists-world-coordinate-columns.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/lists': minor
+---
+
+Add a `geometry` column/condition source (issue #3671, "Reporting World Coordinates in Lists"): `propertyName` selects `X` | `Y` | `Z` (default `X`) of the element's World Coordinate — the fully composed, resolved `IfcLocalPlacement` chain in the project's own coordinate system and IFC Z-up axes, project length units. This is PROJECT space, distinct from the map/WGS84 georeferenced frame. `ListDataProvider` gains an optional `getWorldPosition(expressId)` accessor to back it; providers built before this existed simply have no World Coordinate columns, the same graceful-degrade contract as every other optional accessor. `geometry` columns resolve through the existing generic numeric sort/filter machinery, so they can be sorted and filtered (`gt`/`lt`/etc.) exactly like any other numeric column.

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -141,6 +141,7 @@ const COMMON_COLUMNS: CommonColumn[] = [
   { id: 'col-site', source: 'spatial', propertyName: 'Site', label: 'Site' },
   { id: 'col-project', source: 'spatial', propertyName: 'Project', label: 'Project' },
   { id: 'col-model', source: 'model', propertyName: 'Model', label: 'Model' },
+  ...(['X', 'Y', 'Z'] as const).map((axis): CommonColumn => ({ id: `col-world-${axis.toLowerCase()}`, source: 'geometry', propertyName: axis, label: `World ${axis}` })),
 ];
 
 /** Union the per-provider complete-discovery results into one column set. */
@@ -708,11 +709,10 @@ const SOURCE_TAG: Record<ColumnDefinition['source'], string> = {
   spatial: 'storey',
   model: 'model',
   zone: 'zone',
+  geometry: 'world',
 };
 
-/** A `spatial` column's tag reflects its level (storey / building / site /
- *  project); a `zone` column's tag reflects its display mode (zone /
- *  straddles); everything else uses the flat per-source tag. */
+/** `spatial`/`zone` tags reflect level/mode; everything else uses the flat per-source tag. */
 function colSourceTag(col: ColumnDefinition): string {
   if (col.source === 'spatial') return (col.propertyName || 'Storey').toLowerCase();
   if (col.source === 'zone') return (col.propertyName || 'Zone').toLowerCase();

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -43,6 +43,8 @@ import {
 import type { ListDefinition, ListResult, ListDataProvider, ListGrouping } from '@/lib/lists';
 import { mergeResultColumns } from '@/lib/lists/merge-result-columns';
 import { extractProjectUnits, ProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
+import { useRenderFrameOffsets } from '@/hooks/useRenderFrameOffsets';
+import { makeWorldPositionGetter } from '@/lib/geo/entity-world-position';
 import { ListBuilder } from './ListBuilder';
 import { ListResultsTable } from './ListResultsTable';
 
@@ -53,7 +55,8 @@ interface ListPanelProps {
 type PanelView = 'library' | 'builder' | 'results';
 
 export function ListPanel({ onClose }: ListPanelProps) {
-  const { ifcDataStore, models } = useIfc();
+  const { ifcDataStore, models, geometryResult } = useIfc();
+  const renderFrame = useRenderFrameOffsets(); // scene-wide frame for World X/Y/Z (issue #3671)
   const [view, setView] = useState<PanelView>('library');
   const [editingList, setEditingList] = useState<ListDefinition | null>(null);
 
@@ -89,13 +92,8 @@ export function ListPanel({ onClose }: ListPanelProps) {
   const zoneApportionment = useViewerStore((s) => s.zoneApportionment);
   const toGlobalId = useViewerStore((s) => s.toGlobalId);
 
-  // Build the {modelId, provider} pairs in a single pass so the two
-  // arrays can never drift out of alignment (skipping a model without
-  // an ifcDataStore must not shift every later model's provider index).
-  // Declared VOLUMEUNIT scale per model, for the zone volume columns (#2508).
-  // Memoized on the MODELS alone: the zone context below is rebuilt whenever
-  // zones or assignments change, and re-extracting a model's unit assignment on
-  // every geometry tick would be real work for a value that cannot have moved.
+  // Declared VOLUMEUNIT scale per model (#2508), memoized on MODELS alone so
+  // zone/assignment changes don't re-derive a value that cannot have moved.
   const volumeScaleByModelId = useMemo(() => {
     const map = new Map<string, number>();
     const scaleOf = (store: IfcDataStore) => (store.source.length > 0
@@ -112,18 +110,19 @@ export function ListPanel({ onClose }: ListPanelProps) {
     return map;
   }, [models, ifcDataStore]);
 
+  // {modelId, provider} pairs, built in one pass so the two arrays can never
+  // drift out of alignment.
   const modelProviderPairs = useMemo(() => {
     const pairs: Array<{ modelId: string; provider: ListDataProvider; store: IfcDataStore }> = [];
     if (models.size > 0) {
       for (const [modelId, model] of models) {
-        // Skip native-metadata models — they don't have a parsed
-        // IfcDataStore, so the list provider can't query them.
-        if (!model.ifcDataStore) continue;
+        if (!model.ifcDataStore) continue; // native-metadata model, nothing to query
         const zoneContext = {
           zoneSets, zoneAssignments,
           apportionment: zoneApportionment,
           volumeSiScale: volumeScaleByModelId.get(modelId) ?? 1,
           toGlobalId: (expressId: number) => toGlobalId(modelId, expressId),
+          getWorldPosition: makeWorldPositionGetter(model.ifcDataStore, model.geometryResult ?? geometryResult, renderFrame, (id) => toGlobalId(modelId, id)),
         };
         pairs.push({ modelId, provider: createListDataProvider(model.ifcDataStore, model.name, zoneContext), store: model.ifcDataStore });
       }
@@ -133,11 +132,12 @@ export function ListPanel({ onClose }: ListPanelProps) {
         apportionment: zoneApportionment,
         volumeSiScale: volumeScaleByModelId.get('default') ?? 1,
         toGlobalId: (expressId: number) => toGlobalId('default', expressId),
+        getWorldPosition: makeWorldPositionGetter(ifcDataStore, geometryResult, renderFrame, (id) => toGlobalId('default', id)),
       };
       pairs.push({ modelId: 'default', provider: createListDataProvider(ifcDataStore, '', zoneContext), store: ifcDataStore });
     }
     return pairs;
-  }, [models, ifcDataStore, zoneSets, zoneAssignments, zoneApportionment, volumeScaleByModelId, toGlobalId]);
+  }, [models, ifcDataStore, geometryResult, renderFrame, zoneSets, zoneAssignments, zoneApportionment, volumeScaleByModelId, toGlobalId]);
 
   const allProviders = useMemo(() => modelProviderPairs.map((p) => p.provider), [modelProviderPairs]);
   const allStores = useMemo(() => modelProviderPairs.map((p) => p.store), [modelProviderPairs]);

--- a/apps/viewer/src/lib/geo/entity-world-position.test.ts
+++ b/apps/viewer/src/lib/geo/entity-world-position.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { GeometryResult } from '@ifc-lite/geometry';
+import type { RenderFrameOffsets } from '../../components/viewer/tools/measure-modes/coordinates.js';
+import { computeEntityLocalCenter, computeEntityWorldCenterZup } from './entity-world-position.js';
+
+/** Minimal synthetic GeometryResult with one mesh's positions given as an
+ *  explicit vertex list so the bounding box is easy to hand-verify. */
+function fixture(expressId: number, verts: Array<[number, number, number]>, origin?: [number, number, number]): GeometryResult {
+  const positions = new Float32Array(verts.flat());
+  return {
+    meshes: [{
+      expressId,
+      positions,
+      origin,
+    } as GeometryResult['meshes'][number]],
+    totalTriangles: 0,
+    totalVertices: verts.length,
+    coordinateInfo: {
+      originShift: { x: 0, y: 0, z: 0 },
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      hasLargeCoordinates: false,
+    },
+  };
+}
+
+describe('computeEntityLocalCenter', () => {
+  it('returns the bounding-box center of the matching mesh (Y-up, renderer frame)', () => {
+    // Vertices span [0,2] x [0,4] x [0,6] -> center (1,2,3).
+    const geo = fixture(5, [[0, 0, 0], [2, 0, 0], [0, 4, 0], [0, 0, 6]]);
+    assert.deepEqual(computeEntityLocalCenter(geo, 5), { x: 1, y: 2, z: 3 });
+  });
+
+  it('folds the per-mesh origin into the bounding box', () => {
+    // Same vertex spread, but origin shifts everything by (10, 20, 30):
+    // bbox becomes [10,12] x [20,24] x [30,36] -> center (11, 22, 33).
+    const geo = fixture(5, [[0, 0, 0], [2, 0, 0], [0, 4, 0], [0, 0, 6]], [10, 20, 30]);
+    assert.deepEqual(computeEntityLocalCenter(geo, 5), { x: 11, y: 22, z: 33 });
+  });
+
+  it('returns null when no mesh matches the target expressId', () => {
+    const geo = fixture(5, [[0, 0, 0], [2, 2, 2]]);
+    assert.equal(computeEntityLocalCenter(geo, 999), null);
+  });
+
+  it('returns null when the geometry result has no meshes', () => {
+    const geo: GeometryResult = { ...fixture(5, [[0, 0, 0]]), meshes: [] };
+    assert.equal(computeEntityLocalCenter(geo, 5), null);
+  });
+
+  it('returns null for a null/undefined geometry result', () => {
+    assert.equal(computeEntityLocalCenter(null, 5), null);
+    assert.equal(computeEntityLocalCenter(undefined, 5), null);
+  });
+});
+
+describe('computeEntityWorldCenterZup', () => {
+  it('with no RTC offset and no origin shift, returns the local bbox center, Z-up-flipped (un-georeferenced model)', () => {
+    // Local (Y-up) center (1, 2, 3); no frame shift applied.
+    // viewerToIfcAxes: {x: p.x, y: -p.z, z: p.y} => {x: 1, y: -3, z: 2}.
+    const geo = fixture(5, [[0, 0, 0], [2, 0, 0], [0, 4, 0], [0, 0, 6]]);
+    const frame: RenderFrameOffsets = {};
+    assert.deepEqual(computeEntityWorldCenterZup(geo, 5, frame), { x: 1, y: -3, z: 2 });
+  });
+
+  it('applies a non-trivial RTC offset + origin shift with the correct axis remap', () => {
+    // Local (Y-up) center: vertices span [9,11] x [19,21] x [29,31] -> (10, 20, 30).
+    const geo = fixture(5, [[9, 19, 29], [11, 21, 31]]);
+    // originShift is recorded in renderer (Y-up) axes.
+    // wasmRtcOffsetIfc is recorded in IFC (Z-up) axes: {x:100, y:200, z:300}.
+    // Converted to renderer axes: ifcToViewerAxes -> {x:100, y:300, z:-200}.
+    // worldYup = local + shift + rtcViewer
+    //          = (10+1+100, 20+2+300, 30+3-200) = (111, 322, -167).
+    // viewerToIfcAxes(worldYup) = {x:111, y: -(-167)=167, z:322}.
+    const frame: RenderFrameOffsets = {
+      originShift: { x: 1, y: 2, z: 3 },
+      wasmRtcOffsetIfc: { x: 100, y: 200, z: 300 },
+    };
+    assert.deepEqual(computeEntityWorldCenterZup(geo, 5, frame), { x: 111, y: 167, z: 322 });
+  });
+
+  it('returns null when the element has no matching mesh (not decoded / no geometry)', () => {
+    const geo = fixture(5, [[0, 0, 0], [2, 2, 2]]);
+    const frame: RenderFrameOffsets = { originShift: { x: 1, y: 1, z: 1 } };
+    assert.equal(computeEntityWorldCenterZup(geo, 999, frame), null);
+  });
+});

--- a/apps/viewer/src/lib/geo/entity-world-position.ts
+++ b/apps/viewer/src/lib/geo/entity-world-position.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared entity World-Coordinate math (IFC Z-up, project space — NOT
+ * map/WGS84). Single source of truth for both the Properties panel's
+ * coordinate readout and the Lists "World X/Y/Z" columns (issue #3671), so
+ * the two features can never disagree about what "World Coordinate" means
+ * for the same element.
+ *
+ * The frame reconstruction itself (RTC offset + origin shift, axis
+ * conversion) already has one shared implementation —
+ * `resolveRenderFrame`/`useRenderFrameOffsets` and `renderToWorldViewer`/
+ * `viewerToIfcAxes` in `measure-modes/coordinates.ts`, which the Properties
+ * panel and the Measure tool's picked-point readout both route through. This
+ * module does not re-derive that: it only adds the piece those don't cover —
+ * finding an ENTITY's local-frame bounding-box center from its meshes — then
+ * hands the result through the existing frame functions.
+ */
+
+import type { GeometryResult } from '@ifc-lite/geometry';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { Point3 } from '@/components/viewer/tools/measure-modes/components';
+import { renderToWorldViewer, viewerToIfcAxes, type RenderFrameOffsets } from '@/components/viewer/tools/measure-modes/coordinates';
+import { getIfcLengthUnitScale } from './effective-georef.js';
+
+export type Vec3 = Point3;
+
+/**
+ * Bounding-box CENTER of `targetExpressId`'s meshes in `geoResult`, in the
+ * render (local scene, Y-up) frame — the frame `scene.getEntityBoundingBox`
+ * and `renderToWorldViewer` both work in. Returns `null` when the geometry
+ * result has no meshes matching `targetExpressId` (not decoded / not yet
+ * loaded / element has no geometry) — callers MUST treat this as
+ * "unavailable", not as the origin.
+ */
+export function computeEntityLocalCenter(
+  geoResult: GeometryResult | null | undefined,
+  targetExpressId: number,
+): Vec3 | null {
+  if (!geoResult?.meshes?.length) return null;
+
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  let found = false;
+
+  for (const mesh of geoResult.meshes) {
+    if (mesh.expressId !== targetExpressId) continue;
+    found = true;
+    const pos = mesh.positions;
+    const o = mesh.origin;
+    const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+    for (let i = 0; i < pos.length; i += 3) {
+      const x = pos[i] + ox, y = pos[i + 1] + oy, z = pos[i + 2] + oz;
+      if (x < minX) minX = x;
+      if (y < minY) minY = y;
+      if (z < minZ) minZ = z;
+      if (x > maxX) maxX = x;
+      if (y > maxY) maxY = y;
+      if (z > maxZ) maxZ = z;
+    }
+  }
+
+  if (!found) return null;
+
+  return { x: (minX + maxX) / 2, y: (minY + maxY) / 2, z: (minZ + maxZ) / 2 };
+}
+
+/**
+ * World Coordinate (IFC Z-up, project space) of `targetExpressId`'s
+ * bounding-box center: the local-frame center with `frame`'s render-frame
+ * shift (RTC offset + origin shift, see `renderToWorldViewer`) added back,
+ * then converted from renderer (Y-up) to IFC (Z-up) axes. `null` when the
+ * element has no matching mesh in `geoResult` (not decoded yet, or has no
+ * geometry) — never a misleading fallback to the origin.
+ */
+export function computeEntityWorldCenterZup(
+  geoResult: GeometryResult | null | undefined,
+  targetExpressId: number,
+  frame: RenderFrameOffsets,
+): Vec3 | null {
+  const localCenter = computeEntityLocalCenter(geoResult, targetExpressId);
+  if (!localCenter) return null;
+  const worldCenterYup = renderToWorldViewer(localCenter, frame);
+  return viewerToIfcAxes(worldCenterYup);
+}
+
+/**
+ * Build the Lists `getWorldPosition` accessor for one model (issue #3671):
+ * resolves the entity's World Coordinate through the shared scene-wide
+ * render frame, then converts the geometry pipeline's SI metres back into
+ * the model's own declared length unit — the shared per-column unit
+ * resolver (routed to via the `QuantityType.Length` tag) expects a raw cell
+ * already in the model's own unit, exactly like a real `IfcQuantityLength`.
+ * `toGlobalId` maps a local express id to `geoResult.meshes`' id space.
+ */
+export function makeWorldPositionGetter(
+  store: IfcDataStore,
+  geoResult: GeometryResult | null | undefined,
+  frame: RenderFrameOffsets,
+  toGlobalId: (expressId: number) => number,
+): (expressId: number) => Vec3 | null {
+  const lengthScale = getIfcLengthUnitScale(store);
+  return (expressId) => {
+    const centerZup = computeEntityWorldCenterZup(geoResult, toGlobalId(expressId), frame);
+    if (!centerZup) return null;
+    if (!(lengthScale > 0)) return centerZup; // defensive: never divide by 0/NaN
+    return { x: centerZup.x / lengthScale, y: centerZup.y / lengthScale, z: centerZup.z / lengthScale };
+  };
+}

--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -31,12 +31,10 @@ import type { ZoneSet, ZoneAssignmentsByElement, ZoneApportionmentCache } from '
 import { validEntry } from '../zones/index.js';
 
 /**
- * Zone assignment data (issue #1810), threaded in from the store so the
- * `zone` column/condition source can resolve without the adapter knowing
- * anything about how zones are authored. `toGlobalId` converts THIS model's
- * local express id to the federated global id `zoneAssignments` is keyed by
- * (single-model fallback: `globalId === expressId`, same contract as
- * `FederationRegistry`).
+ * Per-model list context: zone data (issue #1810) plus later loosely-related
+ * extras (volume units, World Coordinates — issue #3671) threaded the same
+ * way. `toGlobalId` maps THIS model's local express id to the federated
+ * global id these are keyed by (single-model fallback: identity).
  */
 export interface ZoneListContext {
   zoneSets: ZoneSet[];
@@ -53,6 +51,8 @@ export interface ZoneListContext {
    *  the model's own `NetVolume` is in, so the shared per-column resolver
    *  converts and labels it identically instead of needing a second path. */
   volumeSiScale?: number;
+  /** World Coordinate in the model's own unit (issue #3671). */
+  getWorldPosition?: (expressId: number) => { x: number; y: number; z: number } | null;
   toGlobalId: (expressId: number) => number;
 }
 
@@ -79,10 +79,9 @@ function materialNamesOf(info: MaterialInfo | null): string[] {
  * several models can tell which file each row came from. Defaults to '' for the
  * single-model legacy path where there's nothing to disambiguate.
  *
- * `zoneContext`, when supplied, enables the `zone` column/condition source
- * (issue #1810). Omit it (the default) and every `zone` column simply
- * resolves to `null` — the same graceful-degradation contract every other
- * optional `ListDataProvider` accessor follows.
+ * `zoneContext`, when supplied, enables the `zone`/`geometry` column sources
+ * (issues #1810, #3671); omitted fields resolve to `null`, same as every
+ * other optional `ListDataProvider` accessor.
  */
 export function createListDataProvider(
   store: IfcDataStore,
@@ -298,6 +297,7 @@ export function createListDataProvider(
     getModelName(): string {
       return modelName;
     },
+    getWorldPosition: (id) => zoneContext?.getWorldPosition?.(id) ?? null,
 
     discoverAllColumns(): DiscoveredColumns {
       if (columnsCache) return columnsCache;

--- a/apps/viewer/src/lib/lists/adapter.world-position.test.ts
+++ b/apps/viewer/src/lib/lists/adapter.world-position.test.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `createListDataProvider`'s `zoneContext.getWorldPosition` (issue #3671)
+ * threads through unchanged — the adapter itself has no geometry knowledge,
+ * it just forwards the raw local expressId to whatever closure the caller
+ * (ListPanel) built.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser } from '@ifc-lite/parser';
+import { createListDataProvider } from './adapter.js';
+
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('Wall000000000000000001A',$,'Wall-A',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('createListDataProvider zoneContext.getWorldPosition (#3671)', () => {
+  it('calls through to zoneContext.getWorldPosition with the raw expressId', async () => {
+    const bytes = new TextEncoder().encode(FIXTURE);
+    const store = await new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+
+    const calls: number[] = [];
+    const provider = createListDataProvider(store, '', {
+      zoneSets: [],
+      zoneAssignments: new Map(),
+      toGlobalId: (id) => id,
+      getWorldPosition: (expressId) => {
+        calls.push(expressId);
+        return { x: 1, y: 2, z: 3 };
+      },
+    });
+
+    assert.deepEqual(provider.getWorldPosition?.(2), { x: 1, y: 2, z: 3 });
+    assert.deepEqual(calls, [2]);
+  });
+
+  it('omitting zoneContext (or its getWorldPosition) resolves to null, not a throw', async () => {
+    const bytes = new TextEncoder().encode(FIXTURE);
+    const store = await new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+
+    // No zoneContext at all — the pre-existing 1-arg call shape
+    // (server-type-parity.test.ts's usage) still compiles/works unchanged.
+    const provider = createListDataProvider(store);
+    assert.equal(provider.getWorldPosition?.(2), null);
+
+    // zoneContext present, but no getWorldPosition on it.
+    const provider2 = createListDataProvider(store, 'model-name', {
+      zoneSets: [],
+      zoneAssignments: new Map(),
+      toGlobalId: (id) => id,
+    });
+    assert.equal(provider2.getWorldPosition?.(2), null);
+  });
+});

--- a/packages/lists/src/engine.geometry.test.ts
+++ b/packages/lists/src/engine.geometry.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * World Coordinate column/condition support (issue #3671) — "Reporting
+ * World Coordinates in Lists". The `geometry` source resolves to one axis of
+ * the element's fully-composed PROJECT-space placement (the resolved
+ * `IfcLocalPlacement` chain), NOT the map/WGS84 georeferenced frame — that
+ * distinction is enforced by the viewer-side `getWorldPosition` provider
+ * hook, not tested here; this only exercises the engine's resolution of
+ * whatever `{x,y,z}` the provider reports.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcTypeEnum, QuantityType } from '@ifc-lite/data';
+import { executeList } from './engine.js';
+import type { ListDataProvider, ListDefinition } from './types.js';
+
+type Pos = { x: number; y: number; z: number };
+
+function createProvider(positions: Map<number, Pos>): ListDataProvider {
+  return {
+    getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1, 2, 3] : []),
+    getEntityName: (id) => `Wall-${id}`,
+    getEntityGlobalId: (id) => `guid-${id}`,
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getEntityTypeName: () => 'IfcWall',
+    getPropertySets: () => [],
+    getQuantitySets: () => [],
+    getWorldPosition: (id) => positions.get(id) ?? null,
+  };
+}
+
+function walls(columns: ListDefinition['columns'], conditions: ListDefinition['conditions'] = []): ListDefinition {
+  return { id: 't', name: 'T', createdAt: 0, updatedAt: 0, entityTypes: [IfcTypeEnum.IfcWall], conditions, columns };
+}
+
+describe('geometry (World Coordinate) column/condition (#3671)', () => {
+  const positions = new Map<number, Pos>([
+    [1, { x: 100.5, y: -25.25, z: 3.1 }],
+    [2, { x: -500, y: 12000, z: -7.5 }],
+    [3, { x: 0, y: 0, z: 0 }],
+  ]);
+
+  it('resolves the X axis by default', () => {
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'X' }]), createProvider(positions));
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(100.5);
+  });
+
+  it('resolves the Y axis', () => {
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'Y' }]), createProvider(positions));
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(-25.25);
+  });
+
+  it('resolves the Z axis', () => {
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'Z' }]), createProvider(positions));
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(3.1);
+  });
+
+  it('matches the axis case-insensitively', () => {
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'y' }]), createProvider(positions));
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(-25.25);
+  });
+
+  it('tags the column as a Length quantity so the unit resolver converts it', () => {
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'X' }]), createProvider(positions));
+    expect(result.columns[0]!.quantityType).toBe(QuantityType.Length);
+  });
+
+  it('a provider with no getWorldPosition resolves every geometry column to null (backward compatible)', () => {
+    const provider: ListDataProvider = {
+      getEntitiesByType: (t) => (t === IfcTypeEnum.IfcWall ? [1] : []),
+      getEntityName: () => 'Wall-1',
+      getEntityGlobalId: () => 'guid-1',
+      getEntityDescription: () => '',
+      getEntityObjectType: () => '',
+      getEntityTag: () => '',
+      getEntityTypeName: () => 'IfcWall',
+      getPropertySets: () => [],
+      getQuantitySets: () => [],
+    };
+    expect(provider.getWorldPosition).toBeUndefined();
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'X' }]), provider);
+    expect(result.rows.every(r => r.values[0] === null)).toBe(true);
+    // No value ever resolved -> the column carries no derived quantityType.
+    expect(result.columns[0]!.quantityType).toBeUndefined();
+  });
+
+  it('sorts a geometry column numerically ascending, mixed signs included', () => {
+    const def = walls([{ id: 'g', source: 'geometry', propertyName: 'X' }]);
+    def.sortBy = { columnId: 'g', direction: 'asc' };
+    const result = executeList(def, createProvider(positions));
+    // x values: 1 -> 100.5, 2 -> -500, 3 -> 0
+    expect(result.rows.map(r => r.entityId)).toEqual([2, 3, 1]);
+  });
+
+  it('sorts a geometry column numerically descending', () => {
+    const def = walls([{ id: 'g', source: 'geometry', propertyName: 'X' }]);
+    def.sortBy = { columnId: 'g', direction: 'desc' };
+    const result = executeList(def, createProvider(positions));
+    expect(result.rows.map(r => r.entityId)).toEqual([1, 3, 2]);
+  });
+
+  it('filters rows via a geometry gt condition', () => {
+    const result = executeList(
+      walls([{ id: 'g', source: 'geometry', propertyName: 'X' }], [
+        { source: 'geometry', propertyName: 'X', operator: 'gt', value: 50 },
+      ]),
+      createProvider(positions),
+    );
+    expect(result.rows.map(r => r.entityId)).toEqual([1]);
+  });
+
+  it('filters rows via a geometry lt condition', () => {
+    const result = executeList(
+      walls([{ id: 'g', source: 'geometry', propertyName: 'X' }], [
+        { source: 'geometry', propertyName: 'X', operator: 'lt', value: 0 },
+      ]),
+      createProvider(positions),
+    );
+    expect(result.rows.map(r => r.entityId)).toEqual([2]);
+  });
+});

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -12,6 +12,7 @@
 import type { PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
 import { isWhollyNumeric, parsePropertyValue } from '@ifc-lite/encoding';
 import { compileNameMatcher } from './name-pattern.js';
+import { getWorldCoordinateValue, extractGeometryColumnValue } from './geometry-column.js';
 import type {
   ListDataProvider,
   ListDefinition,
@@ -372,12 +373,12 @@ function getConditionValue(
       return getPropertyValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
     case 'quantity':
       return getQuantityValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
-    case 'spatial':
-      return getSpatialValue(entityId, condition.propertyName, provider);
-    case 'model':
-      return provider.getModelName?.() || null;
+    case 'spatial': return getSpatialValue(entityId, condition.propertyName, provider);
+    case 'model': return provider.getModelName?.() || null;
     case 'zone':
       return getZoneValue(entityId, condition.psetName ?? '', condition.propertyName, provider);
+    case 'geometry':
+      return getWorldCoordinateValue(entityId, condition.propertyName, provider);
     default:
       return null;
   }
@@ -594,17 +595,16 @@ function extractColumnValues(
         values[i] = codes.length > 0 ? uniqueJoin(codes) : null;
         break;
       }
-      case 'spatial':
-        values[i] = getSpatialValue(entityId, col.propertyName, provider);
-        break;
-      case 'model':
-        values[i] = provider.getModelName?.() || null;
-        break;
+      case 'spatial': values[i] = getSpatialValue(entityId, col.propertyName, provider); break;
+      case 'model': values[i] = provider.getModelName?.() || null; break;
       case 'zone':
         values[i] = getZoneValue(entityId, col.psetName ?? '', col.propertyName, provider);
         if (isZoneVolumeMode(col.propertyName) && columnMeta[i].quantityType === undefined) {
           columnMeta[i].quantityType = VOLUME_QUANTITY_TYPE;
         }
+        break;
+      case 'geometry':
+        values[i] = extractGeometryColumnValue(entityId, col.propertyName, provider, columnMeta[i]);
         break;
       default:
         values[i] = null;

--- a/packages/lists/src/geometry-column.ts
+++ b/packages/lists/src/geometry-column.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `geometry` column/condition source (issue #3671): the element's World
+ * Coordinate (project-space placement, IFC Z-up, project length unit) — see
+ * `ListDataProvider.getWorldPosition` in `types.ts` for the exact contract.
+ * Split out of `engine.ts` to keep that file under its module-size budget.
+ */
+
+import { QuantityType } from '@ifc-lite/data';
+import type { CellValue, ListDataProvider } from './types.js';
+
+/** The `quantityType` tag a resolved geometry value carries, so the shared
+ *  per-column unit resolver treats a World X/Y/Z cell exactly like a Length
+ *  quantity column, no dedicated unit-kind code needed downstream. */
+const WORLD_COORDINATE_QUANTITY_TYPE = QuantityType.Length;
+
+/** Resolve a `geometry` column/condition to one axis of the element's World
+ *  Coordinate. `axis` is matched case-insensitively (`X` default). */
+export function getWorldCoordinateValue(
+  entityId: number,
+  axis: string,
+  provider: ListDataProvider,
+): CellValue {
+  const pos = provider.getWorldPosition?.(entityId);
+  if (!pos) return null;
+  switch (axis.toUpperCase()) {
+    case 'Y': return pos.y;
+    case 'Z': return pos.z;
+    case 'X':
+    default: return pos.x;
+  }
+}
+
+/** `extractColumnValues`'s `geometry` case: resolves the cell AND tags
+ *  `meta.quantityType` (once, from the first non-null value) in one call. */
+export function extractGeometryColumnValue(
+  entityId: number,
+  axis: string,
+  provider: ListDataProvider,
+  meta: { quantityType?: number },
+): CellValue {
+  const val = getWorldCoordinateValue(entityId, axis, provider);
+  if (val !== null && meta.quantityType === undefined) meta.quantityType = WORLD_COORDINATE_QUANTITY_TYPE;
+  return val;
+}

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -162,6 +162,7 @@ export interface ListDataProvider {
     homeValue: number | null;
     shares: Array<{ zoneName: string; value: number }>;
   } | null;
+  getWorldPosition?(expressId: number): { x: number; y: number; z: number } | null; // World Coordinate, PROJECT-space not map/WGS84 (#3671)
 }
 
 /** A classification reference exposed to the list engine (code + name). */
@@ -253,9 +254,9 @@ export interface PropertyCondition {
    * - `zone` — a location-zone assignment (issue #1810); `psetName` holds the
    *   zone-SET id, `propertyName` selects `Zone` (default, the zone name —
    *   or the straddled zones joined when the element crosses a boundary) or
-   *   `Straddles` (boolean)
+   *   `Straddles` (boolean); `geometry` is the World Coordinate (#3671) — `propertyName` selects axis `X` (default) | `Y` | `Z`
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone';
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone' | 'geometry';
   /** Property set name (for property/quantity sources); the zone-SET id for `zone`. */
   psetName?: string;
   /** Attribute / property / quantity name, the spatial level for `spatial`
@@ -287,12 +288,11 @@ export interface ColumnDefinition {
    * Where the column value comes from. `material` / `classification` are
    * multi-valued (joined with ", "); `spatial` is a spatial-container name at
    * the level named by `propertyName` (`Container` | `Storey` (default) |
-   * `Building` | `Site` | `Project`); `model` is the source model / file name
-   * (federation identity); `zone` is a location-zone assignment (issue
-   * #1810) — see `PropertyCondition.source` for the exact `psetName`/
-   * `propertyName` contract, shared verbatim between conditions and columns.
+   * `Building` | `Site` | `Project`); `model`/`zone`/`geometry` — see
+   * `PropertyCondition.source` for the exact `psetName`/`propertyName`
+   * contract, shared verbatim between conditions and columns.
    */
-  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone';
+  source: 'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone' | 'geometry';
   /** For property: pset name. For quantity: qset name. For zone: the zone-SET id. */
   psetName?: string;
   /** Attribute / property / quantity name, the spatial level for `spatial`


### PR DESCRIPTION
## Summary

Closes #3671

Adds a `geometry` column/condition source to the Lists engine so a user can add World X / World Y / World Z columns to a list, sort by them, and immediately find elements far from the project origin — exactly like sorting an Area or Volume column today.

### Reading of the issue

The issue's screenshot and wording ("show in a list the World Coordinates values of every single object... X,Y,Z should be separate numerical properties") match how Revit/Solibri-style schedules report "World Coordinates": the fully composed **project-space** placement (the resolved `IfcLocalPlacement` chain — parent × local, IFC Z-up axes, project length unit), not the map/WGS84 georeferenced frame (`IfcMapConversion`/`IfcProjectedCRS`). Those are a separate, unrelated concern in this codebase (`getEffectiveGeoreference` and friends) and are not touched here.

### Frame and provenance

The value is resolved through the viewer's existing shared render-frame resolver — `useRenderFrameOffsets()` / `resolveRenderFrame()` in `apps/viewer/src/hooks/useRenderFrameOffsets.ts` — the same one the Properties panel's coordinate readout and the Measure tool's picked-point readout already use (`renderToWorldViewer`/`viewerToIfcAxes` in `apps/viewer/src/components/viewer/tools/measure-modes/coordinates.ts`). Reusing it means all three surfaces can never disagree about where an element actually is. A new pure helper, `apps/viewer/src/lib/geo/entity-world-position.ts`, adds only the piece that resolver doesn't already provide — finding an entity's local-frame mesh bounding-box center — then hands it through the existing frame functions.

An **un-georeferenced model** still reports sensible local coordinates (no RTC offset applied — never a misleading fallback to null or the origin); this is exercised directly in `entity-world-position.test.ts`.

The geometry pipeline scales all mesh vertices to SI metres regardless of the file's declared `LENGTHUNIT`; `getIfcLengthUnitScale` converts back to the model's own declared unit before the value reaches the list engine, so it composes with the existing `list-column-units.ts` unit-display/override machinery unmodified — the column is simply tagged `quantityType: QuantityType.Length`, exactly like a real `IfcQuantityLength` quantity, and gets sorting, filtering (`gt`/`lt`/etc.), and per-column unit conversion "for free" from existing engine code.

### What's new

- `packages/lists/src/types.ts`: `geometry` added to `ColumnDefinition`/`PropertyCondition.source`; `ListDataProvider.getWorldPosition?(expressId)` (optional, same graceful-degrade contract as every other accessor).
- `packages/lists/src/geometry-column.ts` (new): axis resolution + quantity-type tagging, split out of `engine.ts` to stay under its module-size budget.
- `packages/lists/src/engine.ts`: wires the `geometry` source into both column extraction and condition filtering.
- `apps/viewer/src/lib/geo/entity-world-position.ts` (new): `computeEntityWorldCenterZup`/`makeWorldPositionGetter`, reusing the existing shared render-frame math.
- `apps/viewer/src/lib/lists/adapter.ts`: `ZoneListContext` gains an optional `getWorldPosition` (bundled the same way `volumeSiScale`/`apportionment` already are).
- `apps/viewer/src/components/viewer/lists/ListPanel.tsx`: builds the per-model `getWorldPosition` closure from `useRenderFrameOffsets()`.
- `apps/viewer/src/components/viewer/lists/ListBuilder.tsx`: adds World X/Y/Z to the column quick-add picker.
- Changeset for `@ifc-lite/lists` (minor — new optional, backward-compatible API).

## Test plan

- [x] `pnpm --filter @ifc-lite/lists exec tsc --noEmit` — clean
- [x] `pnpm --filter @ifc-lite/viewer exec tsc --noEmit` — clean
- [x] `pnpm --filter @ifc-lite/lists test -- run` — 245/245 passed (incl. new `engine.geometry.test.ts`: axis resolution, case-insensitive axis, Length quantity-type tagging, backward compatibility with no `getWorldPosition`, numeric sort asc/desc, `gt`/`lt` condition filtering)
- [x] Viewer list/geo test files (`entity-world-position.test.ts`, `adapter.world-position.test.ts`, `server-type-parity.test.ts`, `list-table-utils.test.ts`, `list-units-integration.test.ts`, `list-column-units.test.ts`, `listSlice.test.ts`) — 62/62 passed
- [x] `node scripts/check-module-size.mjs` — passes (0 growth violations; two new files stay under the 400-line threshold, no allowlist entries needed)
- [x] `node scripts/check-unused-locals.mjs` — passes for touched packages (pre-existing, unrelated `packages/embed-sdk` standalone-compile failure noted but not caused by this change)
- [x] `node scripts/check-test-wiring.mjs` — passes
- [x] `pnpm run check:vitest-timeout-audit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added World X, World Y, and World Z columns to lists.
  - Lists can now sort and filter elements by project-space world coordinates.
  - Coordinates respect model units and IFC axis conventions.
  - Added support for gracefully handling unavailable coordinate data.

- **Bug Fixes**
  - Improved entity center calculations across meshes, offsets, origins, and missing geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->