### PR TITLE
fix(gates): check-module-size --update settles its own row before writing it

### DIFF
--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -107,6 +107,17 @@
  * that shows up in the shell history and still costs a reviewable line in the
  * digest pin. `check-unused-locals.mjs --update` has no such safeguard.
  *
+ * `--update` MEASURES THIS FILE AND REWRITES IT IN THE SAME RUN, so its own row
+ * is a fixed point rather than a measurement (`lib/module-size-self-pin.mjs`).
+ * The ALLOWLIST_DIGESTS block below is one line per scope, so a sweep that adds
+ * or removes a scope changes this file's length AFTER its row would have been
+ * written. It used to write the pre-rewrite count, report success and exit 0;
+ * the next plain run measured the real file and failed, on the one gate whose
+ * job is to stop exactly that (#3727, #3693). Two consequences to expect: a
+ * sweep that adds a scope prints a RAISED line for this file, which is honest
+ * rather than the tool exempting itself, and it needs `--allow-raise` like any
+ * other raise -- which the new scope's own row needed anyway.
+ *
  * `--update` IS SCOPED to the files your change touched (#3398), derived from
  * `git diff` against the merge base with main plus anything untracked. It used
  * to re-record every row in the tree, which sounds harmless — it only ever
@@ -142,9 +153,9 @@ import {
   allowlistDigests,
   evaluate,
   staleRows,
-  planUpdate,
   renderAllowlist,
 } from './lib/module-size-ratchet.mjs';
+import { readSelfPin, renderPinBlock, settleUpdate } from './lib/module-size-self-pin.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPTS_DIR, '..');
@@ -186,6 +197,14 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts|mjs|cjs)$/;
  * by 100 leaves the total unchanged. A scope's digest moves for ANY change to
  * ANY of its rows, so loosening the ratchet always costs one reviewable line
  * here.
+ *
+ * HERE is not the only non-circular home, and the third one is on the record
+ * rather than chosen: an unmeasured sidecar (`SOURCE_RE` matches only TS and
+ * Node sources, so a `.json` beside this file is walked past) would keep the
+ * anti-circularity and the reviewable line while dissolving the self-reference
+ * that `lib/module-size-self-pin.mjs` exists to settle. It is not free -- it
+ * retargets the regeneration contract and every message naming this file -- so
+ * it is a follow-up, not a fix smuggled into one.
  *
  * SHARDED BY SCOPE, one entry per `packages/<name>` / `apps/<name>` /
  * `rust/<crate>` (#3291). A single repo-wide digest had the same visibility but
@@ -252,7 +271,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/source-dalux': '11927553717016520308',
   'packages/source-dropbox': '13897585807232807340',
   'packages/viewer': '17290688824834287099',
-  'scripts': '10576945509463692918',
+  'scripts': '15076856583646664407',
 };
 
 function parseArgs(argv) {
@@ -509,7 +528,17 @@ if (args.update) {
   }
   console.log(scopeNote);
 
-  const { next, raised, added, lowered, removed } = planUpdate(files, allowlist, changed);
+  // This script IS one of the measured files, and the digest block it is about
+  // to rewrite sits inside it, so the rows and its own size determine each
+  // other. Settle that loop before writing anything (lib/module-size-self-pin.mjs).
+  const self = readSelfPin(args.root);
+  let settled;
+  try {
+    settled = settleUpdate({ files, allowlist, changed, self });
+  } catch (err) {
+    fail(`${err.message}\n\nNothing was written.`);
+  }
+  const { next, raised, added, lowered, removed } = settled.plan;
 
   const loosening = [...raised, ...added];
   if (loosening.length > 0 && !args.allowRaise) {
@@ -541,29 +570,24 @@ if (args.update) {
   // The pin lives in this script, not in the allowlist (see ALLOWLIST_DIGESTS):
   // a digest stored beside the rows it guards is circular. Rewrite it here so
   // the regeneration is one command, not one command plus a hand edit that the
-  // next reader has to remember.
-  const nextDigests = allowlistDigests(next);
-  const nextBlock = `const ALLOWLIST_DIGESTS = {\n${[...nextDigests]
-    .map(([scope, d]) => `  '${scope}': '${d}',`)
-    .join('\n')}\n};`;
+  // next reader has to remember. `settled.selfText` is the exact content the
+  // rows above were planned against, so the two cannot disagree.
+  const nextDigests = settled.digests;
   const nextDigest = [...nextDigests].map(([s2, d]) => `${s2}=${d}`).join(' ');
-  const selfPath = join(args.root, 'scripts', 'check-module-size.mjs');
-  const PIN_RE = /^const ALLOWLIST_DIGESTS = \{[\s\S]*?^\};$/m;
-  let pinned = false;
-  try {
-    const selfText = readFileSync(selfPath, 'utf8');
-    if (PIN_RE.test(selfText)) {
-      // A replacer FUNCTION, not a string: `$&` and friends are substitution
-      // patterns in a string replacement, so a scope containing `$&` would
-      // splice the matched block back into itself. Needs a directory named
-      // with `$&`, so it is unlikely rather than impossible -- and free to rule
-      // out. (The old code passed a pure-digit string, which had no such hazard.)
-      writeFileSync(selfPath, selfText.replace(PIN_RE, () => nextBlock));
-      pinned = true;
+  const pinned = settled.selfText !== null;
+  if (pinned) {
+    try {
+      writeFileSync(self.path, settled.selfText);
+    } catch (err) {
+      // The allowlist is already on disk and was written for the file this
+      // write was meant to produce. Saying so is the whole point: a swallowed
+      // failure here leaves exactly the mismatch #3727 is about.
+      fail(
+        `wrote ${args.allowlist} but could not re-pin ${self.path}: ${err.message}\n\n` +
+          `The allowlist now describes a digest block that was never written. Set it by hand ` +
+          `to:\n\n${renderPinBlock(nextDigests)}`,
+      );
     }
-  } catch {
-    // --root points at a synthetic tree (the test harness does exactly this),
-    // so there is no pin to move. Print the value instead of pretending.
   }
 
   for (const row of lowered) console.log(`lowered:${row}`);
@@ -576,7 +600,7 @@ if (args.update) {
   );
   console.log(
     pinned
-      ? `check-module-size: ALLOWLIST_DIGESTS re-pinned in ${selfPath} (${nextDigests.size} scopes). Commit both.`
+      ? `check-module-size: ALLOWLIST_DIGESTS re-pinned in ${self.path} (${nextDigests.size} scopes). Commit both.`
       : `check-module-size: no ALLOWLIST_DIGESTS pin found under ${args.root}; the new digests are ${nextDigest}.`,
   );
 
@@ -586,7 +610,12 @@ if (args.update) {
   // success for a run that fixed nothing the contributor was failing on. The
   // docstring admitted this in prose and the code did not act on it, which is
   // the same shape as the header claim this whole issue is about.
-  const after = evaluate(files, next);
+  //
+  // `settled.files` carries the count of the exact text written above, so it IS
+  // the tree on disk and a second walk would re-derive the same answer. The
+  // measurement this run STARTED from would not: that is how the check could
+  // confirm a baseline the same run had broken (#3727).
+  const after = evaluate(settled.files, next);
   if (after.newOffenders.length > 0 || after.grew.length > 0) {
     console.error(`
 check-module-size: the allowlist was rewritten, but the gate is STILL RED for

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -37,6 +37,7 @@ import {
   allowlistDigest,
   allowlistDigests,
   allowlistScope,
+  countLines,
   parseAllowlist,
 } from './lib/module-size-ratchet.mjs';
 
@@ -716,4 +717,188 @@ test('a scoped regenerate that leaves the gate red exits 1 and names the sweep',
   assert.equal(code, 1, out);
   assert.match(out, /the gate is STILL RED for\s+files outside this change's scope/);
   assert.match(out, /--all --allow-raise/);
+});
+
+// ---------------------------------------------------------------------------
+// The gate measures ITSELF and rewrites itself in the same run (#3727, #3693).
+// `--update` planned against the pre-rewrite size, so a sweep that changed the
+// SCOPE COUNT moved the digest block's line count after the row for
+// scripts/check-module-size.mjs had already been written. It reported success
+// and exited 0; the next plain run measured the real file and failed. Green
+// locally, red in CI, no local reproduction, on the one gate whose whole job is
+// to stop that shape.
+//
+// Both cases assert the SAME property from two failure modes, and the property
+// is idempotence: whatever --update writes, the very next plain run must be
+// green with zero contributor action in between.
+// ---------------------------------------------------------------------------
+
+/**
+ * A stand-in for the gate's own source: `lines` long, carrying a pin block with
+ * `scopes` entries. The committed one is never written by a test.
+ */
+function selfStandIn(dir, lines, scopes) {
+  const head = [
+    '// stand-in for scripts/check-module-size.mjs',
+    'const ALLOWLIST_DIGESTS = {',
+    ...scopes.map((s) => `  '${s}': '1',`),
+    '};',
+  ];
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  const path = join(dir, 'scripts', 'check-module-size.mjs');
+  writeFileSync(path, `${head.join('\n')}\n${source(lines - head.length)}`);
+  return path;
+}
+
+/** The gate's own count, so an assertion cannot measure by a rule the gate does not use. */
+function selfLines(path) {
+  return countLines(readFileSync(path, 'utf8'));
+}
+
+/**
+ * The digest block the run WROTE into the stand-in, read back off disk and
+ * parsed with a spelling of its own -- not `renderPinBlock` run backwards, and
+ * not recomputed from the allowlist. Recomputing is what makes an idempotence
+ * check tautological: the pin would then be derived from the same rows it is
+ * supposed to be checked against, so a block that disagreed with them could not
+ * show up. This reads what a contributor's next run reads.
+ */
+function pinnedDigests(dir) {
+  const text = readFileSync(join(dir, 'scripts', 'check-module-size.mjs'), 'utf8');
+  const block = /^const ALLOWLIST_DIGESTS = \{$([\s\S]*?)^\};$/m.exec(text);
+  assert.ok(block, 'the run must leave a digest block behind');
+  const out = {};
+  for (const [, scope, digest] of block[1].matchAll(/^ {2}'(.+)': '(\d+)',$/gm)) out[scope] = digest;
+  return out;
+}
+
+/**
+ * The plain gate, run against what the update left on disk: its allowlist AND
+ * the pin it wrote. Both halves have to agree or this run fails, which is the
+ * whole property -- `--update` then a plain run, green, with nothing done in
+ * between.
+ */
+function rerunPlain(dir, allowlistPath) {
+  return run(dir, null, { allowlistPath, digest: pinnedDigests(dir) });
+}
+
+test('--update settles its OWN row when a new scope grows its digest block (#3727)', () => {
+  // The self file is allowlisted at its exact size, so the extra pin line takes
+  // it one past its own budget. The row written must be the post-rewrite count.
+  const { dir, git } = gitTree({ 'packages/a/big.ts': 500 });
+  const self = selfStandIn(dir, 450, ['packages/a', 'scripts']);
+  // COMMITTED, so it is not in the change's diff and the scoped run would leave
+  // it alone -- which is the point. The only thing that puts it back in scope is
+  // this run's own rewrite of it. An untracked stand-in is already in `changed`
+  // and makes that half of the fix untestable here.
+  git('add', '--', 'scripts/check-module-size.mjs');
+  git('commit', '-qm', 'pin');
+  const before = `${HEADER}   500 packages/a/big.ts\n   450 scripts/check-module-size.mjs\n`;
+  // A file in a NEW scope: that is what makes the block gain a line.
+  writeSource(dir, 'apps/b/new_god.tsx', 401);
+
+  const upd = run(dir, before, { extra: ['--update', '--allow-raise'] });
+  assert.equal(upd.code, 0, upd.out);
+  assert.equal(selfLines(self), 451, 'the rewrite grew the file');
+  assert.match(
+    readFileSync(upd.allowlistPath, 'utf8'),
+    /^\s+451 scripts\/check-module-size\.mjs$/m,
+    'the row must record the size the run produced, not the one it started from',
+  );
+  assert.match(upd.out, /RAISED:\s+scripts\/check-module-size\.mjs: 451 lines, budget 450/);
+
+  const after = rerunPlain(dir, upd.allowlistPath);
+  assert.equal(after.code, 0, after.out);
+  assert.match(after.out, /0 new over 400/);
+});
+
+test('--update settles its own row when the rewrite pushes it OVER the limit (#3693)', () => {
+  // The other failure mode, and it is not the same one: here the self file has
+  // no row at all (it sits exactly at the limit), so the extra pin line makes it
+  // a NEW OFFENDER rather than a grown one. A fix that only re-measured rows
+  // already in the allowlist would still leave this red.
+  //
+  // It also settles at 402, not 401, and that is the case a single recount
+  // misses: the first pin line comes from `apps/b`, which takes the file to 401
+  // and therefore EARNS IT A ROW — and that row creates the `scripts` scope,
+  // which is a second pin line. Only a fixed point converges here.
+  const { dir } = gitTree({ 'packages/a/big.ts': 500 });
+  const self = selfStandIn(dir, 400, ['packages/a']);
+  const before = `${HEADER}   500 packages/a/big.ts\n`;
+  writeSource(dir, 'apps/b/new_god.tsx', 401);
+
+  const upd = run(dir, before, { extra: ['--update', '--allow-raise'] });
+  assert.equal(upd.code, 0, upd.out);
+  assert.equal(selfLines(self), 402);
+  assert.match(readFileSync(upd.allowlistPath, 'utf8'), /^\s+402 scripts\/check-module-size\.mjs$/m);
+  assert.match(upd.out, /ADDED:\s+scripts\/check-module-size\.mjs: 402 lines \(new exemption\)/);
+
+  const after = rerunPlain(dir, upd.allowlistPath);
+  assert.equal(after.code, 0, after.out);
+  assert.match(after.out, /0 new over 400/);
+});
+
+test('settling its own row does not annex any OTHER out-of-scope row', () => {
+  // The counterweight to the two above: --update reaches its own file because
+  // the run itself wrote that file, and for no other reason. A row with real
+  // headroom that this change never touched keeps its committed budget
+  // (#3398 — `--update` has annexed unrelated rows before).
+  const { dir } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  selfStandIn(dir, 450, ['packages/a', 'packages/b', 'scripts']);
+  const before =
+    `${HEADER}   500 packages/a/big.ts\n   460 packages/b/slack.ts\n` +
+    `   450 scripts/check-module-size.mjs\n`;
+  writeSource(dir, 'apps/b/new_god.tsx', 401);
+
+  const upd = run(dir, before, { extra: ['--update', '--allow-raise'] });
+  assert.equal(upd.code, 0, upd.out);
+  assert.match(
+    readFileSync(upd.allowlistPath, 'utf8'),
+    /^\s+460 packages\/b\/slack\.ts$/m,
+    'the untouched row keeps its committed budget, headroom and all',
+  );
+  assert.doesNotMatch(upd.out, /slack\.ts/);
+});
+
+test('the post-write check reads the tree the run PRODUCED, not the one it measured', () => {
+  // The other half of the same staleness, and it fails the opposite way: a
+  // sweep that REMOVES scopes shrinks the digest block, so the self file ends
+  // the run smaller than it started. Here it lands back under the limit and
+  // rightly loses its row -- but the starting measurement still says 403, and a
+  // post-write check reading that would report the gate STILL RED and exit 1
+  // over a file that is 399 lines on disk. A false red on a correct write is
+  // the same lie as the false green above, pointed the other way.
+  const dir = tree({ 'packages/a/big.ts': 500 });
+  const self = selfStandIn(dir, 403, ['packages/a', 'packages/c', 'packages/d', 'packages/e', 'scripts']);
+  const before =
+    `${HEADER}   500 packages/a/big.ts\n   450 packages/c/gone.ts\n   450 packages/d/gone.ts\n` +
+    `   450 packages/e/gone.ts\n   403 scripts/check-module-size.mjs\n`;
+
+  const upd = run(dir, before, { extra: ['--update', '--all'] });
+  assert.equal(upd.code, 0, upd.out);
+  assert.equal(selfLines(self), 399, 'the rewrite shrank the file');
+  assert.doesNotMatch(readFileSync(upd.allowlistPath, 'utf8'), /check-module-size\.mjs/);
+
+  const after = rerunPlain(dir, upd.allowlistPath);
+  assert.equal(after.code, 0, after.out);
+});
+
+test('a REFUSED update leaves the pinned file byte-for-byte untouched', () => {
+  // settleUpdate settles in memory precisely so that the refusal at the
+  // --allow-raise gate can still leave the tree alone. The existing refusal
+  // cases assert the ALLOWLIST is unchanged; nothing asserted the file the run
+  // also rewrites, so a version that re-pinned before checking the gate would
+  // have printed "Nothing was written" over a file it had just written.
+  const { dir } = gitTree({ 'packages/a/big.ts': 500 });
+  const self = selfStandIn(dir, 450, ['packages/a', 'scripts']);
+  const untouched = readFileSync(self, 'utf8');
+  const before = `${HEADER}   500 packages/a/big.ts\n   450 scripts/check-module-size.mjs\n`;
+  writeSource(dir, 'apps/b/new_god.tsx', 401);
+
+  // No --allow-raise: the new scope's row is an ADD, so the run must refuse.
+  const { code, out, allowlistPath } = run(dir, before, { extra: ['--update'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /Nothing was written/);
+  assert.equal(readFileSync(self, 'utf8'), untouched, 'the pin block must not have moved');
+  assert.equal(readFileSync(allowlistPath, 'utf8'), before);
 });

--- a/scripts/lib/module-size-self-pin.mjs
+++ b/scripts/lib/module-size-self-pin.mjs
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one place `scripts/check-module-size.mjs` is measured BY a run that also
+ * rewrites it: where its pin lives, what the pin looks like, and how to plan an
+ * update whose own row survives the rewrite.
+ *
+ * The gate pins its allowlist digests in its own source (see ALLOWLIST_DIGESTS
+ * there for why the pin cannot live beside the rows it guards), and that source
+ * is itself a measured `.mjs` module under `scripts/`. So `--update` closes a
+ * loop: the rows it writes determine the digest block, the block's line count
+ * determines the file's size, and the file's size determines its own row.
+ *
+ * `--update` used to walk that loop exactly once, in the wrong order: it
+ * measured the tree, wrote the row for `scripts/check-module-size.mjs`, and
+ * only THEN rewrote the block. A sweep that changes the SCOPE COUNT moves the
+ * block's line count, so the row it had already written described a file that
+ * no longer existed — and the post-write self-check re-used the same stale
+ * measurement, so the command reported success and exited 0 on a baseline it
+ * had just broken. The next plain run measured the file for real and failed:
+ * green locally, red in CI, no local reproduction, on the one gate whose whole
+ * job is to stop that (#3727, #3693).
+ *
+ * `settleUpdate` walks the loop to a FIXED POINT instead, and does it entirely
+ * in memory so that a refusal (`--update` declining to raise a budget) still
+ * leaves the tree byte-for-byte untouched.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { allowlistDigests, countLines, planUpdate } from './module-size-ratchet.mjs';
+
+/**
+ * The pinned file, as the walk spells it. The walk normalises separators
+ * (`relative(root, p).split('\\').join('/')`), and this is what that produces
+ * for the gate's own source, so `settleUpdate` can match its row by equality.
+ * Deriving it a second time at the call site is what would let the two drift.
+ */
+export const SELF_REL = 'scripts/check-module-size.mjs';
+
+/**
+ * The ALLOWLIST_DIGESTS block in `scripts/check-module-size.mjs`, matched from
+ * its `const` line to the first line that is exactly `};`. Non-greedy on
+ * purpose: the block is the FIRST such object in the file.
+ */
+export const PIN_RE = /^const ALLOWLIST_DIGESTS = \{[\s\S]*?^\};$/m;
+
+/** The block as it is written back: one reviewable line per scope (#3291). */
+export function renderPinBlock(digests) {
+  const rows = [...digests].map(([scope, digest]) => `  '${scope}': '${digest}',`);
+  return `const ALLOWLIST_DIGESTS = {\n${rows.join('\n')}\n};`;
+}
+
+/**
+ * `{ path, text }` for the pinned file under `root`, with `text` null when
+ * there is no pin to move. That is the synthetic tree the test harness builds
+ * under `--root`: a documented case, not an error, and the caller prints the
+ * digests instead of writing them.
+ */
+export function readSelfPin(root) {
+  const path = join(root, SELF_REL);
+  try {
+    const text = readFileSync(path, 'utf8');
+    if (PIN_RE.test(text)) return { path, text };
+  } catch {
+    // No file under this root, which reads the same as no pin in it.
+  }
+  return { path, text: null };
+}
+
+/**
+ * `text` with its pin block replaced by `digests`.
+ *
+ * A replacer FUNCTION, not a string: `$&` and friends are substitution patterns
+ * in a string replacement, so a scope containing `$&` would splice the matched
+ * block back into itself. Needs a directory named with `$&`, so it is unlikely
+ * rather than impossible -- and free to rule out.
+ */
+export function repin(text, digests, render = renderPinBlock) {
+  return text.replace(PIN_RE, () => render(digests));
+}
+
+/**
+ * Bound on the fixed-point iteration. An unbounded loop over a self-referential
+ * file is a HANG, which is the one failure mode nothing reports — worse than
+ * the wrong answer it would be replacing.
+ *
+ * With `renderPinBlock` the map is `lines -> L1 if lines > LIMIT else L0`,
+ * where L1 and L0 differ by the single line the self row's scope adds, so it
+ * has a fixed point two passes in and this bound is unreachable today. It is a
+ * backstop against a future renderer whose block length depends on something
+ * else, and `render` is injectable so a test can BE that renderer — a bound
+ * nothing can reach is a bound nobody has checked.
+ */
+export const MAX_SETTLE_PASSES = 8;
+
+/**
+ * Plan the allowlist rewrite against the file the rewrite will PRODUCE, not the
+ * one on disk when the run started. `self` is what `readSelfPin` returned.
+ *
+ * Two things move between passes, and both are the point:
+ *  - the self file's measured line count, so the row records the post-rewrite
+ *    size rather than the pre-rewrite one;
+ *  - the SCOPE, when that count actually moves. A scoped `--update` re-records
+ *    only the files the change touched (#3398), and a run whose own write grows
+ *    that file has touched it — leaving it out is what stranded the row over its
+ *    budget with no scoped rerun able to reach it. Nothing else is annexed: the
+ *    self path joins the scope only on a pass where the projection disagrees
+ *    with the measurement.
+ *
+ * Returns `{ plan, digests, selfText, files, passes }`, where `files` is the
+ * measurement the plan settled on. That is what the tree WILL hold once the
+ * caller writes `selfText`, so it — not the measurement the run started from —
+ * is what the post-write check must evaluate. THROWS if it does not settle,
+ * because the caller has written nothing yet and "could not decide" must not
+ * reach the tree as a half-applied sweep.
+ */
+export function settleUpdate({ files, allowlist, changed, self, render = renderPinBlock }) {
+  let nextFiles = files;
+  let nextChanged = changed;
+  let drift = '';
+  for (let passes = 1; passes <= MAX_SETTLE_PASSES; passes += 1) {
+    const plan = planUpdate(nextFiles, allowlist, nextChanged);
+    const digests = allowlistDigests(plan.next);
+    const selfText = self.text === null ? null : repin(self.text, digests, render);
+    const measured = nextFiles.find((f) => f.rel === SELF_REL);
+    const lines = selfText === null ? null : countLines(selfText);
+    if (lines === null || measured === undefined || measured.lines === lines) {
+      return { plan, digests, selfText, files: nextFiles, passes };
+    }
+    drift = `${measured.lines} -> ${lines}`;
+    nextFiles = nextFiles.map((f) => (f.rel === SELF_REL ? { ...f, lines } : f));
+    nextChanged = nextChanged === null ? null : new Set([...nextChanged, SELF_REL]);
+  }
+  throw new Error(
+    `${SELF_REL} never settled: rewriting its digest block keeps changing its own line count ` +
+      `(last ${drift}) after ${MAX_SETTLE_PASSES} passes, so any row written for it would already ` +
+      `be stale. This is a defect in the gate, not in your change.`,
+  );
+}

--- a/scripts/lib/module-size-self-pin.mjs
+++ b/scripts/lib/module-size-self-pin.mjs
@@ -137,6 +137,12 @@ export function settleUpdate({ files, allowlist, changed, self, render = renderP
   throw new Error(
     `${SELF_REL} never settled: rewriting its digest block keeps changing its own line count ` +
       `(last ${drift}) after ${MAX_SETTLE_PASSES} passes, so any row written for it would already ` +
-      `be stale. This is a defect in the gate, not in your change.`,
+      `be stale. This is a defect in the gate, not in your change.\n\n` +
+      `REMEDY: the renderer that writes the digest block has to reach a fixed point — one line ` +
+      `per scope, so a scope count that changes the block's length must not in turn change the ` +
+      `scope count. Restore a renderer with that property (git history for ` +
+      `\`allowlistDigests\`/\`repin\` is the place to look), then re-run \`--update\`. Until then ` +
+      `the allowlist can still be edited by hand: the row for ${SELF_REL} must equal that file's ` +
+      `line count AFTER its digest block is written.`,
   );
 }

--- a/scripts/lib/module-size-self-pin.test.mjs
+++ b/scripts/lib/module-size-self-pin.test.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit tests for the self-pin fixed point (#3727, #3693).
+ *
+ * The end-to-end shape -- `--update` then a plain run, both green -- is pinned
+ * in `scripts/check-module-size.test.mjs` against the real script. What is here
+ * is what that run reaches only indirectly or not at all: the loop's REFUSAL
+ * when the file's size never settles (the real renderer converges too fast to
+ * exercise it), and the scope join, which the end-to-end fixtures cannot
+ * isolate because their stand-in self file is untracked and therefore already
+ * in the change's scope.
+ *
+ * Run: node --test scripts/lib/module-size-self-pin.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  MAX_SETTLE_PASSES,
+  PIN_RE,
+  SELF_REL,
+  readSelfPin,
+  renderPinBlock,
+  repin,
+  settleUpdate,
+} from './module-size-self-pin.mjs';
+import { countLines, parseAllowlist } from './module-size-ratchet.mjs';
+
+/**
+ * A file of `lines` real lines whose head is the pin block, followed by a
+ * SECOND object literal. The second `};` is not decoration: it is what makes a
+ * greedy PIN_RE observably wrong, and the real file will grow one the first
+ * time anybody adds a const object below the pin.
+ */
+function selfSource(lines, scopes) {
+  const head = ['const ALLOWLIST_DIGESTS = {', ...scopes.map((s) => `  '${s}': '1',`), '};'];
+  const tail = ['const OTHER = {', "  'keep': 'me',", '};'];
+  const fill = lines - head.length - tail.length;
+  const body = Array.from({ length: fill }, (_, i) => `const l${i} = ${i};`);
+  return `${[...head, ...body, ...tail].join('\n')}\n`;
+}
+
+test('repin replaces the block in place and leaves the rest of the file alone', () => {
+  const text = selfSource(10, ['old']);
+  const out = repin(text, new Map([['packages/a', '7']]));
+  assert.match(out, /^const ALLOWLIST_DIGESTS = \{\n {2}'packages\/a': '7',\n\};$/m);
+  assert.doesNotMatch(out, /'old'/);
+  assert.match(out, /const l0 = 0;/);
+});
+
+test('a scope containing a substitution pattern is spliced literally, not expanded', () => {
+  // `$&` is a replacement pattern in String.replace's string form, so a string
+  // replacer would inject the matched block back into itself.
+  const out = repin(selfSource(6, ['old']), new Map([['packages/$&', '1']]));
+  assert.match(out, /'packages\/\$&': '1',/);
+  assert.equal(out.match(/const ALLOWLIST_DIGESTS/g).length, 1);
+});
+
+test('renderPinBlock gives every scope its own line (#3291)', () => {
+  const block = renderPinBlock(new Map([['apps/v', '1'], ['packages/a', '2']]));
+  assert.equal(countLines(`${block}\n`), 4);
+  assert.ok(PIN_RE.test(`${block}\n`));
+});
+
+test('readSelfPin answers null for a tree with no pin, and the text when there is one', () => {
+  // The synthetic tree the harness builds under --root has no pin to move.
+  // That is a documented case, and the caller keys "print instead of write" off
+  // it, so an exception escaping here would abort a legitimate run.
+  const dir = mkdtempSync(join(tmpdir(), 'self-pin-'));
+  assert.equal(readSelfPin(dir).text, null, 'no file at all');
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  writeFileSync(join(dir, SELF_REL), 'const x = 1;\n');
+  assert.equal(readSelfPin(dir).text, null, 'a file with no pin block in it');
+  writeFileSync(join(dir, SELF_REL), selfSource(6, ['packages/a']));
+  assert.match(readSelfPin(dir).text, /ALLOWLIST_DIGESTS/);
+});
+
+test('settleUpdate records the self row at the size the rewrite PRODUCES', () => {
+  // The defect: the row was written from the size measured before the block was
+  // rewritten. One extra scope, one extra line, one stale row.
+  // big.ts carries HEADROOM (measured 500, budget 520). Without it, in-scope and
+  // out-of-scope re-recording produce the same number and the "nothing else was
+  // annexed" assertion below cannot fail.
+  const allowlist = parseAllowlist('520 packages/a/big.ts\n450 scripts/check-module-size.mjs\n', 'x');
+  const files = [
+    { rel: 'packages/a/big.ts', lines: 500 },
+    { rel: 'apps/b/new.ts', lines: 401 },
+    { rel: SELF_REL, lines: 450 },
+  ];
+  const settled = settleUpdate({
+    files,
+    allowlist,
+    changed: new Set(['apps/b/new.ts']),
+    self: { path: SELF_REL, text: selfSource(450, ['packages/a', 'scripts']) },
+  });
+  assert.equal(settled.plan.next.get(SELF_REL), 451);
+  assert.equal(countLines(settled.selfText), 451);
+  // The self file joined the scope because THIS RUN rewrote it. Nothing else
+  // did: packages/a/big.ts was never touched, so it keeps its committed budget.
+  assert.equal(settled.plan.next.get('packages/a/big.ts'), 520, 'its committed budget, headroom and all');
+});
+
+test('settleUpdate leaves the self row alone when the block length does not move', () => {
+  // The counterweight: a run that does not change the scope count must not
+  // annex its own row's headroom either. Nothing here is in scope.
+  const allowlist = parseAllowlist('500 packages/a/big.ts\n450 scripts/check-module-size.mjs\n', 'x');
+  const settled = settleUpdate({
+    files: [
+      { rel: 'packages/a/big.ts', lines: 500 },
+      { rel: SELF_REL, lines: 440 },
+    ],
+    allowlist,
+    changed: new Set(),
+    self: { path: SELF_REL, text: selfSource(440, ['packages/a', 'scripts']) },
+  });
+  assert.equal(settled.passes, 1);
+  assert.equal(settled.plan.next.get(SELF_REL), 450, 'the committed budget, not the measured 440');
+});
+
+test('settleUpdate settles on the first pass when there is no pin to move', () => {
+  const settled = settleUpdate({
+    files: [{ rel: 'packages/a/big.ts', lines: 500 }],
+    allowlist: parseAllowlist('500 packages/a/big.ts\n', 'x'),
+    changed: null,
+    self: { path: SELF_REL, text: null },
+  });
+  assert.equal(settled.passes, 1);
+  assert.equal(settled.selfText, null);
+});
+
+test('settleUpdate REFUSES rather than looping when the size never settles', () => {
+  // The bound exists because an unbounded fixed-point iteration over a
+  // self-referential file is a hang, and a hang is the one failure nothing
+  // reports. `renderPinBlock` converges in three passes, so the only way to
+  // exercise the refusal is to BE the future renderer the bound guards against:
+  // one whose block length depends on something other than the scope count.
+  let renders = 0;
+  assert.throws(
+    () =>
+      settleUpdate({
+        files: [{ rel: SELF_REL, lines: 500 }],
+        allowlist: parseAllowlist('500 scripts/check-module-size.mjs\n', 'x'),
+        changed: null,
+        self: { path: SELF_REL, text: selfSource(500, ['packages/a']) },
+        render: (digests) => {
+          renders += 1;
+          return `${renderPinBlock(digests)}${renders % 2 === 1 ? '\n// pad' : ''}`;
+        },
+      }),
+    /after 8 passes/,
+  );
+  assert.equal(renders, MAX_SETTLE_PASSES);
+});
+
+test('the pin block match stops at its OWN closing brace, not a later one', () => {
+  // Non-greedy is the whole reason `repin` does not swallow everything between
+  // the pin block and the next `};` in the file. selfSource now carries a second
+  // object below the block, so a greedy match is visible here.
+  const out = repin(selfSource(12, ['packages/a']), new Map([['packages/b', '9']]));
+  assert.match(out, /'packages\/b': '9',/);
+  assert.match(out, /^const OTHER = \{$/m, 'the object below the pin must survive intact');
+  assert.match(out, /^ {2}'keep': 'me',$/m);
+});
+
+test('settleUpdate settles on the first pass when the walk never measured the pinned file', () => {
+  // The pin exists but no row of `files` names it: it was exempted, or the walk
+  // did not reach it. There is nothing to feed back, so the answer is the plain
+  // plan -- not a loop that runs to the bound and then reads a row that is not
+  // there.
+  const settled = settleUpdate({
+    files: [{ rel: 'packages/a/big.ts', lines: 500 }],
+    allowlist: parseAllowlist('500 packages/a/big.ts\n', 'x'),
+    changed: null,
+    self: { path: SELF_REL, text: selfSource(500, ['packages/a']) },
+  });
+  assert.equal(settled.passes, 1);
+  assert.equal(settled.plan.next.get(SELF_REL), undefined);
+  assert.match(settled.selfText, /'packages\/a':/);
+});

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -347,7 +347,7 @@
    957 scripts/check-issue-queue.mjs
    448 scripts/check-legacy-entity-coverage.mjs
   1145 scripts/check-loader-hook-specifier-match.mjs
-   694 scripts/check-module-size.mjs
+   723 scripts/check-module-size.mjs
    951 scripts/check-pr-review-signal.mjs
    771 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs


### PR DESCRIPTION
Closes #3727. Closes #3693.

Two issues, one root cause.

## The defect

`--update` measured the tree, wrote the allowlist, and only *then* rewrote the `ALLOWLIST_DIGESTS` block that lives inside `check-module-size.mjs` itself — one line per scope. So a sweep that changes the scope count changes that file's length **after** its own row was written. The post-write self-check then re-read the same stale measurement, so the command exited 0 on a baseline it had just broken.

#3727 (row exists, the extra pin line pushes the file past its budget) and #3693 (no row, the extra pin line makes it a new offender) are the same defect seen from two sides.

## End-to-end, the real script against synthetic git trees

| | `--update --allow-raise` | file on disk | row written | next plain run |
|---|---|---|---|---|
| **#3727 before** | exit 0 | 451 | `450` | **exit 1** — `451 lines, budget 450` |
| **#3727 after** | exit 0, `RAISED … 451` | 451 | `451` | exit 0 |
| **#3693 before** | exit 0 | 401 | *(none)* | **exit 1** — `401 lines, no allowlist row` |
| **#3693 after** | exit 0, `ADDED … 402` | 402 | `402` | exit 0 |

**#3693 settles at 402, not 401**, and that is the whole argument for a fixed point rather than a second pass: the first pin line takes the file to 401, which *earns it a row*, which creates the `scripts` scope, which is a second pin line. Only iterating to a fixed point converges there.

## Mutation red counts — every piece of the fix deleted separately

single-pass instead of fixed point **5 red** · scope widened repo-wide **2** · self never joins scope **2** · post-write check reads the pre-sweep measurement **1** · re-pin written before the `--allow-raise` refusal **1** · `PIN_RE` made greedy **4** · `measured === undefined` guard dropped **1** · digests corrupted in the written pin block **5**.

Four of those only go red because of the second review round — an independent mutation reviewer proved they were green before it. The biggest: `rerunPlain` recomputed the pin from the allowlist, so the idempotence check could not see a pin that disagreed with what the run actually wrote. It now parses the block on disk. The `#3727` e2e fixture also **commits** its stand-in now, so the scope join is load-bearing there rather than in one unit test only.

## Allowlist diff: 2 lines, 1 row

```
-   694 scripts/check-module-size.mjs
+   723 scripts/check-module-size.mjs
```

Nothing else. Regenerated with the scoped `--update` after rebasing, never `--update --all` — which annexes rows across unrelated scopes and has caused two red mains this week.

The budgeted file went **735 → 723** during review: both `/simplify` reviewers independently asked for a deeper seam, so `SELF_REL`, the read, the `PIN_RE` test and the projection closure moved into `scripts/lib/module-size-self-pin.mjs`, and the never-passed `maxPasses` parameter, the `seen` array and a duplicated return went away. That is 12 lines *below* the inherited state, not above it.

## Gates

`node --test scripts/*.test.mjs scripts/lib/*.test.mjs` **1372/1372** · `check-test-wiring` 0 · `check-test-glob-coverage` 0 · `check-source-text-assertions` 0 · `pnpm lint` 0 · `pnpm typecheck` 0 · plain gate `OK (2319 files, 362 allowlisted, 0 new over 400)`.

## Dismissed, with the reason on the record

- **"Delete the duplicated unit test"** — rejected. Mutation shows deleting the scope-join line is caught *only* there; the e2e sibling is blind to it because its stand-in is untracked.
- **A `chmod`-based test for the re-pin write failure** — deferred. `chmod 0444` is a no-op under root, which is how CI containers commonly run, so the test would pass by not testing. That is the absence-reads-as-success shape, not coverage. The path was exercised by hand instead and fails loudly with a self-consistent block.
- **Move the pin to a `.json` sidecar** (altitude review) — deferred and recorded in the docstring. It would dissolve the self-reference outright, since `SOURCE_RE` walks past `.json`; that is a design change, not this fix.
- **"The scope join is annexation"** — a reviewer reproduced it and then refuted it: the narrow variant lowers the same row one run later and is non-idempotent 14 runs in 79.

## Residual, stated rather than hidden

Two PRs that each add a new scope both settle their own row at +1; their merge conflicts in the digest block, and a human resolving it sees a file +2 against a +1 row. Pre-fix `main` has the same shape one line worse, and git *refuses* the merge rather than passing it silently — so it is not the exit-0-certifying-a-false-state class this PR is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZNiLBzRCkZqWBJNsjDts6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module-size allowlist updates so self-measuring checks settle consistently before validation.
  * Prevented incomplete or non-converging updates from modifying the source file or allowlist.
  * Ensured subsequent module-size checks accurately reflect finalized file measurements.

* **Tests**
  * Added regression coverage for self-updating behavior, digest changes, refused updates, and preserving unrelated allowlist entries.

* **Chores**
  * Updated the allowed size budget for the module-size checker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->