### PR TITLE
fix(lists): an unknown World Coordinate axis reports the X value instead of nothing

### DIFF
--- a/.changeset/lists-unknown-world-axis-null.md
+++ b/.changeset/lists-unknown-world-axis-null.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/lists': patch
+---
+
+A World Coordinate column whose axis is not `X`, `Y` or `Z` now resolves to an empty cell instead of silently reporting the X coordinate.
+
+`getWorldCoordinateValue` matched the axis with `case 'X': default: return pos.x;`, so the explicit `X` case and the fallback shared a body. Any other axis — a hand-edited saved list definition, a definition written by a build that knows an axis this one does not — got the X coordinate under a header saying something else. A blank cell is a visible gap; a plausible number under the wrong label is a wrong answer that reads as a right one, and nothing downstream can tell the two apart.
+
+Blank or whitespace-only still means `X`, which is the documented default for a column created without an axis. Whitespace-only is treated as absent rather than as an unknown axis, matching how a blank name is handled elsewhere.
+
+No existing column changes: the Lists builder offers only `X`, `Y` and `Z` (`ListBuilder.tsx`), so no axis a user can pick today is affected. The change protects persisted definitions and forward compatibility.

--- a/.changeset/lists-unknown-world-axis-null.md
+++ b/.changeset/lists-unknown-world-axis-null.md
@@ -6,6 +6,8 @@ A World Coordinate column whose axis is not `X`, `Y` or `Z` now resolves to an e
 
 `getWorldCoordinateValue` matched the axis with `case 'X': default: return pos.x;`, so the explicit `X` case and the fallback shared a body. Any other axis — a hand-edited saved list definition, a definition written by a build that knows an axis this one does not — got the X coordinate under a header saying something else. A blank cell is a visible gap; a plausible number under the wrong label is a wrong answer that reads as a right one, and nothing downstream can tell the two apart.
 
-Blank or whitespace-only still means `X`, which is the documented default for a column created without an axis. Whitespace-only is treated as absent rather than as an unknown axis, matching how a blank name is handled elsewhere.
+Blank or whitespace-only still means `X`, which is the documented default for a column created without an axis. ("Whitespace" is JavaScript's `trim()` definition, so a zero-width space is an unknown axis rather than a blank one — a distinction with no known producer, noted rather than coded around.)
+
+The same resolver backs geometry **conditions**, so this narrows the filter too: a condition on an unknown axis now matches no rows, `exists` included. That is reachable only from a hand-edited or imported definition — the Lists builder constructs geometry columns and never geometry conditions — but it is a behaviour change and is now pinned by a test rather than inherited.
 
 No existing column changes: the Lists builder offers only `X`, `Y` and `Z` (`ListBuilder.tsx`), so no axis a user can pick today is affected. The change protects persisted definitions and forward compatibility.

--- a/packages/lists/src/engine.geometry.test.ts
+++ b/packages/lists/src/engine.geometry.test.ts
@@ -53,6 +53,24 @@ describe('geometry (World Coordinate) column/condition (#3671)', () => {
     expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(100.5);
   });
 
+  it('an axis that is not X/Y/Z resolves to null, not to X (#3734)', () => {
+    // `case 'X'` and `default` used to share a body, so a column whose axis is
+    // anything else reported the X coordinate under a header saying something
+    // else. A blank cell is a visible gap; a plausible number under the wrong
+    // label is a wrong answer that reads as a right one.
+    const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'Q' }]), createProvider(positions));
+    expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBeNull();
+  });
+
+  it('a blank axis still means X, which is the documented default (#3734)', () => {
+    // The narrowing above must not swallow the default. Whitespace-only counts
+    // as absent, matching how a blank name is treated elsewhere in the repo.
+    for (const axis of ['', '  ', 'x']) {
+      const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: axis }]), createProvider(positions));
+      expect(result.rows.find(r => r.entityId === 1)!.values[0], `axis ${JSON.stringify(axis)}`).toBe(100.5);
+    }
+  });
+
   it('resolves the Y axis', () => {
     const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: 'Y' }]), createProvider(positions));
     expect(result.rows.find(r => r.entityId === 1)!.values[0]).toBe(-25.25);

