### PR TITLE
feat(viewer): show and select the parent IfcElementAssembly

### DIFF
--- a/apps/viewer/src/components/viewer/PropertiesPanel.assembly-select.test.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.assembly-select.test.tsx
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #3620: selecting a member of an IfcElementAssembly gave no
+ * indication of that relationship near the IfcClass label, and no way to
+ * jump to the assembly itself. This pins the fix: a "Part of Assembly"
+ * badge appears when the selected element is decomposed by an
+ * IfcElementAssembly (via IfcRelAggregates), and clicking it selects the
+ * assembly -- including when the assembly itself owns no geometry, which is
+ * the normal case (its meshes hang off the aggregated parts, not the
+ * assembly entity).
+ *
+ * Driven the way a user drives it: mount the real panel over a REAL parsed
+ * store (the panel walks a `ModelQuery`, which a cast stub cannot satisfy --
+ * AGENTS.md), click the badge, and read the store back.
+ */
+
+import '@/test/setup-dom.js';
+
+import { after, afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { PropertiesPanel } from './PropertiesPanel.js';
+
+const MODEL_ID = 'm1';
+const ID_OFFSET = 1_000_000;
+
+/**
+ * `#50 Assembly A` decomposes into the two columns `#60`/`#61` via
+ * IFCRELAGGREGATES -- and, like every IfcElementAssembly, carries no
+ * IfcProductDefinitionShape of its own; only the columns render. `#42 Wall A`
+ * is an ordinary element in no aggregation at all -- the control.
+ */
+const MINI_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project0000000000000a',$,'P',$,$,$,$,$,$);
+#42=IFCWALL('0Wall00000000000000042',$,'Wall A',$,$,$,$,$,$);
+#50=IFCELEMENTASSEMBLY('0Assembly00000000050',$,'Assembly A',$,$,$,$,$,$,$);
+#60=IFCCOLUMN('0Column0000000000060',$,'Column A',$,$,$,$,$,$);
+#61=IFCCOLUMN('0Column0000000000061',$,'Column B',$,$,$,$,$,$);
+#51=IFCRELAGGREGATES('0RelAgg00000000051',$,$,$,#50,(#60,#61));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let miniStore: Promise<IfcDataStore> | null = null;
+function parseMiniStore(): Promise<IfcDataStore> {
+  if (!miniStore) {
+    const bytes = new TextEncoder().encode(MINI_IFC);
+    miniStore = new IfcParser().parseColumnar(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    );
+  }
+  return miniStore;
+}
+
+let initialState: ReturnType<typeof useViewerStore.getState>;
+
+async function seed(selectedExpressId: number): Promise<void> {
+  const parsed = await parseMiniStore();
+  useViewerStore.setState({
+    models: new Map([[MODEL_ID, {
+      id: MODEL_ID,
+      name: MODEL_ID,
+      ifcDataStore: parsed,
+      // The assembly owns no geometry -- geometryResult stays null/empty for
+      // every case here, including the ordinary-element control, so the
+      // panel is never leaning on a mesh existing to do its job.
+      geometryResult: null,
+      visible: true,
+      idOffset: ID_OFFSET,
+      maxExpressId: 100_000,
+      loadedAt: 1,
+    }]]) as never,
+    activeModelId: MODEL_ID,
+    selectedEntity: { modelId: MODEL_ID, expressId: selectedExpressId },
+    selectedEntityId: selectedExpressId + ID_OFFSET,
+    selectedEntityIds: new Set<number>(),
+  });
+}
+
+function assemblyBadge(container: HTMLElement): HTMLElement | null {
+  return [...container.querySelectorAll<HTMLElement>('button')]
+    .find((b) => b.textContent?.includes('Part of Assembly')) ?? null;
+}
+
+describe('Properties panel -- "Part of Assembly" (#3620)', () => {
+  before(() => {
+    initialState = useViewerStore.getState();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useViewerStore.setState(initialState, true);
+  });
+
+  after(() => {
+    useViewerStore.setState(initialState, true);
+  });
+
+  it('shows a clickable badge naming the parent assembly for a member element', async () => {
+    await seed(60); // Column A, a member of Assembly A
+    const container = render(<PropertiesPanel />);
+
+    const badge = assemblyBadge(container);
+    assert.ok(badge, 'expected a "Part of Assembly" badge for an assembly member');
+    assert.ok(badge!.textContent?.includes('Assembly A'), `badge should name the assembly, got: ${badge!.textContent}`);
+  });
+
+  it('selects the parent assembly -- geometry-less -- when the badge is clicked', async () => {
+    await seed(60); // Column A
+    const container = render(<PropertiesPanel />);
+
+    click(assemblyBadge(container)!);
+
+    const s = useViewerStore.getState();
+    assert.equal(s.selectedEntity?.expressId, 50, 'selection must move to the assembly, not stay on the part');
+    assert.equal(s.selectedEntity?.modelId, MODEL_ID);
+  });
+
+  it('re-renders on the assembly itself after the click -- no crash, no blank panel, though it owns no geometry', async () => {
+    await seed(60);
+    const container = render(<PropertiesPanel />);
+
+    click(assemblyBadge(container)!);
+
+    // The panel must now describe the assembly, proving it rendered a full
+    // properties view for an entity with no mesh of its own.
+    assert.ok(container.textContent?.includes('Assembly A'), 'panel should now show the assembly\'s own name');
+    assert.ok(container.textContent?.includes('IfcElementAssembly'), 'panel should show the assembly\'s IfcClass');
+  });
+
+  it('control: an ordinary element in no assembly shows no badge, selection unaffected', async () => {
+    await seed(42); // Wall A -- not in any IfcRelAggregates
+    const container = render(<PropertiesPanel />);
+
+    assert.equal(assemblyBadge(container), null, 'a plain wall must not get an assembly badge');
+    assert.equal(useViewerStore.getState().selectedEntity?.expressId, 42);
+  });
+});

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -16,7 +16,6 @@ import {
   Calculator,
   Tag,
   MousePointer2,
-  ArrowUpDown,
   PenLine,
   Crosshair,
   Box,
@@ -57,6 +56,8 @@ import { ScheduleCard } from './properties/ScheduleCard';
 import { TaskEditCard } from './properties/TaskEditCard';
 import { DocumentCard } from './properties/DocumentCard';
 import { RelationshipsCard } from './properties/RelationshipsCard';
+import { SpatialLocationBadge } from './properties/SpatialLocationBadge';
+import { AssemblyBadge } from './properties/AssemblyBadge';
 import type { PropertySet, QuantitySet } from './properties/encodingUtils';
 import { BsddCard } from './properties/BsddCard';
 import { GeoreferencingPanel } from './properties/GeoreferencingPanel';
@@ -155,6 +156,7 @@ export function PropertiesPanel() {
   // Relationship navigation: select a related entity (e.g. an IfcZone) to show
   // its attributes, or isolate a group's members in 3D (#1075).
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
+  const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
   const setSelectedEntityIds = useViewerStore((s) => s.setSelectedEntityIds);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
@@ -451,6 +453,16 @@ export function PropertiesPanel() {
     if (!originalExpressId || !modelQuery) return null;
     return modelQuery.entity(originalExpressId);
   }, [selectedEntity, modelQuery]);
+
+  // Issue #3620: the selected element gives no indication it is a member of
+  // an IfcElementAssembly, nor a way to select that assembly. `decomposedBy`
+  // walks the IfcRelAggregates edge to the parent; gate on the parent's type
+  // so a plain spatial/aggregation parent that isn't an assembly stays quiet.
+  const assemblyParent = useMemo(() => {
+    const parent = entityNode?.decomposedBy();
+    if (!parent || parent.type !== 'IfcElementAssembly') return null;
+    return { expressId: parent.expressId, name: parent.name || undefined };
+  }, [entityNode]);
 
   // Overlay-only entity record (duplicates, scripted adds). Carries
   // the type + positional attributes the StoreEditor recorded — used
@@ -752,6 +764,22 @@ export function PropertiesPanel() {
       window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
     }
   }, [selectedEntity, setSelectedEntity, setSelectedEntityIds, cameraCallbacks]);
