### PR TITLE
fix(review): name the correct file in a wrong-file PROOF_OF_WORK_FAILED

### DIFF
--- a/scripts/review/quote-line-coupling.mjs
+++ b/scripts/review/quote-line-coupling.mjs
@@ -131,6 +131,16 @@ export function addedLinesMatching(patch, quote) {
  * to a retry than "try again", and #3769 itself notes a same-prompt retry
  * has no particular reason to fix an attribution it was never told was wrong.
  *
+ * HARDENING, not a bug fix: today `claimedPath` always arrives as a literal
+ * `Map` key (`checkProofOfWork` does `input.files.get(rc.path)` before this
+ * function is ever called, so a spelling mismatch is already caught by that
+ * `!file` branch). The naked `path === claimedPath` this replaced was
+ * therefore safe in practice, but only by that implicit contract with its
+ * one caller -- standalone, it fails on a `./`-prefixed or backslash-separated
+ * spelling of the same file, producing the nonsensical self-referential
+ * message this comment is attached to. Normalising makes the function correct
+ * on its own terms for any future caller, not just this one.
+ *
  * @param {Map<string, {patch: string}>} files every file sent to the model
  * @param {string} claimedPath the file `riskiest_change.path` named
  * @param {string} quote `riskiest_change.quoted_line`
@@ -138,22 +148,31 @@ export function addedLinesMatching(patch, quote) {
  * @returns {string}
  */
 export function quotedLineFailureMessage(files, claimedPath, quote, minChars) {
-  let elsewhere = null;
+  const claimedKey = normalizePathForSelfMatch(claimedPath);
+  const elsewhere = [];
   for (const [path, file] of files) {
-    if (path === claimedPath) continue;
-    if (quoteAppearsIn(file.patch, quote, minChars)) {
-      elsewhere = path;
-      break;
-    }
+    if (normalizePathForSelfMatch(path) === claimedKey) continue;
+    if (quoteAppearsIn(file.patch, quote, minChars)) elsewhere.push(path);
   }
   const base =
     `\`riskiest_change.quoted_line\` is not a line of \`${claimedPath}\`'s patch (or is shorter than ` +
     `${minChars} characters, which would not be evidence of anything): ` +
     `${JSON.stringify(String(quote).slice(0, 120))}.`;
-  if (elsewhere) {
+  if (elsewhere.length === 1) {
     return (
-      `${base} This exact line IS in \`${elsewhere}\`'s patch instead -- the file attribution is wrong, ` +
-      `not the quote. REMEDY: re-run; the correct \`riskiest_change.path\` is \`${elsewhere}\`.`
+      `${base} This exact line IS in \`${elsewhere[0]}\`'s patch instead -- the file attribution is wrong, ` +
+      `not the quote. REMEDY: re-run; the correct \`riskiest_change.path\` is \`${elsewhere[0]}\`.`
+    );
+  }
+  if (elsewhere.length > 1) {
+    // AMBIGUOUS: naming only the first Map-iteration-order match would be a
+    // confident-sounding but unearned single answer -- disclose the spread
+    // instead of picking one for the model.
+    const named = elsewhere.map((p) => `\`${p}\``).join(', ');
+    return (
+      `${base} This exact line IS in ${elsewhere.length} other reviewed files' patches instead (${named}) ` +
+      '-- the file attribution is wrong, but which of these it belongs to cannot be told from the quote ' +
+      'alone. REMEDY: re-run and name the specific file the quote came from.'
     );
   }
   return (
@@ -163,3 +182,21 @@ export function quotedLineFailureMessage(files, claimedPath, quote, minChars) {
   );
 }
 
+/**
+ * Same-file check for `quotedLineFailureMessage`'s self-match guard ONLY --
+ * not a general path resolver. Strips a leading `./` and folds `\` to `/`, so
+ * `./a/b.ts`, `a/b.ts` and `a\b.ts` compare equal.
+ *
+ * Case is deliberately NOT folded. Paths here are POSIX diff paths
+ * (`+++ b/path`) and case-SENSITIVE on the Linux CI this runs in, so two
+ * distinctly-cased paths are, on that filesystem, two different files; folding
+ * case would make a real other file compare equal to `claimedPath` and get
+ * silently excluded from the "elsewhere" search -- the opposite failure mode,
+ * a false self-match hiding a genuine wrong-file finding.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function normalizePathForSelfMatch(path) {
+  return String(path).replace(/\\/g, '/').replace(/^\.\//, '');
+}

--- a/scripts/review/quote-line-coupling.mjs
+++ b/scripts/review/quote-line-coupling.mjs
@@ -114,3 +114,52 @@ export function addedLinesMatching(patch, quote) {
   return out;
 }
 
+/**
+ * The `PROOF_OF_WORK_FAILED` message for a `riskiest_change.quoted_line` that
+ * failed `quoteAppearsIn` against the file it was attributed to (#3769).
+ * DIAGNOSTIC ONLY: by the time this runs the quote has already been rejected
+ * -- nothing here decides pass or fail, only what the model is TOLD about
+ * why, so `claude-review.yml`'s existing one-time retry for this reason
+ * (#3757) gets a targeted correction instead of "pick a different line",
+ * which does not address a wrong-file cause at all.
+ *
+ * #3769 measured this shape deterministically, three times on one PR: an
+ * extraction refactor where the quoted line moved into a NEW file, but the
+ * model named the OLD file it used to live in. So before falling back to the
+ * original "quit early" remedy, check whether the quote is a whole line of
+ * some OTHER reviewed file's patch -- if it is, that is strictly more useful
+ * to a retry than "try again", and #3769 itself notes a same-prompt retry
+ * has no particular reason to fix an attribution it was never told was wrong.
+ *
+ * @param {Map<string, {patch: string}>} files every file sent to the model
+ * @param {string} claimedPath the file `riskiest_change.path` named
+ * @param {string} quote `riskiest_change.quoted_line`
+ * @param {number} minChars
+ * @returns {string}
+ */
+export function quotedLineFailureMessage(files, claimedPath, quote, minChars) {
+  let elsewhere = null;
+  for (const [path, file] of files) {
+    if (path === claimedPath) continue;
+    if (quoteAppearsIn(file.patch, quote, minChars)) {
+      elsewhere = path;
+      break;
+    }
+  }
+  const base =
+    `\`riskiest_change.quoted_line\` is not a line of \`${claimedPath}\`'s patch (or is shorter than ` +
+    `${minChars} characters, which would not be evidence of anything): ` +
+    `${JSON.stringify(String(quote).slice(0, 120))}.`;
+  if (elsewhere) {
+    return (
+      `${base} This exact line IS in \`${elsewhere}\`'s patch instead -- the file attribution is wrong, ` +
+      `not the quote. REMEDY: re-run; the correct \`riskiest_change.path\` is \`${elsewhere}\`.`
+    );
+  }
+  return (
+    `${base} This is the one thing a model that quit early cannot fake. REMEDY: re-run. Quote a WHOLE ` +
+    'line, not a fragment; and if the line you nominated is too long to reproduce exactly, nominate a ' +
+    'SHORTER line from the same file instead -- any real line of the diff proves you read it.'
+  );
+}
+

--- a/scripts/review/validate-findings.mjs
+++ b/scripts/review/validate-findings.mjs
@@ -154,7 +154,7 @@ import { isMainEntry } from '../lib/is-main-entry.mjs';
 // ./quote-line-coupling.mjs (module-size budget). Imported (not `export ...
 // from`) because this file also calls them itself, and re-exported below so
 // every existing import of them from this file keeps working unchanged.
-import { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching } from './quote-line-coupling.mjs';
+import { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching, quotedLineFailureMessage } from './quote-line-coupling.mjs';
 // One constant, imported rather than re-spelled: a reworded copy here would
 // stop matching the rows build-review-input writes, and the partial-review
 // marker would silently claim a full review (#3679).
@@ -682,14 +682,11 @@ function checkProofOfWork({ response, input }) {
     );
   }
   if (!quoteAppearsIn(file.patch, rc.quoted_line, MIN_PROOF_QUOTE_CHARS)) {
+    // Message-building (including the #3769 wrong-file lookup) lives in
+    // quotedLineFailureMessage: this file is at zero module-size headroom.
     throw new ValidateFindingsError(
       'PROOF_OF_WORK_FAILED',
-      `\`riskiest_change.quoted_line\` is not a line of \`${rc.path}\`'s patch (or is shorter than ` +
-        `${MIN_PROOF_QUOTE_CHARS} characters, which would not be evidence of anything): ` +
-        `${JSON.stringify(String(rc.quoted_line).slice(0, 120))}. This is the one thing a model that ` +
-        'quit early cannot fake. REMEDY: re-run. Quote a WHOLE line, not a fragment; and if the ' +
-        'line you nominated is too long to reproduce exactly, nominate a SHORTER line from the ' +
-        'same file instead -- any real line of the diff proves you read it.',
+      quotedLineFailureMessage(input.files, rc.path, rc.quoted_line, MIN_PROOF_QUOTE_CHARS),
     );
   }
 }

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -47,6 +47,7 @@ import {
   siblingVerifies,
 } from './validate-findings.mjs';
 import { addedLineRanges, OMITTED_FOR_PROMPT_REASON } from './build-review-input.mjs';
+import { quotedLineFailureMessage } from './quote-line-coupling.mjs'; // #3769: direct unit coverage below
 // #3652: the retry prompt this file's own tests exercise below.
 import { buildPrompt } from './run-reviewer.mjs';
 
@@ -1079,6 +1080,71 @@ test('RED, shape 3: a `//!` doc-comment quoted without its marker', () => {
     riskiest_change: { path: PATH_C, quoted_line: 'Handles the georeferenced wall placement path.' },
   });
   assert.throws(() => validate({ response: res, input }), (e) => e.reason === 'PROOF_OF_WORK_FAILED');
+});
+
+// ============================================================ #3769: WRONG FILE
+//
+// A real, whole, long-enough quote -- but `riskiest_change.path` names a
+// DIFFERENT file than the one the quote's patch actually contains it in.
+// checkProofOfWork correctly refuses this (the quote is not a line of the
+// NAMED file's patch), so the check is not loosened here. What changes is the
+// message: when the quote IS a whole line of some OTHER reviewed file's
+// patch, the failure names that file, so the retry #3757 already runs for
+// PROOF_OF_WORK_FAILED gets a corrected attribution instead of "pick a
+// different line" -- which does not address a wrong-file cause at all.
+
+test('quotedLineFailureMessage: direct unit coverage of the lookup, both outcomes', () => {
+  const files = new Map([[PATH_A, { patch: PATCH_A }], [PATH_B, { patch: PATCH_B }]]);
+  const found = quotedLineFailureMessage(files, PATH_A, 'registry.set("wall", parseWall);', 8);
+  assert.match(found, new RegExp(`This exact line IS in \`${PATH_B}\`'s patch instead`));
+  const notFound = quotedLineFailureMessage(files, PATH_A, 'nowhere at all in either patch', 8);
+  assert.doesNotMatch(notFound, /This exact line IS in/);
+  assert.match(notFound, /quit early cannot fake/);
+  // Excluded path is never checked against itself, even if the quote happens
+  // to be a real line of ITS OWN patch -- checkProofOfWork only calls this
+  // once quoteAppearsIn(file.patch, ...) against claimedPath already failed,
+  // so a match there would be a contradiction, not a genuine "elsewhere".
+  const selfMatch = quotedLineFailureMessage(files, PATH_A, PROOF_LINE, 8);
+  assert.doesNotMatch(selfMatch, new RegExp(`IS in \`${PATH_A}\`'s patch instead`));
+});
+
+test('RED, shape 4 (#3769): a real quote attributed to the wrong file is still refused, and names the right one', () => {
+  const input = { headSha: SHA, files: new Map([[PATH_A, { path: PATH_A, patch: PATCH_A, addedLineRanges: addedLineRanges(PATCH_A) }], [PATH_B, { path: PATH_B, patch: PATCH_B, addedLineRanges: addedLineRanges(PATCH_B) }]]), unreviewable: [] };
+  // The quote is real and whole -- it is PATCH_B's added line -- but attributed
+  // to PATH_A, exactly #3769's shape (an extracted function narrated by the
+  // file it used to live in).
+  const res = response({
+    files_reviewed: [PATH_A, PATH_B],
+    riskiest_change: { path: PATH_A, quoted_line: 'registry.set("wall", parseWall);' },
+  });
+  let err;
+  assert.throws(() => validate({ response: res, input }), (e) => { err = e; return e.reason === 'PROOF_OF_WORK_FAILED'; });
+  // The check still refuses it -- this is diagnostics, not a loosened gate.
+  assert.match(err.message, /is not a line of `packages\/x\/y\.ts`'s patch/);
+  // But the message now names the file the quote actually IS in.
+  assert.match(err.message, new RegExp(`This exact line IS in \`${PATH_B}\`'s patch instead`));
+  assert.match(err.message, new RegExp(`the correct \`riskiest_change\\.path\` is \`${PATH_B}\``));
+});
+
+test('CONTROL (#3769): a quote that is fabricated -- real in NO reviewed file -- gets the original remedy, no false file name', () => {
+  const input = { headSha: SHA, files: new Map([[PATH_A, { path: PATH_A, patch: PATCH_A, addedLineRanges: addedLineRanges(PATCH_A) }], [PATH_B, { path: PATH_B, patch: PATCH_B, addedLineRanges: addedLineRanges(PATCH_B) }]]), unreviewable: [] };
+  const res = response({
+    files_reviewed: [PATH_A, PATH_B],
+    riskiest_change: { path: PATH_A, quoted_line: 'this line appears nowhere in any patch' },
+  });
+  let err;
+  assert.throws(() => validate({ response: res, input }), (e) => { err = e; return e.reason === 'PROOF_OF_WORK_FAILED'; });
+  assert.doesNotMatch(err.message, /This exact line IS in/, 'must not invent a file when the quote is genuinely nowhere');
+  assert.match(err.message, /Quote a WHOLE line, not a fragment/, 'falls back to the original remedy text');
+});
+
+test('CONTROL (#3769): a correct citation -- right file, real line -- still passes', () => {
+  const input = { headSha: SHA, files: new Map([[PATH_A, { path: PATH_A, patch: PATCH_A, addedLineRanges: addedLineRanges(PATCH_A) }], [PATH_B, { path: PATH_B, patch: PATCH_B, addedLineRanges: addedLineRanges(PATCH_B) }]]), unreviewable: [] };
+  const res = response({
+    files_reviewed: [PATH_A, PATH_B],
+    riskiest_change: { path: PATH_B, quoted_line: 'registry.set("wall", parseWall);' },
+  });
+  assert.doesNotThrow(() => validate({ response: res, input }));
 });
 
 test('GREEN: the retry prompt fences the failure and asks for a DIFFERENT real line', () => {

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -1108,6 +1108,59 @@ test('quotedLineFailureMessage: direct unit coverage of the lookup, both outcome
   assert.doesNotMatch(selfMatch, new RegExp(`IS in \`${PATH_A}\`'s patch instead`));
 });
 
+// HARDENING (not a live-bug fix -- see the function's own doc comment):
+// `checkProofOfWork` always calls this with a `claimedPath` that is already a
+// literal `Map` key, so a spelling mismatch here is unreachable through that
+// caller today. These tests call the exported function directly, the same way
+// #3769's own scratch script did, to pin the guard's behaviour on its own
+// terms rather than through that one caller's contract.
+test('quotedLineFailureMessage: self-match guard survives a ./-prefixed or backslash spelling of the same file', () => {
+  const files = new Map([[PATH_A, { patch: PATCH_A }]]);
+  for (const spelling of [`./${PATH_A}`, PATH_A.replace(/\//g, '\\')]) {
+    const msg = quotedLineFailureMessage(files, spelling, PROOF_LINE, 8);
+    assert.doesNotMatch(
+      msg,
+      /This exact line IS in/,
+      `claimedPath ${JSON.stringify(spelling)} should self-match ${JSON.stringify(PATH_A)}`,
+    );
+  }
+});
+
+test('quotedLineFailureMessage: self-match guard does NOT fold case (paths are case-sensitive here)', () => {
+  // The mirror of the test above: two DIFFERENT files that happen to differ
+  // only by case must NOT be treated as the same file. A case-folding
+  // normalisation would make this wrongly "self-match" and hide a real
+  // wrong-file attribution.
+  const files = new Map([[PATH_A, { patch: PATCH_A }]]);
+  const msg = quotedLineFailureMessage(files, PATH_A.toUpperCase(), PROOF_LINE, 8);
+  assert.match(msg, new RegExp(`This exact line IS in \`${PATH_A}\`'s patch instead`));
+});
+
+test('quotedLineFailureMessage: several matching files are disclosed together, not just the first by iteration order', () => {
+  const files = new Map([
+    [PATH_A, { patch: PATCH_B }],
+    [PATH_B, { patch: PATCH_B }],
+    [UNREVIEWABLE, { patch: PATCH_A }],
+  ]);
+  const msg = quotedLineFailureMessage(files, UNREVIEWABLE, 'registry.set("wall", parseWall);', 8);
+  assert.match(msg, /IS in 2 other reviewed files' patches instead/);
+  assert.match(msg, new RegExp(`\`${PATH_A}\`.*\`${PATH_B}\`|\`${PATH_B}\`.*\`${PATH_A}\``));
+  assert.doesNotMatch(msg, /the correct `riskiest_change\.path` is/);
+});
+
+test('quotedLineFailureMessage: the no-other-file fallback stays byte-identical', () => {
+  const files = new Map([[PATH_A, { patch: PATCH_A }]]);
+  const msg = quotedLineFailureMessage(files, PATH_A, 'nowhere at all in either patch', 8);
+  assert.strictEqual(
+    msg,
+    '`riskiest_change.quoted_line` is not a line of `packages/x/y.ts`\'s patch (or is shorter than 8 ' +
+      'characters, which would not be evidence of anything): "nowhere at all in either patch". This is the ' +
+      'one thing a model that quit early cannot fake. REMEDY: re-run. Quote a WHOLE line, not a fragment; ' +
+      'and if the line you nominated is too long to reproduce exactly, nominate a SHORTER line from the ' +
+      'same file instead -- any real line of the diff proves you read it.',
+  );
+});
+
 test('RED, shape 4 (#3769): a real quote attributed to the wrong file is still refused, and names the right one', () => {
   const input = { headSha: SHA, files: new Map([[PATH_A, { path: PATH_A, patch: PATCH_A, addedLineRanges: addedLineRanges(PATCH_A) }], [PATH_B, { path: PATH_B, patch: PATCH_B, addedLineRanges: addedLineRanges(PATCH_B) }]]), unreviewable: [] };
   // The quote is real and whole -- it is PATCH_B's added line -- but attributed


### PR DESCRIPTION
## Summary

#3769 measured a deterministic `PROOF_OF_WORK_FAILED` shape: an extraction refactor moves a real line into a new file, and the model's `riskiest_change.quoted_line` is real and byte-exact but attributed to the file it used to live in (proof-of-work quote lookup on the wrong `patch`). `checkProofOfWork` correctly rejects this — the check itself is unchanged and stays strict — but the failure message gave no signal beyond "quit early cannot fake", which does not address a wrong-file cause and left the retry `claude-review.yml` already runs once for this reason (#3757) with no better a second attempt than "pick any other line".

`quotedLineFailureMessage` (new, in the sibling `scripts/review/quote-line-coupling.mjs` — `validate-findings.mjs` is at zero module-size headroom, so no new logic goes there) checks whether the quote is a whole line of some *other* reviewed file's patch before falling back to the original remedy text. When it is, the message now names that file directly. This is diagnostic-only: it never changes whether the check passes, only what the model is told about why it failed, so the existing retry gets a targeted correction instead of a blind second guess.

`validate-findings.mjs` shrank from 1103 to 1100 lines (moving the message-construction, including the new lookup, into the sibling), leaving 3 lines of real headroom rather than the zero it had before.

**#3770** (a same-file, correct-line, single-character content drift — a dropped trailing `;`, verified byte-exact by `xxd` in the issue) is a separate shape. The quote there is genuinely different content, not whitespace or encoding drift, so the check is correct and the model is at fault — nothing in this PR touches that path, and no code change is proposed for it. The remedy already in place is the retry #3757 added (further generalized, out of this PR's scope, by #3801).

## Controls

- A genuinely wrong file attribution is still refused (RED, shape 4 test).
- A genuinely fabricated quote (real in no reviewed file) is still refused, with the original remedy text and no invented file name (control test).
- A correct citation (right file, real line) still passes (control test).
- Mutation-tested: removing the `path === claimedPath` exclusion guard breaks a test; making the pass/fail check itself permissive (finding the quote "anywhere" instead of in the named file) breaks two tests.

## Test plan

- [x] `node --test scripts/review/validate-findings.test.mjs` — 87 pass, 0 fail
- [x] `node --test scripts/review/post-review.test.mjs` — 75 pass
- [x] `node --test scripts/review/lane-canary.test.mjs` — 10 pass
- [x] `node --test scripts/review/run-reviewer.test.mjs` — 30 pass (this branch predates #3801, which adds 3 more)
- [x] `node --test scripts/check-review-posted.test.mjs` — 65 pass
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `node scripts/check-source-text-assertions.mjs` — OK
- [x] No changeset (scripts/-only change)

Closes #3769

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proof-of-work validation messages when a quoted line is attributed to the wrong file.
  * Error messages now identify the file containing the quoted line and provide corrected attribution guidance.
  * Ambiguous quotes appearing in multiple files are reported clearly.
  * Fabricated quotes continue to receive the standard remediation message.
  * Correctly attributed quotes continue to pass validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->