### PR TITLE
fix(viewer): assembly selection highlights nothing, and leaves a stale multi-selection

### DIFF
--- a/.changeset/viewer-assembly-parent-selection.md
+++ b/.changeset/viewer-assembly-parent-selection.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/viewer': minor
+---
+
+The Properties panel now shows a "Part of Assembly" badge when the selected element is aggregated into an `IfcElementAssembly`, and clicking it selects that assembly (#3620).
+
+An assembly owns no mesh of its own, so selecting it highlights its renderable parts with the assembly kept as the primary selection, rather than framing the camera on something the renderer then leaves unlit.

--- a/apps/viewer/src/components/viewer/PropertiesPanel.assembly-select.test.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.assembly-select.test.tsx
@@ -139,6 +139,43 @@ describe('Properties panel -- "Part of Assembly" (#3620)', () => {
     assert.ok(container.textContent?.includes('IfcElementAssembly'), 'panel should show the assembly\'s IfcClass');
   });
 
+  // Kills the mutation `setSelectedEntityIds([...renderableParts, globalId])`
+  // -> `setSelectedEntityIds([])`. An IfcElementAssembly owns no mesh and the
+  // renderer highlights by direct mesh-id match, so clearing the part's
+  // highlight and selecting the bare assembly id lit nothing at all -- the
+  // camera framed the truss while the model went dark.
+  it('highlights the assembly\'s renderable parts, assembly id last so it stays primary', async () => {
+    await seed(60);
+    const partIds = [60 + ID_OFFSET, 61 + ID_OFFSET];
+    useViewerStore.setState({
+      cameraCallbacks: { resolveHighlightIds: () => partIds },
+    } as never);
+
+    const container = render(<PropertiesPanel />);
+    click(assemblyBadge(container)!);
+
+    const ids = [...useViewerStore.getState().selectedEntityIds];
+    assert.deepEqual(ids, [...partIds, 50 + ID_OFFSET],
+      'renderable parts must be highlighted, with the assembly id LAST (#1133)');
+  });
+
+  // Kills the mutation "drop the selectedEntitiesSet clear". Four consumers
+  // (MeasureQuantities, basketVisibleSet, useBCF, the LLM context builder)
+  // prefer that set over selectedEntity, so a stale one left standing makes
+  // them report the entities selected BEFORE this click.
+  it('clears a stale model-aware multi-selection', async () => {
+    await seed(60);
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set([`${MODEL_ID}:60`, `${MODEL_ID}:61`]),
+    } as never);
+
+    const container = render(<PropertiesPanel />);
+    click(assemblyBadge(container)!);
+
+    assert.equal(useViewerStore.getState().selectedEntitiesSet.size, 0,
+      'the multi-select channel must not keep reporting the pre-click entities');
+  });
+
   it('control: an ordinary element in no assembly shows no badge, selection unaffected', async () => {
     await seed(42); // Wall A -- not in any IfcRelAggregates
     const container = render(<PropertiesPanel />);

--- a/apps/viewer/src/components/viewer/PropertiesPanel.tsx
+++ b/apps/viewer/src/components/viewer/PropertiesPanel.tsx
@@ -27,6 +27,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useViewerStore } from '@/store';
+import { useSelectAssembly } from './properties/useSelectAssembly';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
 import { configureMutationView } from '@/utils/configureMutationView';
@@ -152,7 +153,6 @@ export function PropertiesPanel() {
   // Relationship navigation: select a related entity (e.g. an IfcZone) to show
   // its attributes, or isolate a group's members in 3D (#1075).
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
-  const setSelectedEntityId = useViewerStore((s) => s.setSelectedEntityId);
   const setSelectedEntityIds = useViewerStore((s) => s.setSelectedEntityIds);
   const isolateEntities = useViewerStore((s) => s.isolateEntities);
   const typeVisibility = useViewerStore((s) => s.typeVisibility);
@@ -761,21 +761,7 @@ export function PropertiesPanel() {
     }
   }, [selectedEntity, setSelectedEntity, setSelectedEntityIds, cameraCallbacks]);
 
