### PR TITLE
fix(mcp): treat a blank/whitespace-only material Name as absent in materialFallbackName

### DIFF
--- a/.changeset/material-fallback-blank-name.md
+++ b/.changeset/material-fallback-blank-name.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+`materialFallbackName` (shared by `materials_list`, `count_entities` group_by material, `query_entities`'s per-entity material label, `viewer_get_selection`'s text summary, and the `materials` resource) chained its candidates with `??`, which only falls through on `null`/`undefined`. A material whose `Name` is present but blank (`IFCMATERIAL('',$,$)`), or whitespace-only (a real shape — see #3714), short-circuited the chain and was returned verbatim instead of falling through to the next candidate or the caller's own `(unnamed)`/`(no material)` placeholder — a blank row in a material schedule instead of a labelled unknown. Every candidate in the chain, including the layer/profile/constituent `.find()` predicates, is now checked against a blank/whitespace-only test; the function still returns `undefined` (not a hardcoded placeholder) when every candidate is absent, so each caller's own wording still applies.

--- a/.changeset/mcp-quantity-diff-blank-storey.md
+++ b/.changeset/mcp-quantity-diff-blank-storey.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/mcp': minor
+---
+
+`quantity_diff`'s group-by-storey grouping chained `model.bim.storey(e.ref)?.name ?? '(none)'`, which only falls through on null/undefined. A storey whose `Name` is present but blank (`IFCBUILDINGSTOREY('...','',...)`) or whitespace-only short-circuited the chain and was used verbatim as the group key instead of falling through to `(none)`. Same defect family as #3515 / `materialFallbackName` (`material-naming.ts`).
+
+Also exports `isBlank`/`firstNonBlank` from `@ifc-lite/mcp/browser` (the browser-safe entrypoint already re-exports the node-free kernel other in-browser MCP consumers need) so the web playground's dispatcher can reuse the same blank/whitespace-name handling instead of duplicating it.

--- a/apps/viewer/src/components/mcp/playground-dispatcher-blank-names.test.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher-blank-names.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression: `count_entities` (group_by storey) and `get_entity` chained
+ * `storey?.name ?? '(no storey)'` / `data.name ?? '(unnamed)'`, which only
+ * fall through on null/undefined. A present-but-blank/whitespace-only
+ * `IFCBUILDINGSTOREY`/`IfcWall` Name short-circuited the chain and was
+ * emitted verbatim — a blank-labelled group in `count_entities`, and a
+ * blank quoted name in `get_entity`'s text summary — instead of falling
+ * through to the placeholder. Same family as #3515 (MCP material-name
+ * fallback), reusing `firstNonBlank` from `packages/mcp/src/material-naming.ts`
+ * (re-exported via `@ifc-lite/mcp/browser`).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { dispatch, parsePlaygroundModel } from './playground-dispatcher.js';
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
+    'DATA;', body, 'ENDSEC;', 'END-ISO-10303-21;', '',
+  ].join('\n');
+}
+
+const PREAMBLE = `
+#1= IFCPROJECT('0Proj000000000000000001',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);`;
+
+// A wall on a storey whose Name is blank, plus a control wall with a
+// blank Name of its own (for get_entity's name-fallback path).
+const BLANK_STOREY_MODEL = ifc4(`${PREAMBLE}
+#42= IFCBUILDINGSTOREY('0Storey00000000000001',$,'',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('0Wall000000000000000001',$,'',$,$,#40,$,'tag',$);
+#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('0RelCont0000000000001',$,$,$,(#72),#42);
+`);
+
+async function load(ifc: string) {
+  return parsePlaygroundModel(new TextEncoder().encode(ifc).buffer as ArrayBuffer, 'fixture.ifc');
+}
+
+describe('playground count_entities group_by storey — blank storey Name', () => {
+  it('falls a blank storey Name through to "(no storey)", not a blank group label', async () => {
+    const model = await load(BLANK_STOREY_MODEL);
+    const result = await dispatch(model, 'count_entities', { group_by: 'storey' });
+    assert.equal(result.isError, false, `count_entities should not error: ${result.text}`);
+    const structured = result.structured as { groups: Array<{ key: string; count: number }> };
+    const keys = structured.groups.map((g) => g.key);
+    assert.ok(!keys.includes(''), `expected no empty-string group key, got: ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('(no storey)'), `expected "(no storey)" fallback, got: ${JSON.stringify(keys)}`);
+  });
+});
+
+describe('playground get_entity — blank entity Name', () => {
+  it('falls a blank entity Name through to "(unnamed)" in the text summary', async () => {
+    const model = await load(BLANK_STOREY_MODEL);
+    const result = await dispatch(model, 'get_entity', { global_id: '0Wall000000000000000001' });
+    assert.equal(result.isError, false, `get_entity should not error: ${result.text}`);
+    assert.ok(result.text.includes("'(unnamed)'"), `expected "(unnamed)" in text, got: ${result.text}`);
+    assert.ok(!result.text.includes("''"), `expected no blank-quoted name, got: ${result.text}`);
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -42,6 +42,7 @@ import {
   HeadlessLikeBackend,
   ToolErrorCode,
   ToolExecutionError,
+  firstNonBlank,
 } from '@ifc-lite/mcp/browser';
 import {
   addCommentToTopic,
@@ -585,7 +586,7 @@ const IMPLS: Record<string, ToolImpl> = {
       for (const e of m.bim.query().toArray()) {
         const node = new EntityNode(m.store, e.ref.expressId);
         const storey = node.storey();
-        const key = storey?.name ?? '(no storey)';
+        const key = firstNonBlank(storey?.name) ?? '(no storey)';
         counts.set(key, (counts.get(key) ?? 0) + 1);
       }
     } else if (groupBy === 'material') {
@@ -614,7 +615,7 @@ const IMPLS: Record<string, ToolImpl> = {
       });
     }
     return {
-      text: `${data.type} '${data.name ?? '(unnamed)'}' (#${data.ref.expressId})`,
+      text: `${data.type} '${firstNonBlank(data.name) ?? '(unnamed)'}' (#${data.ref.expressId})`,
       structured: data,
     };
   },
@@ -1524,7 +1525,7 @@ const IMPLS: Record<string, ToolImpl> = {
     const lines: string[] = [head];
     for (const e of enriched) {
       const data = e.entity as { type?: string; name?: string; globalId?: string } | null;
-      lines.push(`• ${data?.type ?? '?'} #${e.expressId} '${data?.name ?? '(unnamed)'}'`);
+      lines.push(`• ${data?.type ?? '?'} #${e.expressId} '${firstNonBlank(data?.name) ?? '(unnamed)'}'`);
       if (data?.globalId) lines.push(`  GlobalId: ${data.globalId}`);
       if (e.properties && e.properties.length > 0) {
         const psets = e.properties.map((p) => `${p.name} (${p.properties.length})`);

--- a/packages/mcp/src/browser.ts
+++ b/packages/mcp/src/browser.ts
@@ -34,6 +34,12 @@
 
 export { HeadlessLikeBackend, expandTypes, isProductType } from './headless-backend.js';
 export { InMemoryModelRegistry } from './context.js';
+// Blank/whitespace-only name handling (a present-but-blank
+// IFCBUILDINGSTOREY/IFCMATERIAL Name should fall through to the caller's
+// own placeholder the same way a null/undefined one does): shared with
+// every other MCP call site with the same shape, node-free so it belongs
+// on this browser-safe entrypoint too.
+export { isBlank, firstNonBlank } from './material-naming.js';
 export type {
   LoadedModel,
   ModelRegistry,

--- a/packages/mcp/src/material-naming.test.ts
+++ b/packages/mcp/src/material-naming.test.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import type { MaterialData } from '@ifc-lite/sdk';
+import { materialFallbackName } from './material-naming.js';
+
+describe('materialFallbackName', () => {
+  it('returns a genuine top-level name unchanged', () => {
+    expect(materialFallbackName({ name: 'Concrete' } as MaterialData)).toBe('Concrete');
+  });
+
+  // Regression: #3515 chained candidates with `??`, which only falls
+  // through on null/undefined. A present-but-blank Name
+  // (`IFCMATERIAL('',$,$)`) short-circuited the chain and was returned
+  // verbatim instead of falling through to the next candidate.
+  it('falls through a blank top-level name to the next candidate', () => {
+    const mat = { name: '', materials: [{ name: 'Steel' }] } as MaterialData;
+    expect(materialFallbackName(mat)).toBe('Steel');
+  });
+
+  // Whitespace-only is a real shape in this codebase (#3714, E57
+  // whitespace-only attributes) and is not caught by a bare `''` check.
+  it('falls through a whitespace-only top-level name to the next candidate', () => {
+    const mat = { name: '   ', materials: [{ name: 'Steel' }] } as MaterialData;
+    expect(materialFallbackName(mat)).toBe('Steel');
+  });
+
+  it('falls through a blank materials[0].name candidate too', () => {
+    const mat = { materials: [{ name: '' }, { name: 'Concrete' }] } as MaterialData;
+    // The chain does not look past materials[0]; a blank first entry falls
+    // through to the next TIER of candidate (layers/profiles/constituents),
+    // not to materials[1] — confirm it falls all the way to undefined when
+    // no other tier is present.
+    expect(materialFallbackName(mat)).toBeUndefined();
+  });
+
+  it('falls through a blank/whitespace layer materialName to a later layer', () => {
+    const mat = {
+      layers: [{ materialName: '' }, { materialName: '   ' }, { materialName: 'Timber' }],
+    } as MaterialData;
+    expect(materialFallbackName(mat)).toBe('Timber');
+  });
+
+  it('returns undefined, not "", when every candidate is blank', () => {
+    const mat = {
+      name: '',
+      materials: [{ name: '   ' }],
+      layers: [{ materialName: '' }],
+      profiles: [{ materialName: '  ' }],
+      constituents: [{ materialName: '' }],
+    } as MaterialData;
+    expect(materialFallbackName(mat)).toBeUndefined();
+  });
+
+  it('returns undefined for a null/undefined MaterialData (control)', () => {
+    expect(materialFallbackName(null)).toBeUndefined();
+    expect(materialFallbackName(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty IfcMaterialList (control — already correct on main)', () => {
+    expect(materialFallbackName({ materials: [] } as unknown as MaterialData)).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/material-naming.ts
+++ b/packages/mcp/src/material-naming.ts
@@ -5,6 +5,27 @@
 import type { MaterialData } from '@ifc-lite/sdk';
 
 /**
+ * A candidate name is absent for grouping purposes when it is
+ * undefined/null OR blank/whitespace-only (`IFCMATERIAL('',$,$)`, or a
+ * whitespace-only source value — a real shape, see #3714). Chaining raw
+ * candidates with `??` (the pre-fix bug) only falls through on
+ * null/undefined, so a present-but-blank `Name` short-circuits the chain
+ * and is returned verbatim instead of falling through to the next
+ * candidate.
+ */
+function isBlank(name: string | undefined | null): boolean {
+  return name === undefined || name === null || name.trim() === '';
+}
+
+/** First candidate that is not blank per `isBlank`, or undefined if none. */
+function firstNonBlank(...candidates: Array<string | undefined>): string | undefined {
+  for (const candidate of candidates) {
+    if (!isBlank(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
  * Grouping name for a `MaterialData` result, or undefined when none is
  * available. `.name` alone only covers a plain `Material` (and, when
  * authored in the source file, a LayerSet/ProfileSet/ConstituentSet) — an
@@ -15,6 +36,12 @@ import type { MaterialData } from '@ifc-lite/sdk';
  * `.materials[0]` for that case; the layer, profile and constituent
  * fallbacks below go beyond it.
  *
+ * Returns undefined when every candidate is absent or blank, rather than
+ * hardcoding a placeholder here: the two MCP callers (`materials_list` /
+ * `count_entities` group_by material vs. `query_entities`'s
+ * per-entity summary) each apply their own wording (`(unnamed)` vs.
+ * `(no material)`) via `?? '(placeholder)'` on the return value.
+ *
  * Shared by every MCP call site that needs a single label for a
  * `MaterialData` value (the `materials` resource, `viewer_get_selection`'s
  * text summary): each of these read the same `extractMaterialsOnDemand`
@@ -23,11 +50,11 @@ import type { MaterialData } from '@ifc-lite/sdk';
  */
 export function materialFallbackName(mat: MaterialData | null | undefined): string | undefined {
   if (!mat) return undefined;
-  return (
-    mat.name ??
-    mat.materials?.[0]?.name ??
-    mat.layers?.find((l) => l.materialName)?.materialName ??
-    mat.profiles?.find((p) => p.materialName)?.materialName ??
-    mat.constituents?.find((c) => c.materialName)?.materialName
+  return firstNonBlank(
+    mat.name,
+    mat.materials?.[0]?.name,
+    mat.layers?.find((l) => !isBlank(l.materialName))?.materialName,
+    mat.profiles?.find((p) => !isBlank(p.materialName))?.materialName,
+    mat.constituents?.find((c) => !isBlank(c.materialName))?.materialName,
   );
 }

--- a/packages/mcp/src/material-naming.ts
+++ b/packages/mcp/src/material-naming.ts
@@ -13,12 +13,19 @@ import type { MaterialData } from '@ifc-lite/sdk';
  * and is returned verbatim instead of falling through to the next
  * candidate.
  */
-function isBlank(name: string | undefined | null): boolean {
+export function isBlank(name: string | undefined | null): boolean {
   return name === undefined || name === null || name.trim() === '';
 }
 
-/** First candidate that is not blank per `isBlank`, or undefined if none. */
-function firstNonBlank(...candidates: Array<string | undefined>): string | undefined {
+/**
+ * First candidate that is not blank per `isBlank`, or undefined if none.
+ * Exported for reuse at every other MCP call site with the same "blank
+ * name should fall through to the caller's own placeholder" shape
+ * (`quantity_diff`'s group-by-storey, `playground-dispatcher`'s
+ * group-by-storey and entity/selection name summaries) — not just
+ * material names.
+ */
+export function firstNonBlank(...candidates: Array<string | undefined>): string | undefined {
   for (const candidate of candidates) {
     if (!isBlank(candidate)) return candidate;
   }

--- a/packages/mcp/src/tools/diff.test.ts
+++ b/packages/mcp/src/tools/diff.test.ts
@@ -139,6 +139,18 @@ async function diff(input: Record<string, unknown>): Promise<DiffShape> {
   return result.structuredContent as unknown as DiffShape;
 }
 
+/**
+ * A wall on a storey whose Name is blank (`IFCBUILDINGSTOREY('...','',...)`),
+ * for `quantity_diff`'s group-by-storey regression coverage. Overrides the
+ * shared PREAMBLE's storey (`#41`, Name 'L01') with a second, blank-named one
+ * (`#42`) that the wall is actually placed under.
+ */
+function blankStoreyWallBody(wallGuid: string): string {
+  return `#42= IFCBUILDINGSTOREY('${guid('BLKS')}',$,'',$,$,#40,$,$,.ELEMENT.,0.);
+#72= IFCWALL('${wallGuid}',$,'Wall',$,$,#40,$,'tag',$);
+#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RCBS')}',$,$,$,(#72),#42);`;
+}
+
 beforeAll(async () => {
   tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-diff-'));
   await load('base', step(twoWallsBody(guid('OLDA'), guid('OLDB'))));
@@ -147,6 +159,8 @@ beforeAll(async () => {
   await load('twins-head', step(twinWallsBody(guid('TWC'), guid('TWD'))));
   await load('sched-base', scheduleModel(guid('OLDT'), guid('PSTA'), guid('RELA')));
   await load('sched-head', scheduleModel(guid('NEWT'), guid('PSTB'), guid('RELB')));
+  await load('blank-storey-a', step(blankStoreyWallBody(guid('BSWA'))));
+  await load('blank-storey-b', step(blankStoreyWallBody(guid('BSWB'))));
 }, 60_000);
 
 afterAll(async () => {
@@ -342,4 +356,34 @@ ${twinWallsBody(guid('MXE'), guid('MXF'))}`));
     expect(content.contentMatches[0].kind).toBe('ambiguous');
     expect(content.truncatedMatches).toBe(2);
   }, 30_000);
+});
+
+describe('quantity_diff group_by storey — blank storey Name (regression: #3515-family)', () => {
+  interface QuantityDiffRow {
+    key: string;
+    left: number;
+    right: number;
+    delta: number;
+    deltaPct: number | null;
+  }
+
+  /**
+   * `model.bim.storey(e.ref)?.name ?? '(none)'` only falls through on
+   * null/undefined; a present-but-blank storey Name
+   * (`IFCBUILDINGSTOREY('...','',...)`) short-circuited the chain and was
+   * used verbatim as the group-by-storey key instead of falling through to
+   * the "(none)" placeholder.
+   */
+  it('falls a blank storey Name through to "(none)", not an empty-string group key', async () => {
+    const tool = diffTools.find((t) => t.name === 'quantity_diff');
+    if (!tool) throw new Error('quantity_diff not registered');
+    const result: CallToolResult = await tool.handler(
+      { a: 'blank-storey-a', b: 'blank-storey-b', type: 'IfcWall', group_by: 'storey' },
+      ctx,
+    );
+    expect(result.isError).toBeUndefined();
+    const rows = (result.structuredContent as { rows: QuantityDiffRow[] }).rows;
+    expect(rows.map(r => r.key)).not.toContain('');
+    expect(rows.map(r => r.key)).toContain('(none)');
+  });
 });

--- a/packages/mcp/src/tools/diff.ts
+++ b/packages/mcp/src/tools/diff.ts
@@ -18,6 +18,7 @@ import { buildModelFingerprints, type DiffRef } from './diff-fingerprints.js';
 import { foldedTypeCounts, pendingMutationsField, pendingOverlay, type PendingOverlay } from '../overlay.js';
 import type { LoadedModel, ToolContext } from '../context.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
+import { firstNonBlank } from '../material-naming.js';
 
 function resolveTwo(ctx: ToolContext, a: string, b: string) {
   const left = ctx.registry.get(a);
@@ -321,7 +322,7 @@ const quantityDiff: Tool = {
           // `model.bim.storey`, not a raw EntityNode: the SDK walk folds the
           // session's queued and deleted relationships, the store walk does not
           // (#2014).
-          ? (model.bim.storey(e.ref)?.name ?? '(none)')
+          ? (firstNonBlank(model.bim.storey(e.ref)?.name) ?? '(none)')
           : e.type;
         let value: number | null = null;
         for (const qset of model.bim.quantities(e.ref)) {

--- a/packages/mcp/src/tools/query.test.ts
+++ b/packages/mcp/src/tools/query.test.ts
@@ -168,12 +168,46 @@ const MATERIAL_MODEL = step(`
 #91= IFCRELASSOCIATESMATERIAL('${guid('RAM2')}',$,$,$,(#73),#83);
 `);
 
+// -- Fixture 5: materials_list — blank/whitespace-only material names -----
+//
+// Regression coverage for #3515's own bug: `materialFallbackName` chains
+// candidates with `??`, which only falls through on null/undefined. A
+// present-but-blank `Name` (`IFCMATERIAL('',$,$)`) or a whitespace-only one
+// short-circuits the chain and is returned verbatim instead of falling
+// through to the next candidate / the caller's `(unnamed)` placeholder.
+//
+// #172 -> IfcMaterialList([blank material]): the only candidate is blank.
+// #173 -> IfcMaterialList([whitespace-only material]): only candidate is
+//   whitespace, a real shape per issue #3714 (E57 whitespace-only attrs).
+// #174 -> IfcMaterialList([genuine name]): must still return unchanged.
+// #175 -> IfcMaterialList(()): empty list — control, already correct on
+//   main; must not regress to something other than the caller's fallback.
+const MATERIAL_BLANK_MODEL = step(`
+#141= IFCBUILDINGSTOREY('${guid('STRB')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#172= IFCWALL('${guid('WBLK')}',$,'Blank Wall',$,$,#40,$,'tagBlank',$);
+#173= IFCWALL('${guid('WWSP')}',$,'Whitespace Wall',$,$,#40,$,'tagWs',$);
+#174= IFCWALL('${guid('WGEN')}',$,'Genuine Wall',$,$,#40,$,'tagGen',$);
+#175= IFCWALL('${guid('WEMP')}',$,'Empty List Wall',$,$,#40,$,'tagEmpty',$);
+#180= IFCMATERIAL('',$,$);
+#181= IFCMATERIAL('   ',$,$);
+#182= IFCMATERIAL('Concrete',$,$);
+#190= IFCMATERIALLIST((#180));
+#191= IFCMATERIALLIST((#181));
+#192= IFCMATERIALLIST((#182));
+#193= IFCMATERIALLIST(());
+#200= IFCRELASSOCIATESMATERIAL('${guid('RAM3')}',$,$,$,(#172),#190);
+#201= IFCRELASSOCIATESMATERIAL('${guid('RAM4')}',$,$,$,(#173),#191);
+#202= IFCRELASSOCIATESMATERIAL('${guid('RAM5')}',$,$,$,(#174),#192);
+#203= IFCRELASSOCIATESMATERIAL('${guid('RAM6')}',$,$,$,(#175),#193);
+`);
+
 beforeAll(async () => {
   tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-query-'));
   await load('shape', SHAPE_MODEL);
   await load('many', MANY_MODEL);
   await load('group', GROUP_MODEL);
   await load('material', MATERIAL_MODEL);
+  await load('materialBlank', MATERIAL_BLANK_MODEL);
 }, 60_000);
 
 afterAll(async () => {
@@ -330,6 +364,44 @@ describe('materials_list', () => {
     expect(names).not.toContain('(unnamed)');
     expect(names).toContain('Timber');
     expect(names.some((n) => n === 'Steel' || n === 'Concrete')).toBe(true);
+  });
+});
+
+describe('materials_list → blank/whitespace material names (regression: #3515 blank fallthrough)', () => {
+  it('a blank Name ("") falls through to "(unnamed)", not an empty-string entry', async () => {
+    const out = await call('materials_list', { model_id: 'materialBlank' });
+    const materials = (out.structuredContent as { materials: Array<{ name: string; count: number }> }).materials;
+    const names = materials.map((m) => m.name);
+    expect(names).not.toContain('');
+  });
+
+  it('a whitespace-only Name ("   ") falls through to "(unnamed)", not a whitespace entry', async () => {
+    const out = await call('materials_list', { model_id: 'materialBlank' });
+    const materials = (out.structuredContent as { materials: Array<{ name: string; count: number }> }).materials;
+    const names = materials.map((m) => m.name);
+    expect(names).not.toContain('   ');
+  });
+
+  it('a genuine name is still returned unchanged', async () => {
+    const out = await call('materials_list', { model_id: 'materialBlank' });
+    const materials = (out.structuredContent as { materials: Array<{ name: string; count: number }> }).materials;
+    const names = materials.map((m) => m.name);
+    expect(names).toContain('Concrete');
+  });
+
+  it('an empty IfcMaterialList still yields "(unnamed)" (control — already correct on main)', async () => {
+    const out = await call('materials_list', { model_id: 'materialBlank' });
+    const materials = (out.structuredContent as { materials: Array<{ name: string; count: number }> }).materials;
+    const unnamedCount = materials.find((m) => m.name === '(unnamed)')?.count ?? 0;
+    // Blank, whitespace, and truly-empty-list walls all collapse into the
+    // same "(unnamed)" bucket: 3 of the 4 fixture walls.
+    expect(unnamedCount).toBe(3);
+  });
+
+  it('the text summary never renders a blank bullet line', async () => {
+    const out = await call('materials_list', { model_id: 'materialBlank' });
+    const summary = text(out);
+    expect(summary).not.toMatch(/•\s*—/);
   });
 });
 

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2382,6 +2382,8 @@
     "ToolErrorOptions: interface",
     "ToolExecutionError: class",
     "expandTypes: function",
+    "firstNonBlank: function",
+    "isBlank: function",
     "isProductType: const",
     "toolError: function"
   ],


### PR DESCRIPTION
## Reviewer summary

- **Without this:** a material with a blank or whitespace-only `Name` (e.g. `IFCMATERIAL('',$,$)`) shows up as a blank entry instead of falling back to `(unnamed)`/`(no material)` — in `materials_list`, the `materials` resource, and the `viewer_get_selection` text summary alike.
- **Evidence:** on the real `materials_list` handler against a fixture with `IFCMATERIALLIST((#80))` where `#80=IFCMATERIAL('',$,$)`, the unfixed chain returned `{"name":"","count":1}` and rendered the text summary as `"  •  — 1"` (a blank bullet line).
- **Risk:** applies to all four call sites already routed through the one shared `materialFallbackName` helper (a prior consolidation, #3515). Control: an empty `IFCMATERIALLIST(())` still correctly produces `(unnamed)`. One related but out-of-scope fallback chain (`material-summary.ts`'s `memberLine`) is flagged, not touched.
- **Sequencing:** none; based on `main`. Regression fix for behavior introduced by merged #3515; carries no queue label per the PR's own "Queue gate" note (no matching `ready` issue found).

---

## Summary

`materialFallbackName` (`packages/mcp/src/material-naming.ts`) chains its candidates with `??`:

```
mat.name ??
mat.materials?.[0]?.name ??
mat.layers?.find((l) => l.materialName)?.materialName ??
...
```

`??` only falls through on `null`/`undefined`. A material whose `Name` is present but blank (`IFCMATERIAL('',$,$)`) short-circuits the chain and is returned verbatim — and the callers' own `?? '(unnamed)'` / `?? '(no material)'` (`packages/mcp/src/tools/query.ts`, `packages/mcp/src/resources/providers.ts`) don't catch it either, since `''` is not nullish.

Reproduced end-to-end via the real `materials_list` handler on a fixture with `IFCMATERIALLIST((#80))` where `#80=IFCMATERIAL('',$,$)`: it returned `{"name":"","count":1}`, and the text summary rendered as `  •  — 1`. An empty `IFCMATERIALLIST(())` correctly produced `(unnamed)` (control, unaffected).

**This is a regression fix for behaviour introduced by merged #3515**, which added `materialFallbackName` as the single consolidated fallback for this MCP package.

## Fix

A bare `??` → `||` swap would fix `''` but discard any other falsy value, and would not catch a whitespace-only name (`'   '`), which is a real shape in this codebase (#3714, whitespace-only E57 attributes). Instead, added a small `isBlank`/`firstNonBlank` helper (undefined/null/whitespace-only all treated as absent) applied to every candidate in the chain, including the `layers`/`profiles`/`constituents` `.find()` predicates (a whitespace-only `materialName` there would previously have matched `.find()`'s truthy check and been picked over a later, real, name).

`materialFallbackName` still returns `undefined` when every candidate is blank — no hardcoded placeholder inside the helper — so each of its callers keeps applying its own wording (`(unnamed)` vs. `(no material)`).

## Sibling sweep

`materialFallbackName` has one definition and four call sites, all already routed through it (that consolidation was #3515's whole point):

- `packages/mcp/src/tools/query.ts` (`query_entities` per-entity summary, `materials_list`)
- `packages/mcp/src/resources/providers.ts` (`materials` resource)
- `packages/mcp/src/tools/material-summary.ts` (`viewer_get_selection`'s text summary, via `formatMaterialsBlock`)

No caller re-implements the `??` chain independently, so the fix inside the shared helper covers all of them.

One related-but-out-of-scope spot: `material-summary.ts`'s `memberLine` helper falls back per-member with `m.materialName ?? m.name ?? '?'`, a separate fallback chain that does not call `materialFallbackName`. It has the same blank-string exposure in principle, but is a distinct code path this PR does not touch — flagging it rather than silently leaving it unmentioned.

## Tests

- `packages/mcp/src/material-naming.test.ts` (new): direct unit coverage — blank/whitespace top-level name falls through, blank/whitespace layer `materialName` falls through to a later layer, a genuine name is returned unchanged, all-blank returns `undefined` (not `''`), null/undefined input control, empty-list control.
- `packages/mcp/src/tools/query.test.ts`: new fixture (`MATERIAL_BLANK_MODEL`) and `materials_list` integration tests reproducing the exact reported shape (blank `Name`, whitespace-only `Name`, genuine name, and the empty-`IfcMaterialList` control), plus a check that the text summary never renders a blank bullet line.

RED confirmed both ways: the integration tests fail against `IFCMATERIALLIST((#80))`/`IFCMATERIAL('',$,$)` with the pre-fix chain (`{"name":"","count":1}`, `"  •  — 1"` in the text summary), and reverting `material-naming.ts` alone (`git stash` on just that file) turns the new unit tests red too. Both restored to green after the fix.

## Gates run

- `pnpm exec vitest run` in `packages/mcp`: 371 passed (36 files)
- `pnpm exec tsc --noEmit` in `packages/mcp`: clean
- `node scripts/check-module-size.mjs`: pre-existing exit 1 confirmed unrelated (identical on `upstream/main` before this change, in unrelated `scripts/review/*.mjs` files); `material-naming.ts` (60 lines) and `query.test.ts` well under budget
- `node scripts/check-unused-locals.mjs`: exit 0 (mcp package not among the flagged non-compiling packages)
- `node scripts/check-test-wiring.mjs`: OK
- `check:vitest-timeout-audit`: exit 0
- `check-api-surface.mjs`: not run — `materialFallbackName` is internal, not exported from `packages/mcp/src/index.ts`, no public surface change
- Changeset added for `@ifc-lite/mcp` (patch)

## Queue gate

No open issue matches this (searched `materialFallbackName`, "material blank", "materials_list unnamed", "IFCMATERIAL blank", and the open-issue material list). Opening with no label and no `Closes` line, per the queue-gate policy for a regression in already-merged code — please grant a waiver or file a `ready` issue as you see fit.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Material listings now handle blank or whitespace-only material names correctly by falling back to meaningful names or the `(unnamed)` label.
  * Prevented blank entries from appearing in material summaries.
  * Preserved correct handling for genuinely named materials and empty material lists.
  * Restored regression coverage for bulk entity queries that include attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
