### PR TITLE
fix(cli): fall a blank/whitespace storey or material name through to the placeholder, not an empty key

### DIFF
--- a/.changeset/cli-blank-storey-material-key.md
+++ b/.changeset/cli-blank-storey-material-key.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`query --group-by storey|material`, `query --unique storey|material`, `ask` (building name, largest storey, largest/smallest element), and `stats` (building name, storey list, material summary) chained their name candidates with `??`/`.filter(Boolean)`/`!name`, which only falls through on null/undefined (or, for `!name`/`Boolean`, only catches a plain empty string). A storey or material whose `Name` is present but blank (`IFCBUILDINGSTOREY('...','',...)`, `IFCMATERIAL('',$,$)`) or whitespace-only short-circuited the chain and was emitted verbatim — an empty-string JSON key from `--group-by`/`--unique` instead of `"(no storey)"`/`"(no material)"`, a blank bullet in `ask`'s `answer:` string, a whitespace-string row in `stats`' material summary. Every site now falls through blank/whitespace candidates to the next one, same shape as `firstNonBlank`/`isBlank` in `packages/mcp/src/material-naming.ts`; a genuine name is still returned unchanged.

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -19,7 +19,67 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const createHeadlessContext = vi.hoisted(() => vi.fn());
 vi.mock('../loader.js', () => ({ createHeadlessContext }));
 
