### PR TITLE
fix(export): setProperty can change a property's declared type within one EXPRESS base

### DIFF
--- a/.changeset/setproperty-declared-type-within-base.md
+++ b/.changeset/setproperty-declared-type-within-base.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/export': patch
+---
+
+`setProperty(…, PropertyValueType.Text)` on a property whose source line declares `IFCLABEL` now exports `IFCTEXT` instead of silently re-declaring `IFCLABEL`. `IfcLabel` → `IfcText` (a value outgrowing 255 characters) and `IfcLabel` → `IfcIdentifier` are ordinary corrections, and neither was expressible: the declared-type gate added in #2482 compares the source token's EXPRESS base against the effective `PropertyValueType`, and since all three collapse to `STRING` the source token always won — so the caller's type was accepted, recorded on the mutation, and then discarded in the exported bytes. A downstream IDS `property` facet with `dataType="IFCTEXT"` could not be satisfied by any sequence of operations.
+
+The gate now distinguishes a `PropertyValueType` that NAMES an `IfcValue` member from one that is merely a shape. `Label`, `Identifier` and `Text` name exactly one member each and no extraction path produces them (the parser collapses every string token to `String` and keeps the token in `dataType`), so one of those can only have come from a caller who asked for it, and it outranks the source token. Shapes keep #2482's precedence unchanged — which is what stops a value-only edit, where the UI passes `String`, from rewriting an untouched neighbouring `IFCTEXT` as `IFCLABEL` when the property set is regenerated. Numeric types are unaffected: `Real` names neither `IfcLengthMeasure` nor `IfcReal`, so the source token still wins there.

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -38,6 +38,32 @@ const value = view.getPropertyValue(entityId, 'Pset_WallCommon', 'FireRating');
 // Returns 'REI 120'
 ```
 
+### Changing a property's declared IFC type
+
+The fifth argument is the property's `PropertyValueType`. Most of its members
+are *shapes* (`String`, `Real`, `Integer`, …) — what the parser collapses a
+source token into — but `Label`, `Identifier` and `Text` each *name* one
+`IfcValue` member, so passing one of those sets the type the exported file
+declares:
+
+```typescript
+import { PropertyValueType } from '@ifc-lite/data';
+
+// A value that outgrew IfcLabel's 255 characters: export it as IfcText.
+view.setProperty(entityId, 'Pset_WallCommon', 'Reference', 'a long description…', PropertyValueType.Text);
+```
+
+The exported line becomes `IFCTEXT('…')` where the source declared
+`IFCLABEL('…')` — which is what an IDS `property` facet with
+`dataType="IFCTEXT"` checks.
+
+Passing a *shape* instead leaves the declared type alone: a value-only edit
+(`String`, the default) keeps whatever token the source line carried, so
+re-serializing a property set never rewrites the declared types of the
+neighbours you did not touch. For the same reason a numeric type cannot be
+changed this way — `Real` names neither `IfcLengthMeasure` nor `IfcReal`, so
+the source token wins.
+
 ### Mutation History
 
 ```typescript

