### PR TITLE
fix(gate): make the source-text allowlist ratchet identity, not count

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -700,6 +700,13 @@ jobs:
       # it must not.
       - name: Check the source-text detector's own regressions
         run: node --test scripts/check-source-text-assertions.test.mjs
+      # ALLOWLIST_CEILING is a count, so a commit that removes one row and adds
+      # a DIFFERENT one leaves the count untouched and the swap invisible
+      # (#3664). This pins the allowlist IDENTITY check that catches it,
+      # against real synthetic git history (same method as
+      # check-module-size.test.mjs's gitTree()).
+      - name: Check the source-text allowlist identity ratchet
+        run: node --test scripts/check-source-text-assertions-identity.test.mjs
       # That gate's SCAN SCOPE is packages/ and apps/ only -- `grep -c rust` over
       # it returns 0 -- so the same AGENTS.md rule was unenforced across the
       # whole rust/ tree, demonstrated rather than inferred: a genuine

--- a/scripts/check-source-text-assertions-identity.test.mjs
+++ b/scripts/check-source-text-assertions-identity.test.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for the allowlist IDENTITY check in
+ * scripts/check-source-text-assertions.mjs (#3664).
+ *
+ * ALLOWLIST_CEILING is a count, and a count cannot tell "one row removed, a
+ * different row added" apart from "nothing changed" -- both leave
+ * allowlist.size exactly where it was. This check compares the current
+ * allowlist against the one committed at this branch's merge base and fails
+ * when a path is present now that was not present there, regardless of
+ * whether the total size moved.
+ *
+ * Method mirrors scripts/check-module-size.test.mjs's `gitTree()`: each case
+ * builds a REAL git repository in a temp dir outside this checkout (so the
+ * derivation cannot quietly read this repo's own history), commits a "base"
+ * state, checks out a "feature" branch, mutates the allowlist and re-runs the
+ * UNMODIFIED gate via `--root`. Nothing here reads the gate's source.
+ *
+ * Fixture test files use the same read-then-.includes shape the gate's own
+ * detector tests pin, so `analyze()` flags them without needing the full
+ * repo's TEST_FILE_RE tree layout beyond `packages/`, `apps/`, `scripts/`.
+ *
+ * Run: node --test scripts/check-source-text-assertions-identity.test.mjs
+ * (a named step of the CI node-test job, and covered by its glob catch-all).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
+const DETECT = join(ROOT, 'scripts', 'source-text-assertion-detect.mjs');
+
+/** A source-text-assertion test fixture the detector flags, naming `rel`. */
+function violatingTest(rel) {
+  return `import { readFileSync } from 'node:fs';
+const p = '${rel}';
+const source = readFileSync(p, 'utf8');
+assert.ok(source.includes('someCall('));
+`;
+}
+
+const cleanup = [];
+process.on('exit', () => {
+  for (const d of cleanup) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * A real git repo, outside any enclosing repository, with `files` (a map of
+ * relative test-file path -> the .txt allowlist content to commit alongside
+ * them, keyed 'allowlist') committed on `main`.
+ */
+function gitTree(testFiles, allowlistText) {
+  const dir = mkdtempSync(join(tmpdir(), 'source-text-identity-'));
+  cleanup.push(dir);
+  for (const d of ['packages', 'apps', 'scripts']) mkdirSync(join(dir, d), { recursive: true });
+  for (const [rel, content] of Object.entries(testFiles)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content);
+  }
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), allowlistText);
+  // The gate reads its own ceiling constant out of ITS base-revision source,
+  // so the synthetic tree needs a copy of the real gate under the same path.
+  // Copying the file under test, rather than writing a stub, is the point:
+  // the identity check's own ceiling-parsing regex is exercised against the
+  // real file, not a hand-written approximation of it.
+  // The detector import is repointed at the REAL file's absolute path rather
+  // than copied alongside: it pulls in `typescript` from this repo's
+  // node_modules, which a temp dir outside the repo cannot resolve, and
+  // nothing under test here is the detector itself (that has its own harness,
+  // scripts/check-source-text-assertions.test.mjs).
+  const gateSrc = readFileSync(GATE, 'utf8').replace(
+    "from './source-text-assertion-detect.mjs'",
+    `from ${JSON.stringify(pathToFileURL(DETECT).href)}`,
+  );
+  assert.notEqual(gateSrc, readFileSync(GATE, 'utf8'), 'detector import rewrite did not match');
+  writeFileSync(join(dir, 'scripts', 'check-source-text-assertions.mjs'), gateSrc);
+
+  const git = (...argv) => {
+    const res = spawnSync('git', ['-C', dir, ...argv], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${argv.join(' ')}: ${res.stdout}${res.stderr}`);
+    return res.stdout;
+  };
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'ratchet@example.invalid');
+  git('config', 'user.name', 'ratchet test');
+  git('add', '-A');
+  git('commit', '-qm', 'base');
+  return { dir, git };
+}
+
+// The GATE IN THE TREE, not the real one at ROOT: ALLOWLIST_CEILING is a
+// constant compiled into the script, not a value it reads from the tree it
+// scans, so a case that varies the ceiling has to run the mutated COPY.
+// `--root` still points scanning (SEARCH_DIRS, ALLOWLIST_PATH) at `dir`.
+function run(dir) {
+  const gateCopy = join(dir, 'scripts', 'check-source-text-assertions.mjs');
+  const res = spawnSync(process.execPath, [gateCopy, '--root', dir], { encoding: 'utf8' });
+  return { code: res.status, out: `${res.stdout}${res.stderr}` };
+}
+
+/** Sets ALLOWLIST_CEILING in the gate copy at `dir/scripts/...mjs` to `n`. */
+function setCeiling(dir, n) {
+  const path = join(dir, 'scripts', 'check-source-text-assertions.mjs');
+  const src = readFileSync(path, 'utf8');
+  const next = src.replace(/const ALLOWLIST_CEILING = \d+;/, `const ALLOWLIST_CEILING = ${n};`);
+  assert.notEqual(next, src, 'ceiling regex did not match the real gate source');
+  writeFileSync(path, next);
+}
+
+const A_TEST = 'apps/v/a.test.ts';
+const B_TEST = 'apps/v/b.test.ts';
+
+test('a same-size swap (A removed, B added, ceiling untouched) fails', () => {
+  const { dir, git } = gitTree(
+    { [A_TEST]: violatingTest(A_TEST) },
+    `${A_TEST}  # cannot convert yet\n`,
+  );
+  setCeiling(dir, 1);
+  git('add', '-A');
+  git('commit', '-qm', 'set ceiling to 1');
+
+  git('checkout', '-q', '-b', 'feature');
+  // Convert A behaviourally (delete the violating fixture) and introduce a
+  // DIFFERENT violation, B, keeping the allowlist at exactly 1 row.
+  unlinkSync(join(dir, A_TEST));
+  const bFull = join(dir, B_TEST);
+  mkdirSync(dirname(bFull), { recursive: true });
+  writeFileSync(bFull, violatingTest(B_TEST));
+  writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), `${B_TEST}  # swapped in\n`);
+  git('add', '-A');
+  git('commit', '-qm', 'swap A for B, same size');
+
+  const { code, out } = run(dir);
+  assert.equal(code, 1, out);
+  assert.match(out, /New allowlist entries not present at the merge base/);
+  assert.match(out, new RegExp(B_TEST.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  // A must NOT be reported as a new entry -- it was removed, not added.
+  assert.doesNotMatch(out.split('New allowlist entries')[1] ?? '', /apps\/v\/a\.test\.ts\n/);
+});
+
+test('removing an entry outright (no replacement, ceiling lowered) passes', () => {
+  const { dir, git } = gitTree(
+    { [A_TEST]: violatingTest(A_TEST), [B_TEST]: violatingTest(B_TEST) },
+    `${A_TEST}  # cannot convert yet\n${B_TEST}  # cannot convert yet\n`,
+  );
+  setCeiling(dir, 2);
+  git('add', '-A');
+  git('commit', '-qm', 'set ceiling to 2');
+
+  git('checkout', '-q', '-b', 'feature');
+  unlinkSync(join(dir, A_TEST));
+  writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), `${B_TEST}  # cannot convert yet\n`);
+  setCeiling(dir, 1);
+  git('add', '-A');
+  git('commit', '-qm', 'convert A, lower ceiling');
+
+  const { code, out } = run(dir);
+  assert.equal(code, 0, out);
+  assert.match(out, /check-source-text-assertions: OK \(1 allowlisted, 0 marked, 0 new\)/);
+});
+
+test('an untouched allowlist and tree passes with no identity failure', () => {
+  const { dir, git } = gitTree(
+    { [A_TEST]: violatingTest(A_TEST) },
+    `${A_TEST}  # cannot convert yet\n`,
+  );
+  setCeiling(dir, 1);
+  git('add', '-A');
+  git('commit', '-qm', 'set ceiling to 1');
+
+  git('checkout', '-q', '-b', 'feature');
+  // No changes at all on the feature branch.
+  const { code, out } = run(dir);
+  assert.equal(code, 0, out);
+  assert.doesNotMatch(out, /New allowlist entries/);
+});
+
+test('a genuinely new violation with no allowlist row still fails as before', () => {
+  const { dir, git } = gitTree({}, '');
+  setCeiling(dir, 0);
+  git('add', '-A');
+  git('commit', '-qm', 'set ceiling to 0');
+
+  git('checkout', '-q', '-b', 'feature');
+  const full = join(dir, A_TEST);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, violatingTest(A_TEST));
+  git('add', '-A');
+  git('commit', '-qm', 'add a violation, no allowlist row');
+
+  const { code, out } = run(dir);
+  assert.equal(code, 1, out);
+  assert.match(out, /Source-text assertions found in NEW test files/);
+  assert.doesNotMatch(out, /New allowlist entries not present at the merge base/);
+});
+
+test('a pure addition (ceiling raised to cover it, nothing removed) passes', () => {
+  const { dir, git } = gitTree(
+    { [A_TEST]: violatingTest(A_TEST) },
+    `${A_TEST}  # cannot convert yet\n`,
+  );
+  setCeiling(dir, 1);
+  git('add', '-A');
+  git('commit', '-qm', 'set ceiling to 1');
+
+  git('checkout', '-q', '-b', 'feature');
+  const full = join(dir, B_TEST);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, violatingTest(B_TEST));
+  writeFileSync(
+    join(dir, 'scripts', 'source-text-assertion-allowlist.txt'),
+    `${A_TEST}  # cannot convert yet\n${B_TEST}  # newly discovered, out of reach\n`,
+  );
+  setCeiling(dir, 2);
+  git('add', '-A');
+  git('commit', '-qm', 'add B, raise ceiling to 2');
+
+  const { code, out } = run(dir);
+  assert.equal(code, 0, out);
+  assert.match(out, /check-source-text-assertions: OK \(2 allowlisted, 0 marked, 0 new\)/);
+});
+
+test('no origin/main and no local main: identity check degrades with a warning, not an error', () => {
+  const { dir } = gitTree(
+    { [A_TEST]: violatingTest(A_TEST) },
+    `${A_TEST}  # cannot convert yet\n`,
+  );
+  setCeiling(dir, 1);
+  const gitCommit = spawnSync('git', ['-C', dir, 'add', '-A'], { encoding: 'utf8' });
+  assert.equal(gitCommit.status, 0, gitCommit.stdout + gitCommit.stderr);
+  const commit = spawnSync('git', ['-C', dir, 'commit', '-qm', 'only commit, branch is main'], {
+    encoding: 'utf8',
+  });
+  assert.equal(commit.status, 0, commit.stdout + commit.stderr);
+  // HEAD IS main here (no divergent branch), so `merge-base main HEAD` trivially
+  // resolves to HEAD itself -- to genuinely exercise "no base resolvable", rename
+  // the branch so neither `origin/main` nor `main` exists.
+  const rename = spawnSync('git', ['-C', dir, 'branch', '-m', 'main', 'not-main'], { encoding: 'utf8' });
+  assert.equal(rename.status, 0, rename.stdout + rename.stderr);
+
+  const { code, out } = run(dir);
+  assert.equal(code, 0, out);
+  assert.match(out, /WARNING -- could not resolve a merge base/);
+  assert.doesNotMatch(out, /New allowlist entries/);
+});

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -81,14 +81,66 @@
  * clean when scripts/ was brought in, so nothing is hidden today -- but it is
  * the same shape of hole, and `tools/**` would also need a row in the frontend
  * CI path filter before a gate there could run.
