### PR TITLE
feat(ci): gate changed tests with the revert oracle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -425,6 +425,38 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # #3661: text review missed 10/10 independently confirmed defect cases even
+  # after rubric retuning. This asks the executable question instead: do this
+  # branch's changed tests fail when its production change is removed?
+  revert-oracle:
+    name: Changed tests observe production
+    needs: [changes, build]
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.frontend == 'true' &&
+      !contains(github.event.pull_request.labels.*.name, 'revert-oracle-exempt')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-output
+          path: packages
+      - name: Prove the changed tests observe the production change
+        run: node scripts/check-test-revert-oracle.mjs --base origin/main --ci --json
+
   typecheck:
     name: Typecheck
     needs: [changes, build]
@@ -1682,7 +1714,7 @@ jobs:
 
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md]
+    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ubuntu-latest
@@ -1691,6 +1723,7 @@ jobs:
         run: |
           declare -A results=(
             [build]="${{ needs.build.result }}"
+            [revert-oracle]="${{ needs.revert-oracle.result }}"
             [typecheck]="${{ needs.typecheck.result }}"
             [lint]="${{ needs.lint.result }}"
             [node-tests]="${{ needs.node-tests.result }}"

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -48,12 +48,8 @@
  * indistinguishable from a real RED, so that text is read as a load failure
  * too — see `LOAD_ERROR_PATTERNS` in `lib/revert-oracle.mjs`.
  *
- * NOT A CI CHECK, DELIBERATELY. It mutates the working tree and it is slow.
- * See the LIMITATIONS block at the bottom of this file, and `--help`, for what
- * wiring it into CI would require.
- *
- * @unwired-by-design it reverse-applies patches to the working tree and reruns
- * a branch's suites twice; a pre-push interrogation tool, not a required check.
+ * CI runs it only in a throwaway, read-only checkout with a hard timeout. An
+ * honest INCONCLUSIVE is advisory; UNOBSERVED and a broken baseline block.
  *
  * USAGE
  *   node scripts/check-test-revert-oracle.mjs [options]
@@ -72,6 +68,7 @@
  *                       Lets you point a version of the oracle you trust at a
  *                       checkout that predates it.
  *   --json              emit a machine-readable result alongside the report
+ *   --ci                block UNOBSERVED/broken baselines; allow INCONCLUSIVE
  */
 
 import { spawnSync } from 'node:child_process';
@@ -92,6 +89,7 @@ import {
   UNOBSERVED,
   SURGICAL_ADVICE,
 } from './lib/revert-oracle.mjs';
+import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 
 const SELF_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const rootFlag = process.argv.indexOf('--root');
@@ -140,7 +138,7 @@ function gitOrDie(args) {
 // ---------------------------------------------------------------------------
 
 function parseArgs(argv) {
-  const opts = { base: 'upstream/main', head: 'HEAD', only: [], tests: [], mutation: null, json: false };
+  const opts = { base: 'upstream/main', head: 'HEAD', only: [], tests: [], mutation: null, json: false, ci: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     const next = () => {
@@ -155,6 +153,7 @@ function parseArgs(argv) {
     else if (a === '--mutation') opts.mutation = next();
     else if (a === '--root') next(); // already consumed above, before ROOT is frozen
     else if (a === '--json') opts.json = true;
+    else if (a === '--ci') opts.ci = true;
     else if (a === '--help' || a === '-h') {
       console.log(readFileSync(fileURLToPath(import.meta.url), 'utf8').split('*/')[0]);
       process.exit(0);
@@ -328,11 +327,13 @@ if (opts.tests.length > 0) {
 console.log(`  files: ${production.length} production, ${testEntries.length} test, ${ignored.length} ignored`);
 
 if (prodPaths.length === 0) {
-  die(EXIT_NOTHING_CHECKED, 'this branch changes no production files; there is nothing whose absence a test could notice.');
+  const message = 'this branch changes no production files; there is nothing whose absence a test could notice.';
+  if (opts.ci) { console.log(`  NOT APPLICABLE: ${message}`); process.exit(0); }
+  die(EXIT_NOTHING_CHECKED, message);
 }
 if (testPaths.length === 0) {
   die(
-    EXIT_NOTHING_CHECKED,
+    opts.ci ? EXIT_UNOBSERVED : EXIT_NOTHING_CHECKED,
     'this branch changes production code and adds/changes NO test file. That is itself the finding: nothing can observe the change.',
     production.map((e) => `changed: ${e.path}`),
   );
@@ -445,7 +446,9 @@ try {
   result.revertedRun = revertedAgg;
   result.prodPaths = prodPaths;
   result.testPaths = testPaths;
-  exitCode = result.exitCode === 0 ? EXIT_OBSERVED : result.verdict === UNOBSERVED ? EXIT_UNOBSERVED : EXIT_INCONCLUSIVE;
+  exitCode = opts.ci
+    ? ciExitCode(result.verdict)
+    : result.exitCode === 0 ? EXIT_OBSERVED : result.verdict === UNOBSERVED ? EXIT_UNOBSERVED : EXIT_INCONCLUSIVE;
 
   if (revertedAgg.kind !== 'pass' && revertedAgg.kind !== 'assertion-failure') {
     const worst = revertedResults.find((r) => r.kind === revertedAgg.kind);
@@ -597,16 +600,10 @@ process.exit(exitCode);
  *    baseline run fails and you get BASELINE-BROKEN. Build first.
  *
  * ---------------------------------------------------------------------------
- * WIRING IT INTO CI — deliberately NOT done
+ * CI POLICY
  * ---------------------------------------------------------------------------
- * This is a thing a person runs before pushing. It reverse-applies production
- * code into the working tree, which is a bad property for a required check, and
- * it runs each affected suite twice. If someone later wants it in CI it would
- * need: (a) its own job on a throwaway checkout, never sharing a workspace with
- * another job; (b) a hard timeout and a concurrency cap, since cost is 2x the
- * affected suites; (c) a policy decision on INCONCLUSIVE, which is common and
- * benign and must NOT fail the build or it will be disabled within a week;
- * (d) `--base origin/main` and a fetch depth that reaches the merge base;
- * (e) an opt-out label, because legitimate refactor-only branches exist.
- * Until those five are decided, leaving it manual is the honest choice.
+ * `test.yml` supplies the five required bounds: its own throwaway checkout, a
+ * hard timeout and workflow concurrency, INCONCLUSIVE-as-advisory, a full clone
+ * with `--base origin/main`, and the maintainer-only `revert-oracle-exempt`
+ * label for legitimate refactors. `--ci` implements that verdict policy.
  * --------------------------------------------------------------------------- */

--- a/scripts/lib/revert-oracle-ci.mjs
+++ b/scripts/lib/revert-oracle-ci.mjs
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** CI blocks real misses and broken baselines; an honest inconclusive is advisory. */
+export function ciExitCode(result) {
+  if (result === 'OBSERVED') return 0;
+  if (result === 'UNOBSERVED') return 1;
+  if (result === 'INCONCLUSIVE') return 0;
+  return 3;
+}

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -41,6 +41,7 @@ import {
   INCONCLUSIVE,
   BASELINE_BROKEN,
 } from './revert-oracle.mjs';
+import { ciExitCode } from './revert-oracle-ci.mjs';
 
 // ---------------------------------------------------------------------------
 // Fixtures: real runner output
@@ -786,6 +787,13 @@ test('verdict: every non-OBSERVED outcome exits non-zero', () => {
 test('verdict: a missing run never reports clean', () => {
   assert.notEqual(verdict({ baseline: null, reverted: green }).exitCode, 0);
   assert.notEqual(verdict({ baseline: green, reverted: null }).exitCode, 0);
+});
+
+test('#3661: CI blocks misses and broken baselines, but not honest inconclusives', () => {
+  assert.equal(ciExitCode(OBSERVED), 0);
+  assert.equal(ciExitCode(UNOBSERVED), 1);
+  assert.equal(ciExitCode(INCONCLUSIVE), 0);
+  assert.notEqual(ciExitCode(BASELINE_BROKEN), 0);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3661.

Rubric tuning did not move the 98% clean rate, while executable adversarial review confirmed 10/10 sampled misses. This promotes the existing revert oracle from a manual diagnostic into the Test workflow: in an isolated read-only checkout it runs changed tests, reverse-applies production hunks, reruns the same tests, and restores byte-identically. `UNOBSERVED` and broken baselines block; honest `INCONCLUSIVE` is advisory. `revert-oracle-exempt` is the maintainer escape hatch for legitimate refactors. The aggregate required Test check now includes the lane.

Bounds: PR-only, frontend-only, existing workflow concurrency, 20-minute hard timeout, full history, shared build artifact, no write token.

Verification:
- Pure oracle/parser suite: 49/49
- `check-module-size` and `check-test-wiring`
- actionlint
- Live local orchestration on this branch: baseline 49/49; reverse apply; correctly classified dead-import result as INCONCLUSIVE; byte-identical restore; CI-mode exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Pull requests with frontend production changes now receive automated validation against their updated tests.
  - Test checks clearly distinguish observed, unobserved, and inconclusive results.
  - Changes without applicable production files are treated as not applicable.
  - Unobserved or broken-baseline results can now prevent the overall test check from passing, while inconclusive results remain non-blocking.
  - Added regression coverage for the new validation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->