### PR TITLE
fix(review): add independent quota fallback

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -276,6 +276,7 @@ jobs:
           # which it is on every run rather than leaving a single-credential setup
           # looking like a redundant one.
           CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           node "$GITHUB_WORKSPACE/scripts/review/run-reviewer.mjs" \
             --rubric "${{ steps.rubric.outputs.path }}" \
@@ -314,6 +315,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set +e
           node "$GITHUB_WORKSPACE/scripts/review/validate-findings.mjs" \

--- a/scripts/review/openai-reviewer.mjs
+++ b/scripts/review/openai-reviewer.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { isMainEntry } from '../lib/is-main-entry.mjs';
+
+export const OPENAI_REVIEW_MODEL = 'gpt-5.6-terra';
+
+export function responseText(response) {
+  if (typeof response?.output_text === 'string' && response.output_text.trim()) {
+    return response.output_text.trim();
+  }
+  return (response?.output ?? [])
+    .flatMap((item) => item?.type === 'message' ? item.content ?? [] : [])
+    .filter((part) => part?.type === 'output_text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join('')
+    .trim();
+}
+
+export async function requestOpenAiReview({ prompt, apiKey, fetchImpl = fetch }) {
+  const response = await fetchImpl('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: OPENAI_REVIEW_MODEL,
+      input: prompt,
+      store: false,
+      tools: [],
+      reasoning: { effort: 'high' },
+      max_output_tokens: 32768,
+    }),
+  });
+  const body = await response.text();
+  let parsed;
+  try { parsed = JSON.parse(body); } catch { parsed = null; }
+  if (!response.ok) {
+    const detail = String(parsed?.error?.message ?? body ?? '(empty)').slice(0, 2000);
+    throw new Error(`OpenAI Responses API returned HTTP ${response.status}: ${detail}`);
+  }
+  if (parsed?.status !== 'completed') {
+    throw new Error(`OpenAI response did not complete (status=${parsed?.status ?? 'missing'}).`);
+  }
+  const text = responseText(parsed);
+  if (!text) throw new Error('OpenAI response completed without output text.');
+  return text;
+}
+
+/** Run async fetch in an isolated child while the Claude CLI path stays synchronous. */
+export function runOpenAiFallback({ prompt, apiKey, spawn = spawnSync }) {
+  const result = spawn(process.execPath, [fileURLToPath(import.meta.url)], {
+    input: prompt,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, OPENAI_API_KEY: apiKey },
+  });
+  if (result.error) throw new Error(`Could not spawn OpenAI fallback: ${result.error.message}`);
+  if (result.status !== 0) {
+    throw new Error(`OpenAI fallback exited ${result.status}: ${String(result.stderr ?? '').trim() || '(empty)'}`);
+  }
+  const text = String(result.stdout ?? '').trim();
+  if (!text) throw new Error('OpenAI fallback exited 0 without output text.');
+  return text;
+}
+
+if (isMainEntry(import.meta.url)) {
+  try {
+    const apiKey = String(process.env.OPENAI_API_KEY ?? '').trim();
+    if (!apiKey) throw new Error('OPENAI_API_KEY is missing.');
+    process.stdout.write(await requestOpenAiReview({ prompt: readFileSync(0, 'utf8'), apiKey }));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/review/openai-reviewer.test.mjs
+++ b/scripts/review/openai-reviewer.test.mjs
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { OPENAI_REVIEW_MODEL, requestOpenAiReview, responseText, runOpenAiFallback } from './openai-reviewer.mjs';
+
+const reply = (body, { ok = true, status = 200 } = {}) => ({ ok, status, text: async () => JSON.stringify(body) });
+
+test('#3803: Responses API receives the unchanged prompt without tools or storage', async () => {
+  let request;
+  const text = await requestOpenAiReview({
+    prompt: 'the exact fenced review prompt',
+    apiKey: 'not-logged',
+    fetchImpl: async (url, init) => {
+      request = { url, init, body: JSON.parse(init.body) };
+      return reply({ status: 'completed', output: [{ type: 'message', content: [{ type: 'output_text', text: '{"findings":[]}' }] }] });
+    },
+  });
+  assert.equal(text, '{"findings":[]}');
+  assert.equal(request.url, 'https://api.openai.com/v1/responses');
+  assert.equal(request.body.model, OPENAI_REVIEW_MODEL);
+  assert.equal(request.body.input, 'the exact fenced review prompt');
+  assert.deepEqual(request.body.tools, []);
+  assert.equal(request.body.store, false);
+  assert.doesNotMatch(JSON.stringify(request.body), /not-logged/);
+});
+
+test('responseText handles the raw REST response shape', () => {
+  assert.equal(responseText({ output: [{ type: 'message', content: [
+    { type: 'output_text', text: 'first' }, { type: 'refusal', refusal: 'no' }, { type: 'output_text', text: ' second' },
+  ] }] }), 'first second');
+});
+
+test('API errors and incomplete or empty replies fail closed', async () => {
+  await assert.rejects(
+    requestOpenAiReview({ prompt: 'p', apiKey: 'k', fetchImpl: async () => reply({ error: { message: 'spent' } }, { ok: false, status: 429 }) }),
+    /HTTP 429: spent/,
+  );
+  await assert.rejects(
+    requestOpenAiReview({ prompt: 'p', apiKey: 'k', fetchImpl: async () => reply({ status: 'incomplete' }) }),
+    /did not complete/,
+  );
+  await assert.rejects(
+    requestOpenAiReview({ prompt: 'p', apiKey: 'k', fetchImpl: async () => reply({ status: 'completed', output: [] }) }),
+    /without output text/,
+  );
+});
+
+test('child wrapper passes the key only through env and returns text', () => {
+  let call;
+  const text = runOpenAiFallback({ prompt: 'p', apiKey: 'secret', spawn: (...args) => {
+    call = args;
+    return { status: 0, stdout: ' answer ', stderr: '' };
+  } });
+  assert.equal(text, 'answer');
+  assert.equal(call[2].input, 'p');
+  assert.equal(call[2].env.OPENAI_API_KEY, 'secret');
+  assert.doesNotMatch(JSON.stringify(call.slice(0, 2)), /secret/);
+});

--- a/scripts/review/run-reviewer.mjs
+++ b/scripts/review/run-reviewer.mjs
@@ -53,6 +53,7 @@
  *                    CLAUDE_CODE_OAUTH_TOKEN with `claude setup-token`.
  *   MODEL_ERROR      Any other non-zero exit or `is_error`. REMEDY: read the
  *                    captured stderr, which is printed verbatim.
+ *   CLI_SILENT_EXIT  Non-zero with no output. The live session-limit shape.
  *   EMPTY_RESPONSE   The CLI succeeded and produced nothing. Treated as failure
  *                    rather than as an empty review.
  *   BAD_ENVELOPE     The CLI's own JSON wrapper did not parse.
@@ -75,6 +76,7 @@ import { randomBytes } from 'node:crypto';
 import { isMainEntry } from '../lib/is-main-entry.mjs';
 import { renderSiblingRow } from './sibling-row.mjs';
 import { buildRetrySection } from './retry-prompt.mjs';
+import { runOpenAiFallback } from './openai-reviewer.mjs';
 
 export class RunReviewerError extends Error {
   constructor(reason, message) {
@@ -358,7 +360,8 @@ export function runReviewer({ prompt, model, spawn = realSpawn, token = null }) 
   }
   const stderr = String(r.stderr ?? '');
   if (r.status !== 0) {
-    const reason = classify(`${stderr}\n${r.stdout ?? ''}`);
+    const output = `${stderr}\n${r.stdout ?? ''}`;
+    const reason = output.trim() === '' ? 'CLI_SILENT_EXIT' : classify(output);
     throw new RunReviewerError(
       reason,
       `The reviewer CLI exited ${r.status}. ${remedyFor(reason)}\n--- stderr ---\n${stderr.trim() || '(empty)'}`,
@@ -409,37 +412,14 @@ function remedyFor(reason) {
 }
 
 /**
- * Run the reviewer, falling back to a SECOND credential when the first is the
- * thing that failed.
- *
- * WHY THIS EXISTS. The lane rests on one manually-refreshed subscription token.
- * It expired once already, and the day it did the lane was dark while every
- * per-PR check looked like an ordinary transient red. CodeRabbit covers about a
- * third of this repository's volume, so a single dead credential means most PRs
- * get no review at all.
- *
- * ONLY TWO REASONS RETRY, and the list is deliberately short:
- *
- *   AUTH_FAILED    - this credential is dead. A different one may not be.
- *   QUOTA_DRAINED  - this POOL is empty. A different account has its own pool.
- *
- * Everything else -- MODEL_ERROR, EMPTY_RESPONSE, BAD_ENVELOPE -- is a property
- * of the request or the model, not of the credential, and retrying it on a
- * second account would burn a second pool to get the same answer. Worse, it
- * would turn a deterministic failure into an intermittent one, which is harder
- * to diagnose than the failure itself.
- *
- * THE FALLBACK IS OPTIONAL. With no second token configured this behaves exactly
- * as before, and says so, because a silent single-credential setup that looks
- * like a redundant one is the failure this whole function is about.
- *
- * @param {{ prompt: string, model: string, tokens: {token: string, label: string}[], spawn: Function }} o
+ * Retry only credential-specific failures: first across independent Claude
+ * accounts, then across providers. Request/model/output failures stay failed.
  */
-export function runReviewerWithFailover({ prompt, model, tokens, spawn }) {
+export function runReviewerWithFailover({ prompt, model, tokens, spawn, providerFallback = null }) {
   if (!Array.isArray(tokens) || tokens.length === 0) {
     throw new RunReviewerError('AUTH_MISSING', 'No usable credential was resolved.');
   }
-  const RETRYABLE = new Set(['AUTH_FAILED', 'QUOTA_DRAINED']);
+  const RETRYABLE = new Set(['AUTH_FAILED', 'QUOTA_DRAINED', 'CLI_SILENT_EXIT']);
   let last;
   for (const [i, t] of tokens.entries()) {
     try {
@@ -449,8 +429,20 @@ export function runReviewerWithFailover({ prompt, model, tokens, spawn }) {
     } catch (err) {
       last = err;
       const more = i + 1 < tokens.length;
-      if (!(err instanceof RunReviewerError) || !RETRYABLE.has(err.reason) || !more) throw err;
+      if (!(err instanceof RunReviewerError) || !RETRYABLE.has(err.reason)) throw err;
+      if (!more) break;
       console.log(`auth: ${t.label} failed with ${err.reason}; trying ${tokens[i + 1].label}.`);
+    }
+  }
+  if (providerFallback) {
+    console.log(`auth: Claude failed with ${last.reason}; trying the independent provider fallback.`);
+    try {
+      return { text: providerFallback(prompt), envelope: { provider: 'openai-fallback' } };
+    } catch (error) {
+      throw new RunReviewerError(
+        'FALLBACK_ERROR',
+        `Claude failed with ${last.reason}, and the independent provider failed: ${error.message}`,
+      );
     }
   }
   throw last;
@@ -521,11 +513,15 @@ function main() {
         : ', NO fallback configured (set CLAUDE_CODE_OAUTH_TOKEN_2 from a second account)'),
   );
 
+  const openAiKey = String(process.env.OPENAI_API_KEY ?? '').trim();
+  console.log(openAiKey ? 'provider fallback: configured.' : 'provider fallback: NOT configured (set OPENAI_API_KEY).');
+
   const { text, envelope } = runReviewerWithFailover({
     prompt,
     model: args.model,
     tokens,
     spawn: realSpawn,
+    providerFallback: openAiKey ? (reviewPrompt) => runOpenAiFallback({ prompt: reviewPrompt, apiKey: openAiKey }) : null,
   });
 
   writeFileSync(args.out, text);

--- a/scripts/review/run-reviewer.test.mjs
+++ b/scripts/review/run-reviewer.test.mjs
@@ -181,6 +181,13 @@ test('a non-zero exit with a usage limit is QUOTA_DRAINED, not an empty review',
   );
 });
 
+test('#3803: the measured exit-1-with-no-output shape is CLI_SILENT_EXIT', () => {
+  assert.throws(
+    () => runReviewer({ prompt: 'x', model: 'sonnet', spawn: () => ({ status: 1, stdout: '', stderr: '' }) }),
+    (error) => error.reason === 'CLI_SILENT_EXIT',
+  );
+});
+
 test('`is_error: true` alongside EXIT 0 still fails', () => {
   // This is the claude-code-action #1644 shape: success by exit code, nothing by
   // content. An exit code alone is not evidence here either.
@@ -245,7 +252,6 @@ const TOKENS = [
   { token: 'sk-ant-oat01-primary', label: 'the primary credential' },
   { token: 'sk-ant-oat01-fallback', label: 'the fallback credential' },
 ];
-const fail = (stderr) => () => ({ status: 1, stdout: '', stderr });
 const okOn = (which) => {
   let n = 0;
   return (_c, _a, _stdin, env) => {
@@ -298,6 +304,51 @@ test('with ONE token it behaves exactly as before', () => {
   assert.equal(calls, 1);
 });
 
+test('#3803: an exhausted Claude pool invokes the independent provider once', () => {
+  let fallbackCalls = 0;
+  const result = runReviewerWithFailover({
+    prompt: 'exact prompt', model: 'sonnet', tokens: [TOKENS[0]],
+    spawn: () => ({ status: 1, stdout: '', stderr: 'Usage limit reached' }),
+    providerFallback: (prompt) => { fallbackCalls += 1; assert.equal(prompt, 'exact prompt'); return '{"findings":[]}'; },
+  });
+  assert.equal(result.text, '{"findings":[]}');
+  assert.equal(result.envelope.provider, 'openai-fallback');
+  assert.equal(fallbackCalls, 1);
+});
+
+test('#3803: a silent Claude CLI exit invokes the independent provider', () => {
+  const result = runReviewerWithFailover({
+    prompt: 'p', model: 'sonnet', tokens: [TOKENS[0]],
+    spawn: () => ({ status: 1, stdout: '', stderr: '' }),
+    providerFallback: () => '{"verdict":"clean"}',
+  });
+  assert.equal(result.text, '{"verdict":"clean"}');
+});
+
+test('#3803: independent-provider failure is explicit, never a clean verdict', () => {
+  assert.throws(
+    () => runReviewerWithFailover({
+      prompt: 'p', model: 'sonnet', tokens: [TOKENS[0]],
+      spawn: () => ({ status: 1, stdout: '', stderr: '429 quota exceeded' }),
+      providerFallback: () => { throw new Error('HTTP 500'); },
+    }),
+    (error) => error.reason === 'FALLBACK_ERROR' && /HTTP 500/.test(error.message),
+  );
+});
+
+test('#3803: model errors never switch providers', () => {
+  let fallbackCalls = 0;
+  assert.throws(
+    () => runReviewerWithFailover({
+      prompt: 'p', model: 'sonnet', tokens: [TOKENS[0]],
+      spawn: () => ({ status: 1, stdout: '', stderr: 'unknown model failure' }),
+      providerFallback: () => { fallbackCalls += 1; return 'wrong'; },
+    }),
+    (error) => error.reason === 'MODEL_ERROR',
+  );
+  assert.equal(fallbackCalls, 0);
+});
+
 test('resolveTokens: the same secret in both slots is REFUSED, not treated as a fallback', () => {
   // An easy mistake while wiring the second one up, and a fallback that shares
   // the primary's pool and expiry fails at exactly the moment it is needed while
@@ -333,4 +384,5 @@ test('THE WIRING: the workflow actually passes the fallback secret', () => {
   const env = step.split('run:')[0];
   assert.match(env, /CLAUDE_CODE_OAUTH_TOKEN:\s*\$\{\{\s*secrets\.CLAUDE_CODE_OAUTH_TOKEN\s*\}\}/);
   assert.match(env, /CLAUDE_CODE_OAUTH_TOKEN_2:\s*\$\{\{\s*secrets\.CLAUDE_CODE_OAUTH_TOKEN_2\s*\}\}/);
+  assert.match(env, /OPENAI_API_KEY:\s*\$\{\{\s*secrets\.OPENAI_API_KEY\s*\}\}/);
 });


### PR DESCRIPTION
Closes #3803.

Adds an OpenAI Responses API fallback after every configured Claude credential is exhausted or rejected. The same fenced prompt flows into the existing validator, judge, and poster. Model/output failures do not switch providers, and fallback errors fail closed. GitHub Models was evaluated and rejected because its inference API was retired on 2026-07-30 (HTTP 410).

The repository still needs an `OPENAI_API_KEY` Actions secret before the live provider path is active; until then every run reports that it is not configured.

Verification:
- `node --test scripts/review/run-reviewer.test.mjs scripts/review/openai-reviewer.test.mjs` (37/37)
- `node scripts/check-module-size.mjs`
- `node scripts/check-test-wiring.mjs`
- focused oxlint