-  // Issue #3620: select the parent IfcElementAssembly from the badge below.
-  // NOT `handleSelectRelatedEntity` above -- that leaves `selectedEntityId`
-  // (the globalId this panel's own render gate requires) at whatever
-  // `setSelectedEntityIds([])` derives, which is null, so its target never
-  // becomes visible in THIS panel. `setSelectedEntityId` is the field every
-  // 3D-pick and search entry point sets first for exactly that reason.
-  const handleSelectAssembly = useCallback((expressId: number) => {
-    if (!selectedEntity) return;
-    setSelectedEntityIds([]);
-    setSelectedEntityId(toGlobalIdFromModels(models, selectedEntity.modelId, expressId));
-    setSelectedEntity({ modelId: selectedEntity.modelId, expressId });
-    if (cameraCallbacks.frameSelection) {
-      window.setTimeout(() => cameraCallbacks.frameSelection?.(), 50);
-    }
-  }, [selectedEntity, models, setSelectedEntity, setSelectedEntityId, setSelectedEntityIds, cameraCallbacks]);
+  const handleSelectAssembly = useSelectAssembly();
 
   // Isolate + select all member objects of a group/zone (the IfcSpace /
   // IfcSpatialZone in an IfcZone — e.g. one dwelling, house number or fire

--- a/apps/viewer/src/components/viewer/properties/useSelectAssembly.ts
+++ b/apps/viewer/src/components/viewer/properties/useSelectAssembly.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { useCallback } from 'react';
+
+import { useViewerStore } from '@/store';
+import { toGlobalIdFromModels } from '@/store/globalId';
+
+/**
+ * Select the parent `IfcElementAssembly` from the "Part of Assembly" badge
+ * (#3620).
+ *
+ * Not `handleSelectRelatedEntity`: that leaves `selectedEntityId` -- the
+ * globalId the properties panel's own render gate requires -- at whatever
+ * `setSelectedEntityIds([])` derives, which is null, so its target never
+ * becomes visible in the panel. `setSelectedEntityId` is the field every
+ * 3D-pick and search entry point sets first, for that reason.
+ */
+export function useSelectAssembly(): (expressId: number) => void {
+  return useCallback((expressId: number) => {
+    const s = useViewerStore.getState();
+    const selected = s.selectedEntity;
+    if (!selected) return;
+    const globalId = toGlobalIdFromModels(s.models, selected.modelId, expressId);
+
+    // An assembly owns no mesh of its own and the renderer highlights by
+    // mesh-id match, so selecting the bare id cleared the part's highlight and
+    // lit nothing in its place -- the camera moved to the right place while
+    // nothing lit up (Viewport.tsx:1156-1167). Highlight the renderable parts,
+    // assembly id LAST so it stays primary (#1133), the shape
+    // SearchModal.text and HierarchyPanel already use.
+    const renderableParts = s.cameraCallbacks.resolveHighlightIds?.([globalId]) ?? [];
+    s.setSelectedEntityIds([...renderableParts, globalId]);
+    s.setSelectedEntityId(globalId);
+    s.setSelectedEntity({ modelId: selected.modelId, expressId });
+
+    // MeasureQuantities, basketVisibleSet, useBCF and the LLM context builder
+    // read this model-aware set in preference to `selectedEntity`, so one left
+    // standing keeps reporting the entities selected BEFORE this click. The
+    // canonical single-select path clears it too (Viewport.tsx:198-200).
+    if (s.selectedEntitiesSet.size > 0) {
+      useViewerStore.setState({ selectedEntitiesSet: new Set<string>() });
+    }
+
+    if (s.cameraCallbacks.frameSelection) {
+      window.setTimeout(() => useViewerStore.getState().cameraCallbacks.frameSelection?.(), 50);
+    }
+  }, []);
+}

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -215,7 +215,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts|mjs|cjs)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '9519768643398465313',
+  'apps/viewer': '14836735350698650008',
   'apps/viewer-embed': '12728481182599147886',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -215,7 +215,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts|mjs|cjs)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '3084272275768153260',
+  'apps/viewer': '9519768643398465313',
   'apps/viewer-embed': '12728481182599147886',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -81,7 +81,7 @@
    886 apps/viewer/src/components/viewer/properties/LocationMap.tsx
    417 apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
    510 apps/viewer/src/components/viewer/properties/TaskEditCard.tsx
-  2205 apps/viewer/src/components/viewer/PropertiesPanel.tsx
+  2189 apps/viewer/src/components/viewer/PropertiesPanel.tsx
   1731 apps/viewer/src/components/viewer/PropertyEditor.tsx
    542 apps/viewer/src/components/viewer/schedule/AnimationSettingsPopover.tsx
    426 apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -81,7 +81,7 @@
    886 apps/viewer/src/components/viewer/properties/LocationMap.tsx
    417 apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
    510 apps/viewer/src/components/viewer/properties/TaskEditCard.tsx
