### PR TITLE
fix(ci): ignore superseded check runs in PR sweep

### DIFF
--- a/scripts/lib/check-rollup.mjs
+++ b/scripts/lib/check-rollup.mjs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * GitHub retains check runs from a cancelled, superseded workflow alongside
+ * the replacement run on the same commit. Required-check evaluation uses the
+ * newest run for a context; counting every historical row instead makes a
+ * green replacement look failed (#3792).
+ *
+ * Deduplication requires both a stable context name and parseable timestamps.
+ * Unknown rows stay visible and ties stay together, preserving the sweep's
+ * fail-closed direction instead of guessing which ambiguous row superseded
+ * which.
+ */
+export function currentRollupChecks(rollup) {
+  const unnamed = [];
+  const groups = new Map();
+  for (const check of rollup ?? []) {
+    const name = check?.__typename === 'StatusContext' ? check?.context : check?.name;
+    if (typeof name !== 'string' || name === '') {
+      unnamed.push(check);
+      continue;
+    }
+    const group = groups.get(name) ?? [];
+    group.push(check);
+    groups.set(name, group);
+  }
+
+  const current = [...unnamed];
+  for (const group of groups.values()) {
+    if (group.length === 1) {
+      current.push(group[0]);
+      continue;
+    }
+    const times = group.map((check) => Date.parse(check?.startedAt ?? ''));
+    if (times.some((time) => !Number.isFinite(time))) {
+      current.push(...group);
+      continue;
+    }
+    const newest = Math.max(...times);
+    current.push(...group.filter((_check, index) => times[index] === newest));
+  }
+  return current;
+}
+
+/** Count the current rollup into pass/fail/pending. */
+export function countCurrentRollup(rollup) {
+  let fail = 0;
+  let pending = 0;
+  let pass = 0;
+  for (const check of currentRollupChecks(rollup)) {
+    const status = String(check?.status ?? '').toUpperCase();
+    if (status && status !== 'COMPLETED') {
+      pending += 1;
+      continue;
+    }
+    const verdict = String(check?.conclusion ?? check?.state ?? '').toUpperCase();
+    if (verdict === 'SUCCESS' || verdict === 'NEUTRAL' || verdict === 'SKIPPED') pass += 1;
+    else if (verdict === '' || verdict === 'PENDING' || verdict === 'EXPECTED') pending += 1;
+    else fail += 1;
+  }
+  return { fail, pending, pass };
+}

--- a/scripts/lib/pr-green-sweep.mjs
+++ b/scripts/lib/pr-green-sweep.mjs
@@ -43,6 +43,8 @@
  */
 
 import { classifyReviewState } from './coderabbit-review-state.mjs';
+import { countCurrentRollup } from './check-rollup.mjs';
+export { currentRollupChecks } from './check-rollup.mjs';
 
 export const DEFAULT_REPO = 'LTplus-AG/ifc-lite';
 
@@ -201,21 +203,7 @@ export function severityOf(row, repo = DEFAULT_REPO) {
  * "nothing failed" from "nothing ran".
  */
 export function countRollup(rollup) {
-  let fail = 0;
-  let pending = 0;
-  let pass = 0;
-  for (const check of rollup ?? []) {
-    const status = String(check?.status ?? '').toUpperCase();
-    if (status && status !== 'COMPLETED') {
-      pending += 1;
-      continue;
-    }
-    const verdict = String(check?.conclusion ?? check?.state ?? '').toUpperCase();
-    if (verdict === 'SUCCESS' || verdict === 'NEUTRAL' || verdict === 'SKIPPED') pass += 1;
-    else if (verdict === '' || verdict === 'PENDING' || verdict === 'EXPECTED') pending += 1;
-    else fail += 1;
-  }
-  return { fail, pending, pass };
+  return countCurrentRollup(rollup);
 }
 
 /** The later of two ISO-8601 instants, ignoring absent/unparseable ones. */

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -10,6 +10,7 @@ import {
   SweepError,
   actionable,
   countRollup,
+  currentRollupChecks,
   disqualify,
   isStaleRun,
   severityOf,
@@ -183,6 +184,34 @@ test('a CANCELLED check counts as failing, not as passing', () => {
     countRollup([{ status: 'COMPLETED', conclusion: 'CANCELLED' }]),
     { fail: 1, pending: 0, pass: 0 },
   );
+});
+
+test('#3792: a successful replacement supersedes a cancelled run with the same name', () => {
+  const counts = countRollup([
+    { name: 'Issue queue', status: 'COMPLETED', conclusion: 'CANCELLED', startedAt: '2026-09-03T18:00:00Z' },
+    { name: 'Issue queue', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:01:00Z' },
+    { name: 'PR review signal', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: '2026-09-03T18:00:00Z' },
+    { name: 'PR review signal', status: 'IN_PROGRESS', conclusion: null, startedAt: '2026-09-03T18:01:00Z' },
+  ]);
+  assert.deepEqual(counts, { fail: 0, pending: 1, pass: 1 });
+});
+
+test('#3792: ambiguous duplicate rows fail closed instead of hiding an old failure', () => {
+  const rows = [
+    { name: 'Test', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: null },
+    { name: 'Test', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:01:00Z' },
+  ];
+  assert.equal(currentRollupChecks(rows).length, 2);
+  assert.deepEqual(countRollup(rows), { fail: 1, pending: 0, pass: 1 });
+});
+
+test('#3792: status contexts dedupe by context while distinct lane names remain distinct', () => {
+  const rows = [
+    { __typename: 'StatusContext', context: 'Vercel', state: 'ERROR', startedAt: '2026-09-03T18:00:00Z' },
+    { __typename: 'StatusContext', context: 'Vercel', state: 'SUCCESS', startedAt: '2026-09-03T18:01:00Z' },
+    { __typename: 'CheckRun', name: 'Test', status: 'COMPLETED', conclusion: 'SUCCESS', startedAt: '2026-09-03T18:01:00Z' },
+  ];
+  assert.deepEqual(countRollup(rows), { fail: 0, pending: 0, pass: 2 });
 });
 
 // --- the three refuse-to-pass-vacuously paths --------------------------------


### PR DESCRIPTION
GitHub retains cancelled and failed check rows beside their newer replacement on the same head. The green sweep counted all of them, so an actually green PR could be reported failing.

Normalize by check context and retain the uniquely newest `startedAt`. Missing/invalid timestamps and ties remain visible, preserving fail-closed behavior. CheckRun names and StatusContext contexts are both covered.

Verification:
- `node --test scripts/lib/pr-green-sweep.test.mjs` (33/33)
- module-size ratchet
- `git diff --check`

Closes #3792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request status reporting by using the latest available result for duplicate checks.
  * Preserved distinct check contexts and handled ambiguous or incomplete timestamps without discarding results.
  * Improved accuracy of pass, pending, and failed check counts.

* **Tests**
  * Added coverage for duplicate checks, newer results superseding older ones, ambiguous timestamps, and independent check contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->