--- a/packages/lists/src/engine.geometry.test.ts
+++ b/packages/lists/src/engine.geometry.test.ts
@@ -65,10 +65,37 @@ describe('geometry (World Coordinate) column/condition (#3671)', () => {
   it('a blank axis still means X, which is the documented default (#3734)', () => {
     // The narrowing above must not swallow the default. Whitespace-only counts
     // as absent, matching how a blank name is treated elsewhere in the repo.
-    for (const axis of ['', '  ', 'x']) {
+    for (const axis of ['', '  ', '\t']) {
       const result = executeList(walls([{ id: 'g', source: 'geometry', propertyName: axis }]), createProvider(positions));
       expect(result.rows.find(r => r.entityId === 1)!.values[0], `axis ${JSON.stringify(axis)}`).toBe(100.5);
     }
+  });
+
+  it('an unknown-axis CONDITION matches nothing, including exists (#3734)', () => {
+    // The same resolver backs conditions, so narrowing the cell narrows the
+    // filter too. `exists` is the one worth pinning: it now answers "no element
+    // has a world position" for a bad axis, which is chosen behaviour, not
+    // inherited. The builder cannot construct a geometry condition at all, so
+    // this is reachable only from a hand-edited or imported definition.
+    const unknown = (operator: 'exists' | 'equals', value?: number) =>
+      executeList(
+        walls([{ id: 'g', source: 'geometry', propertyName: 'X' }], [
+          { id: 'c', source: 'geometry', propertyName: 'Q', operator, value } as never,
+        ]),
+        createProvider(positions),
+      ).rows.length;
+    expect(unknown('exists')).toBe(0);
+    expect(unknown('equals', 100.5)).toBe(0);
+
+    // A known axis still filters, so the zero above is the axis and not a
+    // condition path that stopped working.
+    const known = executeList(
+      walls([{ id: 'g', source: 'geometry', propertyName: 'X' }], [
+        { id: 'c', source: 'geometry', propertyName: 'X', operator: 'equals', value: 100.5 } as never,
+      ]),
+      createProvider(positions),
+    );
+    expect(known.rows.length).toBe(1);
   });
 
   it('resolves the Y axis', () => {

--- a/packages/lists/src/geometry-column.ts
+++ b/packages/lists/src/geometry-column.ts
@@ -18,7 +18,16 @@ import type { CellValue, ListDataProvider } from './types.js';
 const WORLD_COORDINATE_QUANTITY_TYPE = QuantityType.Length;
 
 /** Resolve a `geometry` column/condition to one axis of the element's World
- *  Coordinate. `axis` is matched case-insensitively (`X` default). */
+ *  Coordinate. `axis` is matched case-insensitively; absent or blank means X.
+ *
+ *  AN AXIS THAT IS NOT X/Y/Z RESOLVES TO NULL, NOT TO X (#3734). It used to
+ *  share the `default` arm with `case 'X'`, so a column whose axis was `Q` --
+ *  a hand-edited saved list, a definition from a schema that grew an axis this
+ *  build does not know -- reported the X coordinate under a header saying
+ *  something else. An empty cell is a visible gap; a plausible number under
+ *  the wrong label is a wrong answer that reads as a right one, and nothing
+ *  downstream can tell them apart. Blank still means X, which is the
+ *  documented default for a column created without an axis. */
 export function getWorldCoordinateValue(
   entityId: number,
   axis: string,
@@ -26,11 +35,12 @@ export function getWorldCoordinateValue(
 ): CellValue {
   const pos = provider.getWorldPosition?.(entityId);
   if (!pos) return null;
-  switch (axis.toUpperCase()) {
+  switch (axis.trim().toUpperCase()) {
     case 'Y': return pos.y;
     case 'Z': return pos.z;
     case 'X':
-    default: return pos.x;
+    case '': return pos.x;
+    default: return null;
   }
 }
 

--- a/packages/lists/src/geometry-column.ts
+++ b/packages/lists/src/geometry-column.ts
@@ -27,7 +27,16 @@ const WORLD_COORDINATE_QUANTITY_TYPE = QuantityType.Length;
  *  something else. An empty cell is a visible gap; a plausible number under
  *  the wrong label is a wrong answer that reads as a right one, and nothing
  *  downstream can tell them apart. Blank still means X, which is the
- *  documented default for a column created without an axis. */
+ *  documented default for a column created without an axis.
+ *
+ *  A DELIBERATE ASYMMETRY WITH THE SIBLING SOURCES, named so it is not read as
+ *  an oversight: `getStoreyName` and the zone resolver in `engine.ts` keep the
+ *  shared `case X: default:` shape and substitute their default for an
+ *  unrecognised selector, which their own doc blocks call intentional. The
+ *  difference is what a wrong answer costs. A storey name under a mislabelled
+ *  header is visibly a name; an X coordinate under a `Q` header is a number
+ *  that looks exactly as right as the correct one. Whether the siblings should
+ *  follow is a separate question and is noted on #3734. */
 export function getWorldCoordinateValue(
   entityId: number,
   axis: string,


### PR DESCRIPTION
Part of #3734. **This does not close that issue** — see the scope note at the end.

`getWorldCoordinateValue` matched its axis as:

```ts
case 'X':
default: return pos.x;
```

`case 'X'` and the fallback share a body, so **every** other axis resolved to the X coordinate. A column whose axis is `Q` rendered the X value under a header saying `Q`. That is the failure mode this repo keeps paying for: a plausible number under the wrong label reads as a right answer, and nothing downstream can tell it from one. An empty cell cannot be mistaken for anything.

Unknown axes now return `null`. Blank and whitespace-only still mean `X`, the documented default for a column created without an axis.

## Blast radius: none today

`ListBuilder.tsx:144` generates the World columns from `['X','Y','Z']`, so no axis a user can select reaches the new branch. A repo-wide walk over json/ts/tsx/md/mjs/yaml finds exactly two `source: 'geometry'` occurrences — that line and the test file. No fixture, preset, template or tour datum carries one; the SDK's list namespace cannot emit `geometry` at all; nothing in `packages/mcp`, `packages/cli` or `packages/embed` imports `@ifc-lite/lists`. The reachable producers are `importListDefinition` (which validates four top-level keys and nothing per column) and raw localStorage — which are exactly the inputs this protects.

## Mutation-checked in both directions

Narrowing a fallback is how a default gets swallowed by accident, so both directions are pinned:

- restore `default: return pos.x` → the unknown-axis test fails, **alone**
- drop the `case '':` arm → both default-axis tests fail, including the pre-existing "resolves the X axis by default"

## The condition path changes too, and that is now chosen rather than inherited

The same resolver backs geometry *conditions*. Measured old vs new for `propertyName: 'Q'`:

| operator | old rows | new rows |
|---|---|---|
| `exists` | [1,2,3] | [] |
| `equals 100.5` | [1] | [] |
| `notEquals 100.5` | [2,3] | [] |

`exists` is the one worth naming: it now answers "no element has a world position" for what is really a bad axis. Still the right answer — a filter on a meaningless axis should select nothing — but it is a behaviour change, so it has a test and a line in the changeset instead of arriving silently. Reachable only from a hand-edited or imported definition; the builder constructs geometry columns and never geometry conditions.

## A deliberate asymmetry, named in the code

`getStoreyName` and the zone resolver keep the same `case X: default:` shape and substitute their default for an unrecognised selector — their doc blocks call that intentional. Rather than leave the package holding two unexplained policies, the reason is written where the difference lives: a storey name under a mislabelled header is visibly a name; an X coordinate under a `Q` header is a number that looks exactly as right as the correct one. Whether the siblings should follow is noted on #3734 rather than widened into this diff.

## Scope

#3734 has five items. The other four are not here, deliberately:

- Its lists item (the cannot-fail default-axis test) was **already fixed on main** by #3739.
- Its parser items 2, 3 and 4 are already implemented in open PRs #3699 and #3695 — those add the `/* was $ */` discriminating fixture, the unterminated-comment case, and the `'rev /* pending */ note'` precedence fixture the issue asks for.
- Its item 1 (stale prose in `rust/core/src/parser/scanner.rs`) lands in a file both of those PRs are rewriting, so a comment-only fix from here would conflict with two open PRs.

`pnpm test --filter @ifc-lite/lists`: 10 files, 247/247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZNiLBzRCkZqWBJNsjDts6