### PR TITLE
fix(review): stop CLEAN_CONTRADICTED deadlocking the lane

### DIFF
--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -387,7 +387,7 @@
    980 scripts/moonshot/m5-constrained-decoding/tasks-tier2.mjs
    661 scripts/review/build-context-pack.mjs
    413 scripts/review/build-review-input.mjs
-   851 scripts/review/post-review.mjs
+   891 scripts/review/post-review.mjs
    443 scripts/review/rubric-eval.mjs
    526 scripts/review/run-reviewer.mjs
    985 scripts/review/validate-findings.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -387,7 +387,7 @@
    980 scripts/moonshot/m5-constrained-decoding/tasks-tier2.mjs
    661 scripts/review/build-context-pack.mjs
    413 scripts/review/build-review-input.mjs
-   891 scripts/review/post-review.mjs
+   880 scripts/review/post-review.mjs
    443 scripts/review/rubric-eval.mjs
    526 scripts/review/run-reviewer.mjs
    985 scripts/review/validate-findings.mjs

--- a/scripts/review/post-review.mjs
+++ b/scripts/review/post-review.mjs
@@ -90,11 +90,16 @@
  *                       POST reported success and the comments are not there.
  *                       REMEDY: re-run. If it recurs, attach the log to
  *                       claude-code-action#1679 rather than re-running forever.
- *   CLEAN_CONTRADICTED  A clean verdict while our own inline findings are
- *                       anchored to this exact head. One of the two runs is
- *                       wrong and a `verdict=clean` marker would bury it.
- *                       REMEDY: re-run the review; if the findings are genuinely
- *                       withdrawn, delete those inline comments first.
+ *   (CLEAN_CONTRADICTED  REMOVED. It threw when this run found nothing while our
+ *                       own findings stood on the same head, and its remedy was
+ *                       "re-run" -- which reproduced the state exactly, so the
+ *                       lane failed forever until a human deleted a comment.
+ *                       Measured on #3669: three consecutive runs, no path out.
+ *                       The standing findings now simply STAND: the marker says
+ *                       `findings` with the confirmed count and the summary
+ *                       states the disagreement. Withdrawal is still possible
+ *                       and still needs a human, but it is no longer the ONLY
+ *                       way out of a red lane.)
  *   SUMMARY_POST_FAILED The marker comment POST/PATCH returned no id.
  *                       REMEDY: check that the posting workflow has write access
  *                       to the pull request, then re-run.
