### PR TITLE
fix(cli): scope ask's volume recipes to building elements

### DIFF
--- a/.changeset/ask-scopes-volume-to-building-elements.md
+++ b/.changeset/ask-scopes-volume-to-building-elements.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`ask`'s "total volume", "largest X" and "smallest X" recipes summed GrossVolume/NetVolume over `bim.query()`'s unfiltered entity list, so an `IfcSpace` or `IfcAnnotation` carrying a volume quantity inflated the answer. `ask` now scopes these to building elements the same way `stats` does, via the shared `filterBuildingElements` helper.

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -67,17 +67,74 @@ describe('ask recipes — blank/whitespace name falls through to "(unnamed)"', (
   });
 
   it('largest-element: blank element Name falls through to "(unnamed)" in the answer', () => {
-    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, type: 'IfcWall', name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
     const result = recipe('largest-element').execute(bim, {}, ['largest wall', 'wall'] as unknown as RegExpMatchArray);
     expect(result.answer).toContain('"(unnamed)"');
     expect(result.answer).not.toContain('""');
   });
 
   it('smallest-element: blank element Name falls through to "(unnamed)" in the answer', () => {
-    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
+    const bim = { query: () => ({ byType: () => ({ toArray: () => [{ ref: 1, type: 'IfcWall', name: '', globalId: 'G1' }] }) }), quantities: () => [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossSideArea', value: 5 }] }] };
     const result = recipe('smallest-element').execute(bim, {}, ['smallest wall', 'wall'] as unknown as RegExpMatchArray);
     expect(result.answer).toContain('"(unnamed)"');
     expect(result.answer).not.toContain('""');
+  });
+});
+
+describe('ask recipes — volume answers are scoped to building elements', () => {
+  /**
+   * `ask` answers about building elements the way `stats` does. An
+   * IfcSpace or IfcAnnotation can carry a GrossVolume/NetVolume quantity
+   * (spaces routinely do, for room-volume reporting) but is not a building
+   * element, so it must not be summed into "total volume", "largest X" or
+   * "smallest X" answers.
+   */
+  it('total-volume: an IfcSpace volume is excluded from the sum', () => {
+    const bim = {
+      query: () => ({
+        toArray: () => [
+          { ref: 1, type: 'IfcWall', name: 'Wall 1' },
+          { ref: 2, type: 'IfcSpace', name: 'Room 1' },
+        ],
+      }),
+      quantities: (ref: number) =>
+        ref === 1
+          ? [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', value: 10 }] }]
+          : [{ name: 'Qto_SpaceBaseQuantities', quantities: [{ name: 'GrossVolume', value: 1000 }] }],
+    };
+    const result = recipe('total-volume').execute(bim, {});
+    expect(result.value).toBe(10);
+  });
+
+  it('total-volume: an IfcAnnotation volume is excluded from the sum', () => {
+    const bim = {
+      query: () => ({
+        toArray: () => [
+          { ref: 1, type: 'IfcWall', name: 'Wall 1' },
+          { ref: 2, type: 'IfcAnnotation', name: 'Note' },
+        ],
+      }),
+      quantities: (ref: number) =>
+        ref === 1
+          ? [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', value: 10 }] }]
+          : [{ name: 'Qto_Whatever', quantities: [{ name: 'GrossVolume', value: 1000 }] }],
+    };
+    const result = recipe('total-volume').execute(bim, {});
+    expect(result.value).toBe(10);
+  });
+
+  it('total-volume: building-element volumes are still summed (control)', () => {
+    const bim = {
+      query: () => ({
+        toArray: () => [
+          { ref: 1, type: 'IfcWall', name: 'Wall 1' },
+          { ref: 2, type: 'IfcSlab', name: 'Slab 1' },
+        ],
+      }),
+      quantities: () => [{ name: 'Qto_BaseQuantities', quantities: [{ name: 'GrossVolume', value: 5 }] }],
+    };
+    const result = recipe('total-volume').execute(bim, {});
+    expect(result.value).toBe(10);
   });
 });
 

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -18,6 +18,7 @@
 
 import { createHeadlessContext } from '../loader.js';
 import { printJson, fatal, hasFlag, firstNonBlank } from '../output.js';
+import { filterBuildingElements } from './stats-aggregation.js';
 
 interface Recipe {
   name: string;
@@ -169,7 +170,7 @@ export const RECIPES: Recipe[] = [
     description: 'Sum volumes across all elements',
     execute: (bim) => {
       let total = 0;
-      for (const e of bim.query().toArray()) {
+      for (const e of filterBuildingElements<any>(bim.query().toArray())) {
         total += getQuantity(bim, e.ref, ['GrossVolume', 'NetVolume']);
       }
       return { answer: `${round(total)} m3 total volume`, value: round(total), unit: 'm3' };
@@ -338,7 +339,7 @@ export const RECIPES: Recipe[] = [
         ? ['GrossSideArea', 'NetSideArea']
         : ['GrossArea', 'NetArea', 'Area', 'GrossSideArea'];
 
-      const entities = bim.query().byType(ifcType).toArray();
+      const entities = filterBuildingElements<any>(bim.query().byType(ifcType).toArray());
       let maxEntity: any = null;
       let maxValue = 0;
       for (const e of entities) {
@@ -375,7 +376,7 @@ export const RECIPES: Recipe[] = [
         ? ['GrossSideArea', 'NetSideArea']
         : ['GrossArea', 'NetArea', 'Area', 'GrossSideArea'];
 
-      const entities = bim.query().byType(ifcType).toArray();
+      const entities = filterBuildingElements<any>(bim.query().byType(ifcType).toArray());
       let minEntity: any = null;
       let minValue = Infinity;
       for (const e of entities) {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -194,7 +194,7 @@
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts
    433 packages/clash/src/duplicates.ts
-   546 packages/cli/src/commands/ask.ts
+   547 packages/cli/src/commands/ask.ts
    495 packages/cli/src/commands/create.ts
    436 packages/cli/src/commands/export.ts
    518 packages/cli/src/commands/extract-entities.ts


### PR DESCRIPTION
`ask`'s `total-volume`, `largest-element` and `smallest-element` recipes summed GrossVolume/NetVolume over unfiltered entity arrays, so a spatial container or annotation carrying a volume quantity was counted. Maintainer decision (deferred from #3650): `ask` answers about building elements the way `stats` does, so the three sites now reuse `filterBuildingElements` from `stats-aggregation.ts`.

Test-first: an IfcSpace and an IfcAnnotation with a volume quantity are excluded (RED: expected 1010 to be 10), a building element control is still summed.

Changeset: `@ifc-lite/cli` patch.

Closes #3773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVtyE6e7uAqwvRYoetXdBK