+ *
+ * IDENTITY, NOT JUST COUNT (#3664): ALLOWLIST_CEILING is a count, and a count
+ * cannot tell "one row removed, a different row added" apart from "nothing
+ * changed" -- both leave allowlist.size exactly where it was. A commit that
+ * deletes file A's row and adds file B's row in the same change satisfies
+ * every check above (B is allowlisted before the "new file" scan runs, A's
+ * removal keeps staleAllowlistEntries empty, and the size still equals the
+ * ceiling), so B is grandfathered without the ceiling ever moving -- the
+ * exact #2531 hole the ceiling was built to close, reopened one level up.
+ *
+ * The fix compares the CURRENT allowlist against the allowlist at this
+ * branch's merge base with origin/main (falling back to local main), the same
+ * derivation scripts/check-module-size.mjs uses for its own scoping. A path in
+ * the current set that the base set did not have is a NEW exemption, full
+ * stop -- identity is the file's path in the allowlist, the same key every
+ * other check in this file already uses to correlate a row with a file.
+ *
+ * A new exemption is only accepted if ALLOWLIST_CEILING rose by at least as
+ * many entries as are new, relative to what the constant read at the base
+ * commit. That reuses the exact-size-match rule below rather than fighting
+ * it: that rule already forces `ceiling(current) - ceiling(base)` to equal
+ * `new.length - removed.length` whenever both commits were themselves
+ * passing, so the only way to satisfy both a same-size swap's arithmetic
+ * (new=1, removed=1, forced ceiling delta 0) and this rule (delta >= 1) is to
+ * not do the swap in one change. Splitting it into a removal (ceiling down)
+ * and, separately, an addition (ceiling up, with its own review and reason)
+ * is not a workaround -- it is the fix: each genuinely new exemption gets its
+ * own reviewable ceiling-raise line instead of hiding behind a coincidental
+ * offset.
+ *
+ * MIGRATION: none. No row in the allowlist needs a new field -- the identity
+ * key is derived entirely from git history, not stored in the file, so every
+ * existing row is already correctly "identified" by the base revision it was
+ * already sitting in.
+ *
+ * DEGRADATION: a merge base is not always resolvable (a shallow local clone,
+ * a worktree with no `origin` remote). When it is not, this check prints a
+ * WARNING and falls back to the count-only checks above -- it does not error
+ * and does not skip silently, because a gate that no-ops when it cannot find
+ * a base is the failure mode this repo keeps hitting.
  */
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 import { analyze } from './source-text-assertion-detect.mjs';
 
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+// --root overrides the scanned tree; only the test harness passes it, to point
+// this UNMODIFIED script at a synthetic git repository. Production CI and
+// local runs take the default -- the real repo root -- exactly as before.
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--root') out.root = argv[++i];
+  }
+  return out;
+}
+const args = parseArgs(process.argv.slice(2));
+const ROOT = args.root ? join(args.root) : join(dirname(fileURLToPath(import.meta.url)), '..');
 // TWO independent barriers hid the same tree, and fixing either alone changes
 // nothing: `scripts/` was never walked, AND `.mjs` was not a test extension.
 // Adding the extension first made this guard report the newly-allowlisted files
