### PR TITLE
test(parser): close two step-comment-trivia gaps flagged in #3734

### DIFF
--- a/packages/parser/test/step-comment-trivia.test.ts
+++ b/packages/parser/test/step-comment-trivia.test.ts
@@ -130,8 +130,19 @@ describe.each(scanners)('$name: a comment is trivia inside a record too', ({ run
 
     // Composition, direction one: a comment opener inside a string literal is
     // ordinary text. Skipping the literal first is what keeps it that way.
+    //
+    // The fixture is deliberately a *complete* `/* ... */` with no closing `*/`
+    // anywhere else in the record: `'rev /* pending note'` never closes the
+    // comment it would open under the wrong precedence. A scanner that checked
+    // for a comment opener before finishing the string literal would treat the
+    // record as carrying an unterminated comment and refuse it (the same
+    // "no record" answer the unterminated-comment case above gives), so this
+    // fixture fails loudly under the wrong precedence instead of happening to
+    // still parse. A record that closes its `/*` before the string's closing
+    // quote (e.g. `'rev /* pending */ note'`) would parse under either
+    // precedence and so would not tell the two apart.
     it('treats a comment opener inside a string literal as literal text', () => {
-        const record = "#4=IFCWALL('rev /* pending */ note',$);";
+        const record = "#4=IFCWALL('rev /* pending note',$);";
         expect(run(file(record))).toEqual([
             { expressId: 4, type: 'IFCWALL', text: spanOf(record, closer) },
         ]);
@@ -168,6 +179,18 @@ describe.each(scanners)('$name: a comment is trivia inside a record too', ({ run
     it('still ignores a record that is entirely inside a comment', () => {
         const records = run(file("/* #9=IFCWALL('x',$); */", "#10=IFCSLAB('b',$);"));
         expect(records.map((r) => r.expressId)).toEqual([10]);
+    });
+
+    // An unterminated comment leaves the record with no terminator, so the
+    // record is refused and the scan ends -- the same answer Rust's
+    // EntityScanner gives on the same input (scanner_tests.rs,
+    // unterminated_comment_inside_a_record_ends_the_scan). Inventing an end
+    // (e.g. treating end-of-buffer as a silent close) would let the scan carry
+    // on past a truncated record and either yield a wrong span for it or
+    // resynchronize on whatever bytes happen to follow.
+    it('an unterminated comment inside a record ends the scan', () => {
+        const records = run(file("#20=IFCWALL('a', /* never closes $);"));
+        expect(records).toEqual([]);
     });
 
     it('parses a comment-free file identically', () => {

--- a/packages/parser/test/step-comment-trivia.test.ts
+++ b/packages/parser/test/step-comment-trivia.test.ts
@@ -131,8 +131,8 @@ describe.each(scanners)('$name: a comment is trivia inside a record too', ({ run
     // Composition, direction one: a comment opener inside a string literal is
     // ordinary text. Skipping the literal first is what keeps it that way.
     //
-    // The fixture is deliberately a *complete* `/* ... */` with no closing `*/`
-    // anywhere else in the record: `'rev /* pending note'` never closes the
+    // The fixture deliberately carries an *unterminated* `/*` opener with no
+    // closing `*/` anywhere in the record: `'rev /* pending note'` never closes the
     // comment it would open under the wrong precedence. A scanner that checked
     // for a comment opener before finishing the string literal would treat the
     // record as carrying an unterminated comment and refuse it (the same

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -128,10 +128,10 @@ impl<'a> EntityScanner<'a> {
         // matched TypeScript half is `skipTrivia` in
         // `packages/parser/src/step-lexing.ts`; change the two together.
         //
-        // Both checks together keep `next_entity` aligned with
-        // `build_entity_index` which is comment-blind today; if a stray
-        // comment-bound entity slips past the scanner, the index also
-        // ignores it, so the entity decoder + scanner stay consistent.
+        // Both checks together are what `build_entity_index` (`decoder.rs`)
+        // relies on for its own comment-awareness: it is a bare loop over
+        // `next_entity`, not a separate scan, so it inherits this method's
+        // comment handling directly rather than needing to duplicate it.
         let bytes = self.bytes;
         let len = bytes.len();
         // Outer loop so a record this scanner refuses (an oversized

--- a/rust/core/src/parser/scanner_tests.rs
+++ b/rust/core/src/parser/scanner_tests.rs
@@ -371,6 +371,20 @@ fn has_non_null_attribute_dollar_inside_a_comment_is_comment_text() {
     assert!(scanner.has_non_null_attribute(0, content.len(), 0));
 }
 
+/// Discriminating sibling of the fixture above (#3734): the real attribute 0
+/// here IS `$`, so a scanner that failed to skip the comment and read its
+/// literal `$` as the attribute value would answer `true`. Both fixtures
+/// exercise a comment ahead of attribute 0 with a `$` inside it, but only
+/// this one is false if the comment is not skipped, so the pair together
+/// catches both a scanner that ignores comments and one that reads their
+/// content.
+#[test]
+fn has_non_null_attribute_dollar_inside_a_comment_before_a_real_null_attribute() {
+    let content = "#1=IFCWALL(/* was $ */ $);";
+    let scanner = EntityScanner::new(content);
+    assert!(!scanner.has_non_null_attribute(0, content.len(), 0));
+}
+
 #[test]
 fn has_non_null_attribute_comment_free_records_unchanged() {
     let content = "#1=IFCWALL('a',$,5);";


### PR DESCRIPTION
Closes #3734 ("Follow-ups from the 2026-09-02 merge train"). Originally addressed two of the five items; now folds in the remaining Rust items (1 and 2) so the PR covers the whole issue. Item 5 and its sub-item are already merged separately (#3739, #3746).

## What this fixes

### TS parser (`packages/parser/test/step-comment-trivia.test.ts`)

Both are test-quality gaps behind already-correct shipped behaviour -- no user-visible defect, no production code changed.

1. **Missing unterminated-comment case.** Rust's scanner has `unterminated_comment_inside_a_record_ends_the_scan` (`rust/core/src/parser/scanner_tests.rs`); the TS side had no equivalent. Added `an unterminated comment inside a record ends the scan`, run across all three TS scanners (`scanEntities`, `scanEntitiesFast`, the inline worker).

2. **Non-discriminating string-literal fixture.** `treats a comment opener inside a string literal as literal text` used `'rev /* pending */ note'` -- a *complete* `/* ... */` inside the literal. That parses identically whether or not the scanner gets literal-vs-comment precedence right, so it could never have caught a regression. Replaced with `'rev /* pending note'` (an unterminated `/*`, no closing `*/` anywhere else in the record): under the wrong precedence the record gets refused as carrying an unterminated comment; it only parses when the string literal is skipped as a whole first.

### Rust scanner (`rust/core/src/parser/scanner.rs`, `scanner_tests.rs`)

3. **Stale doc-comment prose.** `EntityScanner::next_entity`'s doc comment claimed `build_entity_index` is "comment-blind today". It is not: `build_entity_index` (`decoder.rs`) is a bare loop over `next_entity`, so it inherits that method's comment-awareness directly rather than duplicating (or missing) it. Corrected the prose.

4. **Non-discriminating `$`-in-comment test.** `has_non_null_attribute_dollar_inside_a_comment_is_comment_text` cannot fail against the regression it names -- it is true whether or not the comment is skipped. Added a discriminating sibling, `has_non_null_attribute_dollar_inside_a_comment_before_a_real_null_attribute`, where the real attribute IS `$`, so a scanner that reads the comment's literal `$` instead of skipping it answers `true` instead of `false`.

## Proof each now discriminates

For the TS items, I temporarily injected the corresponding bug into `tokenizer.ts`, confirmed the test failed, then reverted (verified `tokenizer.ts` is unchanged in the diff -- only the test file is touched):

- Dropped the `!inString` guard on the fast scanner's comment-open check (so it treats an in-string `/*` as a real comment opener). The new string-literal test failed as expected. I then also swapped in the *old* complete-comment fixture against the same injected bug and confirmed it kept passing -- concrete evidence the old fixture was non-discriminating.
- Changed the unterminated-comment handling to silently skip past the `/*` opener as ordinary text instead of refusing the record. The new unterminated-comment test failed as expected (it found a spurious record instead of `[]`).

For the Rust `$`-in-comment sibling: changed `has_non_null_attribute`'s trivia-skip to read `content[pos]` directly instead of calling `skip_step_trivia`. The new test (`has_non_null_attribute_dollar_inside_a_comment_before_a_real_null_attribute`) failed as expected, while the pre-existing `has_non_null_attribute_dollar_inside_a_comment_is_comment_text` stayed green -- confirming the new fixture catches what the old one could not. Reverted afterward.

## Testing

- `pnpm vitest run` in `packages/parser`: 90/90+ test files passing (`test/step-comment-trivia.test.ts`: 30/30).
- `tsc --noEmit` in `packages/parser`: clean.
- `cargo test -p ifc-lite-core --lib parser::scanner`: 25/25 passing.
- `node scripts/check-module-size.mjs`: OK, 0 new files over 400 lines.
- `node scripts/check-test-wiring.mjs`: OK.
- `pnpm run check:vitest-timeout-audit`: 0 config-unknown.

No changeset: test-only change, matching the precedent of the other recent test-only PR (#3702), which also carried none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing behavior for records containing unterminated comments within string literals.
  * Such malformed input is now rejected consistently, with no records produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