-  2189 apps/viewer/src/components/viewer/PropertiesPanel.tsx
+  2146 apps/viewer/src/components/viewer/PropertiesPanel.tsx
   1731 apps/viewer/src/components/viewer/PropertyEditor.tsx
    542 apps/viewer/src/components/viewer/schedule/AnimationSettingsPopover.tsx
    426 apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx


### PR DESCRIPTION
Follow-up to #3711, which merged before these fixes were ready. Both defects are on `main` now.

## 1. Clicking "Part of Assembly" leaves the 3D view unhighlighted

`handleSelectAssembly` cleared `selectedEntityIds` and set `selectedEntityId` to the assembly's bare globalId. The renderer highlights by direct mesh-id match (`packages/renderer/src/index.ts:2064-2067`) and an `IfcElementAssembly` owns no mesh — #3711's own test asserts that — so the part's highlight went out and the assembly's id matched nothing.

The camera still moves, because `frameSelection` resolves renderable ids internally (`Viewport.tsx:1133`). Only the highlight is missed. That is exactly the failure `resolveHighlightIds` exists to prevent, described verbatim at `Viewport.tsx:1156-1167`: *"the camera moved to the right place while nothing lit up."*

Store state after the click, from a live run:

```
selectedEntityIds = []
selectedEntityId  = 1000050
```

Repro: precast model, an `IfcElementAssembly` truss aggregating columns. Click a column (it highlights) → click "Part of Assembly" → panel switches to the assembly and the camera frames the truss, but the entire model is unhighlighted.

**Fix:** the established pattern from `SearchModal.text.tsx:139-140` and `HierarchyPanel` (#1133) — resolve the renderable parts and highlight those, with the assembly id **last** so it stays the primary selection.

## 2. A stale multi-selection survives the click

`selectedEntitiesSet`, the model-aware channel, was never cleared. The canonical single-select path clears both sets (`Viewport.tsx:198-200`).

Live run after seeding a Ctrl+click multi-selection of `#60`/`#61` and clicking the badge:

```
selectedEntity      = {"modelId":"m1","expressId":50}   // the assembly
selectedEntityIds   = []
selectedEntitiesSet = [ 'm1:60', 'm1:61' ]              // stale
```

Four consumers prefer `selectedEntitiesSet` over `selectedEntity` and therefore report the old selection: `tools/MeasureQuantities.tsx:242`, `store/basketVisibleSet.ts:233`, `hooks/useBCF.ts:424`, `lib/llm/context-builder.ts:207`.

Repro: Ctrl+click two columns of an assembly, click "Part of Assembly". The panel shows the assembly; Measure/Quantities sums the two columns; a BCF viewpoint saved now records the two columns as its components; the LLM context says "2 entities selected".

## Structure

The handler moved to `properties/useSelectAssembly.ts`. It reads everything from the store, so it does not need the panel's scope — and `PropertiesPanel.tsx` was 7 lines over its module-size budget with the fixes inline. Splitting is the house rule's answer, and it leaves the file **15 lines under** budget, so the allowlist row is **lowered**, not raised.

Removing the now-unused `setSelectedEntityId` selector also puts `apps/viewer`'s unused-locals count back on baseline — caught by `pnpm lint`, which the gates run individually miss.

## Not fixed, deliberately

`decomposedBy()` returns `nodes[0]` and `IfcRelNests` shares the Aggregates edge bucket, so an element with **both** a nesting parent and an assembly parent shows the badge according to which relationship the exporter wrote first. Proven on the same model, two orderings:

```
NESTS-first: decomposedBy(#60) = #70 IfcDistributionElement -> badge? false
AGG-first:   decomposedBy(#60) = #50 IfcElementAssembly     -> badge? true
```

Real, but it needs a new public accessor on `EntityNode` in `@ifc-lite/query` (`getRelated` is private), it is cosmetic, and how often real exports produce that shape is unproven. Worth its own issue rather than widening this one.

## Also

A changeset for the feature, which #3711 shipped without.

## Verified

Tests drive the real panel and the real store and each names the mutation it kills. Against the pre-fix handler both fail (`not ok 4`, `not ok 5`) and pass after. 6/6 assembly-select, `tsc --noEmit` clean, `pnpm lint` no errors, `check-module-size` exits 0 with one row lowered and none raised.

Checked and clean: traversal direction is right, a self-referencing or cyclic aggregate cannot hang (single hop, not a loop), elements in no assembly are unaffected, and the parent lookup is one memoized CSR row read rather than a graph walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNuDHNx7vdoKq4ETeXn4vX