@@ -444,8 +449,8 @@ export function summaryBody({ sha, findings, count, judgedAway = 0, capped = 0 }
   const short = sha.slice(0, 9);
   const n = findings.length;
   if (count === 0) {
-    // Reachable only when `n` is 0 as well: the caller refuses CLEAN_CONTRADICTED
-    // before it gets here, and `count >= n` is enforced one step earlier.
+    // Reachable only when `n` is 0 as well: `count >= n` is enforced one step
+    // earlier, and the `n === 0 && count > 0` case is handled by the branch below.
     // A REVIEW JUDGED TO NOTHING IS NOT A REVIEW THAT FOUND NOTHING. The judge
     // can reject every validated finding, and without this line the only record
     // that they ever existed is a runner log that expires -- while the PR shows
@@ -469,6 +474,28 @@ export function summaryBody({ sha, findings, count, judgedAway = 0, capped = 0 }
       '',
       // No thumbs-down footer here on purpose: see STATED HOLES 6.
       marker(sha, 'clean', 0),
+    ].join('\n');
+  }
+  if (n === 0) {
+    // `count > 0` with `n === 0`: this run found nothing while earlier findings
+    // from this reviewer stand on the same commit. Without this branch the
+    // generic form below renders "0 findings" as a heading and then "1 inline
+    // comment confirmed" underneath -- a body that contradicts itself in two
+    // consecutive lines, which is what the old CLEAN_CONTRADICTED throw was
+    // really protecting the reader from. Say the actual state instead.
+    return [
+      `### Claude review - ${count} standing finding${count === 1 ? '' : 's'} for \`${short}\``,
+      '',
+      `This run reviewed the diff and found nothing to flag, but ${count} inline ` +
+        `comment${count === 1 ? '' : 's'} from an earlier run ${count === 1 ? 'is' : 'are'} still ` +
+        'anchored to this commit and nobody has withdrawn them.',
+      '',
+      'They stand. Two runs disagreed about the same code, and this note records that rather than ' +
+        'resolving it by fiat: the marker below says `findings`, so nothing reads this as a pass. ' +
+        'If the earlier findings are wrong, delete those inline comments and re-run — the verdict ' +
+        'becomes `clean` on its own once they are gone.',
+      '',
+      marker(sha, 'findings', count),
     ].join('\n');
   }
   return [
@@ -799,13 +826,26 @@ function main() {
         'attach the log to anthropics/claude-code-action#1679 rather than re-running indefinitely.',
     );
   }
+  // This run found nothing while our own findings stand on this commit.
+  //
+  // This used to throw CLEAN_CONTRADICTED, which DEADLOCKED: its remedy said
+  // "re-run", but a re-run reproduces the state exactly, so the lane failed
+  // forever until a human deleted a comment. Three consecutive runs on #3669.
+  // Its premise was wrong too -- it warned a `verdict=clean` marker would bury
+  // the disagreement, but the verdict below derives from `confirmed`, so it was
+  // already going to be `findings`.
+  //
+  // The findings are anchored to this head and nobody withdrew them, so they
+  // STAND: marker `findings`, summary states the disagreement, exit 0. A
+  // disagreement between two runs is a fact to record, not a failure to post.
+  // Withdrawal still works and still needs a human -- delete the comments,
+  // re-run, `confirmed` drops to 0 -- but it is no longer the only way out.
   if (findings.length === 0 && confirmed > 0) {
-    throw new PostReviewError(
-      'CLEAN_CONTRADICTED',
-      `This run found nothing, yet ${confirmed} inline finding(s) from \`${author}\` are anchored to ` +
-        `${args.sha.slice(0, 9)}. One of the two runs is wrong about the same commit, and a ` +
-        '`verdict=clean` marker would bury the disagreement under a pass. REMEDY: re-run the review; if ' +
-        'those findings are genuinely withdrawn, delete the inline comments first.',
+    console.log(
+      `CONTRADICTED: this run found nothing, yet ${confirmed} inline finding(s) from ` +
+        `\`${author}\` are anchored to ${args.sha.slice(0, 9)}. Those findings STAND: the marker ` +
+        'records `findings`, not `clean`, so the gate does not read this as a pass. If they are ' +
+        'genuinely withdrawn, delete the inline comments and re-run.',
     );
   }
 

--- a/scripts/review/post-review.mjs
+++ b/scripts/review/post-review.mjs
@@ -478,11 +478,9 @@ export function summaryBody({ sha, findings, count, judgedAway = 0, capped = 0 }
   }
   if (n === 0) {
     // `count > 0` with `n === 0`: this run found nothing while earlier findings
-    // from this reviewer stand on the same commit. Without this branch the
-    // generic form below renders "0 findings" as a heading and then "1 inline
-    // comment confirmed" underneath -- a body that contradicts itself in two
-    // consecutive lines, which is what the old CLEAN_CONTRADICTED throw was
-    // really protecting the reader from. Say the actual state instead.
+    // stand on the same commit. Without this branch the generic form below
+    // renders "0 findings" as a heading over "1 inline comment confirmed" -- a
+    // body contradicting itself in two consecutive lines. Say the state instead.
     return [
       `### Claude review - ${count} standing finding${count === 1 ? '' : 's'} for \`${short}\``,
       '',
@@ -492,7 +490,7 @@ export function summaryBody({ sha, findings, count, judgedAway = 0, capped = 0 }
       '',
       'They stand. Two runs disagreed about the same code, and this note records that rather than ' +
         'resolving it by fiat: the marker below says `findings`, so nothing reads this as a pass. ' +
-        'If the earlier findings are wrong, delete those inline comments and re-run — the verdict ' +
+        'If the earlier findings are wrong, delete those inline comments and re-run; the verdict ' +
         'becomes `clean` on its own once they are gone.',
       '',
       marker(sha, 'findings', count),
@@ -826,20 +824,11 @@ function main() {
         'attach the log to anthropics/claude-code-action#1679 rather than re-running indefinitely.',
     );
   }
-  // This run found nothing while our own findings stand on this commit.
-  //
-  // This used to throw CLEAN_CONTRADICTED, which DEADLOCKED: its remedy said
-  // "re-run", but a re-run reproduces the state exactly, so the lane failed
-  // forever until a human deleted a comment. Three consecutive runs on #3669.
-  // Its premise was wrong too -- it warned a `verdict=clean` marker would bury
-  // the disagreement, but the verdict below derives from `confirmed`, so it was
-  // already going to be `findings`.
-  //
-  // The findings are anchored to this head and nobody withdrew them, so they
+  // This run found nothing while our own findings stand on this commit. They
   // STAND: marker `findings`, summary states the disagreement, exit 0. A
   // disagreement between two runs is a fact to record, not a failure to post.
-  // Withdrawal still works and still needs a human -- delete the comments,
-  // re-run, `confirmed` drops to 0 -- but it is no longer the only way out.
+  // Withdrawal still needs a human but is no longer the only way out of a red
+  // lane. Why this replaced a throw: see CLEAN_CONTRADICTED in the header.
   if (findings.length === 0 && confirmed > 0) {
     console.log(
       `CONTRADICTED: this run found nothing, yet ${confirmed} inline finding(s) from ` +

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -41,7 +41,7 @@ const SCRIPT = join(HERE, 'post-review.mjs');
 // The rest of this file drives the script as a SUBPROCESS, which is right for the
 // GitHub-facing behaviour. The posting cap is a pure function of the findings
 // file, so it is exercised directly.
-import { readFindings, MAX_POSTED_FINDINGS, summaryBody, readJudgedAway, readCappedCount } from './post-review.mjs';
+import { readFindings, MAX_POSTED_FINDINGS, summaryBody, readJudgedAway, readCappedCount, marker } from './post-review.mjs';
 const GATE = join(HERE, '..', 'check-review-posted.mjs');
 const SHIPPED_CFG = join(HERE, '..', 'review-posted.config.json');
 const SHIPPED = JSON.parse(readFileSync(SHIPPED_CFG, 'utf8'));
@@ -585,16 +585,48 @@ test('a clean run over our OWN standing findings records them instead of deadloc
   // "0 findings" as a heading over "1 inline comment confirmed".
   assert.doesNotMatch(bodies, /### Claude review - 0 finding/);
   assert.match(bodies, /standing finding/);
+
+  // The file's stated last defence: run the REAL gate over what was posted.
+  // A marker this module considers well-formed is worth nothing if the gate
+  // that reads it disagrees, and that pairing is what this suite exists for.
+  const g = runGate(r.state);
+  assert.equal(g.code, 0, `the gate must accept the contradicted end state:\n${g.out}`);
 });
 
-test('the withdrawal path still reaches clean once the comments are gone', () => {
-  // The escape hatch the old error described is the ONLY thing that still needs
-  // a human, and it must keep working: delete the inline comments, re-run, and
-  // the verdict becomes clean through the ordinary path. Without this test the
-  // fix above could have made `clean` unreachable and nothing would say so.
-  const r = runPoster({ findings: [], state: { reviewComments: [] } });
+test('WITHDRAWAL: a standing findings marker is DOWNGRADED to clean once the comments go', () => {
+  // The escape hatch the old error described is the only thing that still needs
+  // a human, and it must keep working. An earlier version of this test ran
+  // `runPoster({ findings: [], state: { reviewComments: [] } })`, which is
+  // byte-identical to the happy-path test above -- it exercised the code and
+  // put NO pressure on the withdrawal property, and its comment claimed a
+  // coverage it did not have. Mutation-checked: only a verdict-always-findings
+  // mutant killed it, which the happy-path test already caught.
+  //
+  // The state that actually matters is the TRANSITION: a `findings` marker is
+  // already standing from the contradicted run, the human deletes the inline
+  // comment, and the re-run must PATCH that marker DOWN to clean rather than
+  // leave a findings marker over a PR with no findings on it.
+  const standing = {
+    id: 700,
+    user: { login: REVIEWER },
+    body: `### Claude review - 1 standing finding for \`${SHA.slice(0, 9)}\`\n\n${'x'}\n\n${marker(SHA, 'findings', 1)}`,
+  };
+  const r = runPoster({ findings: [], state: { issueComments: [standing], reviewComments: [] } });
   assert.equal(r.code, 0, r.out);
-  assert.match(allBodies(r.state), new RegExp(`<!-- ifc-lite-review sha=${SHA} verdict=clean count=0`));
+
+  const bodies = allBodies(r.state);
+  assert.match(
+    bodies,
+    new RegExp(`<!-- ifc-lite-review sha=${SHA} verdict=clean count=0`),
+    'the standing findings marker must be downgraded to clean',
+  );
+  assert.doesNotMatch(bodies, /verdict=findings/, 'no findings marker may survive the withdrawal');
+  // One marker comment, PATCHed in place -- not a second one posted alongside.
+  assert.equal(
+    r.state.issueComments.filter((c) => /ifc-lite-review sha=/.test(c.body ?? '')).length,
+    1,
+    'the withdrawal must PATCH the standing marker, not post a rival',
+  );
 });
 
 // ========================================================= identity boundaries

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -552,7 +552,16 @@ test('a re-run after a TRANSIENT drop re-posts the finding and then passes', () 
   assert.match(second.state.issueComments[0].body, /count=2 -->/);
 });
 
-test('FAIL: a clean verdict over our OWN findings on this head is refused', () => {
+test('a clean run over our OWN standing findings records them instead of deadlocking', () => {
+  // This used to throw CLEAN_CONTRADICTED and exit 1. The remedy it printed was
+  // "re-run the review", but a re-run reproduces the state exactly: the prior
+  // comment is still anchored, this run still finds nothing. So the lane failed
+  // FOREVER on that commit until a human deleted a comment. Measured on #3669:
+  // three consecutive runs, identical failure, no path out.
+  //
+  // The requirement that mattered has not changed and is still asserted below:
+  // a `verdict=clean` marker must never bury a live finding. What changed is
+  // that the honest outcome -- the findings STAND -- is now reachable.
   const seeded = {
     id: 901,
     user: { login: REVIEWER },
@@ -563,9 +572,29 @@ test('FAIL: a clean verdict over our OWN findings on this head is refused', () =
     body: 'An earlier run of this same head found this.',
   };
   const r = runPoster({ findings: [], state: { reviewComments: [seeded] } });
-  assert.equal(r.code, 1, r.out);
-  assert.match(r.out, /CLEAN_CONTRADICTED/);
-  assert.doesNotMatch(allBodies(r.state), /verdict=clean/, 'a clean marker must not bury a live finding');
+
+  assert.equal(r.code, 0, `the lane must not deadlock:\n${r.out}`);
+  assert.match(r.out, /CONTRADICTED/, 'the disagreement must be stated in the log, not swallowed');
+
+  const bodies = allBodies(r.state);
+  // THE ORIGINAL INVARIANT, unchanged.
+  assert.doesNotMatch(bodies, /verdict=clean/, 'a clean marker must not bury a live finding');
+  // ...and the marker the gate reads says findings, with the confirmed count.
+  assert.match(bodies, new RegExp(`<!-- ifc-lite-review sha=${SHA} verdict=findings count=1`));
+  // The summary must not contradict itself the way the generic body would:
+  // "0 findings" as a heading over "1 inline comment confirmed".
+  assert.doesNotMatch(bodies, /### Claude review - 0 finding/);
+  assert.match(bodies, /standing finding/);
+});
+
+test('the withdrawal path still reaches clean once the comments are gone', () => {
+  // The escape hatch the old error described is the ONLY thing that still needs
+  // a human, and it must keep working: delete the inline comments, re-run, and
+  // the verdict becomes clean through the ordinary path. Without this test the
+  // fix above could have made `clean` unreachable and nothing would say so.
+  const r = runPoster({ findings: [], state: { reviewComments: [] } });
+  assert.equal(r.code, 0, r.out);
+  assert.match(allBodies(r.state), new RegExp(`<!-- ifc-lite-review sha=${SHA} verdict=clean count=0`));
 });
 
 // ========================================================= identity boundaries


### PR DESCRIPTION
The review lane failed 16 of its last 60 runs. Two were `CLEAN_CONTRADICTED`, and that error could not be cleared by anything it told you to do.

## The deadlock

`post-review.mjs` threw when a run found nothing while that reviewer's own inline findings were still anchored to the same head. Its remedy read *"re-run the review"*. A re-run reproduces the state exactly — the prior comments are still anchored, this run still finds nothing — so the lane failed on that commit **forever**, until a human deleted a comment by hand.

Measured on #3669: three consecutive runs, identical failure, no path out.

## Its premise was also wrong about its own code

The error warned that *"a `verdict=clean` marker would bury the disagreement under a pass"*. But the verdict two lines below it is

```js
const verdict = confirmed === 0 ? 'clean' : 'findings';
```

derived from what is **confirmed on the PR**, not from this run's output. In the contradicted case it was already going to be `findings`. The marker was never the thing at risk.

## What was actually at risk

The summary body. With `findings=[]` and `count=1`, `summaryBody` fell through to its generic form and rendered:

```
### Claude review - 0 findings for abc123def
...
1 inline comment from this reviewer confirmed on this commit.
```

A heading contradicting the line beneath it. That is worth refusing. It is not worth deadlocking over.

## The fix

The findings are anchored to this head and nobody withdrew them, so **they stand**. `summaryBody` gains an explicit `n === 0 && count > 0` branch saying so, the marker records `findings` with the confirmed count so the gate cannot read it as a pass, and the lane exits 0 — a disagreement between two runs is a fact to record, not a failure to post.

The withdrawal path is unchanged and still needs a human: delete the inline comments, re-run, `confirmed` drops to 0, verdict becomes `clean` through the ordinary path. It is simply no longer the *only* way out of a red lane.

## On the tests

The first version of the withdrawal test **could not fail** — `runPoster({ findings: [], state: { reviewComments: [] } })` is byte-identical to the happy-path test forty lines above, since an empty `reviewComments` is the harness default. Its comment claimed a coverage it did not have.

It now tests the transition that actually matters and nothing else covered: a standing `findings` marker, the comment deleted, and the re-run **patching that marker down to `clean`** rather than leaving a findings marker over a PR with no findings on it. Mutation-proven, and it catches a mutant the old version did not — breaking the carrier lookup so the poster posts a rival marker instead of patching.

The contradicted test now also runs the real gate over its end state, which is this suite's stated last defence and something four other tests already do.

## Verified by running, unpiped

```
node --test scripts/review/*.test.mjs         255 pass, 0 fail
node scripts/check-module-size.mjs            exit 0
node scripts/check-source-text-assertions.mjs exit 0
pnpm lint                                     exit 0
```

`post-review.mjs` 851 → 880; row and `scripts` digest updated. The allowlist diff against main shows only that row.

A pre-flight review confirmed the marker is honest (its count is `confirmed`, read back from the PR, and no consumer compares it to a findings file), that no hole opened on the judge, cap, partial or validates-to-zero paths, and that body and marker cannot disagree because both derive from `confirmed` and `upsertAndVerify` refuses a marker it cannot read back.

No changeset: `scripts/` only, publishes nothing.

Related: #3730 (the review signal certifies lane presence, not review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review posting now completes successfully when a clean scan conflicts with existing inline findings.
  - Conflicting review results are reported clearly while preserving the confirmed findings count.
  - Removing previously reported findings now correctly updates the review status to clean.

- **Reliability**
  - Review status markers remain consistent as findings are confirmed or withdrawn.
  - Module-size checks now produce stable, accurate results when updating size allowances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->