### PR TITLE
fix(viewer): "Show in context" destroys an active isolation and outlives its own control

### DIFF
--- a/.changeset/viewer-show-in-context.md
+++ b/.changeset/viewer-show-in-context.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/viewer': minor
+---
+
+New "Show in context" action in the Properties panel header (#3618): fades every other entity translucent and frames the camera on the selected one, so an object behind other geometry stays visible in its surroundings instead of being isolated away from them.
+
+It preserves an active isolation rather than discarding it, and tears its own fade down when the panel closes, so a fade can never outlive the only control able to clear it.

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
@@ -210,6 +210,35 @@ describe('EntityHeaderActions — "Show in context"', () => {
     assert.strictEqual(useViewerStore.getState().ghostExceptEntities, null);
   });
 
+  // Kills the mutation "install B's fade without releasing A's first". Moving the
+  // context view from A to B read the isolation A had already widened and recorded
+  // THAT as B's prior, so clearing restored the A-widened set and left A admitted
+  // permanently. CodeRabbit CLI on #3737, major.
+  it('A -> B -> clear leaves the original isolation, with neither A nor B admitted', () => {
+    resetStore();
+    const original = new Set([9_999]);
+    useViewerStore.setState({ selectedEntityId: SELECTED, isolatedEntities: original });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+
+    click(ghostButton); // fade on A (SELECTED), isolation widened by A
+    assert.ok(useViewerStore.getState().isolatedEntities?.has(SELECTED));
+
+    // Selection moves to B and the user clicks again: the button is OFF for B,
+    // so this installs B's fade rather than clearing.
+    useViewerStore.setState({ selectedEntityId: OTHER });
+    const c2 = render(<EntityHeaderActions />);
+    click(Array.from(c2.querySelectorAll('button'))[1]);
+
+    click(Array.from(c2.querySelectorAll('button'))[1]); // clear B
+
+    const iso = useViewerStore.getState().isolatedEntities;
+    assert.ok(iso?.has(9_999), 'the original isolation survives');
+    assert.ok(!iso?.has(SELECTED), 'A must not be left admitted');
+    assert.ok(!iso?.has(OTHER), 'B must not be left admitted');
+  });
+
   // CodeRabbit on #3737 reported the mirror-image bug: recording ownership on
   // every render meant that with the fade on A and the selection moved to B,
   // cleanup compared B against A's set and left the model faded forever.

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
@@ -158,8 +158,25 @@ describe('EntityHeaderActions — "Show in context"', () => {
     );
   });
 
