### PR TITLE
fix(viewer-embed): stop re-multiplying IfcSpace and IfcOpeningElement alpha

### DIFF
--- a/.changeset/embed-space-opening-alpha.md
+++ b/.changeset/embed-space-opening-alpha.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/viewer-embed': patch
+---
+
+Stop the embed re-multiplying `IfcSpace` and `IfcOpeningElement` alpha, so it draws the same store the full viewer does.
+
+**Default appearance changes for hosts that show spaces or openings.** Both are off by default (`TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spaces` and `.openings` are `false`), so an embed that never turns them on is unaffected: those meshes are filtered out before this pass and were never drawn. A host that switches either on, through `setTypeVisibility` or a persisted preference, now sees them at the alpha the Rust styling table assigns (`IfcSpace` 0.3, `IfcOpeningElement` 0.4) rather than the 0.09 and 0.12 the clamp produced. They look roughly three times more solid. That is the appearance the full viewer has had since #677.
+
+`useModelViewGeometry` re-multiplied both classes down to `Math.min(alpha * 0.3, 0.3)` after the visibility filter. `ViewportContainer` removed exactly that under #677, because it stomped lens and property-set colour rules even when the caller had explicitly chosen alpha 1.0, and because the defaults already carry the translucency so applying it twice was never intended. The embed kept it, so the same protocol against the same store produced two pictures.
+
+When it bit: the clamp lived in a React memo, so it only reached the GPU on an upload from that mesh list. That is the initial load, a model swap, colours applied while streaming was still running, and any type-visibility toggle, which re-uploads the visible set. The sequence that reproduces it is colour a space, then turn spaces on, and the space comes back at 0.3.
+
+When it did not: a colour sent after load is unaffected. `SET_COLORS` also queues `pendingMeshColorUpdates`, which `useGeometryStreaming` pushes straight into `scene.updateMeshColors`, while the geometry effect takes its early return on an unchanged mesh count. In that ordering the embed already drew the host's alpha.

--- a/apps/viewer-embed/src/components/EmbedViewer.meshAlpha.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.meshAlpha.test.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The embed passes mesh alpha through, like the full viewer.
+ *
+ * `useModelViewGeometry` used to re-multiply `IfcSpace` and `IfcOpeningElement`
+ * down to `min(alpha * 0.3, 0.3)` after the visibility filter.
+ * `ViewportContainer` dropped exactly that under #677, because it stomped lens
+ * and property-set colour rules even when the caller had explicitly chosen
+ * alpha 1.0. The embed kept it, so the same store rendered two ways.
+ *
+ * Assertions are on the alpha in the mesh list handed to `Viewport`, which is
+ * what this memo decides. It is not a claim about drawn pixels: a colour that
+ * arrives after load reaches the GPU by another route entirely
+ * (`pendingMeshColorUpdates` into `scene.updateMeshColors`), and never passed
+ * through the clamp even before this change.
+ */
+
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import type { MeshData } from '@ifc-lite/geometry';
+
+let lastViewportGeometry: MeshData[] | null = null;
+vi.mock('@/components/viewer/Viewport', () => ({
+  Viewport: (props: { geometry: MeshData[] | null }) => {
+    lastViewportGeometry = props.geometry;
+    return null;
+  },
+}));
+vi.mock('@/components/viewer/ViewportOverlays', () => ({ ViewportOverlays: () => null }));
+vi.mock('@/hooks/useWebGPU', () => ({
+  useWebGPU: () => ({ supported: true, checking: false, reason: null }),
+}));
+
+function mesh(expressId: number, ifcType: string, alpha: number): MeshData {
+  return {
+    expressId,
+    ifcType,
+    positions: new Float32Array(0),
+    normals: new Float32Array(0),
+    indices: new Uint32Array(0),
+    color: [1, 0, 0, alpha],
+  };
+}
+
+/**
+ * The alphas `rust/processing/src/style/mod.rs` assigns these two classes, plus
+ * an explicit 1.0 standing in for a host `setColors` override, plus a wall as
+ * the control that was never clamped.
+ */
+const MESHES = [
+  mesh(1, 'IfcSpace', 0.3),
+  mesh(2, 'IfcOpeningElement', 0.4),
+  mesh(3, 'IfcSpace', 1),
+  mesh(4, 'IfcWall', 1),
+];
+
+const geometryResult = { meshes: MESHES, totalVertices: 0, totalTriangles: 0 };
+
+vi.mock('@/hooks/useIfc', () => ({
+  useIfc: () => ({
+    geometryResult,
+    ifcDataStore: null,
+    loadFile: vi.fn(async () => {}),
+    loading: false,
+    models: new Map(),
+    clearAllModels: vi.fn(),
+    addModel: vi.fn(async () => 'stub-model-id'),
+  }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const { EmbedViewer } = await import('./EmbedViewer.js');
+const { useViewerStore } = await import('@/store');
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+/** Alpha per express id, as handed to `Viewport`. */
+async function alphas(): Promise<Record<number, number>> {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(React.createElement(EmbedViewer));
+  });
+  mounted.push({ root, container });
+  return Object.fromEntries((lastViewportGeometry ?? []).map((m) => [m.expressId, m.color[3]]));
+}
+
+beforeEach(() => {
+  lastViewportGeometry = null;
+  window.history.replaceState({}, '', '/');
+  // Spaces and openings are OFF by default, so without this the meshes under
+  // test are filtered out before the alpha pass and every assertion is vacuous.
+  useViewerStore.setState({
+    selectedEntityIds: new Set<number>(),
+    selectedEntityId: null,
+    isolatedEntities: null,
+    cameraCallbacks: {},
+    typeVisibility: {
+      ...useViewerStore.getState().typeVisibility,
+      spaces: true,
+      openings: true,
+      site: true,
+    },
+  });
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(new ArrayBuffer(8), { status: 200 })));
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.unstubAllGlobals();
+});
+
+describe('EmbedViewer: mesh alpha reaches Viewport unchanged', () => {
+  it('leaves the styling alphas alone for IfcSpace and IfcOpeningElement', async () => {
+    // KILLS: restoring the `.map` that re-multiplied by 0.3. With it, the
+    // styling defaults arrive as 0.09 and 0.12, a third of what styling.rs
+    // assigns, and the embed draws them three times fainter than the viewer.
+    const a = await alphas();
+
+    expect(a[1]).toBe(0.3);
+    expect(a[2]).toBe(0.4);
+  });
+
+  it('leaves an explicit opaque colour opaque', async () => {
+    // KILLS: the same `.map`, and specifically its `Math.min(..., 0.3)` ceiling,
+    // which is what made a host's explicit alpha 1.0 unrecoverable rather than
+    // merely dimmed. This is the case #677 was filed for.
+    const a = await alphas();
+
+    expect(a[3]).toBe(1);
+  });
+
+  it('never touched classes outside the two, which is why the wall is here', async () => {
+    // KILLS: widening the clamp to every mesh. Without this the two assertions
+    // above would still pass under a filter that dimmed everything, since they
+    // only look at the two classes the old code named.
+    const a = await alphas();
+
+    expect(a[4]).toBe(1);
+  });
+});

