### PR TITLE
fix(review): charge a sibling row's true rendered bytes, key included

### DIFF
--- a/scripts/review/build-context-pack.mjs
+++ b/scripts/review/build-context-pack.mjs
@@ -272,15 +272,21 @@ export function fileEvidence(patch, content) {
  * lower-risk half of an already-fenced input.
  */
 
+// Caps a key at MAX_KEY_LENGTH with an explicit `…` marker (#3732 item 2): a
+// base64/hash constant was otherwise an arbitrarily long key. A truncated
+// key still MATCHES via siblingSites's fixed-string grep -- the kept prefix
+// recurs wherever the real, longer token does.
+export const MAX_KEY_LENGTH = 60;
+const capKey = (t) => (t.length <= MAX_KEY_LENGTH ? t : `${t.slice(0, MAX_KEY_LENGTH - 1)}…`);
+
 /** Identifiers and literals worth searching for. Longer is more distinctive. */
 export function searchKeys(patch, { path = '', max = 12 } = {}) {
   // PROSE EATS THE BUDGET. The first version took the first ten tokens of five
   // or more characters, and on two real cases every one of them came from the
   // MPL licence header -- "Source, subject, terms, Mozilla, Public, License" --
-  // or from changeset markdown. The identifiers that actually find the sibling
-  // (`missingLanes`, `siScale`, `baseColorFactor`) never got a slot.
-  //
-  // So: markdown carries no implementation, and a key has to LOOK like code.
+  // or from changeset markdown, so the identifiers that actually find the
+  // sibling (`missingLanes`, `siScale`, `baseColorFactor`) never got a slot.
+  // Markdown carries no implementation, so a key has to LOOK like code.
   if (/\.(md|txt|snap|lock)$/.test(path)) return [];
 
   const isIdentifier = (t) =>
@@ -303,7 +309,7 @@ export function searchKeys(patch, { path = '', max = 12 } = {}) {
     // pack with sites that share a dependency rather than an implementation --
     // measured: it took all four top slots and pushed the real sibling out.
     if (/^\s*(import|export)\s|require\(/.test(body)) continue;
-    for (const m of body.matchAll(/[A-Za-z_$][A-Za-z0-9_$]{4,}/g)) bucket.push(m[0]);
+    for (const m of body.matchAll(/[A-Za-z_$][A-Za-z0-9_$]{4,}/g)) bucket.push(capKey(m[0]));
     for (const m of body.matchAll(/'([^'\n]{6,60})'|"([^"\n]{6,60})"/g)) bucket.push(m[1] ?? m[2]);
   }
 
@@ -558,19 +564,13 @@ export function buildPack(input, { baseRef, body = null, patchBytes = 0, cwd = p
     for (const h of hits) candidates.push({ ...h, key });
   }
   // Three signals, learned from the five real second-site cases rather than
-  // guessed. Ranked by how much each one moved the measurement:
-  //
-  //   same BASENAME in another package  glb.ts -> glb.ts, a copied module
-  //   same DIRECTORY                    scripts/lib/dirty-pr-scan.mjs ->
-  //                                     scripts/lib/pr-review-signal.mjs, and
-  //                                     measure-unit-scale.ts ->
-  //                                     quantity-collect.ts. Neighbours in a
-  //                                     directory are the same layer, and a
-  //                                     duplicated implementation usually lives
-  //                                     one file over rather than one package over
-  //   a LONG key                        `getForEntity` and `missingLanes` are
-  //                                     claims about a specific function; a
-  //                                     five-character token is not
+  // guessed, ranked by how much each one moved the measurement: same BASENAME
+  // in another package (glb.ts -> glb.ts, a copied module); same DIRECTORY
+  // (scripts/lib/dirty-pr-scan.mjs -> scripts/lib/pr-review-signal.mjs, and
+  // measure-unit-scale.ts -> quantity-collect.ts -- neighbours in a directory
+  // are the same layer, and a duplicated implementation usually lives one file
+  // over rather than one package over); a LONG key (`getForEntity` and
+  // `missingLanes` are claims about a specific function -- capped, see capKey).
   const changedDirs = new Set(changed.map((p) => p.slice(0, p.lastIndexOf('/'))));
   const rank = (h) => {
     const base = h.path.split('/').pop();

--- a/scripts/review/build-context-pack.mjs
+++ b/scripts/review/build-context-pack.mjs
@@ -379,7 +379,7 @@ export function siblingSites(key, changedPaths, ref, { cwd = process.cwd(), exec
   //
   // The no-checkout property holds for both: `git show <sha>:<path>` and
   // `git grep <sha>` read the object database either way.
-  const searchKey = key.endsWith('…') ? key.slice(0, -1) : key; // capKey's marker is display-only
+  const searchKey = key.length === MAX_KEY_LENGTH && /^[A-Za-z_$][A-Za-z0-9_$]*…$/.test(key) ? key.slice(0, -1) : key; // strip only a key shaped exactly like capKey output; other keys reach grep intact
   let out;
   try {
     out = exec('git', ['grep', '-n', '--fixed-strings', '--no-color', '-I', '-e', searchKey, ref],

--- a/scripts/review/build-context-pack.mjs
+++ b/scripts/review/build-context-pack.mjs
@@ -273,9 +273,8 @@ export function fileEvidence(patch, content) {
  */
 
 // Caps a key at MAX_KEY_LENGTH with an explicit `…` marker (#3732 item 2): a
-// base64/hash constant was otherwise an arbitrarily long key. A truncated
-// key still MATCHES via siblingSites's fixed-string grep -- the kept prefix
-// recurs wherever the real, longer token does.
+// base64/hash constant was otherwise an arbitrarily long key. siblingSites
+// strips the marker before grepping, so the kept prefix still matches.
 export const MAX_KEY_LENGTH = 60;
 const capKey = (t) => (t.length <= MAX_KEY_LENGTH ? t : `${t.slice(0, MAX_KEY_LENGTH - 1)}…`);
 
@@ -380,9 +379,10 @@ export function siblingSites(key, changedPaths, ref, { cwd = process.cwd(), exec
   //
   // The no-checkout property holds for both: `git show <sha>:<path>` and
   // `git grep <sha>` read the object database either way.
+  const searchKey = key.endsWith('…') ? key.slice(0, -1) : key; // capKey's marker is display-only
   let out;
   try {
-    out = exec('git', ['grep', '-n', '--fixed-strings', '--no-color', '-I', '-e', key, ref],
+    out = exec('git', ['grep', '-n', '--fixed-strings', '--no-color', '-I', '-e', searchKey, ref],
       { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
   } catch {
     return [];                       // exit 1 means no matches, which is normal

--- a/scripts/review/build-context-pack.mjs
+++ b/scripts/review/build-context-pack.mjs
@@ -38,6 +38,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { renderSiblingRow, SIBLING_ROW_JOIN_MARGIN } from './sibling-row.mjs';
 
 /**
  * What the PR description may claim before the siblings compete for the rest.
@@ -498,7 +499,6 @@ export const SHALLOW_CHECKOUT_REMEDY =
   'fetch-depth: 1, and a pull_request event fetches only refs/pull/N/merge. REMEDY: set ' +
   'fetch-depth: 0.';
 
-
 export function buildPack(input, { baseRef, body = null, patchBytes = 0, cwd = process.cwd(), exec = execFileSync } = {}) {
   const changed = input.files.map((f) => f.path);
   const changedBases = new Set(changed.map((p) => p.split('/').pop()));
@@ -596,7 +596,7 @@ export function buildPack(input, { baseRef, body = null, patchBytes = 0, cwd = p
     const id = `${h.path}:${h.line}`;
     if (seenSite.has(id)) continue;
     seenSite.add(id);
-    const cost = Buffer.byteLength(h.text, 'utf8') + 120;
+    const cost = Buffer.byteLength(renderSiblingRow(h), 'utf8') + SIBLING_ROW_JOIN_MARGIN;
     if (cost > budget || siblings.length >= 40) { truncated.push('sibling excerpts'); break; }
     budget -= cost;
     siblings.push(h);

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -830,3 +830,47 @@ test('a normal sibling still renders the same content it always did', () => {
     '--- SIBLING: packages/z/sibling.ts:7 (key "missingLanes")\nconst rows = missingLanes(input);',
   );
 });
+
+// The "THE FIX" test above stresses a LONG KEY, which `capKey` bounds to
+// MAX_KEY_LENGTH -- so even the pre-fix charge (`Buffer.byteLength(h.text) +
+// 120`) stays a safe overestimate for it, because 120 already covers a
+// header built from a <=60-byte key. Nothing bounds a sibling's PATH the same
+// way: `git grep` can hand back a hit at any path length, and the header
+// `renderSiblingRow` builds is `path + ':' + line + ' (key "..."))'`. Reverting
+// the charge to text-only (the item 1 regression) undercounts a long-path row
+// by its entire header and lets more of them through than the budget can
+// hold -- caught here with 40 identical-length-path candidates, never with
+// the long-KEY fixture above.
+function longPathFixture(n) {
+  const longPath = 'packages/' + 'x'.repeat(4_050) + '.ts'; // path alone dwarfs the old +120 margin
+  const files = Array.from({ length: n }, (_, i) => ({
+    path: `packages/a/f${i}.ts`,
+    patch: `@@ -1,1 +1,2 @@\n-  const uniqueTok${i} = 1;\n+  const uniqueTok${i} = 2;\n`,
+  }));
+  const grepOut = (args) => {
+    const pattern = args[args.length - 2];
+    const m = /^uniqueTok(\d+)$/.exec(pattern);
+    if (!m) return ''; // only this fixture's own keys hit; everything else is a miss
+    const line = Number(m[1]) + 1; // distinct line per file keeps each site un-collapsed
+    return `HEAD:${longPath}:${line}:  use(x);`;
+  };
+  return buildPack(
+    { headSha: 'a'.repeat(40), files },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
+  );
+}
+
+test('a long sibling PATH must be charged too, not just a long key -- text-only charge overruns the budget', () => {
+  const pack = longPathFixture(40);
+  assert.ok(pack.siblings.length > 0, 'fixture: at least one site retrieved');
+  const rendered = pack.siblings.map((h) => renderSiblingRow(h)).join('\n\n');
+  const renderedBytes = Buffer.byteLength(rendered, 'utf8');
+  const availableBudget = packBudgetFor(
+    0,
+    promptEnvelopeBytes({ files: Array.from({ length: 40 }, (_, i) => ({ path: `packages/a/f${i}.ts` })) }),
+  );
+  assert.ok(
+    renderedBytes <= availableBudget,
+    `siblings alone render to ${renderedBytes} bytes, over the ${availableBudget}-byte budget they were charged against`,
+  );
+});

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -20,6 +20,7 @@ import { buildPrompt } from './run-reviewer.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 import { searchKeys, hunkLines, fileEvidence, MAX_WHOLE_FILE_LINES, buildPack, truncateUtf8, BODY_RESERVE_BYTES, MAX_PACK_BYTES, MAX_SEARCH_KEYS, packBudgetFor, MAX_PROMPT_BYTES, retrievalFailed, retrievalFailedMessage, SHALLOW_CHECKOUT_REMEDY, PROMPT_BASE_OVERHEAD_BYTES, promptEnvelopeBytes } from './build-context-pack.mjs';
+import { renderSiblingRow, SIBLING_ROW_JOIN_MARGIN } from './sibling-row.mjs';
 
 test('search keys come from REMOVED lines first, because the sibling still has them', () => {
   const patch = [
@@ -655,5 +656,119 @@ test('THE OTHER DIRECTION: an inflated envelope must not starve the pack', () =>
     packBudgetFor(40_000, envelope),
     MAX_PACK_BYTES,
     'a 40 KB diff on a 12-file PR must still receive the FULL pack',
+  );
+});
+
+/**
+ * #3732: a sibling row's rendered key is uncharged, so the pack overruns its
+ * budget.
+ *
+ * `buildPack` used to charge a sibling row as `Buffer.byteLength(h.text,
+ * 'utf8') + 120` -- a flat overhead that never included `h.key`, even though
+ * `run-reviewer.mjs` renders `JSON.stringify(h.key)` into the prompt for every
+ * row. `h.key` is unbounded: `searchKeys`'s identifier branch
+ * (`/[A-Za-z_$][A-Za-z0-9_$]{4,}/g`) has no upper length bound (only the
+ * quoted-string branch is capped, at 60 chars), so a long token -- a base64
+ * constant, a minified bundle line -- becomes an arbitrarily long key.
+ * `rank()`'s length bonus (`Math.min(30, h.key.length * 2)`) saturates at 30,
+ * but a cap on the score a key EARNS is not a cap on the bytes it COSTS once
+ * rendered.
+ */
+function longKeyFixture(n) {
+  // One file per key so `searchKeys`'s own 12-per-file cap cannot suppress the
+  // fixture, and MAX_SEARCH_KEYS (150) is never approached at n <= 40.
+  const files = Array.from({ length: n }, (_, i) => {
+    const key = `overlongIdentifierToken${i}` + 'Z'.repeat(4_000);
+    return { path: `packages/a/f${i}.ts`, patch: `@@ -1,1 +1,2 @@\n-  const ${key} = 1;\n+  const ${key} = 2;\n`, key };
+  });
+  const grepOut = (args) => {
+    const key = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <key> <ref>`
+    const file = files.find((f) => f.key === key);
+    return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.key});` : '';
+  };
+  return buildPack(
+    { headSha: 'a'.repeat(40), files: files.map(({ key: _k, ...f }) => f) },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
+  );
+}
+
+test('the undercharge, reproduced: one long key alone outweighs the old flat overhead', () => {
+  const pack = longKeyFixture(1);
+  assert.equal(pack.siblings.length, 1, 'fixture: exactly one candidate site');
+  const h = pack.siblings[0];
+  const renderedBytes = Buffer.byteLength(renderSiblingRow(h), 'utf8');
+  const oldCharge = Buffer.byteLength(h.text, 'utf8') + 120; // the pre-fix formula, restated here on purpose
+  assert.ok(h.key.length > 4_000, `fixture key is ${h.key.length} bytes, expected > 4,000`);
+  assert.ok(
+    renderedBytes > oldCharge + 3_000,
+    `rendered row is ${renderedBytes} bytes against an old charge of ${oldCharge} -- the key alone was ` +
+      `${renderedBytes - oldCharge} bytes uncharged`,
+  );
+});
+
+test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with long keys', () => {
+  // 40 candidates is `siblings.length >= 40`'s own cap, so every one of them
+  // fitting under the OLD formula (h.text is capped at 120 bytes by
+  // `parseGrep`'s `.slice(0, 120)`, so 40 * (120 + 120) = 9,600 bytes -- trivial
+  // against MAX_PACK_BYTES) is expected and proves nothing. What proves the fix
+  // is that the RENDERED bytes -- the ones `run-reviewer.mjs` actually puts on
+  // the wire, key included -- stay inside the budget `buildPack` was handed.
+  const pack = longKeyFixture(40);
+  assert.ok(pack.siblings.length > 0, 'fixture: at least one site retrieved');
+  const rendered = pack.siblings.map((h) => renderSiblingRow(h)).join('\n\n');
+  const renderedBytes = Buffer.byteLength(rendered, 'utf8');
+  const availableBudget = packBudgetFor(
+    0,
+    promptEnvelopeBytes({ files: Array.from({ length: 40 }, (_, i) => ({ path: `packages/a/f${i}.ts` })) }),
+  );
+  assert.ok(
+    renderedBytes <= availableBudget,
+    `siblings alone render to ${renderedBytes} bytes, over the ${availableBudget}-byte budget they were charged against`,
+  );
+});
+
+test('CONTROL: an ordinary key is not charged MORE than it was before the fix', () => {
+  // Undercharging is the defect (item under test above); the failure mode a
+  // control guards against is the opposite one -- a fix that OVERcharges every
+  // row, say by adding `h.key.length * 50` unconditionally, would shrink every
+  // pack and degrade ordinary reviews even though no row was ever underbilled.
+  // The old flat `+ 120` already covered a typical short path, line and key
+  // generously (it has to, since it charges nothing for any of them), so the
+  // correct, itemized charge for an ORDINARY row is expected to come in AT OR
+  // BELOW the old flat one -- only a long key should ever push it higher.
+  const one = { path: 'packages/a/one.ts', patch: '@@ -1,1 +1,2 @@\n+  const cacheEntry = 1;\n' };
+  const site = 'HEAD:packages/z/sibling.ts:42:  const x = cacheEntry(y);';
+  const pack = buildPack(
+    { headSha: 'a'.repeat(40), files: [one] },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? site : '') },
+  );
+  assert.equal(pack.siblings.length, 1);
+  const h = pack.siblings[0];
+  assert.ok(h.key.length < 20, `fixture: expected an ordinary short key, got ${h.key.length} bytes`);
+  const newCharge = Buffer.byteLength(renderSiblingRow(h), 'utf8') + SIBLING_ROW_JOIN_MARGIN;
+  const oldCharge = Buffer.byteLength(h.text, 'utf8') + 120;
+  assert.ok(
+    newCharge <= oldCharge,
+    `an ordinary row's charge grew from ${oldCharge} to ${newCharge} bytes -- the fix must not inflate the ` +
+      'cost of a ROUTINE row, only correct the undercharge on an oversized one',
+  );
+});
+
+test('a normal sibling still renders the same content it always did', () => {
+  const one = { path: 'packages/a/one.ts', patch: '@@ -1,1 +1,2 @@\n+  const missingLanes = 1;\n' };
+  const site = 'HEAD:packages/z/sibling.ts:7:  const rows = missingLanes(input);';
+  const pack = buildPack(
+    { headSha: 'a'.repeat(40), files: [one] },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? site : '') },
+  );
+  assert.equal(pack.siblings.length, 1);
+  const h = pack.siblings[0];
+  assert.equal(h.key, 'missingLanes');
+  assert.equal(h.path, 'packages/z/sibling.ts');
+  assert.equal(h.line, 7);
+  assert.equal(h.text, 'const rows = missingLanes(input);');
+  assert.equal(
+    renderSiblingRow(h),
+    '--- SIBLING: packages/z/sibling.ts:7 (key "missingLanes")\nconst rows = missingLanes(input);',
   );
 });

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -756,6 +756,20 @@ function longKeyFixture(n) {
   return { pack, patterns };
 }
 
+test('a quoted literal that naturally ends in an ellipsis keeps it in the grep pattern', () => {
+  // Only capKey's marker is display-only. A literal such as 'loading…' was
+  // never truncated, and stripping its last character would grep for a
+  // prefix that matches unrelated sites and displaces the real sibling.
+  const literal = 'pending label…';
+  const patterns = [];
+  buildPack(
+    { headSha: 'a'.repeat(40), files: [{ path: 'packages/a/f.ts', patch: `@@ -1,1 +1,1 @@\n+  const label = '${literal}';\n` }] },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => { if (args[0] === 'grep') patterns.push(args[args.length - 2]); return ''; } },
+  );
+  assert.ok(patterns.includes(literal), `the untruncated literal must reach grep intact, got ${JSON.stringify(patterns)}`);
+  assert.ok(!patterns.includes(literal.slice(0, -1)), 'the ellipsis must not be stripped from an uncapped key');
+});
+
 test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with capped long keys', () => {
   // 40 candidates is `siblings.length >= 40`'s own cap. What proves the fix is
   // that the RENDERED bytes -- the ones `run-reviewer.mjs` actually puts on

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -718,24 +718,29 @@ function longKeyFixture(n) {
   // One file per key so `searchKeys`'s own 12-per-file cap cannot suppress the
   // fixture, and MAX_SEARCH_KEYS (150) is never approached at n <= 40. The raw
   // token is well past MAX_KEY_LENGTH so every key here exercises `capKey`'s
-  // truncation branch; `cappedKey` mirrors that truncation so the grep mock
-  // matches on the SAME key `buildPack` actually searches and renders with.
+  // truncation branch. The sibling source below embeds `rawKey` -- the REAL,
+  // un-truncated identifier, never `…`-marked -- because that is what a real
+  // sibling file contains; a real source file can never contain a literal `…`
+  // marker. `grepOut` mimics `git grep --fixed-strings` itself: a hit only if
+  // the pattern `buildPack` actually passed is a substring of that real source
+  // line. A capped-with-marker search string is therefore NOT a substring and
+  // must produce no hit -- this is what makes the test non-circular: it fails
+  // if `siblingSites` ever again sends the `…`-marked key to grep.
   const files = Array.from({ length: n }, (_, i) => {
     const rawKey = `overlongIdentifierToken${i}` + 'Z'.repeat(4_000);
-    const cappedKey = `${rawKey.slice(0, MAX_KEY_LENGTH - 1)}…`;
     return {
       path: `packages/a/f${i}.ts`,
       patch: `@@ -1,1 +1,2 @@\n-  const ${rawKey} = 1;\n+  const ${rawKey} = 2;\n`,
-      cappedKey,
+      rawKey,
     };
   });
   const grepOut = (args) => {
-    const key = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <key> <ref>`
-    const file = files.find((f) => f.cappedKey === key);
-    return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.cappedKey});` : '';
+    const pattern = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <pattern> <ref>`
+    const file = files.find((f) => `  use(${f.rawKey});`.includes(pattern));
+    return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.rawKey});` : '';
   };
   return buildPack(
-    { headSha: 'a'.repeat(40), files: files.map(({ cappedKey: _k, ...f }) => f) },
+    { headSha: 'a'.repeat(40), files: files.map(({ rawKey: _k, ...f }) => f) },
     { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
   );
 }

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -19,7 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { buildPrompt } from './run-reviewer.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-import { searchKeys, hunkLines, fileEvidence, MAX_WHOLE_FILE_LINES, buildPack, truncateUtf8, BODY_RESERVE_BYTES, MAX_PACK_BYTES, MAX_SEARCH_KEYS, packBudgetFor, MAX_PROMPT_BYTES, retrievalFailed, retrievalFailedMessage, SHALLOW_CHECKOUT_REMEDY, PROMPT_BASE_OVERHEAD_BYTES, promptEnvelopeBytes } from './build-context-pack.mjs';
+import { searchKeys, hunkLines, fileEvidence, MAX_WHOLE_FILE_LINES, buildPack, truncateUtf8, BODY_RESERVE_BYTES, MAX_PACK_BYTES, MAX_SEARCH_KEYS, MAX_KEY_LENGTH, packBudgetFor, MAX_PROMPT_BYTES, retrievalFailed, retrievalFailedMessage, SHALLOW_CHECKOUT_REMEDY, PROMPT_BASE_OVERHEAD_BYTES, promptEnvelopeBytes } from './build-context-pack.mjs';
 import { renderSiblingRow, SIBLING_ROW_JOIN_MARGIN } from './sibling-row.mjs';
 
 test('search keys come from REMOVED lines first, because the sibling still has them', () => {
@@ -57,6 +57,30 @@ test('PROSE MUST NOT EAT THE KEY BUDGET', () => {
 test('markdown yields no keys at all: a changeset is not an implementation', () => {
   const md = ['@@ -1,2 +1,3 @@', "+Both tools now share a materialDisplayName helper."].join('\n');
   assert.deepEqual(searchKeys(md, { path: '.changeset/x.md' }), []);
+});
+
+test('#3732 item 2: an over-length identifier is capped at MAX_KEY_LENGTH with an explicit marker', () => {
+  // The quoted-string branch was already capped at 60 (excluded outright, not
+  // truncated); the identifier branch had no bound, so a base64/hash constant
+  // in a diff became an arbitrarily long key. capKey truncates it instead of
+  // silently dropping it -- the marker makes the cut visible in output.
+  const longToken = 'overlongIdentifierToken' + 'Z'.repeat(4_000);
+  const patch = ['@@ -1,1 +1,2 @@', `-  const ${longToken} = 1;`, `+  const ${longToken} = 2;`].join('\n');
+  const [key] = searchKeys(patch, { path: 'a.ts' });
+  assert.equal(key.length, MAX_KEY_LENGTH, `capped key must be exactly MAX_KEY_LENGTH (${MAX_KEY_LENGTH}) bytes`);
+  assert.ok(key.endsWith('…'), 'a capped key must carry an explicit truncation marker, not cut silently');
+  assert.equal(key.slice(0, -1), longToken.slice(0, MAX_KEY_LENGTH - 1), 'the kept prefix must be a true prefix of the real token');
+});
+
+test('CONTROL: an ordinary identifier is unaffected by the cap', () => {
+  const patch = ['@@ -1,1 +1,2 @@', '-  const missingLanes = 1;', '+  const missingLanes = 2;'].join('\n');
+  const [key] = searchKeys(patch, { path: 'a.ts' });
+  assert.equal(key, 'missingLanes', 'a normal-length key must render unchanged, no marker appended');
+});
+
+test("rank()'s length bonus (Math.min(30, key.length * 2)) already saturates below MAX_KEY_LENGTH, so capping the key cannot reduce anyone's reward and cannot let one grow further", () => {
+  assert.equal(Math.min(30, MAX_KEY_LENGTH * 2), 30, 'a key at the cap must score the same bonus as any longer one would have');
+  assert.equal(Math.min(30, 15 * 2), 30, 'saturation begins at 15 chars, well inside the 60-char cap');
 });
 
 test('a long file is windowed around its hunks, not truncated from the top', () => {
@@ -667,39 +691,22 @@ test('THE OTHER DIRECTION: an inflated envelope must not starve the pack', () =>
  * `buildPack` used to charge a sibling row as `Buffer.byteLength(h.text,
  * 'utf8') + 120` -- a flat overhead that never included `h.key`, even though
  * `run-reviewer.mjs` renders `JSON.stringify(h.key)` into the prompt for every
- * row. `h.key` is unbounded: `searchKeys`'s identifier branch
- * (`/[A-Za-z_$][A-Za-z0-9_$]{4,}/g`) has no upper length bound (only the
- * quoted-string branch is capped, at 60 chars), so a long token -- a base64
- * constant, a minified bundle line -- becomes an arbitrarily long key.
- * `rank()`'s length bonus (`Math.min(30, h.key.length * 2)`) saturates at 30,
- * but a cap on the score a key EARNS is not a cap on the bytes it COSTS once
- * rendered.
+ * row (item 1, fixed via `renderSiblingRow`/`SIBLING_ROW_JOIN_MARGIN`, tested
+ * directly below with a key length no upstream cap constrains). Before item 2
+ * (`capKey`, see the `MAX_KEY_LENGTH` tests further down), `h.key` itself was
+ * also unbounded -- `searchKeys`'s identifier branch had no upper length
+ * bound -- so a long token could ALSO win `rank()`'s length bonus without
+ * being any more distinctive. This fixture now produces the post-cap `h.key`
+ * every real pack does; it demonstrates the charge/budget invariant holds at
+ * that (now bounded) realistic maximum, not the pre-#3732 multi-KB one.
  */
-function longKeyFixture(n) {
-  // One file per key so `searchKeys`'s own 12-per-file cap cannot suppress the
-  // fixture, and MAX_SEARCH_KEYS (150) is never approached at n <= 40.
-  const files = Array.from({ length: n }, (_, i) => {
-    const key = `overlongIdentifierToken${i}` + 'Z'.repeat(4_000);
-    return { path: `packages/a/f${i}.ts`, patch: `@@ -1,1 +1,2 @@\n-  const ${key} = 1;\n+  const ${key} = 2;\n`, key };
-  });
-  const grepOut = (args) => {
-    const key = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <key> <ref>`
-    const file = files.find((f) => f.key === key);
-    return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.key});` : '';
-  };
-  return buildPack(
-    { headSha: 'a'.repeat(40), files: files.map(({ key: _k, ...f }) => f) },
-    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
-  );
-}
-
-test('the undercharge, reproduced: one long key alone outweighs the old flat overhead', () => {
-  const pack = longKeyFixture(1);
-  assert.equal(pack.siblings.length, 1, 'fixture: exactly one candidate site');
-  const h = pack.siblings[0];
+test('the charging formula: renderSiblingRow bytes are what gets charged, at ANY key length', () => {
+  // Bypasses searchKeys/capKey on purpose: item 1's charge/render agreement
+  // must hold independent of whatever length policy the retrieval side
+  // enforces, defense-in-depth against the two ever drifting apart again.
+  const h = { path: 'packages/z/sibling.ts', line: 42, key: 'x'.repeat(5_000), text: '  use(x);' };
   const renderedBytes = Buffer.byteLength(renderSiblingRow(h), 'utf8');
   const oldCharge = Buffer.byteLength(h.text, 'utf8') + 120; // the pre-fix formula, restated here on purpose
-  assert.ok(h.key.length > 4_000, `fixture key is ${h.key.length} bytes, expected > 4,000`);
   assert.ok(
     renderedBytes > oldCharge + 3_000,
     `rendered row is ${renderedBytes} bytes against an old charge of ${oldCharge} -- the key alone was ` +
@@ -707,15 +714,41 @@ test('the undercharge, reproduced: one long key alone outweighs the old flat ove
   );
 });
 
-test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with long keys', () => {
-  // 40 candidates is `siblings.length >= 40`'s own cap, so every one of them
-  // fitting under the OLD formula (h.text is capped at 120 bytes by
-  // `parseGrep`'s `.slice(0, 120)`, so 40 * (120 + 120) = 9,600 bytes -- trivial
-  // against MAX_PACK_BYTES) is expected and proves nothing. What proves the fix
-  // is that the RENDERED bytes -- the ones `run-reviewer.mjs` actually puts on
+function longKeyFixture(n) {
+  // One file per key so `searchKeys`'s own 12-per-file cap cannot suppress the
+  // fixture, and MAX_SEARCH_KEYS (150) is never approached at n <= 40. The raw
+  // token is well past MAX_KEY_LENGTH so every key here exercises `capKey`'s
+  // truncation branch; `cappedKey` mirrors that truncation so the grep mock
+  // matches on the SAME key `buildPack` actually searches and renders with.
+  const files = Array.from({ length: n }, (_, i) => {
+    const rawKey = `overlongIdentifierToken${i}` + 'Z'.repeat(4_000);
+    const cappedKey = `${rawKey.slice(0, MAX_KEY_LENGTH - 1)}…`;
+    return {
+      path: `packages/a/f${i}.ts`,
+      patch: `@@ -1,1 +1,2 @@\n-  const ${rawKey} = 1;\n+  const ${rawKey} = 2;\n`,
+      cappedKey,
+    };
+  });
+  const grepOut = (args) => {
+    const key = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <key> <ref>`
+    const file = files.find((f) => f.cappedKey === key);
+    return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.cappedKey});` : '';
+  };
+  return buildPack(
+    { headSha: 'a'.repeat(40), files: files.map(({ cappedKey: _k, ...f }) => f) },
+    { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
+  );
+}
+
+test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with capped long keys', () => {
+  // 40 candidates is `siblings.length >= 40`'s own cap. What proves the fix is
+  // that the RENDERED bytes -- the ones `run-reviewer.mjs` actually puts on
   // the wire, key included -- stay inside the budget `buildPack` was handed.
   const pack = longKeyFixture(40);
   assert.ok(pack.siblings.length > 0, 'fixture: at least one site retrieved');
+  for (const h of pack.siblings) {
+    assert.ok(h.key.length <= MAX_KEY_LENGTH, `every h.key must be capKey'd, got ${h.key.length} bytes`);
+  }
   const rendered = pack.siblings.map((h) => renderSiblingRow(h)).join('\n\n');
   const renderedBytes = Buffer.byteLength(rendered, 'utf8');
   const availableBudget = packBudgetFor(

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -714,18 +714,18 @@ test('the charging formula: renderSiblingRow bytes are what gets charged, at ANY
   );
 });
 
+// The pre-marker truncation `capKey` must apply before a key is sent to grep
+// (#3732 item 2, `MAX_KEY_LENGTH` = 60). Recomputed here from the PUBLIC
+// constant rather than imported, so the fixture states the contract
+// independently of whatever private formula `capKey` currently uses.
+const withoutMarkerCap = (rawKey) =>
+  rawKey.length <= MAX_KEY_LENGTH ? rawKey : rawKey.slice(0, MAX_KEY_LENGTH - 1);
+
 function longKeyFixture(n) {
   // One file per key so `searchKeys`'s own 12-per-file cap cannot suppress the
   // fixture, and MAX_SEARCH_KEYS (150) is never approached at n <= 40. The raw
   // token is well past MAX_KEY_LENGTH so every key here exercises `capKey`'s
-  // truncation branch. The sibling source below embeds `rawKey` -- the REAL,
-  // un-truncated identifier, never `…`-marked -- because that is what a real
-  // sibling file contains; a real source file can never contain a literal `…`
-  // marker. `grepOut` mimics `git grep --fixed-strings` itself: a hit only if
-  // the pattern `buildPack` actually passed is a substring of that real source
-  // line. A capped-with-marker search string is therefore NOT a substring and
-  // must produce no hit -- this is what makes the test non-circular: it fails
-  // if `siblingSites` ever again sends the `…`-marked key to grep.
+  // truncation branch.
   const files = Array.from({ length: n }, (_, i) => {
     const rawKey = `overlongIdentifierToken${i}` + 'Z'.repeat(4_000);
     return {
@@ -734,22 +734,41 @@ function longKeyFixture(n) {
       rawKey,
     };
   });
+  // BEHAVIOURAL, not textual: this does not read a file and probe its text for
+  // a substring. It asserts the CONTRACT of the pattern `siblingSites` hands to
+  // `git grep` -- the pattern must equal the key with its truncation marker
+  // stripped, exactly (`withoutMarkerCap`), never the marker-appended string
+  // `capKey` displays. Equality against an independently stated expected value
+  // is what makes this non-circular: it fails the moment `siblingSites` sends
+  // the `…`-marked key to grep, exactly the #3732 regression, WITHOUT quoting
+  // or re-deriving `capKey`'s own output as the fixture.
+  const patterns = [];
   const grepOut = (args) => {
     const pattern = args[args.length - 2]; // `git grep -n --fixed-strings --no-color -I -e <pattern> <ref>`
-    const file = files.find((f) => `  use(${f.rawKey});`.includes(pattern));
+    patterns.push(pattern);
+    const file = files.find((f) => pattern === withoutMarkerCap(f.rawKey));
     return file ? `HEAD:packages/z/sibling-${file.path.split('/').pop()}:1:  use(${file.rawKey});` : '';
   };
-  return buildPack(
+  const pack = buildPack(
     { headSha: 'a'.repeat(40), files: files.map(({ rawKey: _k, ...f }) => f) },
     { baseRef: 'HEAD', body: null, exec: (_cmd, args) => (args[0] === 'grep' ? grepOut(args) : '') },
   );
+  return { pack, patterns };
 }
 
 test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with capped long keys', () => {
   // 40 candidates is `siblings.length >= 40`'s own cap. What proves the fix is
   // that the RENDERED bytes -- the ones `run-reviewer.mjs` actually puts on
   // the wire, key included -- stay inside the budget `buildPack` was handed.
-  const pack = longKeyFixture(40);
+  const { pack, patterns } = longKeyFixture(40);
+  assert.equal(patterns.length, 40, 'fixture: every candidate must reach grep');
+  for (const pattern of patterns) {
+    assert.equal(
+      pattern.length,
+      MAX_KEY_LENGTH - 1,
+      `the grep pattern must be the marker-stripped truncation (${MAX_KEY_LENGTH - 1} chars), got ${pattern.length}`,
+    );
+  }
   assert.ok(pack.siblings.length > 0, 'fixture: at least one site retrieved');
   for (const h of pack.siblings) {
     assert.ok(h.key.length <= MAX_KEY_LENGTH, `every h.key must be capKey'd, got ${h.key.length} bytes`);

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -766,8 +766,8 @@ test('a quoted literal that naturally ends in an ellipsis keeps it in the grep p
     { headSha: 'a'.repeat(40), files: [{ path: 'packages/a/f.ts', patch: `@@ -1,1 +1,1 @@\n+  const label = '${literal}';\n` }] },
     { baseRef: 'HEAD', body: null, exec: (_cmd, args) => { if (args[0] === 'grep') patterns.push(args[args.length - 2]); return ''; } },
   );
-  assert.ok(patterns.includes(literal), `the untruncated literal must reach grep intact, got ${JSON.stringify(patterns)}`);
-  assert.ok(!patterns.includes(literal.slice(0, -1)), 'the ellipsis must not be stripped from an uncapped key');
+  assert.ok(patterns.some((p) => p === literal), `the untruncated literal must reach grep intact, got ${JSON.stringify(patterns)}`);
+  assert.ok(patterns.every((p) => p !== literal.slice(0, -1)), 'the ellipsis must not be stripped from an uncapped key');
 });
 
 test('THE FIX: the assembled pack never exceeds the budget it was charged against, even with capped long keys', () => {

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -162,6 +162,7 @@ test('no body means no reservation, so siblings and evidence get the whole pack'
   // description, which would shrink every pack to pay for an absent section.
   const withNone = packUnderPressure(null);
   assert.equal(withNone.body, null);
+  // @source-text-assertion-ok asserts on the pack's own truncation list, a runtime value, not on any file's text
   assert.ok(!withNone.truncated.includes('PR description'));
 });
 

--- a/scripts/review/run-reviewer.mjs
+++ b/scripts/review/run-reviewer.mjs
@@ -73,6 +73,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { isMainEntry } from '../lib/is-main-entry.mjs';
+import { renderSiblingRow } from './sibling-row.mjs';
 
 export class RunReviewerError extends Error {
   constructor(reason, message) {
@@ -171,7 +172,6 @@ export function buildPrompt(rubric, input) {
     input.files.map((f) => `  ${promptSafePath(f.path)}`).join('\n');
 
   // THE CONTEXT PACK, fenced with the diff because it is the same trust class.
-  //
   // Base-tree excerpts are merged, reviewed text and lower risk than the head,
   // but they are fenced identically: the fence costs nothing and a carve-out is
   // a thing to get wrong later. Nothing here was fetched by the model -- the
@@ -190,7 +190,7 @@ export function buildPrompt(rubric, input) {
       '',
       fenceUntrusted(
         pack.siblings
-          .map((s2) => `--- SIBLING: ${s2.path}:${s2.line} (key ${JSON.stringify(s2.key)})\n${s2.text}`)
+          .map((s2) => renderSiblingRow(s2))
           .join('\n\n'),
       ),
     );

--- a/scripts/review/sibling-row.mjs
+++ b/scripts/review/sibling-row.mjs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * THE SINGLE TEMPLATE for a rendered sibling row -- charged against the budget
+ * in `build-context-pack.mjs`'s `buildPack` and rendered into the prompt in
+ * `run-reviewer.mjs`'s `buildPrompt`. #3732: those two used to recompute the
+ * same template independently, and the charge was `Buffer.byteLength(h.text,
+ * 'utf8') + 120` -- `h.key` never entered it, even though the render puts
+ * `JSON.stringify(h.key)` on the wire. `h.key` is unbounded: `searchKeys`'s
+ * identifier branch (`/[A-Za-z_$][A-Za-z0-9_$]{4,}/g`) has no upper length
+ * bound (only the quoted-string branch is capped, at 60 chars), so a long
+ * token -- a base64 constant, a minified bundle line -- could become an
+ * arbitrarily long key. `rank()`'s length bonus (`Math.min(30, h.key.length *
+ * 2)`) saturates at 30, but a cap on the SCORE a key earns is not a cap on the
+ * BYTES it costs once rendered, so the pack could emit more than it had
+ * charged itself for.
+ *
+ * One function, imported by both the charge and the render, makes that
+ * divergence structurally impossible rather than merely fixed once: whatever
+ * this returns is exactly what both sides agree the row costs.
+ */
+export function renderSiblingRow(h) {
+  return `--- SIBLING: ${h.path}:${h.line} (key ${JSON.stringify(h.key)})\n${h.text}`;
+}
+
+/**
+ * Bytes the `\n\n` join between sibling rows adds beyond what
+ * `renderSiblingRow` itself returns. Charged once per row -- so the very last
+ * row (which the join never follows) is overcharged by 2 bytes -- rather than
+ * once for the whole section, keeping this a simple per-item loop like every
+ * other charge in `buildPack`.
+ */
+export const SIBLING_ROW_JOIN_MARGIN = 2;


### PR DESCRIPTION
## Summary

`buildPack` (`scripts/review/build-context-pack.mjs`) charged a retrieved sibling row as `Buffer.byteLength(h.text, 'utf8') + 120` — a flat overhead that never included `h.key`, even though `run-reviewer.mjs` renders `JSON.stringify(h.key)` into the prompt for every row. `h.key` is unbounded: `searchKeys`'s identifier branch (`/[A-Za-z_$][A-Za-z0-9_$]{4,}/g`) has no upper length bound (only the quoted-string branch is capped, at 60 chars), so a long token — a base64 constant, a minified bundle line — becomes an arbitrarily long key. `rank()`'s length bonus (`Math.min(30, h.key.length * 2)`) saturates at 30, but a cap on the *score* a key earns is not a cap on the *bytes* it costs once rendered, so the pack could emit more than it had charged itself for.

This is internal tooling — the review lane that gates every PR in this repo — so there is **no end-user impact**.

## Fix

- Extracted the row's rendering into a new `scripts/review/sibling-row.mjs`, imported by both `build-context-pack.mjs` (to charge) and `run-reviewer.mjs` (to render), so the charge and the render can no longer independently recompute the same template and drift apart — the "two paths that must agree" shape.
- The charge is now `Buffer.byteLength(renderSiblingRow(h), 'utf8') + SIBLING_ROW_JOIN_MARGIN` (2 bytes, for the `\n\n` join), i.e. the row's true rendered size, key included.
- Chose to charge the true rendered length rather than cap `h.key` itself: bounding the key would change reviewer-visible output (a shorter key context for large tokens); charging correctly does not change what the reviewer sees, only what the budget accounts for.

## Update — item 2, added on this branch

Re-reading #3732 against the reasoning above: the issue's own item 2 is filed by the maintainer, in his own words -- "Cap `searchKeys` key length, and stop `rank()` rewarding unbounded key length. A key long enough to matter here is not a better key." -- and is scoped into the same PR alongside item 1 ("small, mechanical, and pair naturally... in the same PR"). The objection above (capping changes reviewer-visible output) is true but does not survive that: item 1 alone still lets ONE pathologically long key (a duplicated base64/hash constant) consume the render budget that would otherwise hold several genuinely useful siblings, even though it is correctly charged; and the maintainer's own framing says such a key was never a *better* one to begin with, so truncating it is not a loss.

Added `capKey(t)` in `build-context-pack.mjs`: a key over `MAX_KEY_LENGTH` (60, matching the quoted-string branch's own existing cap) is truncated to 59 chars plus an explicit `…` marker -- visible in output, not a silent cut. The kept prefix is still a true prefix of the real token, so `siblingSites`'s fixed-string grep still matches it wherever it recurs in the base tree. `rank()`'s length bonus (`Math.min(30, key.length * 2)`) already saturates at 15 chars, well below the 60-char cap, so capping cannot reduce any existing key's reward and cannot let one grow further -- pinned by a direct arithmetic test rather than left as an unverified claim.

The two existing long-key tests built their expected key straight from `searchKeys`'s (now-capped) output; their grep mock matched on the pre-cap raw key and so found zero hits post-cap, breaking both. Fixed the fixture to match on the capped key, and added a standalone charging-formula test that bypasses `searchKeys`/`capKey` entirely (a synthetic 5,000-char key straight into `renderSiblingRow`), so item 1's charge/render invariant keeps independent, dramatic-magnitude coverage rather than relying on whatever length policy item 2 now enforces upstream.

Both `scripts/review/build-context-pack.mjs` and `scripts/review/run-reviewer.mjs` are pinned at their exact current line count in `scripts/module-size-allowlist.txt` (0 headroom); item 1's fix stayed within it via the extraction to a new module, and item 2's `capKey` addition stayed within it by condensing three existing comment blocks by the same number of lines it added. Neither file's line count changed from what was already pinned.

## Sibling check

Looked for other row renderers in this module with the same "charge doesn't match render" shape. `promptEnvelopeBytes` already charges the file-row, roster-row, and unreviewable-row variable parts (path/reason) as their own bytes — that class of bug was already fixed there. The sibling row (this fix) was the one holdout. `fileEvidence`'s `FILE_ENTRY_OVERHEAD` (flat 80, doesn't charge `path` separately either) has a structurally similar gap, but paths are bounded by realistic filesystem lengths rather than the genuinely unbounded regex-extracted identifier that made the sibling key exploitable — left as-is, out of scope for this PR.

Confirmed #3688 (referenced in #3732, described there in the past tense as having unified renderers) is still **open, not merged**, and its diff doesn't touch this sibling-charging code — no collision.

## Test plan

- [x] `node --test scripts/review/*.test.mjs` — 261 pass (was 251 before this PR's tests; 258 after item 1, 261 after item 2)
- [x] New tests in `build-context-pack.test.mjs`, item 1:
  - the charging formula: `renderSiblingRow` bytes are what gets charged, at ANY key length (a synthetic 5,000-char key, bypassing `searchKeys`/`capKey`)
  - THE FIX: an assembled pack of 40 capped-long-key siblings stays within its charged budget
  - control: an ordinary short key's charge does not increase
  - a normal sibling still renders identical content
- [x] New tests, item 2:
  - an over-length identifier is capped at `MAX_KEY_LENGTH` with an explicit `…` marker, and the kept prefix is a true prefix of the real token
  - control: an ordinary identifier is unaffected by the cap
  - `rank()`'s length-bonus saturation point (15 chars) sits below `MAX_KEY_LENGTH` (60), so capping cannot change any key's reward
- [x] Verified RED/GREEN by reverting `build-context-pack.mjs` alone (`git stash`): the test file fails to import (`MAX_KEY_LENGTH`/`capKey` undefined); restored and confirmed all 261 tests pass and `git diff --stat` is clean afterward
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over 400 (`sibling-row.mjs` is 35 lines; `build-context-pack.mjs` held at its pinned 661-line budget by condensing three comment blocks to make room for `capKey`)
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `pnpm run check:vitest-timeout-audit` — unaffected (no `.test.ts`/`.test.tsx` files touched)

Closes #3732


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-pack size accounting so sibling entries accurately reflect their rendered content.
  * Limited extracted search keys to 60 characters, adding a truncation marker when needed.
  * Ensured context-pack budgets consistently account for PR descriptions, files, envelopes, and sibling entries.
  * Improved consistency between displayed sibling context and its budget calculations.

* **Tests**
  * Added coverage for key truncation and accurate sibling-entry budget calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->