+
+  // Issue #3620: select the parent IfcElementAssembly from the badge below.
+  // NOT `handleSelectRelatedEntity` above -- that leaves `selectedEntityId`
+  // (the globalId this panel's own render gate requires) at whatever
+  // `setSelectedEntityIds([])` derives, which is null, so its target never
+  // becomes visible in THIS panel. `setSelectedEntityId` is the field every
+  // 3D-pick and search entry point sets first for exactly that reason.
+  const handleSelectAssembly = useCallback((expressId: number) => {
+    if (!selectedEntity) return;
+    setSelectedEntityIds([]);
+    setSelectedEntityId(toGlobalIdFromModels(models, selectedEntity.modelId, expressId));
+    setSelectedEntity({ modelId: selectedEntity.modelId, expressId });
+    if (cameraCallbacks.frameSelection) {
+      window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
+    }
+  }, [selectedEntity, models, setSelectedEntity, setSelectedEntityId, setSelectedEntityIds, cameraCallbacks]);
 
   // Isolate + select all member objects of a group/zone (the IfcSpace /
   // IfcSpatialZone in an IfcZone — e.g. one dwelling, house number or fire
@@ -1397,40 +1425,10 @@ export function PropertiesPanel() {
         )}
 
         {/* Spatial Location */}
-        {renderedSpatialInfo && (
-          <div className="flex items-center gap-2 text-xs border border-emerald-500/30 bg-emerald-50/50 dark:bg-emerald-900/10 px-2 py-1.5 text-emerald-800 dark:text-emerald-400 min-w-0">
-            <Layers className="h-3.5 w-3.5 shrink-0" />
-            <span className="font-bold uppercase tracking-wide truncate min-w-0 flex-1">{renderedSpatialInfo.storeyName}</span>
-            <div className="flex items-center gap-1.5 shrink-0">
-              {renderedSpatialInfo.elevation !== undefined && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-emerald-600/70 dark:text-emerald-500/70 font-mono whitespace-nowrap">
-                      {renderedSpatialInfo.elevation >= 0 ? '+' : ''}{renderedSpatialInfo.elevation.toFixed(2)}m
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="text-xs">Elevation: {renderedSpatialInfo.elevation >= 0 ? '+' : ''}{renderedSpatialInfo.elevation.toFixed(2)}m from ground</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-              {renderedSpatialInfo.height !== undefined && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="flex items-center gap-1 text-emerald-500/60 dark:text-emerald-400/60 font-mono text-[10px] whitespace-nowrap">
-                      <ArrowUpDown className="h-2.5 w-2.5 shrink-0" />
-                      <span className="hidden sm:inline">{renderedSpatialInfo.height.toFixed(2)}m</span>
-                      <span className="sm:hidden">{renderedSpatialInfo.height.toFixed(1)}m</span>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p className="text-xs">Height: {renderedSpatialInfo.height.toFixed(2)}m to next storey</p>
-                  </TooltipContent>
-                </Tooltip>
-              )}
-            </div>
-          </div>
-        )}
+        <SpatialLocationBadge spatialInfo={renderedSpatialInfo} />
+
+        {/* Part of Assembly (#3620) */}
+        <AssemblyBadge assembly={assemblyParent} onSelect={handleSelectAssembly} />
 
         {/* World coordinates + Georeferencing — single consolidated section */}
         {(entityCoordinates || renderedGeoref || editMode) && (

--- a/apps/viewer/src/components/viewer/properties/AssemblyBadge.tsx
+++ b/apps/viewer/src/components/viewer/properties/AssemblyBadge.tsx
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Box } from 'lucide-react';
+
+export interface AssemblyParentInfo {
+  expressId: number;
+  name?: string;
+}
+
+/** Issue #3620: a selected element that is a member of an IfcElementAssembly
+ *  (via IfcRelAggregates) gives no indication of that relationship anywhere
+ *  near the IfcClass label — the reporter could not tell the part belonged to
+ *  an assembly, nor select the assembly itself. This badge surfaces the
+ *  parent and, on click, selects it via the same `onSelect` path the
+ *  Relationships card already uses for related entities. */
+export function AssemblyBadge({ assembly, onSelect }: {
+  assembly: AssemblyParentInfo | null;
+  onSelect: (expressId: number) => void;
+}) {
+  if (!assembly) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(assembly.expressId)}
+      className="flex items-center gap-2 text-xs border border-indigo-500/30 bg-indigo-50/50 dark:bg-indigo-900/10 px-2 py-1.5 text-indigo-800 dark:text-indigo-400 min-w-0 w-full text-left hover:bg-indigo-100/60 dark:hover:bg-indigo-900/20 transition-colors"
+      title="Select the parent assembly"
+    >
+      <Box className="h-3.5 w-3.5 shrink-0" />
+      <span className="font-bold uppercase tracking-wide shrink-0">Part of Assembly</span>
+      <span className="truncate min-w-0 flex-1 font-mono">{assembly.name || `#${assembly.expressId}`}</span>
+    </button>
+  );
+}

