### PR TITLE
fix(scripts): teach check-source-text-assertions to see .mjs reads

### DIFF
--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -154,7 +154,7 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '
 // new)" while its own detector flagged 14 files it never opened. A prohibited
 // source-text assertion landed in #3633 and survived eight rounds of hardening
 // underneath that green.
-const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|mjs)$/;
+const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|mjs|cjs|js)$/;
 
 const ALLOWLIST_PATH = join(ROOT, 'scripts', 'source-text-assertion-allowlist.txt');
 
@@ -208,9 +208,9 @@ const ALLOWLIST_PATH = join(ROOT, 'scripts', 'source-text-assertion-allowlist.tx
  */
 // 8 -> 22. Not new debt: 14 files always in violation, only now visible,
 // grandfathered in the commit that makes them visible. Ratchets DOWN only.
-// 22 -> 31 (#3754): SOURCE_LITERAL lacked `mjs`, so scripts/'s all-.mjs files
-// named no "source file" -- same shape, 9 more always-violating files.
-const ALLOWLIST_CEILING = 31;
+// 22 -> 31 (#3754): SOURCE_LITERAL lacked `mjs` -- same shape, 9 more files.
+// 31 -> 33 (#3754 follow-up): still lacked `cjs`/`js` -- 2 more, same shape.
+const ALLOWLIST_CEILING = 33;
 
 function walk(dir, found = []) {
   // Fail closed. Swallowing an unreadable directory would let this guard

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -206,11 +206,11 @@ const ALLOWLIST_PATH = join(ROOT, 'scripts', 'source-text-assertion-allowlist.tx
  * than shipped for the convenience of one file.
  * Raised in the same commit as the row, which is what this constant forces.
  */
-// 8 -> 22. The jump is not new debt: it is 14 files that were always in
-// violation and are only now visible, grandfathered in the same commit that
-// makes them visible, which is exactly what this constant exists to force. The
-// list still only ratchets DOWN from here.
-const ALLOWLIST_CEILING = 22;
+// 8 -> 22. Not new debt: 14 files always in violation, only now visible,
+// grandfathered in the commit that makes them visible. Ratchets DOWN only.
+// 22 -> 31 (#3754): SOURCE_LITERAL lacked `mjs`, so scripts/'s all-.mjs files
+// named no "source file" -- same shape, 9 more always-violating files.
+const ALLOWLIST_CEILING = 31;
 
 function walk(dir, found = []) {
   // Fail closed. Swallowing an unreadable directory would let this guard

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -1341,6 +1341,36 @@ assert.match(cfg, /x/);
   );
 });
 
+// The CommonJS analogue of the import-specifier false positive above (#3754
+// follow-up): a bare `require('./sibling.cjs')` LOADS a module, same as an
+// `import` specifier, and every `.cjs`/`.js` test in this repo opens with one.
+test('a require(".../x.cjs") specifier alone does not name a source file', () => {
+  assert.equal(
+    flagged(`
+const { evaluate } = require('./check-issue-queue.cjs');
+const { readFileSync } = require('node:fs');
+const cfg = readFileSync('./x.json', 'utf8');
+assert.match(cfg, /x/);
+`),
+    false,
+  );
+});
+
+// The exclusion must stay narrow: `require.resolve(...)` returns a PATH, not a
+// loaded module -- the CommonJS spelling of `join(dirname(...), 'x.cjs')` --
+// and reading THAT path is exactly the pairing rule's subject. Excluding it
+// too would reopen the hole isModuleSpecifierLiteral exists to close.
+test('require.resolve(".../x.cjs") is not excluded — reading through it is still caught', () => {
+  assert.equal(
+    flagged(`
+const { readFileSync } = require('node:fs');
+const body = readFileSync(require.resolve('./sibling.cjs'), 'utf8');
+assert.match(body, /function evaluate/);
+`),
+    true,
+  );
+});
+
 // ---------------------------------------------------------------------------
 // 6. End to end: the probe above, inverted (#3754). Plants the issue's exact
 // shape in a synthetic scripts/ tree and asserts the UNMODIFIED gate goes RED
@@ -1393,4 +1423,65 @@ test('PLANTED PROBE - delete me', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// 7. Same end-to-end shape, on the two extensions an adversarial review of
+// #3754 found still uncovered: TEST_FILE_RE/SOURCE_LITERAL gained `mjs` but
+// not `cjs` or plain `js`, so scripts/space-dcel-e2e.cjs's shape was still
+// invisible after #3754 landed.
+// ---------------------------------------------------------------------------
+
+function plantEndToEnd(extension) {
+  const dir = mkdtempSync(join(tmpdir(), `source-text-${extension}-plant-`));
+  try {
+    for (const d of ['packages', 'apps', 'scripts']) mkdirSync(join(dir, d), { recursive: true });
+    writeFileSync(
+      join(dir, 'scripts', `plant-subject.${extension}`),
+      'module.exports.evaluate = function evaluate() { return true; };\n',
+    );
+    // CommonJS `require`, which #3754's follow-up must not treat as a module
+    // specifier exclusion the way it treats an ESM import: it reads its own
+    // sibling via `require.resolve`, a path lookup, not a module load.
+    writeFileSync(
+      join(dir, 'scripts', `plant-subject.test.${extension}`),
+      `const { test } = require('node:test');
+const { readFileSync } = require('node:fs');
+const assert = require('node:assert/strict');
+
+test('PLANTED PROBE - delete me', () => {
+  const body = readFileSync(require.resolve('./plant-subject.${extension}'), 'utf8');
+  assert.match(body, /function evaluate/);
+});
+`,
+    );
+    writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), '');
+    const realGateSrc = readFileSync(GATE, 'utf8');
+    const gateSrc = realGateSrc
+      .replace("from './source-text-assertion-detect.mjs'", `from ${JSON.stringify(pathToFileURL(DETECT).href)}`)
+      .replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
+    assert.notEqual(gateSrc, realGateSrc, 'ceiling/import rewrite did not match the real gate source');
+    const gateCopy = join(dir, 'scripts', 'check-source-text-assertions.mjs');
+    writeFileSync(gateCopy, gateSrc);
+
+    const r = spawnSync(process.execPath, [gateCopy, '--root', dir], { encoding: 'utf8', timeout: 120_000 });
+    const output = `${r.stdout}${r.stderr}`;
+    assert.notEqual(r.status, 0, `the planted assertion must fail the gate, got exit 0:\n${output}`);
+    assert.match(
+      output,
+      new RegExp(`scripts/plant-subject\\.test\\.${extension}:\\d+`),
+      `the offending file:line must be named in the output:\n${output}`,
+    );
+    assert.doesNotMatch(output, /0 new\)/, 'must not report the planted violation as "0 new"');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('a planted .cjs source-text assertion in scripts/ is caught end to end, not reported as "0 new"', () => {
+  plantEndToEnd('cjs');
+});
+
+test('a planted .js source-text assertion in scripts/ is caught end to end, not reported as "0 new"', () => {
+  plantEndToEnd('js');
 });

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -29,13 +29,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { analyze } from './source-text-assertion-detect.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
+const DETECT = join(ROOT, 'scripts', 'source-text-assertion-detect.mjs');
 
 const flagged = (src) => analyze(src).flagged;
 
@@ -1245,4 +1247,150 @@ const source = readFileSync('Thing.ts', 'utf8');
     false,
     'TSX now parses `<string>value` — if TypeScript changed, this test measures the wrong thing',
   );
