### PR TITLE
fix(export): route the merged exporter's last express-id readers through the shared home

### DIFF
--- a/rust/export/examples/merge_ifc.rs
+++ b/rust/export/examples/merge_ifc.rs
@@ -19,6 +19,7 @@
 use std::collections::HashMap;
 use std::time::Instant;
 
+use ifc_lite_core::express_id::parse_express_id;
 use ifc_lite_export::{export_merged_models, MergedModel, MergedOptions, UnitReconciliation};
 
 fn main() {
@@ -146,11 +147,20 @@ fn self_check(step: &str) -> (usize, usize, usize) {
             *guid_counts.entry(g).or_default() += 1;
         }
         // Count references to ids that were never written.
-        for r in refs_in(line) {
+        let (refs, past_bound) = refs_in(line);
+        for r in refs {
             if !ids.contains(&r) {
                 dangling += 1;
             }
         }
+        // A run past u32::MAX is dangling BY CONSTRUCTION: no id column can hold
+        // it, so no line can ever have been written under it. It has to be added
+        // here rather than dropped, because `rewrite_refs` emits such a run into
+        // the merged output verbatim (#3421) — dropping it would make the one
+        // reference class that is guaranteed dangling the one class this verdict
+        // cannot see, and the example would exit 0 on the file that proves the
+        // bug.
+        dangling += past_bound;
     }
 
     let dup_guids = guid_counts.values().filter(|&&c| c > 1).count();
@@ -174,11 +184,20 @@ fn type_token(line: &str) -> Option<String> {
     Some(rest[..end].trim().to_ascii_uppercase())
 }
 
-/// Every `#N` reference in a line, ignoring the leading id and quoted strings.
-fn refs_in(line: &str) -> Vec<u32> {
+/// Every `#N` reference in a line, ignoring the leading id and quoted strings,
+/// plus a count of the runs that named an id too large to be one.
+///
+/// The digit run goes to the workspace's one express-id home (#3421) rather
+/// than a hand-rolled accumulator: this one used plain `*`/`+`, which panics on
+/// overflow in a debug build and wraps onto a real low-numbered entity in a
+/// release one. A run past `u32::MAX` is not returned as an id, because there
+/// is no id to return — but it is COUNTED, so the caller can still say it saw
+/// one. Returning only the ids would trade a wrong answer for a silent one.
+fn refs_in(line: &str) -> (Vec<u32>, usize) {
     let after_eq = line.find('=').map(|e| &line[e..]).unwrap_or(line);
     let bytes = after_eq.as_bytes();
     let mut out = Vec::new();
+    let mut past_bound = 0usize;
     let mut i = 0;
     let mut in_str = false;
     while i < bytes.len() {
@@ -187,20 +206,19 @@ fn refs_in(line: &str) -> Vec<u32> {
             in_str = !in_str;
         } else if !in_str && c == b'#' {
             let mut j = i + 1;
-            let mut n = 0u32;
-            let mut any = false;
             while j < bytes.len() && bytes[j].is_ascii_digit() {
-                n = n * 10 + (bytes[j] - b'0') as u32;
                 j += 1;
-                any = true;
             }
-            if any {
-                out.push(n);
+            if j > i + 1 {
+                match parse_express_id(&bytes[i + 1..j]) {
+                    Some(n) => out.push(n),
+                    None => past_bound += 1,
+                }
                 i = j;
                 continue;
             }
         }
         i += 1;
     }
-    out
+    (out, past_bound)
 }

--- a/rust/export/src/merged/line_edit.rs
+++ b/rust/export/src/merged/line_edit.rs
@@ -12,10 +12,21 @@
 
 use std::collections::HashSet;
 
+use ifc_lite_core::express_id::parse_express_id;
+
 /// Rewrite every `#N` reference in a STEP entity line. `remap(n)` returns
 /// `Some(absolute_id)` to redirect a reference (no offset), or `None` to apply
 /// `offset`. Single-quoted strings are passed through as raw bytes (a `#` there
 /// is literal text), tracking only in/out-of-string state.
+///
+/// A reference above `u32::MAX` is copied through verbatim (#3421). It used to
+/// saturate (CR #2952), which beats the wrapping this file's siblings did but is
+/// still wrong here: `u32::MAX` is itself a legal express id, so the clamped
+/// value went on to `remap` and `offset` like any other and could be redirected
+/// onto a real entity — the same collision, moved onto the sentinel. Emitting
+/// the digits unchanged leaves the reference exactly as authored and exactly as
+/// dangling, and agrees with [`crate::step_text::refs_in_line`], which no longer
+/// collects it (#3740).
 pub fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32>) -> String {
     let mut out: Vec<u8> = Vec::with_capacity(line.len() + 8);
     let mut i = 0;
@@ -30,20 +41,18 @@ pub fn rewrite_refs(line: &[u8], offset: u32, remap: &impl Fn(u32) -> Option<u32
         }
         if !in_string && b == b'#' {
             let mut j = i + 1;
-            let mut n: u32 = 0;
-            let mut any = false;
             while j < line.len() && line[j].is_ascii_digit() {
-                // Saturate rather than wrap: a malformed reference number wider than
-                // u32 must not silently wrap onto a small, valid id (CR #2952). A
-                // clamped id stays dangling (caught downstream), never mis-pointed.
-                n = n.saturating_mul(10).saturating_add((line[j] - b'0') as u32);
                 j += 1;
-                any = true;
             }
-            if any {
-                let target = remap(n).unwrap_or_else(|| n.saturating_add(offset));
-                out.push(b'#');
-                out.extend_from_slice(target.to_string().as_bytes());
+            if j > i + 1 {
+                match parse_express_id(&line[i + 1..j]) {
+                    Some(n) => {
+                        let target = remap(n).unwrap_or_else(|| n.saturating_add(offset));
+                        out.push(b'#');
+                        out.extend_from_slice(target.to_string().as_bytes());
+                    }
+                    None => out.extend_from_slice(&line[i..j]),
+                }
                 i = j;
                 continue;
             }
@@ -160,13 +169,22 @@ fn split_args(args: &str) -> Vec<&str> {
 }
 
 /// Parse an argument that is exactly one reference (`"#7"` → `7`).
+///
+/// The digit run goes to the workspace's one express-id home rather than to a
+/// local `str::parse` (#3421). Both refuse above `u32::MAX` today, so this is
+/// not a behaviour fix; it is here so this file states the bound once, in
+/// `rewrite_refs` and in the drop analysis that has to agree with it.
+///
+/// `empty::single_ref` and `plan::parse_single_ref` are the same three lines
+/// against `str::parse` and are deliberately left alone: they are correct at
+/// the bound, so folding them in would be a pure refactor riding on a fix.
 fn parse_ref(arg: &str) -> Option<u32> {
     let t = arg.trim();
     let digits = t.strip_prefix('#')?;
     if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
-    digits.parse().ok()
+    parse_express_id(digits.as_bytes())
 }
 
 /// True when `arg` is a list literal (`(…)`).

--- a/rust/export/src/merged/line_edit_tests.rs
+++ b/rust/export/src/merged/line_edit_tests.rs
@@ -97,3 +97,83 @@ fn rewriting_preserves_every_other_attribute_verbatim() {
     };
     assert_eq!(out, "#9=IFCRELDEFINESBYPROPERTIES('g',$,'A, (b) #2',$,(#3),#4);");
 }
+
+/// #3421, both directions of the express-id bound in `rewrite_refs`.
+///
+/// #3740 migrated this crate's other reference reader (`step_text::refs_in_line`)
+/// off wrapping arithmetic and left this one, which had been given a different
+/// third policy: saturate (CR #2952). Saturating removed the wrap but clamped to
+/// `u32::MAX`, which is itself a legal express id and goes through `remap` and
+/// `offset` like any other — the same collision with a real entity, moved onto
+/// the sentinel.
+#[test]
+fn an_oversized_reference_is_neither_wrapped_nor_clamped_onto_a_real_id() {
+    let mut remap = std::collections::HashMap::new();
+    remap.insert(2u32, 100u32);
+    remap.insert(u32::MAX, 200u32);
+    let out = rewrite_refs(
+        b"#3=IFCRELAGGREGATES('g',$,$,$,#4294967298,(#1));",
+        10,
+        &|n| remap.get(&n).copied(),
+    );
+    assert!(
+        !out.contains("#100"),
+        "wrapping 2^32+2 to #2 puts the reference through #2's remap: {out}"
+    );
+    assert!(
+        !out.contains("#200"),
+        "clamping to u32::MAX puts the reference through u32::MAX's remap: {out}"
+    );
+    assert!(
+        out.contains("#4294967298"),
+        "the digits must survive as authored, so the reference stays exactly \
+         as dangling as it was: {out}"
+    );
+    assert!(out.contains("(#11)"), "real references still shift: {out}");
+
+    // The other half of the saturating path, which the remap above shadows:
+    // with NOTHING mapped for u32::MAX the clamp fell through to `offset`, and
+    // `u32::MAX.saturating_add(offset)` is still u32::MAX — a legal express id
+    // another model in the merge may really hold.
+    let unmapped = rewrite_refs(b"#3=IFCX(#4294967298);", 10, &|_| None);
+    assert_eq!(
+        unmapped, "#13=IFCX(#4294967298);",
+        "clamping to u32::MAX and offsetting it lands the reference on a legal \
+         express id instead of leaving it dangling"
+    );
+}
+
+#[test]
+fn a_reference_at_exactly_u32_max_is_still_remapped() {
+    // The other direction: u32::MAX is a legal express id, so it must still be
+    // read as one and go through the remap rather than being dropped.
+    let mut remap = std::collections::HashMap::new();
+    remap.insert(u32::MAX, 200u32);
+    // The line's own id shifts by the offset like any other reference.
+    let out = rewrite_refs(b"#3=IFCX(#4294967295);", 10, &|n| remap.get(&n).copied());
+    assert_eq!(out, "#13=IFCX(#200);");
+}
+
+#[test]
+fn classify_refs_holds_the_same_bound_as_the_rewrite() {
+    // `parse_ref` shares the bound, so the drop analysis and the rewrite cannot
+    // disagree about which digit runs are references at all (#3421).
+    let slots = classify_refs("#9=IFCRELAGGREGATES('g',$,$,$,#4294967298,(#4294967297));")
+        .expect("parseable line");
+    assert!(
+        slots.is_empty(),
+        "2^32+2 and 2^32+1 must not wrap onto the real #2 and #1, which would \
+         let the drop analysis rewrite or delete a line over an entity it never \
+         referenced: {slots:?}"
+    );
+
+    // And a legal u32::MAX argument is still a reference in the slot it sits in.
+    let at_bound = classify_refs("#9=IFCX(#4294967295,(#4294967294));").expect("parseable line");
+    assert_eq!(
+        at_bound,
+        vec![
+            (u32::MAX, RefSlot::Single),
+            (u32::MAX - 1, RefSlot::ListElement)
+        ]
+    );
+}

--- a/rust/export/src/merged/tests.rs
+++ b/rust/export/src/merged/tests.rs
@@ -6,7 +6,7 @@
 //! the `_tests.rs` suffix convention.
 
 use super::*;
-use ifc_lite_core::EntityScanner;
+use ifc_lite_core::{express_id::parse_express_id, EntityScanner};
 
 fn scan_ids(step: &str) -> Vec<u32> {
     let bytes = step.as_bytes();
@@ -55,36 +55,7 @@ fn merge_two_models_unifies_project_and_offsets_ids() {
     );
 
     // No dangling references: every #ref resolves to a written id.
-    let idset: std::collections::HashSet<u32> = ids.into_iter().collect();
-    for line in merged.lines().filter(|l| l.starts_with('#')) {
-        // collect refs after the leading id
-        let body = &line[1..];
-        let after_eq = body.find('=').map(|e| &body[e..]).unwrap_or(body);
-        let mut i = 0;
-        let bytes = after_eq.as_bytes();
-        let mut in_str = false;
-        while i < bytes.len() {
-            let c = bytes[i];
-            if c == b'\'' {
-                in_str = !in_str;
-            } else if !in_str && c == b'#' {
-                let mut j = i + 1;
-                let mut n = 0u32;
-                let mut any = false;
-                while j < bytes.len() && bytes[j].is_ascii_digit() {
-                    n = n * 10 + (bytes[j] - b'0') as u32;
-                    j += 1;
-                    any = true;
-                }
-                if any {
-                    assert!(idset.contains(&n), "dangling ref #{n}");
-                    i = j;
-                    continue;
-                }
-            }
-            i += 1;
-        }
-    }
+    assert_no_dangling(&merged);
 }
 // `escape()` and `detect_schema()` are no longer private forks of this
 // module: `merged.rs` imports `escape` from `step_text.rs` and `detect_schema`
@@ -399,14 +370,22 @@ fn assert_no_dangling(step: &str) {
                 in_str = !in_str;
             } else if !in_str && c == b'#' {
                 let mut j = i + 1;
-                let mut n = 0u32;
-                let mut any = false;
                 while j < bytes.len() && bytes[j].is_ascii_digit() {
-                    n = n * 10 + (bytes[j] - b'0') as u32;
                     j += 1;
-                    any = true;
                 }
-                if any {
+                if j > i + 1 {
+                    // Through the shared express-id home, so the oracle holds the
+                    // same bound as the code it audits (#3421). A run past
+                    // u32::MAX is dangling by construction — no id column can
+                    // hold it — and `rewrite_refs` now emits such a run
+                    // verbatim, so this is the assertion that would see it. The
+                    // old `n * 10 + d` accumulator could not: it overflowed
+                    // (a debug panic) or wrapped onto a real written id and
+                    // passed.
+                    let digits = String::from_utf8_lossy(&bytes[i + 1..j]);
+                    let n = parse_express_id(&bytes[i + 1..j]).unwrap_or_else(|| {
+                        panic!("dangling ref #{digits} (above u32::MAX) in {line:?}")
+                    });
                     assert!(ids.contains(&n), "dangling ref #{n} in {line:?}");
                     i = j;
                     continue;
@@ -415,6 +394,27 @@ fn assert_no_dangling(step: &str) {
             i += 1;
         }
     }
+}
+
+#[test]
+#[should_panic(expected = "above u32::MAX")]
+fn the_dangling_oracle_reports_a_reference_past_the_id_space() {
+    // `rewrite_refs` now emits a reference above u32::MAX verbatim (#3421), so
+    // this oracle is the assertion that has to see it, and the 20-odd tests that
+    // call it are only as good as its bound. `#4294967297` is 2^32+1: the old
+    // `n * 10 + d` accumulator wrapped it onto the real, written `#1` and let the
+    // merged file pass as free of dangling references.
+    assert_no_dangling("#1=IFCPROJECT('g',$);\n#2=IFCSHAPEREPRESENTATION(#4294967297);\n");
+}
+
+#[test]
+fn the_dangling_oracle_resolves_a_reference_at_exactly_u32_max() {
+    // The other direction: u32::MAX is a legal express id on both sides, so a
+    // record written under it must satisfy a reference naming it rather than be
+    // reported as dangling.
+    assert_no_dangling(
+        "#4294967295=IFCPROJECT('g',$);\n#2=IFCSHAPEREPRESENTATION(#4294967295);\n",
+    );
 }
 
 /// Every `#N` reference in a line's attribute list (after `=`), skipping the
@@ -431,15 +431,15 @@ fn refs_in_line(line: &str) -> Vec<u32> {
             in_str = !in_str;
         } else if !in_str && c == b'#' {
             let mut j = i + 1;
-            let mut n = 0u32;
-            let mut any = false;
             while j < bytes.len() && bytes[j].is_ascii_digit() {
-                n = n * 10 + (bytes[j] - b'0') as u32;
                 j += 1;
-                any = true;
             }
-            if any {
-                out.push(n);
+            if j > i + 1 {
+                // Drops a run past u32::MAX, mirroring the production
+                // `step_text::refs_in_line` this helper stands in for (#3421).
+                if let Some(n) = parse_express_id(&bytes[i + 1..j]) {
+                    out.push(n);
+                }
                 i = j;
                 continue;
             }

--- a/rust/geometry/tests/issue_3421_content_hash_oversized_ref.rs
+++ b/rust/geometry/tests/issue_3421_content_hash_oversized_ref.rs
@@ -1,0 +1,214 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regression for #3421 at the site where a wrapped express-id REFERENCE stops
+//! being untidy and becomes a wrong picture: the geometry content-dedup hash.
+//!
+//! #3740 fixed the hash itself and pinned it at the unit level
+//! (`content_hash_tests.rs`: an oversized child ref hashes like a missing one
+//! and unlike the real entity it would wrap onto). This file guards the
+//! CONSEQUENCE that made it worth fixing, which a signature comparison cannot
+//! show: what the two caches keyed on that signature then do.
+//!
+//! `sig_walk_bytes` used to accumulate a `#<digits>` reference with
+//! `wrapping_mul`/`wrapping_add`. `#4294967303` is `2^32 + 7`, so it wrapped to
+//! `7` and the walk recursed into the REAL entity `#7` — the signature of a
+//! profile naming a nonexistent entity became, bit for bit, the signature of a
+//! profile naming `#7`. That signature is the key of:
+//!
+//! * `GeometryRouter::geometry_routing_key`, which a host uses to send
+//!   byte-identical geometry to the same worker, and
+//! * `item_dedup_cache`, consulted BEFORE meshing, whose hit returns the
+//!   earlier item's mesh AND its instancing `rep_identity`.
+//!
+//! So the collision produced a mis-instancing, not a mis-parse. Run against the
+//! parent of #3740 the third test below reports it directly: the item whose
+//! profile names nothing is handed the other item's 200x300x1000 box.
+//!
+//! The oversized reference sits one level DOWN, in the profile, because that is
+//! the only place it can sit and still be reached. `rust/core`'s tokenizer
+//! refuses the whole record when the reference is a direct attribute of the
+//! item being decoded (#3395/#3432), so such an item never reaches the router.
+//! The dedup hash, by contrast, walks the subtree from RAW BYTES and never
+//! decodes it — which is exactly why its own accumulator had to be fixed
+//! separately, and why a fix confined to `rust/core` left this hole open.
+//!
+//! Both directions run through the SAME shape, so nothing separates them but
+//! the bound: `#4294967295` is `u32::MAX`, a legal express id, and this model
+//! defines a real entity under it; `#4294967303` is one bound too far and
+//! defines nothing.
+
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use ifc_lite_geometry::GeometryRouter;
+
+/// `2^32 + 7` — wraps onto the real 2D placement `#7` in a `u32` accumulator,
+/// and names no entity in any store that can hold an express id.
+const WRAPS_ONTO_SEVEN: &str = "4294967303";
+
+/// `u32::MAX`. The model below DEFINES this entity, byte-identical to `#7`, so
+/// a reader that still binds it hashes the same subtree `#7` does, and a reader
+/// that refuses it does not.
+const AT_THE_BOUND: &str = "4294967295";
+
+/// A model with three extrusions whose profiles are byte-identical except for
+/// the express id of the profile's `Position` reference:
+///
+/// * `#10` names the real `#7`, extruded by `#20`, worn by wall `#50`.
+/// * `#11` names `position_ref_b`, extruded by `#21`, worn by wall `#51`.
+/// * `#12` names the real `#7` again, extruded by `#22`, worn by wall `#52` —
+///   the control, proving the assertions below can tell "same" from
+///   "different" rather than reporting "different" for everything.
+///
+/// `#4294967295` is defined as a byte-identical twin of `#7`, so a reference to
+/// it and a reference to `#7` MUST hash alike: the signature is renumbering-
+/// invariant by design (it folds the resolved subtree, never the id).
+fn model_with(position_ref_b: &str) -> String {
+    format!(
+        "ISO-10303-21;\n\
+         HEADER;\n\
+         FILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('','',(''),(''),'','','');\n\
+         FILE_SCHEMA(('IFC4'));\n\
+         ENDSEC;\n\
+         DATA;\n\
+         #1=IFCCARTESIANPOINT((0.,0.,0.));\n\
+         #2=IFCDIRECTION((0.,0.,1.));\n\
+         #3=IFCDIRECTION((1.,0.,0.));\n\
+         #4=IFCAXIS2PLACEMENT3D(#1,#2,#3);\n\
+         #5=IFCCARTESIANPOINT((17.,-4.));\n\
+         #6=IFCDIRECTION((0.,1.));\n\
+         #7=IFCAXIS2PLACEMENT2D(#5,#6);\n\
+         #4294967295=IFCAXIS2PLACEMENT2D(#5,#6);\n\
+         #10=IFCRECTANGLEPROFILEDEF(.AREA.,'P',#7,200.,300.);\n\
+         #11=IFCRECTANGLEPROFILEDEF(.AREA.,'P',#{position_ref_b},200.,300.);\n\
+         #12=IFCRECTANGLEPROFILEDEF(.AREA.,'P',#7,200.,300.);\n\
+         #20=IFCEXTRUDEDAREASOLID(#10,#4,#2,1000.);\n\
+         #21=IFCEXTRUDEDAREASOLID(#11,#4,#2,1000.);\n\
+         #22=IFCEXTRUDEDAREASOLID(#12,#4,#2,1000.);\n\
+         #30=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#20));\n\
+         #31=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#21));\n\
+         #32=IFCSHAPEREPRESENTATION($,'Body','SweptSolid',(#22));\n\
+         #40=IFCPRODUCTDEFINITIONSHAPE($,$,(#30));\n\
+         #41=IFCPRODUCTDEFINITIONSHAPE($,$,(#31));\n\
+         #42=IFCPRODUCTDEFINITIONSHAPE($,$,(#32));\n\
+         #50=IFCWALL('0GUIDwallAAAAAAAAAAAAA',$,'W',$,$,$,#40,$);\n\
+         #51=IFCWALL('0GUIDwallBBBBBBBBBBBBB',$,'W',$,$,$,#41,$);\n\
+         #52=IFCWALL('0GUIDwallCCCCCCCCCCCCC',$,'W',$,$,$,#42,$);\n\
+         ENDSEC;\n\
+         END-ISO-10303-21;\n"
+    )
+}
+
+/// The routing keys of walls `#50` (real `#7`), `#51` (`position_ref_b`) and
+/// `#52` (real `#7`), in that order.
+fn routing_keys(content: &str) -> [Option<u128>; 3] {
+    let bytes = content.as_bytes();
+    let mut decoder = EntityDecoder::with_index(bytes, build_entity_index(bytes));
+    let router = GeometryRouter::with_units(bytes, &mut decoder);
+    [50u32, 51, 52].map(|wall| {
+        let element = decoder
+            .decode_by_id(wall)
+            .unwrap_or_else(|e| panic!("decode wall #{wall}: {e}"));
+        router.geometry_routing_key(&element, &mut decoder)
+    })
+}
+
+#[test]
+fn an_oversized_reference_does_not_collide_with_the_entity_it_wraps_onto() {
+    let [a, b, c] = routing_keys(&model_with(WRAPS_ONTO_SEVEN));
+
+    // The control pair: two items whose subtrees name the SAME real placement
+    // must still share a key. Without this, "a != b" below would also pass if
+    // the hash had simply stopped deduping everything.
+    assert_eq!(
+        a, c,
+        "two byte-identical items must still share a content-dedup key"
+    );
+    assert!(a.is_some(), "a wall with geometry must have a routing key");
+
+    assert_ne!(
+        a, b,
+        "#{WRAPS_ONTO_SEVEN} is 2^32+7 and names no entity, but a wrapping \
+         accumulator resolved it to the real #7 — giving the two items one \
+         dedup key, so the second is served the first's mesh and collated into \
+         its instance template (#3421)"
+    );
+}
+
+#[test]
+fn a_reference_at_exactly_u32_max_still_binds_to_its_entity() {
+    // The other direction, through the same shape. u32::MAX is a LEGAL express
+    // id and this model defines it, so refusing it would trade the #3421
+    // collision for a lost reference — geometry that silently stops deduping,
+    // or resolves to nothing at all.
+    let [a, b, c] = routing_keys(&model_with(AT_THE_BOUND));
+    assert_eq!(a, c, "the control pair must still share a key");
+    assert_eq!(
+        a, b,
+        "#{AT_THE_BOUND} is u32::MAX, a legal express id, and names an entity \
+         byte-identical to #7; the signature folds the resolved subtree rather \
+         than the id, so binding it must produce the same key (#3421)"
+    );
+}
+
+#[test]
+fn the_dedup_cache_does_not_serve_a_wrapped_reference_the_other_item_s_mesh() {
+    // End-to-end through the cache the key feeds, not just the key: mesh the
+    // real item first so it lands in `item_dedup_cache`, then ask for the item
+    // whose profile position reference is 2^32+7. Pre-fix the cache answered
+    // with the first item's mesh before the mesher was ever consulted.
+    let content = model_with(WRAPS_ONTO_SEVEN);
+    let bytes = content.as_bytes();
+    let mut decoder = EntityDecoder::with_index(bytes, build_entity_index(bytes));
+    let router = GeometryRouter::with_units(bytes, &mut decoder);
+
+    let real = decoder.decode_by_id(20).expect("decode #20");
+    let real_mesh = router
+        .process_representation_item(&real, &mut decoder)
+        .expect("the real extrusion meshes");
+    assert!(
+        !real_mesh.positions.is_empty(),
+        "the control item must produce geometry, or the cache is never \
+         populated and this test proves nothing"
+    );
+
+    let cached_after_real = router.dedup_unique_count();
+    assert_eq!(cached_after_real, 1, "the control item must populate the cache");
+
+    let oversized = decoder.decode_by_id(21).expect("decode #21");
+    match router.process_representation_item(&oversized, &mut decoder) {
+        // Refusing to mesh an item whose profile names no entity is the honest
+        // outcome; being handed SOMEONE ELSE'S geometry is not.
+        Err(_) => {}
+        Ok(mesh) => {
+            // Ask the cache, not the vertices. A hit is precisely "no new entry
+            // was inserted", which is what a colliding key causes; comparing
+            // positions only infers it, and would infer it WRONGLY if the mesher
+            // ever resolved `#11` to something that happened to mesh like `#10`.
+            // `#7` is deliberately a translated, rotated placement rather than
+            // the identity for the same reason.
+            assert_eq!(
+                router.dedup_unique_count(),
+                2,
+                "an item whose profile reference names no entity was served an \
+                 unrelated item's mesh out of the content-dedup cache: no new \
+                 entry was inserted, so the key collided (#3421)"
+            );
+            assert_ne!(
+                mesh.positions, real_mesh.positions,
+                "and its geometry is the other item's, vertex for vertex (#3421)"
+            );
+        }
+    }
+
+    // The control still dedups: a third item byte-identical to #20 must hit.
+    let twin = decoder.decode_by_id(22).expect("decode #22");
+    let twin_mesh = router
+        .process_representation_item(&twin, &mut decoder)
+        .expect("the twin extrusion meshes");
+    assert_eq!(
+        twin_mesh.positions, real_mesh.positions,
+        "byte-identical items must still dedup to the same mesh"
+    );
+}


### PR DESCRIPTION
Closes #3750.

Follow-up to #3421, which #3740 closed. #3740 migrated `content_hash.rs`, `step_text.rs` and `prepass.rs` onto `ifc_lite_core::express_id::parse_express_id`. Two things in `rust/export` were outside its diff.

## 1. A third answer to one question

`rust/export/src/merged/line_edit.rs:39` **saturated** rather than wrapped:

```rust
n = n.saturating_mul(10).saturating_add((line[j] - b'0') as u32);
```

Saturating is not #3421's damage — it cannot bind a reference to a real low-numbered entity. But it made `#4294967298` and `#4294967295` the same id, and accepted a malformed reference as a valid one, which the exporter then remapped and emitted. The repo was holding three answers to one question (refuse / saturate / wrap). Now one.

**Behaviour change at the boundary, stated because it is real:** an over-`u32` run used to be clamped to `#4294967295` and then remapped and offset like a genuine id. It is now copied through verbatim, so the merged file carries the reference as authored — the same state the input file was already in. Every call site was traced: `rewrite_refs` has one caller (`merged/mod.rs:308`), returns a `String`, and its `None` arm copies the run through, so no line is dropped. `parse_ref`'s callers already used `str::parse::<u32>`, which refused above `u32::MAX`, so `None` there is the same value as before.

## 2. The example's verdict could not see the class it now emits

`examples/merge_ifc.rs::refs_in` silently dropped a reference it could not parse, while `self_check` used that output to count dangling references — and **that count is the example's PASS/FAIL verdict and its exit code**. So the one reference class dangling *by construction* was the one class the verdict could not count.

Measured, binary run directly and `$?` read on the next line, never through a pipe:

| | output | exit |
|---|---|---|
| fixed | `dangling references : 1`, `result: FAIL` | **1** |
| mutated back (`None => {}`) | `dangling references : 0`, `result: PASS` | **0** |

on a merged file whose line 16 is `#10=IFCAXIS2PLACEMENT3D(#8,#9,#4294967298);`.

**The mirror risk was checked, because a verdict that fails on good input would be worse than the bug.** `refused` counts per *reference*, not per line. It is reachable only after a `#` outside a string followed by digits, and only when `parse_express_id` refuses a 10+ digit run — so `$`, `*`, empty slots and `#` inside strings cannot be miscounted. Verified on a clean merge carrying `$` slots, a `*` slot, `#99` inside a string and an `''`-escaped string containing `#1`: `dangling references : 0`, `result: PASS`, exit 0.

## 3. The mis-instancing #3740 fixed, now pinned

`rust/geometry/tests/issue_3421_content_hash_oversized_ref.rs` pins the case with a failing-before test #3740 did not carry. Mutating `content_hash.rs:354` back to a wrapping accumulator turns **2 of 3 red**.

## Two defects the review caught in my own work

Both were the same mistake this PR is about — a guard that cannot observe what it guards — and both are worth naming rather than quietly fixing:

- The `self_check` regression above **was introduced by this branch**. `refs_in` dropping refusals was mine, in the same diff that makes `rewrite_refs` emit that exact class. Caught by review, reproduced by hand, fixed.
- The dedup test's `Ok` arm used mesh-position equality as a proxy for "came from the cache", and its `#7` was `IFCAXIS2PLACEMENT2D((0.,0.),(1.,0.))` — the identity. An identity fallback in core would have failed the assertion on **correct** code. The oracle is now `router.dedup_unique_count()` (a hit is precisely "no new entry inserted"), and `#7` is translated and rotated — measured positions start `[167.0, -104.0, 0.0, 167.0, 96.0, 0.0]` — so no fallback can mimic a hit.

## Deliberately deferred

Reporting a refused *reference* to the user. The definition side reports through `rust/core/src/parser/oversized_ids.rs`; the reference side has no per-load channel, and inventing one is a design change. Filed as #3752.

## Verification

`cargo test --workspace --no-fail-fast`: **2527 passed, 0 failed, 36 ignored**, exit 0. `cargo clippy --workspace --all-targets -- -D warnings`: exit 0, zero warnings — run independently twice, once by the reviewer and once by me. No changeset: no published package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZNiLBzRCkZqWBJNsjDts6