### PR TITLE
fix(scripts): dedupe pr-green-sweep's rollup by check name before counting

### DIFF
--- a/scripts/lib/pr-green-sweep-rollup.mjs
+++ b/scripts/lib/pr-green-sweep-rollup.mjs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * Turns a raw `statusCheckRollup` (GitHub's per-PR list of CheckRun and
+ * StatusContext rows) into pass/fail/pending counts, deduping the stale
+ * duplicate rows a cancelled-and-superseded workflow run leaves behind
+ * (#3792, #3797). Split out of `pr-green-sweep.mjs` as its own coherent unit
+ * -- rollup counting is a distinct concern from sweep orchestration -- so
+ * it's independently readable and testable.
+ */
+
+/**
+ * Classify a single rollup row the way `countRollup` counts it, without
+ * accumulating -- shared by `countRollup` and `dedupeByName`'s tie-break so
+ * the two can never disagree about what "failing" means.
+ * @returns {'pending' | 'pass' | 'fail'}
+ */
+function classifyCheck(check) {
+  const status = String(check?.status ?? '').toUpperCase();
+  if (status && status !== 'COMPLETED') return 'pending';
+  const verdict = String(check?.conclusion ?? check?.state ?? '').toUpperCase();
+  if (verdict === 'SUCCESS' || verdict === 'NEUTRAL' || verdict === 'SKIPPED') return 'pass';
+  if (verdict === '' || verdict === 'PENDING' || verdict === 'EXPECTED') return 'pending';
+  return 'fail';
+}
+
+/**
+ * Drop a stale duplicate check row before counting.
+ *
+ * GitHub does not remove the check runs of a cancelled workflow run: when a
+ * push (or a superseding `pull_request` event under `concurrency`) cancels an
+ * in-flight run, that run's check runs stay attached to the head commit
+ * alongside the fresh ones under the same lane name. `statusCheckRollup` then
+ * carries two rows for one lane, and counting both charges the PR with the
+ * cancelled one even though every live lane is green (#3792).
+ *
+ * Only rows that share an identifying name are deduped -- a row with neither
+ * `name` nor `context` (the CheckRun/StatusContext key fields) is never
+ * merged with anything, so an ungrouped duplicate cannot be silently dropped
+ * by a key that does not actually identify the lane. `name` and `context` are
+ * different namespaces (a CheckRun and a legacy StatusContext can share the
+ * same string with no relation to each other), so the key is prefixed with
+ * which field produced it -- an unrelated same-named row in the other
+ * namespace can never collide with it (#3797).
+ *
+ * Among rows sharing a key, the newest `startedAt` wins, matching how
+ * GitHub's own required-status-check evaluation resolves duplicates -- but
+ * only when supersession is actually established (both timestamps parse and
+ * differ). GitHub emits `startedAt: null` for a job cancelled while still
+ * queued, and same-second timestamps make an exact tie plausible; in either
+ * case there is no basis to call one row "newer". Treating an unknown or
+ * tied timestamp as "definitely older" (as `!Number.isFinite` did) lets a
+ * live, currently-failing row be silently overwritten by an unrelated stale
+ * success. Under-counting a failure is the dangerous direction here -- a
+ * false "FAILING" just wastes a look, a false "GREEN" ships a broken PR --
+ * so when supersession can't be established, the failing row wins (#3797).
+ */
+function dedupeByName(rollup) {
+  const named = [];
+  const unnamed = [];
+  const newestByName = new Map();
+  for (const check of rollup) {
+    const key =
+      check?.name != null ? `name:${check.name}` : check?.context != null ? `context:${check.context}` : null;
+    if (key == null) {
+      unnamed.push(check);
+      continue;
+    }
+    const startedAt = typeof check?.startedAt === 'string' ? Date.parse(check.startedAt) : NaN;
+    const prior = newestByName.get(key);
+    if (!prior) {
+      newestByName.set(key, { check, startedAt });
+      continue;
+    }
+    const bothDated = Number.isFinite(startedAt) && Number.isFinite(prior.startedAt);
+    if (bothDated && startedAt !== prior.startedAt) {
+      // Supersession is established: strictly newer wins outright, whatever
+      // its verdict (this is what lets a fresh SUCCESS retire a stale
+      // CANCELLED, and what lets a fresh CANCELLED still count as failing).
+      if (startedAt > prior.startedAt) newestByName.set(key, { check, startedAt });
+      continue;
+    }
+    // Inconclusive: an unparseable/missing timestamp on either side, or an
+    // exact tie. Don't let it hide a failure -- keep whichever row is
+    // failing; if neither or both are failing, the count comes out the same
+    // either way, so keep the one already recorded (order-independent).
+    if (classifyCheck(check) === 'fail' && classifyCheck(prior.check) !== 'fail') {
+      newestByName.set(key, { check, startedAt });
+    }
+  }
+  for (const { check } of newestByName.values()) named.push(check);
+  return [...named, ...unnamed];
+}
+
+/**
+ * Count a `statusCheckRollup` into pass/fail/pending.
+ *
+ * An EMPTY rollup counts to all zeros, which is why the caller must never read
+ * `fail === 0` as green on its own -- `runCount` is the signal that separates
+ * "nothing failed" from "nothing ran".
+ */
+export function countRollup(rollup) {
+  let fail = 0;
+  let pending = 0;
+  let pass = 0;
+  for (const check of dedupeByName(rollup ?? [])) {
+    const verdict = classifyCheck(check);
+    if (verdict === 'pending') pending += 1;
+    else if (verdict === 'pass') pass += 1;
+    else fail += 1;
+  }
+  return { fail, pending, pass };
+}

--- a/scripts/lib/pr-green-sweep.mjs
+++ b/scripts/lib/pr-green-sweep.mjs
@@ -194,6 +194,43 @@ export function severityOf(row, repo = DEFAULT_REPO) {
 }
 
 /**
+ * Drop a stale duplicate check row before counting.
+ *
+ * GitHub does not remove the check runs of a cancelled workflow run: when a
+ * push (or a superseding `pull_request` event under `concurrency`) cancels an
+ * in-flight run, that run's check runs stay attached to the head commit
+ * alongside the fresh ones under the same lane name. `statusCheckRollup` then
+ * carries two rows for one lane, and counting both charges the PR with the
+ * cancelled one even though every live lane is green (#3792).
+ *
+ * Only rows that share an identifying name are deduped -- a row with neither
+ * `name` nor `context` (the CheckRun/StatusContext key fields) is never
+ * merged with anything, so an ungrouped duplicate cannot be silently dropped
+ * by a key that does not actually identify the lane. Among rows sharing a
+ * name, the newest `startedAt` wins, matching how GitHub's own
+ * required-status-check evaluation resolves duplicates.
+ */
+function dedupeByName(rollup) {
+  const named = [];
+  const unnamed = [];
+  const newestByName = new Map();
+  for (const check of rollup) {
+    const key = check?.name ?? check?.context ?? null;
+    if (key == null) {
+      unnamed.push(check);
+      continue;
+    }
+    const startedAt = typeof check?.startedAt === 'string' ? Date.parse(check.startedAt) : NaN;
+    const prior = newestByName.get(key);
+    if (!prior || !Number.isFinite(prior.startedAt) || (Number.isFinite(startedAt) && startedAt >= prior.startedAt)) {
+      newestByName.set(key, { check, startedAt });
+    }
+  }
+  for (const { check } of newestByName.values()) named.push(check);
+  return [...named, ...unnamed];
+}
+
+/**
  * Count a `statusCheckRollup` into pass/fail/pending.
  *
  * An EMPTY rollup counts to all zeros, which is why the caller must never read
@@ -204,7 +241,7 @@ export function countRollup(rollup) {
   let fail = 0;
   let pending = 0;
   let pass = 0;
-  for (const check of rollup ?? []) {
+  for (const check of dedupeByName(rollup ?? [])) {
     const status = String(check?.status ?? '').toUpperCase();
     if (status && status !== 'COMPLETED') {
       pending += 1;

--- a/scripts/lib/pr-green-sweep.mjs
+++ b/scripts/lib/pr-green-sweep.mjs
@@ -43,6 +43,9 @@
  */
 
 import { classifyReviewState } from './coderabbit-review-state.mjs';
+import { countRollup } from './pr-green-sweep-rollup.mjs';
+
+export { countRollup } from './pr-green-sweep-rollup.mjs';
 
 export const DEFAULT_REPO = 'LTplus-AG/ifc-lite';
 
@@ -191,68 +194,6 @@ export function disqualify(row, repo = DEFAULT_REPO) {
  */
 export function severityOf(row, repo = DEFAULT_REPO) {
   return disqualify(row, repo)?.severity ?? SEVERITY.GREEN;
-}
-
-/**
- * Drop a stale duplicate check row before counting.
- *
- * GitHub does not remove the check runs of a cancelled workflow run: when a
- * push (or a superseding `pull_request` event under `concurrency`) cancels an
- * in-flight run, that run's check runs stay attached to the head commit
- * alongside the fresh ones under the same lane name. `statusCheckRollup` then
- * carries two rows for one lane, and counting both charges the PR with the
- * cancelled one even though every live lane is green (#3792).
- *
- * Only rows that share an identifying name are deduped -- a row with neither
- * `name` nor `context` (the CheckRun/StatusContext key fields) is never
- * merged with anything, so an ungrouped duplicate cannot be silently dropped
- * by a key that does not actually identify the lane. Among rows sharing a
- * name, the newest `startedAt` wins, matching how GitHub's own
- * required-status-check evaluation resolves duplicates.
- */
-function dedupeByName(rollup) {
-  const named = [];
-  const unnamed = [];
-  const newestByName = new Map();
-  for (const check of rollup) {
-    const key = check?.name ?? check?.context ?? null;
-    if (key == null) {
-      unnamed.push(check);
-      continue;
-    }
-    const startedAt = typeof check?.startedAt === 'string' ? Date.parse(check.startedAt) : NaN;
-    const prior = newestByName.get(key);
-    if (!prior || !Number.isFinite(prior.startedAt) || (Number.isFinite(startedAt) && startedAt >= prior.startedAt)) {
-      newestByName.set(key, { check, startedAt });
-    }
-  }
-  for (const { check } of newestByName.values()) named.push(check);
-  return [...named, ...unnamed];
-}
-
-/**
- * Count a `statusCheckRollup` into pass/fail/pending.
- *
- * An EMPTY rollup counts to all zeros, which is why the caller must never read
- * `fail === 0` as green on its own -- `runCount` is the signal that separates
- * "nothing failed" from "nothing ran".
- */
-export function countRollup(rollup) {
-  let fail = 0;
-  let pending = 0;
-  let pass = 0;
-  for (const check of dedupeByName(rollup ?? [])) {
-    const status = String(check?.status ?? '').toUpperCase();
-    if (status && status !== 'COMPLETED') {
-      pending += 1;
-      continue;
-    }
-    const verdict = String(check?.conclusion ?? check?.state ?? '').toUpperCase();
-    if (verdict === 'SUCCESS' || verdict === 'NEUTRAL' || verdict === 'SKIPPED') pass += 1;
-    else if (verdict === '' || verdict === 'PENDING' || verdict === 'EXPECTED') pending += 1;
-    else fail += 1;
-  }
-  return { fail, pending, pass };
 }
 
 /** The later of two ISO-8601 instants, ignoring absent/unparseable ones. */

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -185,6 +185,43 @@ test('a CANCELLED check counts as failing, not as passing', () => {
   );
 });
 
+test('a CANCELLED run superseded by a fresh SUCCESS under the same name does not count as failing', () => {
+  // GitHub does not remove the check runs of a cancelled workflow run: when a
+  // push cancels an in-flight run under concurrency, the CANCELLED run's check
+  // runs stay attached to the head commit alongside the fresh SUCCESS ones
+  // under the same names. The rollup then carries two rows for one lane -- the
+  // newest startedAt is the one that decides the lane's verdict, matching how
+  // GitHub's required-status-check evaluation resolves duplicates. Refs #3792.
+  const counts = countRollup([
+    { name: 'PR review signal', status: 'COMPLETED', conclusion: 'CANCELLED', startedAt: '2026-09-03T18:00:00Z' },
+    { name: 'PR review signal', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:05:00Z' },
+    { name: 'Issue queue', status: 'COMPLETED', conclusion: 'CANCELLED', startedAt: '2026-09-03T18:00:00Z' },
+    { name: 'Issue queue', status: 'IN_PROGRESS', conclusion: null, startedAt: '2026-09-03T18:05:00Z' },
+  ]);
+  assert.deepEqual(counts, { fail: 0, pending: 1, pass: 1 });
+});
+
+test('a lone CANCELLED check with no fresher duplicate of the same name still counts as failing', () => {
+  // Control: dedupe must not launder a genuine cancellation that nothing
+  // superseded -- only a same-named newer row may excuse an older CANCELLED one.
+  const counts = countRollup([
+    { name: 'Typecheck', status: 'COMPLETED', conclusion: 'CANCELLED', startedAt: '2026-09-03T18:00:00Z' },
+    { name: 'Rust tests', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:05:00Z' },
+  ]);
+  assert.deepEqual(counts, { fail: 1, pending: 0, pass: 1 });
+});
+
+test('duplicate check rows without a usable name fall back to counting every row (no silent merge)', () => {
+  // StatusContext rows key off `context`, not `name`; entries with neither are
+  // never merged with anything, so an ungrouped duplicate cannot be silently
+  // dropped by a key that does not actually identify the lane.
+  const counts = countRollup([
+    { status: 'COMPLETED', conclusion: 'CANCELLED' },
+    { status: 'COMPLETED', conclusion: 'SUCCESS' },
+  ]);
+  assert.deepEqual(counts, { fail: 1, pending: 0, pass: 1 });
+});
+
 // --- the three refuse-to-pass-vacuously paths --------------------------------
 
 /** A `gh` stub that answers each call from a table keyed by a substring. */

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -222,6 +222,63 @@ test('duplicate check rows without a usable name fall back to counting every row
   assert.deepEqual(counts, { fail: 1, pending: 0, pass: 1 });
 });
 
+// --- #3797: dedupe must not hide a real failure -----------------------------
+
+test('a FAILURE with a null startedAt (cancelled while still queued) beats a stale same-named SUCCESS, either array order', () => {
+  // GitHub emits startedAt: null for a job cancelled before it started -- the
+  // exact scenario #3792/#3797 target. An unknown timestamp must not be
+  // treated as "definitely older": that let a live FAILURE be silently
+  // overwritten by an unrelated stale SUCCESS. Refs #3797.
+  const live = { name: 'Deploy', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: null };
+  const stale = { name: 'Deploy', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:00:00Z' };
+  assert.deepEqual(countRollup([live, stale]), { fail: 1, pending: 0, pass: 0 }, 'live, stale order');
+  assert.deepEqual(countRollup([stale, live]), { fail: 1, pending: 0, pass: 0 }, 'stale, live order');
+});
+
+test('two FAILUREs with no parseable startedAt on either side both stay counted, either array order', () => {
+  // Neither row's timestamp is usable, so supersession cannot be established
+  // at all -- both are failing, so the count must not depend on which one the
+  // dedupe map happens to keep.
+  const a = { name: 'Deploy', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: null };
+  const b = { name: 'Deploy', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: 'not-a-date' };
+  assert.deepEqual(countRollup([a, b]), { fail: 1, pending: 0, pass: 0 }, 'a, b order');
+  assert.deepEqual(countRollup([b, a]), { fail: 1, pending: 0, pass: 0 }, 'b, a order');
+});
+
+test('a CheckRun `name` never collides with an unrelated StatusContext `context` sharing the same string, either array order', () => {
+  // `name` (CheckRun) and `context` (StatusContext) are different namespaces.
+  // An older genuinely-failing CheckRun("Deploy") must not be masked by a
+  // newer, unrelated StatusContext also called "Deploy". Refs #3797.
+  const checkRunFailure = {
+    name: 'Deploy',
+    status: 'COMPLETED',
+    conclusion: 'FAILURE',
+    startedAt: '2026-09-03T18:00:00Z',
+  };
+  const statusContextSuccess = { context: 'Deploy', state: 'SUCCESS', startedAt: '2026-09-03T18:05:00Z' };
+  assert.deepEqual(
+    countRollup([checkRunFailure, statusContextSuccess]),
+    { fail: 1, pending: 0, pass: 1 },
+    'CheckRun, StatusContext order',
+  );
+  assert.deepEqual(
+    countRollup([statusContextSuccess, checkRunFailure]),
+    { fail: 1, pending: 0, pass: 1 },
+    'StatusContext, CheckRun order',
+  );
+});
+
+test('an exact startedAt tie between a SUCCESS and a CANCELLED keeps the failure visible, either array order', () => {
+  // Second-granularity timestamps make a genuine tie plausible. The tie-break
+  // must not be "whichever the array lists last" (>=) -- on a tie, supersession
+  // is not established, so the failing row must win regardless of order.
+  const same = '2026-09-03T18:00:00Z';
+  const success = { name: 'Deploy', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: same };
+  const cancelled = { name: 'Deploy', status: 'COMPLETED', conclusion: 'CANCELLED', startedAt: same };
+  assert.deepEqual(countRollup([success, cancelled]), { fail: 1, pending: 0, pass: 0 }, 'success, cancelled order');
+  assert.deepEqual(countRollup([cancelled, success]), { fail: 1, pending: 0, pass: 0 }, 'cancelled, success order');
+});
+
 // --- the three refuse-to-pass-vacuously paths --------------------------------
 
 /** A `gh` stub that answers each call from a table keyed by a substring. */


### PR DESCRIPTION
## Summary

- `scripts/lib/pr-green-sweep.mjs` `countRollup` classified any `CANCELLED` check-run row as a failure. GitHub does not remove the check runs of a cancelled workflow run: when a push (or a superseding `pull_request` event under `concurrency`) cancels an in-flight run, its check runs stay attached to the head commit alongside the fresh ones under the same lane name. The rollup then carries two rows per lane, and the sweep charged the PR with the stale `CANCELLED` row even though the same-named fresh row was `SUCCESS` — a green PR read `FAILING`.
- Fix: rows that share an identifying name (`name` for a CheckRun, `context` for a StatusContext) now collapse to the one with the newest `startedAt` before counting, matching how GitHub's own required-status-check evaluation resolves duplicates. A row with neither key is never merged with anything (no silent drop from an unidentifiable key), and a lone `CANCELLED` row with no fresher same-named duplicate still counts as failing — a genuine cancellation is not laundered.

## Test plan
- [x] `node --test scripts/lib/pr-green-sweep.test.mjs` — 33/33 pass (this is exactly the invocation `test.yml` runs at `.github/workflows/test.yml:1061`)
- [x] RED reproduced first: a new test pinning the duplicate-name/newest-`startedAt` case failed against the pre-fix `countRollup` (`fail: 2` instead of `fail: 0`)
- [x] Mutation 1 (keep the oldest row instead of the newest) fails the new test
- [x] Mutation 2 (drop every `CANCELLED` row unconditionally, over-permissive) fails three tests, including both control cases
- [x] Control: a lone `CANCELLED` row with no fresher same-named duplicate, and a duplicate pair with no usable name, both still count as failing
- [x] `node scripts/check-module-size.mjs` — exit 0 (only pre-existing unrelated notes)
- [x] `node scripts/check-test-wiring.mjs` — OK

Closes #3792

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request status reporting by preventing cancelled workflow checks from being counted twice.
  * Newer check results now take precedence when duplicate status entries exist.
  * Checks without identifiable names continue to be counted independently.

* **Tests**
  * Added coverage for duplicate, cancelled, successful, in-progress, and unnamed check results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->