--- a/packages/export/src/declared-nominal-value-type.test.ts
+++ b/packages/export/src/declared-nominal-value-type.test.ts
@@ -216,10 +216,21 @@ describe('declaredNominalValueType: which source tokens are written back', () =>
 
   it('rejects a member whose family disagrees with the value type', () => {
     // A session that retyped the property explicitly. The caller wins.
-    expect(declaredNominalValueType('x', PropertyValueType.Label, 'IFCLENGTHMEASURE')).toBeNull();
     expect(declaredNominalValueType(1, PropertyValueType.Real, 'IFCTEXT')).toBeNull();
     expect(declaredNominalValueType(true, PropertyValueType.Boolean, 'IFCLOGICAL')).toBeNull();
     expect(declaredNominalValueType(true, PropertyValueType.Logical, 'IFCBOOLEAN')).toBeNull();
+  });
+
+  it('a caller-named member outranks a disagreeing source token, and emits the same text', () => {
+    // `Label` over an `IFCLENGTHMEASURE` is the same "caller retyped it, caller
+    // wins" case as the test above, but since #3715 the answer is reached by
+    // NAMING `IfcLabel` rather than by falling through to the shape-derived
+    // path. Both write the identical line, which is the assertion that matters
+    // — the return value is an implementation detail, the emitted token is not.
+    expect(declaredNominalValueType('x', PropertyValueType.Label, 'IFCLENGTHMEASURE')).toBe('IfcLabel');
+    expect(serializeNominalValue('x', PropertyValueType.Label, 'IFCLENGTHMEASURE')).toBe(
+      "IFCLABEL('x')",
+    );
   });
 
   it('rejects a value that does not fit the member’s base', () => {
@@ -248,8 +259,11 @@ describe('declaredNominalValueType: which source tokens are written back', () =>
 
   it('a property with no dataType is unchanged', () => {
     // Every AUTHORED property, and every property read through a base table
-    // that does not carry the token.
-    expect(declaredNominalValueType('x', PropertyValueType.Text, undefined)).toBeNull();
+    // that does not carry the token. A caller-NAMED member answers with its own
+    // member here since #3715 (there is no source token to outrank), and the
+    // emitted text is the same one the shape-derived fallback wrote.
+    expect(declaredNominalValueType('x', PropertyValueType.String, undefined)).toBeNull();
+    expect(serializeNominalValue('x', PropertyValueType.Text, undefined)).toBe("IFCTEXT('x')");
     expect(serializeNominalValue('x', PropertyValueType.Text, undefined)).toBe(
       serializeNominalValue('x', PropertyValueType.Text, ''),
     );
@@ -268,5 +282,47 @@ describe('declaredNominalValueType: which source tokens are written back', () =>
     expect(serializeNominalValue(1.5e-7, PropertyValueType.Real, 'IFCACMEWIDGETCODE')).toBe(
       'IFCREAL(1.5E-7)',
     );
+  });
+});
+
+describe('a caller-named member changes the declared type within one EXPRESS base (#3715)', () => {
+  // `IfcLabel` -> `IfcText` (a value outgrowing 255 characters) and
+  // `IfcLabel` -> `IfcIdentifier` are ordinary corrections. Both were
+  // unexpressible: the two agree on STRING, so gate 2 handed it to the source
+  // token and the request was discarded with nothing reported.
+  it('honours Text and Identifier over a source IFCLABEL', () => {
+    expect(serializeNominalValue('42', PropertyValueType.Text, 'IFCLABEL')).toBe("IFCTEXT('42')");
+    expect(serializeNominalValue('42', PropertyValueType.Identifier, 'IFCLABEL')).toBe(
+      "IFCIDENTIFIER('42')",
+    );
+    // …in both directions, and onto itself.
+    expect(serializeNominalValue('42', PropertyValueType.Label, 'IFCTEXT')).toBe("IFCLABEL('42')");
+    expect(serializeNominalValue('42', PropertyValueType.Label, 'IFCLABEL')).toBe("IFCLABEL('42')");
+  });
+
+  it('does NOT let a bare shape rewrite a neighbour’s token (#2482 stands)', () => {
+    // The regression this fix had to avoid. Editing one property regenerates
+    // the whole set, and a value-only edit passes `String` — the shape the
+    // extractor collapses every string token into. If a shape outranked the
+    // source token, every untouched `IFCTEXT` / `IFCIDENTIFIER` neighbour would
+    // be rewritten `IFCLABEL`, which is #2482 verbatim.
+    expect(serializeNominalValue('prose', PropertyValueType.String, 'IFCTEXT')).toBe(
+      "IFCTEXT('prose')",
+    );
+    expect(serializeNominalValue('id-7', PropertyValueType.String, 'IFCIDENTIFIER')).toBe(
+      "IFCIDENTIFIER('id-7')",
+    );
+    // Numerics have no named member at all — `Real` collapses `IfcLengthMeasure`
+    // and `IfcReal` alike — so the source token keeps winning there.
+    expect(serializeNominalValue(2500, PropertyValueType.Real, 'IFCLENGTHMEASURE')).toBe(
+      'IFCLENGTHMEASURE(2500.)',
+    );
+  });
+
+  it('a named member does not smuggle a non-string value into a string token', () => {
+    // Gate 3's job, unchanged: the value still has to fit STRING. These take
+    // the shape-derived path exactly as they did before.
+    expect(declaredNominalValueType(42, PropertyValueType.Text, 'IFCLABEL')).toBeNull();
+    expect(declaredNominalValueType(null, PropertyValueType.Text, 'IFCLABEL')).toBeNull();
   });
 });

--- a/packages/export/src/declared-property-type.ts
+++ b/packages/export/src/declared-property-type.ts
@@ -39,6 +39,21 @@
  *    both from the same token — the source token is the more specific of the
  *    two and wins.
  *
+ *    **Unless the caller NAMED a member** ({@link NAMED_MEMBERS}, #3715). Gate 2
+ *    as written could not express `IfcLabel` → `IfcText`: both are STRING, so
+ *    "the two agree" and the source token won, silently discarding the request.
+ *    The information it was missing is whether the caller CHOSE the type or
+ *    merely echoed the shape the extractor derived — and that is already in the
+ *    `PropertyValueType`, because the two are different members of it.
+ *    `String` / `Real` are SHAPES, which is all the extractor can produce (it
+ *    collapses `IFCLABEL`, `IFCTEXT` and `IFCIDENTIFIER` to `String` and keeps
+ *    the token only in `dataType`); `Label` / `Identifier` / `Text` NAME one
+ *    `IfcValue` member each and no extraction path produces them, so one of
+ *    those can only have come from a caller who asked for it. A named member is
+ *    therefore authoritative over the source token; a shape keeps gate 2's
+ *    precedence, which is what stops a value-only edit — the UI passes `String`
+ *    — from rewriting a neighbouring `IFCTEXT` as `IFCLABEL` all over again.
+ *
  * 3. **The VALUE must be representable in that base.** `serializeTypedMarker`
  *    coerces, so without this an `IFCLENGTHMEASURE` carrying a non-numeric
  *    value would be written as `IFCLENGTHMEASURE(NaN)`, where the shape-derived
@@ -106,6 +121,27 @@ import { serializePropertyValue } from './property-value-serialization.js';
 
 /** The SELECT `IfcPropertySingleValue.NominalValue` is declared as. */
 const NOMINAL_VALUE_SELECT = 'IfcValue';
+
+/**
+ * The `IfcValue` member each `PropertyValueType` NAMES OUTRIGHT — as opposed to
+ * the shapes (`String`, `Real`, `Integer`, …) an extractor collapses a source
+ * token into. See gate 2 in the module docstring: this map is what lets a caller
+ * change a property's declared type WITHIN one EXPRESS base (#3715), which the
+ * base-agreement rule alone made unexpressible.
+ *
+ * Only the string family appears, and that is not an omission: these three are
+ * the only `PropertyValueType` members that name exactly one `IfcValue` member.
+ * There is deliberately no entry for `Real` or `Integer` — `IfcLengthMeasure`,
+ * `IfcReal` and every other numeric leaf all collapse to `Real`, so it names
+ * nothing and must keep gate 2's "source token wins", which is #2482's whole
+ * point. `Enum`, `Reference` and `List` are property CLASSES rather than
+ * `NominalValue` tokens and are handled by {@link serializePropertyValue}.
+ */
+const NAMED_MEMBERS: ReadonlyMap<PropertyValueType, string> = new Map([
+  [PropertyValueType.Label, 'IfcLabel'],
+  [PropertyValueType.Identifier, 'IfcIdentifier'],
+  [PropertyValueType.Text, 'IfcText'],
+]);
 
 /** UPPERCASE STEP token → `[schema-cased type name, EXPRESS base]`. */
 let nominalValueLeaves: Map<string, readonly [string, string]> | null = null;
@@ -238,6 +274,13 @@ export function declaredNominalValueType(
   dataType: string | undefined,
 ): string | null {
   if (value === null || value === undefined) return null;
+  // The caller NAMED a member rather than echoing a shape (#3715), so it
+  // outranks the source token even inside one EXPRESS base — see gate 2.
+  // A non-string value is left exactly where it was: `valueFitsBase` would
+  // have rejected it below, and `serializePropertyValue` writes the same
+  // token for these three anyway, so this branch changes nothing for it.
+  const named = NAMED_MEMBERS.get(type);
+  if (named !== undefined) return typeof value === 'string' ? named : null;
   if (!dataType) return null;
   const leaf = lookupNominalValueLeaf(dataType.trim().toUpperCase());
   if (!leaf) return null;

--- a/packages/export/src/set-property-declared-type.test.ts
+++ b/packages/export/src/set-property-declared-type.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #3715 end-to-end: `setProperty(…, PropertyValueType.Text)` on a property whose
+ * source line declares `IFCLABEL` must export `IFCTEXT`.
+ *
+ * The unit-level rule lives in `declared-nominal-value-type.test.ts`. This file
+ * drives the whole path the issue reports against — parse, `setProperty`,
+ * `StepExporter`, RE-PARSE — because that is where the defect was visible and
+ * the unit assertion alone would not have caught the merge in
+ * `MutablePropertyView.getForEntity` that hands the exporter its `type` and
+ * `dataType` separately.
+ *
+ * The re-parse is the point: an IDS `property` facet with `dataType="IFCTEXT"`
+ * reads the token back out of the exported file, and before this fix it kept
+ * reporting `is "IFCLABEL", expected "IFCTEXT"` no matter what the session did.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, extractPropertiesOnDemand } from '@ifc-lite/parser';
+import { PropertyValueType } from '@ifc-lite/data';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+/** A wall carrying one string property whose line declares its token. */
+const SOURCE = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0project0000000000000a',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('0wall00000000000000001',$,'W',$,$,$,$,$,$);
+#996=IFCPROPERTYSINGLEVALUE('RUS_LandID',$,IFCLABEL('77:01:0004042:1234'),$);
+#997=IFCPROPERTYSINGLEVALUE('Untouched',$,IFCTEXT('prose'),$);
+#998=IFCPROPERTYSET('0pset00000000000000001',$,'RusSet_AGR',$,(#996,#997));
+#999=IFCRELDEFINESBYPROPERTIES('0rel000000000000000001',$,$,$,(#10),#998);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parse(bytes: ArrayBuffer) {
+  return new IfcParser().parseColumnar(bytes, { disableWorkerScan: true });
+}
+
+/**
+ * Export the model with `RUS_LandID` re-typed to `valueType`, and report both
+ * the emitted line and the token a re-parse reads back from it.
+ */
+async function exportWithType(
+  valueType: PropertyValueType,
+  value: string = '77:01:0004042:1234',
+): Promise<{ line: string; reparsedDataType: string | undefined; untouched: string }> {
+  const store = await parse(new TextEncoder().encode(SOURCE).buffer as ArrayBuffer);
+  const entityId = store.entityIndex.byType.get('IFCWALL')![0];
+
+  const view = new MutablePropertyView(null, 'm');
+  view.setOnDemandExtractor(id => extractPropertiesOnDemand(store, id));
+  view.setExpressIdWatermark(1_000_000);
+  view.setProperty(entityId, 'RusSet_AGR', 'RUS_LandID', value, valueType);
+
+  const { content } = new StepExporter(store, view).export({
+    schema: 'IFC4',
+    includeGeometry: false,
+  });
+  const text = new TextDecoder().decode(content);
+  const lineOf = (name: string) =>
+    text.split('\n').find(l => l.includes(`'${name}'`))?.trim() ?? '';
+
+  const reparsed = await parse(content.slice().buffer as ArrayBuffer);
+  const wallId = reparsed.entityIndex.byType.get('IFCWALL')![0];
+  const prop = extractPropertiesOnDemand(reparsed, wallId)
+    .flatMap(p => p.properties)
+    .find(p => p.name === 'RUS_LandID');
+
+  return {
+    line: lineOf('RUS_LandID'),
+    reparsedDataType: prop?.dataType,
+    untouched: lineOf('Untouched'),
+  };
+}
+
+describe('setProperty can change a declared type within one EXPRESS base (#3715)', () => {
+  it('IFCLABEL -> IFCTEXT survives export and re-parse', async () => {
+    const { line, reparsedDataType } = await exportWithType(PropertyValueType.Text);
+    expect(line).toContain("IFCTEXT('77:01:0004042:1234')");
+    expect(line).not.toContain('IFCLABEL');
+    // What an IDS `dataType="IFCTEXT"` facet reads. The request used to be
+    // accepted, recorded, and then discarded in the exported bytes.
+    expect(reparsedDataType).toBe('IFCTEXT');
+  });
+
+  it('IFCLABEL -> IFCIDENTIFIER likewise', async () => {
+    const { line, reparsedDataType } = await exportWithType(PropertyValueType.Identifier);
+    expect(line).toContain("IFCIDENTIFIER('77:01:0004042:1234')");
+    expect(reparsedDataType).toBe('IFCIDENTIFIER');
+  });
+
+  it('regenerating the set does not rewrite an untouched neighbour’s token (#2482)', async () => {
+    // Editing `RUS_LandID` rewrites the whole property set, so `Untouched` is
+    // re-serialized too. Its source `IFCTEXT` must survive: this is the defect
+    // the base-agreement rule exists to prevent, and the one a fix that let any
+    // requested type win would have re-introduced.
+    const { untouched } = await exportWithType(PropertyValueType.Text);
+    expect(untouched).toContain("IFCTEXT('prose')");
+  });
+
+  it('a value-only edit leaves the source token alone', async () => {
+    // The UI path: `setProperty` with no meaningful type, which defaults to
+    // `String` — a shape, not a member. It must not narrow `IFCLABEL` or widen
+    // it; the source token stays.
+    const { line, reparsedDataType } = await exportWithType(PropertyValueType.String, 'new-value');
+    expect(line).toContain("IFCLABEL('new-value')");
+    expect(reparsedDataType).toBe('IFCLABEL');
+  });
+});


### PR DESCRIPTION
Closes #3715.

`setProperty(entityId, pset, prop, value, PropertyValueType.Text)` on a property whose source line declares `IFCLABEL` exported `IFCLABEL` again. The request was accepted, recorded on the mutation with `valueType: 7`, and then discarded in the bytes — with nothing reporting it. `IfcLabel → IfcText` (a value outgrowing 255 characters) and `IfcLabel → IfcIdentifier` are ordinary corrections, and neither was expressible through the mutation API at all.

## Cause

The declared-type gate (#2482) compares the source token's EXPRESS base against the effective `PropertyValueType` and, when the two agree, keeps the source token as the more specific of the two. That is right for the case it was written for — regenerating a property set must not rewrite the declared types of neighbours nobody touched — but `IfcLabel`, `IfcText` and `IfcIdentifier` all collapse to `STRING`, so within that base the source token always won and a deliberate change was indistinguishable from a no-op.

## Fix

The missing information is whether the caller **chose** the type or merely echoed the shape the extractor derived — and it turns out to be present already, in the `PropertyValueType` itself:

- `String`, `Real`, `Integer`, … are **shapes**, and a shape is all an extractor can produce: the parser collapses `IFCLABEL` / `IFCTEXT` / `IFCIDENTIFIER` to `String` and keeps the token only in `dataType`.
- `Label`, `Identifier`, `Text` each **name** exactly one `IfcValue` member, and *no extraction path in the tree produces them* (verified by search across `packages/` and `apps/`: every producer is a caller, never a parser).

So one of those three can only have come from a caller who asked for it. A named member now outranks the source token; a shape keeps #2482's precedence untouched.

That distinction is what stops the fix re-inflicting the defect it sits on top of. A value-only edit passes `String` — the default, and what the viewer's property editor sends — so regenerating a set still leaves every untouched `IFCTEXT` neighbour declared `IFCTEXT`. Numerics are unaffected for the same reason in reverse: `Real` names neither `IfcLengthMeasure` nor `IfcReal`, so there is nothing to outrank the source token with, which is #2482's whole point.

**No API change** — no new field, no signature change, no existing caller affected. The issue suggested carrying an "explicitly requested" flag on the mutation; that turned out to be unnecessary, and avoiding it keeps `Mutation`, `PropertyMutation`, the CRDT bind, the CSV connector and `StoreEditor` out of the diff entirely. Gates 1, 3 and 4 are untouched: a named member still has to carry a string value, and a non-string one takes exactly the path it took before.

## Evidence

The issue's own reproduction, run against the branch — parse, `setProperty`, export, **re-parse**:

| requested `PropertyValueType` | before | after | re-parsed `dataType` |
| --- | --- | --- | --- |
| `Text` | `IFCLABEL('77:01:…')` | **`IFCTEXT('77:01:…')`** | `IFCTEXT` |
| `Identifier` | `IFCLABEL('77:01:…')` | **`IFCIDENTIFIER('77:01:…')`** | `IFCIDENTIFIER` |
| `Label` | `IFCLABEL(…)` | `IFCLABEL(…)` | `IFCLABEL` |
| `String` | `IFCLABEL(…)` | `IFCLABEL(…)` | `IFCLABEL` |
| `Integer` | `IFCINTEGER(42)` | `IFCINTEGER(42)` | `IFCINTEGER` |
| `Boolean` | `IFCBOOLEAN(.T.)` | `IFCBOOLEAN(.T.)` | `IFCBOOLEAN` |

The re-parse column is the reported symptom: an IDS `property` facet with `dataType="IFCTEXT"` reads the token back out of the exported file, and before this it kept reporting `is "IFCLABEL", expected "IFCTEXT"` no matter what the session did.

## Tests

`set-property-declared-type.test.ts` drives the whole path rather than the function, because the defect lived in the seam where `MutablePropertyView.getForEntity` hands the exporter the caller's `type` and the source `dataType` separately — a unit assertion alone never crosses it. Both directions are covered, since the risk here is the regression next to the fix, not the fix: a named member overrides the source token; a bare shape does not; a named member still cannot smuggle a non-string value into a string token.

**Verified by mutation, not by inspection**: with the production branch removed, all four defect assertions fail and the #2482 guards stay green.

Two existing assertions in `declared-nominal-value-type.test.ts` moved from the function's **return value** to its **emitted text**. Both cases now reach the same token by naming it instead of falling through to the shape-derived path, so the exported line is byte-identical — asserted explicitly (`IFCLABEL('x')`, `IFCTEXT('x')`), which is the property that actually matters and the one that cannot silently drift.

## Verification

- `pnpm test --filter @ifc-lite/export --filter @ifc-lite/mutations --filter @ifc-lite/collab` — 86 + 12 + 50 files pass
- `pnpm typecheck` — 89 tasks, all test files in a program
- `oxlint` on the changed files — clean

Not run locally (Windows toolchain gaps; both run in CI): `pnpm docs:check-samples` cannot spawn `node_modules/.bin/tsc` here, and its `--listFiles` correlation compiles 0 of 270 snippets on Windows — I checked by breaking a snippet deliberately and getting the same green, so the local result is not evidence either way. The new snippet uses the same ambient globals and import as its neighbours in that file, and the call shape it documents is the one the (typechecked) e2e test makes.

Three gates are red on a **clean tree** at this branch's base commit and are not from this PR — confirmed by stashing everything and re-running: `check-api-surface` (`@ifc-lite/embed-sdk: TypeVisibilityFlags`), `check-module-size` (`scripts/review/build-context-pack.mjs`, `build-review-input.mjs`, `rubric-eval.mjs`, all over 400 with no row) and `check-source-text-assertions`.

## Note on the queue

#3715 carries no `ready` label, so the `Issue queue` row will be red. Only `louistrue` is in `labelAuthorities`, so I cannot apply it. Per the live `main` ruleset (id 11806334) the required contexts are `Build + WASM + Rust + Node`, `parity (in-tree fixtures, committed reference)` and `PR review signal` — `Issue queue` is not among them, so this blocks no merge, but it needs a maintainer label to go green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `setProperty` now supports changing string-valued IFC properties between `Label`, `Identifier`, and `Text` types.
  * Exported files can correctly declare updated types such as `IFCTEXT` and `IFCIDENTIFIER`.

* **Bug Fixes**
  * Corrected conversions involving `IfcLabel` values while preserving existing behavior for numeric and shape types.

* **Documentation**
  * Added guidance on changing a property's declared IFC type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->