### PR TITLE
fix(review): diagnose wrong-file proof quotes

### DIFF
--- a/scripts/review/lib/finding-proof-of-work.mjs
+++ b/scripts/review/lib/finding-proof-of-work.mjs
@@ -11,7 +11,7 @@
  */
 
 import { ValidateFindingsError } from './validate-findings-error.mjs';
-import { quoteAppearsIn } from '../quote-line-coupling.mjs';
+import { quoteAppearsIn, quotedLineFailureMessage } from '../quote-line-coupling.mjs';
 
 /** @param {unknown} v */
 const isNonEmptyString = (v) => typeof v === 'string' && v.trim() !== '';
@@ -74,12 +74,7 @@ export function checkProofOfWork({ response, input }) {
   if (!quoteAppearsIn(file.patch, rc.quoted_line, MIN_PROOF_QUOTE_CHARS)) {
     throw new ValidateFindingsError(
       'PROOF_OF_WORK_FAILED',
-      `\`riskiest_change.quoted_line\` is not a line of \`${rc.path}\`'s patch (or is shorter than ` +
-        `${MIN_PROOF_QUOTE_CHARS} characters, which would not be evidence of anything): ` +
-        `${JSON.stringify(String(rc.quoted_line).slice(0, 120))}. This is the one thing a model that ` +
-        'quit early cannot fake. REMEDY: re-run. Quote a WHOLE line, not a fragment; and if the ' +
-        'line you nominated is too long to reproduce exactly, nominate a SHORTER line from the ' +
-        'same file instead -- any real line of the diff proves you read it.',
+      quotedLineFailureMessage(input.files, rc.path, rc.quoted_line, MIN_PROOF_QUOTE_CHARS),
     );
   }
 }

--- a/scripts/review/quote-line-coupling.mjs
+++ b/scripts/review/quote-line-coupling.mjs
@@ -114,3 +114,45 @@ export function addedLinesMatching(patch, quote) {
   return out;
 }
 