--- a/apps/viewer/src/components/viewer/properties/SpatialLocationBadge.tsx
+++ b/apps/viewer/src/components/viewer/properties/SpatialLocationBadge.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { Layers, ArrowUpDown } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+export interface SpatialLocationInfo {
+  storeyName: string;
+  elevation?: number;
+  height?: number;
+}
+
+/** The selected entity's containing storey, with elevation/height readouts.
+ *  Extracted out of PropertiesPanel.tsx as a plain presentational sibling —
+ *  it owns no state of its own, it only renders `spatialInfo`. */
+export function SpatialLocationBadge({ spatialInfo }: { spatialInfo: SpatialLocationInfo | null }) {
+  if (!spatialInfo) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-xs border border-emerald-500/30 bg-emerald-50/50 dark:bg-emerald-900/10 px-2 py-1.5 text-emerald-800 dark:text-emerald-400 min-w-0">
+      <Layers className="h-3.5 w-3.5 shrink-0" />
+      <span className="font-bold uppercase tracking-wide truncate min-w-0 flex-1">{spatialInfo.storeyName}</span>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {spatialInfo.elevation !== undefined && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-emerald-600/70 dark:text-emerald-500/70 font-mono whitespace-nowrap">
+                {spatialInfo.elevation >= 0 ? '+' : ''}{spatialInfo.elevation.toFixed(2)}m
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="text-xs">Elevation: {spatialInfo.elevation >= 0 ? '+' : ''}{spatialInfo.elevation.toFixed(2)}m from ground</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {spatialInfo.height !== undefined && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="flex items-center gap-1 text-emerald-500/60 dark:text-emerald-400/60 font-mono text-[10px] whitespace-nowrap">
+                <ArrowUpDown className="h-2.5 w-2.5 shrink-0" />
+                <span className="hidden sm:inline">{spatialInfo.height.toFixed(2)}m</span>
+                <span className="sm:hidden">{spatialInfo.height.toFixed(1)}m</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="text-xs">Height: {spatialInfo.height.toFixed(2)}m to next storey</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #3620.

The reporter selects an element that is a member of an `IfcElementAssembly` (via `IfcRelAggregates`) and gets no indication of that relationship anywhere near the IfcClass label, and no way to select the assembly itself. This PR implements exactly the workflow described in the issue:

- The properties panel's entity header now shows a "Part of Assembly" badge, right below the GlobalId / spatial-location row, whenever the selected element is decomposed by an `IfcElementAssembly`. It reads the parent via the existing `EntityNode.decomposedBy()` (walks the `IfcRelAggregates` inverse edge) and gates on the parent's type.
- Clicking the badge selects the assembly.

### The geometry-less assembly case

An `IfcElementAssembly` almost always owns no representation of its own — its meshes hang off the aggregated parts — so this is exactly the case the issue lives in. The click path does **not** touch isolation/highlight geometry resolution at all (out of scope — see below); it is a plain selection, which the properties panel renders from the entity's attributes/psets, not from its mesh. The one thing that does need to be geometry-aware is `selectedEntityId` (the globalId every 3D-pick/search entry point sets first, and the field this panel's own render gate keys off): the existing `handleSelectRelatedEntity` (used by the Relationships card for Voids/Fills/Groups/Connections) clears it to `null` as a side effect of `setSelectedEntityIds([])`, which would have collapsed the panel to the model-metadata fallback view after every click. I did not reuse it; the new `handleSelectAssembly` sets `selectedEntityId` explicitly via `toGlobalIdFromModels`, matching the pattern every other selection entry point (`Viewport.tsx`'s `handlePickForSelection`, search, hierarchy tree) already uses. `handleSelectRelatedEntity` itself is untouched — that's a separate, pre-existing gap outside this issue's scope.

A regression test drives this with a real parsed `IfcElementAssembly` that owns no geometry, and asserts the panel renders the assembly's own name/class correctly after the click — not just that the store's `selectedEntity` field changed.

### Scope note — #3389 / #3338 (assembly-expansion resolver)

I read #3389 (open, routes the viewer-embed `ISOLATE` channel through the assembly-expansion resolver) and #3338 (the systemic gate) before starting. This PR does **not** touch `isolateEntities`, `resolveHighlightIds`, or any isolation/highlight channel — a plain `setSelectedEntity`/`setSelectedEntityId` selection is a different code path with its own existing, working geometry-less-assembly handling in `Viewport.tsx`'s `frameSelection`/`resolveHighlightIds` (already on `main`, independent of #3389). No overlap with #3389's allowlist or gate.

### Module-size note

`PropertiesPanel.tsx` is allowlisted at its exact current line count (0 headroom), so it could not grow at all. I extracted the existing inline "spatial location" badge (storey name/elevation/height) into its own sibling component, `properties/SpatialLocationBadge.tsx`, which freed enough room for the new `properties/AssemblyBadge.tsx` feature while keeping `PropertiesPanel.tsx` at 2203 lines (budget 2205). Both new files are well under the 400-line new-file threshold.

## What I ran

- `pnpm turbo typecheck --filter=@ifc-lite/viewer` — clean.
- `node scripts/check-module-size.mjs` — OK, 0 new files over 400, `PropertiesPanel.tsx` shrank from 2205 to 2203.
- `node scripts/check-unused-locals.mjs` — pre-existing `packages/embed-sdk` "does not compile standalone" failure only; unrelated to this diff.
- `node scripts/check-test-wiring.mjs` — OK.
- `pnpm run check:vitest-timeout-audit` — no new unprotected/unknown entries from this diff.
- Targeted test run: the new `PropertiesPanel.assembly-select.test.tsx` (4/4 pass) plus every existing `PropertiesPanel`/`properties/*` test file (110/110 pass, including `PropertiesPanel.group-isolate.test.tsx`, the existing geometry-less-assembly isolation regression test) — no regressions.

## Test plan

- [x] Select a member of an `IfcElementAssembly`: badge appears naming the assembly.
- [x] Click the badge: panel now shows the assembly's own attributes/class, even though the assembly owns no geometry.
- [x] Control: select an ordinary element in no assembly — no badge, selection behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436