### PR TITLE
fix(review): fail over opaque early exits

### DIFF
--- a/scripts/review/run-reviewer.mjs
+++ b/scripts/review/run-reviewer.mjs
@@ -53,7 +53,8 @@
  *                    CLAUDE_CODE_OAUTH_TOKEN with `claude setup-token`.
  *   MODEL_ERROR      Any other non-zero exit or `is_error`. REMEDY: read the
  *                    captured stderr, which is printed verbatim.
- *   CLI_SILENT_EXIT  Non-zero with no output. The live session-limit shape.
+ *   CLI_SILENT_EXIT  Non-zero with no diagnostic stderr. The live session-limit
+ *                    shape may still leave an opaque JSON envelope on stdout.
  *   EMPTY_RESPONSE   The CLI succeeded and produced nothing. Treated as failure
  *                    rather than as an empty review.
  *   BAD_ENVELOPE     The CLI's own JSON wrapper did not parse.
@@ -361,7 +362,18 @@ export function runReviewer({ prompt, model, spawn = realSpawn, token = null }) 
   const stderr = String(r.stderr ?? '');
   if (r.status !== 0) {
     const output = `${stderr}\n${r.stdout ?? ''}`;
-    const reason = output.trim() === '' ? 'CLI_SILENT_EXIT' : classify(output);
+    const classified = classify(output);
+    // Run 33802488121 measured the second early-exit shape: exit 1 and empty
+    // stderr, but an opaque stdout envelope that contains no recognised
+    // diagnostic. It is still an exit before a usable review, and treating the
+    // envelope's mere bytes as MODEL_ERROR prevents the independent provider
+    // from taking over. Preserve specific auth/quota text wherever the CLI
+    // writes it; only the otherwise-unclassified, stderr-empty shape is silent.
+    const reason = classified !== 'MODEL_ERROR'
+      ? classified
+      : stderr.trim() === ''
+        ? 'CLI_SILENT_EXIT'
+        : 'MODEL_ERROR';
     throw new RunReviewerError(
       reason,
       `The reviewer CLI exited ${r.status}. ${remedyFor(reason)}\n--- stderr ---\n${stderr.trim() || '(empty)'}`,
@@ -407,6 +419,9 @@ function remedyFor(reason) {
   }
   if (reason === 'AUTH_FAILED') {
     return 'AUTH_FAILED. REMEDY: refresh the token with `claude setup-token` and update the CLAUDE_CODE_OAUTH_TOKEN secret.';
+  }
+  if (reason === 'CLI_SILENT_EXIT') {
+    return 'CLI_SILENT_EXIT: the CLI exited before producing a usable review. REMEDY: use an independent provider or inspect the captured process output.';
   }
   return 'MODEL_ERROR. REMEDY: read the captured stderr below.';
 }

--- a/scripts/review/run-reviewer.test.mjs
+++ b/scripts/review/run-reviewer.test.mjs
@@ -188,6 +188,17 @@ test('#3803: the measured exit-1-with-no-output shape is CLI_SILENT_EXIT', () =>
   );
 });
 
+test('#3812: exit 1 with empty stderr and an opaque stdout envelope is CLI_SILENT_EXIT', () => {
+  assert.throws(
+    () => runReviewer({
+      prompt: 'x',
+      model: 'sonnet',
+      spawn: () => ({ status: 1, stdout: '{"type":"result","subtype":"error"}', stderr: '' }),
+    }),
+    (error) => error.reason === 'CLI_SILENT_EXIT' && /independent provider/.test(error.message),
+  );
+});
+
 test('`is_error: true` alongside EXIT 0 still fails', () => {
   // This is the claude-code-action #1644 shape: success by exit code, nothing by
   // content. An exit code alone is not evidence here either.
@@ -323,6 +334,17 @@ test('#3803: a silent Claude CLI exit invokes the independent provider', () => {
     providerFallback: () => '{"verdict":"clean"}',
   });
   assert.equal(result.text, '{"verdict":"clean"}');
+});
+
+test('#3812: an opaque stdout envelope with empty stderr invokes the independent provider', () => {
+  let fallbackCalls = 0;
+  const result = runReviewerWithFailover({
+    prompt: 'p', model: 'sonnet', tokens: [TOKENS[0]],
+    spawn: () => ({ status: 1, stdout: '{"type":"result","subtype":"error"}', stderr: '' }),
+    providerFallback: () => { fallbackCalls += 1; return '{"verdict":"clean"}'; },
+  });
+  assert.equal(result.text, '{"verdict":"clean"}');
+  assert.equal(fallbackCalls, 1);
 });
 
 test('#3803: independent-provider failure is explicit, never a clean verdict', () => {


### PR DESCRIPTION
Closes #3812.

Live run 33802488121 measured Claude exiting 1 with empty stderr and an opaque stdout envelope. The harness treated the envelope bytes as an unknown model diagnostic, so it skipped the independent-provider fallback.

This preserves known auth/quota classifications and unknown non-empty stderr as `MODEL_ERROR`, while treating otherwise-unclassified exit-1/empty-stderr results as the early-exit class eligible for failover.

Verification: `node --test scripts/review/run-reviewer.test.mjs scripts/review/openai-reviewer.test.mjs` (44/44).

Live follow-up: dispatch the review-lane canary after merge; independent provider execution still requires the repository `OPENAI_API_KEY` secret.