### PR TITLE
fix(gates): record the six scripts/review rows that leave main's ratchet red

### DIFF
--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -252,7 +252,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/source-dalux': '11927553717016520308',
   'packages/source-dropbox': '13897585807232807340',
   'packages/viewer': '17290688824834287099',
-  'scripts': '7432628421945259767',
+  'scripts': '4386814201325981117',
 };
 
 function parseArgs(argv) {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -382,9 +382,12 @@
    415 scripts/moonshot/m5-constrained-decoding/dsl.mjs
    621 scripts/moonshot/m5-constrained-decoding/run-tier2.mjs
    980 scripts/moonshot/m5-constrained-decoding/tasks-tier2.mjs
-   733 scripts/review/post-review.mjs
-   427 scripts/review/run-reviewer.mjs
-   892 scripts/review/validate-findings.mjs
+   661 scripts/review/build-context-pack.mjs
+   413 scripts/review/build-review-input.mjs
+   851 scripts/review/post-review.mjs
+   443 scripts/review/rubric-eval.mjs
+   526 scripts/review/run-reviewer.mjs
+   985 scripts/review/validate-findings.mjs
    688 scripts/source-text-assertion-detect.mjs
    504 scripts/test-geometry-regression.mjs
   2196 scripts/test-wasm-contract.mjs


### PR DESCRIPTION
## What

`node scripts/check-module-size.mjs` exits 1 on `main` at 0a372b7f3. That is the exact command the Node tests lane runs (`.github/workflows/test.yml:739-740`), and the "grew past budget" check measures the whole tree rather than the files a branch touches (`scripts/check-module-size.mjs:466-473`, `:654`), so **every open PR inherits the failure**. #3719 is failing on it right now.

This records the six `scripts/review/*.mjs` rows at their measured counts and re-pins the one scope that moved. Seven lines.

## How main got here

Three merges, and main has been red since the middle one.

**#3668 (463daae54)** grew or added four review scripts:

```
run-reviewer.mjs        427 -> 513
build-review-input.mjs  356 -> 413   (crosses 400)
rubric-eval.mjs         315 -> 382
build-context-pack.mjs  new at 661
```

**#3689 (55d5d1707)** extended the gate to cover `.mjs` and the `scripts/` tree, and recorded the first rows for `scripts/review/`. It recorded from a tree that was one merge stale: it wrote `run-reviewer.mjs` at **427**, its size *before* #3668, and gave `build-context-pack.mjs` (661) and `build-review-input.mjs` (413) no row at all. **The gate was red the moment the gate extension landed.**

**#3686 (7fa32291c)** then grew four more:

```
post-review.mjs        733 -> 851
run-reviewer.mjs       513 -> 526
validate-findings.mjs  892 -> 985
rubric-eval.mjs        382 -> 443
```

## Why not the repo-wide sweep

`--update --all --allow-raise` is the script's sanctioned path and I built that version first. It also tightens **43 rows across 17 unrelated scopes** to zero headroom and touches 18 pin lines — 71 changed lines against 7. Every open branch that adds a line to any of those files then has to re-record before it can go green.

The red lives entirely in the `scripts` scope, so that cost buys nothing here. Measured, not assumed: with the sweep, #3719 has to re-record two of its own rows; with this, #3719 cherry-picks clean (`Auto-merging` both files, no conflict) and its gate goes straight to `OK … 0 new over 400`.

The sweep is still worth doing. It belongs in its own PR, when nothing is waiting on it.

## Justification for the six rows

The gate's error text asks for one in the PR. They are review tooling that landed in other PRs. Splitting them is a change to files this PR did not write, while `main` is red and blocking every open PR. All six are recorded at their **exact** measured count with zero slack, so further growth still fails.

`build-review-input.mjs` (413) and `rubric-eval.mjs` (443) are the two within easy trimming reach. Splitting the `scripts/review` tree stays open as separate work and needs an owner. I checked all 200 open issues and nothing currently tracks it.

## The gate is fine; the CI wiring is not

Both obvious hypotheses are closed, so please don't "fix" the script. An unpinned scope drifts and fails the gate (`:617`), and a pin left behind for a scope with no rows fails too (`:622-623`); `--update` fails closed when it cannot derive the changed set (`:383-424`) and refuses raises without `--allow-raise` (`:508-522`).

What let two individually-green PRs merge into a red main is that `test.yml` triggers only on `pull_request` and `push` (`:6-17`), with no `merge_group` and nothing requiring a fresh base. Both were certified against trees that no longer existed at merge time, and a whole-tree gate is maximally exposed to that. That same header already documents an earlier instance of the class from 2026-08-12 (#2551 and #2538), so this is the second occurrence. Worth its own issue; this PR does not depend on it.

## Verified by running, not asserted

- Gate exits 0: `OK (2295 files measured, 361 allowlisted, 0 new over 400)`.
- Each of the six rows equals its file's exact line count (`851/526/985/661/413/443`), zero slack on all six.
- The digest value is the one the gate's own failure message prints; no other scope needed re-pinning.
- Reverting just the digest line makes the gate fail, so both changed lines are load-bearing.
- Running `--update --all` on this branch reports **0 raised, 0 added** and leaves all seven lines untouched, so this hand edit is a fixed point of the generator — byte-identical to what the repo-wide sweep would write for this scope.
- `renderAllowlist(parseAllowlist(...))` reproduces the file byte-for-byte, so sort order and column width are canonical, not hand-approximated.
- `node --test scripts/check-module-size.test.mjs scripts/lib/module-size-ratchet.test.mjs` → 63/63 pass.
- `pnpm lint` → no errors.
- #3719 cherry-picks this cleanly and its gate goes to 0.

## Not included

No changeset: scripts-only, publishes nothing. Matches #3689, the last change to this allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNuDHNx7vdoKq4ETeXn4vX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal module-size validation records to reflect current tooling.
  - Added newly tracked review utilities to the module-size allowlist.
  - Revised recorded size budgets for several review scripts.
  - Synchronized validation metadata with the current allowlist contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->