### PR TITLE
fix(viewer): expand a geometry-less assembly to its aggregated parts on isolate

### DIFF
--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1012,6 +1012,9 @@ export function Viewport({
       // never touches aggregation.
       const resolveRenderableIds = (
         ids: readonly number[],
+        // Named so the warning below points at the entry point the user
+        // pressed: Frame and a highlight isolate share this one resolution.
+        caller: 'resolveHighlightIds' | 'frameSelection',
         boundsOf: (id: number) => BoundingBox3D | null = createRenderableBoundsLookup(),
       ): number[] => {
         const geom = geometryRef.current;
@@ -1023,17 +1026,13 @@ export function Viewport({
           toGlobalId: (modelId, expressId) =>
             toGlobalIdFromModels(useViewerStore.getState().models, modelId, expressId),
         });
-        // Nothing in the RESOLVED set can render + streaming finished means a
-        // genuinely blank isolate (#3426 residual — see aggregation.ts's doc on
-        // the fallback above). Counting `resolved` would miss the case the
-        // fallback itself creates: all of a geometry-less assembly's parts are
-        // carried forward, so the set is non-empty while still holding no mesh.
-        // Gated on streaming so the ordinary "hasn't arrived yet" case is silent.
-        if (
-          hasNoRenderableTarget(ids, resolved, hasGeometry) &&
-          !isGeometryLoadStreaming(useViewerStore.getState())
-        ) {
-          console.warn('[Viewport] resolveHighlightIds: nothing renderable for', ids);
+        // Nothing in the RESOLVED set renders + streaming finished = a blank
+        // isolate. Counting `resolved` misses it: the #3426 fallback carries
+        // every aggregated part forward, so the set is non-empty and mesh-less.
+        // The streaming gate keeps the ordinary "hasn't arrived yet" silent.
+        const streaming = isGeometryLoadStreaming(useViewerStore.getState());
+        if (hasNoRenderableTarget(ids, resolved, hasGeometry) && !streaming) {
+          console.warn(`[Viewport] ${caller}: nothing renderable for`, ids);
         }
         return resolved;
       };
@@ -1144,7 +1143,7 @@ export function Viewport({
           // frameSelection moved the camera to an assembly that stayed
           // unhighlighted, because the renderer highlights `selectedEntityIds`
           // directly and that set still held the geometry-less assembly id.
-          const framedIds = resolveRenderableIds(ids, boundsOf);
+          const framedIds = resolveRenderableIds(ids, 'frameSelection', boundsOf);
           for (const id of framedIds) {
             const b = boundsOf(id);
             if (!b) continue;
@@ -1178,7 +1177,7 @@ export function Viewport({
         // to the right place while nothing lit up. Returns `[]`, not the
         // input, for an id with neither geometry nor renderable parts, so a
         // caller can fall back to its own default.
-        resolveHighlightIds: (ids) => resolveRenderableIds(ids),
+        resolveHighlightIds: (ids) => resolveRenderableIds(ids, 'resolveHighlightIds'),
         frameEntities: (ids: number[]) => {
           // Frame an explicit id set. Ids are federated GLOBAL ids — the same
           // id space the scene meshes carry (single model: global === express).

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -47,6 +47,7 @@ import {
 } from '../../utils/viewportUtils.js';
 import { setGlobalCanvasRef, setGlobalRendererRef, clearGlobalRefs } from '../../hooks/useBCF.js';
 import { expandToGeometryBearingIds } from '../../utils/aggregation.js';
+import { hasNoRenderableTarget } from '@/lib/isolation/resolveIsolationIds';
 import { toGlobalIdFromModels } from '@/store/globalId';
 
 import { useMouseControls, type MouseState } from './useMouseControls.js';
@@ -1022,10 +1023,16 @@ export function Viewport({
           toGlobalId: (modelId, expressId) =>
             toGlobalIdFromModels(useViewerStore.getState().models, modelId, expressId),
         });
-        // Empty here + streaming finished means truly nothing to expand to
-        // (#3426 residual — see aggregation.ts's doc on the fallback above).
+        // Nothing in the RESOLVED set can render + streaming finished means a
+        // genuinely blank isolate (#3426 residual — see aggregation.ts's doc on
+        // the fallback above). Counting `resolved` would miss the case the
+        // fallback itself creates: all of a geometry-less assembly's parts are
+        // carried forward, so the set is non-empty while still holding no mesh.
         // Gated on streaming so the ordinary "hasn't arrived yet" case is silent.
-        if (resolved.length === 0 && ids.length > 0 && !isGeometryLoadStreaming(useViewerStore.getState())) {
+        if (
+          hasNoRenderableTarget(ids, resolved, hasGeometry) &&
+          !isGeometryLoadStreaming(useViewerStore.getState())
+        ) {
           console.warn('[Viewport] resolveHighlightIds: nothing renderable for', ids);
         }
         return resolved;

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1016,12 +1016,19 @@ export function Viewport({
         const geom = geometryRef.current;
         if (!geom) return [];
         const hasGeometry = (id: number) => boundsOf(id) !== null;
-        return expandToGeometryBearingIds(ids, hasGeometry, {
+        const resolved = expandToGeometryBearingIds(ids, hasGeometry, {
           resolve: resolveEntityRef,
           relationshipsFor: relationshipsForModel,
           toGlobalId: (modelId, expressId) =>
             toGlobalIdFromModels(useViewerStore.getState().models, modelId, expressId),
         });
+        // Empty here + streaming finished means truly nothing to expand to
+        // (#3426 residual — see aggregation.ts's doc on the fallback above).
+        // Gated on streaming so the ordinary "hasn't arrived yet" case is silent.
+        if (resolved.length === 0 && ids.length > 0 && !isGeometryLoadStreaming(useViewerStore.getState())) {
+          console.warn('[Viewport] resolveHighlightIds: nothing renderable for', ids);
+        }
+        return resolved;
       };
 
       // Register camera callbacks for ViewCube and other controls

--- a/apps/viewer/src/lib/isolation/resolveIsolationIds.test.ts
+++ b/apps/viewer/src/lib/isolation/resolveIsolationIds.test.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { hasNoRenderableTarget } from './resolveIsolationIds.js';
+
+/** `hasGeometry` stand-in: exactly the ids whose mesh is on screen right now. */
+const rendering = (...ids: number[]) => {
+  const set = new Set(ids);
+  return (id: number) => set.has(id);
+};
+
+describe('hasNoRenderableTarget (#3741, the warning gate for #3426)', () => {
+  it('is quiet when a resolved id renders', () => {
+    assert.equal(hasNoRenderableTarget([10], [10], rendering(10)), false);
+  });
+
+  it('is quiet when the assembly itself is mesh-less but a resolved part renders', () => {
+    // The ordinary #3338 expansion: 10 has no mesh, its parts 11/12 do.
+    assert.equal(hasNoRenderableTarget([10], [11, 12], rendering(11, 12)), false);
+    assert.equal(hasNoRenderableTarget([10], [11, 12], rendering(12)), false);
+  });
+
+  it('fires when the #3426 fallback carried parts that none of them render', () => {
+    // The case a `resolved.length === 0` test steps straight past: the
+    // fallback in expandToGeometryBearingIds carries ALL aggregated parts
+    // forward, so the set is non-empty while holding no mesh at all.
+    assert.equal(hasNoRenderableTarget([10], [11, 12], rendering()), true);
+  });
+
+  it('fires when there was nothing to expand to at all', () => {
+    assert.equal(hasNoRenderableTarget([10], [], rendering(99)), true);
+  });
+
+  it('never fires for an empty request', () => {
+    assert.equal(hasNoRenderableTarget([], [], rendering()), false);
+  });
+});

--- a/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
+++ b/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
@@ -18,7 +18,7 @@
  * FILTERED mesh list (`ViewportContainer.tsx`'s `filteredGeometry`), and
  * `TYPE_VISIBILITY_SEMANTIC_DEFAULTS` ships `spaces`, `spatialZones`,
  * `openings` and `virtualElements` OFF (`store/constants.ts`). So `[]` is what
- * the resolver answers for THREE different situations that it cannot tell
+ * the resolver answers for FOUR different situations that it cannot tell
  * apart from the outside:
  *
  *   - the ids are hidden by a type toggle right now (an `IfcSpace` at the
@@ -40,28 +40,19 @@
  * starts showing the right thing as soon as the toggle flips or the batch
  * lands.
  *
- * #3426, correcting #3382: the third situation used to fall all the way back
- * to the raw ids too, which converts one empty viewport (isolating `[]`) into
- * a DIFFERENT empty viewport (isolating a geometry-less id with no mesh) —
- * the assembly's own id never matches anything, streamed or not. Closed in
+ * The third situation is handled one level down, in
  * `expandToGeometryBearingIds` (`utils/aggregation.ts`), which
- * `resolveHighlightIds` (`Viewport.tsx`) is built on: when none of an
- * assembly's aggregated parts currently render, it now falls back to ALL of
- * them (not just the currently-meshed ones) instead of dropping the id — so
- * this module receives a non-empty `resolved` for that case and unions it in
- * exactly as it already does for an ordinary element.
+ * `resolveHighlightIds` (`Viewport.tsx`) is built on: it expands a
+ * geometry-less id to its aggregated parts, falling back to ALL of them when
+ * none of them currently render (#3426). This module just receives a
+ * non-empty `resolved` for that case and unions it in as it does for any
+ * ordinary element.
  *
- * The residual gap, stated rather than papered over: the fourth situation — no
- * geometry AND no aggregated descendant at all — has nothing to expand to;
- * this still unions in the bare raw id and the viewport goes blank, with no
- * distinguishing signal available at this layer (this function only ever sees
- * ids, not the model graph). `resolveRenderableIds` in `Viewport.tsx` is where
- * that distinction IS visible (it already resolved-and-found-nothing), so it
- * is what surfaces a console warning once streaming has finished — see the
- * comment there. What is fixed here is #3338 (assembly parts contributed
- * through every channel) and, now, the third row of #3426 (geometry-less WITH
- * parts). The fourth row (geometry-less, no parts) is the one case a resolver
- * genuinely cannot help with, because there is nothing to resolve to.
+ * The fourth has nothing to expand to, so it stays a blank isolate: this
+ * module unions in the bare raw id and no mesh ever matches it. That case is
+ * invisible from here — this function only ever sees ids, never the model
+ * graph — so the signal for it lives in `resolveRenderableIds`
+ * (`Viewport.tsx`), which warns once streaming has finished.
  */
 export function resolveIsolationIds(
   resolver: ((ids: number[]) => number[]) | undefined,

--- a/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
+++ b/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
@@ -70,3 +70,28 @@ export function resolveIsolationIds(
   const resolved = resolver?.([...rawIds]) ?? [];
   return [...new Set([...resolved, ...rawIds])];
 }
+
+/**
+ * Whether an isolate/highlight request resolved to a set with nothing that can
+ * render right now. This is the condition `resolveRenderableIds`
+ * (`Viewport.tsx`) warns on once geometry streaming has finished, i.e. the
+ * fourth situation above plus its post-#3426 sibling.
+ *
+ * `resolved.length === 0` is NOT that condition any more. Since #3426 the
+ * resolver falls back to ALL of a geometry-less id's aggregated parts, so a
+ * NON-empty `resolved` can still be entirely mesh-less — an assembly whose
+ * parts never render is exactly the blank viewport the warning exists to
+ * surface, and counting the result would step straight past it. Renderability
+ * has to be asked per resolved id instead.
+ *
+ * An empty request is not a defect, so it never warns. The caller owns the
+ * streaming gate: mid-stream, "nothing renders yet" is the expected state.
+ */
+export function hasNoRenderableTarget(
+  requested: readonly number[],
+  resolved: readonly number[],
+  hasGeometry: (id: number) => boolean,
+): boolean {
+  if (requested.length === 0) return false;
+  return !resolved.some(hasGeometry);
+}

--- a/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
+++ b/apps/viewer/src/lib/isolation/resolveIsolationIds.ts
@@ -26,9 +26,11 @@
  *   - their meshes have not streamed in yet (`filteredGeometry` is non-null
  *     from the FIRST batch and grows incrementally, so a mesh that has not
  *     arrived reads exactly like one that does not exist);
- *   - they are genuinely geometry-less with no renderable aggregated part.
+ *   - they are geometry-less but have `IfcRelAggregates` parts that will
+ *     render (an `IfcElementAssembly` and the like);
+ *   - they are genuinely geometry-less with no aggregated part at all.
  *
- * Only the third deserves "do nothing". Treating all three that way makes an
+ * Only the last deserves "do nothing". Treating all four that way makes an
  * IDS/lens/SDK/embed isolate of a hidden-type set a silent no-op, which is why
  * `PropertiesPanel.tsx`'s zone isolate (#1075) and `SearchModal.filter.tsx`'s
  * "Isolate in 3D" (#2660) both keep the raw ids on an empty resolve — the
@@ -38,13 +40,28 @@
  * starts showing the right thing as soon as the toggle flips or the batch
  * lands.
  *
- * The residual gap, stated rather than papered over: for the third situation
- * this still isolates a set with no mesh in it and the viewport goes blank
- * (#3426). Closing that needs a resolver that can see UNFILTERED geometry and
- * so can say "geometry is in and nothing here renders" as a fact distinct from
- * `[]`; that is Viewport/ViewportContainer plumbing, not a policy this
- * function can infer. What is fixed here is #3338: an assembly whose parts DO
- * render now contributes those parts in every channel that routes through here.
+ * #3426, correcting #3382: the third situation used to fall all the way back
+ * to the raw ids too, which converts one empty viewport (isolating `[]`) into
+ * a DIFFERENT empty viewport (isolating a geometry-less id with no mesh) —
+ * the assembly's own id never matches anything, streamed or not. Closed in
+ * `expandToGeometryBearingIds` (`utils/aggregation.ts`), which
+ * `resolveHighlightIds` (`Viewport.tsx`) is built on: when none of an
+ * assembly's aggregated parts currently render, it now falls back to ALL of
+ * them (not just the currently-meshed ones) instead of dropping the id — so
+ * this module receives a non-empty `resolved` for that case and unions it in
+ * exactly as it already does for an ordinary element.
+ *
+ * The residual gap, stated rather than papered over: the fourth situation — no
+ * geometry AND no aggregated descendant at all — has nothing to expand to;
+ * this still unions in the bare raw id and the viewport goes blank, with no
+ * distinguishing signal available at this layer (this function only ever sees
+ * ids, not the model graph). `resolveRenderableIds` in `Viewport.tsx` is where
+ * that distinction IS visible (it already resolved-and-found-nothing), so it
+ * is what surfaces a console warning once streaming has finished — see the
+ * comment there. What is fixed here is #3338 (assembly parts contributed
+ * through every channel) and, now, the third row of #3426 (geometry-less WITH
+ * parts). The fourth row (geometry-less, no parts) is the one case a resolver
+ * genuinely cannot help with, because there is nothing to resolve to.
  */
 export function resolveIsolationIds(
   resolver: ((ids: number[]) => number[]) | undefined,

--- a/apps/viewer/src/sdk/adapters/visibility-adapter.assembly.test.ts
+++ b/apps/viewer/src/sdk/adapters/visibility-adapter.assembly.test.ts
@@ -133,4 +133,32 @@ describe('SDK visibility adapter: isolate() and #3338 assembly expansion', () =>
     assert.equal(calls.length, 1, 'isolate() must still install an isolation');
     assert.deepEqual(calls[0], [ASSEMBLY_GLOBAL_ID], 'an empty resolve falls back to the raw ids');
   });
+
+  // #3426, correcting #3382: the previous test's `emptyResolver` stood in for
+  // EVERY reason a resolver answers `[]`, including a geometry-less assembly
+  // whose parts genuinely never render — but for that case, falling back to
+  // the raw (parent) id is the bug: the assembly has no mesh either, so
+  // isolating `[ASSEMBLY_GLOBAL_ID]` blanks the viewport exactly as isolating
+  // `[]` would have, just with an extra step. `expandToGeometryBearingIds`
+  // (`utils/aggregation.ts`) no longer answers `[]` for this case: when none
+  // of an assembly's parts currently render, the real `resolveHighlightIds`
+  // now falls back to ALL of the assembly's aggregated parts rather than
+  // dropping it — this mock mirrors that corrected contract.
+  it('a resolver that expands to un-rendered aggregated parts is unioned in, not discarded (#3426)', () => {
+    const structuralResolver = (ids: number[]) =>
+      ids.flatMap((id) => (id === ASSEMBLY_GLOBAL_ID ? [PART_A_GLOBAL_ID, PART_B_GLOBAL_ID] : []));
+    const store = makeStore(structuralResolver);
+    const adapter = createVisibilityAdapter(store);
+
+    adapter.isolate([{ modelId: MODEL_ID, expressId: ASSEMBLY_EXPRESS_ID }]);
+
+    const calls = (store.getState().isolateEntities as unknown as { calls: number[][] }).calls;
+    assert.equal(calls.length, 1);
+    assert.deepEqual(
+      [...calls[0]].sort((a, b) => a - b),
+      [ASSEMBLY_GLOBAL_ID, PART_A_GLOBAL_ID, PART_B_GLOBAL_ID],
+      'isolating a geometry-less assembly must install its parts, not just the ' +
+      'parent id the parts belong to — the parent alone has no mesh to render',
+    );
+  });
 });

--- a/apps/viewer/src/utils/aggregation.test.ts
+++ b/apps/viewer/src/utils/aggregation.test.ts
@@ -145,7 +145,7 @@ describe('expandToGeometryBearingIds', () => {
         : { modelId: 'A', expressId: globalId },
     relationshipsFor: (modelId) =>
       modelId === 'A'
-        ? makeRelationships({ 10: [11, 12] })
+        ? makeRelationships({ 10: [11, 12], 20: [21, 22] })
         : modelId === 'B'
           ? makeRelationships({ 10: [11] })
           : undefined,
@@ -175,6 +175,28 @@ describe('expandToGeometryBearingIds', () => {
 
   it('dedups when an assembly and one of its parts are both selected', () => {
     assert.deepStrictEqual(expandToGeometryBearingIds([11, 10], hasGeometry, access), [11, 12]);
+  });
+
+  // #3426, correcting #3382: `hasGeometry` is a point-in-time mesh/bounds
+  // check — during streaming, or behind a type-visibility filter, it says
+  // "no" for a part that legitimately has geometry and just hasn't rendered
+  // YET. Assembly 20's parts (21, 22) are neither in `meshed`.
+  it('falls back to ALL aggregated parts when none of them currently render (#3426)', () => {
+    assert.deepStrictEqual(expandToGeometryBearingIds([20], hasGeometry, access), [21, 22]);
+  });
+
+  it('the #3426 fallback still dedups and composes with an ordinary meshed id', () => {
+    assert.deepStrictEqual(
+      expandToGeometryBearingIds([20, 14], hasGeometry, access),
+      [21, 22, 14],
+    );
+  });
+
+  // Control: an entity with NO aggregated descendants at all (13) is still
+  // dropped — the #3426 fallback only helps an id that HAS parts to expand
+  // to; there is nothing here to expand id 13 into.
+  it('control: an entity with no aggregated descendants at all is still dropped', () => {
+    assert.deepStrictEqual(expandToGeometryBearingIds([13], hasGeometry, access), []);
   });
 
   // frameSelection and resolveHighlightIds live in a useImperativeHandle

--- a/apps/viewer/src/utils/aggregation.test.ts
+++ b/apps/viewer/src/utils/aggregation.test.ts
@@ -145,13 +145,13 @@ describe('expandToGeometryBearingIds', () => {
         : { modelId: 'A', expressId: globalId },
     relationshipsFor: (modelId) =>
       modelId === 'A'
-        ? makeRelationships({ 10: [11, 12], 20: [21, 22] })
+        ? makeRelationships({ 10: [11, 12], 20: [21, 22], 30: [31, 32] })
         : modelId === 'B'
           ? makeRelationships({ 10: [11] })
           : undefined,
     toGlobalId: (modelId, expressId) => (modelId === 'B' ? expressId + 1000 : expressId),
   };
-  const meshed = new Set([11, 12, 14, 1011]);
+  const meshed = new Set([11, 12, 14, 1011, 31]);
   const hasGeometry = (id: number) => meshed.has(id);
 
   it('expands a geometry-less assembly into its meshed parts', () => {
@@ -197,6 +197,20 @@ describe('expandToGeometryBearingIds', () => {
   // to; there is nothing here to expand id 13 into.
   it('control: an entity with no aggregated descendants at all is still dropped', () => {
     assert.deepStrictEqual(expandToGeometryBearingIds([13], hasGeometry, access), []);
+  });
+
+  // Two-way control on the #3426 fallback itself: it must fire ONLY when
+  // NONE of an assembly's parts currently render, not whenever any part is
+  // unmeshed. Assembly 30 has two parts (31 meshed, 32 not) -- if the
+  // fallback fired on ANY partial gap instead of gating on `foundGeometry`,
+  // this would (wrongly) also pull in 32. A mutation that always appends the
+  // full descendant set regardless of `foundGeometry` passes every OTHER
+  // case in this file untouched (`push`'s dedup absorbs the redundant add
+  // when the full set and the meshed subset are identical), so this is the
+  // one case that actually distinguishes "gated on foundGeometry" from
+  // "always expand".
+  it('does NOT fall back to the unmeshed sibling when at least one part already renders', () => {
+    assert.deepStrictEqual(expandToGeometryBearingIds([30], hasGeometry, access), [31]);
   });
 
   // frameSelection and resolveHighlightIds live in a useImperativeHandle

--- a/apps/viewer/src/utils/aggregation.ts
+++ b/apps/viewer/src/utils/aggregation.ts
@@ -114,10 +114,29 @@ export interface AggregationModelAccess {
  * pressing Frame moved the camera nowhere. Expanding here makes an assembly
  * frame as the union of its parts.
  *
- * Ids that already have geometry pass through untouched and in order. An id
- * with neither geometry nor geometry-bearing parts is dropped, exactly as the
- * caller's own `continue` would have dropped it. Resolution stays inside one
- * model: descendants are mapped back through the SAME model's offset.
+ * Ids that already have geometry pass through untouched and in order.
+ *
+ * When NONE of an id's aggregated parts currently satisfy `hasGeometry`
+ * either, this falls back to ALL of its aggregated descendants rather than
+ * dropping the id (#3426, correcting #3382). `hasGeometry` here is a
+ * point-in-time check — it reads whatever the caller's mesh/bounds lookup
+ * currently has, which during streaming or behind a type-visibility filter
+ * says "no" for a part that has geometry and simply hasn't rendered YET.
+ * Dropping the id in that state and leaving the caller to isolate/highlight
+ * nothing (or the parent's own geometry-less id) blanks the viewport for an
+ * entity that unambiguously DOES have renderable content once its parts
+ * arrive. Falling back to the full descendant set is free when they never
+ * render (an id with no mesh simply never matches a renderer's whitelist,
+ * same reasoning as `resolveIsolationIds`'s raw-id union) and self-heals the
+ * moment streaming completes or the filter is toggled off.
+ *
+ * An id with neither geometry nor ANY aggregated descendant at all is still
+ * dropped, exactly as the caller's own `continue` would have dropped it —
+ * that is the one case this function genuinely cannot help with, because
+ * there is nothing to expand to.
+ *
+ * Resolution stays inside one model: descendants are mapped back through the
+ * SAME model's offset.
  */
 export function expandToGeometryBearingIds(
   globalIds: readonly number[],
@@ -139,9 +158,21 @@ export function expandToGeometryBearingIds(
     const { modelId, expressId } = access.resolve(globalId);
     const relationships = access.relationshipsFor(modelId);
     if (!relationships) continue;
-    for (const descendant of collectAggregatedDescendants(relationships, expressId)) {
-      const partGlobalId = access.toGlobalId(modelId, descendant);
-      if (hasGeometry(partGlobalId)) push(partGlobalId);
+    const descendantGlobalIds = collectAggregatedDescendants(relationships, expressId).map(
+      (descendant) => access.toGlobalId(modelId, descendant),
+    );
+    let foundGeometry = false;
+    for (const partGlobalId of descendantGlobalIds) {
+      if (hasGeometry(partGlobalId)) {
+        push(partGlobalId);
+        foundGeometry = true;
+      }
+    }
+    if (!foundGeometry) {
+      // Not currently meshed doesn't mean never meshed (#3426) — carry every
+      // aggregated part forward so the caller has something durable to
+      // converge on, instead of silently losing the id.
+      for (const partGlobalId of descendantGlobalIds) push(partGlobalId);
     }
   }
   return out;


### PR DESCRIPTION
## Summary

#3426 (correcting #3382, itself correcting #3389/#3405 patterns) reported that
the empty-resolver fallback the maintainer had approved does not fix the
geometry-less-assembly case: isolating an `IfcElementAssembly` — which owns no
geometry itself, only its `IfcRelAggregates` parts do — still went to a blank
viewport, because falling back to the raw (parent) id just isolates a
different id with no mesh either.

## Root cause

`resolveHighlightIds` (`Viewport.tsx`'s `resolveRenderableIds`, wired into
`cameraCallbacks.resolveHighlightIds` and used by every isolation channel via
the shared `resolveIsolationIds`) is built on `expandToGeometryBearingIds`
(`apps/viewer/src/utils/aggregation.ts`). That helper replaced a geometry-less
id with the SUBSET of its aggregated parts that currently render, and dropped
the id entirely when none of them did — which happens both while streaming
(transient, self-heals) and for an assembly whose parts just haven't rendered
YET for any reason. Dropping the id there left every caller isolating the raw
assembly id, which has no mesh.

## Fix

`expandToGeometryBearingIds` now falls back to **all** of an id's aggregated
parts when none of them currently render, instead of dropping the id.
Carrying an id with no current mesh is free — the isolation set is a
whitelist the renderer matches mesh ids against, so an id with no mesh simply
never matches until its mesh streams in or a type-visibility toggle flips.
This is the exact self-healing reasoning #3382's raw-id union already relies
on, applied one level down (to the assembly's parts instead of the assembly
itself).

An id with **neither** geometry nor any aggregated descendant at all is still
dropped — there is nothing to expand it to, and this is the one case a
resolver genuinely cannot help with. For that case, `resolveRenderableIds`
now emits a console warning once geometry streaming has finished, so a
genuinely un-renderable isolate is no longer a silent blank viewport with no
signal — gated on streaming-complete so the warning never fires for the
ordinary, expected "hasn't arrived yet" case.

## Why one shared fix, no per-channel changes

Every isolation channel (`LensPanel`, `PropertiesPanel`, both `SearchModal`
isolate paths, `useIDS`, `useBCF`, `useEmbedUrlParams`, the embed bridge
`handler.ts`, and the SDK/MCP `visibility-adapter.ts`) routes through
`cameraCallbacks.resolveHighlightIds` via the shared `resolveIsolationIds` —
confirmed with a sibling sweep of both symbols. The fix lives in the one
resolver every channel already shares, so no call site needed touching.

## Tests

- `apps/viewer/src/utils/aggregation.test.ts`: new cases for the fallback
  (falls back to all parts when none currently render, composes/dedups with
  an ordinary meshed id) and a control (an id with no aggregated descendants
  at all is still dropped, unchanged).
- `apps/viewer/src/sdk/adapters/visibility-adapter.assembly.test.ts`: a new
  case documenting the SDK/MCP channel's contract for a resolver that expands
  to un-rendered aggregated parts.
- Verified RED (reverted `aggregation.ts`, new `aggregation.test.ts` cases
  fail: 2 of 22) and GREEN (restored, all pass) before pushing.

## Scope note

Open PR #3389 nominally claimed #3426's parent issue (#3338) but is stale and
`CONFLICTING` against current `main` — the maintainer already consolidated its
useful parts into merged #3585. This PR branches fresh off `upstream/main`
(`ab8e76e88`, which already contains #3585) and does not build on #3389.

Note: this PR closes #3426 (the geometry-less-assembly correction to #3382) but does not complete #3338 — that issue's own open design question (resolver-level automatic expansion vs. an explicit hierarchy-panel drill-down action) is unresolved, as #3382's and #3585's scope notes already state; do not treat this PR as closing #3338.

Closes #3426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation behavior for assemblies whose geometry is still streaming or not currently rendered.
  * Preserved aggregated assembly parts during visibility and highlight resolution instead of dropping valid targets.
  * Added warnings when requested IDs resolve to no renderable geometry after streaming completes.
  * Continued excluding entities with neither geometry nor aggregated descendants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
