### PR TITLE
fix(review): wire fallbacks into lane canary

### DIFF
--- a/.github/workflows/review-lane-canary.yml
+++ b/.github/workflows/review-lane-canary.yml
@@ -62,6 +62,8 @@ jobs:
         continue-on-error: true
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          CLAUDE_CODE_OAUTH_TOKEN_2: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN_2 }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set +e
           node scripts/review/lane-canary.mjs 2>&1 | tee "$RUNNER_TEMP/canary.log"

--- a/scripts/review/lane-canary.test.mjs
+++ b/scripts/review/lane-canary.test.mjs
@@ -162,6 +162,14 @@ test('THE CANARY RUNS THE LANE\'S REAL PIPELINE, not a shortcut past it', () => 
   }
 });
 
+test('#3808: the live canary passes every review fallback credential', () => {
+  const workflow = readFileSync(join(HERE, '..', '..', '.github/workflows/review-lane-canary.yml'), 'utf8');
+  const step = workflow.split('- name: Ask the reviewer for a known answer')[1]?.split('- name: Raise or update')[0] ?? '';
+  for (const secret of ['CLAUDE_CODE_OAUTH_TOKEN', 'CLAUDE_CODE_OAUTH_TOKEN_2', 'OPENAI_API_KEY']) {
+    assert.match(step, new RegExp(`${secret}:\\s*\\$\\{\\{\\s*secrets\\.${secret}\\s*\\}\\}`));
+  }
+});
+
 test('THE FIXTURE PASSES THE VALIDATOR THE LANE ACTUALLY RUNS, and it can still refuse', () => {
   // The canary's third failure was a fixture the pipeline refused before the
   // reviewer's verdict could be judged: `headSha` was `canary000...ca`, which


### PR DESCRIPTION
Closes #3808.

Passes both fallback credentials into the real scheduled canary invocation and pins the workflow wiring.

Verification: `node --test scripts/review/lane-canary.test.mjs` (11/11); module-size ratchet.