+/**
+ * Explain a proof quote attributed to the wrong reviewed file (#3769).
+ * Diagnostic only: the caller has already rejected the quote against its
+ * claimed patch. Finding it elsewhere improves the one corrective retry but
+ * never weakens the proof-of-work decision.
+ */
+export function quotedLineFailureMessage(files, claimedPath, quote, minChars) {
+  const claimedKey = normalizePathForSelfMatch(claimedPath);
+  const elsewhere = [];
+  for (const [path, file] of files) {
+    if (normalizePathForSelfMatch(path) === claimedKey) continue;
+    if (quoteAppearsIn(file.patch, quote, minChars)) elsewhere.push(path);
+  }
+  const base =
+    `\`riskiest_change.quoted_line\` is not a line of \`${claimedPath}\`'s patch (or is shorter than ` +
+    `${minChars} characters, which would not be evidence of anything): ` +
+    `${JSON.stringify(String(quote).slice(0, 120))}.`;
+  if (elsewhere.length === 1) {
+    return (
+      `${base} This exact line IS in \`${elsewhere[0]}\`'s patch instead -- the file attribution is wrong, ` +
+      `not the quote. REMEDY: re-run; the correct \`riskiest_change.path\` is \`${elsewhere[0]}\`.`
+    );
+  }
+  if (elsewhere.length > 1) {
+    const named = elsewhere.map((path) => `\`${path}\``).join(', ');
+    return (
+      `${base} This exact line IS in ${elsewhere.length} other reviewed files' patches instead (${named}) ` +
+      '-- the file attribution is wrong, but which one it belongs to cannot be told from the quote alone. ' +
+      'REMEDY: re-run and name the specific file the quote came from.'
+    );
+  }
+  return (
+    `${base} This is the one thing a model that quit early cannot fake. REMEDY: re-run. Quote a WHOLE ` +
+    'line, not a fragment; and if the line you nominated is too long to reproduce exactly, nominate a ' +
+    'SHORTER line from the same file instead -- any real line of the diff proves you read it.'
+  );
+}
+
+/** Compare spellings only for excluding the claimed file from the search. */
+function normalizePathForSelfMatch(path) {
+  return String(path).replace(/\\/g, '/').replace(/^\.\//, '');
+}

--- a/scripts/review/validate-findings.mjs
+++ b/scripts/review/validate-findings.mjs
@@ -153,7 +153,7 @@ import { ValidateFindingsError } from './lib/validate-findings-error.mjs';
 // quotableLines/quoteAppearsIn/lineIsAdded/addedLinesMatching moved to
 // ./quote-line-coupling.mjs (module-size budget). Re-exported below so every
 // existing import of them from this file keeps working unchanged.
-import { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching } from './quote-line-coupling.mjs';
+import { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching, quotedLineFailureMessage } from './quote-line-coupling.mjs';
 // readText/stripFence/parseRaw/readInput moved to ./lib/review-input-reader.mjs
 // (module-size budget, #3795). Imported (not `export ... from`) because
 // main() below calls `readInput` and `parseRaw` itself, and re-exported so
@@ -230,7 +230,7 @@ export function parseArgs(argv) {
 }
 
 
-export { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching };
+export { quotableLines, quoteAppearsIn, lineIsAdded, addedLinesMatching, quotedLineFailureMessage };
 
 export { ValidateFindingsError };
 export { stripFence, readInput };

--- a/scripts/review/validate-findings.test.mjs
+++ b/scripts/review/validate-findings.test.mjs
@@ -38,6 +38,7 @@ import {
   lineIsAdded,
   quotableLines,
   quoteAppearsIn,
+  quotedLineFailureMessage,
   sanitizeBody,
   sanitizeLabel,
   sanitizePath,
@@ -889,6 +890,37 @@ test('quoteAppearsIn enforces its minimum length in both directions', () => {
   assert.equal(quoteAppearsIn(PATCH_A, '   ', 3), false);
   assert.equal(quoteAppearsIn(PATCH_A, 'return n;', 3), true);
   assert.equal(quoteAppearsIn(PATCH_A, 'return n;', 20), false, 'the floor is what rejects it, not the patch');
+});
+
+test('#3769: a rejected proof quote names the other reviewed file that contains it', () => {
+  const moved = 'const movedImplementation = buildCanonicalResult();';
+  const files = new Map([
+    ['packages/old.ts', { patch: '@@ -1 +1 @@\n+const replacement = true;' }],
+    ['packages/new.ts', { patch: `@@ -1 +1 @@\n+${moved}` }],
+  ]);
+  const message = quotedLineFailureMessage(files, 'packages/old.ts', moved, 8);
+  assert.match(message, /file attribution is wrong/);
+  assert.match(message, /correct `riskiest_change\.path` is `packages\/new\.ts`/);
+});
+
+test('#3769: the wrong-file diagnostic never self-matches an equivalent path spelling', () => {
+  const quote = 'const substantiveProofLine = true;';
+  const files = new Map([['packages/a.ts', { patch: `@@ -1 +1 @@\n+${quote}` }]]);
+  const message = quotedLineFailureMessage(files, './packages\\a.ts', quote, 8);
+  assert.doesNotMatch(message, /file attribution is wrong/);
+  assert.match(message, /model that quit early cannot fake/);
+});
+
+test('#3769: an ambiguous wrong-file quote names every candidate instead of guessing one', () => {
+  const quote = 'return sharedSubstantiveValue;';
+  const files = new Map([
+    ['claimed.ts', { patch: '@@ -1 +1 @@\n+return somethingElse;' }],
+    ['first.ts', { patch: `@@ -1 +1 @@\n+${quote}` }],
+    ['second.ts', { patch: `@@ -1 +1 @@\n+${quote}` }],
+  ]);
+  const message = quotedLineFailureMessage(files, 'claimed.ts', quote, 8);
+  assert.match(message, /2 other reviewed files/);
+  assert.match(message, /`first\.ts`, `second\.ts`/);
 });
 
 test('stripFence removes one fence and refuses to guess at anything else', () => {


### PR DESCRIPTION
Closes #3769. Supersedes conflicted #3805 on current `main`.

When a byte-exact proof quote is attributed to the wrong reviewed file, validation remains strict but now names the file that actually contains it, giving the existing one-shot retry a targeted correction. Ambiguous matches name every candidate; fabricated quotes retain the original remedy; equivalent spellings of the claimed path cannot self-match.

Verification:
- `node --test scripts/review/validate-findings.test.mjs` (89/89)
- `node scripts/check-module-size.mjs`
- `node scripts/check-source-text-assertions.mjs`