### PR TITLE
feat(viewer): "Show in context" — fade other geometry around a selected entity

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -6,9 +6,6 @@ import { useMemo, useState, useCallback, useEffect } from 'react';
 import {
   Copy,
   Check,
-  Focus,
-  EyeOff,
-  Eye,
   Building2,
   Layers,
   Layers2,
@@ -62,6 +59,7 @@ import { BsddCard } from './properties/BsddCard';
 import { GeoreferencingPanel } from './properties/GeoreferencingPanel';
 import { RawStepCard } from './properties/RawStepCard';
 import { UnitDisplayControl } from './properties/UnitDisplayControl';
+import { EntityHeaderActions } from './properties/EntityHeaderActions';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
 import { isMaterialDefinitionType } from '@/utils/materialDefinitionTypes';
 
@@ -150,8 +148,6 @@ export function PropertiesPanel() {
   const zoneAssignments = useViewerStore((s) => s.zoneAssignments);
   const selectedModelId = useViewerStore((s) => s.selectedModelId);
   const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
-  const toggleEntityVisibility = useViewerStore((s) => s.toggleEntityVisibility);
-  const isEntityVisible = useViewerStore((s) => s.isEntityVisible);
   // Relationship navigation: select a related entity (e.g. an IfcZone) to show
   // its attributes, or isolate a group's members in 3D (#1075).
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
@@ -1320,46 +1316,7 @@ export function PropertiesPanel() {
             )}
           </div>
           <div className="flex gap-1 shrink-0">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="rounded-none hover:bg-zinc-200 dark:hover:bg-zinc-700"
-                  onClick={() => {
-                    if (selectedEntityId && cameraCallbacks.frameSelection) {
-                      cameraCallbacks.frameSelection();
-                    }
-                  }}
-                >
-                  <Focus className="h-3.5 w-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Zoom to</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  className="rounded-none hover:bg-zinc-200 dark:hover:bg-zinc-700"
-                  onClick={() => {
-                    if (selectedEntityId) {
-                      toggleEntityVisibility(selectedEntityId);
-                    }
-                  }}
-                >
-                  {selectedEntityId && isEntityVisible(selectedEntityId) ? (
-                    <EyeOff className="h-3.5 w-3.5" />
-                  ) : (
-                    <Eye className="h-3.5 w-3.5" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {selectedEntityId && isEntityVisible(selectedEntityId) ? 'Hide' : 'Show'}
-              </TooltipContent>
-            </Tooltip>
+            <EntityHeaderActions />
             {/* Display-unit converter (issue #1573 proposal 2) — covers both
                 the Properties and Quantities tabs below, so it lives in the
                 shared header rather than inside either TabsContent. */}

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #3618: from an Entity List row a user can select an object and reach the
+ * Properties panel's "info tab", but the existing "Zoom to" button does not
+ * help when the object sits behind other geometry, and full Isolate ("I")
+ * hides everything else and loses spatial context. "Show in context" reuses
+ * the already-shared X-Ray channel (`ghostExceptEntities`, driven by Clash,
+ * IDS and BCF) so the rest of the model fades translucent instead of
+ * disappearing, and frames the camera on the selected entity in the same
+ * click.
+ *
+ * Driven through the REAL `EntityHeaderActions` component and the real store,
+ * never by calling `setGhostExceptEntities` directly — the defect class this
+ * repo keeps re-finding is a handler wired to the wrong id or channel.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { EntityHeaderActions } from './EntityHeaderActions.js';
+
+const SELECTED = 4_000_042;
+const OTHER = 4_000_099;
+
+function resetStore(): void {
+  useViewerStore.setState({
+    selectedEntityId: null,
+    ghostExceptEntities: null,
+    isolatedEntities: null,
+    hiddenEntities: new Set<number>(),
+    cameraCallbacks: {},
+  });
+}
+
+describe('EntityHeaderActions — "Show in context"', () => {
+  afterEach(() => {
+    cleanup();
+    resetStore();
+  });
+
+  it('ghosts every other entity and frames the camera, without isolating (hiding) anything', () => {
+    let framed = 0;
+    resetStore();
+    useViewerStore.setState({
+      selectedEntityId: SELECTED,
+      cameraCallbacks: { frameSelection: () => { framed += 1; } },
+    });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+    assert.ok(ghostButton, 'expected three header buttons (Zoom to, Show in context, Hide/Show)');
+
+    click(ghostButton);
+
+    const state = useViewerStore.getState();
+    assert.deepStrictEqual(
+      state.ghostExceptEntities && Array.from(state.ghostExceptEntities),
+      [SELECTED],
+      'ghostExceptEntities must hold exactly the selected entity',
+    );
+    assert.strictEqual(state.isolatedEntities, null, 'ghosting must not also isolate (hide) the rest');
+    assert.strictEqual(framed, 1, 'the camera must frame the selected entity in the same click');
+  });
+
+  it('toggles off on a second click, clearing the ghost channel', () => {
+    resetStore();
+    useViewerStore.setState({
+      selectedEntityId: SELECTED,
+      ghostExceptEntities: new Set([SELECTED]),
+      cameraCallbacks: {},
+    });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+
+    click(ghostButton);
+
+    assert.strictEqual(useViewerStore.getState().ghostExceptEntities, null);
+  });
+
+  it('does not clear a ghost context installed for a DIFFERENT entity — clicking sets its own', () => {
+    resetStore();
+    useViewerStore.setState({
+      selectedEntityId: SELECTED,
+      ghostExceptEntities: new Set([OTHER]),
+      cameraCallbacks: {},
+    });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+
+    click(ghostButton);
+
+    assert.deepStrictEqual(
+      Array.from(useViewerStore.getState().ghostExceptEntities ?? []),
+      [SELECTED],
+      'a click for the selected entity must replace the previous ghost set with its own',
+    );
+  });
+
+  it('control: "Zoom to" and "Hide" keep their existing, unrelated behaviour', () => {
+    let framed = 0;
+    resetStore();
+    useViewerStore.setState({
+      selectedEntityId: SELECTED,
+      cameraCallbacks: { frameSelection: () => { framed += 1; } },
+    });
+
+    const container = render(<EntityHeaderActions />);
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const [zoomButton, , hideButton] = buttons;
+
+    click(zoomButton);
+    assert.strictEqual(framed, 1);
+    assert.strictEqual(useViewerStore.getState().ghostExceptEntities, null, 'Zoom to must not touch ghosting');
+
+    click(hideButton);
+    assert.ok(
+      useViewerStore.getState().hiddenEntities.has(SELECTED),
+      'Hide must still hide the selected entity, unchanged by the new button',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Header action buttons for the selected entity (Properties panel "info tab"):
+ * Zoom to, Hide/Show, and Show in context (ghost).
+ *
+ * "Show in context" answers #3618: from an Entity List row, a user can select
+ * a row and reach this panel, but "Zoom to" alone does not help when the
+ * object sits behind other geometry, and full Isolate (the "I" shortcut, via
+ * `isolateEntity`) hides everything else and loses spatial context. This
+ * button instead reuses the existing X-Ray channel
+ * (`ghostExceptEntities`/`setGhostExceptEntities`, already shared by Clash,
+ * IDS and BCF) to fade every other entity translucent while framing the
+ * camera on the selected one, so the object is visible through the rest of
+ * the model instead of disappearing behind it or isolating it away from its
+ * surroundings.
+ */
+
+import { Focus, EyeOff, Eye, Ghost } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useViewerStore } from '@/store';
+
+export function EntityHeaderActions() {
+  const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
+  const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
+  const toggleEntityVisibility = useViewerStore((s) => s.toggleEntityVisibility);
+  const isEntityVisible = useViewerStore((s) => s.isEntityVisible);
+  const ghostExceptEntities = useViewerStore((s) => s.ghostExceptEntities);
+  const setGhostExceptEntities = useViewerStore((s) => s.setGhostExceptEntities);
+
+  const isGhosted = selectedEntityId != null &&
+    ghostExceptEntities !== null &&
+    ghostExceptEntities.size === 1 &&
+    ghostExceptEntities.has(selectedEntityId);
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="rounded-none hover:bg-zinc-200 dark:hover:bg-zinc-700"
+            onClick={() => {
+              if (selectedEntityId && cameraCallbacks.frameSelection) {
+                cameraCallbacks.frameSelection();
+              }
+            }}
+          >
+            <Focus className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Zoom to</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className={`rounded-none hover:bg-zinc-200 dark:hover:bg-zinc-700 ${isGhosted ? 'text-primary' : ''}`}
+            onClick={() => {
+              if (!selectedEntityId) return;
+              if (isGhosted) {
+                setGhostExceptEntities(null);
+              } else {
+                setGhostExceptEntities(new Set([selectedEntityId]));
+                cameraCallbacks.frameSelection?.();
+              }
+            }}
+          >
+            <Ghost className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isGhosted ? 'Clear "show in context"' : 'Show in context (fade the rest, keep it visible)'}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="rounded-none hover:bg-zinc-200 dark:hover:bg-zinc-700"
+            onClick={() => {
+              if (selectedEntityId) {
+                toggleEntityVisibility(selectedEntityId);
+              }
+            }}
+          >
+            {selectedEntityId && isEntityVisible(selectedEntityId) ? (
+              <EyeOff className="h-3.5 w-3.5" />
+            ) : (
+              <Eye className="h-3.5 w-3.5" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          {selectedEntityId && isEntityVisible(selectedEntityId) ? 'Hide' : 'Show'}
+        </TooltipContent>
+      </Tooltip>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #3618

## Reading of the issue

The user's workflow: select a row in an Entity List, then use the info tab's "Zoom to" to find that object in 3D. When the object is occluded by other geometry, "Zoom to" moves the camera but the nearer geometry still renders in front, so the object stays invisible. Isolate (the `I` shortcut) solves visibility but hides everything else, which loses the surrounding context the user wants to keep. The issue's proposed solution is explicit: "show the selected object with the other objects in transparent mode."

**Interpretation chosen**: add a "Show in context" action next to the existing Zoom to / Hide buttons in the Properties panel header (the "information tab" the issue refers to). It fades every other entity translucent and frames the camera on the selected one in the same click, so the object is visible *through* the rest of the model instead of disappearing behind it or isolating it away from its surroundings. This reuses the store's existing `ghostExceptEntities` X-Ray channel, which Clash, IDS and BCF already drive for exactly this "focused subset, rest still visible" presentation — so the render-side behaviour is already proven, not new.

The issue's alternative ("a section box around the selected object") is not implemented: a general-purpose Section tool with cardinal and custom planes already exists in this viewer, so a per-entity auto section box would be new surface for a need the ghost/X-ray toggle already covers more directly. Happy to add it separately if the maintainer still wants it after seeing this.

## Files touched

- `apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx` (new) — Zoom to / Show in context / Hide, extracted out of `PropertiesPanel.tsx`.
- `apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx` (new) — drives the real component + store; includes a control proving Zoom to / Hide behaviour is unchanged.
- `apps/viewer/src/components/viewer/PropertiesPanel.tsx` — the three header buttons replaced with `<EntityHeaderActions />`.

**Why extracted rather than edited in place**: `PropertiesPanel.tsx`'s `scripts/module-size-allowlist.txt` budget is 2205, and the file was at exactly 2205 lines before this change — any net-positive edit would fail `check-module-size.mjs`, which this repo's house rules forbid raising. Net effect on `PropertiesPanel.tsx` is -43 lines (2205 → 2162).

**Overlap note**: none of these three files, nor `visibilitySlice.ts` (unedited — `setGhostExceptEntities` already existed and is called as-is), appear in the open-PR file-overlap check for `apps/viewer`. A sibling agent is reportedly working on a Lists world-coordinates column (issue #3671) concurrently; this PR does not touch any Lists column/registry file (`apps/viewer/src/components/viewer/lists/**`, `apps/viewer/src/lib/units/list-column-units.ts`), so there should be no collision.

## What I ran

- `pnpm typecheck` (turbo, all 89 tasks + `typecheck-tests.mjs` across 48 packages) — clean.
- `node scripts/check-module-size.mjs` — OK, 0 new over budget (only pre-existing informational headroom notes).
- `node scripts/check-unused-locals.mjs` — no new unused locals.
- `node scripts/check-test-wiring.mjs` — OK.
- `pnpm run check:vitest-timeout-audit` — passes (exit 0).
- `pnpm lint` (oxlint) — 0 errors (5 pre-existing warnings elsewhere, unrelated).
- New test file directly via `tsx --test`: 4/4 passing, including a control that "Zoom to" and "Hide" behave exactly as before.
- All other `apps/viewer/src/components/viewer/properties/*.test.{ts,tsx}` (12 files, 101 tests) — all passing.
- `apps/viewer/src/components/viewer/PropertiesPanel.group-isolate.test.tsx` (6 tests) — all passing, confirming the adjacent isolate-in-3D flow is unaffected.

Base: `upstream/main` @ `bc0906e18053717b184a06ef022abee4012c4f49`.

TypeScript-only change; no Rust/WASM touched. `apps/viewer` is private (no changeset needed).