### PR TITLE
fix(gates): record check-source-text-assertions.mjs, red on main since #3712

### DIFF
--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -252,7 +252,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/source-dalux': '11927553717016520308',
   'packages/source-dropbox': '13897585807232807340',
   'packages/viewer': '17290688824834287099',
-  'scripts': '4386814201325981117',
+  'scripts': '10576945509463692918',
 };
 
 function parseArgs(argv) {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -350,6 +350,7 @@
    694 scripts/check-module-size.mjs
    951 scripts/check-pr-review-signal.mjs
    771 scripts/check-review-posted.mjs
+   446 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
    612 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs


### PR DESCRIPTION
`node scripts/check-module-size.mjs` exits 1 on main. That is the exact command the Node tests lane runs, and the gate measures the **whole tree** rather than a branch's own diff, so every open PR inherits the failure.

```
scripts/check-source-text-assertions.mjs: 446 lines, no allowlist row
```

## Cause

#3712 (`fac3535a0`) grew that file past the 400-line rule without recording it. Its own CI was green because it was certified against a base where the file was still under the limit — the base-has-moved shape of #3726, and the second time today that two individually-green merges combined into a red main.

Measured across the 24 commits merged tonight: the twelve up to and including `eb3000aa2` are green, the twelve from `fac3535a0` onward are red. The boundary is exactly that commit.

## The change

Two lines. One allowlist row at the exact measured count (zero slack, so further growth still fails) plus the matching `scripts` digest.

Deliberately **not** a `--update --all` sweep — that annexes rows across unrelated scopes and forces every other open branch to re-record, which is how the allowlist got into trouble this morning.

Justification the gate asks for: the file is a CI gate that grew while being made same-scope-aware. Splitting it is real work and does not belong in a commit whose job is unblocking a red main; it stays open as follow-up.

## Verified by running

- `node scripts/check-module-size.mjs` — exit 0, `OK (2314 files measured, 362 allowlisted, 0 new over 400)`. Was exit 1.
- Baseline probe: restoring main's versions of both files reproduces exit 1 with **exactly one** complaint and nothing else, so this two-line change is the whole delta between red and green for this gate.
- Fixed point: `--update` on the committed state reports `0 lowered, 0 removed, 0 raised, 0 added` and leaves the file byte-identical.
- Digest is gate-verified rather than hand-computed: the gate recomputes per-scope digests and hard-fails on mismatch, so exit 0 means it independently agrees.
- `node --test scripts/check-module-size.test.mjs scripts/lib/module-size-ratchet.test.mjs` — 63 pass, 0 fail.
- `git diff origin/main -- scripts/module-size-allowlist.txt` shows exactly one added row; no other scope's digest moved.

## Two notes for whoever reads this next

`node scripts/check-source-text-assertions.mjs` exits 1 in a **fresh worktree** with `Cannot find package 'typescript'`. That is missing `node_modules`, not a defect — CI runs `pnpm install` first. Recording it so nobody reads an install failure as a gate failure.

`origin/fix/module-size-ratchet-main` (`5eafd2ccb`) touches these same two files and the same `scripts` digest. Its diagnosis is stale — it re-records six `scripts/review/*` rows that are already correct at current main, and it does not add the row that is actually red. Two branches moving one scope's pin will conflict, and a careless resolution could drop this row and re-red main. It should be closed or rebased.

Scope: this proves the module-size lane. Other lanes were not run here.

No changeset: scripts-only, publishes nothing. Matches #3723, the last change to this allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module-size validation settings to reflect current allowlist contents.
  * Added the source-text assertion check to module-size tracking with an established size budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->