-  // The teardown must be narrow: a clash/IDS fade holds many entities and owns
-  // its own release, so unmounting the properties panel must not wipe it.
+  // The teardown must not fire on someone else's fade. Ownership is recorded when
+  // this control installs one, so a foreign ghost -- of ANY size -- survives.
+  // Codex on #3737: IDS row focus and Layer Diff both install SINGLETON ghosts
+  // and record their own ownership, so a "size === 1 and has(selection)" test
+  // would have torn down their presentation.
+  it('leaves a foreign singleton ghost standing on unmount', () => {
+    resetStore();
+    const foreign = new Set([SELECTED]);
+    useViewerStore.setState({ selectedEntityId: SELECTED, ghostExceptEntities: foreign });
+
+    render(<EntityHeaderActions />);
+    cleanup();
+    assert.strictEqual(
+      useViewerStore.getState().ghostExceptEntities,
+      foreign,
+      "a singleton ghost this control did not install must survive -- contents are not ownership",
+    );
+  });
+
   it('leaves a foreign multi-entity ghost standing on unmount', () => {
     resetStore();
     const foreign = new Set([SELECTED, OTHER]);
@@ -167,12 +184,52 @@ describe('EntityHeaderActions — "Show in context"', () => {
 
     render(<EntityHeaderActions />);
     cleanup();
-    const after = useViewerStore.getState().ghostExceptEntities;
-    assert.deepStrictEqual(
-      after && [...after].sort(),
-      [...foreign].sort(),
-      "another feature's ghost must survive this panel unmounting",
+    assert.strictEqual(useViewerStore.getState().ghostExceptEntities, foreign);
+  });
+
+  // CodeRabbit on #3737 reported the mirror-image bug: recording ownership on
+  // every render meant that with the fade on A and the selection moved to B,
+  // cleanup compared B against A's set and left the model faded forever.
+  // Identity-based ownership makes the current selection irrelevant by
+  // construction, which is what this pins. It is NOT a killing test for that
+  // mutation -- the harness only flushes inside act(), which it does not export,
+  // so no re-render happens between the setState and cleanup and the stale-ref
+  // version passes it too. The mutation is killed by the foreign-singleton test
+  // above, which fails without identity ownership.
+  it('tears its own fade down regardless of the current selection', () => {
+    resetStore();
+    useViewerStore.setState({ selectedEntityId: SELECTED });
+    const container = render(<EntityHeaderActions />);
+    click(Array.from(container.querySelectorAll('button'))[1]);
+
+    // Selection moves while the fade stays installed for SELECTED.
+    useViewerStore.setState({ selectedEntityId: OTHER });
+    cleanup();
+
+    assert.strictEqual(
+      useViewerStore.getState().ghostExceptEntities,
+      null,
+      'our own fade must still be torn down once the selection has moved on',
     );
+  });
+
+  // Codex on #3737: preserving an isolation that excludes the selection hides the
+  // very entity being shown -- isEntityVisible rejects ids absent from
+  // isolatedEntities, and ghosting only fades what survived that filter, so the
+  // camera framed something invisible.
+  it('admits the selected entity into a preserved isolation that excludes it', () => {
+    resetStore();
+    useViewerStore.setState({
+      selectedEntityId: SELECTED,
+      isolatedEntities: new Set([OTHER]),
+    });
+
+    const container = render(<EntityHeaderActions />);
+    click(Array.from(container.querySelectorAll('button'))[1]);
+
+    const iso = useViewerStore.getState().isolatedEntities;
+    assert.ok(iso?.has(SELECTED), 'the entity being shown must be inside the isolation');
+    assert.ok(iso?.has(OTHER), 'the rest of the isolation must be preserved');
   });
 
   it('control: "Zoom to" and "Hide" keep their existing, unrelated behaviour', () => {

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
@@ -103,6 +103,78 @@ describe('EntityHeaderActions — "Show in context"', () => {
     );
   });
 
+  // Kills the mutation `restoreVisibilityState({isolated, ...})` ->
+  // `setGhostExceptEntities(...)`. That setter nulls `isolatedEntities`
+  // unconditionally and nothing captured it, so isolating and then fading
+  // destroyed the isolation for good -- the whole building reappeared faded,
+  // and toggling back left it solid with the isolation gone.
+  it('preserves an active isolation when entering and leaving "Show in context"', () => {
+    resetStore();
+    const isolation = new Set([SELECTED, OTHER]);
+    useViewerStore.setState({ selectedEntityId: SELECTED, isolatedEntities: isolation });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+
+    click(ghostButton);
+    const entered = useViewerStore.getState();
+    assert.deepStrictEqual(
+      entered.isolatedEntities && [...entered.isolatedEntities].sort(),
+      [...isolation].sort(),
+      'entering must not destroy the isolation',
+    );
+    assert.deepStrictEqual(entered.ghostExceptEntities && [...entered.ghostExceptEntities], [SELECTED]);
+
+    click(ghostButton);
+    const left = useViewerStore.getState();
+    assert.strictEqual(left.ghostExceptEntities, null, 'leaving clears the fade');
+    assert.deepStrictEqual(
+      left.isolatedEntities && [...left.isolatedEntities].sort(),
+      [...isolation].sort(),
+      'leaving must leave the isolation standing',
+    );
+  });
+
+  // Kills the mutation "drop the unmount teardown". PropertiesPanel renders
+  // nothing without a selection, so the button unmounts on deselect; without
+  // teardown the model stayed faded with no control able to undo it.
+  it('tears its own fade down when the panel unmounts (deselection)', () => {
+    resetStore();
+    useViewerStore.setState({ selectedEntityId: SELECTED });
+
+    const container = render(<EntityHeaderActions />);
+    click(Array.from(container.querySelectorAll('button'))[1]);
+    assert.deepStrictEqual(
+      useViewerStore.getState().ghostExceptEntities &&
+        [...useViewerStore.getState().ghostExceptEntities!],
+      [SELECTED],
+    );
+
+    cleanup();
+    assert.strictEqual(
+      useViewerStore.getState().ghostExceptEntities,
+      null,
+      'a fade with no control left to clear it must not survive the panel',
+    );
+  });
+
+  // The teardown must be narrow: a clash/IDS fade holds many entities and owns
+  // its own release, so unmounting the properties panel must not wipe it.
+  it('leaves a foreign multi-entity ghost standing on unmount', () => {
+    resetStore();
+    const foreign = new Set([SELECTED, OTHER]);
+    useViewerStore.setState({ selectedEntityId: SELECTED, ghostExceptEntities: foreign });
+
+    render(<EntityHeaderActions />);
+    cleanup();
+    const after = useViewerStore.getState().ghostExceptEntities;
+    assert.deepStrictEqual(
+      after && [...after].sort(),
+      [...foreign].sort(),
+      "another feature's ghost must survive this panel unmounting",
+    );
+  });
+
   it('control: "Zoom to" and "Hide" keep their existing, unrelated behaviour', () => {
     let framed = 0;
     resetStore();

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.test.tsx
@@ -187,6 +187,29 @@ describe('EntityHeaderActions — "Show in context"', () => {
     assert.strictEqual(useViewerStore.getState().ghostExceptEntities, foreign);
   });
 
+  // Kills the mutation "leave the widened isolation in place". Admitting the
+  // selection is a TEMPORARY widening for the duration of the context view; if
+  // leaving keeps it, the user's isolation silently gains an entity they never
+  // added. Codex asked for exactly this: retain enough prior state to restore
+  // the original isolation when the context view ends.
+  it('narrows the isolation back when the context view ends', () => {
+    resetStore();
+    const original = new Set([OTHER]);
+    useViewerStore.setState({ selectedEntityId: SELECTED, isolatedEntities: original });
+
+    const container = render(<EntityHeaderActions />);
+    const ghostButton = Array.from(container.querySelectorAll('button'))[1];
+
+    click(ghostButton);
+    assert.ok(useViewerStore.getState().isolatedEntities?.has(SELECTED), 'widened while shown');
+
+    click(ghostButton);
+    const after = useViewerStore.getState().isolatedEntities;
+    assert.ok(after?.has(OTHER), 'the original isolation comes back');
+    assert.ok(!after?.has(SELECTED), 'the temporary admission must not persist');
+    assert.strictEqual(useViewerStore.getState().ghostExceptEntities, null);
+  });
+
   // CodeRabbit on #3737 reported the mirror-image bug: recording ownership on
   // every render meant that with the fade on A and the selection moved to B,
   // cleanup compared B against A's set and left the model faded forever.

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
@@ -38,14 +38,22 @@ export function EntityHeaderActions() {
   // The fade outlives this component: PropertiesPanel renders nothing without a
   // selection, so deselecting leaves the whole model translucent with its only
   // control gone (there is no other UI caller of clearGhost and no shortcut).
-  // Tear down on unmount, but only OUR fade -- a singleton set holding exactly
-  // the entity we were showing. A clash or IDS ghost holds many entities and
-  // owns its own teardown, so it is left standing.
-  const ghostRef = useRef<{ id: number | null; set: ReadonlySet<number> | null }>({ id: null, set: null });
-  ghostRef.current = { id: selectedEntityId ?? null, set: ghostExceptEntities };
+  //
+  // Ownership is recorded when THIS control installs the fade, not derived from
+  // the set's contents at cleanup time. Content is not proof of ownership: IDS
+  // row focus (useIDS.ts:685-689) and Layer Diff (LayerDiffView.tsx:92-96) both
+  // install singleton ghosts and record their own ownership, so a
+  // "size === 1 and has(selection)" test at unmount would tear down THEIR
+  // presentation. Recording it per render had the mirror-image bug: with the
+  // fade on A and the selection moved to B, cleanup compared B against A's set,
+  // matched nothing, and left the model faded forever.
+  const ownedGhost = useRef<ReadonlySet<number> | null>(null);
   useEffect(() => () => {
-    const { id, set } = ghostRef.current;
-    if (id != null && set !== null && set.size === 1 && set.has(id)) {
+    const owned = ownedGhost.current;
+    if (!owned) return;
+    // Identity, not contents: if anything replaced the channel since, it is
+    // theirs to clear.
+    if (useViewerStore.getState().ghostExceptEntities === owned) {
       useViewerStore.getState().clearGhost();
     }
   }, []);
@@ -85,6 +93,7 @@ export function EntityHeaderActions() {
               if (isGhosted) {
                 // clearGhost, not setGhostExceptEntities(null): it preserves
                 // isolation, which the setter clears.
+                ownedGhost.current = null;
                 clearGhost();
               } else {
                 // Not setGhostExceptEntities: that clears isolatedEntities
@@ -93,11 +102,24 @@ export function EntityHeaderActions() {
                 // good. Writing both channels keeps it. The pair is coherent --
                 // isolation filters, ghosting fades what survived it -- and
                 // restoreVisibilityState documents it as reachable and legal.
+                // An isolation that does not contain the selection would hide
+                // the very entity being shown: isEntityVisible rejects every id
+                // absent from isolatedEntities, and ghosting only fades what
+                // survived that filter, so the camera would frame something
+                // invisible. Admit the selection rather than drop the isolation.
+                const isolated = isolatedEntities === null
+                  ? null
+                  : isolatedEntities.has(selectedEntityId)
+                    ? isolatedEntities
+                    : new Set([...isolatedEntities, selectedEntityId]);
                 restoreVisibilityState({
-                  isolated: isolatedEntities,
+                  isolated,
                   ghostExcept: new Set([selectedEntityId]),
                   hidden: hiddenEntities,
                 });
+                // Read the identity BACK: restoreVisibilityState copies the set
+                // it is given, so the object handed in is not the one installed.
+                ownedGhost.current = useViewerStore.getState().ghostExceptEntities;
                 cameraCallbacks.frameSelection?.();
               }
             }}

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
@@ -18,7 +18,7 @@
  * surroundings.
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Focus, EyeOff, Eye, Ghost } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -33,7 +33,6 @@ export function EntityHeaderActions() {
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
   const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
   const restoreVisibilityState = useViewerStore((s) => s.restoreVisibilityState);
-  const clearGhost = useViewerStore((s) => s.clearGhost);
 
   // The fade outlives this component: PropertiesPanel renders nothing without a
   // selection, so deselecting leaves the whole model translucent with its only
@@ -47,16 +46,39 @@ export function EntityHeaderActions() {
   // presentation. Recording it per render had the mirror-image bug: with the
   // fade on A and the selection moved to B, cleanup compared B against A's set,
   // matched nothing, and left the model faded forever.
-  const ownedGhost = useRef<ReadonlySet<number> | null>(null);
-  useEffect(() => () => {
-    const owned = ownedGhost.current;
-    if (!owned) return;
-    // Identity, not contents: if anything replaced the channel since, it is
-    // theirs to clear.
-    if (useViewerStore.getState().ghostExceptEntities === owned) {
-      useViewerStore.getState().clearGhost();
+  //
+  // The claim carries the isolation as it was BEFORE the fade, because entering
+  // may widen it to admit the selection (below) and leaving has to give the user
+  // back the isolation they had, not the widened one.
+  const owned = useRef<{ ghost: ReadonlySet<number>; priorIsolation: Set<number> | null } | null>(null);
+
+  // `explicit` separates the two ways the fade ends. A user clicking a toggle that
+  // renders as ON is asking for the channel to clear, whoever installed it, so the
+  // click path always clears. Unmount is implicit and silent, so it only touches a
+  // fade this control installed -- that is the case where clearing someone else's
+  // presentation would be invisible and wrong.
+  const releaseGhost = useCallback((explicit: boolean) => {
+    const claim = owned.current;
+    const s = useViewerStore.getState();
+    // Identity, not contents: anything that replaced the channel since is theirs,
+    // and its prior isolation is not ours to restore.
+    const ours = claim !== null && s.ghostExceptEntities === claim.ghost;
+    owned.current = null;
+    if (ours) {
+      // Give back the isolation as it was BEFORE the fade widened it.
+      s.restoreVisibilityState({
+        isolated: claim.priorIsolation,
+        ghostExcept: null,
+        hidden: s.hiddenEntities,
+      });
+    } else if (explicit && s.ghostExceptEntities !== null) {
+      // Not ours, but the user asked. clearGhost preserves isolation, and we have
+      // no prior isolation to restore because we never widened one.
+      s.clearGhost();
     }
   }, []);
+
+  useEffect(() => () => releaseGhost(false), [releaseGhost]);
 
   const isGhosted = selectedEntityId != null &&
     ghostExceptEntities !== null &&
@@ -93,8 +115,7 @@ export function EntityHeaderActions() {
               if (isGhosted) {
                 // clearGhost, not setGhostExceptEntities(null): it preserves
                 // isolation, which the setter clears.
-                ownedGhost.current = null;
-                clearGhost();
+                releaseGhost(true);
               } else {
                 // Not setGhostExceptEntities: that clears isolatedEntities
                 // unconditionally and nothing captured it, so isolating a zone
@@ -117,9 +138,11 @@ export function EntityHeaderActions() {
                   ghostExcept: new Set([selectedEntityId]),
                   hidden: hiddenEntities,
                 });
-                // Read the identity BACK: restoreVisibilityState copies the set
-                // it is given, so the object handed in is not the one installed.
-                ownedGhost.current = useViewerStore.getState().ghostExceptEntities;
+                // Read the ghost identity BACK: restoreVisibilityState copies the
+                // set it is given, so the object handed in is not the one
+                // installed. Keep the ORIGINAL isolation, not the widened one.
+                const installed = useViewerStore.getState().ghostExceptEntities;
+                if (installed) owned.current = { ghost: installed, priorIsolation: isolatedEntities };
                 cameraCallbacks.frameSelection?.();
               }
             }}

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
@@ -18,6 +18,7 @@
  * surroundings.
  */
 
+import { useEffect, useRef } from 'react';
 import { Focus, EyeOff, Eye, Ghost } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -29,7 +30,25 @@ export function EntityHeaderActions() {
   const toggleEntityVisibility = useViewerStore((s) => s.toggleEntityVisibility);
   const isEntityVisible = useViewerStore((s) => s.isEntityVisible);
   const ghostExceptEntities = useViewerStore((s) => s.ghostExceptEntities);
-  const setGhostExceptEntities = useViewerStore((s) => s.setGhostExceptEntities);
+  const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
+  const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
+  const restoreVisibilityState = useViewerStore((s) => s.restoreVisibilityState);
+  const clearGhost = useViewerStore((s) => s.clearGhost);
+
+  // The fade outlives this component: PropertiesPanel renders nothing without a
+  // selection, so deselecting leaves the whole model translucent with its only
+  // control gone (there is no other UI caller of clearGhost and no shortcut).
+  // Tear down on unmount, but only OUR fade -- a singleton set holding exactly
+  // the entity we were showing. A clash or IDS ghost holds many entities and
+  // owns its own teardown, so it is left standing.
+  const ghostRef = useRef<{ id: number | null; set: ReadonlySet<number> | null }>({ id: null, set: null });
+  ghostRef.current = { id: selectedEntityId ?? null, set: ghostExceptEntities };
+  useEffect(() => () => {
+    const { id, set } = ghostRef.current;
+    if (id != null && set !== null && set.size === 1 && set.has(id)) {
+      useViewerStore.getState().clearGhost();
+    }
+  }, []);
 
   const isGhosted = selectedEntityId != null &&
     ghostExceptEntities !== null &&
@@ -64,9 +83,21 @@ export function EntityHeaderActions() {
             onClick={() => {
               if (!selectedEntityId) return;
               if (isGhosted) {
-                setGhostExceptEntities(null);
+                // clearGhost, not setGhostExceptEntities(null): it preserves
+                // isolation, which the setter clears.
+                clearGhost();
               } else {
-                setGhostExceptEntities(new Set([selectedEntityId]));
+                // Not setGhostExceptEntities: that clears isolatedEntities
+                // unconditionally and nothing captured it, so isolating a zone
+                // and then fading around a member destroyed the isolation for
+                // good. Writing both channels keeps it. The pair is coherent --
+                // isolation filters, ghosting fades what survived it -- and
+                // restoreVisibilityState documents it as reachable and legal.
+                restoreVisibilityState({
+                  isolated: isolatedEntities,
+                  ghostExcept: new Set([selectedEntityId]),
+                  hidden: hiddenEntities,
+                });
                 cameraCallbacks.frameSelection?.();
               }
             }}

--- a/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
+++ b/apps/viewer/src/components/viewer/properties/EntityHeaderActions.tsx
@@ -18,11 +18,23 @@
  * surroundings.
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Focus, EyeOff, Eye, Ghost } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useViewerStore } from '@/store';
+
+/**
+ * The fade this control installed, and the isolation as it stood BEFORE it.
+ *
+ * Module scope, not a ref: the claim describes the store's single shared ghost
+ * channel, not this component's own state, and the control is a singleton (one
+ * properties panel). A per-instance ref loses the claim across a remount -- and
+ * across a selection change that remounts rather than re-renders -- which leaves
+ * the previous entity admitted in the isolation with nothing able to take it back
+ * out.
+ */
+let ownedClaim: { ghost: ReadonlySet<number>; priorIsolation: Set<number> | null } | null = null;
 
 export function EntityHeaderActions() {
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
@@ -30,8 +42,6 @@ export function EntityHeaderActions() {
   const toggleEntityVisibility = useViewerStore((s) => s.toggleEntityVisibility);
   const isEntityVisible = useViewerStore((s) => s.isEntityVisible);
   const ghostExceptEntities = useViewerStore((s) => s.ghostExceptEntities);
-  const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
-  const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
   const restoreVisibilityState = useViewerStore((s) => s.restoreVisibilityState);
 
   // The fade outlives this component: PropertiesPanel renders nothing without a
@@ -50,7 +60,6 @@ export function EntityHeaderActions() {
   // The claim carries the isolation as it was BEFORE the fade, because entering
   // may widen it to admit the selection (below) and leaving has to give the user
   // back the isolation they had, not the widened one.
-  const owned = useRef<{ ghost: ReadonlySet<number>; priorIsolation: Set<number> | null } | null>(null);
 
   // `explicit` separates the two ways the fade ends. A user clicking a toggle that
   // renders as ON is asking for the channel to clear, whoever installed it, so the
@@ -58,12 +67,12 @@ export function EntityHeaderActions() {
   // fade this control installed -- that is the case where clearing someone else's
   // presentation would be invisible and wrong.
   const releaseGhost = useCallback((explicit: boolean) => {
-    const claim = owned.current;
+    const claim = ownedClaim;
     const s = useViewerStore.getState();
     // Identity, not contents: anything that replaced the channel since is theirs,
     // and its prior isolation is not ours to restore.
     const ours = claim !== null && s.ghostExceptEntities === claim.ghost;
-    owned.current = null;
+    ownedClaim = null;
     if (ours) {
       // Give back the isolation as it was BEFORE the fade widened it.
       s.restoreVisibilityState({
@@ -128,21 +137,27 @@ export function EntityHeaderActions() {
                 // absent from isolatedEntities, and ghosting only fades what
                 // survived that filter, so the camera would frame something
                 // invisible. Admit the selection rather than drop the isolation.
-                const isolated = isolatedEntities === null
+                // Release any fade we still own FIRST, so a move from A to B
+                // computes B's prior isolation from the ORIGINAL set rather than
+                // from the one A widened. Without this, A -> B -> clear restores
+                // the A-widened isolation and leaves A admitted for good.
+                releaseGhost(true);
+                const base = useViewerStore.getState().isolatedEntities;
+                const isolated = base === null
                   ? null
-                  : isolatedEntities.has(selectedEntityId)
-                    ? isolatedEntities
-                    : new Set([...isolatedEntities, selectedEntityId]);
+                  : base.has(selectedEntityId)
+                    ? base
+                    : new Set([...base, selectedEntityId]);
                 restoreVisibilityState({
                   isolated,
                   ghostExcept: new Set([selectedEntityId]),
-                  hidden: hiddenEntities,
+                  hidden: useViewerStore.getState().hiddenEntities,
                 });
                 // Read the ghost identity BACK: restoreVisibilityState copies the
                 // set it is given, so the object handed in is not the one
                 // installed. Keep the ORIGINAL isolation, not the widened one.
                 const installed = useViewerStore.getState().ghostExceptEntities;
-                if (installed) owned.current = { ghost: installed, priorIsolation: isolatedEntities };
+                if (installed) ownedClaim = { ghost: installed, priorIsolation: base };
                 cameraCallbacks.frameSelection?.();
               }
             }}


### PR DESCRIPTION
Follow-up to #3709, which merged before these fixes were ready. Both defects are on `main` now.

## 1. "Show in context" destroys an active isolation (high)

`EntityHeaderActions.tsx:69` installs the fade with `setGhostExceptEntities`, and `visibilitySlice.ts:312-316` nulls `isolatedEntities` unconditionally:

```ts
setGhostExceptEntities: (ids) => set({
  ghostExceptEntities: ids ? new Set(ids) : null,
  isolatedEntities: null,   // <- unconditional
}),
```

Nothing captured the prior isolation, so it is gone. Ran it against the real store:

```
after enter  -> isolated: null   ghost: Set(1) { 101 }
after leave  -> isolated: null   ghost: null
```

Repro: Properties → an IfcZone → "Isolate in 3D" → header "Show in context" → **the whole building reappears faded** instead of fading around the selected member → click again → building is back solid and the isolation is permanently lost. Reachable from every isolate entry point: `HierarchyPanel.tsx:403,432,469,534`, `SearchModal.filter.tsx:442,471`, `LensPanel.tsx:1426`.

Every other installer of this channel captures prior state first (clash/IDS via ownership records, Space Sketch and the anonymized-export preview via `restoreVisibilityState`/`usePreviewIsolation`). This one captured nothing.

**Fix:** not capture-and-replay. `restoreVisibilityState` already documents the both-non-null pair as reachable and coherent — isolation filters, ghosting fades what survived it — so the button writes both channels and the isolation simply never dies. Leaving uses `clearGhost`, which already preserves isolation, instead of the setter, which clears it.

## 2. The fade outlives its only control (medium)

`PropertiesPanel` renders nothing without a selection, so deselecting unmounts the button while the fade stays installed. `clearSelection` never touches `ghostExceptEntities`:

```
after deselect -> selectedEntityId: null   ghost: Set(1) { 101 }
```

The whole model is left translucent with no way to undo it: there is no other UI caller of `clearGhost` and no shortcut (`useKeyboardControls.ts` has F/H/Z only). `ViewportOverlays.tsx:229-246` shows "N ghosted" but it is `role="status"`, not a control. Recovery is select-anything-then-click-twice.

Secondary cost: in the Cesium world view, selection is folded into the GLB key only while ghosting is on (`useCesiumModel.ts:210-225`), so a forgotten fade turns every later click into a multi-megabyte GLB rebuild.

**Fix:** the component tears its own fade down on unmount. Deliberately narrow — a singleton set holding exactly the entity this panel was showing — so a clash or IDS fade, which holds many entities and owns its own release, is left standing. There is a test pinning that.

## Not fixed, deliberately

`isGhosted` still reads OFF when the selection moves while a fade is installed (the fade is around the previous entity). Display state only, no data or state loss, and fixing it means deciding whether the fade should follow the selection — a design question rather than a correctness one.

## Also

A changeset for the feature, which #3709 shipped without. `check-changesets.mjs` does not require one, so the release notes would simply have missed a new user-visible button.

## Tests

Three, all driving the real component and the real store rather than calling setters, each naming the mutation it kills. Against the pre-fix code:

```
not ok 4 - preserves an active isolation when entering and leaving "Show in context"
not ok 5 - tears its own fade down when the panel unmounts (deselection)
```

## Verified

7/7 `EntityHeaderActions.test.tsx`, `tsc --noEmit` clean, `pnpm lint` no errors, `check-module-size` exits 0.

Checked and clean: no #3720-style alpha re-multiplication — the ghost alpha *replaces* material alpha (`packages/renderer/src/index.ts:1866,1892`) and `fallback` is re-read each frame, so nothing compounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNuDHNx7vdoKq4ETeXn4vX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Show in context” action to the Properties panel.
  - Fades other entities and frames the selected entity while preserving active isolation.
  - Removes the action’s visual fade when the panel closes.

- **Bug Fixes**
  - Improved visibility-state handling when toggling “Show in context.”
  - Preserves hidden entities and unrelated multi-entity ghosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->