### PR TITLE
feat(export): drop empty spatial containers as part of the merge plan

### DIFF
--- a/.changeset/merged-export-drop-empty-containers.md
+++ b/.changeset/merged-export-drop-empty-containers.md
@@ -1,0 +1,8 @@
+---
+'@ifc-lite/export': minor
+'@ifc-lite/cli': minor
+---
+
+Merged export can now drop spatial containers the merge leaves holding nothing — the step of IfcOpenShell/BlenderBIM's "Merge Projects" recipe that container *matching* (`mergeSites` / `mergeBuildings` / `mergeStoreys`) does not cover. `MergedExporter` takes `dropEmptyContainers` (off by default, so existing output is byte-identical) and reports `stats.droppedContainerCount`; the CLI exposes it as `ifc-lite merge … --drop-empty-containers`, and the native merge as `MergedOptions::drop_empty_containers` / `MergedStats::dropped_container_count`.
+
+An `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` / `IfcSpace` counts as empty when it contains no surviving element, directly aggregates no surviving non-spatial object, and transitively aggregates no non-empty spatial child; `IfcProject` is never a candidate. Emptiness is judged on the **merged** model — after visibility filtering and after spatial unification — so a container that only a later model fills is kept. Because the drop happens inside the merge plan rather than as a pass over the assembled bytes, nothing is ever written referencing a dropped container (a relationship that named one is narrowed; one left with no subject goes with it), so no dangling-reference clean-up pass has to follow and a native consumer never has to materialise the merged file to do it.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -783,6 +783,7 @@ The merger unifies spatial hierarchy (sites, buildings, storeys) by name and ele
 | `--merge-sites <mode>` | IfcSite matching across models: `single` (unify iff each model has exactly one site, Name ignored) or `by-name` (Name match only, no single-instance fallback). Omitted: Name match, else single-instance fallback |
 | `--merge-buildings <mode>` | Same modes as `--merge-sites`, applied to IfcBuilding |
 | `--merge-storeys <mode>` | IfcBuildingStorey matching: `by-name`, `by-elevation`, or `by-name-then-elevation` (default) |
+| `--drop-empty-containers` | Leave out spatial containers (site, building, storey, space) the merge finds holding nothing — the "Merge Projects" recipe step matching alone does not cover. Off by default |
 | `--out <file>` | Output file (required) |
 | `--json` | Output merge stats as JSON |
 

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -479,6 +479,42 @@ instance of that container type. `'by-name'` requires a Name match with no
 single-instance fallback. All three fields are optional; omitting one keeps
 the pre-existing combined heuristic for that container type.
 
+#### Dropping empty containers
+
+Matching decides which containers *are the same*; it says nothing about the ones
+that end up holding nothing. `dropEmptyContainers` is the recipe's other step:
+
+```typescript
+import { MergedExporter } from '@ifc-lite/export';
+
+const exporter = new MergedExporter([
+  { id: 'arch', name: 'Architecture', dataStore: store1 },
+  { id: 'struct', name: 'Structure', dataStore: store2 },
+]);
+
+const result = exporter.export({ schema: 'IFC4', dropEmptyContainers: true });
+console.log(result.stats.droppedContainerCount);
+```
+
+An `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` / `IfcSpace` is empty when it
+contains no surviving element (`IfcRelContainedInSpatialStructure`), directly
+aggregates no surviving non-spatial object, and transitively aggregates no
+non-empty spatial child. `IfcProject` is never a candidate. Note this makes a
+room with no element inside it a candidate: spaces are usually contained by a
+storey, not by their own contents.
+
+Emptiness is judged on the **merged** model, after visibility filtering and
+spatial unification — a container that only a later model fills is kept. The
+dropped containers are excluded from the merge plan rather than deleted
+afterwards, so nothing is ever written referencing them: a relationship that
+named one is narrowed, and one left with no subject is dropped with it. A
+dropped container's own placement / representation entities are left behind
+unreferenced (valid STEP, just inert). The flag is off by default, and a merge
+with nothing to drop produces byte-identical output either way.
+
+The CLI exposes the same step as `ifc-lite merge … --drop-empty-containers`, and
+the native (Rust) merge as `MergedOptions::drop_empty_containers`.
+
 `'normalize'` rescales all `IfcCartesianPoint`/`IfcCartesianPointList` coordinates,
 scalar lengths (extrusion depths, profile dimensions, radii, thicknesses, storey
 elevations, `IfcVector.Magnitude`, CSG primitive sizes), `IfcLengthMeasure`

--- a/docs/guide/federation.md
+++ b/docs/guide/federation.md
@@ -129,6 +129,7 @@ containers.
 | `--merge-sites` | `single` / `by-name` | combined heuristic | How `IfcSite` records are matched across models |
 | `--merge-buildings` | `single` / `by-name` | combined heuristic | How `IfcBuilding` records are matched |
 | `--merge-storeys` | `by-name` / `by-elevation` / `by-name-then-elevation` | combined heuristic | How `IfcBuildingStorey` records are matched |
+| `--drop-empty-containers` | flag | off | Leave out sites, buildings, storeys and spaces the merged model leaves holding nothing (the "Merge Projects" recipe step matching alone does not cover) |
 | `--json` | flag | off | Emit machine-readable stats (entity counts, warnings) to stdout |
 
 ## FederatedModel Type

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -70,6 +70,10 @@ export async function mergeCommand(args: string[]): Promise<void> {
     fatal(`--merge-storeys must be one of: ${STOREY_MODES.join(', ')}`);
   }
 
+  // Leave out spatial containers the merge finds holding nothing — the step of
+  // the "Merge Projects" recipe the matching flags above do not cover (#3643).
+  const dropEmptyContainers = hasFlag(args, '--drop-empty-containers');
+
   // Collect all positional args as input files
   const files: string[] = [];
   for (let i = 0; i < args.length; i++) {
@@ -107,6 +111,7 @@ export async function mergeCommand(args: string[]): Promise<void> {
     mergeSites: mergeSitesFlag,
     mergeBuildings: mergeBuildingsFlag,
     mergeStoreys: mergeStoreysFlag,
+    dropEmptyContainers,
   });
 
   await writeFile(outPath, result.content, 'utf-8');
