### PR TITLE
fix(ci): mark check-rollup.mjs as unwired-by-design

### DIFF
--- a/scripts/lib/check-rollup.mjs
+++ b/scripts/lib/check-rollup.mjs
@@ -12,6 +12,14 @@
  * Unknown rows stay visible and ties stay together, preserving the sweep's
  * fail-closed direction instead of guessing which ambiguous row superseded
  * which.
+ *
+ * @unwired-by-design this is a helper for the PR-sweep toolchain
+ * (`scripts/lib/pr-green-sweep.mjs`, invoked from `scripts/check-pr-green.mjs`,
+ * which carries the same marker for the same reason: every verdict depends on
+ * transient GitHub state, so a required check built on it would fail for
+ * reasons that have nothing to do with the diff under test). The logic here
+ * IS wired: `scripts/lib/pr-green-sweep.test.mjs` runs in CI and exercises
+ * `currentRollupChecks` directly (see its `#3792` cases).
  */
 export function currentRollupChecks(rollup) {
   const unnamed = [];


### PR DESCRIPTION
## Summary
- `node scripts/check-test-wiring.mjs` currently fails on `main` (`a5e10037b`): `scripts/lib/check-rollup.mjs` (added by #3800) is named like a gate script but is only imported by `scripts/lib/pr-green-sweep.mjs`, itself only reachable through `scripts/check-pr-green.mjs` — already `@unwired-by-design` because every verdict it produces depends on transient GitHub state. `check-rollup.mjs` never got the same marker.
- Its dedup logic is not untested: `scripts/lib/pr-green-sweep.test.mjs` (wired into `test.yml`) exercises `currentRollupChecks` directly via the `#3792` cases, 33/33 passing. Only the reachability declaration was missing.
- On PR #3800's own head commit, `Build packages + WASM` and the downstream `Node tests` job (which runs `check-test-wiring.mjs`) both show `cancelled`, not `success` — the wiring gate never actually ran to completion on that PR, so the gap went unseen through merge.

## Change
Adds an `@unwired-by-design` header line to `scripts/lib/check-rollup.mjs`, following the same rationale already accepted for `scripts/check-pr-green.mjs`. No workflow YAML touched, no changes to `pr-green-sweep*.mjs` (out of scope: PR #3797 is reconciling `check-rollup.mjs` with `scripts/lib/pr-green-sweep-rollup.mjs` separately).

## Test plan
- [x] `node scripts/check-test-wiring.mjs` — now `OK` (was failing before this change)
- [x] `node scripts/check-module-size.mjs` — OK
- [x] `node scripts/check-source-text-assertions.mjs` — OK
- [x] `node --test scripts/check-test-wiring.test.mjs` — 55/55 pass
- [x] `node --test scripts/lib/pr-green-sweep.test.mjs` — 33/33 pass (unchanged, confirms the dedup logic this comment describes still tests green)

Closes #3814