-const { askCommand } = await import('./ask.js');
+const { askCommand, RECIPES } = await import('./ask.js');
+
+function recipe(name: string) {
+  const r = RECIPES.find((r) => r.name === name);
+  if (!r) throw new Error(`recipe not found: ${name}`);
+  return r;
+}
+
+describe('ask recipes — blank/whitespace name falls through to "(unnamed)"', () => {
+  /**
+   * Regression: a present-but-blank/whitespace `IfcBuilding.Name` was
+   * chained with `buildings[0]?.name ?? '(unnamed)'`, which only falls
+   * through on null/undefined, so the `answer:` string rendered
+   * `Building: ` (or `Building:    `) instead of `Building: (unnamed)`.
+   */
+  it('building-name: blank Name falls through to "(unnamed)"', () => {
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ name: '' }] }) }) };
+    const result = recipe('building-name').execute(bim, {});
+    expect(result.answer).toBe('Building: (unnamed)');
+    expect(result.name).toBe('(unnamed)');
+  });
+
+  it('building-name: whitespace-only Name falls through to "(unnamed)"', () => {
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ name: '   ' }] }) }) };
+    const result = recipe('building-name').execute(bim, {});
+    expect(result.answer).toBe('Building: (unnamed)');
+  });
+
+  it('building-name: a genuine name is returned unchanged (control)', () => {
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ name: 'Main Building' }] }) }) };
+    const result = recipe('building-name').execute(bim, {});
+    expect(result.answer).toBe('Building: Main Building');
+  });
+
+  it('tallest-storey: blank storey Name falls through to "(unnamed)"', () => {
+    const bim = { storeys: () => [{ ref: 1, name: '' }], contains: () => [{}, {}] };
+    const result = recipe('tallest-storey').execute(bim, {});
+    expect(result.answer).toBe('Largest storey: (unnamed) with 2 elements');
+    expect(result.storey).toBe('(unnamed)');
+  });
+
+  it('tallest-storey: a genuine storey Name is returned unchanged (control)', () => {
+    const bim = { storeys: () => [{ ref: 1, name: 'Level 1' }], contains: () => [{}] };
+    const result = recipe('tallest-storey').execute(bim, {});
+    expect(result.storey).toBe('Level 1');
+  });
+
+  it('largest-element: blank element Name falls through to "(unnamed)" in the answer', () => {
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
+    const result = recipe('largest-element').execute(bim, {}, ['largest wall', 'wall'] as unknown as RegExpMatchArray);
+    expect(result.answer).toContain('"(unnamed)"');
+    expect(result.answer).not.toContain('""');
+  });
+
+  it('smallest-element: blank element Name falls through to "(unnamed)" in the answer', () => {
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
+    const result = recipe('smallest-element').execute(bim, {}, ['smallest wall', 'wall'] as unknown as RegExpMatchArray);
+    expect(result.answer).toContain('"(unnamed)"');
+    expect(result.answer).not.toContain('""');
+  });
+});
 
 describe('askCommand when the matched recipe throws', () => {
   let stdout: string;

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -17,7 +17,7 @@
  */
 
 import { createHeadlessContext } from '../loader.js';
-import { printJson, fatal, hasFlag } from '../output.js';
+import { printJson, fatal, hasFlag, firstNonBlank } from '../output.js';
 
 interface Recipe {
   name: string;
@@ -26,7 +26,7 @@ interface Recipe {
   execute: (bim: any, store: any, match?: RegExpMatchArray) => any;
 }
 
-const RECIPES: Recipe[] = [
+export const RECIPES: Recipe[] = [
   // --- Counting recipes ---
   {
     name: 'count-walls',
@@ -239,7 +239,7 @@ const RECIPES: Recipe[] = [
     description: 'Get the building name',
     execute: (bim) => {
       const buildings = bim.query().byType('IfcBuilding').toArray();
-      const name = buildings[0]?.name ?? '(unnamed)';
+      const name = firstNonBlank(buildings[0]?.name) ?? '(unnamed)';
       return { answer: `Building: ${name}`, name };
     },
   },
@@ -266,7 +266,7 @@ const RECIPES: Recipe[] = [
         const contained = bim.contains(s.ref);
         if (contained.length > maxCount) {
           maxCount = contained.length;
-          maxName = s.name ?? '(unnamed)';
+          maxName = firstNonBlank(s.name) ?? '(unnamed)';
         }
       }
       return { answer: `Largest storey: ${maxName} with ${maxCount} elements`, storey: maxName, elementCount: maxCount };
@@ -352,7 +352,7 @@ const RECIPES: Recipe[] = [
         return { answer: `No ${ifcType} entities found`, count: 0 };
       }
       return {
-        answer: `Largest ${ifcType}: "${maxEntity.name ?? '(unnamed)'}" with ${round(maxValue)} (m2 or m3)`,
+        answer: `Largest ${ifcType}: "${firstNonBlank(maxEntity.name) ?? '(unnamed)'}" with ${round(maxValue)} (m2 or m3)`,
         name: maxEntity.name,
         globalId: maxEntity.globalId,
         value: round(maxValue),
@@ -389,7 +389,7 @@ const RECIPES: Recipe[] = [
         return { answer: `No ${ifcType} entities with quantities found`, count: 0 };
       }
       return {
-        answer: `Smallest ${ifcType}: "${minEntity.name ?? '(unnamed)'}" with ${round(minValue)} (m2 or m3)`,
+        answer: `Smallest ${ifcType}: "${firstNonBlank(minEntity.name) ?? '(unnamed)'}" with ${round(minValue)} (m2 or m3)`,
         name: minEntity.name,
         globalId: minEntity.globalId,
         value: round(minValue),

--- a/packages/cli/src/commands/query-output.test.ts
+++ b/packages/cli/src/commands/query-output.test.ts
@@ -16,6 +16,7 @@ import {
   outputAggregation,
   outputGroupBy,
   outputEntities,
+  computeUniqueValues,
 } from './query-output.js';
 
 interface FakeEntity {
@@ -278,6 +279,99 @@ describe('outputGroupBy', () => {
     json.spy.mockRestore();
     const parsed = JSON.parse(json.chunks.join(''));
     expect(Object.keys(parsed)).toHaveLength(1);
+  });
+
+  /**
+   * Regression: a present-but-blank storey Name (`IFCBUILDINGSTOREY('...','',...)`)
+   * was chained with `storey?.name ?? '(no storey)'`, which only falls
+   * through on null/undefined. A blank name short-circuited the chain and
+   * was emitted verbatim as an empty-string JSON key instead of falling
+   * through to the "(no storey)" placeholder. Kills reverting the fix back
+   * to a bare `??`.
+   */
+  it('falls a blank storey Name through to "(no storey)", not an empty-string key', () => {
+    const blankStoreyBim = fakeBim({ storeys: { 1: { name: '' }, 2: { name: '   ' } } });
+    const json = captureStdout();
+    outputGroupBy(
+      [{ ref: 1, type: 'IfcWall' }, { ref: 2, type: 'IfcWall' }] as FakeEntity[],
+      'storey',
+      undefined,
+      blankStoreyBim,
+      true,
+    );
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(Object.keys(parsed)).not.toContain('');
+    expect(parsed['(no storey)']?.count).toBe(2);
+  });
+
+  /** Control: a genuine storey Name is still returned unchanged. */
+  it('groups by a genuine storey Name unchanged', () => {
+    const namedStoreyBim = fakeBim({ storeys: { 1: { name: 'Level 1' } } });
+    const json = captureStdout();
+    outputGroupBy([{ ref: 1, type: 'IfcWall' }] as FakeEntity[], 'storey', undefined, namedStoreyBim, true);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(Object.keys(parsed)).toEqual(['Level 1']);
+  });
+
+  /**
+   * Regression: same defect on the material chain
+   * (`mat?.materials?.[0] ?? mat?.name ?? '(no material)'`) — a blank
+   * `materials[0]` short-circuited to an empty-string key.
+   */
+  it('falls a blank material name through to "(no material)", not an empty-string key', () => {
+    const blankMatBim = fakeBim({ materials: { 1: { materials: [''] } } });
+    const json = captureStdout();
+    outputGroupBy([{ ref: 1, type: 'IfcWall' }] as FakeEntity[], 'material', undefined, blankMatBim, true);
+    json.spy.mockRestore();
+    const parsed = JSON.parse(json.chunks.join(''));
+    expect(Object.keys(parsed)).not.toContain('');
+    expect(parsed['(no material)']?.count).toBe(1);
+  });
+});
+
+describe('computeUniqueValues', () => {
+  /**
+   * Regression: `--unique storey` chained `storey?.name ?? '(no storey)'`,
+   * only falling through on null/undefined. A blank/whitespace-only storey
+   * Name short-circuited the chain and produced a blank-label distinct
+   * value instead of the "(no storey)" placeholder.
+   */
+  it('falls a blank/whitespace storey Name through to "(no storey)"', () => {
+    const bim = fakeBim({ storeys: { 1: { name: '' }, 2: { name: '   ' } } });
+    const counts = computeUniqueValues([{ ref: 1 }, { ref: 2 }] as FakeEntity[], 'storey', bim);
+    expect(counts.has('')).toBe(false);
+    expect(counts.has('   ')).toBe(false);
+    expect(counts.get('(no storey)')).toBe(2);
+  });
+
+  it('a genuine storey Name is returned unchanged', () => {
+    const bim = fakeBim({ storeys: { 1: { name: 'Level 1' } } });
+    const counts = computeUniqueValues([{ ref: 1 }] as FakeEntity[], 'storey', bim);
+    expect(counts.get('Level 1')).toBe(1);
+  });
+
+  /** Same defect on the material chain. */
+  it('falls a blank/whitespace material name through to "(no material)"', () => {
+    const bim = fakeBim({ materials: { 1: { materials: [''] }, 2: { name: '   ' } } });
+    const counts = computeUniqueValues([{ ref: 1 }, { ref: 2 }] as FakeEntity[], 'material', bim);
+    expect(counts.has('')).toBe(false);
+    expect(counts.has('   ')).toBe(false);
+    expect(counts.get('(no material)')).toBe(2);
+  });
+
+  it('a genuine material name is returned unchanged', () => {
+    const bim = fakeBim({ materials: { 1: { materials: ['Concrete'] } } });
+    const counts = computeUniqueValues([{ ref: 1 }] as FakeEntity[], 'material', bim);
+    expect(counts.get('Concrete')).toBe(1);
+  });
+
+  /** Control: a truly absent storey/material still gets the placeholder. */
+  it('a truly absent storey still yields "(no storey)" (control)', () => {
+    const bim = fakeBim();
+    const counts = computeUniqueValues([{ ref: 1 }] as FakeEntity[], 'storey', bim);
+    expect(counts.get('(no storey)')).toBe(1);
   });
 });
 

--- a/packages/cli/src/commands/query-output.ts
+++ b/packages/cli/src/commands/query-output.ts
@@ -8,7 +8,7 @@
  */
 
 import { findPropertyInSets } from '@ifc-lite/query';
-import { printJson, formatTable, hasFlag, fatal } from '../output.js';
+import { printJson, formatTable, hasFlag, fatal, firstNonBlank } from '../output.js';
 import { getQuantityValue } from './query-aggregation.js';
 
 /** Valid built-in grouping keys */
@@ -201,10 +201,12 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
       groupValue = e.type;
     } else if (groupByKey === 'storey') {
       const storey = bim.storey(e.ref);
-      groupValue = storey?.name ?? '(no storey)';
+      groupValue = firstNonBlank(storey?.name) ?? '(no storey)';
     } else if (groupByKey === 'material') {
       const mat = bim.materials(e.ref);
-      groupValue = mat?.materials?.[0] ?? mat?.name ?? '(no material)';
+      const first = mat?.materials?.[0];
+      const firstMatName = typeof first === 'string' ? first : first?.name;
+      groupValue = firstNonBlank(firstMatName, mat?.name) ?? '(no material)';
     } else if (groupByKey.includes('.')) {
       // PsetName.PropName
       const [psetName, propName] = groupByKey.split('.', 2);
@@ -286,6 +288,50 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
       process.stdout.write(`\n  Total: ${entities.length} entities in ${groups.size} groups\n\n`);
     }
   }
+}
+
+/**
+ * B6/F8: `--unique` distinct-value counts for `material`, `storey`, `type`,
+ * or a `PsetName.PropName` path. Pulled out of `queryCommand` so the
+ * blank/whitespace-name handling (`firstNonBlank`) is unit-testable without
+ * a fixture model.
+ */
+export function computeUniqueValues(entities: any[], uniqueProp: string, bim: any): Map<string, number> {
+  const valueCounts = new Map<string, number>();
+
+  if (uniqueProp === 'material') {
+    for (const e of entities) {
+      const mat = bim.materials(e.ref);
+      const first = mat?.materials?.[0];
+      const firstName = typeof first === 'string' ? first : first?.name;
+      const val = firstNonBlank(firstName, mat?.name) ?? '(no material)';
+      valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
+    }
+  } else if (uniqueProp === 'storey') {
+    for (const e of entities) {
+      const storey = bim.storey(e.ref);
+      const val = firstNonBlank(storey?.name) ?? '(no storey)';
+      valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
+    }
+  } else if (uniqueProp === 'type') {
+    for (const e of entities) {
+      valueCounts.set(e.type, (valueCounts.get(e.type) ?? 0) + 1);
+    }
+  } else {
+    const dotIdx = uniqueProp.indexOf('.');
+    if (dotIdx <= 0) fatal(`Invalid --unique path: "${uniqueProp}". Expected: PsetName.PropName, or one of: material, storey, type`);
+    const psetName = uniqueProp.slice(0, dotIdx);
+    const propName = uniqueProp.slice(dotIdx + 1);
+
+    for (const e of entities) {
+      const psets = bim.properties(e.ref);
+      const prop = findPropertyInSets<any>(psets, psetName, propName);
+      const val = prop?.value != null ? String(prop.value) : '(no value)';
+      valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
+    }
+  }
+
+  return valueCounts;
 }
 
 export function outputEntities(entities: any[], args: string[], bim: any, jsonOutput: boolean): void {

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -10,11 +10,10 @@
  * classifications, attributes, relationships, type properties.
  */
 
-import { findPropertyInSets } from '@ifc-lite/query';
 import { createHeadlessContext } from '../loader.js';
 import { printJson, getFlag, hasFlag, fatal, validateLimit } from '../output.js';
 import { STANDARD_QTO_MAP, sortEntities } from './query-aggregation.js';
-import { VALID_GROUP_BY_KEYS, outputCount, outputSum, outputAggregation, outputGroupBy, outputEntities } from './query-output.js';
+import { VALID_GROUP_BY_KEYS, outputCount, outputSum, outputAggregation, outputGroupBy, outputEntities, computeUniqueValues } from './query-output.js';
 import { applyWhereFilter, parseWhereFilter, compareValues, normalizeBooleanValue } from './where-filter.js';
 
 export { applyWhereFilter, parseWhereFilter, compareValues, normalizeBooleanValue };
@@ -215,40 +214,7 @@ export async function queryCommand(args: string[]): Promise<void> {
     if (!targetType) fatal('--unique requires --type (e.g., --type IfcWall --unique material)');
 
     const entities = bim.query().byType(...targetType.split(',')).toArray();
-    const valueCounts = new Map<string, number>();
-
-    if (uniqueProp === 'material') {
-      // B6: Support --unique material
-      for (const e of entities) {
-        const mat = bim.materials(e.ref);
-        const first = mat?.materials?.[0];
-        const firstName = typeof first === 'string' ? first : first?.name;
-        const val = firstName ?? mat?.name ?? '(no material)';
-        valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
-      }
-    } else if (uniqueProp === 'storey') {
-      for (const e of entities) {
-        const storey = bim.storey(e.ref);
-        const val = storey?.name ?? '(no storey)';
-        valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
-      }
-    } else if (uniqueProp === 'type') {
-      for (const e of entities) {
-        valueCounts.set(e.type, (valueCounts.get(e.type) ?? 0) + 1);
-      }
-    } else {
-      const dotIdx = uniqueProp.indexOf('.');
-      if (dotIdx <= 0) fatal(`Invalid --unique path: "${uniqueProp}". Expected: PsetName.PropName, or one of: material, storey, type`);
-      const psetName = uniqueProp.slice(0, dotIdx);
-      const propName = uniqueProp.slice(dotIdx + 1);
-
-      for (const e of entities) {
-        const psets = bim.properties(e.ref);
-        const prop = findPropertyInSets<any>(psets, psetName, propName);
-        const val = prop?.value != null ? String(prop.value) : '(no value)';
-        valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
-      }
-    }
+    const valueCounts = computeUniqueValues(entities, uniqueProp, bim);
 
     if (jsonOutput) {
       const result: Record<string, number> = {};

--- a/packages/cli/src/commands/stats-aggregation.test.ts
+++ b/packages/cli/src/commands/stats-aggregation.test.ts
@@ -23,6 +23,8 @@ import {
   computeWindowWallRatio,
   computeGrossFloorArea,
   computeMaterialSummary,
+  computeStoreyNames,
+  computeBuildingName,
   computeValidation,
   type QuantitySet,
   type PropertySet,
@@ -245,6 +247,58 @@ describe('computeMaterialSummary', () => {
     const bim = fakeBim({}, {}, { 1: null, 2: { name: 'Wood' } });
     const summary = computeMaterialSummary(bim, [{ ref: 1 }, { ref: 2 }], n => n);
     expect(summary).toEqual([{ name: 'Wood', count: 1, volume: 0 }]);
+  });
+
+  /**
+   * Regression: `firstName ?? mat?.name` followed by `if (!matName)
+   * continue;` skips a plain empty-string name (falsy) but a
+   * whitespace-only name (`IFCMATERIAL('   ',$,$)`) is truthy and used
+   * verbatim as the Map key — a blank-looking row in the material
+   * schedule instead of being skipped like a genuinely absent material.
+   */
+  it('a whitespace-only material name is skipped, not counted under a whitespace key', () => {
+    const bim = fakeBim({}, {}, { 1: { name: '   ' }, 2: { name: 'Wood' } });
+    const summary = computeMaterialSummary(bim, [{ ref: 1 }, { ref: 2 }], n => n);
+    expect(summary).toEqual([{ name: 'Wood', count: 1, volume: 0 }]);
+  });
+});
+
+describe('computeStoreyNames', () => {
+  /**
+   * Regression: `storeys.map(s => s.name).filter(Boolean)` drops a plain
+   * empty-string Name (falsy) but keeps a whitespace-only one
+   * (`IFCBUILDINGSTOREY('...','   ',...)`, truthy) as a blank-looking
+   * entry in the storey list.
+   */
+  it('drops blank and whitespace-only storey names, keeps genuine ones', () => {
+    expect(computeStoreyNames([{ name: '' }, { name: '   ' }, { name: 'Level 1' }])).toEqual(['Level 1']);
+  });
+
+  it('returns an empty array when every storey is unnamed (control)', () => {
+    expect(computeStoreyNames([{ name: '' }, { name: undefined }])).toEqual([]);
+  });
+});
+
+describe('computeBuildingName', () => {
+  /**
+   * Regression: `buildings[0]?.name ?? '(unnamed)'` only falls through on
+   * null/undefined; a present-but-blank/whitespace-only `IfcBuilding.Name`
+   * was returned verbatim instead of the "(unnamed)" placeholder.
+   */
+  it('falls a blank building Name through to "(unnamed)"', () => {
+    expect(computeBuildingName([{ name: '' }])).toBe('(unnamed)');
+  });
+
+  it('falls a whitespace-only building Name through to "(unnamed)"', () => {
+    expect(computeBuildingName([{ name: '   ' }])).toBe('(unnamed)');
+  });
+
+  it('returns a genuine building Name unchanged (control)', () => {
+    expect(computeBuildingName([{ name: 'Main Building' }])).toBe('Main Building');
+  });
+
+  it('returns "(unnamed)" when there is no building at all (control)', () => {
+    expect(computeBuildingName([])).toBe('(unnamed)');
   });
 });
 

--- a/packages/cli/src/commands/stats-aggregation.ts
+++ b/packages/cli/src/commands/stats-aggregation.ts
@@ -10,6 +10,7 @@
  */
 
 import { findPropertyInSets } from '@ifc-lite/query';
+import { firstNonBlank, isBlank } from '../output.js';
 
 export interface QuantitySet {
   name: string;
@@ -147,6 +148,24 @@ export function computeGrossFloorArea<R>(
   return grossFloorArea === 0 ? fallbackTotalFloorArea : grossFloorArea;
 }
 
+/**
+ * Distinct, display-ready storey names: blank/whitespace-only Names
+ * (`IFCBUILDINGSTOREY('...','',...)`) are dropped, same as a genuinely
+ * absent one, rather than surfacing as a blank entry in the storey list.
+ */
+export function computeStoreyNames(storeys: Array<{ name?: string | null }>): string[] {
+  return storeys.map(s => s.name).filter((name): name is string => !isBlank(name));
+}
+
+/**
+ * The first `IfcBuilding`'s display name, or `'(unnamed)'` when absent OR
+ * blank/whitespace-only — `?? '(unnamed)'` alone only falls through on
+ * null/undefined, so a present-but-blank `Name` was returned verbatim.
+ */
+export function computeBuildingName(buildings: Array<{ name?: string | null }>): string {
+  return firstNonBlank(buildings[0]?.name) ?? '(unnamed)';
+}
+
 export interface MaterialSummaryEntry {
   name: string;
   count: number;
@@ -172,7 +191,11 @@ export function computeMaterialSummary<R>(
     const mat = bim.materials(e.ref);
     const first = mat?.materials?.[0];
     const firstName = typeof first === 'string' ? first : first?.name;
-    const matName = firstName ?? mat?.name;
+    // A whitespace-only name (`IFCMATERIAL('   ',$,$)`) is falsy-but-truthy
+    // — a bare `!matName` guard on `firstName ?? mat?.name` let it through
+    // as a whitespace-string map key instead of skipping it like a
+    // genuinely blank/absent one.
+    const matName = firstNonBlank(firstName, mat?.name);
     if (!matName) continue;
 
     materialCounts.set(matName, (materialCounts.get(matName) ?? 0) + 1);

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -17,6 +17,8 @@ import {
   computeGrossFloorArea,
   computeMaterialSummary,
   computeValidation,
+  computeStoreyNames,
+  computeBuildingName,
   sumQuantity,
 } from './stats-aggregation.js';
 
@@ -33,11 +35,11 @@ export async function statsCommand(args: string[]): Promise<void> {
 
   // Storeys
   const storeys = bim.storeys();
-  const storeyNames = storeys.map((s: any) => s.name).filter(Boolean);
+  const storeyNames = computeStoreyNames(storeys);
 
   // Building name
   const buildings = bim.query().byType('IfcBuilding').toArray();
-  const buildingName = buildings[0]?.name ?? '(unnamed)';
+  const buildingName = computeBuildingName(buildings);
 
   // Element counts by type
   const ELEMENT_TYPES = [

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -165,6 +165,28 @@ export function validateLimit(raw: string | undefined, flagName = '--limit'): nu
 }
 
 /**
+ * A candidate string is absent for display/grouping purposes when it is
+ * undefined/null OR blank/whitespace-only (`IFCMATERIAL('',$,$)`,
+ * `IFCBUILDINGSTOREY('...','',...)`, or a whitespace-only source value — a
+ * real shape, see #3714). Chaining raw candidates with `??` only falls
+ * through on null/undefined, so a present-but-blank `Name` short-circuits
+ * the chain and is emitted verbatim (an empty-string JSON key, a blank
+ * label) where a placeholder belongs. Mirrors the shape introduced in
+ * `packages/mcp/src/material-naming.ts` for the same defect family.
+ */
+export function isBlank(value: string | undefined | null): boolean {
+  return value === undefined || value === null || value.trim() === '';
+}
+
+/** First candidate that is not blank per `isBlank`, or undefined if none. */
+export function firstNonBlank(...candidates: Array<string | undefined | null>): string | undefined {
+  for (const candidate of candidates) {
+    if (!isBlank(candidate)) return candidate ?? undefined;
+  }
+  return undefined;
+}
+
+/**
  * Get positional arguments (non-flag arguments).
  */
 export function getPositionalArgs(args: string[]): string[] {


### PR DESCRIPTION
## Reviewer summary

Without this fix, a blank `IFCBUILDINGSTOREY`/`IFCMATERIAL` `Name` corrupts machine-readable CLI output: `query --group-by storey --json` emits `{"": {"count": 1}}` — an empty-string JSON key — instead of a labelled `"(no storey)"` group, with the same shape for `--group-by material`, `--unique storey|material`, and blank labels in `ask`'s answer strings and `stats`' building/storey/material summaries. Any script or agent parsing the `--json` output loses the group entirely or keys off an empty string. Root cause: `storey?.name ?? '(no storey)'` and similar chains only fall through on `null`/`undefined`, not on a present-but-blank or whitespace-only string. Fix is additive and narrow — a shared `isBlank`/`firstNonBlank` helper (mirroring the already-reviewed `packages/mcp/src/material-naming.ts` from #3725) applied only at the identified fallback sites; a genuine name is verified unchanged via control tests, bounding blast radius to CLI output formatting. No sequencing dependency on other open PRs.

## What this fixes

`ifc-lite query --type IfcWall --group-by storey --json` on a fixture with a blank storey `Name` (`IFCBUILDINGSTOREY('...','',...)`) produces `{"": {"count": 1}}` — an empty-string JSON key instead of `"(no storey)"`. Text mode prints a blank label. Same shape for `--group-by material` with `IFCMATERIAL('',$,$)`, and for `--unique storey`/`--unique material`.

Root cause: `storey?.name ?? '(no storey)'` and `mat?.materials?.[0] ?? mat?.name ?? '(no material)'` use `??`, which only falls through on `null`/`undefined`. A present-but-blank (or whitespace-only) `Name` short-circuits the chain and is emitted verbatim where a placeholder belongs. This corrupts scriptable `--json` output — an agent or tool parsing the result gets an empty key instead of a labelled group.

Same family, reproduced and fixed alongside:
- `ask`'s `building-name`, `tallest-storey`, `largest-element`, `smallest-element` recipes rendered a blank instead of `(unnamed)` in the `answer:` string.
- `stats`' building name, storey list (`.filter(Boolean)` misses whitespace-only), and material summary (`!matName` misses whitespace-only, so a whitespace string became a Map key) had the same gap.

## Fix

Added `isBlank`/`firstNonBlank` to `packages/cli/src/output.ts` — same shape as `packages/mcp/src/material-naming.ts` (PR #3725, same defect family: a blank `IFCMATERIAL` Name). Applied at every site above. `--unique`'s inline logic and `stats.ts`'s inline building-name/storey-name logic were pulled into testable pure functions (`computeUniqueValues` in `query-output.ts`, `computeBuildingName`/`computeStoreyNames` in `stats-aggregation.ts`) alongside the fix, since neither had a unit-testable seam before.

Both directions verified: a blank/whitespace value now yields the placeholder, and a genuine name is still returned unchanged; the existing "(no storey)"/"(no material)"/"(unnamed)" behaviour for a truly absent value is unchanged (control tests included).

## Test plan
- [x] `packages/cli`: `pnpm test` — 610 passed, 8 skipped (pre-existing skips unrelated to this change)
- [x] `pnpm tsc --noEmit` in `packages/cli` — clean
- [x] New regression tests in `query-output.test.ts`, `ask.test.ts`, `stats-aggregation.test.ts`; each RED-confirmed against the pre-fix code by temporarily reverting the source change, then restored to GREEN
- [x] `check-module-size.mjs`, `check-unused-locals.mjs`, `check-test-wiring.mjs` — clean on touched files
- [x] Changeset added (`@ifc-lite/cli` patch)

## Gate

I could not find an open issue covering this defect (searched `gh issue list`/`gh search issues` for "blank storey", "no storey", empty-key, `--group-by`, `--unique material`). Not applying a label myself. Flagging for a waiver or a `ready` issue, same as #3725 (the sibling PR for the MCP material-name instance of this same defect family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