--- a/apps/viewer-embed/src/components/useModelViewGeometry.ts
+++ b/apps/viewer-embed/src/components/useModelViewGeometry.ts
@@ -73,15 +73,14 @@ export function useModelViewGeometry(
       (mesh) => !isTypeHidden(mesh.ifcType, hiddenTypes) && isTypeVisible(mesh.ifcType, typeVisibility),
     );
 
-    return meshes.map((mesh) => {
-      if (mesh.ifcType === 'IfcSpace' || mesh.ifcType === 'IfcOpeningElement') {
-        return {
-          ...mesh,
-          color: [mesh.color[0], mesh.color[1], mesh.color[2], Math.min(mesh.color[3] * 0.3, 0.3)] as [number, number, number, number],
-        };
-      }
-      return mesh;
-    });
+    // Mesh alpha flows through unchanged. The embed used to re-multiply IfcSpace
+    // and IfcOpeningElement down to `min(alpha * 0.3, 0.3)` here; the full viewer
+    // dropped exactly that under #677 because it stomped lens and property-set
+    // colour rules even when the caller had explicitly chosen alpha 1.0. Defaults
+    // still come from styling.rs, which already assigns IfcSpace 0.3 and
+    // IfcOpeningElement 0.4, so the translucency survives without being applied
+    // twice.
+    return meshes;
   }, [merged, typeVisibility, hiddenTypes, hasPlacedGeometry]);
 
   return { geometry, contentVersion };


### PR DESCRIPTION
The embed clamped `IfcSpace` and `IfcOpeningElement` to `Math.min(alpha * 0.3, 0.3)` after the visibility filter. `ViewportContainer` removed exactly that under #677, because it stomped lens and property-set colour rules even when the caller had explicitly chosen alpha 1.0, and because `styling.rs` already assigns the translucency (`IfcSpace` 0.3, `IfcOpeningElement` 0.4) so applying it twice was never intended. The embed kept it, so the same protocol against the same store drew two pictures.

## What a host sees

Hosts that show either class now see them at the styling alpha rather than 0.09 and 0.12, so roughly three times more solid, matching the full viewer since #677. Both toggles are off by default, so an embed that never turns them on is unaffected: those meshes are filtered out before this pass and were never drawn. That paragraph leads the changeset, because it is the only part a host notices.

## When the clamp actually bit

Worth stating precisely, because an earlier draft of this claim on #3682 got it wrong and two reviewers caught it.

It bit on uploads from the React mesh list: initial load, model swap, colours applied while streaming was still running, and any type-visibility toggle, which re-uploads the visible set. The sequence that reproduces it is colour a space, then turn spaces on, and the space comes back at 0.3.

It did **not** bite a colour sent after load. `SET_COLORS` also queues `pendingMeshColorUpdates`, which `useGeometryStreaming` pushes straight into `scene.updateMeshColors` (`:766-780`), while the geometry effect takes its early return on an unchanged mesh count (`:434-438`). In that ordering the embed already drew the host's alpha.

## Mutations, each applied and counted

| Mutation | Result |
|---|---|
| restore the clamp | 2 of 3 fail |
| widen the clamp to every mesh | 3 of 3 fail |

The second is why the fixture carries a wall as a control. Without it, both other assertions would pass under a filter that dimmed everything, since they only inspect the two classes the old code named.

Assertions are on the alpha in the mesh list handed to `Viewport`, which is what this memo decides. Deliberately not a claim about drawn pixels, for the recolour-path reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNuDHNx7vdoKq4ETeXn4vX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transparency rendering for spaces and openings in the embedded viewer.
  * Preserved alpha values supplied by styling, preventing unintended additional transparency.
  * Kept post-load color updates and opaque overrides functioning as expected.

* **Tests**
  * Added coverage verifying alpha values for spaces, openings, walls, and opaque overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->