+});
+
+// ---------------------------------------------------------------------------
+// 5. `.mjs` recognition (#3754): scripts/ is almost entirely `.mjs`, and
+// SOURCE_LITERAL — the "does a string literal in the tree NAME a source
+// file" half of the pairing rule — did not include it, so every read idiom
+// (`new URL(..., import.meta.url)`, `join(...)`, `resolve(...)`, a literal
+// relative path) was blind on that tree regardless of shape: `namesASourceFile`
+// returned false before taint tracking ever ran. The issue's own end-to-end
+// probe, appended to the real scripts/check-review-posted.test.mjs, reported
+// "OK (22 allowlisted, 30 marked, 0 new)".
+// ---------------------------------------------------------------------------
+
+test('an .mjs sibling read via new URL(..., import.meta.url) is flagged, the exact #3754 probe shape', () => {
+  assert.ok(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const body = readFileSync(new URL('./check-review-posted.mjs', import.meta.url), 'utf8');
+assert.match(body, /function evaluate/);
+`),
+  );
+});
+
+test('an .mjs sibling read via join(__dirname, ...) is flagged', () => {
+  assert.ok(
+    flagged(`
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+const body = readFileSync(join(__dirname, 'x.mjs'), 'utf8');
+assert.match(body, /function evaluate/);
+`),
+  );
+});
+
+test('an .mjs sibling read via a literal relative path is flagged', () => {
+  assert.ok(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const body = readFileSync('./x.mjs', 'utf8');
+assert.match(body, /function evaluate/);
+`),
+  );
+});
+
+// A module specifier is not a read: Node ESM requires the extension on every
+// relative import, so once `mjs` joined SOURCE_LITERAL, a plain
+// `import { evaluate } from './check-issue-queue.mjs'` — present at the top of
+// nearly every scripts/*.test.mjs file — satisfied namesASourceFile on its
+// own. Combined with the taint analysis's deliberately over-eager, unscoped
+// name set (source-text-assertion-detect.mjs), that turned one ordinary
+// import into false positives on completely unrelated predicates elsewhere in
+// the same file (measured: a `spawnSync` result's `.output` in
+// scripts/check-issue-queue.test.mjs, flagged with the import alone gating
+// the file open). This is not hypothetical, it is what the naive `mjs` fix
+// did before isModuleSpecifierLiteral was added.
+test('an .mjs import specifier alone does not name a source file', () => {
+  assert.equal(
+    flagged(`
+import { evaluate } from './check-issue-queue.mjs';
+import { readFileSync } from 'node:fs';
+const cfg = readFileSync('./x.json', 'utf8');
+function run(cb) { return cb(cfg); }
+const out = run((c) => process.env.x);
+assert.match(out, /READY/);
+`),
+    false,
+  );
+});
+
+test('a dynamic import(".../x.mjs") specifier alone does not name a source file', () => {
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const cfg = readFileSync('./x.json', 'utf8');
+async function load() { return import('./sibling.mjs'); }
+assert.match(cfg, /x/);
+`),
+    false,
+  );
+});
+
+// A re-export is the same shape as an import for this purpose.
+test('an .mjs re-export specifier alone does not name a source file', () => {
+  assert.equal(
+    flagged(`
+export * from './check-issue-queue.mjs';
+import { readFileSync } from 'node:fs';
+const cfg = readFileSync('./x.json', 'utf8');
+assert.match(cfg, /x/);
+`),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 6. End to end: the probe above, inverted (#3754). Plants the issue's exact
+// shape in a synthetic scripts/ tree and asserts the UNMODIFIED gate goes RED
+// — a regression test that pins "the gate can fail in scripts/", which nothing
+// did before this.
+// ---------------------------------------------------------------------------
+
+test('a planted .mjs source-text assertion in scripts/ is caught end to end, not reported as "0 new"', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'source-text-mjs-plant-'));
+  try {
+    for (const d of ['packages', 'apps', 'scripts']) mkdirSync(join(dir, d), { recursive: true });
+    writeFileSync(
+      join(dir, 'scripts', 'plant-subject.mjs'),
+      'export function evaluate() { return true; }\n',
+    );
+    writeFileSync(
+      join(dir, 'scripts', 'plant-subject.test.mjs'),
+      `import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('PLANTED PROBE - delete me', () => {
+  const body = readFileSync(new URL('./plant-subject.mjs', import.meta.url), 'utf8');
+  assert.match(body, /function evaluate/);
+});
+`,
+    );
+    writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), '');
+    // A copy of the real gate with its ceiling zeroed (the synthetic allowlist
+    // is empty) and its detector import repointed at the real file, the same
+    // rewrite check-source-text-assertions-identity.test.mjs uses so this
+    // exercises the shipped gate rather than a hand-written stand-in.
+    const realGateSrc = readFileSync(GATE, 'utf8');
+    const gateSrc = realGateSrc
+      .replace("from './source-text-assertion-detect.mjs'", `from ${JSON.stringify(pathToFileURL(DETECT).href)}`)
+      .replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
+    assert.notEqual(gateSrc, realGateSrc, 'ceiling/import rewrite did not match the real gate source');
+    const gateCopy = join(dir, 'scripts', 'check-source-text-assertions.mjs');
+    writeFileSync(gateCopy, gateSrc);
+
+    const r = spawnSync(process.execPath, [gateCopy, '--root', dir], { encoding: 'utf8', timeout: 120_000 });
+    const output = `${r.stdout}${r.stderr}`;
+    assert.notEqual(r.status, 0, `the planted assertion must fail the gate, got exit 0:\n${output}`);
+    assert.match(
+      output,
+      /scripts\/plant-subject\.test\.mjs:\d+/,
+      `the offending file:line must be named in the output:\n${output}`,
+    );
+    assert.doesNotMatch(output, /0 new\)/, 'must not report the planted violation as "0 new"');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -64,6 +64,7 @@ scripts/check-module-size.mjs apps/landing # walks apps/ for .ts/.tsx; apps/land
 scripts/check-module-size.test.mjs apps/landing # same walk, in the harness
 scripts/check-wasm-disposal.mjs apps/landing # walks apps/ for WASM handles; apps/landing holds none
 scripts/check-source-text-assertions.mjs apps/landing # walks apps/ for test files; apps/landing has none
+scripts/check-source-text-assertions.test.mjs apps/landing # `apps` is a synthetic mkdtemp directory name (['packages', 'apps', 'scripts']), not a real read; the walk after mkdir hits the real apps/ tree, same walk as above
 scripts/check-source-text-assertions-identity.test.mjs apps/landing # same walk, in the harness
 scripts/check-loader-hook-specifier-match.mjs apps/landing # walks apps/ for loader hooks; apps/landing has none
 scripts/check-loader-hook-specifier-match.test.mjs apps/landing # same walk, in the harness

--- a/scripts/source-text-assertion-allowlist.txt
+++ b/scripts/source-text-assertion-allowlist.txt
@@ -118,3 +118,11 @@ scripts/release-crates-order.test.mjs  # 12 hits
 scripts/release-tag-commit.test.mjs  # 8 hits
 scripts/release-version-changed.test.mjs  # 6 hits
 scripts/sync-versions.test.mjs  # 15 hits
+
+# --- Added by #3754's follow-up, when TEST_FILE_RE/SOURCE_LITERAL finally
+# included `cjs`/`js` (an adversarial review of #3754 found the same blindness
+# one extension short of closed) ---
+# Same shape as the `mjs` row above, on the two extensions that round it out.
+# The ceiling moved 31 -> 33 to match.
+packages/pointcloud/src/streaming/worker-bundle.test.ts  # 5 hits -- reads dist/streaming/inline-worker.js, the published bundle, and asserts on its literal text (contains "export const INLINE_WORKER_CODE", is >50KB, does not start with import/export). Genuinely source-text: this IS the artifact under test, and there is no behaviour to drive instead -- the test exists specifically to pin the shape of a build output.
+scripts/check-benchmark-regression.test.mjs  # 4 hits -- same detector-false-positive class as packages/create-ifc-lite/test/config-fixers.test.ts above: every hit is on `report`/`out`, the markdown/stdout that a spawned `check-benchmark-regression.js` child process GENERATED, not on any file this test's own source reads. The `.js` literal that now names a "source file" is the spawned script's path, never read as text.

--- a/scripts/source-text-assertion-allowlist.txt
+++ b/scripts/source-text-assertion-allowlist.txt
@@ -74,3 +74,47 @@ scripts/review/lane-canary.test.mjs  # 7 hits
 scripts/review/post-review.test.mjs  # 60 hits
 scripts/review/run-reviewer.test.mjs  # 3 hits
 scripts/review/validate-findings.test.mjs  # 46 hits
+
+# --- Added by #3754, when SOURCE_LITERAL finally included `mjs` ---
+# The scanner had walked scripts/ since #3639 and READ_NAMES/taint tracking
+# never depended on an extension, but namesASourceFile's literal allowlist did
+# -- ts/tsx/mts/rs/css/scss, no mjs -- so every one of these files, which is
+# entirely `.mjs`, failed that half of the gate and was invisible regardless of
+# which read idiom it used. A planted `readFileSync(new URL('./x.mjs',
+# import.meta.url), 'utf8'))` followed by `assert.match(...)` reported "0 new".
+#
+# NOT historical debt in the sense #3639's rows were: these files were already
+# being scanned, just never opened, so the debt is exactly as old as each file.
+# Grandfathered here so the widened literal set can land without converting
+# nine files in the same commit; the ceiling moved 22 -> 31 to match.
+#
+# Two shapes, both genuinely blocked today:
+#   - check-issue-queue, check-pr-review-signal and check-review-posted: the
+#     taint set is flat and unscoped (deliberately, see
+#     source-text-assertion-detect.mjs), and a config object read once at
+#     module scope (SHIPPED, the workflow text) shares a parameter name --
+#     `payload`, `r`, `wf` -- with an unrelated spawnSync() result destructured
+#     the same way `packages/data/scripts/generate-ifc-schema.test.ts` already
+#     is: `{ code: r.status, output: \`${r.stdout}${r.stderr}\` }`. The
+#     predicates that fire are on that behavioural output, not on the file
+#     text the taint traces back to.
+#   - check-agents-md-size, check-rust-semver, release-crates-order,
+#     release-tag-commit, release-version-changed and sync-versions: genuinely
+#     read Cargo.toml / Cargo.lock / a workflow YAML / a budgets file and
+#     assert on the text with a regex, the shape this gate exists to flag --
+#     several already carry `@source-text-assertion-ok` siblings for the same
+#     reasoning as scripts/review/run-judge.test.mjs ("a missing YAML key or
+#     CLI flag has no behaviour to assert on"). Converting these to per-line
+#     markers or a behavioural harness is real work, tracked as follow-up, not
+#     done in the commit that first makes the gate able to see them.
+#
+# Each row carries its hit count at the time of widening, same caveat as above.
+scripts/check-agents-md-size.test.mjs  # 6 hits
+scripts/check-issue-queue.test.mjs  # 70 hits
+scripts/check-pr-review-signal.test.mjs  # 109 hits
+scripts/check-review-posted.test.mjs  # 13 hits
+scripts/check-rust-semver.test.mjs  # 11 hits
+scripts/release-crates-order.test.mjs  # 12 hits
+scripts/release-tag-commit.test.mjs  # 8 hits
+scripts/release-version-changed.test.mjs  # 6 hits
+scripts/sync-versions.test.mjs  # 15 hits

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -144,6 +144,7 @@
  */
 
 import ts from 'typescript';
+import { isModuleSpecifierLiteral } from './source-text-assertion-module-specifier.mjs';
 
 /**
  * The taint source: a disk read, however the call is qualified. This used to be
@@ -156,14 +157,13 @@ const READ_NAMES = new Set(['readFileSync', 'readFile']);
 /**
  * Names a SOURCE file as a literal. Fixture formats (.ifc, .json, .csv, …) are
  * deliberately absent: reading a fixture and asserting on it is a normal test.
+ * `mjs` joined the list for #3754 -- `scripts/` is 271 `.mjs` files against 5
+ * `.ts`, so this half of the pairing rule never matched what it read.
  *
- * Applied to string and template-literal CONTENT from the tree, so a `.ts`
- * filename that appears only in prose cannot satisfy it. That used to need a
- * comment-stripping pass, and it was load-bearing rather than tidy: three
- * unrelated tests mention a `.ts` filename in a comment while reading a wasm
- * binary or a JSON manifest, and matching those flagged all three.
+ * Applied to string/template-literal CONTENT, not PROSE -- load-bearing:
+ * three tests once got flagged by a `.ts` filename in a comment.
  */
-const SOURCE_LITERAL = /^[^'"`\n]*\.(ts|tsx|mts|rs|css|scss)$/;
+const SOURCE_LITERAL = /^[^'"`\n]*\.(ts|tsx|mts|mjs|rs|css|scss)$/;
 
 /**
  * Text predicates. `test` and `exec` are here because this repo already writes
@@ -592,7 +592,7 @@ function namesASourceFile(sourceFile) {
   walk(sourceFile, (n) => {
     if (found) return;
     if (ts.isStringLiteralLike(n)) {
-      if (SOURCE_LITERAL.test(n.text)) found = true;
+      if (!isModuleSpecifierLiteral(n) && SOURCE_LITERAL.test(n.text)) found = true;
       return;
     }
     // A template with substitutions has no single `.text`; each literal span is

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -157,13 +157,13 @@ const READ_NAMES = new Set(['readFileSync', 'readFile']);
 /**
  * Names a SOURCE file as a literal. Fixture formats (.ifc, .json, .csv, …) are
  * deliberately absent: reading a fixture and asserting on it is a normal test.
- * `mjs` joined the list for #3754 -- `scripts/` is 271 `.mjs` files against 5
- * `.ts`, so this half of the pairing rule never matched what it read.
+ * `mjs` joined for #3754 -- `scripts/` is 271 `.mjs` against 5 `.ts`, so this
+ * half never matched what it read. `cjs`/`js` joined for the same follow-up.
  *
  * Applied to string/template-literal CONTENT, not PROSE -- load-bearing:
  * three tests once got flagged by a `.ts` filename in a comment.
  */
-const SOURCE_LITERAL = /^[^'"`\n]*\.(ts|tsx|mts|mjs|rs|css|scss)$/;
+const SOURCE_LITERAL = /^[^'"`\n]*\.(ts|tsx|mts|mjs|cjs|js|rs|css|scss)$/;
 
 /**
  * Text predicates. `test` and `exec` are here because this repo already writes

--- a/scripts/source-text-assertion-module-specifier.mjs
+++ b/scripts/source-text-assertion-module-specifier.mjs
@@ -22,8 +22,28 @@
  * `stdout`. `.ts`/`.tsx`/`.mts` never hit this because this repo's TS imports
  * omit the extension, so the same hole was latent there too and this closes it
  * for every extension, not only the new one.
+ *
+ * `cjs`/`js` joining SOURCE_LITERAL for the same follow-up brought the CommonJS
+ * analogue of the same problem: `require('./sibling.cjs')` LOADS a module, the
+ * same act an `import` specifier performs, so it belongs in this exclusion
+ * too -- a bare `require(...)` call's first argument is treated exactly like an
+ * import/export specifier or a dynamic `import(...)` argument below.
+ *
+ * Deliberately NOT extended to `require.resolve(...)`: that call returns a
+ * PATH, not a loaded module, and is this codebase's CommonJS spelling of the
+ * `join(dirname(fileURLToPath(import.meta.url)), 'thing.mjs')` idiom the
+ * detect module's own docblock says resolves taint correctly once the literal
+ * is recognised -- `readFileSync(require.resolve('./thing.cjs'), 'utf8')`
+ * naming and then reading its own sibling is exactly the pairing rule's
+ * subject, and excluding it here would reopen the hole this file exists to
+ * close.
  */
 import ts from 'typescript';
+
+/** TRUE for the bare identifier `require`, never `require.resolve` or similar. */
+function isBareRequireCallee(expr) {
+  return ts.isIdentifier(expr) && expr.text === 'require';
+}
 
 export function isModuleSpecifierLiteral(node) {
   const parent = node.parent;
@@ -35,6 +55,8 @@ export function isModuleSpecifierLiteral(node) {
     parent.expression.kind === ts.SyntaxKind.ImportKeyword &&
     parent.arguments[0] === node
   )
+    return true;
+  if (ts.isCallExpression(parent) && isBareRequireCallee(parent.expression) && parent.arguments[0] === node)
     return true;
   return false;
 }

--- a/scripts/source-text-assertion-module-specifier.mjs
+++ b/scripts/source-text-assertion-module-specifier.mjs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sibling-extracted from source-text-assertion-detect.mjs (#3754) to keep that
+ * file under its module-size budget; imported there and nowhere else.
+ *
+ * TRUE when `node` is the module specifier of a static or dynamic import/
+ * re-export -- `from './x.mjs'`, `export * from './x.mjs'`, `import('./x.mjs')`
+ * -- rather than a string a test wrote to name a file it reads.
+ *
+ * Needed because #3754 added `mjs` to SOURCE_LITERAL: Node ESM requires the
+ * extension on every relative import, so `scripts/**\/*.test.mjs` names its
+ * own subject in a `.mjs` import literal on line one, every time. Without this
+ * exclusion that import alone satisfied `namesASourceFile` on nearly every
+ * file in the tree, and the pairing rule's deliberately over-eager taint
+ * propagation (a helper's return value taints its own name; any call to that
+ * name then taints its binding, regardless of that call's actual arguments --
+ * see `computeTainted` in source-text-assertion-detect.mjs) turned one `.mjs`
+ * import into hundreds of unrelated hits on values like a spawned process's
+ * `stdout`. `.ts`/`.tsx`/`.mts` never hit this because this repo's TS imports
+ * omit the extension, so the same hole was latent there too and this closes it
+ * for every extension, not only the new one.
+ */
+import ts from 'typescript';
+
+export function isModuleSpecifierLiteral(node) {
+  const parent = node.parent;
+  if (!parent) return false;
+  if ((ts.isImportDeclaration(parent) || ts.isExportDeclaration(parent)) && parent.moduleSpecifier === node)
+    return true;
+  if (
+    ts.isCallExpression(parent) &&
+    parent.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    parent.arguments[0] === node
+  )
+    return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

`check-source-text-assertions.mjs` reported "0 new" on a deliberately planted source-text assertion in `scripts/`, exactly as described in #3754. Root cause is narrower than the issue's own hypothesis (read-idiom shapes): `SOURCE_LITERAL` in `source-text-assertion-detect.mjs` — the "does a string literal name a source file" half of the pairing rule — only recognised `ts|tsx|mts|rs|css|scss`. Taint tracking itself never depended on the extension (`join(...)`, `resolve(...)`, `new URL(..., import.meta.url)`, and a literal relative path all resolve taint correctly once the literal is recognised), only this allowlist did — so every read of a `.mjs` sibling in `scripts/` (which is 271 `.mjs` files against 5 `.ts`) was invisible regardless of shape.

**Naive fix was unsafe on its own.** Adding `mjs` to `SOURCE_LITERAL` alone made `namesASourceFile` trip on the file's own `import { x } from './y.mjs'` — Node ESM requires the extension on every relative import, so this is present on line one of nearly every `scripts/*.test.mjs` file. Combined with the detector's deliberately over-eager, unscoped taint set, one ordinary import turned into hundreds of false positives on unrelated predicates (measured: a `spawnSync` result's `.output` in `scripts/check-issue-queue.test.mjs`). Added `isModuleSpecifierLiteral` (sibling-extracted to `scripts/source-text-assertion-module-specifier.mjs` to hold `check-module-size`'s pinned budget) to exclude import/export/dynamic-import specifiers — this closes the same latent hole for every extension, not only the new one (TS/TSX imports never hit it before only because this repo's TS imports omit the extension).

## Pre-existing violations recorded

Widening the check to actually see `scripts/`'s `.mjs` reads surfaced 9 files that were always in violation and invisible until now — not new debt. Recorded in `scripts/source-text-assertion-allowlist.txt` with reasons (two shapes: 3 files are the flat-taint-set false-positive class the docblock already documents for `generate-ifc-schema.test.ts`; 6 files genuinely read a Cargo.toml/lockfile/workflow-yaml/budgets file and assert on the text). `ALLOWLIST_CEILING` raised 22 → 31 in the same commit.

## Verification

- Reproduced RED first: planted the issue's exact probe in `scripts/check-review-posted.test.mjs`, ran the unmodified gate, got exit 0 / "OK (22 allowlisted, 30 marked, 0 new)".
- After the fix, planted the same shape in a *different*, non-allowlisted file (`scripts/check-test-wiring.test.mjs`) and confirmed exit 1 naming the exact offending line — proof the fix actually executes rather than degrading.
- `node --test scripts/check-source-text-assertions.test.mjs scripts/check-source-text-assertions-identity.test.mjs scripts/check-rust-source-text-assertions.test.mjs` — 117 pass, including new regression coverage: each read idiom named in the issue, the import-specifier false-positive this fix could reintroduce, and an end-to-end test that plants the probe in a synthetic `scripts/` tree via `--root` and asserts the unmodified gate goes red.
- `node scripts/check-source-text-assertions.mjs` on the branch — OK (31 allowlisted, 30 marked, 0 new).
- `node scripts/check-module-size.mjs` — OK, 0 new over 400 (both touched files held at/under their pinned budgets by condensing comments and sibling-extracting `isModuleSpecifierLiteral`).
- `node scripts/check-test-wiring.mjs` — OK.
- `pnpm run check:vitest-timeout-audit` — unaffected (no `.test.ts`/`.test.tsx` touched).
- **Merged-onto-main verification** (never pushed): cloned the branch, pointed `origin` at `LTplus-AG/ifc-lite`, checked out fresh `origin/main` (020932aad, newer than this branch's base), merged this branch on top, `pnpm install`, ran the gate there: `OK (31 allowlisted, 30 marked, 0 new), identity-checked vs origin/main (020932aad)` — the identity check ran for real (not the silent no-op fallback #3712 hit), confirming this does not redden `main`. Re-planted the probe on that same scratch merge and confirmed it's still caught there too.

## #3742

Checked for collision: #3742 touches `scripts/review/build-context-pack.mjs`, `scripts/review/run-reviewer.mjs`, and a new `scripts/review/sibling-row.mjs` — none overlap with the files this PR touches (`check-source-text-assertions.mjs`, `source-text-assertion-detect.mjs`, `source-text-assertion-allowlist.txt`, the new `source-text-assertion-module-specifier.mjs`, and this gate's own test file). No collision.

## Follow-up: .cjs and .js (adversarial review)

An adversarial review of this PR found the same blindness one extension short
of closed: `TEST_FILE_RE`/`SOURCE_LITERAL` saw `.mjs` but not `.cjs` or plain
`.js`, and the repo has a real file this could still not see,
`scripts/space-dcel-e2e.cjs`. Reproduced RED first: planted the issue's shape
in a synthetic `.cjs` file and a `.js` file under `scripts/`, ran the
unmodified gate, both reported "0 new" (not even walked).

- `TEST_FILE_RE`/`SOURCE_LITERAL`: added `cjs`, `js`.
- `isModuleSpecifierLiteral`: extended to a bare `require('./x.js')` call's
  argument, the CommonJS analogue of an ESM import specifier — without it,
  every `.cjs`/`.js` test's own top-of-file `require` of a sibling module
  would satisfy `namesASourceFile` and reproduce the false-positive storm the
  `.mjs` import exclusion exists to prevent (regression-tested). Deliberately
  **not** extended to `require.resolve(...)`: that returns a path, not a
  loaded module — the CommonJS spelling of the `join(dirname(...), 'x.mjs')`
  idiom this detector already resolves correctly — and reading through it is
  exactly this gate's subject, so a planted `readFileSync(require.resolve(...))`
  read is still caught (regression-tested, the blind-spot direction).
- Widening surfaced two pre-existing violations, invisible until now, both
  grandfathered with reasons in `source-text-assertion-allowlist.txt`:
  `packages/pointcloud/src/streaming/worker-bundle.test.ts` (genuinely reads a
  build artifact and asserts on its text) and
  `scripts/check-benchmark-regression.test.mjs` (detector false positive, same
  class as `config-fixers.test.ts` — every hit is on a spawned child process's
  generated markdown/stdout). `ALLOWLIST_CEILING` raised 31 → 33 in the same
  commit, never `--update`/`--allow-raise`.
- Regression tests mirror the existing `.mjs` coverage: `require()`-specifier
  unit tests, a `require.resolve()` blind-spot check, and planted `.cjs`/`.js`
  end-to-end tests against the real gate (asserting its exit code, not a mock).
- Verified by merging this branch onto a scratch clone of fresh
  `origin/main` (`b45180b78`, newer than this branch's base) with `origin`
  pointed at `LTplus-AG/ifc-lite`, `pnpm install`, then running the gate
  there: `OK (33 allowlisted, 30 marked, 0 new), identity-checked vs
  origin/main (b45180b78)` — the identity check ran for real, not the silent
  fallback.
- `node scripts/check-module-size.mjs` — OK, both touched files trimmed back
  to their pinned budgets (446/688 lines).

Closes #3754

