### PR TITLE
fix(cli): ifc-lite schema documented a bim.query.* namespace that run/eval do not have

### DIFF
--- a/.changeset/cli-schema-describes-run-eval-bim.md
+++ b/.changeset/cli-schema-describes-run-eval-bim.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`ifc-lite schema` now describes the `bim` object that `ifc-lite run` and `ifc-lite eval` actually hand to scripts (#3763). It printed `@ifc-lite/sandbox`'s `NAMESPACE_SCHEMAS` verbatim, which describes the browser sandbox bridge: there `bim.query.properties(ref)`, `bim.query.entity(...)` and ~19 siblings really are methods. The CLI's `bim` is a raw `BimContext`, where `query()` starts a builder chain and those methods sit at the top level, so every `bim.query.X(...)` call copied out of the dump — the command's whole purpose is API discovery for LLM tools — threw `TypeError: bim.query.X is not a function` on first use.
+
+The dump now carries a `bim` namespace holding the top-level `BimContext` methods (`bim.properties(ref)`, `bim.quantities(ref)`, `bim.storeys()`, …) and a `query` namespace holding the builder chain reached via `bim.query()` (`byType`, `where`, `limit`, `toArray`, `count`, …). Both method lists are reflected off `BimContext.prototype` and `QueryBuilder.prototype` rather than transcribed, on the reduced-fallback path too, so they cannot drift from the runtime; a new test walks the emitted dump and resolves every documented path on a live context.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1067,7 +1067,7 @@ ifc-lite schema              # Full schema with params and return types
 ifc-lite schema --compact    # Minimal: names and descriptions only
 ```
 
-The schema includes the runtime SDK namespaces: `model`, `query`, `viewer`, `mutate`, `store`, `lens`, `create`, `files`, `schedule`, `clash`, `export`, and their methods with parameter names, return types, and LLM semantic hints.
+The dump matches the `bim` object `run`/`eval` hand to scripts: a root `bim` namespace with its top-level methods (`entity`, `properties`, `contains`, `on`, …), plus the runtime SDK namespaces `model`, `query`, `viewer`, `mutate`, `store`, `lens`, `create`, `files`, `schedule`, `clash`, `export` — where `query` is the builder chain reached via `bim.query()` (`.byType(...).where(...).toArray()`), not a flat namespace — and their methods with parameter names, return types, and LLM semantic hints.
 
 ---
 

--- a/docs/guide/scripting-sdk.md
+++ b/docs/guide/scripting-sdk.md
@@ -95,7 +95,7 @@ ifc-lite schema              # full schema with params and return types
 ifc-lite schema --compact    # names and descriptions only
 ```
 
-The schema covers the scriptable namespaces, `model`, `query`, `viewer`, `mutate`, `store`, `lens`, `create`, `files`, `schedule`, `clash`, and `export`, and includes each method's parameter names, return type, and LLM semantic hints (`useWhen`, task tags). Running `ifc-lite schema` first is the recommended way to author correct `eval`/`run` code. See [Using with LLM Terminals](cli.md#using-with-llm-terminals) for the wider agent workflow.
+`ifc-lite schema` documents the `bim` object `eval`/`run` actually hand your script — a root `bim` namespace of top-level methods, plus the scriptable namespaces `model`, `query`, `viewer`, `mutate`, `store`, `lens`, `create`, `files`, `schedule`, `clash`, and `export` — and includes each method's parameter names, return type, and LLM semantic hints (`useWhen`, task tags). There `query` is the chain reached via `bim.query()` (`.byType(...).toArray()`), not a namespace of standalone lookups. That differs from the sandbox's own bridge schema shown below, where `bim.query.byType(...)` runs and returns data in one call — the sandbox and `eval`/`run` hand scripts different `bim` shapes, so pick the one matching where the script will run. Running `ifc-lite schema` first is the recommended way to author correct `eval`/`run` code. See [Using with LLM Terminals](cli.md#using-with-llm-terminals) for the wider agent workflow.
 
 ## The sandbox
 

--- a/packages/cli/src/commands/schema.runtime-shape.test.ts
+++ b/packages/cli/src/commands/schema.runtime-shape.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 interface DumpedNamespace {
   namespace: string;
   description?: string;
-  methods: { name: string }[];
+  methods: { name: string; params?: string[]; returns?: string }[];
 }
 
 async function dumpSchema(): Promise<DumpedNamespace[]> {
@@ -48,11 +48,20 @@ async function dumpSchema(): Promise<DumpedNamespace[]> {
   return JSON.parse(out.join('')) as DumpedNamespace[];
 }
 
-/** Value-function own property names on a prototype, minus the constructor. */
-function prototypeMethods(proto: object): string[] {
+/**
+ * Value-function own property names on a prototype, minus the constructor,
+ * plus getters whose value is itself callable (e.g. `BimContext.prototype.on`)
+ * when a live `instance` is supplied to invoke them against.
+ */
+function prototypeMethods(proto: object, instance?: object): string[] {
   return Object.getOwnPropertyNames(proto).filter((name) => {
     if (name === 'constructor') return false;
-    return typeof Object.getOwnPropertyDescriptor(proto, name)?.value === 'function';
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (typeof desc?.value === 'function') return true;
+    if (typeof desc?.get === 'function' && instance) {
+      return typeof (instance as Record<string, unknown>)[name] === 'function';
+    }
+    return false;
   });
 }
 
@@ -64,7 +73,7 @@ describe('ifc-lite schema describes the run/eval bim object', () => {
     expect(root, 'a root `bim` namespace must be documented').toBeDefined();
 
     const documented = new Set(root!.methods.map((m) => m.name));
-    const runtime = prototypeMethods(BimContext.prototype);
+    const runtime = prototypeMethods(BimContext.prototype, new BimContext({ backend: {} as never }));
 
     // Every runtime top-level method is documented …
     expect([...runtime].sort()).toEqual([...documented].filter((n) => runtime.includes(n)).sort());
@@ -136,5 +145,32 @@ describe('ifc-lite schema describes the run/eval bim object', () => {
     }
 
     expect(unresolved).toEqual([]);
+  });
+
+  it('documents the callable `on` accessor on the bim root', async () => {
+    const dump = await dumpSchema();
+
+    const root = dump.find((ns) => ns.namespace === 'bim');
+    const on = root!.methods.find((m) => m.name === 'on');
+
+    expect(on, 'bim.on is a getter returning a bound function; it must appear in the dump').toBeDefined();
+  });
+
+  it("describes bim.entity and query().byType() from their own runtime signatures, not the sandbox bridge's", async () => {
+    const dump = await dumpSchema();
+
+    const root = dump.find((ns) => ns.namespace === 'bim');
+    const entity = root!.methods.find((m) => m.name === 'entity');
+    // The bridge's `entity` takes (modelId, expressId) and returns `BimEntity | null`
+    // because it resolves the ref itself; the CLI's raw `BimContext.entity`
+    // takes a single `EntityRef` (see packages/sdk/src/context.ts).
+    expect(entity?.params).toEqual(['ref']);
+    expect(entity?.returns).toBe('EntityData | null');
+
+    const query = dump.find((ns) => ns.namespace === 'query');
+    const byType = query!.methods.find((m) => m.name === 'byType');
+    // The bridge's `byType` runs the whole chain and returns `BimEntity[]`;
+    // the CLI's `QueryBuilder.byType` returns `this` to keep chaining.
+    expect(byType?.returns).toBe('this');
   });
 });

--- a/packages/cli/src/commands/schema.runtime-shape.test.ts
+++ b/packages/cli/src/commands/schema.runtime-shape.test.ts
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite schema` must describe the `bim` object that `ifc-lite run` and
+ * `ifc-lite eval` hand to scripts (#3763).
+ *
+ * The command used to print `@ifc-lite/sandbox`'s `NAMESPACE_SCHEMAS`
+ * verbatim. That schema describes the browser sandbox bridge, where
+ * `query.properties(ref)` really is a method. The CLI's `bim` is a raw
+ * `BimContext`, where `query()` is a builder-starter and `properties` and its
+ * ~20 siblings live at the top level. Every `bim.query.X(...)` call an agent
+ * copied out of the schema dump threw `TypeError: ... is not a function`.
+ *
+ * This test walks the DUMP and asserts every documented path resolves on the
+ * real runtime object, so the two cannot drift apart again. The runtime is
+ * reflected, not transcribed: a new `BimContext` method that nothing
+ * documents fails here too.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { BimContext, QueryBuilder } from '@ifc-lite/sdk';
+import { schemaCommand } from './schema.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface DumpedNamespace {
+  namespace: string;
+  description?: string;
+  methods: { name: string }[];
+}
+
+async function dumpSchema(): Promise<DumpedNamespace[]> {
+  const out: string[] = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    out.push(String(chunk));
+    return true;
+  });
+  const previousExitCode = process.exitCode;
+  try {
+    await schemaCommand([]);
+  } finally {
+    process.exitCode = previousExitCode;
+  }
+  return JSON.parse(out.join('')) as DumpedNamespace[];
+}
+
+/** Value-function own property names on a prototype, minus the constructor. */
+function prototypeMethods(proto: object): string[] {
+  return Object.getOwnPropertyNames(proto).filter((name) => {
+    if (name === 'constructor') return false;
+    return typeof Object.getOwnPropertyDescriptor(proto, name)?.value === 'function';
+  });
+}
+
+describe('ifc-lite schema describes the run/eval bim object', () => {
+  it('documents the BimContext top-level methods, not a bim.query.* namespace', async () => {
+    const dump = await dumpSchema();
+
+    const root = dump.find((ns) => ns.namespace === 'bim');
+    expect(root, 'a root `bim` namespace must be documented').toBeDefined();
+
+    const documented = new Set(root!.methods.map((m) => m.name));
+    const runtime = prototypeMethods(BimContext.prototype);
+
+    // Every runtime top-level method is documented …
+    expect([...runtime].sort()).toEqual([...documented].filter((n) => runtime.includes(n)).sort());
+    // … and nothing documented is missing from the runtime.
+    expect([...documented].filter((n) => !runtime.includes(n))).toEqual([]);
+
+    // The methods the old dump filed under `query` are the top-level ones.
+    for (const name of ['properties', 'quantities', 'entity', 'attributes', 'relationships']) {
+      expect(documented.has(name)).toBe(true);
+    }
+  });
+
+  it('documents the query builder chain, not a flat query namespace', async () => {
+    const dump = await dumpSchema();
+
+    const query = dump.find((ns) => ns.namespace === 'query');
+    expect(query, 'a `query` namespace must be documented').toBeDefined();
+
+    const documented = query!.methods.map((m) => m.name).sort();
+    expect(documented).toEqual(prototypeMethods(QueryBuilder.prototype).sort());
+
+    // The sandbox-bridge-only entries must be gone: on the CLI's `bim` there
+    // is no `query.properties`, and `selection` is `bim.viewer.getSelection`.
+    for (const name of ['properties', 'quantities', 'selection', 'storeys']) {
+      expect(documented).not.toContain(name);
+    }
+  });
+
+  it('resolves every documented path on a live BimContext', async () => {
+    const dump = await dumpSchema();
+
+    // A backend is never called here — only the namespace objects the
+    // constructor builds are inspected.
+    const bim = new BimContext({ backend: {} as never });
+
+    const unresolved: string[] = [];
+    for (const ns of dump) {
+      if (ns.namespace === 'bim') {
+        for (const m of ns.methods) {
+          if (typeof (bim as unknown as Record<string, unknown>)[m.name] !== 'function') {
+            unresolved.push(`bim.${m.name}`);
+          }
+        }
+        continue;
+      }
+      if (ns.namespace === 'query') {
+        for (const m of ns.methods) {
+          if (typeof (QueryBuilder.prototype as unknown as Record<string, unknown>)[m.name] !== 'function') {
+            unresolved.push(`bim.query().${m.name}`);
+          }
+        }
+        continue;
+      }
+      // `create`'s methods are auto-discovered off `IfcCreator.prototype`, and
+      // on the runtime they are reached through the creator `bim.create.project()`
+      // returns rather than off `bim.create` itself. That is its own mismatch,
+      // not #3763's; only the namespace object is checked here.
+      const methods = ns.namespace === 'create' ? [] : ns.methods;
+      const target = (bim as unknown as Record<string, unknown>)[ns.namespace];
+      if (target == null || (typeof target !== 'object' && typeof target !== 'function')) {
+        unresolved.push(`bim.${ns.namespace}`);
+        continue;
+      }
+      for (const m of methods) {
+        if (typeof (target as Record<string, unknown>)[m.name] !== 'function') {
+          unresolved.push(`bim.${ns.namespace}.${m.name}`);
+        }
+      }
+    }
+
+    expect(unresolved).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/schema.success.test.ts
+++ b/packages/cli/src/commands/schema.success.test.ts
@@ -29,9 +29,9 @@ import { describe, expect, it, vi, afterEach } from 'vitest';
 vi.mock('@ifc-lite/sandbox/schema', () => ({
   NAMESPACE_SCHEMAS: [
     {
-      name: 'query',
-      doc: 'Query entities',
-      methods: [{ name: 'byType', doc: 'Filter by IFC type', params: [], returns: 'Entity[]' }],
+      name: 'lens',
+      doc: 'Lens visualization',
+      methods: [{ name: 'presets', doc: 'Get built-in lens presets', params: [], returns: 'unknown[]' }],
     },
   ],
 }));
@@ -68,10 +68,16 @@ describe('schemaCommand when the sandbox schema loads', () => {
       // And it is genuinely the real schema being emitted, not the fallback
       // reached without a warning — otherwise this would pass for the wrong
       // reason if the mock ever stopped taking effect.
+      //
+      // The dump also carries the two namespaces reflected off the SDK
+      // runtime (`bim` and the query builder, #3763), so the mocked namespace
+      // is looked up by name rather than by position.
       const parsed = JSON.parse(out.join(''));
       expect(Array.isArray(parsed)).toBe(true);
-      expect(parsed).toHaveLength(1);
-      expect(parsed[0]).toMatchObject({ namespace: 'query', description: 'Query entities' });
+      expect(parsed.find((ns: { namespace: string }) => ns.namespace === 'lens')).toMatchObject({
+        namespace: 'lens',
+        description: 'Lens visualization',
+      });
     } finally {
       // The test runner's own exit-status flag, not a per-test sandbox.
       process.exitCode = previousExitCode;

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -30,13 +30,81 @@ const RUNTIME_METHOD_DOCS: Record<string, string> = {
   first: 'Run the chain and return the first entity, or null',
   count: 'Run the chain and return the number of matches',
   refs: 'Run the chain and return entity refs only',
+  on: 'Subscribe to an event, e.g. bim.on("selection:changed", handler)',
 };
 
-/** Own value-function property names on a prototype, minus the constructor. */
-function prototypeMethods(proto: object): string[] {
+/**
+ * Parameter names and return types for `BimContext` / `QueryBuilder` methods,
+ * transcribed from their own signatures in `packages/sdk/src/context.ts` and
+ * `packages/sdk/src/namespaces/query.ts` (#3763 follow-up).
+ *
+ * `describe()` used to spread the sandbox bridge's own `paramNames`/`tsReturn`
+ * onto these methods. The bridge runs a whole query synchronously and returns
+ * plain data (`bim.query.byType(...): BimEntity[]`, `entity(modelId, expressId)`),
+ * which is not the shape the CLI's raw `BimContext`/`QueryBuilder` have
+ * (`byType(...types): this`, `entity(ref: EntityRef)`) — copying it produced a
+ * schema entry an agent could follow into a TypeError or a chain that stops
+ * one link early.
+ */
+const RUNTIME_METHOD_SIGNATURES: Record<string, { paramNames?: string[]; tsReturn: string }> = {
+  // BimContext
+  query: { tsReturn: 'QueryBuilder' },
+  matchingActiveFilter: { tsReturn: 'EntityData[] | null' },
+  entity: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+  attributes: { paramNames: ['ref'], tsReturn: 'EntityAttributeData[]' },
+  properties: { paramNames: ['ref'], tsReturn: 'PropertySetData[]' },
+  quantities: { paramNames: ['ref'], tsReturn: 'QuantitySetData[]' },
+  classifications: { paramNames: ['ref'], tsReturn: 'ClassificationData[]' },
+  materials: { paramNames: ['ref'], tsReturn: 'MaterialData | null' },
+  typeProperties: { paramNames: ['ref'], tsReturn: 'TypePropertiesData | null' },
+  documents: { paramNames: ['ref'], tsReturn: 'DocumentData[]' },
+  relationships: { paramNames: ['ref'], tsReturn: 'EntityRelationshipsData' },
+  property: { paramNames: ['ref', 'psetName', 'propName'], tsReturn: 'string | number | boolean | null' },
+  quantity: { paramNames: ['ref', 'qsetNameOrQuantityName', 'quantityName?'], tsReturn: 'number | null' },
+  related: { paramNames: ['ref', 'relType', 'direction'], tsReturn: 'EntityData[]' },
+  containedIn: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+  contains: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+  decomposedBy: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+  decomposes: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+  storey: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+  path: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+  storeys: { tsReturn: 'EntityData[]' },
+  on: { paramNames: ['event', 'handler'], tsReturn: 'void' },
+  // QueryBuilder
+  model: { paramNames: ['modelId'], tsReturn: 'this' },
+  byType: { paramNames: ['...types'], tsReturn: 'this' },
+  where: { paramNames: ['psetName', 'propName', 'operator?', 'value?'], tsReturn: 'this' },
+  limit: { paramNames: ['n'], tsReturn: 'this' },
+  offset: { paramNames: ['n'], tsReturn: 'this' },
+  toArray: { tsReturn: 'EntityData[]' },
+  first: { tsReturn: 'EntityData | null' },
+  count: { tsReturn: 'number' },
+  refs: { tsReturn: 'EntityRef[]' },
+};
+
+/**
+ * Own value-function property names on a prototype, minus the constructor,
+ * plus getters whose value is itself callable (e.g. `BimContext.prototype.on`,
+ * a getter returning a bound subscription function) — the CLI exposes those
+ * the same way as a method, so a filter that only checked `.value` silently
+ * dropped them from the dump (#3763 follow-up).
+ *
+ * A getter can't be classified from the prototype alone — invoking it there
+ * runs the getter with `this` bound to the bare prototype, not an instance,
+ * which is exactly the state `on`'s getter needs (`this._boundOn`, set in
+ * the constructor) to return the function rather than `undefined`. `instance`
+ * lets a caller supply a real object to invoke the getter against; without
+ * one, getters are skipped rather than guessed at.
+ */
+function prototypeMethods(proto: object, instance?: object): string[] {
   return Object.getOwnPropertyNames(proto).filter((name) => {
     if (name === 'constructor') return false;
-    return typeof Object.getOwnPropertyDescriptor(proto, name)?.value === 'function';
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (typeof desc?.value === 'function') return true;
+    if (typeof desc?.get === 'function' && instance) {
+      return typeof (instance as Record<string, unknown>)[name] === 'function';
+    }
+    return false;
   });
 }
 
@@ -53,8 +121,12 @@ function prototypeMethods(proto: object): string[] {
  *
  * Method lists are reflected off `BimContext.prototype` and
  * `QueryBuilder.prototype` — the objects `run`/`eval` construct — rather than
- * transcribed, so this cannot drift from the runtime. Docs and parameter names
- * are carried over from the bridge schema by name where it has them.
+ * transcribed, so this cannot drift from the runtime. Params and return types
+ * come from `RUNTIME_METHOD_SIGNATURES`, not the bridge schema: the bridge
+ * describes its own (different) call shape, and copying its `paramNames` /
+ * `tsReturn` here just relabelled the wrong signature (#3763 follow-up). Only
+ * `llmSemantics` (`useWhen`, `taskTags`) is still carried over from the
+ * bridge entry by name, where it has one.
  */
 function withRuntimeQueryShape(schemas: any[]): any[] {
   const bridgeQuery = schemas.find((ns) => ns?.name === 'query');
@@ -64,18 +136,26 @@ function withRuntimeQueryShape(schemas: any[]): any[] {
 
   const describe = (name: string) => {
     const fromBridge = bridgeMethods.get(name);
+    const signature = RUNTIME_METHOD_SIGNATURES[name];
     return {
       ...(fromBridge ?? {}),
       name,
       doc: RUNTIME_METHOD_DOCS[name] ?? fromBridge?.doc ?? name,
+      paramNames: signature?.paramNames,
+      tsReturn: signature?.tsReturn ?? fromBridge?.tsReturn,
     };
   };
+
+  // Constructed only to invoke the `on` getter against real instance state
+  // (see `prototypeMethods`) — no backend method is called during
+  // construction or by this dump.
+  const bimInstance = new BimContext({ backend: {} as never });
 
   return [
     {
       name: 'bim',
       doc: 'Top-level methods on the `bim` object (call as bim.<method>(...))',
-      methods: prototypeMethods(BimContext.prototype).map(describe),
+      methods: prototypeMethods(BimContext.prototype, bimInstance).map(describe),
     },
     {
       name: 'query',

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -9,7 +9,82 @@
  * Useful for LLM tools to discover available commands and methods.
  */
 
+import { BimContext, QueryBuilder } from '@ifc-lite/sdk';
 import { printJson, hasFlag } from '../output.js';
+
+/**
+ * Doc strings for the `BimContext` / `QueryBuilder` methods that
+ * `NAMESPACE_SCHEMAS` does not name (#3763). Only prose lives here — the
+ * method LIST itself is reflected off the runtime classes below, so a method
+ * added or removed upstream changes the dump without an edit here, and
+ * `schema.runtime-shape.test.ts` fails if the two ever disagree.
+ */
+const RUNTIME_METHOD_DOCS: Record<string, string> = {
+  query: 'Start a query chain: bim.query().byType(...).toArray()',
+  model: 'Restrict the chain to one model',
+  byType: "Filter by IFC type e.g. 'IfcWall'",
+  where: 'Filter by a property-set value',
+  limit: 'Cap the number of results',
+  offset: 'Skip the first n results',
+  toArray: 'Run the chain and return the entities',
+  first: 'Run the chain and return the first entity, or null',
+  count: 'Run the chain and return the number of matches',
+  refs: 'Run the chain and return entity refs only',
+};
+
+/** Own value-function property names on a prototype, minus the constructor. */
+function prototypeMethods(proto: object): string[] {
+  return Object.getOwnPropertyNames(proto).filter((name) => {
+    if (name === 'constructor') return false;
+    return typeof Object.getOwnPropertyDescriptor(proto, name)?.value === 'function';
+  });
+}
+
+/**
+ * Replace the sandbox bridge's flat `query` namespace with the two shapes the
+ * CLI's `bim` object actually has.
+ *
+ * `NAMESPACE_SCHEMAS` describes the browser sandbox bridge, where
+ * `bim.query.properties(ref)` is a real method. `ifc-lite run` / `ifc-lite eval`
+ * hand scripts a raw `BimContext` instead: `query()` starts a builder and
+ * `properties`, `quantities`, `relationships` and ~19 siblings sit at the top
+ * level of `bim`. Emitting the bridge shape here made every `bim.query.X(...)`
+ * call an agent copied out of `ifc-lite schema` throw a TypeError (#3763).
+ *
+ * Method lists are reflected off `BimContext.prototype` and
+ * `QueryBuilder.prototype` — the objects `run`/`eval` construct — rather than
+ * transcribed, so this cannot drift from the runtime. Docs and parameter names
+ * are carried over from the bridge schema by name where it has them.
+ */
+function withRuntimeQueryShape(schemas: any[]): any[] {
+  const bridgeQuery = schemas.find((ns) => ns?.name === 'query');
+  const bridgeMethods = new Map<string, any>(
+    (bridgeQuery?.methods ?? []).map((m: any) => [m.name, m]),
+  );
+
+  const describe = (name: string) => {
+    const fromBridge = bridgeMethods.get(name);
+    return {
+      ...(fromBridge ?? {}),
+      name,
+      doc: RUNTIME_METHOD_DOCS[name] ?? fromBridge?.doc ?? name,
+    };
+  };
+
+  return [
+    {
+      name: 'bim',
+      doc: 'Top-level methods on the `bim` object (call as bim.<method>(...))',
+      methods: prototypeMethods(BimContext.prototype).map(describe),
+    },
+    {
+      name: 'query',
+      doc: 'Query builder chain — start it with bim.query()',
+      methods: prototypeMethods(QueryBuilder.prototype).map(describe),
+    },
+    ...schemas.filter((ns) => ns?.name !== 'query'),
+  ];
+}
 
 export async function schemaCommand(args: string[]): Promise<void> {
   const compact = hasFlag(args, '--compact');
@@ -49,7 +124,7 @@ export async function schemaCommand(args: string[]): Promise<void> {
     process.exitCode = 1;
   }
 
-  const output = schemas.map(ns => ({
+  const output = withRuntimeQueryShape(schemas).map(ns => ({
     namespace: ns.name,
     description: ns.doc,
     methods: ns.methods.map((m: any) => {
@@ -80,22 +155,10 @@ function getStaticSchema(): any[] {
         { name: 'activeId', doc: 'Get active model ID' },
       ],
     },
-    {
-      name: 'query', doc: 'Query entities',
-      methods: [
-        { name: 'all', doc: 'Get all entities' },
-        { name: 'byType', doc: 'Filter by IFC type', paramNames: ['...types'] },
-        { name: 'entity', doc: 'Get single entity', paramNames: ['modelId', 'expressId'] },
-        { name: 'attributes', doc: 'Entity IFC attributes', paramNames: ['entity'] },
-        { name: 'properties', doc: 'Property sets', paramNames: ['entity'] },
-        { name: 'quantities', doc: 'Quantity sets', paramNames: ['entity'] },
-        { name: 'classifications', doc: 'Classification references', paramNames: ['entity'] },
-        { name: 'materials', doc: 'Material assignments', paramNames: ['entity'] },
-        { name: 'typeProperties', doc: 'Type-level properties', paramNames: ['entity'] },
-        { name: 'documents', doc: 'Linked documents', paramNames: ['entity'] },
-        { name: 'relationships', doc: 'Structural relationships', paramNames: ['entity'] },
-      ],
-    },
+    // No `query` entry: `withRuntimeQueryShape` reflects the `bim` root and
+    // the query-builder chain off the SDK classes, on the fallback path too,
+    // so a hand-written copy here could only rot (and the one that used to
+    // live here documented the sandbox bridge's `bim.query.*`, #3763).
     {
       name: 'export', doc: 'Multi-format export',
       methods: [

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -33,53 +33,65 @@ const RUNTIME_METHOD_DOCS: Record<string, string> = {
   on: 'Subscribe to an event, e.g. bim.on("selection:changed", handler)',
 };
 
+type MethodSignature = { paramNames?: string[]; tsReturn: string };
+
 /**
  * Parameter names and return types for `BimContext` / `QueryBuilder` methods,
  * transcribed from their own signatures in `packages/sdk/src/context.ts` and
  * `packages/sdk/src/namespaces/query.ts` (#3763 follow-up).
  *
+ * Keyed per class, not by bare method name: `BimContext` and `QueryBuilder`
+ * are reflected separately in `withRuntimeQueryShape`, and a future method
+ * that shares a name across both classes (their param/return shapes need not
+ * match) would otherwise read the wrong entry silently.
+ *
  * `describe()` used to spread the sandbox bridge's own `paramNames`/`tsReturn`
- * onto these methods. The bridge runs a whole query synchronously and returns
- * plain data (`bim.query.byType(...): BimEntity[]`, `entity(modelId, expressId)`),
+ * onto these methods, with the bridge as a fallback when a method had no
+ * entry here. The bridge runs a whole query synchronously and returns plain
+ * data (`bim.query.byType(...): BimEntity[]`, `entity(modelId, expressId)`),
  * which is not the shape the CLI's raw `BimContext`/`QueryBuilder` have
- * (`byType(...types): this`, `entity(ref: EntityRef)`) — copying it produced a
- * schema entry an agent could follow into a TypeError or a chain that stops
- * one link early.
+ * (`byType(...types): this`, `entity(ref: EntityRef)`) — falling back to it
+ * produced a schema entry an agent could follow into a TypeError or a chain
+ * that stops one link early. `describe()` now throws instead of falling back,
+ * so a new runtime method with no entry here fails the dump loudly (and
+ * `schema.runtime-shape.test.ts` with it) rather than shipping mislabelled.
  */
-const RUNTIME_METHOD_SIGNATURES: Record<string, { paramNames?: string[]; tsReturn: string }> = {
-  // BimContext
-  query: { tsReturn: 'QueryBuilder' },
-  matchingActiveFilter: { tsReturn: 'EntityData[] | null' },
-  entity: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
-  attributes: { paramNames: ['ref'], tsReturn: 'EntityAttributeData[]' },
-  properties: { paramNames: ['ref'], tsReturn: 'PropertySetData[]' },
-  quantities: { paramNames: ['ref'], tsReturn: 'QuantitySetData[]' },
-  classifications: { paramNames: ['ref'], tsReturn: 'ClassificationData[]' },
-  materials: { paramNames: ['ref'], tsReturn: 'MaterialData | null' },
-  typeProperties: { paramNames: ['ref'], tsReturn: 'TypePropertiesData | null' },
-  documents: { paramNames: ['ref'], tsReturn: 'DocumentData[]' },
-  relationships: { paramNames: ['ref'], tsReturn: 'EntityRelationshipsData' },
-  property: { paramNames: ['ref', 'psetName', 'propName'], tsReturn: 'string | number | boolean | null' },
-  quantity: { paramNames: ['ref', 'qsetNameOrQuantityName', 'quantityName?'], tsReturn: 'number | null' },
-  related: { paramNames: ['ref', 'relType', 'direction'], tsReturn: 'EntityData[]' },
-  containedIn: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
-  contains: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
-  decomposedBy: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
-  decomposes: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
-  storey: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
-  path: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
-  storeys: { tsReturn: 'EntityData[]' },
-  on: { paramNames: ['event', 'handler'], tsReturn: 'void' },
-  // QueryBuilder
-  model: { paramNames: ['modelId'], tsReturn: 'this' },
-  byType: { paramNames: ['...types'], tsReturn: 'this' },
-  where: { paramNames: ['psetName', 'propName', 'operator?', 'value?'], tsReturn: 'this' },
-  limit: { paramNames: ['n'], tsReturn: 'this' },
-  offset: { paramNames: ['n'], tsReturn: 'this' },
-  toArray: { tsReturn: 'EntityData[]' },
-  first: { tsReturn: 'EntityData | null' },
-  count: { tsReturn: 'number' },
-  refs: { tsReturn: 'EntityRef[]' },
+const RUNTIME_METHOD_SIGNATURES: { bim: Record<string, MethodSignature>; query: Record<string, MethodSignature> } = {
+  bim: {
+    query: { tsReturn: 'QueryBuilder' },
+    matchingActiveFilter: { tsReturn: 'EntityData[] | null' },
+    entity: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+    attributes: { paramNames: ['ref'], tsReturn: 'EntityAttributeData[]' },
+    properties: { paramNames: ['ref'], tsReturn: 'PropertySetData[]' },
+    quantities: { paramNames: ['ref'], tsReturn: 'QuantitySetData[]' },
+    classifications: { paramNames: ['ref'], tsReturn: 'ClassificationData[]' },
+    materials: { paramNames: ['ref'], tsReturn: 'MaterialData | null' },
+    typeProperties: { paramNames: ['ref'], tsReturn: 'TypePropertiesData | null' },
+    documents: { paramNames: ['ref'], tsReturn: 'DocumentData[]' },
+    relationships: { paramNames: ['ref'], tsReturn: 'EntityRelationshipsData' },
+    property: { paramNames: ['ref', 'psetName', 'propName'], tsReturn: 'string | number | boolean | null' },
+    quantity: { paramNames: ['ref', 'qsetNameOrQuantityName', 'quantityName?'], tsReturn: 'number | null' },
+    related: { paramNames: ['ref', 'relType', 'direction'], tsReturn: 'EntityData[]' },
+    containedIn: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+    contains: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+    decomposedBy: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+    decomposes: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+    storey: { paramNames: ['ref'], tsReturn: 'EntityData | null' },
+    path: { paramNames: ['ref'], tsReturn: 'EntityData[]' },
+    storeys: { tsReturn: 'EntityData[]' },
+    on: { paramNames: ['event', 'handler'], tsReturn: 'void' },
+  },
+  query: {
+    model: { paramNames: ['modelId'], tsReturn: 'this' },
+    byType: { paramNames: ['...types'], tsReturn: 'this' },
+    where: { paramNames: ['psetName', 'propName', 'operator?', 'value?'], tsReturn: 'this' },
+    limit: { paramNames: ['n'], tsReturn: 'this' },
+    offset: { paramNames: ['n'], tsReturn: 'this' },
+    toArray: { tsReturn: 'EntityData[]' },
+    first: { tsReturn: 'EntityData | null' },
+    count: { tsReturn: 'number' },
+    refs: { tsReturn: 'EntityRef[]' },
+  },
 };
 
 /**
@@ -134,15 +146,26 @@ function withRuntimeQueryShape(schemas: any[]): any[] {
     (bridgeQuery?.methods ?? []).map((m: any) => [m.name, m]),
   );
 
-  const describe = (name: string) => {
+  const describe = (proto: 'bim' | 'query') => (name: string) => {
     const fromBridge = bridgeMethods.get(name);
-    const signature = RUNTIME_METHOD_SIGNATURES[name];
+    const signature = RUNTIME_METHOD_SIGNATURES[proto][name];
+    if (!signature) {
+      // A method exists on the runtime prototype but nobody transcribed its
+      // signature into RUNTIME_METHOD_SIGNATURES — fail loudly rather than
+      // fall back to the bridge's (differently shaped) entry, so a new
+      // BimContext/QueryBuilder method cannot ship mislabelled (#3763 follow-up).
+      throw new Error(
+        `RUNTIME_METHOD_SIGNATURES.${proto} has no entry for '${name}' — add its ` +
+          `paramNames/tsReturn, transcribed from packages/sdk/src/context.ts or ` +
+          `packages/sdk/src/namespaces/query.ts.`,
+      );
+    }
     return {
-      ...(fromBridge ?? {}),
-      name,
       doc: RUNTIME_METHOD_DOCS[name] ?? fromBridge?.doc ?? name,
-      paramNames: signature?.paramNames,
-      tsReturn: signature?.tsReturn ?? fromBridge?.tsReturn,
+      name,
+      paramNames: signature.paramNames,
+      tsReturn: signature.tsReturn,
+      llmSemantics: fromBridge?.llmSemantics,
     };
   };
 
@@ -155,12 +178,12 @@ function withRuntimeQueryShape(schemas: any[]): any[] {
     {
       name: 'bim',
       doc: 'Top-level methods on the `bim` object (call as bim.<method>(...))',
-      methods: prototypeMethods(BimContext.prototype, bimInstance).map(describe),
+      methods: prototypeMethods(BimContext.prototype, bimInstance).map(describe('bim')),
     },
     {
       name: 'query',
       doc: 'Query builder chain — start it with bim.query()',
-      methods: prototypeMethods(QueryBuilder.prototype).map(describe),
+      methods: prototypeMethods(QueryBuilder.prototype).map(describe('query')),
     },
     ...schemas.filter((ns) => ns?.name !== 'query'),
   ];

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -18,19 +18,28 @@ import { printJson, hasFlag } from '../output.js';
  * method LIST itself is reflected off the runtime classes below, so a method
  * added or removed upstream changes the dump without an edit here, and
  * `schema.runtime-shape.test.ts` fails if the two ever disagree.
+ *
+ * Keyed per class, like `RUNTIME_METHOD_SIGNATURES` below (#3763 follow-up):
+ * `bim` and `query` are reflected off two different prototypes, so a bare
+ * name shared between them (there is none today, but nothing prevented it)
+ * would otherwise read whichever entry came first.
  */
-const RUNTIME_METHOD_DOCS: Record<string, string> = {
-  query: 'Start a query chain: bim.query().byType(...).toArray()',
-  model: 'Restrict the chain to one model',
-  byType: "Filter by IFC type e.g. 'IfcWall'",
-  where: 'Filter by a property-set value',
-  limit: 'Cap the number of results',
-  offset: 'Skip the first n results',
-  toArray: 'Run the chain and return the entities',
-  first: 'Run the chain and return the first entity, or null',
-  count: 'Run the chain and return the number of matches',
-  refs: 'Run the chain and return entity refs only',
-  on: 'Subscribe to an event, e.g. bim.on("selection:changed", handler)',
+const RUNTIME_METHOD_DOCS: { bim: Record<string, string>; query: Record<string, string> } = {
+  bim: {
+    query: 'Start a query chain: bim.query().byType(...).toArray()',
+    on: 'Subscribe to an event, e.g. bim.on("selection:changed", handler)',
+  },
+  query: {
+    model: 'Restrict the chain to one model',
+    byType: "Filter by IFC type e.g. 'IfcWall'",
+    where: 'Filter by a property-set value',
+    limit: 'Cap the number of results',
+    offset: 'Skip the first n results',
+    toArray: 'Run the chain and return the entities',
+    first: 'Run the chain and return the first entity, or null',
+    count: 'Run the chain and return the number of matches',
+    refs: 'Run the chain and return entity refs only',
+  },
 };
 
 type MethodSignature = { paramNames?: string[]; tsReturn: string };
@@ -136,9 +145,20 @@ function prototypeMethods(proto: object, instance?: object): string[] {
  * transcribed, so this cannot drift from the runtime. Params and return types
  * come from `RUNTIME_METHOD_SIGNATURES`, not the bridge schema: the bridge
  * describes its own (different) call shape, and copying its `paramNames` /
- * `tsReturn` here just relabelled the wrong signature (#3763 follow-up). Only
- * `llmSemantics` (`useWhen`, `taskTags`) is still carried over from the
- * bridge entry by name, where it has one.
+ * `tsReturn` here just relabelled the wrong signature (#3763 follow-up).
+ *
+ * The bridge's `query` namespace (`bridgeQuery` below) is a flat list of the
+ * same ~20 entity-lookup methods that sit at the top level of `bim`
+ * (`entity`, `properties`, `quantities`, ...). That is the namespace those
+ * methods belong to on the bridge, and it is only ever used as a `doc` /
+ * `llmSemantics` fallback for the `bim` prototype. It is never consulted for
+ * the `query` builder-chain prototype: `QueryBuilder`'s `byType`/`where`/
+ * `limit`/… have no counterpart there (the bridge runs a whole chain
+ * synchronously instead of building one), so reading `bridgeMethods` by bare
+ * name for that prototype could silently attach an unrelated bridge method's
+ * doc to a same-named builder method. `RUNTIME_METHOD_DOCS.query` documents
+ * every builder method already, so restricting the fallback to `bim` needs
+ * no "no entry" carve-out.
  */
 function withRuntimeQueryShape(schemas: any[]): any[] {
   const bridgeQuery = schemas.find((ns) => ns?.name === 'query');
@@ -147,7 +167,7 @@ function withRuntimeQueryShape(schemas: any[]): any[] {
   );
 
   const describe = (proto: 'bim' | 'query') => (name: string) => {
-    const fromBridge = bridgeMethods.get(name);
+    const fromBridge = proto === 'bim' ? bridgeMethods.get(name) : undefined;
     const signature = RUNTIME_METHOD_SIGNATURES[proto][name];
     if (!signature) {
       // A method exists on the runtime prototype but nobody transcribed its
@@ -161,7 +181,7 @@ function withRuntimeQueryShape(schemas: any[]): any[] {
       );
     }
     return {
-      doc: RUNTIME_METHOD_DOCS[name] ?? fromBridge?.doc ?? name,
+      doc: RUNTIME_METHOD_DOCS[proto][name] ?? fromBridge?.doc ?? name,
       name,
       paramNames: signature.paramNames,
       tsReturn: signature.tsReturn,


### PR DESCRIPTION
`ifc-lite schema` listed `properties`, `entity`, `quantities` and friends under a static `query` namespace, while `run`/`eval` expose them on `bim.*` and `bim.query()` is a builder chain. The dump now emits a `bim` namespace and a `query` namespace whose method lists are reflected off `BimContext.prototype` and `QueryBuilder.prototype`, with docs and params carried over from the bridge schema by name; the reduced-fallback path had the same wrong static entry and now takes the same remap.

`schema.runtime-shape.test.ts` walks the emitted dump and resolves every documented path on a live context, so a documented method that the runtime does not have fails the test. RED: three failures (missing `bim` namespace, flat `query`, unresolved paths).

Scoped out: `bim.create.*` documents `IfcCreator.prototype` while the runtime reaches it through `bim.create.project()`; same class, different namespace, flagged in the test for a follow-up.

Changeset: `@ifc-lite/cli` patch.

Closes #3763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVtyE6e7uAqwvRYoetXdBK