### PR TITLE
fix(ci): declare rollup helper unwired

### DIFF
--- a/scripts/lib/check-rollup.mjs
+++ b/scripts/lib/check-rollup.mjs
@@ -1,6 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+// @unwired-by-design Pure helper imported by the transient-state PR green sweep; its behavior is covered by pr-green-sweep.test.mjs.
 
 /**
  * GitHub retains check runs from a cancelled, superseded workflow alongside


### PR DESCRIPTION
Closes #3814.

The helper added by #3800 is intentionally reached through the transient-state PR sweep rather than used as a standalone CI gate. Declare that design explicitly so `check-test-wiring` no longer fails on `main`.

Verification:
- `node scripts/check-test-wiring.mjs`
- `node --test scripts/lib/pr-green-sweep.test.mjs` (33/33)