@@ -119,12 +124,16 @@ export async function mergeCommand(args: string[]): Promise<void> {
       fileSize: result.stats.fileSize,
       federatedModelCount: result.stats.federatedModelCount,
       normalizedModelCount: result.stats.normalizedModelCount,
+      droppedContainerCount: result.stats.droppedContainerCount,
       warnings: result.stats.warnings,
     });
   } else {
     process.stderr.write(`Merged ${result.stats.modelCount} models → ${outPath} (${result.stats.totalEntityCount} entities)\n`);
     if (result.stats.normalizedModelCount > 0) {
       process.stderr.write(`Normalized ${result.stats.normalizedModelCount} model(s) into the first file's unit\n`);
+    }
+    if (result.stats.droppedContainerCount > 0) {
+      process.stderr.write(`Dropped ${result.stats.droppedContainerCount} empty spatial container(s)\n`);
     }
     for (const warning of result.stats.warnings) {
       process.stderr.write(`Warning: ${warning}\n`);

--- a/packages/export/src/merged-empty-containers.test.ts
+++ b/packages/export/src/merged-empty-containers.test.ts
@@ -127,6 +127,10 @@ describe('MergedExporter dropEmptyContainers', () => {
     const asked = new MergedExporter(models()).export({ ...OPTIONS, dropEmptyContainers: true });
 
     expect(baseline.stats.droppedContainerCount).toBe(0);
+    // The run that ASKED is the one that could misreport: with the flag absent
+    // the count is 0 by construction, so only this assertion can catch a planner
+    // that claims a drop it did not make.
+    expect(asked.stats.droppedContainerCount).toBe(0);
     // Byte-identical: asking for the drop cannot perturb a merge with nothing
     // to drop (the header is deterministic apart from the timestamp, which both
     // exports take in the same test tick).

--- a/packages/export/src/merged-empty-containers.test.ts
+++ b/packages/export/src/merged-empty-containers.test.ts
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `dropEmptyContainers` (#3643): the "Merge Projects" recipe step that container
+ * MATCHING (`mergeSites` / `mergeBuildings` / `mergeStoreys`) leaves behind.
+ *
+ * Asserted through the public `MergedExporter`, on the emitted STEP text: a
+ * container that ends up holding nothing is not written, nothing that survives
+ * still names it, and a container only a later model fills is kept.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { MergedExporter, type MergeModelInput } from './merged-exporter.js';
+import { asSourceBytes, type IfcDataStore } from '@ifc-lite/parser';
+
+type MockEntityRef = { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number };
+type MockDataStore = Omit<IfcDataStore, 'entityIndex'> & {
+  entityIndex: { byId: Map<number, MockEntityRef>; byType: Map<string, number[]> };
+};
+type MockMergeModelInput = Omit<MergeModelInput, 'dataStore'> & { dataStore: MockDataStore };
+
+/** Build a minimal IfcDataStore from `[expressId, type, stepText]` lines. */
+function buildModel(id: string, entries: Array<[number, string, string]>): MockMergeModelInput {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const byId = new Map<number, MockEntityRef>();
+  const byType = new Map<string, number[]>();
+  let offset = 0;
+  for (const [expressId, type, text] of entries) {
+    const encoded = encoder.encode(text);
+    const upper = type.toUpperCase();
+    byId.set(expressId, { expressId, type: upper, byteOffset: offset, byteLength: encoded.byteLength, lineNumber: 0 });
+    if (!byType.has(upper)) byType.set(upper, []);
+    byType.get(upper)!.push(expressId);
+    parts.push(encoded);
+    offset += encoded.byteLength;
+  }
+  const source = new Uint8Array(offset);
+  let pos = 0;
+  for (const part of parts) {
+    source.set(part, pos);
+    pos += part.byteLength;
+  }
+  const dataStore = {
+    fileSize: offset,
+    schemaVersion: 'IFC4',
+    entityCount: entries.length,
+    parseTime: 0,
+    source: asSourceBytes(source),
+    entityIndex: { byId, byType },
+  } as unknown as MockDataStore;
+  return { id, name: id, dataStore };
+}
+
+const decode = (bytes: Uint8Array) => new TextDecoder().decode(bytes);
+
+/** A valid 22-char IFC GlobalId from a short, charset-safe label. */
+const guid = (label: string): string => (label + '0'.repeat(22)).slice(0, 22);
+
+/** Every `#N` reference in the output with no `#N=` definition. */
+function danglingRefs(content: string): number[] {
+  const defined = new Set<number>();
+  for (const m of content.matchAll(/(^|\n)#(\d+)=/g)) defined.add(+m[2]);
+  const dangling = new Set<number>();
+  for (const m of content.matchAll(/#(\d+)/g)) {
+    if (!defined.has(+m[1])) dangling.add(+m[1]);
+  }
+  return [...dangling].sort((a, b) => a - b);
+}
+
+/**
+ * Project → Site → Building → two storeys; the wall sits on the storey named by
+ * `wallStorey`, so the other storey holds nothing.
+ */
+function tree(salt: string, wallStorey: 4 | 5): MockMergeModelInput {
+  return buildModel(`m${salt}`, [
+    [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p' + salt)}',$,'P',$,$,$,$,$,$);`],
+    [2, 'IFCSITE', `#2=IFCSITE('${guid('s' + salt)}',$,'Site',$,$,$,$,$,$,$,$,$,$,$);`],
+    [3, 'IFCBUILDING', `#3=IFCBUILDING('${guid('b' + salt)}',$,'Building',$,$,$,$,$,$,$,$,$);`],
+    [4, 'IFCBUILDINGSTOREY', `#4=IFCBUILDINGSTOREY('${guid('g' + salt)}',$,'Level 0',$,$,$,$,$,$,0.);`],
+    [5, 'IFCBUILDINGSTOREY', `#5=IFCBUILDINGSTOREY('${guid('f' + salt)}',$,'Level 1',$,$,$,$,$,$,3.);`],
+    [6, 'IFCWALL', `#6=IFCWALL('${guid('w' + salt)}',$,'Wall',$,$,$,$,$,$);`],
+    [7, 'IFCRELAGGREGATES', `#7=IFCRELAGGREGATES('${guid('a' + salt)}',$,$,$,#1,(#2));`],
+    [8, 'IFCRELAGGREGATES', `#8=IFCRELAGGREGATES('${guid('c' + salt)}',$,$,$,#2,(#3));`],
+    [9, 'IFCRELAGGREGATES', `#9=IFCRELAGGREGATES('${guid('d' + salt)}',$,$,$,#3,(#4,#5));`],
+    [10, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', `#10=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('e' + salt)}',$,$,$,(#6),#${wallStorey});`],
+  ]);
+}
+
+const OPTIONS = { schema: 'IFC4' as const, projectStrategy: 'keep-first' as const };
+
+describe('MergedExporter dropEmptyContainers', () => {
+  it('drops a storey no model fills, and leaves nothing naming it', () => {
+    const merged = new MergedExporter([tree('0', 4), tree('1', 4)] as MergeModelInput[])
+      .export({ ...OPTIONS, dropEmptyContainers: true });
+    const content = decode(merged.content);
+
+    expect(merged.stats.droppedContainerCount).toBe(1);
+    expect(content).not.toContain("'Level 1'");
+    expect(content).toContain("'Level 0'");
+    // Its site and building only hold a storey, and survive on that alone.
+    expect(content).toContain('=IFCSITE(');
+    expect(content).toContain('=IFCBUILDING(');
+    // The aggregation that listed both storeys is narrowed, not withheld.
+    const storeyId = /#(\d+)=IFCBUILDINGSTOREY/.exec(content)![1];
+    expect(content).toContain(`,(#${storeyId}));`);
+    expect(danglingRefs(content)).toEqual([]);
+  });
+
+  it('keeps a container that only a later model fills', () => {
+    // Model A's Level 1 is empty; model B's same-named storey carries the wall
+    // and unifies onto it. Emptiness is a fact about the MERGED model.
+    const merged = new MergedExporter([tree('0', 4), tree('1', 5)] as MergeModelInput[])
+      .export({ ...OPTIONS, dropEmptyContainers: true });
+    const content = decode(merged.content);
+
+    expect(merged.stats.droppedContainerCount).toBe(0);
+    expect(content).toContain("'Level 1'");
+    expect(danglingRefs(content)).toEqual([]);
+  });
+
+  it('is off by default and inert when nothing is empty', () => {
+    const models = () => [tree('0', 4), tree('1', 5)] as MergeModelInput[];
+    const baseline = new MergedExporter(models()).export(OPTIONS);
+    const asked = new MergedExporter(models()).export({ ...OPTIONS, dropEmptyContainers: true });
+
+    expect(baseline.stats.droppedContainerCount).toBe(0);
+    // Byte-identical: asking for the drop cannot perturb a merge with nothing
+    // to drop (the header is deterministic apart from the timestamp, which both
+    // exports take in the same test tick).
+    expect(decode(asked.content).split('DATA;')[1]).toBe(decode(baseline.content).split('DATA;')[1]);
+  });
+
+  it('keeps an empty container a non-relationship entity names', () => {
+    // Nothing can narrow a reference from a non-IfcRel entity, so dropping the
+    // space would leave a dangling `#ref` — it stays instead.
+    const model = buildModel('m0', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p')}',$,'P',$,$,$,$,$,$);`],
+      [2, 'IFCSPACE', `#2=IFCSPACE('${guid('sp')}',$,'Space',$,$,$,$,$,$,$,$);`],
+      [3, 'IFCRELAGGREGATES', `#3=IFCRELAGGREGATES('${guid('a')}',$,$,$,#1,(#2));`],
+      [4, 'IFCPRESENTATIONLAYERASSIGNMENT', '#4=IFCPRESENTATIONLAYERASSIGNMENT(\'L\',$,(#2),$);'],
+    ]);
+    const merged = new MergedExporter([model] as MergeModelInput[])
+      .export({ ...OPTIONS, dropEmptyContainers: true });
+    const content = decode(merged.content);
+
+    expect(merged.stats.droppedContainerCount).toBe(0);
+    expect(content).toContain('=IFCSPACE(');
+    expect(danglingRefs(content)).toEqual([]);
+  });
+
+  it('drops an empty space and the relationships that only named it', () => {
+    const model = buildModel('m0', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('p')}',$,'P',$,$,$,$,$,$);`],
+      [2, 'IFCBUILDINGSTOREY', `#2=IFCBUILDINGSTOREY('${guid('g')}',$,'Level 0',$,$,$,$,$,$,0.);`],
+      [3, 'IFCSPACE', `#3=IFCSPACE('${guid('sp')}',$,'Empty room',$,$,$,$,$,$,$,$);`],
+      [4, 'IFCWALL', `#4=IFCWALL('${guid('w')}',$,'Wall',$,$,$,$,$,$);`],
+      [5, 'IFCRELAGGREGATES', `#5=IFCRELAGGREGATES('${guid('a')}',$,$,$,#1,(#2));`],
+      [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('c')}',$,$,$,#2,(#3));`],
+      [7, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', `#7=IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('e')}',$,$,$,(#4),#2);`],
+      [8, 'IFCPROPERTYSET', `#8=IFCPROPERTYSET('${guid('ps')}',$,'Pset_SpaceCommon',$,());`],
+      [9, 'IFCRELDEFINESBYPROPERTIES', `#9=IFCRELDEFINESBYPROPERTIES('${guid('r')}',$,$,$,(#3),#8);`],
+    ]);
+    const merged = new MergedExporter([model] as MergeModelInput[])
+      .export({ ...OPTIONS, dropEmptyContainers: true });
+    const content = decode(merged.content);
+
+    expect(merged.stats.droppedContainerCount).toBe(1);
+    expect(content).not.toContain('=IFCSPACE(');
+    // The aggregation and the property assignment named only the dropped space,
+    // so both go with it — while the storey that holds the wall stays.
+    expect(content).not.toContain('=IFCRELDEFINESBYPROPERTIES(');
+    expect(content).toContain('=IFCBUILDINGSTOREY(');
+    expect(content).toContain('=IFCWALL(');
+    // The property set itself is left behind, unreferenced but valid.
+    expect(content).toContain('=IFCPROPERTYSET(');
+    expect(danglingRefs(content)).toEqual([]);
+  });
+});

--- a/packages/export/src/merged-empty-containers.ts
+++ b/packages/export/src/merged-empty-containers.ts
@@ -1,0 +1,389 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Empty-spatial-container analysis for the merged exporter (issue #3643) — the
+ * step of IfcOpenShell/BlenderBIM's "Merge Projects" recipe that container
+ * *matching* (`mergeSites` / `mergeBuildings` / `mergeStoreys`) leaves behind.
+ *
+ * An `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` / `IfcSpace` is empty when
+ * it contains no surviving element (`IfcRelContainedInSpatialStructure`),
+ * directly aggregates no surviving non-spatial object, and transitively
+ * aggregates no non-empty spatial child. `IfcProject` is never a candidate.
+ *
+ * Emptiness is a fact about the MERGED model, not about one input: a site that
+ * is empty in its own file is not empty once a later model's storeys are unified
+ * onto it. So this runs across every model — after visibility filtering and
+ * after spatial unification, the two things that make a container empty in the
+ * first place — and yields the express ids the emit loop then never writes.
+ * Nothing is emitted referencing them, so no dangling-reference clean-up pass
+ * has to follow; that is why this belongs inside the merge rather than after it.
+ *
+ * The Rust twin is `rust/export/src/merged/empty.rs`, which the native merged
+ * export (`export_merged_models`) drives from the same rules.
+ */
+
+import type { IfcSourceBytes } from '@ifc-lite/parser';
+import { asSourceBytes } from '@ifc-lite/parser';
+import { splitTopLevelArgs } from './step-argument-parser.js';
+import type { CompleteEntityIndex } from './entity-iteration.js';
+
+/**
+ * Spatial container types dropped when they end up empty. `IfcProject` is
+ * deliberately absent: it is the file's root, never a candidate.
+ */
+const CONTAINER_TYPES = new Set([
+  'IFCSITE',
+  'IFCBUILDING',
+  'IFCBUILDINGSTOREY',
+  'IFCSPACE',
+]);
+
+/**
+ * Relationships that express spatial structure, as
+ * `[relatingAttributeIndex, relatedAttributeIndex]` — `IfcRelAggregates` names
+ * the whole first, the containment relationships name the parts first.
+ */
+const STRUCTURE_RELATIONS: Record<string, [number, number]> = {
+  IFCRELAGGREGATES: [4, 5],
+  IFCRELCONTAINEDINSPATIALSTRUCTURE: [5, 4],
+  IFCRELREFERENCEDINSPATIALSTRUCTURE: [5, 4],
+};
+
+/** One model as the analysis sees it, in the merge's own terms. */
+export interface EmptyContainerModelView {
+  /** Complete entity index (primary + deferred atoms). */
+  entities: CompleteEntityIndex;
+  /** The model's source bytes. */
+  source: IfcSourceBytes;
+  /** Visible express ids, or `null` when the whole model is exported. */
+  included: ReadonlySet<number> | null;
+  /** Local express id → final express id, for containers unified onto an
+   *  earlier model's (the spatial-unification remap). */
+  sharedRemap: ReadonlyMap<number, number>;
+  /** Express-id offset applied to this model in the merged file. */
+  offset: number;
+  /** True when the model unifies into the first model's project / unit space. */
+  compatible: boolean;
+}
+
+/** Which containers the emit loop must not write. */
+export interface EmptyContainerPlan {
+  /** Per input model (same order): local express ids never emitted. */
+  droppedByModel: Set<number>[];
+  /** Containers dropped, counted in the MERGED model (a container unified
+   *  across three inputs counts once). */
+  droppedCount: number;
+}
+
+/** True when `typeUpper` is a droppable spatial container type. */
+function isSpatialContainerType(typeUpper: string): boolean {
+  return CONTAINER_TYPES.has(typeUpper);
+}
+
+/**
+ * A model with nothing to analyse — the placeholder for an input whose source
+ * bytes are missing (a cache-restored, metadata-only store), which the emit loop
+ * skips too. Keeps the caller's per-model arrays aligned with its inputs.
+ */
+export const EMPTY_MODEL_VIEW: EmptyContainerModelView = {
+  entities: new Map(),
+  source: asSourceBytes(new Uint8Array()),
+  included: null,
+  sharedRemap: new Map(),
+  offset: 0,
+  compatible: false,
+};
+
+/**
+ * Plan which spatial containers the merge leaves holding nothing.
+ *
+ * The returned local ids are what the caller withholds from the output; every
+ * surviving line that named one is narrowed (or withheld with it) by
+ * `filterHiddenRefsFromRelationshipLine`, which is what keeps the result free of
+ * dangling references.
+ */
+export function planEmptyContainerDrops(models: EmptyContainerModelView[]): EmptyContainerPlan {
+  const nodes = new Set<number>();
+  const hasContent = new Set<number>();
+  const blocked = new Set<number>();
+  /** Spatial child node → its container nodes (upward edges for the sweep). */
+  const parents = new Map<number, number[]>();
+  const guidNode = new Map<string, number>();
+  const containersByModel: Array<Map<number, number>> = [];
+
+  for (const view of models) {
+    const canon = canonicalContainers(view, guidNode);
+    containersByModel.push(canon);
+    for (const node of canon.values()) nodes.add(node);
+    recordEdges(view, canon, hasContent, parents);
+    recordBlocks(view, canon, blocked);
+  }
+
+  // A container is non-empty when it holds something, is blocked, or has a
+  // non-empty spatial child — the last propagated upward from the first two.
+  // The visited check also makes a self-referential aggregation terminate.
+  const nonEmpty = new Set<number>([...hasContent, ...blocked]);
+  const stack = [...nonEmpty];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    for (const parent of parents.get(node) ?? []) {
+      if (!nonEmpty.has(parent)) {
+        nonEmpty.add(parent);
+        stack.push(parent);
+      }
+    }
+  }
+
+  const dropped = new Set([...nodes].filter(node => !nonEmpty.has(node)));
+  return {
+    droppedByModel: containersByModel.map(canon => {
+      const ids = new Set<number>();
+      for (const [localId, node] of canon) {
+        if (dropped.has(node)) ids.add(localId);
+      }
+      return ids;
+    }),
+    droppedCount: dropped.size,
+  };
+}
+
+/**
+ * Map each of this model's visible containers to its node in the merged model:
+ * the container it was unified onto, the earlier instance that already carries
+ * its GlobalId, or its own final express id. Mirrors the emit loop's
+ * unification order (iteration order, first occurrence wins).
+ */
+function canonicalContainers(
+  view: EmptyContainerModelView,
+  guidNode: Map<string, number>,
+): Map<number, number> {
+  const canon = new Map<number, number>();
+  for (const [localId, ref] of view.entities) {
+    if (view.included !== null && !view.included.has(localId)) continue;
+    if (!isSpatialContainerType(ref.type.toUpperCase())) continue;
+    const unified = view.sharedRemap.get(localId);
+    if (unified !== undefined) {
+      canon.set(localId, unified);
+      continue;
+    }
+    const finalId = localId + view.offset;
+    if (!view.compatible) {
+      canon.set(localId, finalId);
+      continue;
+    }
+    const guid = leadingGuid(lineOf(view, localId));
+    if (guid === null) {
+      canon.set(localId, finalId);
+      continue;
+    }
+    const known = guidNode.get(guid);
+    if (known === undefined) guidNode.set(guid, finalId);
+    canon.set(localId, known ?? finalId);
+  }
+  return canon;
+}
+
+/**
+ * Record what this model contributes to each container: contained elements and
+ * aggregated objects become content; aggregated spatial children become upward
+ * edges, so a non-empty storey keeps its building and its site.
+ */
+function recordEdges(
+  view: EmptyContainerModelView,
+  canon: Map<number, number>,
+  hasContent: Set<number>,
+  parents: Map<number, number[]>,
+): void {
+  if (canon.size === 0) return;
+  for (const [localId, ref] of view.entities) {
+    if (view.included !== null && !view.included.has(localId)) continue;
+    const slots = STRUCTURE_RELATIONS[ref.type.toUpperCase()];
+    if (slots === undefined) continue;
+    const attrs = topLevelAttrs(lineOf(view, localId));
+    if (attrs === null) continue;
+    const [relatingIndex, relatedIndex] = slots;
+    const relating = singleRef(attrs[relatingIndex] ?? '');
+    // Not a container (an IfcProject aggregating its sites, say) — its children
+    // are roots of the spatial tree, with nothing above them to keep.
+    if (relating === null) continue;
+    const parent = canon.get(relating);
+    if (parent === undefined) continue;
+    for (const child of refList(attrs[relatedIndex] ?? '')) {
+      if (view.included !== null && !view.included.has(child)) continue;
+      const childNode = canon.get(child);
+      if (childNode === undefined) {
+        hasContent.add(parent);
+        continue;
+      }
+      const edges = parents.get(childNode);
+      if (edges === undefined) parents.set(childNode, [parent]);
+      else edges.push(parent);
+    }
+  }
+}
+
+/**
+ * Block every container this model names in a way the emit loop could not
+ * rewrite. Dropping such a container would leave a dangling `#ref`, so it stays
+ * (counting as non-empty, which keeps its ancestors too) instead.
+ *
+ * Rewritable is: a reference from an objectified relationship (`IfcRel*`) that
+ * nothing else references, since `filterHiddenRefsFromRelationshipLine` can
+ * strip it from a list or withhold the whole line. Everything else — a
+ * non-relationship referrer, a reference nested inside a typed value, or a
+ * relationship that is itself referenced (withholding it would dangle in turn) —
+ * blocks.
+ */
+function recordBlocks(
+  view: EmptyContainerModelView,
+  canon: Map<number, number>,
+  blocked: Set<number>,
+): void {
+  if (canon.size === 0) return;
+  const referrers: number[] = [];
+  const referencedRelationships = new Set<number>();
+  for (const [localId, ref] of view.entities) {
+    if (view.included !== null && !view.included.has(localId)) continue;
+    let namesContainer = false;
+    for (const target of argRefs(view.source.slice(ref.byteOffset, ref.byteOffset + ref.byteLength))) {
+      if (canon.has(target)) namesContainer = true;
+      const targetType = view.entities.get(target)?.type.toUpperCase();
+      if (targetType?.startsWith('IFCREL')) referencedRelationships.add(target);
+    }
+    if (namesContainer) referrers.push(localId);
+  }
+
+  for (const localId of referrers) {
+    const typeUpper = view.entities.get(localId)!.type.toUpperCase();
+    const rewritable = typeUpper.startsWith('IFCREL') && !referencedRelationships.has(localId);
+    const line = lineOf(view, localId);
+    const slots = classifyRefs(line);
+    if (slots === null) {
+      // The argument list could not be parsed, so no rewrite can narrow this
+      // line: every container it names has to stay.
+      for (const target of argRefs(line)) {
+        const node = canon.get(target);
+        if (node !== undefined) blocked.add(node);
+      }
+      continue;
+    }
+    for (const [target, nested] of slots) {
+      const node = canon.get(target);
+      if (node === undefined) continue;
+      if (nested || !rewritable) blocked.add(node);
+    }
+  }
+}
+
+/** The entity's STEP line text. */
+function lineOf(view: EmptyContainerModelView, localId: number): string {
+  const ref = view.entities.get(localId);
+  if (ref === undefined) return '';
+  return view.source.decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
+}
+
+/** Top-level arguments of a `#id=TYPE(…);` line, or `null` when unparseable. */
+function topLevelAttrs(line: string): string[] | null {
+  const match = line.match(/^#\d+\s*=\s*\w+\(([\s\S]*)\)\s*;?\s*$/);
+  if (!match) return null;
+  return splitTopLevelArgs(match[1]).map(arg => arg.trim());
+}
+
+/** Parse an argument that is exactly one reference (`"#7"` → `7`). */
+function singleRef(arg: string): number | null {
+  const match = arg.trim().match(/^#(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+/** Parse a `(#a,#b,…)` list argument into ids. */
+function refList(arg: string): number[] {
+  const trimmed = arg.trim();
+  if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) return [];
+  const inner = trimmed.slice(1, -1).trim();
+  if (inner === '') return [];
+  const ids: number[] = [];
+  for (const item of splitTopLevelArgs(inner)) {
+    const id = singleRef(item);
+    if (id !== null) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Every reference in a line's argument list, paired with whether it sits
+ * somewhere neither `filterHiddenRefsFromRelationshipLine` can strip (a direct
+ * list element) nor withhold the line for (a whole single-valued attribute) —
+ * i.e. nested inside a list of lists or a typed value. `null` when the line's
+ * argument list cannot be parsed at all: a line no rewrite can narrow, which the
+ * analysis must treat as a blocker rather than as "names nothing".
+ */
+function classifyRefs(line: string): Array<[number, boolean]> | null {
+  const attrs = topLevelAttrs(line);
+  if (attrs === null) return null;
+  const out: Array<[number, boolean]> = [];
+  for (const attr of attrs) {
+    const direct = singleRef(attr);
+    if (direct !== null) {
+      out.push([direct, false]);
+      continue;
+    }
+    if (attr.startsWith('(') && attr.endsWith(')')) {
+      const inner = attr.slice(1, -1).trim();
+      if (inner === '') continue;
+      for (const item of splitTopLevelArgs(inner)) {
+        const id = singleRef(item);
+        if (id !== null) out.push([id, false]);
+        else for (const nested of argRefs(item)) out.push([nested, true]);
+      }
+      continue;
+    }
+    for (const nested of argRefs(attr)) out.push([nested, true]);
+  }
+  return out;
+}
+
+/**
+ * Every `#N` reference in a chunk of STEP text, skipping quoted strings (where a
+ * `#` is literal) and any leading `#id=` (the line's own id). Reads bytes rather
+ * than decoded text so the reverse-reference scan never decodes a whole model.
+ */
+function argRefs(text: Uint8Array | string): number[] {
+  const bytes = typeof text === 'string' ? new TextEncoder().encode(text) : text;
+  const eq = bytes.indexOf(0x3d /* = */);
+  const from = eq === -1 ? 0 : eq + 1;
+  const out: number[] = [];
+  let inString = false;
+  for (let i = from; i < bytes.length; i++) {
+    const byte = bytes[i];
+    if (byte === 0x27 /* ' */) {
+      inString = !inString;
+      continue;
+    }
+    if (inString || byte !== 0x23 /* # */) continue;
+    let j = i + 1;
+    let value = 0;
+    while (j < bytes.length && bytes[j] >= 0x30 && bytes[j] <= 0x39) {
+      value = value * 10 + (bytes[j] - 0x30);
+      j++;
+    }
+    if (j > i + 1) {
+      out.push(value);
+      i = j - 1;
+    }
+  }
+  return out;
+}
+
+/** The GlobalId (first quoted attribute) of a rooted entity's line. */
+function leadingGuid(line: string): string | null {
+  const open = line.indexOf('(');
+  if (open === -1) return null;
+  const first = line.indexOf("'", open + 1);
+  if (first === -1) return null;
+  const second = line.indexOf("'", first + 1);
+  if (second === -1) return null;
+  const raw = line.slice(first + 1, second);
+  return /^[0-9A-Za-z_$]{22}$/.test(raw) ? raw : null;
+}

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -13,10 +13,8 @@
 import type { IfcDataStore, IfcSourceBytes } from '@ifc-lite/parser';
 import {
   generateHeader,
-  deterministicGlobalId,
   IfcParser,
   asSourceBytes,
-  getInheritanceChainAcrossSchemas,
 } from '@ifc-lite/parser';
 import { decodeIfcString } from '@ifc-lite/encoding';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
@@ -32,6 +30,18 @@ import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type
 import { StepExporter } from './step-exporter.js';
 import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
 import { groupSubContextsByKey, planInfrastructureUnify } from './merged-subcontext.js';
+import { remapEntityText } from './merged-remap.js';
+import {
+  extractGlobalIdFast,
+  mintUniqueGuid,
+  readLeadingGuid,
+  replaceGlobalId,
+} from './merged-guid.js';
+import {
+  planEmptyContainerDrops,
+  EMPTY_MODEL_VIEW,
+  type EmptyContainerModelView,
+} from './merged-empty-containers.js';
 
 /**
  * UTF-8 decode of `[start, end)` of a model's source, accepting either the raw
@@ -50,40 +60,6 @@ const SHARED_INFRASTRUCTURE_TYPES = new Set([
   'IFCGEOMETRICREPRESENTATIONCONTEXT',
   'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
 ]);
-
-/**
- * An IfcGloballyUniqueId is exactly 22 characters of the buildingSMART base64
- * alphabet. We use this to recognise a rooted entity (IfcRoot subtype) by its
- * first attribute. Geometry/list entities never carry a string there, but some
- * non-rooted RESOURCE entities lead with a Name/Identifier string that can
- * legitimately be 22 charset chars (e.g. a coded property key). Those are
- * excluded with a schema-derived rootedness check ({@link isRootedType}) so
- * their Name is never mistaken for a GlobalId — otherwise the GlobalId
- * reconciliation could drop or rename them.
- */
-const GLOBAL_ID_RE = /^[0-9A-Za-z_$]{22}$/;
-
-/**
- * Whether `type` is an IfcRoot subtype — a schema-derived replacement for a
- * hand-maintained denylist of "non-rooted types whose first attribute happens
- * to be a string". A denylist has to be told about every such type by hand and
- * silently under-covers as the schema grows — `IfcMaterialProfileWithOffsets`
- * and several other resource types were missing and got their leading Name
- * treated as a GlobalId, corrupting ordinary model data on a collision.
- *
- * `getInheritanceChainAcrossSchemas` walks the bundled IFC2X3/IFC4/IFC4X3
- * schema union to the entity's root ancestor; a rooted entity's chain always
- * ends in `IfcRoot`. This mirrors the Rust side's `IfcType::is_subtype_of`
- * schema check, so the two implementations of "is this rooted" agree instead
- * of drifting apart as separate hand-maintained lists.
- *
- * A type unknown to every bundled schema (typo, vendor extension) yields an
- * empty chain and is treated as non-rooted — the same safe-miss direction the
- * old denylist documented: it just skips one GlobalId reconciliation.
- */
-export function isRootedType(type: string): boolean {
-  return getInheritanceChainAcrossSchemas(type).includes('IfcRoot');
-}
 
 /** True for IfcRelationship subtypes (objectified relationships). */
 function isRelationshipType(typeUpper: string): boolean {
@@ -189,6 +165,9 @@ interface ModelMergePlan {
   guidRewrite: Map<number, string>;
   /** Local express id → original GlobalId (rooted entities only). */
   localGuids: Map<number, string>;
+  /** Empty spatial containers this model must not write (#3643); every line
+   *  naming one is narrowed, or withheld with it. */
+  droppedContainerIds?: ReadonlySet<number>;
 }
 
 /**
@@ -355,6 +334,17 @@ export interface MergeExportOptions {
    */
   mergeStoreys?: 'by-name' | 'by-elevation' | 'by-name-then-elevation';
 
+  /**
+   * Drop spatial containers (`IfcSite` / `IfcBuilding` / `IfcBuildingStorey` /
+   * `IfcSpace`) the merge leaves holding nothing — the "Merge Projects" recipe
+   * step the matching options above do not cover (#3643). Emptiness is judged on
+   * the MERGED model, after visibility filtering and spatial unification, so a
+   * container only a later model fills is kept; see
+   * `merged-empty-containers.ts` for the exact rule. Off by default: output is
+   * byte-identical to a merge that never asked for it.
+   */
+  dropEmptyContainers?: boolean;
+
   /** Apply visibility filtering to each model before merging */
   visibleOnly?: boolean;
   /** Hidden entity IDs per model (local expressIds) */
@@ -407,6 +397,12 @@ export interface MergeExportResult {
      * modes (or when every model already shared the first model's unit).
      */
     normalizedModelCount: number;
+    /**
+     * Spatial containers dropped for holding nothing, counted in the merged
+     * model (a container unified across three inputs counts once). Always 0
+     * unless {@link MergeExportOptions.dropEmptyContainers} is set.
+     */
+    droppedContainerCount: number;
     /**
      * Human-readable advisories about the merge (empty on a clean single-unit
      * merge). Notably flags when federation produced more than one IfcProject,
@@ -493,6 +489,7 @@ export class MergedExporter {
     }
     const models = withUsableSource(this.models);
     const setup = this.buildMergeSetup(options, models);
+    const containerDrops = this.planContainerDrops(options, models, setup);
 
     const allEntityLines: string[] = [];
     // Tracks every GlobalId already emitted → its final express id + unit scale,
@@ -518,6 +515,7 @@ export class MergedExporter {
       if (!isFirstModel && !mode.compatible) federatedModelCount++;
       if (mode.normalized) { normalizedModelCount++; this.collectNormalizeCaveats(model, normalizeWarnings); }
       const plan = this.planModel(model, completeIndex, isFirstModel, mode.compatible, mode.lengthFactor, setup, guidToFinalId);
+      this.applyContainerDrops(plan, containerDrops?.byModel.get(model.id));
 
       const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
       for (const [expressId, entityRef] of completeIndex) {
@@ -539,7 +537,7 @@ export class MergedExporter {
 
     return {
       content,
-      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount, normalizedModelCount, normalizeWarnings),
+      stats: this.buildStats(allEntityLines.length, content.byteLength, federatedModelCount, normalizedModelCount, normalizeWarnings, containerDrops?.count ?? 0),
     };
   }
 
@@ -556,7 +554,7 @@ export class MergedExporter {
     }
     return {
       content,
-      stats: this.buildStats(doc.allEntityLines.length, content.byteLength, doc.federatedModelCount, doc.normalizedModelCount, doc.normalizeWarnings),
+      stats: this.buildStats(doc.allEntityLines.length, content.byteLength, doc.federatedModelCount, doc.normalizedModelCount, doc.normalizeWarnings, doc.droppedContainerCount),
     };
   }
 
@@ -578,7 +576,7 @@ export class MergedExporter {
     }
     return {
       content,
-      stats: this.buildStats(doc.allEntityLines.length, content.size, doc.federatedModelCount, doc.normalizedModelCount, doc.normalizeWarnings),
+      stats: this.buildStats(doc.allEntityLines.length, content.size, doc.federatedModelCount, doc.normalizedModelCount, doc.normalizeWarnings, doc.droppedContainerCount),
     };
   }
 
@@ -597,6 +595,7 @@ export class MergedExporter {
     federatedModelCount: number;
     normalizedModelCount: number;
     normalizeWarnings: Set<string>;
+    droppedContainerCount: number;
     totalEntities: number;
   }> {
     const onProgress = options.onProgress;
@@ -610,6 +609,7 @@ export class MergedExporter {
     // without edits pass through unchanged (no export/parse cost).
     const models = withUsableSource(await this.bakeMutatedModels());
     const setup = this.buildMergeSetup(options, models);
+    const containerDrops = this.planContainerDrops(options, models, setup);
 
     const allEntityLines: string[] = [];
     const guidToFinalId = new Map<string, GuidRecord>();
@@ -651,6 +651,7 @@ export class MergedExporter {
       if (!isFirstModel && !mode.compatible) federatedModelCount++;
       if (mode.normalized) { normalizedModelCount++; this.collectNormalizeCaveats(model, normalizeWarnings); }
       const plan = this.planModel(model, completeIndex, isFirstModel, mode.compatible, mode.lengthFactor, setup, guidToFinalId);
+      this.applyContainerDrops(plan, containerDrops?.byModel.get(model.id));
       const sourceSchema = (model.dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4';
 
       let entityCount = 0;
@@ -691,7 +692,7 @@ export class MergedExporter {
     }
     await new Promise(r => setTimeout(r, 0));
 
-    return { header, allEntityLines, federatedModelCount, normalizedModelCount, normalizeWarnings, totalEntities };
+    return { header, allEntityLines, federatedModelCount, normalizedModelCount, normalizeWarnings, droppedContainerCount: containerDrops?.count ?? 0, totalEntities };
   }
 
   /**
@@ -747,6 +748,7 @@ export class MergedExporter {
     federatedModelCount: number,
     normalizedModelCount: number,
     normalizeWarnings: Set<string>,
+    droppedContainerCount: number,
   ): MergeExportResult['stats'] {
     const warnings: string[] = [];
     if (federatedModelCount > 0) {
@@ -760,7 +762,52 @@ export class MergedExporter {
       );
     }
     warnings.push(...normalizeWarnings);
-    return { modelCount: this.models.length, totalEntityCount, fileSize, federatedModelCount, normalizedModelCount, warnings };
+    return { modelCount: this.models.length, totalEntityCount, fileSize, federatedModelCount, normalizedModelCount, droppedContainerCount, warnings };
+  }
+
+  /**
+   * Plan the empty spatial containers of the whole merge (#3643), or `null` when
+   * the caller did not ask for the drop. Reproduces the same spatial unification
+   * {@link planModel} will, so emptiness is judged on the containers the merge
+   * actually keeps rather than on each file in isolation.
+   */
+  private planContainerDrops(
+    options: MergeExportOptions,
+    models: MergeModelInput[],
+    setup: MergeSetup,
+  ): { byModel: Map<string, Set<number>>; count: number } | null {
+    if (!options.dropEmptyContainers) return null;
+    const views: EmptyContainerModelView[] = models.map((model, index) => {
+      const source = model.dataStore.source;
+      if (!source || source.length === 0) return EMPTY_MODEL_VIEW;
+      const entities = getCompleteEntityIndex(model.dataStore);
+      const mode = this.resolveModelMode(model, index === 0, setup);
+      const sharedRemap = new Map<number, number>();
+      if (index > 0 && mode.compatible) {
+        this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, mode.lengthFactor, sharedRemap, new Set(), setup);
+      }
+      return {
+        entities,
+        source: asSourceBytes(source),
+        included: this.computeIncludedEntityIds(model, options, entities, source)?.included ?? null,
+        sharedRemap,
+        offset: setup.modelOffsets.get(model.id)!,
+        compatible: mode.compatible,
+      };
+    });
+    const plan = planEmptyContainerDrops(views);
+    return {
+      byModel: new Map(models.map((model, index) => [model.id, plan.droppedByModel[index]])),
+      count: plan.droppedCount,
+    };
+  }
+
+  /** Fold a model's dropped containers into its plan: the container lines are
+   *  skipped outright, and {@link renderEntity} narrows every line naming one. */
+  private applyContainerDrops(plan: ModelMergePlan, dropped: ReadonlySet<number> | undefined): void {
+    if (dropped === undefined || dropped.size === 0) return;
+    plan.droppedContainerIds = dropped;
+    for (const id of dropped) plan.skipEntityIds.add(id);
   }
 
   /**
@@ -1035,7 +1082,7 @@ export class MergedExporter {
     // One cheap pass to read each rooted entity's GlobalId (first attribute).
     const localGuids = new Map<number, string>();
     for (const [id, ref] of completeIndex) {
-      const guid = this.extractGlobalIdFast(ref, source);
+      const guid = extractGlobalIdFast(ref, source);
       if (guid !== null) localGuids.set(id, guid);
     }
 
@@ -1085,7 +1132,7 @@ export class MergedExporter {
           sharedRemap.set(id, prior.finalId);
           skipEntityIds.add(id);
         } else {
-          guidRewrite.set(id, this.mintUniqueGuid(guid, model.id, guidToFinalId, pendingMinted));
+          guidRewrite.set(id, mintUniqueGuid(guid, model.id, guidToFinalId, pendingMinted));
         }
       }
     }
@@ -1139,18 +1186,27 @@ export class MergedExporter {
       entityText = filtered;
     }
 
+    // A dropped empty spatial container (#3643) is never written, so any line
+    // naming one is narrowed the same way — or withheld with it. Runs in LOCAL
+    // id space, before the remap below, like the visibility narrowing above.
+    if (plan.droppedContainerIds !== undefined) {
+      const kept = filterHiddenRefsFromRelationshipLine(entityText, id => plan.droppedContainerIds!.has(id));
+      if (kept === null) return null;
+      entityText = kept;
+    }
+
     // Remap ids. Fast path: the first model (offset 0, no remaps) is byte-identical.
     let finalText: string;
     if (offset === 0 && plan.sharedRemap.size === 0) {
       finalText = entityText;
     } else {
-      finalText = this.remapEntityText(entityText, offset, plan.sharedRemap);
+      finalText = remapEntityText(entityText, offset, plan.sharedRemap);
     }
 
     // Re-stamp the GlobalId for a federated entity whose id collides.
     const mintedGuid = plan.guidRewrite.get(localId);
     if (mintedGuid !== undefined) {
-      finalText = this.replaceGlobalId(finalText, mintedGuid);
+      finalText = replaceGlobalId(finalText, mintedGuid);
     }
 
     // Normalize units: rescale every length/area/volume-valued datum into the
@@ -1174,7 +1230,7 @@ export class MergedExporter {
     // Emitted entities are not sharedRemap keys, so their final id is
     // localId + offset.
     if (plan.localGuids.has(localId)) {
-      const emittedGuid = this.readLeadingGuid(finalText)
+      const emittedGuid = readLeadingGuid(finalText)
         ?? mintedGuid ?? plan.localGuids.get(localId);
       if (emittedGuid !== undefined) {
         guidToFinalId.set(emittedGuid, { finalId: localId + offset, scale: mode.effectiveScale });
@@ -1182,148 +1238,6 @@ export class MergedExporter {
     }
 
     return finalText;
-  }
-
-  /**
-   * Read the GlobalId (first quoted attribute) from an already-rendered STEP
-   * line. Used to register the id that was actually emitted, after any id
-   * remap, GlobalId re-stamp, or schema conversion. Returns null if the first
-   * quoted token is not a 22-char GlobalId.
-   */
-  private readLeadingGuid(entityText: string): string | null {
-    const open = entityText.indexOf('(');
-    if (open === -1) return null;
-    const q1 = entityText.indexOf("'", open + 1);
-    if (q1 === -1) return null;
-    const q2 = entityText.indexOf("'", q1 + 1);
-    if (q2 === -1) return null;
-    const raw = entityText.slice(q1 + 1, q2);
-    return GLOBAL_ID_RE.test(raw) ? raw : null;
-  }
-
-  /**
-   * Mint a fresh, deterministic, collision-free GlobalId for an entity whose id
-   * collides. Seeded from the original GlobalId and the model's stable id so the
-   * output is reproducible and does not churn when an unrelated earlier model
-   * changes size; checked against both already-emitted ids and the ids minted
-   * so far for this model.
-   */
-  private mintUniqueGuid(
-    original: string,
-    modelId: string,
-    guidToFinalId: Map<string, GuidRecord>,
-    pendingMinted: Set<string>,
-  ): string {
-    let candidate = deterministicGlobalId(`${original}#${modelId}`);
-    let n = 0;
-    while (guidToFinalId.has(candidate) || pendingMinted.has(candidate)) {
-      candidate = deterministicGlobalId(`${original}#${modelId}#${n++}`);
-    }
-    pendingMinted.add(candidate);
-    return candidate;
-  }
-
-  /**
-   * Read an entity's GlobalId (first attribute) by decoding only its head.
-   * Returns the 22-char id for a rooted entity, or `null` for any entity whose
-   * first attribute is not a GlobalId (geometry, lists, property atoms, …).
-   */
-  private extractGlobalIdFast(ref: ExportEntityRef, source: IfcSourceBytes): string | null {
-    // Non-rooted resource entities (property/quantity/material/style/actor …)
-    // lead with a Name string that can itself be 22 charset chars; never treat
-    // those as a GlobalId or reconciliation would drop/rename them.
-    if (!isRootedType(ref.type ?? '')) return null;
-    // 128 bytes comfortably spans `#<id>=<LONGEST_TYPE_NAME>('<22-char id>'`,
-    // so the GlobalId is always fully inside the window.
-    const end = Math.min(ref.byteOffset + 128, ref.byteOffset + ref.byteLength);
-    const head = decodeRange(source, ref.byteOffset, end);
-    const open = head.indexOf('(');
-    if (open === -1) return null;
-    let i = open + 1;
-    while (i < head.length && (head[i] === ' ' || head[i] === '\t' || head[i] === '\n' || head[i] === '\r')) i++;
-    if (head[i] !== "'") return null;
-    // A GlobalId never contains a quote (charset excludes it), so the next
-    // quote closes it.
-    const close = head.indexOf("'", i + 1);
-    if (close === -1) return null;
-    const raw = head.slice(i + 1, close);
-    return GLOBAL_ID_RE.test(raw) ? raw : null;
-  }
-
-  /**
-   * Replace an entity's GlobalId (first quoted attribute) with `newGuid`.
-   * `newGuid` is a 22-char IFC id (no quote in its charset), so this is safe.
-   */
-  private replaceGlobalId(entityText: string, newGuid: string): string {
-    const open = entityText.indexOf('(');
-    if (open === -1) return entityText;
-    const q1 = entityText.indexOf("'", open + 1);
-    if (q1 === -1) return entityText;
-    const q2 = entityText.indexOf("'", q1 + 1);
-    if (q2 === -1) return entityText;
-    return entityText.slice(0, q1 + 1) + newGuid + entityText.slice(q2);
-  }
-
-  /**
-   * Remap all #ID references in a STEP entity line.
-   * Applies offset to all IDs, then overrides with specific remappings.
-   *
-   * Only `#<digits>` tokens in code positions are rewritten; tokens inside
-   * single-quoted STEP strings (e.g. a 'Room #205' Name or a 'http://x#42'
-   * URL) are left untouched so string attribute values are not corrupted.
-   */
-  private remapEntityText(
-    entityText: string,
-    offset: number,
-    sharedRemap: Map<number, number>,
-  ): string {
-    const remapId = (originalId: number): string => {
-      // Check if this ID has a specific remap (project, shared infrastructure)
-      const remapped = sharedRemap.get(originalId);
-      if (remapped !== undefined) {
-        return `#${remapped}`;
-      }
-      // Apply offset
-      return `#${originalId + offset}`;
-    };
-
-    let out = '';
-    let inString = false;
-    for (let i = 0; i < entityText.length; i++) {
-      const char = entityText[i];
-
-      if (inString) {
-        out += char;
-        if (char === "'") {
-          // STEP escapes a literal quote by doubling it ('').
-          if (entityText[i + 1] === "'") {
-            out += entityText[i + 1];
-            i++;
-          } else {
-            inString = false;
-          }
-        }
-        continue;
-      }
-
-      if (char === "'") {
-        inString = true;
-        out += char;
-        continue;
-      }
-
-      if (char === '#' && entityText[i + 1] >= '0' && entityText[i + 1] <= '9') {
-        let j = i + 1;
-        while (j < entityText.length && entityText[j] >= '0' && entityText[j] <= '9') j++;
-        const originalId = parseInt(entityText.slice(i + 1, j), 10);
-        out += remapId(originalId);
-        i = j - 1;
-        continue;
-      }
-
-      out += char;
-    }
-    return out;
   }
 
   /**

--- a/packages/export/src/merged-guid.ts
+++ b/packages/export/src/merged-guid.ts
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * GlobalId reading, minting and re-stamping for the merged exporter — the JS
+ * twin of `rust/export/src/merged/guid.rs`.
+ *
+ * Split out of `merged-exporter.ts` (none of it used `this`) so the rules for
+ * recognising and reconciling an `IfcGloballyUniqueId` live in one module rather
+ * than inside the merge loop.
+ */
+
+import { deterministicGlobalId, getInheritanceChainAcrossSchemas } from '@ifc-lite/parser';
+import type { IfcSourceBytes } from '@ifc-lite/parser';
+import { asSourceBytes } from '@ifc-lite/parser';
+import type { ExportEntityRef } from './entity-iteration.js';
+
+/**
+ * An IfcGloballyUniqueId is exactly 22 characters of the buildingSMART base64
+ * alphabet. We use this to recognise a rooted entity (IfcRoot subtype) by its
+ * first attribute. Geometry/list entities never carry a string there, but some
+ * non-rooted RESOURCE entities lead with a Name/Identifier string that can
+ * legitimately be 22 charset chars (e.g. a coded property key). Those are
+ * excluded with a schema-derived rootedness check ({@link isRootedType}) so
+ * their Name is never mistaken for a GlobalId — otherwise the GlobalId
+ * reconciliation could drop or rename them.
+ */
+const GLOBAL_ID_RE = /^[0-9A-Za-z_$]{22}$/;
+
+/**
+ * Whether `type` is an IfcRoot subtype — a schema-derived replacement for a
+ * hand-maintained denylist of "non-rooted types whose first attribute happens
+ * to be a string". A denylist has to be told about every such type by hand and
+ * silently under-covers as the schema grows — `IfcMaterialProfileWithOffsets`
+ * and several other resource types were missing and got their leading Name
+ * treated as a GlobalId, corrupting ordinary model data on a collision.
+ *
+ * `getInheritanceChainAcrossSchemas` walks the bundled IFC2X3/IFC4/IFC4X3
+ * schema union to the entity's root ancestor; a rooted entity's chain always
+ * ends in `IfcRoot`. This mirrors the Rust side's `IfcType::is_subtype_of`
+ * schema check, so the two implementations of "is this rooted" agree instead
+ * of drifting apart as separate hand-maintained lists.
+ *
+ * A type unknown to every bundled schema (typo, vendor extension) yields an
+ * empty chain and is treated as non-rooted — the same safe-miss direction the
+ * old denylist documented: it just skips one GlobalId reconciliation.
+ */
+export function isRootedType(type: string): boolean {
+  return getInheritanceChainAcrossSchemas(type).includes('IfcRoot');
+}
+
+/**
+ * Read the GlobalId (first quoted attribute) from an already-rendered STEP
+ * line. Used to register the id that was actually emitted, after any id
+ * remap, GlobalId re-stamp, or schema conversion. Returns null if the first
+ * quoted token is not a 22-char GlobalId.
+ */
+export function readLeadingGuid(entityText: string): string | null {
+  const open = entityText.indexOf('(');
+  if (open === -1) return null;
+  const q1 = entityText.indexOf("'", open + 1);
+  if (q1 === -1) return null;
+  const q2 = entityText.indexOf("'", q1 + 1);
+  if (q2 === -1) return null;
+  const raw = entityText.slice(q1 + 1, q2);
+  return GLOBAL_ID_RE.test(raw) ? raw : null;
+}
+
+/**
+ * Mint a fresh, deterministic, collision-free GlobalId for an entity whose id
+ * collides. Seeded from the original GlobalId and the model's stable id so the
+ * output is reproducible and does not churn when an unrelated earlier model
+ * changes size; checked against both already-emitted ids and the ids minted
+ * so far for this model.
+ */
+export function mintUniqueGuid(
+  original: string,
+  modelId: string,
+  emitted: ReadonlyMap<string, unknown>,
+  pendingMinted: Set<string>,
+): string {
+  let candidate = deterministicGlobalId(`${original}#${modelId}`);
+  let n = 0;
+  while (emitted.has(candidate) || pendingMinted.has(candidate)) {
+    candidate = deterministicGlobalId(`${original}#${modelId}#${n++}`);
+  }
+  pendingMinted.add(candidate);
+  return candidate;
+}
+
+/**
+ * Read an entity's GlobalId (first attribute) by decoding only its head.
+ * Returns the 22-char id for a rooted entity, or `null` for any entity whose
+ * first attribute is not a GlobalId (geometry, lists, property atoms, …).
+ */
+export function extractGlobalIdFast(
+  ref: ExportEntityRef,
+  source: Uint8Array | IfcSourceBytes,
+): string | null {
+  // Non-rooted resource entities (property/quantity/material/style/actor …)
+  // lead with a Name string that can itself be 22 charset chars; never treat
+  // those as a GlobalId or reconciliation would drop/rename them.
+  if (!isRootedType(ref.type ?? '')) return null;
+  // 128 bytes comfortably spans `#<id>=<LONGEST_TYPE_NAME>('<22-char id>'`,
+  // so the GlobalId is always fully inside the window.
+  const end = Math.min(ref.byteOffset + 128, ref.byteOffset + ref.byteLength);
+  const head = asSourceBytes(source).decodeUtf8(ref.byteOffset, end);
+  const open = head.indexOf('(');
+  if (open === -1) return null;
+  let i = open + 1;
+  while (i < head.length && (head[i] === ' ' || head[i] === '\t' || head[i] === '\n' || head[i] === '\r')) i++;
+  if (head[i] !== "'") return null;
+  // A GlobalId never contains a quote (charset excludes it), so the next
+  // quote closes it.
+  const close = head.indexOf("'", i + 1);
+  if (close === -1) return null;
+  const raw = head.slice(i + 1, close);
+  return GLOBAL_ID_RE.test(raw) ? raw : null;
+}
+
+/**
+ * Replace an entity's GlobalId (first quoted attribute) with `newGuid`.
+ * `newGuid` is a 22-char IFC id (no quote in its charset), so this is safe.
+ */
+export function replaceGlobalId(entityText: string, newGuid: string): string {
+  const open = entityText.indexOf('(');
+  if (open === -1) return entityText;
+  const q1 = entityText.indexOf("'", open + 1);
+  if (q1 === -1) return entityText;
+  const q2 = entityText.indexOf("'", q1 + 1);
+  if (q2 === -1) return entityText;
+  return entityText.slice(0, q1 + 1) + newGuid + entityText.slice(q2);
+}

--- a/packages/export/src/merged-remap.ts
+++ b/packages/export/src/merged-remap.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Express-id remapping for the merged exporter: rewrite every `#N` reference of
+ * one model's STEP line into the merged file's id space.
+ *
+ * Split out of `merged-exporter.ts` (it never used `this`) so the id-rewriting
+ * rule lives in one small module next to the other merge-time line surgery
+ * (`merged-empty-containers.ts`, `merged-subcontext.ts`).
+ */
+
+/**
+ * Remap all #ID references in a STEP entity line.
+ * Applies offset to all IDs, then overrides with specific remappings.
+ *
+ * Only `#<digits>` tokens in code positions are rewritten; tokens inside
+ * single-quoted STEP strings (e.g. a 'Room #205' Name or a 'http://x#42'
+ * URL) are left untouched so string attribute values are not corrupted.
+ */
+export function remapEntityText(
+  entityText: string,
+  offset: number,
+  sharedRemap: ReadonlyMap<number, number>,
+): string {
+  const remapId = (originalId: number): string => {
+    // Check if this ID has a specific remap (project, shared infrastructure)
+    const remapped = sharedRemap.get(originalId);
+    if (remapped !== undefined) {
+      return `#${remapped}`;
+    }
+    // Apply offset
+    return `#${originalId + offset}`;
+  };
+
+  let out = '';
+  let inString = false;
+  for (let i = 0; i < entityText.length; i++) {
+    const char = entityText[i];
+
+    if (inString) {
+      out += char;
+      if (char === "'") {
+        // STEP escapes a literal quote by doubling it ('').
+        if (entityText[i + 1] === "'") {
+          out += entityText[i + 1];
+          i++;
+        } else {
+          inString = false;
+        }
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      inString = true;
+      out += char;
+      continue;
+    }
+
+    if (char === '#' && entityText[i + 1] >= '0' && entityText[i + 1] <= '9') {
+      let j = i + 1;
+      while (j < entityText.length && entityText[j] >= '0' && entityText[j] <= '9') j++;
+      const originalId = parseInt(entityText.slice(i + 1, j), 10);
+      out += remapId(originalId);
+      i = j - 1;
+      continue;
+    }
+
+    out += char;
+  }
+  return out;
+}

--- a/packages/export/src/rooted-type-sweep.parity.test.ts
+++ b/packages/export/src/rooted-type-sweep.parity.test.ts
@@ -17,7 +17,7 @@
  * `rust/export/examples/dump_rooted_type_sweep.rs` +
  * a one-off script) against the exhaustive type sweep, then checked against
  * the Rust classifier — not hand-derived from reading either implementation.
- * Testing `isRootedType` (the real merged-exporter.ts call site) against a
+ * Testing `isRootedType` (the real merged-guid.ts call site) against a
  * fixture generated from `getInheritanceChainAcrossSchemas` directly is not
  * circular: `isRootedType` is a thin wrapper around that same function today,
  * but the test exercises the actual production entry point, so a future
@@ -37,7 +37,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { isRootedType } from './merged-exporter.js';
+import { isRootedType } from './merged-guid.js';
 
 interface SweepCase {
   type: string;

--- a/rust/export/examples/merge_ifc.rs
+++ b/rust/export/examples/merge_ifc.rs
@@ -9,10 +9,12 @@
 //! the webview JS `MergedExporter`.
 //!
 //!     cargo run --release -p ifc-lite-export --example merge_ifc -- \
-//!         [--assume-shared] <a.ifc> <b.ifc> [more.ifc ...] <out.ifc>
+//!         [--assume-shared] [--drop-empty-containers] <a.ifc> <b.ifc> [more.ifc ...] <out.ifc>
 //!
 //! The last path is the output. `--assume-shared` treats every model as sharing
 //! the first model's unit (skips the compatibility check).
+//! `--drop-empty-containers` leaves out spatial containers the merge finds
+//! holding nothing (issue #3643).
 
 use std::collections::HashMap;
 use std::time::Instant;
@@ -22,11 +24,12 @@ use ifc_lite_export::{export_merged_models, MergedModel, MergedOptions, UnitReco
 fn main() {
     let mut args: Vec<String> = std::env::args().skip(1).collect();
     let assume_shared = args.iter().any(|a| a == "--assume-shared");
-    args.retain(|a| a != "--assume-shared");
+    let drop_empty_containers = args.iter().any(|a| a == "--drop-empty-containers");
+    args.retain(|a| a != "--assume-shared" && a != "--drop-empty-containers");
 
     if args.len() < 3 {
         eprintln!(
-            "usage: merge_ifc [--assume-shared] <a.ifc> <b.ifc> [more.ifc ...] <out.ifc>\n\
+            "usage: merge_ifc [--assume-shared] [--drop-empty-containers] <a.ifc> <b.ifc> [more.ifc ...] <out.ifc>\n\
              (need at least two input files plus an output path)"
         );
         std::process::exit(2);
@@ -66,6 +69,7 @@ fn main() {
         } else {
             UnitReconciliation::Auto
         },
+        drop_empty_containers,
         ..Default::default()
     };
 
@@ -86,6 +90,7 @@ fn main() {
     println!("entities written    : {}", stats.written);
     println!("IfcProject count    : {projects}");
     println!("federated models    : {}", stats.federated_model_count);
+    println!("empty containers dropped: {}", stats.dropped_container_count);
     println!("unit_rescale_required: {}", stats.unit_rescale_required);
     for w in &stats.warnings {
         println!("warning             : {w}");

--- a/rust/export/src/merged/empty.rs
+++ b/rust/export/src/merged/empty.rs
@@ -25,7 +25,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::guid::extract_global_id_fast;
 use super::line_edit::{arg_refs, classify_refs, RefSlot};
-use super::plan::{resolve_included, unify_spatial, ModelIndex};
+use super::plan::{next_offset, resolve_included, unify_spatial, ModelIndex};
 use super::spatial::{nth_attr, ContainerMergeStrategy, SpatialLookup, StoreyMergeStrategy};
 use super::units::ModelUnitMode;
 use super::{MergedModel, MergedOptions};
@@ -107,10 +107,17 @@ fn plan_container_drops(models: &[MergedModel], ctx: &DropCtx) -> DropPlan {
     // are cheap to retain; the byte-indexed models are not, and are dropped as
     // soon as each model's contribution to the graph is recorded.
     let mut per_model_containers: Vec<Vec<(u32, Node)>> = Vec::with_capacity(models.len());
+    let mut offset: u32 = 0;
 
     for (i, model) in models.iter().enumerate() {
         let index = ModelIndex::build(model.content);
         let included = resolve_included(&index, &model.included);
+        // Stop where the emit loop will stop. A model past the EXPRESS-id cut is
+        // never written, so counting its content here would keep a container
+        // nothing in the output actually fills — and report it as surviving.
+        // Same rule, one home (`plan::next_offset`), so the two cannot disagree.
+        let Some(next) = next_offset(offset, &included) else { break };
+        offset = next;
         let compatible = ctx.compatible.get(i).copied().unwrap_or(false);
         let mut remap: HashMap<u32, u32> = HashMap::new();
         if i > 0 && compatible {

--- a/rust/export/src/merged/empty.rs
+++ b/rust/export/src/merged/empty.rs
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Drop spatial containers that end up holding nothing — the step of
+//! IfcOpenShell/BlenderBIM's "Merge Projects" recipe that container *matching*
+//! ([`super::spatial`]) leaves behind (issue #3643).
+//!
+//! An `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` / `IfcSpace` is empty when
+//! it contains no surviving element (`IfcRelContainedInSpatialStructure`),
+//! directly aggregates no surviving non-spatial object, and transitively
+//! aggregates no non-empty spatial child. `IfcProject` is never a candidate.
+//!
+//! Emptiness is a property of the MERGED model, not of one input: a site that is
+//! empty in its own file is not empty once a later model's storeys are unified
+//! onto it. So this runs as a pre-pass over every model — after visibility
+//! filtering and after spatial unification, the two things that make a container
+//! empty in the first place — and yields the per-model express ids the emit loop
+//! then never writes. Nothing is emitted referencing them, so there is no
+//! dangling-reference clean-up pass to follow (which is the whole reason this
+//! belongs in the merge rather than after it).
+//!
+//! A dropped container's own placement / representation entities are left behind
+//! unreferenced: valid STEP, just inert. Chasing them is not worth a second
+//! graph walk.
+
+use std::collections::{HashMap, HashSet};
+
+use super::guid::extract_global_id_fast;
+use super::line_edit::{arg_refs, classify_refs, RefSlot};
+use super::plan::{resolve_included, unify_spatial, ModelIndex};
+use super::spatial::{nth_attr, ContainerMergeStrategy, SpatialLookup, StoreyMergeStrategy};
+use super::units::ModelUnitMode;
+use super::{MergedModel, MergedOptions};
+
+/// Spatial container types that are dropped when they end up empty. `IfcProject`
+/// is deliberately absent: it is the file's root, never a candidate.
+const CONTAINER_TYPES: [&str; 4] =
+    ["IFCSITE", "IFCBUILDING", "IFCBUILDINGSTOREY", "IFCSPACE"];
+
+/// A container in the MERGED model: the (model index, express id) of the first
+/// instance, so every input's copy of a unified container maps to one node.
+type Node = (usize, u32);
+
+/// Inputs the pre-pass needs to reproduce the emit loop's unification verdicts.
+struct DropCtx<'a> {
+    spatial_lookup: &'a SpatialLookup,
+    merge_sites: ContainerMergeStrategy,
+    merge_buildings: ContainerMergeStrategy,
+    merge_storeys: StoreyMergeStrategy,
+    /// Per model: whether it unifies into the first model (same verdict the emit
+    /// loop uses, from `units::resolve_model_modes`).
+    compatible: &'a [bool],
+}
+
+/// Which containers the emit loop must not write.
+pub(super) struct DropPlan {
+    /// Per input model: local express ids never emitted.
+    pub(super) per_model: Vec<HashSet<u32>>,
+    /// Containers dropped, counted in the MERGED model (a container unified
+    /// across three inputs counts once).
+    pub(super) count: usize,
+}
+
+/// The merged-model container graph accumulated across every input.
+#[derive(Default)]
+struct Graph {
+    /// Every container node seen.
+    nodes: HashSet<Node>,
+    /// Nodes holding a surviving non-spatial object (element or aggregate).
+    has_content: HashSet<Node>,
+    /// Nodes something references in a way the emit loop cannot rewrite, so they
+    /// have to stay. Treated as non-empty, which keeps their ancestors too.
+    blocked: HashSet<Node>,
+    /// Spatial child → its containers (upward edges for the emptiness sweep).
+    parents: HashMap<Node, Vec<Node>>,
+}
+
+/// True when `type_upper` is a droppable spatial container type.
+fn is_container_type(type_upper: &str) -> bool {
+    CONTAINER_TYPES.contains(&type_upper)
+}
+
+/// Plan which spatial containers the merge leaves holding nothing, or `None`
+/// when the caller did not ask for it ([`MergedOptions::drop_empty_containers`]).
+pub(super) fn plan_drops(
+    models: &[MergedModel],
+    opts: &MergedOptions,
+    spatial_lookup: &SpatialLookup,
+    modes: &[ModelUnitMode],
+) -> Option<DropPlan> {
+    if !opts.drop_empty_containers {
+        return None;
+    }
+    let compatible: Vec<bool> = modes.iter().map(|m| m.compatible).collect();
+    Some(plan_container_drops(models, &DropCtx {
+        spatial_lookup,
+        merge_sites: opts.merge_sites,
+        merge_buildings: opts.merge_buildings,
+        merge_storeys: opts.merge_storeys,
+        compatible: &compatible,
+    }))
+}
+
+/// Plan which spatial containers the merge leaves holding nothing.
+fn plan_container_drops(models: &[MergedModel], ctx: &DropCtx) -> DropPlan {
+    let mut graph = Graph::default();
+    let mut guid_node: HashMap<String, Node> = HashMap::new();
+    // Containers are a tiny fraction of a model, so the per-model container maps
+    // are cheap to retain; the byte-indexed models are not, and are dropped as
+    // soon as each model's contribution to the graph is recorded.
+    let mut per_model_containers: Vec<Vec<(u32, Node)>> = Vec::with_capacity(models.len());
+
+    for (i, model) in models.iter().enumerate() {
+        let index = ModelIndex::build(model.content);
+        let included = resolve_included(&index, &model.included);
+        let compatible = ctx.compatible.get(i).copied().unwrap_or(false);
+        let mut remap: HashMap<u32, u32> = HashMap::new();
+        if i > 0 && compatible {
+            let mut skip: HashSet<u32> = HashSet::new();
+            unify_spatial(
+                ctx.spatial_lookup,
+                &index,
+                &mut remap,
+                &mut skip,
+                ctx.merge_sites,
+                ctx.merge_buildings,
+                ctx.merge_storeys,
+                1.0,
+            );
+        }
+
+        let canon = canonical_containers(&index, &included, &remap, compatible, i, &mut guid_node);
+        graph.nodes.extend(canon.values().copied());
+        record_edges(&index, &included, &canon, &mut graph);
+        record_blocks(&index, &included, &canon, &mut graph);
+        per_model_containers.push(canon.into_iter().collect());
+    }
+
+    // A container is non-empty when it holds something, is blocked, or has a
+    // non-empty spatial child — the last propagated upward from the first two.
+    // The `insert` guard also makes a self-referential aggregation terminate.
+    let mut non_empty: HashSet<Node> =
+        graph.has_content.union(&graph.blocked).copied().collect();
+    let mut stack: Vec<Node> = non_empty.iter().copied().collect();
+    while let Some(node) = stack.pop() {
+        let Some(parents) = graph.parents.get(&node) else { continue };
+        for &parent in parents {
+            if non_empty.insert(parent) {
+                stack.push(parent);
+            }
+        }
+    }
+
+    let dropped: HashSet<Node> =
+        graph.nodes.iter().copied().filter(|n| !non_empty.contains(n)).collect();
+    let per_model = per_model_containers
+        .iter()
+        .map(|locals| {
+            locals.iter().filter(|(_, n)| dropped.contains(n)).map(|&(id, _)| id).collect()
+        })
+        .collect();
+    DropPlan { per_model, count: dropped.len() }
+}
+
+/// Map each of this model's visible containers to its node in the merged model:
+/// the first model's container when spatial unification matched it there, the
+/// earlier instance when an earlier model already emitted its GlobalId, else
+/// itself. Mirrors the emit loop's unification order (source order, first wins).
+fn canonical_containers(
+    index: &ModelIndex,
+    included: &HashSet<u32>,
+    remap: &HashMap<u32, u32>,
+    compatible: bool,
+    model: usize,
+    guid_node: &mut HashMap<String, Node>,
+) -> HashMap<u32, Node> {
+    let mut canon = HashMap::new();
+    for &id in &index.order {
+        if !included.contains(&id) {
+            continue;
+        }
+        let Some(ty) = index.type_of.get(&id) else { continue };
+        if !is_container_type(ty) {
+            continue;
+        }
+        let node = if let Some(&target) = remap.get(&id) {
+            (0, target)
+        } else if compatible {
+            match index.line_bytes(id).and_then(|b| extract_global_id_fast(ty, b)) {
+                Some(guid) => *guid_node.entry(guid).or_insert((model, id)),
+                None => (model, id),
+            }
+        } else {
+            (model, id)
+        };
+        canon.insert(id, node);
+    }
+    canon
+}
+
+/// Record what this model contributes to each container: contained elements and
+/// aggregated objects become content; aggregated spatial children become upward
+/// edges, so a non-empty storey keeps its building and site.
+fn record_edges(
+    index: &ModelIndex,
+    included: &HashSet<u32>,
+    canon: &HashMap<u32, Node>,
+    graph: &mut Graph,
+) {
+    for &id in &index.order {
+        if !included.contains(&id) {
+            continue;
+        }
+        let Some(ty) = index.type_of.get(&id) else { continue };
+        // (relating attribute, related attribute) — `IfcRelAggregates` names the
+        // whole first, the containment relationships name the parts first.
+        let (relating, related) = match ty.as_str() {
+            "IFCRELAGGREGATES" => (4, 5),
+            "IFCRELCONTAINEDINSPATIALSTRUCTURE" | "IFCRELREFERENCEDINSPATIALSTRUCTURE" => (5, 4),
+            _ => continue,
+        };
+        let Some(line) = index.line_str(id) else { continue };
+        let Some(parent) = nth_attr(&line, relating)
+            .and_then(single_ref)
+            .and_then(|local| canon.get(&local).copied())
+        else {
+            // Not a container (an `IfcProject` aggregating its sites, say) — its
+            // children are roots of the spatial tree, with nothing above to keep.
+            continue;
+        };
+        for child_local in nth_attr(&line, related).map(ref_list).unwrap_or_default() {
+            if !included.contains(&child_local) {
+                continue;
+            }
+            match canon.get(&child_local) {
+                Some(&child) => graph.parents.entry(child).or_default().push(parent),
+                None => {
+                    graph.has_content.insert(parent);
+                }
+            }
+        }
+    }
+}
+
+/// Block every container this model references in a way the emit loop could not
+/// rewrite. Dropping such a container would leave a dangling `#ref`, so it stays
+/// (and counts as non-empty, keeping its ancestors) instead.
+///
+/// Prunable is: a reference from an objectified relationship (`IfcRel*`) that
+/// nothing else references, since the emit loop can strip it from a list or drop
+/// the whole relationship line. Everything else — a non-relationship referrer, a
+/// reference nested inside a typed value, or a relationship that is itself
+/// referenced (dropping it would dangle in turn) — blocks.
+fn record_blocks(
+    index: &ModelIndex,
+    included: &HashSet<u32>,
+    canon: &HashMap<u32, Node>,
+    graph: &mut Graph,
+) {
+    if canon.is_empty() {
+        return;
+    }
+    let mut referrers: Vec<u32> = Vec::new();
+    let mut referenced_rels: HashSet<u32> = HashSet::new();
+    let mut refs: Vec<u32> = Vec::new();
+    for &id in &index.order {
+        if !included.contains(&id) {
+            continue;
+        }
+        let Some(bytes) = index.line_bytes(id) else { continue };
+        refs.clear();
+        arg_refs(bytes, &mut refs);
+        let mut hits_container = false;
+        for &r in &refs {
+            hits_container |= canon.contains_key(&r);
+            if index.type_of.get(&r).is_some_and(|t| t.starts_with("IFCREL")) {
+                referenced_rels.insert(r);
+            }
+        }
+        if hits_container {
+            referrers.push(id);
+        }
+    }
+
+    for id in referrers {
+        let ty = index.type_of.get(&id).map(String::as_str).unwrap_or("");
+        let prunable = ty.starts_with("IFCREL") && !referenced_rels.contains(&id);
+        let Some(line) = index.line_str(id) else { continue };
+        let Some(slots) = classify_refs(&line) else {
+            // The argument list could not be parsed, so no rewrite can narrow
+            // this line: every container it names has to stay.
+            refs.clear();
+            arg_refs(line.as_bytes(), &mut refs);
+            for r in &refs {
+                if let Some(&node) = canon.get(r) {
+                    graph.blocked.insert(node);
+                }
+            }
+            continue;
+        };
+        for (r, slot) in slots {
+            let Some(&node) = canon.get(&r) else { continue };
+            let rewritable = match slot {
+                RefSlot::Single | RefSlot::ListElement => prunable,
+                RefSlot::Nested => false,
+            };
+            if !rewritable {
+                graph.blocked.insert(node);
+            }
+        }
+    }
+}
+
+/// Parse a single `#N` reference attribute (`"#4"` → `4`).
+fn single_ref(arg: &str) -> Option<u32> {
+    arg.trim().strip_prefix('#')?.parse().ok()
+}
+
+/// Parse a `(#a,#b,…)` list attribute into ids.
+fn ref_list(arg: &str) -> Vec<u32> {
+    arg.trim()
+        .trim_start_matches('(')
+        .trim_end_matches(')')
+        .split(',')
+        .filter_map(single_ref)
+        .collect()
+}
+

--- a/rust/export/src/merged/empty.rs
+++ b/rust/export/src/merged/empty.rs
@@ -324,3 +324,6 @@ fn ref_list(arg: &str) -> Vec<u32> {
         .collect()
 }
 
+#[cfg(test)]
+#[path = "empty_tests.rs"]
+mod empty_tests;

--- a/rust/export/src/merged/empty_tests.rs
+++ b/rust/export/src/merged/empty_tests.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for `empty.rs`, split out under the house pattern (AGENTS.md): the
+//! production module stays under the module-size ratchet, and this file is
+//! exempt via the `_tests.rs` suffix.
+//!
+//! The end-to-end behaviour (what a merged file does and does not contain) is
+//! asserted in `tests.rs`; what is pinned here is the emptiness decision itself,
+//! reached through the same entry point the merge uses.
+
+use super::*;
+
+/// Build the drop plan for `models` exactly as `export_merged_models` does.
+fn plan(models: &[&str]) -> DropPlan {
+    let inputs: Vec<MergedModel> = models
+        .iter()
+        .enumerate()
+        .map(|(i, m)| MergedModel { content: m.as_bytes(), id: i.to_string(), included: None })
+        .collect();
+    let first = ModelIndex::build(inputs[0].content);
+    let order: Vec<u32> = first.order.clone();
+    let lookup = SpatialLookup::build(
+        &order,
+        &|id| first.line_str(id),
+        &|id| first.type_of.get(&id).cloned(),
+    );
+    let opts = MergedOptions { drop_empty_containers: true, ..Default::default() };
+    let modes = crate::merged::units::resolve_model_modes(&inputs, opts.unit_reconciliation, 1.0);
+    plan_drops(&inputs, &opts, &lookup, &modes).expect("flag is set")
+}
+
+fn file(entities: &str) -> String {
+    format!(
+        "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n{entities}ENDSEC;\nEND-ISO-10303-21;\n"
+    )
+}
+
+/// Site → Building → two storeys; only the first storey contains a wall.
+fn one_populated_storey() -> String {
+    file(concat!(
+        "#1=IFCPROJECT('p0',$,'P',$,$,$,$,$,$);\n",
+        "#2=IFCSITE('s0',$,'Site',$,$,$,$,$,$,$,$,$,$,$);\n",
+        "#3=IFCBUILDING('b0',$,'Building',$,$,$,$,$,$,$,$,$);\n",
+        "#4=IFCBUILDINGSTOREY('l0',$,'Level 0',$,$,$,$,$,$,0.);\n",
+        "#5=IFCBUILDINGSTOREY('l1',$,'Level 1',$,$,$,$,$,$,3000.);\n",
+        "#6=IFCWALL('w0',$,'Wall',$,$,$,$,$,$);\n",
+        "#7=IFCRELAGGREGATES('r0',$,$,$,#1,(#2));\n",
+        "#8=IFCRELAGGREGATES('r1',$,$,$,#2,(#3));\n",
+        "#9=IFCRELAGGREGATES('r2',$,$,$,#3,(#4,#5));\n",
+        "#10=IFCRELCONTAINEDINSPATIALSTRUCTURE('r3',$,$,$,(#6),#4);\n",
+    ))
+}
+
+#[test]
+fn drops_only_the_storey_that_holds_nothing() {
+    let dropped = plan(&[&one_populated_storey()]);
+    assert_eq!(dropped.count, 1);
+    assert_eq!(dropped.per_model[0], HashSet::from([5]));
+}
+
+#[test]
+fn keeps_ancestors_of_a_populated_container() {
+    // Site and Building hold no element directly — only a storey that does — so
+    // the upward sweep is the only thing keeping them.
+    let dropped = plan(&[&one_populated_storey()]);
+    assert!(!dropped.per_model[0].contains(&2), "site of a populated storey must stay");
+    assert!(!dropped.per_model[0].contains(&3), "building of a populated storey must stay");
+}
+
+#[test]
+fn a_container_only_a_later_model_fills_is_not_empty() {
+    // Model A's storey is empty in A; model B's same-named storey carries a wall
+    // and unifies onto it. Emptiness is a fact about the MERGED model, so the
+    // storey survives — the reason this runs across every model, not per file.
+    let a = file(concat!(
+        "#1=IFCPROJECT('p0',$,'P',$,$,$,$,$,$);\n",
+        "#2=IFCSITE('s0',$,'Site',$,$,$,$,$,$,$,$,$,$,$);\n",
+        "#3=IFCBUILDING('b0',$,'Building',$,$,$,$,$,$,$,$,$);\n",
+        "#4=IFCBUILDINGSTOREY('l0',$,'Level 0',$,$,$,$,$,$,0.);\n",
+        "#5=IFCRELAGGREGATES('r0',$,$,$,#1,(#2));\n",
+        "#6=IFCRELAGGREGATES('r1',$,$,$,#2,(#3));\n",
+        "#7=IFCRELAGGREGATES('r2',$,$,$,#3,(#4));\n",
+    ));
+    let b = file(concat!(
+        "#1=IFCPROJECT('p1',$,'P',$,$,$,$,$,$);\n",
+        "#2=IFCSITE('s1',$,'Site',$,$,$,$,$,$,$,$,$,$,$);\n",
+        "#3=IFCBUILDING('b1',$,'Building',$,$,$,$,$,$,$,$,$);\n",
+        "#4=IFCBUILDINGSTOREY('l1',$,'Level 0',$,$,$,$,$,$,0.);\n",
+        "#5=IFCWALL('w1',$,'Wall',$,$,$,$,$,$);\n",
+        "#6=IFCRELAGGREGATES('r1',$,$,$,#3,(#4));\n",
+        "#7=IFCRELCONTAINEDINSPATIALSTRUCTURE('r2',$,$,$,(#5),#4);\n",
+    ));
+    let dropped = plan(&[&a, &b]);
+    assert_eq!(dropped.count, 0, "no container is empty once both models are in");
+    assert!(dropped.per_model.iter().all(HashSet::is_empty));
+}
+
+#[test]
+fn a_container_a_non_relationship_names_is_kept() {
+    // Nothing can rewrite a reference from a non-relationship entity, so an
+    // otherwise-empty space stays rather than leaving a dangling `#ref`.
+    let model = file(concat!(
+        "#1=IFCPROJECT('p0',$,'P',$,$,$,$,$,$);\n",
+        "#2=IFCSPACE('sp0',$,'Space',$,$,$,$,$,$,$,$);\n",
+        "#3=IFCRELAGGREGATES('r0',$,$,$,#1,(#2));\n",
+        "#4=IFCX('x',(#2));\n",
+    ));
+    assert_eq!(plan(&[&model]).count, 0);
+}
+
+#[test]
+fn ref_helpers_read_step_attributes() {
+    assert_eq!(single_ref(" #42 "), Some(42));
+    assert_eq!(single_ref("$"), None);
+    assert_eq!(ref_list("(#1,#2)"), vec![1, 2]);
+    assert_eq!(ref_list("()"), Vec::<u32>::new());
+    assert!(is_container_type("IFCSPACE"));
+    assert!(!is_container_type("IFCPROJECT"), "the project root is never a candidate");
+}

--- a/rust/export/src/merged/line_edit.rs
+++ b/rust/export/src/merged/line_edit.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
-//! STEP entity-line surgery for the merged exporter's container drop
-//! ([`super::empty`]): classify where a `#N` reference sits in the argument
-//! list, and rewrite a line that references a dropped entity.
+//! STEP entity-line surgery for the merged exporter: rewrite the `#N`
+//! references of one model's line into the merged file's id space, classify
+//! where a reference sits in the argument list, and rewrite a line that
+//! references an entity being dropped ([`super::empty`]).
 //!
 //! Slot classification is what makes dropping safe. A reference in a *list*
 //! (`(#7,#8)`) can be removed and the line kept; a reference in a *single-valued*
@@ -10,6 +11,48 @@
 //! all.
 
 use std::collections::HashSet;
+
+/// Rewrite every `#N` reference in a STEP entity line. `remap(n)` returns
+/// `Some(absolute_id)` to redirect a reference (no offset), or `None` to apply
+/// `offset`. Single-quoted strings are passed through as raw bytes (a `#` there
+/// is literal text), tracking only in/out-of-string state.
+pub fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32>) -> String {
+    let mut out: Vec<u8> = Vec::with_capacity(line.len() + 8);
+    let mut i = 0;
+    let mut in_string = false;
+    while i < line.len() {
+        let b = line[i];
+        if b == b'\'' {
+            in_string = !in_string;
+            out.push(b'\'');
+            i += 1;
+            continue;
+        }
+        if !in_string && b == b'#' {
+            let mut j = i + 1;
+            let mut n: u32 = 0;
+            let mut any = false;
+            while j < line.len() && line[j].is_ascii_digit() {
+                // Saturate rather than wrap: a malformed reference number wider than
+                // u32 must not silently wrap onto a small, valid id (CR #2952). A
+                // clamped id stays dangling (caught downstream), never mis-pointed.
+                n = n.saturating_mul(10).saturating_add((line[j] - b'0') as u32);
+                j += 1;
+                any = true;
+            }
+            if any {
+                let target = remap(n).unwrap_or_else(|| n.saturating_add(offset));
+                out.push(b'#');
+                out.extend_from_slice(target.to_string().as_bytes());
+                i = j;
+                continue;
+            }
+        }
+        out.push(b);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
 
 /// Where a `#N` reference sits in an entity's top-level argument list.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/rust/export/src/merged/line_edit.rs
+++ b/rust/export/src/merged/line_edit.rs
@@ -215,3 +215,6 @@ pub(super) fn decide_line(line: &str, dropped: &HashSet<u32>) -> LineDecision {
     LineDecision::Rewrite(rebuilt)
 }
 
+#[cfg(test)]
+#[path = "line_edit_tests.rs"]
+mod line_edit_tests;

--- a/rust/export/src/merged/line_edit.rs
+++ b/rust/export/src/merged/line_edit.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MPL-2.0
+//! STEP entity-line surgery for the merged exporter's container drop
+//! ([`super::empty`]): classify where a `#N` reference sits in the argument
+//! list, and rewrite a line that references a dropped entity.
+//!
+//! Slot classification is what makes dropping safe. A reference in a *list*
+//! (`(#7,#8)`) can be removed and the line kept; a reference in a *single-valued*
+//! attribute (`#7`) cannot — the line has to go with it. Anything nested deeper
+//! is neither, and the caller treats it as a reason not to drop the target at
+//! all.
+
+use std::collections::HashSet;
+
+/// Where a `#N` reference sits in an entity's top-level argument list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RefSlot {
+    /// A whole top-level attribute is the reference (`…,#7,…`).
+    Single,
+    /// A direct element of a top-level list attribute (`…,(#7,#8),…`).
+    ListElement,
+    /// Anywhere else (inside a nested list or a typed value), where neither
+    /// removing the element nor dropping the line is a safe rewrite.
+    Nested,
+}
+
+/// What to do with a line that references at least one dropped entity.
+pub(super) enum LineDecision {
+    /// Emit the line unchanged (it references nothing dropped).
+    Keep,
+    /// Do not emit the line at all.
+    Skip,
+    /// Emit this rewritten line instead (dropped list elements removed).
+    Rewrite(String),
+}
+
+/// Collect every `#N` reference in a line's ARGUMENT list, skipping the leading
+/// `#id=` (which is the line's own id, not an outgoing reference).
+pub(super) fn arg_refs(line: &[u8], out: &mut Vec<u32>) {
+    let start = line.iter().position(|&b| b == b'=').map_or(0, |i| i + 1);
+    crate::step_text::refs_in_line(&line[start..], out);
+}
+
+/// Byte offsets of the opening and closing parenthesis of the top-level argument
+/// list of `#id=TYPE(…);`, honouring quoted strings and nested parentheses.
+fn arg_span(line: &str) -> Option<(usize, usize)> {
+    let bytes = line.as_bytes();
+    let from = bytes.iter().position(|&b| b == b'=').map_or(0, |i| i + 1);
+    let open = from + bytes[from..].iter().position(|&b| b == b'(')?;
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut i = open;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if c == b'\'' {
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                    continue;
+                }
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' => in_string = true,
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((open, i));
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Split a STEP argument list body into its top-level arguments, as slices of
+/// the input (quotes and nested parentheses aware). `""` yields one empty arg.
+fn split_args(args: &str) -> Vec<&str> {
+    let bytes = args.as_bytes();
+    let mut out = Vec::new();
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_string {
+            if c == b'\'' {
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                    continue;
+                }
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\'' => in_string = true,
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b',' if depth == 0 => {
+                out.push(&args[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    out.push(&args[start..]);
+    out
+}
+
+/// Parse an argument that is exactly one reference (`"#7"` → `7`).
+fn parse_ref(arg: &str) -> Option<u32> {
+    let t = arg.trim();
+    let digits = t.strip_prefix('#')?;
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    digits.parse().ok()
+}
+
+/// True when `arg` is a list literal (`(…)`).
+fn is_list(arg: &str) -> bool {
+    arg.len() >= 2 && arg.starts_with('(') && arg.ends_with(')')
+}
+
+/// Classify every reference in `line` by the argument slot it occupies, or
+/// `None` when the line's argument list cannot be parsed at all — a line no
+/// rewrite can narrow, which the drop analysis must treat as a blocker rather
+/// than as "names nothing".
+pub(super) fn classify_refs(line: &str) -> Option<Vec<(u32, RefSlot)>> {
+    let mut out = Vec::new();
+    let (open, close) = arg_span(line)?;
+    for arg in split_args(&line[open + 1..close]) {
+        let trimmed = arg.trim();
+        if let Some(n) = parse_ref(trimmed) {
+            out.push((n, RefSlot::Single));
+            continue;
+        }
+        if is_list(trimmed) {
+            for element in split_args(&trimmed[1..trimmed.len() - 1]) {
+                match parse_ref(element) {
+                    Some(n) => out.push((n, RefSlot::ListElement)),
+                    None => push_nested(element, &mut out),
+                }
+            }
+            continue;
+        }
+        push_nested(trimmed, &mut out);
+    }
+    Some(out)
+}
+
+/// Record every reference inside `text` as [`RefSlot::Nested`].
+fn push_nested(text: &str, out: &mut Vec<(u32, RefSlot)>) {
+    let mut refs = Vec::new();
+    crate::step_text::refs_in_line(text.as_bytes(), &mut refs);
+    out.extend(refs.into_iter().map(|n| (n, RefSlot::Nested)));
+}
+
+/// Decide what to emit for `line` given the set of entity ids being dropped.
+///
+/// A single-valued reference to a dropped entity takes the line with it; a list
+/// element is removed, and a list left empty also takes the line (an
+/// objectified relationship with no subjects is not valid IFC). Callers must
+/// only reach this with lines the drop analysis already cleared as prunable —
+/// [`classify_refs`] is what it clears them with, so the two cannot disagree.
+pub(super) fn decide_line(line: &str, dropped: &HashSet<u32>) -> LineDecision {
+    let mut refs = Vec::new();
+    arg_refs(line.as_bytes(), &mut refs);
+    if !refs.iter().any(|r| dropped.contains(r)) {
+        return LineDecision::Keep;
+    }
+    let Some((open, close)) = arg_span(line) else { return LineDecision::Keep };
+    let args = split_args(&line[open + 1..close]);
+    let mut rebuilt = String::with_capacity(line.len());
+    rebuilt.push_str(&line[..=open]);
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            rebuilt.push(',');
+        }
+        let trimmed = arg.trim();
+        if parse_ref(trimmed).is_some_and(|n| dropped.contains(&n)) {
+            return LineDecision::Skip;
+        }
+        if !is_list(trimmed) {
+            rebuilt.push_str(arg);
+            continue;
+        }
+        let elements = split_args(&trimmed[1..trimmed.len() - 1]);
+        let kept: Vec<&str> = elements
+            .iter()
+            .copied()
+            .filter(|e| !parse_ref(e).is_some_and(|n| dropped.contains(&n)))
+            .collect();
+        if kept.len() == elements.len() {
+            rebuilt.push_str(arg);
+            continue;
+        }
+        if kept.iter().all(|e| e.trim().is_empty()) {
+            return LineDecision::Skip;
+        }
+        rebuilt.push('(');
+        rebuilt.push_str(&kept.join(","));
+        rebuilt.push(')');
+    }
+    rebuilt.push_str(&line[close..]);
+    LineDecision::Rewrite(rebuilt)
+}
+

--- a/rust/export/src/merged/line_edit_tests.rs
+++ b/rust/export/src/merged/line_edit_tests.rs
@@ -10,6 +10,20 @@ fn dropped(ids: &[u32]) -> HashSet<u32> {
 }
 
 #[test]
+fn rewrite_refs_offsets_and_redirects() {
+    let mut remap = std::collections::HashMap::new();
+    remap.insert(2u32, 100u32);
+    let out = rewrite_refs(
+        b"#3=IFCRELAGGREGATES('r #2',$,$,$,#1,(#2));",
+        10,
+        &|n| remap.get(&n).copied(),
+    );
+    // #1 offset by 10 → #11; #2 redirected → #100; '#2' in the string untouched.
+    assert!(out.contains("#11,(#100))"));
+    assert!(out.contains("'r #2'"));
+}
+
+#[test]
 fn classifies_single_list_and_nested_references() {
     let line = "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2,#3));";
     let slots = classify_refs(line).expect("parseable line");

--- a/rust/export/src/merged/line_edit_tests.rs
+++ b/rust/export/src/merged/line_edit_tests.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for `line_edit.rs`, split out under the house pattern (AGENTS.md):
+//! the production module stays under the module-size ratchet, and this file is
+//! exempt via the `_tests.rs` suffix.
+
+use super::*;
+
+fn dropped(ids: &[u32]) -> HashSet<u32> {
+    ids.iter().copied().collect()
+}
+
+#[test]
+fn classifies_single_list_and_nested_references() {
+    let line = "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2,#3));";
+    let slots = classify_refs(line).expect("parseable line");
+    assert_eq!(slots[0], (1, RefSlot::Single));
+    assert_eq!(slots[1], (2, RefSlot::ListElement));
+    assert_eq!(slots[2], (3, RefSlot::ListElement));
+    // A reference one level deeper is neither removable nor line-fatal.
+    let nested = classify_refs("#9=IFCX('g',((#4)),#5);").expect("parseable line");
+    assert!(nested.contains(&(4, RefSlot::Nested)));
+    assert!(nested.contains(&(5, RefSlot::Single)));
+}
+
+#[test]
+fn an_unparseable_line_classifies_as_none_rather_than_as_empty() {
+    // "no argument list" must be distinguishable from "names nothing": the drop
+    // analysis blocks on the first and would happily drop on the second.
+    assert!(classify_refs("#9=IFCRELAGGREGATES;").is_none());
+    assert!(classify_refs("#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2)").is_none());
+}
+
+#[test]
+fn a_hash_inside_a_string_is_not_a_reference() {
+    let slots = classify_refs("#9=IFCSITE('g',$,'Site #7',$,$,$,$,$,$);").expect("parseable line");
+    assert!(slots.is_empty());
+    let mut refs = Vec::new();
+    arg_refs(b"#9=IFCSITE('g',$,'Site #7',$,$,$,$,$,$);", &mut refs);
+    assert!(refs.is_empty(), "quoted text is not a reference: {refs:?}");
+}
+
+#[test]
+fn arg_refs_skips_the_line_s_own_id() {
+    let mut refs = Vec::new();
+    arg_refs(b"#12=IFCRELAGGREGATES('g',$,$,$,#1,(#2));", &mut refs);
+    assert_eq!(refs, vec![1, 2]);
+}
+
+#[test]
+fn keeps_a_line_that_names_nothing_dropped() {
+    let line = "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2,#3));";
+    assert!(matches!(decide_line(line, &dropped(&[7])), LineDecision::Keep));
+}
+
+#[test]
+fn strips_a_dropped_list_element_and_keeps_the_rest() {
+    let line = "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2,#3));";
+    let LineDecision::Rewrite(out) = decide_line(line, &dropped(&[2])) else {
+        panic!("expected a rewrite");
+    };
+    assert_eq!(out, "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#3));");
+}
+
+#[test]
+fn drops_the_line_when_a_list_empties() {
+    let line = "#9=IFCRELAGGREGATES('g',$,$,$,#1,(#2,#3));";
+    assert!(matches!(decide_line(line, &dropped(&[2, 3])), LineDecision::Skip));
+}
+
+#[test]
+fn drops_the_line_when_a_single_valued_reference_goes() {
+    // Relating object dropped: the relationship has no subject left to name.
+    let line = "#9=IFCRELCONTAINEDINSPATIALSTRUCTURE('g',$,$,$,(#2),#1);";
+    assert!(matches!(decide_line(line, &dropped(&[1])), LineDecision::Skip));
+}
+
+#[test]
+fn rewriting_preserves_every_other_attribute_verbatim() {
+    // Commas, parentheses and hashes inside quoted text must survive untouched.
+    let line = "#9=IFCRELDEFINESBYPROPERTIES('g',$,'A, (b) #2',$,(#2,#3),#4);";
+    let LineDecision::Rewrite(out) = decide_line(line, &dropped(&[2])) else {
+        panic!("expected a rewrite");
+    };
+    assert_eq!(out, "#9=IFCRELDEFINESBYPROPERTIES('g',$,'A, (b) #2',$,(#3),#4);");
+}

--- a/rust/export/src/merged/mod.rs
+++ b/rust/export/src/merged/mod.rs
@@ -234,15 +234,11 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
         let is_first = i == 0;
         let index = ModelIndex::build(model.content);
         let included = plan::resolve_included(&index, &model.included);
-        // Placing this model would push the merged EXPRESS-id space past u32::MAX.
-        // Wrapping the offset would silently duplicate ids and rewrite references
-        // to the wrong entities (CR #2952), so stop here instead: the file emitted
-        // so far is valid, and the unmerged tail is reported for the caller to gate.
-        // Bound by the largest VISIBLE id, not `index.max_id`: an excluded high id
-        // is never emitted, so it must not consume id space or omit a later model
-        // that would actually fit (CR #2952).
-        let max_visible_id = included.iter().copied().max().unwrap_or(0);
-        let Some(next_offset) = offset.checked_add(max_visible_id) else {
+        // Placing this model would push the merged EXPRESS-id space past u32::MAX,
+        // so stop here instead: the file emitted so far is valid, and the unmerged
+        // tail is reported for the caller to gate. `plan::next_offset` is the single
+        // home for that bound — the drop pre-pass stops at the same model.
+        let Some(next) = plan::next_offset(offset, &included) else {
             stats.unmerged_model_count = models.len() - i;
             stats.warnings.push(format!(
                 "merged EXPRESS id space would exceed u32::MAX; stopped after {i} model(s), {} model(s) not merged.",
@@ -262,8 +258,11 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
             stats.unit_rescale_required = true;
         }
 
-        // Empty spatial containers this model must not write (#3643).
-        let dropped_containers = drop_plan.as_ref().map(|p| &p.per_model[i]).filter(|d| !d.is_empty());
+        // Empty spatial containers this model must not write (#3643). The plan
+        // covers only the models that will actually be emitted, so a model past
+        // the id-space cut has no entry — `get` rather than index.
+        let dropped_containers =
+            drop_plan.as_ref().and_then(|p| p.per_model.get(i)).filter(|d| !d.is_empty());
 
         let salt = model_salt(model, i);
         let plan = build_plan(&index, is_first, compatible, PlanCtx {
@@ -361,7 +360,7 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
             stats.written += 1;
         }
 
-        offset = next_offset;
+        offset = next;
     }
 
     if stats.federated_model_count > 0 {

--- a/rust/export/src/merged/mod.rs
+++ b/rust/export/src/merged/mod.rs
@@ -37,7 +37,7 @@ use crate::step_text::escape;
 
 use guid::{read_leading_guid, replace_global_id, GuidMinter};
 pub use guid::{deterministic_global_id, leading_rooted_global_id};
-use line_edit::LineDecision;
+use line_edit::{rewrite_refs, LineDecision};
 use plan::{build_plan, model_salt, ModelIndex, PlanCtx};
 use units::{resolve_length_scale, resolve_model_modes};
 
@@ -305,7 +305,7 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
             let remapped = if offset == 0 && plan.shared_remap.is_empty() {
                 String::from_utf8_lossy(bytes).into_owned()
             } else {
-                plan::rewrite_refs(bytes, offset, &|n| plan.shared_remap.get(&n).copied())
+                rewrite_refs(bytes, offset, &|n| plan.shared_remap.get(&n).copied())
             };
             let after_guid = match plan.guid_rewrite.get(&id) {
                 Some(g) => replace_global_id(&remapped, g),

--- a/rust/export/src/merged/mod.rs
+++ b/rust/export/src/merged/mod.rs
@@ -23,7 +23,9 @@
 //! (kept as its own project, never mis-scaled) and [`MergedStats::unit_rescale_required`]
 //! is set so the caller can gate that case to the JS path.
 
+mod empty;
 mod guid;
+mod line_edit;
 mod plan;
 mod spatial;
 mod units;
@@ -35,8 +37,9 @@ use crate::step_text::escape;
 
 use guid::{read_leading_guid, replace_global_id, GuidMinter};
 pub use guid::{deterministic_global_id, leading_rooted_global_id};
+use line_edit::LineDecision;
 use plan::{build_plan, model_salt, ModelIndex, PlanCtx};
-use units::{resolve_length_scale, units_compatible};
+use units::{resolve_length_scale, resolve_model_modes};
 
 pub use spatial::{ContainerMergeStrategy, StoreyMergeStrategy};
 
@@ -90,6 +93,14 @@ pub struct MergedOptions {
     pub merge_buildings: ContainerMergeStrategy,
     /// `IfcBuildingStorey` matching strategy.
     pub merge_storeys: StoreyMergeStrategy,
+    /// Drop spatial containers (`IfcSite` / `IfcBuilding` / `IfcBuildingStorey` /
+    /// `IfcSpace`) that the merge leaves holding nothing — the "Merge Projects"
+    /// recipe step that container matching alone does not cover (#3643).
+    /// Emptiness is judged on the MERGED model, after visibility filtering and
+    /// spatial unification, and an emptied container is simply never planned, so
+    /// nothing is written referencing it. Off by default: output is byte-identical
+    /// to a merge that never asked for it.
+    pub drop_empty_containers: bool,
 }
 
 impl Default for MergedOptions {
@@ -102,6 +113,7 @@ impl Default for MergedOptions {
             merge_sites: ContainerMergeStrategy::default(),
             merge_buildings: ContainerMergeStrategy::default(),
             merge_storeys: StoreyMergeStrategy::default(),
+            drop_empty_containers: false,
         }
     }
 }
@@ -123,6 +135,10 @@ pub struct MergedStats {
     /// that was federated rather than rescaled — the caller should route that
     /// case to the JS path if true single-project normalization is required.
     pub unit_rescale_required: bool,
+    /// Spatial containers dropped for holding nothing, counted in the merged
+    /// model (a container unified across three inputs counts once). Always 0
+    /// unless [`MergedOptions::drop_empty_containers`] is set.
+    pub dropped_container_count: usize,
     /// Human-readable notes (e.g. federation relaxing `IfcSingleProjectInstance`).
     pub warnings: Vec<String>,
 }
@@ -168,6 +184,7 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
         federated_model_count: 0,
         unmerged_model_count: 0,
         unit_rescale_required: false,
+        dropped_container_count: 0,
         warnings: Vec::new(),
     };
 
@@ -200,6 +217,13 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
     let primary_scale = resolve_length_scale(models[0].content);
     drop(first);
 
+    // Unit verdicts for every model, resolved once: the empty-container pre-pass
+    // has to know which models unify before anything is written, and the emit
+    // loop below must reach the same verdict — so both read this one answer.
+    let modes = resolve_model_modes(models, opts.unit_reconciliation, primary_scale);
+    let drop_plan = empty::plan_drops(models, opts, &spatial_lookup, &modes);
+    stats.dropped_container_count = drop_plan.as_ref().map_or(0, |p| p.count);
+
     // Running cross-model state.
     let mut guid_to_final: HashMap<String, (u32, f64)> = HashMap::new();
     let mut emitted_guids: HashSet<String> = HashSet::new();
@@ -227,31 +251,19 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
             break;
         };
 
-        // Unit mode.
-        let this_scale = resolve_length_scale(model.content);
-        let (compatible, effective_scale) = if is_first {
-            (true, primary_scale)
-        } else {
-            match opts.unit_reconciliation {
-                // AssumeShared unifies regardless of the declared unit, so the
-                // model's entities join the FIRST model's unit space: store
-                // `primary_scale`, not the model's own. Storing `this_scale` would
-                // make a later model's duplicate GlobalId fail the
-                // `units_compatible(scale, primary_scale)` gate and be re-stamped
-                // instead of unified (CR #2952).
-                UnitReconciliation::AssumeShared => (true, primary_scale),
-                _ if units_compatible(this_scale, primary_scale) => (true, this_scale),
-                UnitReconciliation::Normalize => {
-                    stats.federated_model_count += 1;
-                    stats.unit_rescale_required = true;
-                    (false, this_scale)
-                }
-                UnitReconciliation::Auto => {
-                    stats.federated_model_count += 1;
-                    (false, this_scale)
-                }
-            }
-        };
+        // Unit mode. Counted here, not where the verdicts are resolved, so an
+        // id-space break above still reports only the models actually merged.
+        let mode = &modes[i];
+        let (compatible, effective_scale) = (mode.compatible, mode.scale);
+        if mode.federated {
+            stats.federated_model_count += 1;
+        }
+        if mode.rescale_required {
+            stats.unit_rescale_required = true;
+        }
+
+        // Empty spatial containers this model must not write (#3643).
+        let dropped_containers = drop_plan.as_ref().map(|p| &p.per_model[i]).filter(|d| !d.is_empty());
 
         let salt = model_salt(model, i);
         let plan = build_plan(&index, is_first, compatible, PlanCtx {
@@ -276,6 +288,21 @@ pub fn export_merged_models(models: &[MergedModel], opts: &MergedOptions) -> (St
                 continue;
             }
             let Some(bytes) = index.line_bytes(id) else { continue };
+            // A dropped container is never written, and any line naming one is
+            // rewritten without it (or dropped with it), so the merge emits no
+            // reference to a line it did not write — no clean-up pass needed.
+            let mut pruned: Option<String> = None;
+            if let Some(dropped) = dropped_containers {
+                if dropped.contains(&id) {
+                    continue;
+                }
+                match line_edit::decide_line(&String::from_utf8_lossy(bytes), dropped) {
+                    LineDecision::Skip => continue,
+                    LineDecision::Rewrite(text) => pruned = Some(text),
+                    LineDecision::Keep => {}
+                }
+            }
+            let bytes: &[u8] = pruned.as_deref().map_or(bytes, str::as_bytes);
             let remapped = if offset == 0 && plan.shared_remap.is_empty() {
                 String::from_utf8_lossy(bytes).into_owned()
             } else {

--- a/rust/export/src/merged/plan.rs
+++ b/rust/export/src/merged/plan.rs
@@ -118,48 +118,6 @@ pub fn resolve_included(index: &ModelIndex, roots: &Option<Vec<u32>>) -> HashSet
     }
 }
 
-/// Rewrite every `#N` reference in a STEP entity line. `remap(n)` returns
-/// `Some(absolute_id)` to redirect a reference (no offset), or `None` to apply
-/// `offset`. Single-quoted strings are passed through as raw bytes (a `#` there
-/// is literal text), tracking only in/out-of-string state.
-pub fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32>) -> String {
-    let mut out: Vec<u8> = Vec::with_capacity(line.len() + 8);
-    let mut i = 0;
-    let mut in_string = false;
-    while i < line.len() {
-        let b = line[i];
-        if b == b'\'' {
-            in_string = !in_string;
-            out.push(b'\'');
-            i += 1;
-            continue;
-        }
-        if !in_string && b == b'#' {
-            let mut j = i + 1;
-            let mut n: u32 = 0;
-            let mut any = false;
-            while j < line.len() && line[j].is_ascii_digit() {
-                // Saturate rather than wrap: a malformed reference number wider than
-                // u32 must not silently wrap onto a small, valid id (CR #2952). A
-                // clamped id stays dangling (caught downstream), never mis-pointed.
-                n = n.saturating_mul(10).saturating_add((line[j] - b'0') as u32);
-                j += 1;
-                any = true;
-            }
-            if any {
-                let target = remap(n).unwrap_or_else(|| n.saturating_add(offset));
-                out.push(b'#');
-                out.extend_from_slice(target.to_string().as_bytes());
-                i = j;
-                continue;
-            }
-        }
-        out.push(b);
-        i += 1;
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
 /// The EXPRESS-id offset the NEXT model would use, or `None` when placing this
 /// model would push the merged id space past `u32::MAX`. Wrapping the offset
 /// would silently duplicate ids and rewrite references to the wrong entities

--- a/rust/export/src/merged/plan.rs
+++ b/rust/export/src/merged/plan.rs
@@ -160,6 +160,23 @@ pub fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32
     String::from_utf8_lossy(&out).into_owned()
 }
 
+/// The EXPRESS-id offset the NEXT model would use, or `None` when placing this
+/// model would push the merged id space past `u32::MAX`. Wrapping the offset
+/// would silently duplicate ids and rewrite references to the wrong entities
+/// (CR #2952), so a `None` here stops the merge instead.
+///
+/// Bound by the largest VISIBLE id, not `index.max_id`: an excluded high id is
+/// never emitted, so it must not consume id space or omit a later model that
+/// would actually fit (CR #2952).
+///
+/// Single home for the rule because two callers must agree on it exactly: the
+/// emit loop, and the empty-container pre-pass (#3643), which has to stop at
+/// the same model — a plan covering models that are never emitted would keep a
+/// container only the unmerged tail fills, and count it as dropped.
+pub(super) fn next_offset(offset: u32, included: &HashSet<u32>) -> Option<u32> {
+    offset.checked_add(included.iter().copied().max().unwrap_or(0))
+}
+
 /// Match this model's `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` onto the
 /// first model's (via `lookup`), recording each match in `shared_remap` (local
 /// id → first-model id) and `skip` (the local line is not emitted).

--- a/rust/export/src/merged/plan_tests.rs
+++ b/rust/export/src/merged/plan_tests.rs
@@ -30,20 +30,6 @@ fn resolve_included_pulls_forward_closure() {
 }
 
 #[test]
-fn rewrite_refs_offsets_and_redirects() {
-    let mut remap = HashMap::new();
-    remap.insert(2u32, 100u32);
-    let out = rewrite_refs(
-        b"#3=IFCRELAGGREGATES('r #2',$,$,$,#1,(#2));",
-        10,
-        &|n| remap.get(&n).copied(),
-    );
-    // #1 offset by 10 → #11; #2 redirected → #100; '#2' in the string untouched.
-    assert!(out.contains("#11,(#100))"));
-    assert!(out.contains("'r #2'"));
-}
-
-#[test]
 fn redundant_rel_aggregates_dropped_only_when_fully_shared() {
     let idx = ModelIndex::build(TWO_STOREYS.as_bytes());
     let mut skip = HashSet::new();

--- a/rust/export/src/merged/tests.rs
+++ b/rust/export/src/merged/tests.rs
@@ -1337,6 +1337,33 @@ fn dropping_is_off_by_default_and_inert_when_nothing_is_empty() {
     assert_eq!(dropped, baseline, "output is byte-identical when nothing is empty");
 }
 
+/// The drop plan must cover only the models the merge actually EMITS. A model
+/// past the EXPRESS-id cut is never written, so treating its content as present
+/// would keep a container nothing in the output fills — and report it as
+/// surviving. Found in review of #3643.
+#[test]
+fn a_model_past_the_id_space_cut_does_not_keep_a_container_alive() {
+    // The first model's near-max id leaves no room for the second, so the merge
+    // stops after model A. A's storey is empty; only the unmerged B fills it.
+    let a = "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#4294967295=IFCBUILDINGSTOREY('STOREYA000000000000001',$,'Level 0',$,$,$,$,$,$,0.);\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+    let b = "ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCBUILDINGSTOREY('STOREYB000000000000001',$,'Level 0',$,$,$,$,$,$,0.);\n\
+#2=IFCWALL('WALLB00000000000000001',$,'Wall',$,$,$,$,$,$);\n\
+#3=IFCRELCONTAINEDINSPATIALSTRUCTURE('RELB000000000000000001',$,$,$,(#2),#1);\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+    let opts = MergedOptions { drop_empty_containers: true, ..Default::default() };
+    let (merged, stats) = export_merged_with_stats(&[a.as_bytes(), b.as_bytes()], &opts);
+
+    assert_eq!(stats.unmerged_model_count, 1, "the second model cannot be placed");
+    // Model B's wall is never emitted, so the storey it would have filled is
+    // genuinely empty in the OUTPUT and must go.
+    assert_eq!(stats.dropped_container_count, 1, "the storey no emitted model fills is dropped");
+    assert_eq!(type_count(&merged, "=IFCBUILDINGSTOREY("), 0, "and is not written");
+    assert_no_dangling(&merged);
+}
+
 /// A real authoring-tool model, self-merged with the flag on: the drop must not
 /// remove anything a model actually uses, and must not dangle a reference.
 #[test]

--- a/rust/export/src/merged/tests.rs
+++ b/rust/export/src/merged/tests.rs
@@ -1261,3 +1261,108 @@ ENDSEC;\nEND-ISO-10303-21;\n"
         "control: the shared wall is likewise unified to a single surviving entity"
     );
 }
+
+/// A federation whose spatial trees unify: model A carries the whole
+/// project→site→building→two-storey tree with a wall on Level 0, model B repeats
+/// the tree (matched by name) and adds nothing to Level 1.
+fn two_models_with_an_empty_storey() -> (String, String) {
+    let head = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n";
+    let tail = "ENDSEC;\nEND-ISO-10303-21;\n";
+    let tree = |salt: &str, wall: &str| {
+        format!(
+            "{head}\
+#1=IFCPROJECT('p{salt}',$,'P',$,$,$,$,$,$);\n\
+#2=IFCSITE('s{salt}',$,'Site',$,$,$,$,$,$,$,$,$,$,$);\n\
+#3=IFCBUILDING('b{salt}',$,'Building',$,$,$,$,$,$,$,$,$);\n\
+#4=IFCBUILDINGSTOREY('g{salt}',$,'Level 0',$,$,$,$,$,$,0.);\n\
+#5=IFCBUILDINGSTOREY('f{salt}',$,'Level 1',$,$,$,$,$,$,3.);\n\
+#6=IFCWALL('{wall}',$,'Wall',$,$,$,$,$,$);\n\
+#7=IFCRELAGGREGATES('a{salt}',$,$,$,#1,(#2));\n\
+#8=IFCRELAGGREGATES('c{salt}',$,$,$,#2,(#3));\n\
+#9=IFCRELAGGREGATES('d{salt}',$,$,$,#3,(#4,#5));\n\
+#10=IFCRELCONTAINEDINSPATIALSTRUCTURE('e{salt}',$,$,$,(#6),#4);\n\
+{tail}"
+        )
+    };
+    (tree("0", "wall000000000000000000"), tree("1", "wall111111111111111111"))
+}
+
+/// #3643: the "Merge Projects" recipe step container matching leaves behind —
+/// a storey no model puts anything in is not written at all, and the merge
+/// emits nothing referencing it, so no clean-up pass has to follow.
+#[test]
+fn empty_container_is_dropped_and_leaves_no_dangling_reference() {
+    let (a, b) = two_models_with_an_empty_storey();
+    let opts = MergedOptions { drop_empty_containers: true, ..Default::default() };
+    let (merged, stats) = export_merged_with_stats(&[a.as_bytes(), b.as_bytes()], &opts);
+
+    // Level 1 is empty in BOTH models, so the one unified storey goes.
+    assert_eq!(stats.dropped_container_count, 1, "one merged container dropped");
+    assert_eq!(type_count(&merged, "'Level 1'"), 0, "the empty storey is not written");
+    assert_eq!(type_count(&merged, "'Level 0'"), 1, "the populated storey survives");
+    assert_eq!(type_count(&merged, "=IFCSITE("), 1, "its site is kept — it holds a storey");
+    assert_eq!(type_count(&merged, "=IFCBUILDING("), 1, "so is its building");
+    assert_eq!(type_count(&merged, "=IFCWALL("), 2, "no element is lost");
+
+    // The aggregation that named it is rewritten without it, not left dangling.
+    let storey = sole_id_of_type(&merged, "'Level 0'");
+    let aggregates: Vec<&str> =
+        merged.lines().filter(|l| l.contains("=IFCRELAGGREGATES(")).collect();
+    assert!(
+        aggregates.iter().any(|l| refs_in_line(l).contains(&storey)),
+        "the surviving storey keeps its parent aggregation: {aggregates:?}"
+    );
+    assert_no_dangling(&merged);
+}
+
+/// The flag is off by default and changes nothing when there is nothing to drop:
+/// asking for the drop on a model whose every container is populated must return
+/// byte-identical output, so enabling it can never perturb an unrelated merge.
+#[test]
+fn dropping_is_off_by_default_and_inert_when_nothing_is_empty() {
+    let (a, b) = two_models_with_an_empty_storey();
+    // Give Level 1 an occupant in model B, so no container is empty any more.
+    let b = b.replace(
+        "#10=IFCRELCONTAINEDINSPATIALSTRUCTURE('e1',$,$,$,(#6),#4);",
+        "#10=IFCRELCONTAINEDINSPATIALSTRUCTURE('e1',$,$,$,(#6),#5);",
+    );
+    let models = [a.as_bytes(), b.as_bytes()];
+
+    let (baseline, base_stats) = export_merged_with_stats(&models, &MergedOptions::default());
+    assert_eq!(base_stats.dropped_container_count, 0, "default drops nothing");
+
+    let opts = MergedOptions { drop_empty_containers: true, ..Default::default() };
+    let (dropped, stats) = export_merged_with_stats(&models, &opts);
+    assert_eq!(stats.dropped_container_count, 0, "every container holds something");
+    assert_eq!(dropped, baseline, "output is byte-identical when nothing is empty");
+}
+
+/// A real authoring-tool model, self-merged with the flag on: the drop must not
+/// remove anything a model actually uses, and must not dangle a reference.
+#[test]
+fn dropping_containers_keeps_a_real_model_intact() {
+    let bytes = fixture_or_skip!("ara3d/duplex.ifc");
+    let models = [bytes.as_slice(), bytes.as_slice()];
+    let baseline = export_merged(&models, &MergedOptions::default());
+    let opts = MergedOptions { drop_empty_containers: true, ..Default::default() };
+    let (merged, stats) = export_merged_with_stats(&models, &opts);
+
+    assert_no_dangling(&merged);
+    assert_eq!(
+        type_count(&merged, "=IFCWALL("),
+        type_count(&baseline, "=IFCWALL("),
+        "no element is lost to the container drop"
+    );
+    let containers = |step: &str| {
+        ["=IFCSITE(", "=IFCBUILDING(", "=IFCBUILDINGSTOREY(", "=IFCSPACE("]
+            .iter()
+            .map(|needle| type_count(step, needle))
+            .sum::<usize>()
+    };
+    assert_eq!(
+        containers(&merged),
+        containers(&baseline) - stats.dropped_container_count,
+        "the containers that disappear are exactly the ones counted as dropped"
+    );
+}
+

--- a/rust/export/src/merged/units.rs
+++ b/rust/export/src/merged/units.rs
@@ -14,8 +14,79 @@
 
 use ifc_lite_core::EntityDecoder;
 
+use super::{MergedModel, UnitReconciliation};
+
 /// Relative tolerance for comparing two length unit scale factors (JS `1e-6`).
 const UNIT_SCALE_TOLERANCE: f64 = 1e-6;
+
+/// The unit verdict for one input model of a merged export.
+pub struct ModelUnitMode {
+    /// The model unifies into the first model's project / unit space.
+    pub compatible: bool,
+    /// The unit scale the model's entities live in once merged.
+    pub scale: f64,
+    /// The model is kept as its own `IfcProject` (incompatible length unit).
+    pub federated: bool,
+    /// `Normalize` was requested but the model was federated instead.
+    pub rescale_required: bool,
+}
+
+/// Resolve the unit verdict of every input model in one place, so the emit loop
+/// and the empty-container pre-pass (which has to know which models unify before
+/// anything is written) cannot disagree about what unifies.
+pub fn resolve_model_modes(
+    models: &[MergedModel],
+    reconciliation: UnitReconciliation,
+    primary_scale: f64,
+) -> Vec<ModelUnitMode> {
+    models
+        .iter()
+        .enumerate()
+        .map(|(i, model)| {
+            let scale = resolve_length_scale(model.content);
+            if i == 0 {
+                return ModelUnitMode {
+                    compatible: true,
+                    scale: primary_scale,
+                    federated: false,
+                    rescale_required: false,
+                };
+            }
+            match reconciliation {
+                // AssumeShared unifies regardless of the declared unit, so the
+                // model's entities join the FIRST model's unit space: report
+                // `primary_scale`, not the model's own. Reporting `this_scale`
+                // would make a later model's duplicate GlobalId fail the
+                // `units_compatible(scale, primary_scale)` gate and be re-stamped
+                // instead of unified (CR #2952).
+                UnitReconciliation::AssumeShared => ModelUnitMode {
+                    compatible: true,
+                    scale: primary_scale,
+                    federated: false,
+                    rescale_required: false,
+                },
+                _ if units_compatible(scale, primary_scale) => ModelUnitMode {
+                    compatible: true,
+                    scale,
+                    federated: false,
+                    rescale_required: false,
+                },
+                UnitReconciliation::Normalize => ModelUnitMode {
+                    compatible: false,
+                    scale,
+                    federated: true,
+                    rescale_required: true,
+                },
+                UnitReconciliation::Auto => ModelUnitMode {
+                    compatible: false,
+                    scale,
+                    federated: true,
+                    rescale_required: false,
+                },
+            }
+        })
+        .collect()
+}
 
 /// Resolve a model's length unit SI scale (metres per length unit, e.g. `0.001`
 /// for a millimetre file). Falls back to `1.0` when no length unit is declared.

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -214,7 +214,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/data': '7334937001846380278',
   'packages/diff': '935169126877539347',
   'packages/drawing-2d': '1202507408514109964',
-  'packages/export': '8294779133777308773',
+  'packages/export': '6651271583538625536',
   'packages/extensions': '8156044843525017433',
   'packages/geometry': '12847835029883478945',
   'packages/ids': '9562546445799669442',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -241,7 +241,7 @@
    808 packages/drawing-2d/src/types.ts
    592 packages/export/src/effective-index.ts
    888 packages/export/src/ifc5-exporter.ts
-  1667 packages/export/src/merged-exporter.ts
+  1578 packages/export/src/merged-exporter.ts
    639 packages/export/src/parquet-exporter.ts
   1062 packages/export/src/reference-collector.ts
    524 packages/export/src/schema-converter.ts


### PR DESCRIPTION
Closes #3643.

Container **matching** (`mergeSites` / `mergeBuildings` / `mergeStoreys`, #1483) decides which containers are the *same*; it says nothing about the ones left holding *nothing*. That is the other step of IfcOpenShell/BlenderBIM's "Merge Projects" recipe, and it now happens **inside** the merge on both paths instead of as a post-pass over the assembled STEP bytes.

## The rule

An `IfcSite` / `IfcBuilding` / `IfcBuildingStorey` / `IfcSpace` is empty when it contains no surviving element (`IfcRelContainedInSpatialStructure`), directly aggregates no surviving non-spatial object, and transitively aggregates no non-empty spatial child. `IfcProject` is never a candidate.

Emptiness is a fact about the **merged** model, not about one input, and is evaluated after visibility filtering and after spatial unification — the two things that make a container empty in the first place. A site empty in its own file is *not* empty once a later model's storeys unify onto it, so the analysis runs across every model before anything is written. There is a test for exactly that case, because a per-file check gets it wrong.

## Why in the plan rather than after it

A post-pass has to delete containers and then chase the wreckage: dangling `IfcRelAggregates` / `IfcRelContainedInSpatialStructure` references and emptied reference lists, or viewers reject the file. Inside the plan that second step does not exist — a dropped container is simply never emitted, a relationship naming one is narrowed, and one left with no subject goes with it. Nothing referencing a dropped container is ever written, so there is nothing to clean up.

That is also what keeps the native path native: the post-pass had to see the assembled bytes, which is what forced the merged STEP back into a JS `Uint8Array` and reinstated the out-of-memory this feature was meant to avoid. A caller of `export_merged_models` can now have both.

**Anything that cannot be rewritten around blocks the drop.** A non-relationship referrer, a reference nested inside a typed value, a relationship that is itself referenced (withholding it would dangle in turn), or a line whose argument list cannot be parsed — in each case the container is kept and counts as non-empty, so its ancestors stay too. Dropping is the special case; keeping is the default.

As the issue notes, a dropped container's own placement / representation entities are left behind unreferenced: valid STEP, just inert. Not worth a second graph walk.

## Surface

| | |
|---|---|
| Rust | `MergedOptions::drop_empty_containers`, `MergedStats::dropped_container_count` |
| TS | `MergeExportOptions.dropEmptyContainers`, `stats.droppedContainerCount` |
| CLI | `ifc-lite merge … --drop-empty-containers` (counted in `--json`) |

Off by default, and a merge with nothing to drop is byte-identical either way — asserted, not asserted-to.

## Commits

1. **`f191cef` — native merge.** New `merged/empty.rs` (merged-model container graph + emptiness sweep) and `merged/line_edit.rs` (reference-slot classification and the line rewrite). The per-model unit verdict moves into `units::resolve_model_modes` so the new pre-pass and the emit loop read one answer instead of two copies of the compatible/federated decision. `examples/merge_ifc` takes the flag.
2. **`43270fa` — JS mirror + CLI + docs.** `merged-empty-containers.ts` is the twin of `empty.rs`, same rule and same blocking conditions. Emit-time narrowing reuses the existing `filterHiddenRefsFromRelationshipLine` rather than growing a second line-rewriting rule — the dropped ids are exactly the "excluded ids" it already knows how to strip.
3. **`c27621c` — tests**, both paths.

`remapEntityText` and the GlobalId helpers move out of `merged-exporter.ts` verbatim (none used `this`; they mirror `merged/guid.rs`). That is what keeps the file inside its size budget: the ratchet row goes **down** 1667 → 1578, not up.

## Evidence

`tests/models/ara3d/duplex.ifc` + `AC20-FZK-Haus.ifc`, both implementations run independently:

| | native (`merge_ifc`) | JS (`ifc-lite merge`) |
|---|---|---|
| containers dropped | 17 | 17 |
| dangling references | 0 | 0 |
| `IfcProject` count | 1 | 1 |

The 17 are `IfcSpace` records no model puts anything in (`IFCSPACE` 28 → 11); the entities that go with them are the relationships that named only those spaces (`IFCRELSPACEBOUNDARY` 346 → 142, `IFCRELDEFINESBYPROPERTIES` 1962 → 1836, `IFCRELAGGREGATES` 11 → 8). No element is lost. `ifc-lite validate` on the result: **0 errors**, and the same single warning/info the baseline merge produces.

Two implementations reaching the same 17 from the same inputs is the check that they have not drifted.

## Verification

- `cargo test -p ifc-lite-export` — 370 + 30 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — pass
- `pnpm test --filter @ifc-lite/export` — 85 files
- `pnpm typecheck` — 89 tasks, 1614/1614 test files in a program
- `node scripts/check-module-size.mjs`, `node scripts/check-api-surface.mjs`, `pnpm docs:check-readmes` — pass

Not run locally (Windows toolchain gaps, both run in CI): `pnpm docs:check-samples` and `pnpm docs:check-generated` spawn `node_modules/.bin/tsc` / a pnpm shim by POSIX name and cannot start here. `packages/cli` has one pre-existing test failure (`geometry-report.test.ts`) present on `main` at the same commit, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merged exports can optionally omit empty sites, buildings, storeys, and spaces; the option is disabled by default.
  * Added `--drop-empty-containers` support to merge commands and examples.
  * Merge results report the number of omitted containers in statistics and CLI output.
  * References to omitted containers are safely removed or adjusted.

* **Documentation**
  * Added guidance on enabling the option and determining container emptiness.

* **Tests**
  * Added coverage for container removal, reference safety, defaults, and merged-model behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->