### PR TITLE
fix(review): classify diff headers by hunk position

### DIFF
--- a/scripts/lib/base-freshness.mjs
+++ b/scripts/lib/base-freshness.mjs
@@ -11,6 +11,8 @@
  * is narrowed the way it is.
  */
 
+import { unifiedDiffLineKind } from './unified-diff.mjs';
+
 /**
  * A repo-relative path token: at least one `/`, and an extension. Deliberately
  * greedy about the characters a path may hold (`@`, `.`, `-`) because package
@@ -94,8 +96,11 @@ const intersect = (files, set) => files.filter((f) => set.has(f));
  */
 export function rowsChangedInPatch(patch, isRepoFile) {
   const changed = new Set();
+  let insideHunk = false;
   for (const line of (patch ?? '').split('\n')) {
-    if (!/^[+-]/.test(line) || /^(\+\+\+|---)/.test(line)) continue;
+    const kind = unifiedDiffLineKind(line, insideHunk);
+    if (kind === 'hunk') { insideHunk = true; continue; }
+    if (kind !== 'added' && kind !== 'removed') continue;
     for (const path of recordedFiles(line.slice(1), isRepoFile)) changed.add(path);
   }
   return changed;

--- a/scripts/lib/unified-diff.mjs
+++ b/scripts/lib/unified-diff.mjs
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Classify a unified-diff line. Header prefixes inside hunks are content (#3634). */
+export function unifiedDiffLineKind(line, insideHunk) {
+  if (line.startsWith('@@')) return 'hunk';
+  if (line.startsWith('\\')) return 'metadata';
+  if (!insideHunk && (line.startsWith('---') || line.startsWith('+++'))) return 'header';
+  if (line.startsWith('+')) return 'added';
+  if (line.startsWith('-')) return 'removed';
+  return 'context';
+}

--- a/scripts/lib/unified-diff.test.mjs
+++ b/scripts/lib/unified-diff.test.mjs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { unifiedDiffLineKind } from './unified-diff.mjs';
+import { rowsChangedInPatch } from './base-freshness.mjs';
+
+test('#3634: file headers and same-prefixed hunk content are distinguished by position', () => {
+  assert.equal(unifiedDiffLineKind('--- a/file', false), 'header');
+  assert.equal(unifiedDiffLineKind('+++ b/file', false), 'header');
+  assert.equal(unifiedDiffLineKind('----', true), 'removed');
+  assert.equal(unifiedDiffLineKind('+++i;', true), 'added');
+});
+
+test('#3634: snapshot rows starting with header prefixes remain changed rows', () => {
+  const patch = [
+    '--- a/scripts/module-size-allowlist.txt',
+    '+++ b/scripts/module-size-allowlist.txt',
+    '@@ -1,1 +1,1 @@',
+    '--- 99 scripts/review/post-review.mjs',
+    '+++ 100 scripts/review/validate-findings.mjs',
+  ].join('\n');
+  assert.deepEqual(
+    [...rowsChangedInPatch(patch, () => true)],
+    ['scripts/review/post-review.mjs', 'scripts/review/validate-findings.mjs'],
+  );
+});

--- a/scripts/review/build-context-pack.mjs
+++ b/scripts/review/build-context-pack.mjs
@@ -40,6 +40,7 @@
 import { execFileSync } from 'node:child_process';
 import { renderSiblingRow, SIBLING_ROW_JOIN_MARGIN } from './sibling-row.mjs';
 import { keptRowCharge, unreviewableRowCharge } from './run-reviewer.mjs';
+import { unifiedDiffLineKind } from '../lib/unified-diff.mjs';
 
 /**
  * What the PR description may claim before the siblings compete for the rest.
@@ -232,14 +233,13 @@ export function showAtRef(ref, path, { cwd = process.cwd(), exec = execFileSync 
 
 /** New-file line numbers a patch touches, so a long file can be windowed. */
 export function hunkLines(patch) {
-  const out = [];
-  let n = 0;
+  const out = []; let n = 0, insideHunk = false;
   for (const line of String(patch).split(/\r?\n/)) {
     const h = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line);
-    if (h) { n = Number(h[1]); continue; }
-    if (line.startsWith('\\')) continue;
-    if (line.startsWith('+') && !line.startsWith('+++')) { out.push(n); n += 1; }
-    else if (line.startsWith('-') && !line.startsWith('---')) { /* no new line */ }
+    if (h) { insideHunk = true; n = Number(h[1]); continue; }
+    const kind = unifiedDiffLineKind(line, insideHunk); if (kind === 'metadata' || kind === 'header') continue;
+    if (kind === 'added') { out.push(n); n += 1; }
+    else if (kind === 'removed') { /* no new line */ }
     else n += 1;
   }
   return out;

--- a/scripts/review/build-context-pack.test.mjs
+++ b/scripts/review/build-context-pack.test.mjs
@@ -97,6 +97,11 @@ test('hunkLines numbers the NEW file, so a window lands where the reader will lo
   assert.deepEqual(hunkLines('@@ -1,2 +10,4 @@\n ctx\n+one\n+two'), [11, 12]);
 });
 
+test('#3634: hunkLines treats diff-header prefixes as content after a hunk starts', () => {
+  const patch = ['--- a/a.ts', '+++ b/a.ts', '@@ -1,2 +1,2 @@', '----', '+++i;'].join('\n');
+  assert.deepEqual(hunkLines(patch), [1]);
+});
+
 /**
  * A pack under REAL budget pressure, which is the only condition the reservation
  * has any effect under. The first version of these tests supplied `exec: () => ''`

--- a/scripts/review/build-review-input.mjs
+++ b/scripts/review/build-review-input.mjs
@@ -105,6 +105,7 @@ import {
 // 600-file long-path diff "fits" 8,476 bytes over the ceiling.
 import { keptRowCharge, unreviewableRowCharge } from './run-reviewer.mjs';
 import { gh, GhError } from '../lib/gh.mjs';
+import { unifiedDiffLineKind } from '../lib/unified-diff.mjs';
 // The gate's pager, not a second copy of it. An earlier version here duplicated
 // it MINUS the one thing it exists for: the probe past a full final page. A PR
 // with exactly MAX_PAGES x PER_PAGE files was therefore fully read and then
@@ -262,27 +263,17 @@ export function isExcluded(path) {
  * Splits on /\r?\n/, where the older walker split on '\n', so `text` carries no
  * trailing `\r`. That is what makes it comparable to `quotableLines`.
  *
- * KNOWN, PRE-EXISTING, NOT FIXED HERE (see #3634): neither the `-`/`---` nor
- * the `+`/`+++` test can tell a file header from content that starts the same
- * way, and the two halves fail DIFFERENTLY, so a fix must cover both:
- *
- *   deleting a markdown `---` rule gives `----`, read as context, which
- *     advances the counter and numbers every later line in that hunk too high;
- *   adding `++i;` gives `+++i;`, which is dropped from the ranges, so
- *     `lineIsAdded` refuses a CORRECT finding on a line the PR really added.
- *
- * `addedLineRanges` behaves exactly as it does on origin/main; the commit
- * message carries the differential evidence.
- *
  * @param {string} patch a unified diff for ONE file
  * @returns {{line: number, text: string, kind: 'added'|'context'|'removed'|'hunk'}[]}
  */
 export function newFileLines(patch) {
   const out = [];
   let newLine = 0;
+  let insideHunk = false;
   for (const line of String(patch).split(/\r?\n/)) {
     const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line);
     if (hunk) {
+      insideHunk = true;
       newLine = Number(hunk[1]);
       out.push({ line: newLine, text: line, kind: 'hunk' });
       continue;
@@ -294,11 +285,12 @@ export function newFileLines(patch) {
     // and rejected 422 by GitHub, reddening the job with no marker. It fires on
     // any file lacking a trailing newline. validate-findings' `quotableLines`
     // already skipped it, so the two halves disagreed about the same diff.
-    if (line.startsWith('\\')) continue;
-    if (line.startsWith('+') && !line.startsWith('+++')) {
+    const kind = unifiedDiffLineKind(line, insideHunk);
+    if (kind === 'metadata' || kind === 'header') continue;
+    if (kind === 'added') {
       out.push({ line: newLine, text: line.slice(1), kind: 'added' });
       newLine += 1;
-    } else if (line.startsWith('-') && !line.startsWith('---')) {
+    } else if (kind === 'removed') {
       // A removed line does not advance the new-file counter.
       out.push({ line: newLine, text: line.slice(1), kind: 'removed' });
     } else {

--- a/scripts/review/build-review-input.test.mjs
+++ b/scripts/review/build-review-input.test.mjs
@@ -71,6 +71,14 @@ test('a `+++` header line is not counted as an addition', () => {
   assert.deepEqual(ranges, [[2, 2]], 'only the real addition counts');
 });
 
+test('#3634: diff-header prefixes inside a hunk are content, not headers', () => {
+  const removedRule = ['--- a/doc.md', '+++ b/doc.md', '@@ -1,3 +1,3 @@', ' # Title', '----', '+replacement', ' tail'].join('\n');
+  assert.deepEqual(addedLineRanges(removedRule), [[2, 2]]);
+
+  const addedIncrement = ['--- a/code.ts', '+++ b/code.ts', '@@ -1,1 +1,2 @@', ' context', '+++i;'].join('\n');
+  assert.deepEqual(addedLineRanges(addedIncrement), [[2, 2]]);
+});
+
 test('the no-newline marker is metadata, not a context line', () => {
   // Counting it shifted every later range by one: a correct finding on the real
   // line was dropped as out-of-range, and a finding one past EOF was posted and


### PR DESCRIPTION
Closes #3634.

Unifies all three review-harness unified-diff classifiers and treats `---` / `+++` prefixes as file headers only before a hunk starts. Added regression coverage for added and removed hunk content, changed-line anchoring, and base-freshness path extraction.

Verification:
- `node --test scripts/lib/unified-diff.test.mjs scripts/review/build-review-input.test.mjs scripts/review/build-context-pack.test.mjs` (81/81)
- `node scripts/check-module-size.mjs`