### PR TITLE
fix(ci): namespace rollup checks by API

### DIFF
--- a/scripts/lib/check-rollup.mjs
+++ b/scripts/lib/check-rollup.mjs
@@ -9,7 +9,10 @@
  * newest run for a context; counting every historical row instead makes a
  * green replacement look failed (#3792).
  *
- * Deduplication requires both a stable context name and parseable timestamps.
+ * Deduplication requires a reporting API type, a stable context name, and
+ * parseable timestamps. A Checks API run and a legacy Status API context with
+ * the same label are independent signals and must never supersede each other
+ * (#3817).
  * Unknown rows stay visible and ties stay together, preserving the sweep's
  * fail-closed direction instead of guessing which ambiguous row superseded
  * which.
@@ -18,14 +21,16 @@ export function currentRollupChecks(rollup) {
   const unnamed = [];
   const groups = new Map();
   for (const check of rollup ?? []) {
-    const name = check?.__typename === 'StatusContext' ? check?.context : check?.name;
+    const type = check?.__typename === 'StatusContext' ? 'StatusContext' : 'CheckRun';
+    const name = type === 'StatusContext' ? check?.context : check?.name;
     if (typeof name !== 'string' || name === '') {
       unnamed.push(check);
       continue;
     }
-    const group = groups.get(name) ?? [];
+    const key = `${type}\x00${name}`;
+    const group = groups.get(key) ?? [];
     group.push(check);
-    groups.set(name, group);
+    groups.set(key, group);
   }
 
   const current = [...unnamed];

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -214,6 +214,16 @@ test('#3792: status contexts dedupe by context while distinct lane names remain 
   assert.deepEqual(countRollup(rows), { fail: 0, pending: 0, pass: 2 });
 });
 
+test('#3817: a same-labelled CheckRun and StatusContext never supersede each other', () => {
+  const rows = [
+    { __typename: 'CheckRun', name: 'Deploy', status: 'COMPLETED', conclusion: 'FAILURE', startedAt: '2026-09-03T09:00:00Z' },
+    { __typename: 'StatusContext', context: 'Deploy', state: 'SUCCESS', startedAt: '2026-09-03T10:00:00Z' },
+  ];
+  assert.equal(currentRollupChecks(rows).length, 2);
+  assert.deepEqual(countRollup(rows), { fail: 1, pending: 0, pass: 1 });
+  assert.deepEqual(countRollup([...rows].reverse()), { fail: 1, pending: 0, pass: 1 });
+});
+
 // --- the three refuse-to-pass-vacuously paths --------------------------------
 
 /** A `gh` stub that answers each call from a table keyed by a substring. */


### PR DESCRIPTION
Closes #3817.

Namespace rollup deduplication by GraphQL reporting type as well as label, so an unrelated legacy StatusContext can never supersede a same-named CheckRun failure. Same-type replacement behavior and fail-closed timestamp handling remain unchanged.

Verification:
- `node --test scripts/lib/pr-green-sweep.test.mjs` (34/34)
- `node scripts/check-test-wiring.mjs`