### PR TITLE
fix(review): stop generated release PR consuming model reviews

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -168,8 +168,27 @@ jobs:
         if: steps.head.outputs.proceed == 'true' && steps.dedup.outputs.covered != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set +e
+          # The rolling changesets PR is generated release metadata, not a new
+          # authored code change. Sending it through the model on every refresh
+          # caused 13 of 23 measured review failures (#3771), and its accumulated
+          # changelogs now exceed the harness's hard patch ceiling. Classify the
+          # exact branch+title pair before downloading or prompting. A near-match
+          # stays on the normal path, and the skip still posts an explicit marker
+          # below, so this can never become an absence that looks like success.
+          target=$(node scripts/review/classify-review-target.mjs \
+            --head-ref "$PR_HEAD_REF" \
+            --title "$PR_TITLE")
+          if [ "$(jq -r .skip <<<"$target")" = "true" ]; then
+            jq -r .reason <<<"$target" > "$RUNNER_TEMP/skip-reason.txt"
+            echo "::notice::$(cat "$RUNNER_TEMP/skip-reason.txt")"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # THE PR BODY, VIA A FILE. Never an argument: it is author-controlled
           # text, and `jq -r` to a file keeps it out of the command line and out
           # of any shell interpolation. build-review-input fences it before it

--- a/scripts/review/classify-review-target.mjs
+++ b/scripts/review/classify-review-target.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { isMainEntry } from '../lib/is-main-entry.mjs';
+
+const RELEASE_BRANCH = 'changeset-release/main';
+const RELEASE_TITLE = 'chore: version packages';
+
+/**
+ * Decide whether a PR contains authored code for the probabilistic reviewer.
+ * Near-matches fail closed onto the normal review path: a branch name alone is
+ * not enough to turn an arbitrary PR into a generated release artifact.
+ */
+export function classifyReviewTarget({ headRef, title }) {
+  if (headRef === RELEASE_BRANCH && title === RELEASE_TITLE) {
+    return {
+      skip: true,
+      reason:
+        'Generated changesets release PR: package versions and changelogs are validated by the deterministic release, changeset, API-surface, build, and test gates.',
+    };
+  }
+  return { skip: false, reason: null };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const value = (flag) => {
+    const i = args.indexOf(flag);
+    if (i < 0 || args[i + 1] === undefined) throw new Error(`${flag} requires a value`);
+    return args[i + 1];
+  };
+  process.stdout.write(`${JSON.stringify(classifyReviewTarget({ headRef: value('--head-ref'), title: value('--title') }))}\n`);
+}
+
+if (isMainEntry(import.meta.url)) main();

--- a/scripts/review/classify-review-target.test.mjs
+++ b/scripts/review/classify-review-target.test.mjs
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyReviewTarget } from './classify-review-target.mjs';
+
+test('#3771: the generated changesets release PR does not consume a model review', () => {
+  const result = classifyReviewTarget({
+    headRef: 'changeset-release/main',
+    title: 'chore: version packages',
+  });
+  assert.equal(result.skip, true);
+  assert.match(result.reason, /deterministic release/);
+});
+
+test('#3771: branch or title near-matches stay on the normal review path', () => {
+  for (const input of [
+    { headRef: 'feature', title: 'chore: version packages' },
+    { headRef: 'changeset-release/main', title: 'chore: version packages with code' },
+    { headRef: 'Changeset-release/main', title: 'chore: version packages' },
+  ]) {
+    assert.deepEqual(classifyReviewTarget(input), { skip: false, reason: null });
+  }
+});


### PR DESCRIPTION
The rolling `changeset-release/main` PR is generated release metadata already covered by deterministic release/version/build gates. It caused 13 of 23 measured review failures and now repeatedly exceeds the harness patch ceiling.

Classify the exact generated branch+title pair before prompt construction and post an explicit `nothing-to-review` marker. Near-matches remain on the normal review path. PR metadata reaches the shell only through environment variables.

Verification:
- `pnpm test` (98/98 tasks)
- `pnpm typecheck` (89/89 tasks; 1,662 test files covered)
- focused review tests (71/71)
- gate wiring and module-size checks

Closes #3771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
  - Automated review processing now recognizes generated release pull requests and marks them as having nothing to review.
  - Pull requests that do not exactly match the generated release pattern continue through the standard review process.
  - Review classification now provides a clear reason when processing is skipped.

- **Reliability**
  - Added coverage for exact matches and near-matching branch or title combinations to ensure consistent review behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->