### PR TITLE
fix(ci): namespace check-rollup dedup key by check type

### DIFF
--- a/scripts/lib/check-rollup.mjs
+++ b/scripts/lib/check-rollup.mjs
@@ -12,6 +12,11 @@
  * Unknown rows stay visible and ties stay together, preserving the sweep's
  * fail-closed direction instead of guessing which ambiguous row superseded
  * which.
+ *
+ * A CheckRun and a StatusContext are different reporting systems (the newer
+ * Checks API vs. the legacy Commit Status API) and must never dedupe against
+ * each other just because their label strings happen to match (#3817) --
+ * the group key is namespaced by `__typename`, not the bare name/context.
  */
 export function currentRollupChecks(rollup) {
   const unnamed = [];
@@ -22,9 +27,10 @@ export function currentRollupChecks(rollup) {
       unnamed.push(check);
       continue;
     }
-    const group = groups.get(name) ?? [];
+    const key = `${check?.__typename ?? ''}:${name}`;
+    const group = groups.get(key) ?? [];
     group.push(check);
-    groups.set(name, group);
+    groups.set(key, group);
   }
 
   const current = [...unnamed];

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -214,6 +214,22 @@ test('#3792: status contexts dedupe by context while distinct lane names remain 
   assert.deepEqual(countRollup(rows), { fail: 0, pending: 0, pass: 2 });
 });
 
+test('#3817: a CheckRun and a same-named StatusContext are distinct lanes, not one group', () => {
+  // A CheckRun called "Deploy" and an unrelated legacy StatusContext whose
+  // context also reads "Deploy" must never dedupe against each other just
+  // because their label strings match -- they are different reporting
+  // systems. Grouping by bare name/context alone would let the newer
+  // StatusContext "supersede" the older CheckRun's real failure.
+  const rows = [
+    { __typename: 'CheckRun', name: 'Deploy', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: '2026-09-03T09:00:00Z' },
+    { __typename: 'StatusContext', context: 'Deploy', state: 'SUCCESS', startedAt: '2026-09-03T10:00:00Z' },
+  ];
+  assert.equal(currentRollupChecks(rows).length, 2);
+  assert.deepEqual(countRollup(rows), { fail: 1, pending: 0, pass: 1 });
+  // Order must not matter.
+  assert.deepEqual(countRollup([...rows].reverse()), { fail: 1, pending: 0, pass: 1 });
+});
+
 // --- the three refuse-to-pass-vacuously paths --------------------------------
 
 /** A `gh` stub that answers each call from a table keyed by a substring. */


### PR DESCRIPTION
## Reviewer summary

- **Without this:** a `CheckRun` and an unrelated legacy `StatusContext` that happen to share a label (e.g. both called `"Deploy"`) collide into one dedup group in `currentRollupChecks`, and the newer row "supersedes" the older by timestamp -- silently dropping a real `CheckRun` failure behind an unrelated `StatusContext` success.
- **Evidence:** ran `countCurrentRollup` directly against `upstream/main`'s `scripts/lib/check-rollup.mjs` (merged in #3800) with `[CheckRun "Deploy" FAILURE, StatusContext "Deploy" SUCCESS]` -> `{"fail":0,"pending":0,"pass":1}` in both array orders. After this fix: `{"fail":1,"pending":0,"pass":1}` in both orders.
- **Context:** while reconciling our now-superseded #3797 (already resolved issue 3792 (no # to avoid a second auto-link) via #3800, which merged first) against #3800's landed code, I re-tested the three defects #3797's review round had found and fixed in its own extraction. Two are absent in #3800's code (unknown/null `startedAt` racing a fresher same-named row; an exact `startedAt` tie) -- both correctly keep the failing row today, order-independent. The third, this cross-type namespace collision, is present. Filed as #3817 with the measured repro before this PR.
- **Scope:** fixes only the namespace-collision gap in `scripts/lib/check-rollup.mjs` plus a regression test in `scripts/lib/pr-green-sweep.test.mjs`. Does not reintroduce #3797's separate `pr-green-sweep-rollup.mjs` extraction -- #3800's `check-rollup.mjs` structure is what's on `main`, so this builds on it rather than re-landing a parallel file.

## Summary

- `currentRollupChecks` grouped rows by the bare name/context string, so a `CheckRun` and a `StatusContext` sharing a label collided into the same group even though they are different reporting systems (newer Checks API vs. legacy Commit Status API).
- Namespace the group key by `__typename` (`` `${typename}:${name}` ``) so the two id-spaces can never collide, while every existing issue 3792 dedup case (single-namespace supersession, ambiguous/unknown timestamps, ties, unnamed rows) is unaffected.

## Test plan

- [x] RED: new test `#3817: a CheckRun and a same-named StatusContext are distinct lanes, not one group` fails against unmodified `check-rollup.mjs` (`1 !== 2` on `currentRollupChecks(rows).length`).
- [x] GREEN: `node --test scripts/lib/pr-green-sweep.test.mjs` -- 34/34 pass after the fix.
- [x] Mutation: reverting the namespaced key back to the bare `name` string fails exactly the new test (33 pass / 1 fail) -- confirms the test actually exercises the fix.
- [x] `node scripts/check-module-size.mjs` -- OK (no budget changes)
- [x] `node scripts/check-source-text-assertions.mjs` -- OK
- `node scripts/check-test-wiring.mjs` still fails the same way it does on unmodified `main` today (`scripts/lib/check-rollup.mjs` has no `@unwired-by-design` header) -- pre-existing per #3814/#3815 (open, unmerged), not something this PR touches or worsens. This PR does not add that header itself to avoid conflicting with #3815's own line-for-line change to the same file's header.

## Related

- Closes #3817.
- Supersedes #3797, which duplicated #3800's already-merged extraction and targeted the now-resolved issue 3792. Recommend leaving #3797 open with a comment (not closing it -- see PR/issue conventions) pointing here, since we never close our own PRs.
