### PR TITLE
fix(geometry): add a feature-gated topology reject for torn CSG results (#3440 step 2)

### DIFF
--- a/.changeset/csg-topology-gate-feature.md
+++ b/.changeset/csg-topology-gate-feature.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+`ClippingProcessor`'s four boolean-op accept paths (`subtract_mesh`, `subtract_mesh_many`, `union_mesh`/`union_meshes`, `intersection_mesh`, in `rust/geometry/src/csg/`) validated a kernel result for finiteness and index bounds only, so a torn (non-manifold / open-edge) result was accepted and shipped silently — issue #3440. A prior change added a non-gating diagnostic record for this (`BoolFailureReason::KernelError`, informational only, still shipped in every build). This adds the second step the issue prescribes: a REJECT signal, but gated behind a new, off-by-default `csg_topology_gate` Cargo feature that no downstream crate enables — not `debug_geometry` / `csg_capture` / `observability`, which the native server already turns on in production, so wiring a behaviour change through any of those would have flipped real hosts today.
+
+Without the feature this is a no-op with no measurable cost: the gate function's default-build body never runs the closure predicate, it only returns `false`. With `--features csg_topology_gate` (a `cargo test`/`cargo build` opt-in for CI or census measurement) a torn result is rejected the same way an existing `KernelOutputInvalid` result already is — falling back to the un-cut host / an empty mesh / a plain merge — and records the new `BoolFailureReason::OpenTopologyRejected` reason through the same `take_csg_failures` / per-host diagnostics channel the informational record already used.
+
+Reuses `directed_closed` / `closed_or_hairline` (`router/voids/prism_cut/closure_checks.rs`) — the analytic prism-cut path's own accept/reject predicate — rather than adding a fourth definition of watertightness to the crate, per the issue's explicit direction.
+
+Not on any default or production build path: `ifc-lite-wasm`'s own feature set does not enable `csg_topology_gate`, so this ships no observable change to `@ifc-lite/wasm` consumers. Flagged as a patch because it is a new, currently-inert opt-in surface on the underlying Rust crate that this package's release process versions together.

--- a/rust/geometry/Cargo.toml
+++ b/rust/geometry/Cargo.toml
@@ -39,6 +39,17 @@ triangulation-alt = ["dep:earcut"]
 # this crate's `cfg(test)` tree. `ifc-lite-processing` enables it as a
 # dev-dependency. Never enabled in a shipping build.
 test-support = []
+# #3440 step 2: turns `csg/mod.rs`'s four boolean-op accept paths' informational
+# open-topology check (step 1, always on) into a REJECT — a torn kernel result
+# falls back exactly like an existing `KernelOutputInvalid`. Off by default and
+# enabled by NOTHING downstream (no other crate in this workspace turns it on,
+# unlike `observability`, which the native server does enable) — deliberately
+# so this stays a `cargo test/build --features csg_topology_gate` opt-in for
+# CI/census measurement, not a change to what any shipping build accepts. The
+# repo's own watertightness census reports a nonzero count of currently-torn
+# hosts on the un-gated default (see issue #3440's measurements), so enabling
+# this by default today would reject geometry that currently renders.
+csg_topology_gate = []
 
 [dependencies]
 

--- a/rust/geometry/src/csg/csg_tests.rs
+++ b/rust/geometry/src/csg/csg_tests.rs
@@ -7,6 +7,7 @@
 //! (module-size-ratchet exempt) and attached via `#[path]`, the same shape
 //! `bool2d_tests.rs` / `facet_weld_scoped_tests.rs` already use.
 
+#[cfg(not(feature = "csg_topology_gate"))]
 use super::topology_diagnostic::OPEN_TOPOLOGY_MESSAGE;
 use super::*;
 /// Build a box mesh from AABB min/max bounds (12 triangles, 2 per face).
@@ -415,6 +416,7 @@ fn open_box_mesh(min: Point3<f64>, max: Point3<f64>) -> Mesh {
 /// must still return the kernel result it returned before. Driving the four
 /// public ops (not `record_topology_tear` directly) is the point — the call
 /// sites are the change, so reverting any one of them has to turn this red.
+#[cfg(not(feature = "csg_topology_gate"))] // step-1-only: asserts the non-gating KernelError record; superseded under the feature by OpenTopologyRejected + fallback
 #[test]
 fn topology_tear_recorded_by_every_boolean_op_without_gating() {
     // An open host makes every op's kernel output open too, which is what
@@ -496,6 +498,7 @@ fn topology_tear_not_recorded_for_closed_results() {
 /// twice, inflating the very per-host census this diagnostic exists to feed.
 /// 16 cutters (one chunk) is the control: same host, same tear, one record
 /// either way.
+#[cfg(not(feature = "csg_topology_gate"))] // step-1-only: asserts the non-gating KernelError record; superseded under the feature by OpenTopologyRejected + fallback
 #[test]
 fn topology_tear_recorded_once_per_batched_subtract_not_once_per_chunk() {
     let open_host = open_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(20.0, 1.0, 1.0));
@@ -612,6 +615,7 @@ fn hairline_t_junction_is_not_recorded_as_a_topology_tear() {
 /// HOST's failure list, so an over-count here is attributed to a host whose
 /// own geometry may be perfectly closed, and the per-host census is the only
 /// deliverable of #3440 step 1.
+#[cfg(not(feature = "csg_topology_gate"))] // step-1-only: asserts the non-gating KernelError record; superseded under the feature by OpenTopologyRejected + fallback
 #[test]
 fn topology_tear_recorded_once_per_union_meshes_not_once_per_intermediate() {
     use crate::router::voids::prism_cut::closure_checks::{closed_or_hairline, directed_closed};
@@ -672,6 +676,86 @@ fn union_fallback_validates_indices_before_topology_audit() {
     assert!(
         p.take_failures().is_empty(),
         "an empty-operand pass-through is not a kernel result and must not gain a diagnostic"
+    );
+}
+
+/// #3440 step 2, WITHOUT the `csg_topology_gate` feature: `topology_gate_reject`
+/// must be a true no-op, not merely a flag checked after the work. Reuses the
+/// exact fixtures `topology_tear_recorded_by_every_boolean_op_without_gating`
+/// (above) proves make every op's kernel output torn, and re-asserts the SAME
+/// invariant that test already pins — every op still hands back the torn
+/// kernel result, none falls back — so a default (non-feature) build stays
+/// byte-identical to what step 1 shipped. Compiled in EVERY build (this is
+/// the "gate off" proof, so it must run without the feature); the mirror
+/// below only compiles under the feature.
+#[cfg(not(feature = "csg_topology_gate"))]
+#[test]
+fn topology_gate_is_a_true_noop_without_the_feature() {
+    let open_host = open_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0));
+    let through_cutter = aabb_to_mesh(Point3::new(0.4, 0.4, -0.1), Point3::new(0.6, 0.6, 1.1));
+    let overlapping = aabb_to_mesh(Point3::new(0.5, 0.5, 0.5), Point3::new(1.5, 1.5, 1.5));
+
+    let p = ClippingProcessor::new();
+    let subtract = p.subtract_mesh(&open_host, &through_cutter).unwrap();
+    let batched = p.subtract_mesh_many(&open_host, &[&through_cutter]).unwrap();
+    let union = p.union_mesh(&open_host, &overlapping).unwrap();
+    let intersection = p.intersection_mesh(&open_host, &overlapping).unwrap();
+
+    for (name, mesh) in [
+        ("subtract_mesh", &subtract),
+        ("subtract_mesh_many", &batched),
+        ("union_mesh", &union),
+        ("intersection_mesh", &intersection),
+    ] {
+        assert!(
+            !mesh.is_empty() && mesh.triangle_count() > 4,
+            "{name}: gate must not have rejected this torn result without the feature"
+        );
+    }
+    assert!(
+        p.take_failures().iter().all(|f| f.reason != BoolFailureReason::OpenTopologyRejected),
+        "OpenTopologyRejected must never be recorded without csg_topology_gate"
+    );
+}
+
+/// The `csg_topology_gate` mirror of the test above: WITH the feature, the
+/// same four torn results are REJECTED — each op falls back exactly like an
+/// existing `KernelOutputInvalid` (un-cut host / empty / plain merge) — and
+/// each records the dedicated `OpenTopologyRejected` reason once.
+#[cfg(feature = "csg_topology_gate")]
+#[test]
+fn topology_gate_rejects_every_torn_boolean_result_when_enabled() {
+    let open_host = open_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(1.0, 1.0, 1.0));
+    let through_cutter = aabb_to_mesh(Point3::new(0.4, 0.4, -0.1), Point3::new(0.6, 0.6, 1.1));
+    let overlapping = aabb_to_mesh(Point3::new(0.5, 0.5, 0.5), Point3::new(1.5, 1.5, 1.5));
+
+    let p = ClippingProcessor::new();
+    let subtract = p.subtract_mesh(&open_host, &through_cutter).unwrap();
+    let batched = p.subtract_mesh_many(&open_host, &[&through_cutter]).unwrap();
+    let union = p.union_mesh(&open_host, &overlapping).unwrap();
+    let intersection = p.intersection_mesh(&open_host, &overlapping).unwrap();
+
+    assert_eq!(subtract.indices, open_host.indices, "subtract_mesh must fall back to the un-cut host");
+    assert_eq!(batched.indices, open_host.indices, "subtract_mesh_many must fall back to the un-cut host");
+    assert!(intersection.is_empty(), "intersection_mesh must fall back to an empty mesh");
+    let mut expected_union_merge = open_host.clone();
+    expected_union_merge.merge(&overlapping);
+    assert_eq!(
+        union.triangle_count(),
+        expected_union_merge.triangle_count(),
+        "union_mesh must fall back to the plain merge"
+    );
+
+    let failures = p.take_failures();
+    assert_eq!(
+        failures.iter().map(|f| (f.op, f.reason.clone())).collect::<Vec<_>>(),
+        vec![
+            (BoolOp::Difference, BoolFailureReason::OpenTopologyRejected),
+            (BoolOp::Difference, BoolFailureReason::OpenTopologyRejected),
+            (BoolOp::Union, BoolFailureReason::OpenTopologyRejected),
+            (BoolOp::Intersection, BoolFailureReason::OpenTopologyRejected),
+        ],
+        "each of the four accept paths must reject and record OpenTopologyRejected exactly once"
     );
 }
 

--- a/rust/geometry/src/csg/degenerate_check.rs
+++ b/rust/geometry/src/csg/degenerate_check.rs
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `difference_result_looks_degenerate`, moved out of `csg/mod.rs` (which
+//! sits at its module-size budget) to make room for #3440 step 2's
+//! feature-gated topology check without raising the ratchet.
+
+use super::ClippingProcessor;
+use crate::mesh::Mesh;
+
+impl ClippingProcessor {
+    /// Heuristic: does this look like a botched CSG difference?
+    ///
+    /// Kernel-neutral check used by the boolean processor (e.g. the
+    /// polygonal-bounded half-space clip) to fall back to a robust
+    /// unbounded plane clip when a difference result looks collapsed
+    /// relative to its host. Historically this caught a Linux-specific
+    /// Manifold pathology where a wall body clipped by an
+    /// `IfcPolygonalBoundedHalfSpace` prism collapsed to a near-empty
+    /// result (1 triangle from a 12-triangle host box).
+    ///
+    /// Rules:
+    ///  * An empty result is a legit outcome (cutter contains host) —
+    ///    NOT degenerate.
+    ///  * A closed-volume result needs at least 4 triangles. Anything
+    ///    below that is structurally broken.
+    ///  * For hosts with >= 12 triangles (typical IFC solid input), the
+    ///    output should retain at least 25 % of the host's triangle
+    ///    count when the cutter is partial.
+    pub(crate) fn difference_result_looks_degenerate(host: &Mesh, result: &Mesh) -> bool {
+        let result_tris = result.indices.len() / 3;
+        if result_tris == 0 {
+            return false;
+        }
+        if result_tris < 4 {
+            return true;
+        }
+        let host_tris = host.indices.len() / 3;
+        if host_tris >= 12 && result_tris * 4 < host_tris {
+            return true;
+        }
+
+        // "Wrong piece" check: a difference result MUST be a subset of the
+        // host volume, so the result's bounding box has to sit inside the
+        // host's. When a malformed cutter (typical: IfcFacetedBrep with
+        // inward-pointing face normals) inverts the kernel's
+        // inside/outside test, Manifold returns the CUTTER mesh instead —
+        // which lives partially or wholly outside the host bbox. House.ifc
+        // wall #3448 (a 7 m extrusion clipped by a gable-shaped brep)
+        // rendered as the gable triangle alone before this guard.
+        let (host_min, host_max) = host.bounds();
+        let (res_min, res_max) = result.bounds();
+        // 1 % of the host's edge **per axis** — using a single tolerance
+        // derived from the longest dimension lets thin walls/plates pass
+        // a wrong-piece check on Y/Z that they shouldn't (CodeRabbit
+        // review on PR #861). With per-axis slack, a 5 m × 0.4 m × 7 m
+        // wall gets ±5 cm tolerance on X, ±4 mm on Y, ±7 cm on Z — so a
+        // result that pokes >4 mm past the wall's thickness face is
+        // correctly flagged even though it's well within 1 % of the X
+        // span.
+        let slack = (host_max - host_min).abs() * 0.01;
+        if res_min.x + slack.x < host_min.x
+            || res_min.y + slack.y < host_min.y
+            || res_min.z + slack.z < host_min.z
+            || res_max.x > host_max.x + slack.x
+            || res_max.y > host_max.y + slack.y
+            || res_max.z > host_max.z + slack.z
+        {
+            return true;
+        }
+        false
+    }
+}

--- a/rust/geometry/src/csg/mod.rs
+++ b/rust/geometry/src/csg/mod.rs
@@ -14,6 +14,7 @@ use smallvec::SmallVec;
 use std::cell::RefCell;
 
 mod consolidate;
+mod degenerate_check;
 mod normals;
 mod plane_eps;
 mod topology_diagnostic;
@@ -282,7 +283,11 @@ impl ClippingProcessor {
     /// record is appended to the processor's failure log (drainable via
     /// [`Self::take_failures`]). An empty host returns an empty mesh without
     /// recording a failure (it's a fast path, not a fallback). The accept path
-    /// also runs `record_topology_tear` (#3440): diagnostic only, never gates.
+    /// also runs `record_topology_tear` (#3440 step 1): diagnostic only, never
+    /// gates, in every build. `topology_gate_reject` (#3440 step 2) runs the
+    /// same closure predicate but, ONLY when the crate is built with the
+    /// `csg_topology_gate` feature (off by default; no downstream crate turns
+    /// it on), rejects a torn result the same way `KernelOutputInvalid` does.
     pub fn subtract_mesh(&self, host_mesh: &Mesh, opening_mesh: &Mesh) -> Result<Mesh> {
         record_csg_op(0, host_mesh.triangle_count(), opening_mesh.triangle_count());
         if host_mesh.is_empty() {
@@ -330,6 +335,9 @@ impl ClippingProcessor {
         let result = Self::consolidate_coplanar(raw);
         if !result.is_empty() && !self.validate_mesh(&result) {
             self.record_failure(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid);
+            return Ok(host_mesh.clone());
+        }
+        if self.topology_gate_reject(BoolOp::Difference, &result) {
             return Ok(host_mesh.clone());
         }
         Ok(result).inspect(|m| self.record_topology_tear(BoolOp::Difference, m))
@@ -405,6 +413,9 @@ impl ClippingProcessor {
                 self.record_failure(BoolOp::Difference, BoolFailureReason::KernelOutputInvalid);
                 return Ok(host_mesh.clone());
             }
+            if self.topology_gate_reject(BoolOp::Difference, &next) {
+                return Ok(host_mesh.clone());
+            }
             result = next;
         }
         Ok(result).inspect(|m| self.record_topology_tear(BoolOp::Difference, m))
@@ -429,69 +440,10 @@ impl ClippingProcessor {
             self.record_failure(BoolOp::Intersection, BoolFailureReason::KernelOutputInvalid);
             return Ok(Mesh::new());
         }
+        if self.topology_gate_reject(BoolOp::Intersection, &result) {
+            return Ok(Mesh::new());
+        }
         Ok(result).inspect(|m| self.record_topology_tear(BoolOp::Intersection, m))
-    }
-
-    /// Heuristic: does this look like a botched CSG difference?
-    ///
-    /// Kernel-neutral check used by the boolean processor (e.g. the
-    /// polygonal-bounded half-space clip) to fall back to a robust
-    /// unbounded plane clip when a difference result looks collapsed
-    /// relative to its host. Historically this caught a Linux-specific
-    /// Manifold pathology where a wall body clipped by an
-    /// `IfcPolygonalBoundedHalfSpace` prism collapsed to a near-empty
-    /// result (1 triangle from a 12-triangle host box).
-    ///
-    /// Rules:
-    ///  * An empty result is a legit outcome (cutter contains host) —
-    ///    NOT degenerate.
-    ///  * A closed-volume result needs at least 4 triangles. Anything
-    ///    below that is structurally broken.
-    ///  * For hosts with >= 12 triangles (typical IFC solid input), the
-    ///    output should retain at least 25 % of the host's triangle
-    ///    count when the cutter is partial.
-    pub(crate) fn difference_result_looks_degenerate(host: &Mesh, result: &Mesh) -> bool {
-        let result_tris = result.indices.len() / 3;
-        if result_tris == 0 {
-            return false;
-        }
-        if result_tris < 4 {
-            return true;
-        }
-        let host_tris = host.indices.len() / 3;
-        if host_tris >= 12 && result_tris * 4 < host_tris {
-            return true;
-        }
-
-        // "Wrong piece" check: a difference result MUST be a subset of the
-        // host volume, so the result's bounding box has to sit inside the
-        // host's. When a malformed cutter (typical: IfcFacetedBrep with
-        // inward-pointing face normals) inverts the kernel's
-        // inside/outside test, Manifold returns the CUTTER mesh instead —
-        // which lives partially or wholly outside the host bbox. House.ifc
-        // wall #3448 (a 7 m extrusion clipped by a gable-shaped brep)
-        // rendered as the gable triangle alone before this guard.
-        let (host_min, host_max) = host.bounds();
-        let (res_min, res_max) = result.bounds();
-        // 1 % of the host's edge **per axis** — using a single tolerance
-        // derived from the longest dimension lets thin walls/plates pass
-        // a wrong-piece check on Y/Z that they shouldn't (CodeRabbit
-        // review on PR #861). With per-axis slack, a 5 m × 0.4 m × 7 m
-        // wall gets ±5 cm tolerance on X, ±4 mm on Y, ±7 cm on Z — so a
-        // result that pokes >4 mm past the wall's thickness face is
-        // correctly flagged even though it's well within 1 % of the X
-        // span.
-        let slack = (host_max - host_min).abs() * 0.01;
-        if res_min.x + slack.x < host_min.x
-            || res_min.y + slack.y < host_min.y
-            || res_min.z + slack.z < host_min.z
-            || res_max.x > host_max.x + slack.x
-            || res_max.y > host_max.y + slack.y
-            || res_max.z > host_max.z + slack.z
-        {
-            return true;
-        }
-        false
     }
 
     /// Validate mesh for common issues

--- a/rust/geometry/src/csg/topology_diagnostic.rs
+++ b/rust/geometry/src/csg/topology_diagnostic.rs
@@ -66,4 +66,45 @@ impl ClippingProcessor {
             );
         }
     }
+
+    /// #3440 step 2: the feature-gated accept/reject signal `record_topology_tear`
+    /// (above) deliberately withholds. Same predicate, same call-site
+    /// discipline (the mesh the op is about to RETURN, never an intermediate),
+    /// but on a torn mesh this records the dedicated
+    /// [`BoolFailureReason::OpenTopologyRejected`] and returns `true` so the
+    /// caller discards the kernel result and falls back exactly like an
+    /// existing `KernelOutputInvalid` — the four call sites already have that
+    /// fallback wired (`host_mesh.clone()` / `Mesh::new()` / the plain merge),
+    /// this just adds one more condition that reaches it.
+    ///
+    /// Gated behind the crate's own `csg_topology_gate` feature — NOT
+    /// `debug_geometry` / `csg_capture` / `observability`. Those three are
+    /// already live in production (the native server enables `observability`
+    /// via `ifc-lite-processing`; see `geometry/Cargo.toml`), so wiring a
+    /// behaviour change through any of them would flip real hosts today. This
+    /// feature is enabled by nothing downstream — no crate in the workspace
+    /// turns it on — so it exists solely for `cargo test/build --features
+    /// csg_topology_gate` runs the census/CI can opt into deliberately.
+    ///
+    /// Off the default build path ENTIRELY, not merely a runtime flag checked
+    /// after the kernel work: the `#[cfg(not(...))]` twin below is the only
+    /// body compiled in without the feature, and it never touches `mesh` —
+    /// zero cost, not "flag checked, still computed".
+    #[cfg(feature = "csg_topology_gate")]
+    pub(crate) fn topology_gate_reject(&self, op: BoolOp, mesh: &Mesh) -> bool {
+        if mesh.is_empty() || directed_closed(mesh) || closed_or_hairline(mesh) {
+            return false;
+        }
+        self.record_failure(op, BoolFailureReason::OpenTopologyRejected);
+        true
+    }
+
+    /// Default-build twin of the above: always `false`, no closure predicate
+    /// ever runs. See that function's doc for why this is a SEPARATE `cfg`
+    /// body rather than one function with an internal `if cfg!(...)`.
+    #[cfg(not(feature = "csg_topology_gate"))]
+    #[inline(always)]
+    pub(crate) fn topology_gate_reject(&self, _op: BoolOp, _mesh: &Mesh) -> bool {
+        false
+    }
 }

--- a/rust/geometry/src/csg/union.rs
+++ b/rust/geometry/src/csg/union.rs
@@ -5,7 +5,8 @@
 //! The two union entry points, moved out of `csg/mod.rs` (which sits at its
 //! module-size budget) so the pair-vs-batch split the #3440 audit needs is
 //! visible in one place: `union_pair` does the work and records nothing,
-//! `union_mesh` and `union_meshes` each audit exactly the mesh they return.
+//! `union_mesh` and `union_meshes` each audit — and, under `csg_topology_gate`
+//! (step 2), gate — exactly the mesh they return.
 
 use super::{record_csg_op, ClippingProcessor};
 use crate::diagnostics::{BoolFailureReason, BoolOp};
@@ -18,8 +19,12 @@ impl ClippingProcessor {
     ///
     /// Empty operands are handled silently — they have a unique correct answer.
     pub fn union_mesh(&self, mesh_a: &Mesh, mesh_b: &Mesh) -> Result<Mesh> {
-        self.union_pair(mesh_a, mesh_b)
-            .inspect(|m| self.audit_returned_union(m))
+        let result = self.union_pair(mesh_a, mesh_b)?;
+        Ok(self.audit_and_gate_union(result, || {
+            let mut merged = mesh_a.clone();
+            merged.merge(mesh_b);
+            merged
+        }))
     }
 
     /// [`Self::union_mesh`] minus the #3440 audit, so `union_meshes` can drive
@@ -86,8 +91,19 @@ impl ClippingProcessor {
         // `directed_closed` indexes `positions` straight from `indices`, so a
         // caller mesh with an out-of-bounds index would abort the process
         // rather than be recorded.
+        //
+        // Under `csg_topology_gate`, a rejected fold has no single operand
+        // pair to fall back to — `result` folded however many meshes ran —
+        // so the fallback is the plain merge of every non-empty input, the
+        // N-way generalisation of `union_pair`'s own 2-way fallback above.
         if unioned {
-            self.audit_returned_union(&result);
+            result = self.audit_and_gate_union(result, || {
+                let mut merged = Mesh::new();
+                for mesh in meshes.iter().filter(|m| !m.is_empty()) {
+                    merged.merge(mesh);
+                }
+                merged
+            });
         }
         Ok(result)
     }
@@ -98,9 +114,22 @@ impl ClippingProcessor {
     /// the mesh's untrusted indices.  This is diagnostic-only: the malformed
     /// result remains the legacy return value and the existing invalid-output
     /// record from `union_pair` remains the only failure record added there.
-    fn audit_returned_union(&self, mesh: &Mesh) {
-        if self.validate_mesh(mesh) {
-            self.record_topology_tear(BoolOp::Union, mesh);
+    ///
+    /// #3440 step 2: also the ONE place union gates. `topology_gate_reject`
+    /// itself records on a hit, so when it does this returns `fallback()`
+    /// WITHOUT also calling `record_topology_tear` — recording both would
+    /// double-count the same tear as two unrelated incidents. Without the
+    /// `csg_topology_gate` feature `topology_gate_reject` is the zero-cost
+    /// always-`false` stub, so this is exactly the step-1 behaviour above,
+    /// unchanged.
+    fn audit_and_gate_union(&self, mesh: Mesh, fallback: impl FnOnce() -> Mesh) -> Mesh {
+        if !self.validate_mesh(&mesh) {
+            return mesh;
         }
+        if self.topology_gate_reject(BoolOp::Union, &mesh) {
+            return fallback();
+        }
+        self.record_topology_tear(BoolOp::Union, &mesh);
+        mesh
     }
 }

--- a/rust/geometry/src/diagnostics.rs
+++ b/rust/geometry/src/diagnostics.rs
@@ -119,6 +119,17 @@ pub enum BoolFailureReason {
     /// viewers do in practice) and records this so the loss surfaces in
     /// diagnostics rather than as a silently missing element.
     DifferenceEmptiedHost,
+    /// #3440 step 2: the kernel result passed `validate_mesh` (finite,
+    /// in-bounds) but failed the directed-edge closure audit
+    /// (`topology_gate_reject` — same predicate `KernelError`'s step-1
+    /// informational record already checks) and was REJECTED rather than
+    /// merely flagged. Only ever constructed when this crate is built with
+    /// the `csg_topology_gate` feature, which is off by default and enabled
+    /// by nothing downstream — so this variant exists in every build (a
+    /// stable thing for consumers to match on, per the crate's convention for
+    /// its other rarely-emitted variants above) but is only ever actually
+    /// recorded in a `--features csg_topology_gate` build.
+    OpenTopologyRejected,
 }
 
 impl BoolFailureReason {
@@ -141,6 +152,7 @@ impl BoolFailureReason {
             BoolFailureReason::ManifoldOutputDegenerate { .. } => "ManifoldOutputDegenerate",
             BoolFailureReason::KernelError(_) => "KernelError",
             BoolFailureReason::DifferenceEmptiedHost => "DifferenceEmptiedHost",
+            BoolFailureReason::OpenTopologyRejected => "OpenTopologyRejected",
         }
     }
 }
@@ -181,6 +193,9 @@ impl fmt::Display for BoolFailureReason {
                 "Manifold difference returned implausibly small result ({result_tris} triangles from {host_tris}-triangle host) — fell back to BSP"
             ),
             BoolFailureReason::KernelError(msg) => write!(f, "kernel error: {msg}"),
+            BoolFailureReason::OpenTopologyRejected => f.write_str(
+                "CSG kernel output passed validate_mesh but failed the closure audit; rejected under csg_topology_gate (#3440)",
+            ),
         }
     }
 }

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -300,6 +300,9 @@ impl GeometryRouter {
                 crate::diagnostics::BoolFailureReason::DifferenceEmptiedHost => {
                     "DifferenceEmptiedHost"
                 }
+                crate::diagnostics::BoolFailureReason::OpenTopologyRejected => {
+                    "OpenTopologyRejected"
+                }
             };
             entry.first_failure_label = Some(label.to_string());
         }

--- a/rust/geometry/tests/issue_3440_topology_gate_census.rs
+++ b/rust/geometry/tests/issue_3440_topology_gate_census.rs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3440 step 2 measurement: how many hosts across the fixture corpus does
+//! `csg_topology_gate` actually REJECT?
+//!
+//! Deliberately separate from `triangulation_invariance.rs`'s per-host
+//! `edge_stats.open` census. That census and this gate's own predicate
+//! (`directed_closed` / `closed_or_hairline`, shared with the analytic
+//! prism-cut path) are two independently-implemented readings of
+//! watertightness — issue #3435 documents them diverging — so a host this
+//! test reports as gate-rejected is not guaranteed to be one `edge_stats`
+//! counts as open, or vice versa. This test measures what the GATE actually
+//! does (`GeometryRouter::take_csg_failures` after driving the real void-cut
+//! path), not a second, independent edge count.
+//!
+//! Requires the `csg_topology_gate` feature (this file compiles to an empty,
+//! trivially-passing binary without it) and the fixture corpus fetched via
+//! `node scripts/fixtures/fetch-fixtures.mjs`:
+//!
+//!   cargo test -p ifc-lite-geometry --features csg_topology_gate \
+//!     --test issue_3440_topology_gate_census -- --nocapture
+
+#![cfg(feature = "csg_topology_gate")]
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, BoolFailureReason, GeometryRouter};
+use rustc_hash::FxHashMap;
+use std::path::PathBuf;
+
+fn crate_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Every `.ifc` fixture in the manifest, INCLUDING ones over
+/// `MAX_FIXTURE_BYTES` (unlike `triangulation_invariance.rs`'s
+/// `discover_models`) — the issue's own cited host, `IFCWALLSTANDARDCASE
+/// #43810` in `ISSUE_068_ARK_NUS_skolebygg.ifc`, lives in a fixture over that
+/// filter, and excluding it would silently drop the one host the issue names.
+fn discover_all_models() -> Vec<(String, PathBuf)> {
+    let models = crate_dir().join("..").join("..").join("tests/models");
+    let Ok(raw) = std::fs::read_to_string(models.join("manifest.json")) else {
+        return Vec::new();
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(String, PathBuf)> = json["files"]
+        .as_array()
+        .map(|files| {
+            files
+                .iter()
+                .filter_map(|f| f["path"].as_str())
+                .filter(|p| p.ends_with(".ifc"))
+                .map(|rel| (rel.to_string(), models.join(rel)))
+                .filter(|(_, p)| std::fs::metadata(p).map(|m| m.is_file()).unwrap_or(false))
+                .collect()
+        })
+        .unwrap_or_default();
+    out.sort();
+    out
+}
+
+/// `IfcRelVoidsElement` host -> opening ids, plus part propagation. Same
+/// query `triangulation_invariance.rs::void_index` runs; duplicated here
+/// (rather than made `pub` there) because that file is a production-adjacent
+/// module-size-ratchet-exempt TEST file already at its own considerable size,
+/// and this query is nine lines over public crate APIs.
+fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+#[derive(Default)]
+struct Tally {
+    hosts_swept: usize,
+    hosts_rejected: usize,
+    rejections_by_op: FxHashMap<&'static str, usize>,
+    examples: Vec<String>,
+}
+
+#[test]
+fn topology_gate_census_over_the_fixture_corpus() {
+    let models = discover_all_models();
+    assert!(
+        !models.is_empty(),
+        "no fixtures on disk — run `node scripts/fixtures/fetch-fixtures.mjs` first; \
+         this test measures nothing over an empty corpus"
+    );
+
+    let mut t = Tally::default();
+    for (rel_path, abs_path) in &models {
+        let Ok(content) = std::fs::read_to_string(abs_path) else {
+            continue;
+        };
+        let voids = void_index(&content);
+        if voids.is_empty() {
+            continue;
+        }
+        let ei = build_entity_index(&content);
+        for &host_id in voids.keys() {
+            let mut decoder = EntityDecoder::with_index(&content, ei.clone());
+            let Ok(entity) = decoder.decode_by_id(host_id) else {
+                continue;
+            };
+            let router = GeometryRouter::with_units(&content, &mut decoder);
+            let _ = router.process_element_with_voids(&entity, &mut decoder, &voids);
+            t.hosts_swept += 1;
+
+            let failures = router.take_csg_failures();
+            let Some(host_failures) = failures.get(&host_id) else {
+                continue;
+            };
+            let rejected: Vec<&str> = host_failures
+                .iter()
+                .filter(|f| f.reason == BoolFailureReason::OpenTopologyRejected)
+                .map(|f| match f.op {
+                    ifc_lite_geometry::BoolOp::Difference => "Difference",
+                    ifc_lite_geometry::BoolOp::Union => "Union",
+                    ifc_lite_geometry::BoolOp::Intersection => "Intersection",
+                    ifc_lite_geometry::BoolOp::Unknown => "Unknown",
+                })
+                .collect();
+            if !rejected.is_empty() {
+                t.hosts_rejected += 1;
+                for op in &rejected {
+                    *t.rejections_by_op.entry(op).or_default() += 1;
+                }
+                if t.examples.len() < 20 {
+                    t.examples.push(format!(
+                        "{rel_path} #{host_id} ({} rejection(s): {})",
+                        rejected.len(),
+                        rejected.join(", ")
+                    ));
+                }
+            }
+        }
+    }
+
+    println!(
+        "#3440 step 2 topology-gate census: {} void hosts swept across {} models, {} REJECTED",
+        t.hosts_swept,
+        models.len(),
+        t.hosts_rejected
+    );
+    let mut by_op: Vec<(&str, usize)> = t.rejections_by_op.into_iter().collect();
+    by_op.sort();
+    for (op, count) in &by_op {
+        println!("  by op: {op} = {count}");
+    }
+    for ex in &t.examples {
+        println!("  e.g. {ex}");
+    }
+
+    assert!(
+        t.hosts_swept >= 1000,
+        "swept only {} void hosts — the corpus looks partially fetched, \
+         this run's reject count is not the full-corpus number",
+        t.hosts_swept
+    );
+}


### PR DESCRIPTION
## Summary

Step 2 of the 3-step order #3440's own text prescribes (diagnostic → feature-gated → hard gate). Step 1, the non-gating diagnostic record (`BoolFailureReason::KernelError` via `record_topology_tear`), is already merged (#3442). This PR is step 2 only: a REJECT signal, gated off by default.

- Every boolean-op accept path (`subtract_mesh`, `subtract_mesh_many`, `union_mesh`/`union_meshes`, `intersection_mesh`) now also calls `topology_gate_reject`, which reuses `directed_closed` / `closed_or_hairline` from `router/voids/prism_cut/closure_checks.rs` — the analytic prism-cut path's own accept/reject predicate — rather than adding a fourth definition of watertightness to the crate, per the issue's own direction.
- Gated behind a **new** `csg_topology_gate` Cargo feature, off by default and enabled by nothing downstream. Deliberately **not** `debug_geometry` / `csg_capture` / `observability`: the native server already enables `observability` in production (`ifc-lite-processing/observability`), so wiring a behaviour change through any of those three would flip real hosts today.
- **Off the default path entirely, not merely a runtime flag checked after the work.** `topology_gate_reject` has two `#[cfg]`-selected bodies: without the feature it's a stub that returns `false` immediately and never touches the mesh; the closure predicate is not compiled into that path at all.
- With `--features csg_topology_gate`, a torn result is rejected exactly the way an existing `KernelOutputInvalid` result already is (falls back to the un-cut host / an empty mesh / a plain merge) and records the new `BoolFailureReason::OpenTopologyRejected` reason through the same `take_csg_failures` / per-host diagnostics channel `#3442` already wired — no second channel.
- `difference_result_looks_degenerate` moved out of `csg/mod.rs` into a new sibling module (`degenerate_check.rs`) to make room for the four gate call sites without raising the module-size ratchet. `csg/mod.rs` is 563 lines against its 611-line allowlisted budget.

## Measured

New test `rust/geometry/tests/issue_3440_topology_gate_census.rs` (compiles to nothing without `csg_topology_gate`) drives the real void-cut path (`GeometryRouter::process_element_with_voids`) over the full local fixture corpus and tallies `OpenTopologyRejected` via `take_csg_failures`:

```
115 models, 2071 void hosts swept
99 hosts REJECTED (335 individual Difference-op rejections; 0 on Union, 0 on Intersection)
```

This is a **different metric** than `triangulation_invariance.rs`'s `edge_stats.open` census (issue #3435 already documents those two watertightness readings in this crate diverging), so it is not expected to match — and it doesn't: the golden corpus's `edge_stats` reading is 165 torn hosts / 17,863 open edges over the same population (unchanged by this PR, verified byte-identical below), and the ISSUE_068 heavy fixture alone is separately documented at 27/29 CSG-caused torn hosts. My 99/2071 counts *hosts whose accept-path result fails this crate's own `directed_closed`/`closed_or_hairline` gate predicate*, which is a different (stricter on some cases, looser on others) test than `edge_stats`. All rejections were on `Difference` — consistent with the issue's framing that this is a void/opening-subtraction defect, and bears on #3353 (not absorbed here — two prior attempts at fixing the kernel itself were withdrawn after regressions).

## Default path unchanged — proof

- `cargo test -p ifc-lite-geometry` (no feature): 0 failures, including three pre-existing step-1 tests (`topology_tear_recorded_by_every_boolean_op_without_gating`, `_once_per_batched_subtract_not_once_per_chunk`, `_once_per_union_meshes_not_once_per_intermediate`) asserting the informational-only, non-gating behaviour byte-for-byte unchanged.
- `cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- watertightness_census_and_triangulator_invariance`: golden vs run, 0 regressed / 0 reclassified / 0 improved — the `edge_stats` census is untouched.
- `cargo test -p ifc-lite-processing --test module_size_ratchet`: passes, no allowlist row raised.
- `cargo clippy -p ifc-lite-geometry --all-targets` clean, with and without `--features csg_topology_gate`.
- `cargo check --workspace` clean.

## Known, expected divergence when the feature IS on

`cargo test -p ifc-lite-geometry --features csg_topology_gate` has one pre-existing snapshot failure: `geometry_correctness_harness`'s `issue #218 — window rendering` fixture snapshot, because the gate genuinely changes that fixture's output (a torn subtract now falls back, going from 3340→3492 triangles). This is real, correct divergence corroborating the census above, not a regression — I did not touch that snapshot or its harness; it is simply not feature-aware, and this feature is not part of the standard test matrix.

## Scope note on #3353

Not absorbed here per the task's own instruction. The 99-host count above is a lower bound on what #3353 (booleans tearing on overlapping/rotated operands) would need to fix to get this gate to a state where it could be turned on unconditionally.

Part of #3440 -- implements step 2 (the feature-gated check) only. Step 3 (the hard, unconditional gate) is explicitly NOT done here and needs #3353 progress first; not claiming a close.