@@ -175,14 +227,52 @@ function walk(dir, found = []) {
   return found;
 }
 
-function loadAllowlist() {
-  if (!existsSync(ALLOWLIST_PATH)) return new Set();
+function parseAllowlistText(text) {
   return new Set(
-    readFileSync(ALLOWLIST_PATH, 'utf8')
+    text
       .split('\n')
       .map((line) => line.replace(/#.*$/, '').trim())
       .filter(Boolean)
   );
+}
+
+function loadAllowlist() {
+  if (!existsSync(ALLOWLIST_PATH)) return new Set();
+  return parseAllowlistText(readFileSync(ALLOWLIST_PATH, 'utf8'));
+}
+
+/**
+ * This worktree's merge base with origin/main, falling back to local main --
+ * identical derivation to scripts/check-module-size.mjs's `changedFiles()`,
+ * reused rather than reinvented so the two gates degrade the same way under
+ * the same shallow-clone and no-remote conditions.
+ *
+ * Returns `{ ref, sha }` or `null` if neither ref has a merge base with HEAD
+ * (no `origin` remote, or a clone too shallow to share history).
+ */
+function resolveBase(root) {
+  const git = (...argv) => spawnSync('git', ['-C', root, ...argv], { encoding: 'utf8' });
+  for (const ref of ['origin/main', 'main']) {
+    const merged = git('merge-base', ref, 'HEAD');
+    const sha = merged.stdout.trim();
+    if (merged.status === 0 && sha !== '') {
+      if (ref !== 'origin/main') {
+        console.warn(
+          `check-source-text-assertions: WARNING -- no merge base with origin/main; fell back ` +
+            `to local '${ref}' (${sha.slice(0, 9)}) for the allowlist identity check. If that ` +
+            `ref is stale, a swapped-in violation could go undetected this run.`
+        );
+      }
+      return { ref, sha };
+    }
+  }
+  return null;
+}
+
+/** `git show <sha>:<relPath>` from `root`, or `null` if the blob is unreadable. */
+function readBlobAt(root, sha, relPath) {
+  const res = spawnSync('git', ['-C', root, 'show', `${sha}:${relPath}`], { encoding: 'utf8' });
+  return res.status === 0 ? res.stdout : null;
 }
 
 const allowlist = loadAllowlist();
@@ -293,11 +383,64 @@ ratcheting.
 `);
 }
 
+// Identity check (#3664): a count cannot tell a swap from an untouched file.
+// Compare the current allowlist against the one at this branch's merge base
+// -- any path present now that was absent there is a NEW exemption, whether
+// or not it was offset by a removal elsewhere in the same change.
+let identitySuffix = '';
+const base = resolveBase(ROOT);
+if (base === null) {
+  console.warn(
+    'check-source-text-assertions: WARNING -- could not resolve a merge base with ' +
+      "origin/main or main; the allowlist identity check is SKIPPED this run. A same-size " +
+      'swap (one entry removed, a different one added) would not be caught. Fetch ' +
+      'origin/main and re-run for full coverage.'
+  );
+} else {
+  const baseAllowlistText = readBlobAt(ROOT, base.sha, 'scripts/source-text-assertion-allowlist.txt');
+  const baseGateText = readBlobAt(ROOT, base.sha, 'scripts/check-source-text-assertions.mjs');
+  if (baseAllowlistText === null || baseGateText === null) {
+    console.warn(
+      `check-source-text-assertions: WARNING -- could not read the allowlist or this gate at ` +
+        `${base.ref} (${base.sha.slice(0, 9)}); the identity check is SKIPPED this run.`
+    );
+  } else {
+    const baseAllowlist = parseAllowlistText(baseAllowlistText);
+    const baseCeilingMatch = baseGateText.match(/const ALLOWLIST_CEILING = (\d+);/);
+    const newEntries = [...allowlist].filter((p) => !baseAllowlist.has(p)).sort();
+    if (newEntries.length > 0) {
+      const baseCeiling = baseCeilingMatch ? Number(baseCeilingMatch[1]) : null;
+      const ceilingRaise = baseCeiling === null ? -Infinity : ALLOWLIST_CEILING - baseCeiling;
+      if (ceilingRaise < newEntries.length) {
+        failed = true;
+        console.error(
+          `\nNew allowlist entries not present at the merge base (${base.ref} @ ${base.sha.slice(0, 9)}):\n`
+        );
+        for (const entry of newEntries) console.error(`  ${entry}`);
+        console.error(`
+An entry that was not in the allowlist at the merge base is a NEW exemption
+from this gate, even when another row was removed in the same change and the
+total count did not move. Counting only the size lets a swap grandfather a
+brand-new violation invisibly (#3664).
+
+Land the removal and the addition as separate changes: lower ALLOWLIST_CEILING
+when you remove a row, and raise it -- by itself, with its own reason --
+when you add one. A change that does both at once cannot pass this check by
+construction, because the ceiling cannot simultaneously satisfy "must equal
+the new total exactly" and "must have room for ${newEntries.length} new
+${newEntries.length === 1 ? 'entry' : 'entries'}" unless nothing was removed alongside it.
+`);
+      }
+    }
+    identitySuffix = `, identity-checked vs ${base.ref} (${base.sha.slice(0, 9)})`;
+  }
+}
+
 if (failed) process.exit(1);
 
 for (const site of markedSites) {
   console.log(`  marked @source-text-assertion-ok: ${site}`);
 }
 console.log(
-  `check-source-text-assertions: OK (${allowlist.size} allowlisted, ${markedSites.length} marked, 0 new)`
+  `check-source-text-assertions: OK (${allowlist.size} allowlisted, ${markedSites.length} marked, 0 new)${identitySuffix}`
 );

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -64,6 +64,7 @@ scripts/check-module-size.mjs apps/landing # walks apps/ for .ts/.tsx; apps/land
 scripts/check-module-size.test.mjs apps/landing # same walk, in the harness
 scripts/check-wasm-disposal.mjs apps/landing # walks apps/ for WASM handles; apps/landing holds none
 scripts/check-source-text-assertions.mjs apps/landing # walks apps/ for test files; apps/landing has none
+scripts/check-source-text-assertions-identity.test.mjs apps/landing # same walk, in the harness
 scripts/check-loader-hook-specifier-match.mjs apps/landing # walks apps/ for loader hooks; apps/landing has none
 scripts/check-loader-hook-specifier-match.test.mjs apps/landing # same walk, in the harness
 scripts/check-tla-chunk-await.test.mjs apps/landing # same walk, in the harness


### PR DESCRIPTION
## Summary

`ALLOWLIST_CEILING` in `scripts/check-source-text-assertions.mjs` only compares `allowlist.size` against a hardcoded number. A commit that removes one allowlisted file's row and adds a *different* file's row leaves the size unchanged and passes -- the new violation is grandfathered without the deliberate ceiling raise the constant exists to force (the swap CodeRabbit flagged on #3662, filed separately as #3664 to keep #3662's own mutation evidence readable).

**Mechanism read from the current code (post-#3662), not the issue's snapshot:** the gate walks `packages/`, `apps/`, `scripts/` for `.test.(ts|tsx|mts|mjs)` files, flags source-text assertions via `analyze()`, subtracts files the allowlist excuses, and separately requires `allowlist.size === ALLOWLIST_CEILING` (both directions checked). Nothing about that comparison has memory of what the allowlist looked like before this change -- it only sees today's count.

**Fix -- identity, not count.** The gate now also resolves this branch's merge base with `origin/main` (falling back to local `main`, identical derivation to `check-module-size.mjs`'s `changedFiles()`), diffs the current allowlist against the one committed there, and treats any path present now that was absent at the base as a new exemption. Identity key = the file's path in the allowlist -- the same key every other check in this gate already uses to correlate a row with a file. Coarser (just the count) is the bug being fixed; finer (e.g. a hash of the violation site) would false-positive on harmless renames/reformats of an already-excused file, so path is the deliberate middle.

A new exemption is only accepted if `ALLOWLIST_CEILING` rose by at least as many entries as are new, relative to the constant's value at the base commit. This reuses the existing exact-size-match rule rather than adding a second, competing one: that rule already forces `ceiling(current) - ceiling(base)` to equal `new.length - removed.length` whenever both commits passed, so a same-size swap (`new=1, removed=1`, forced ceiling delta `0`) can never satisfy `delta >= 1` -- it is unsatisfiable **by construction**, not by an extra check that could itself be forgotten. Splitting the removal and the addition into separate changes is the fix, not a workaround: each new exemption gets its own reviewable ceiling-raise line instead of hiding behind a coincidental offset.

**Migration: none.** The identity key is derived entirely from git history, not stored in the allowlist file, so no existing row needs a new field or one-time regeneration.

**Degradation.** When no merge base is resolvable (shallow clone, no `origin` remote -- exercised for real in this environment, see below), the gate prints a `WARNING` and falls back to the existing count-only checks rather than erroring or silently skipping.

## Tests (`scripts/check-source-text-assertions-identity.test.mjs`, new)

Built against real synthetic git repos (temp dir, `git init`, same method as `check-module-size.test.mjs`'s `gitTree()`), running the unmodified gate via a new `--root` flag:

- same-size swap (A removed, B added, ceiling untouched) -> **fails**, names B, does not name A
- pure removal (ceiling lowered to match) -> **passes**
- untouched allowlist -> **passes**
- new violation with no allowlist row at all -> **still fails** (pre-existing offender path, unaffected)
- pure addition (ceiling raised to cover it, nothing removed) -> **passes**
- no resolvable merge base -> **degrades with a warning**, does not error, exits 0

All 6 pass. All 75 pre-existing cases in `check-source-text-assertions.test.mjs` still pass, including the e2e "gate passes on the repo" case.

## Verification run

- `node scripts/check-source-text-assertions.mjs` against the current tree: **exits 0** (22 allowlisted, 9 marked, 0 new). In this checkout `origin` is a stale personal fork with neither file at its merge base with `HEAD`, so the identity check itself prints its degrade-warning and the run falls back to count-only -- demonstrating the degrade path live, not just in the synthetic harness. Manually confirmed `upstream/main` (the real base) has both files and a valid merge base, so the identity check runs for real in a normal clone / CI checkout.
- `node scripts/check-test-wiring.mjs` -- OK
- `pnpm run check:vitest-timeout-audit` -- unaffected, OK
- `node scripts/check-ci-path-coverage.mjs` -- initially failed: the new test harness's synthetic-tree setup (`['packages', 'apps', 'scripts']`) reads the literal string `apps`, which the coverage scanner resolves down to the already-known `apps/landing` hole (no TS/tests there). Added one line to `scripts/ci-path-coverage-allowlist.txt`, following the exact existing convention for every other tree-walking gate's harness (`check-module-size.test.mjs apps/landing # same walk, in the harness`, etc.) -- OK after.
- `node --test scripts/check-ci-path-coverage.test.mjs`, `scripts/check-test-glob-coverage.test.mjs` -- OK

## Related but not absorbed

Read the open-PR list for file overlap (`scripts`, `.github`) before starting -- no overlap with this file set. #3672/#3689 (module-size `.mjs` scanning) and #3658/#3710 (finding quote/line coupling) are unrelated files, left untouched.

Closes #3664