### PR TITLE
fix(review): make rubric eval exercise corrective retry

### DIFF
--- a/scripts/review/eval-validation.mjs
+++ b/scripts/review/eval-validation.mjs
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { RETRYABLE_VALIDATION_REASONS } from './retry-prompt.mjs';
+
+export const REVIEWER_FAULT = new Set([
+  'RAW_UNPARSEABLE',
+  'RESPONSE_TRUNCATED',
+  'SCHEMA_INVALID',
+  'VERDICT_CONTRADICTS_FINDINGS',
+  'PROOF_OF_WORK_FAILED',
+  'VALIDATION_EMPTY',
+]);
+
+export const INSTRUMENT_FAULT = new Set([
+  'BAD_ARGS',
+  'NO_RAW',
+  'NO_INPUT',
+  'NO_OUT',
+  'RAW_UNREADABLE',
+  'RAW_EMPTY',
+  'INPUT_UNREADABLE',
+  'INPUT_INVALID',
+  'OUT_UNWRITABLE',
+]);
+
+export function validatorReason(said) {
+  return /(?:^|\n)\u274c ([A-Z0-9_]+):/.exec(String(said))?.[1] ?? null;
+}
+
+function validate({ validatePath, outPath, inputPath, findingsPath }) {
+  const processResult = spawnSync(
+    process.execPath,
+    [validatePath, '--raw', outPath, '--input', inputPath, '--out', findingsPath],
+    { encoding: 'utf8' },
+  );
+  return {
+    processResult,
+    said: `${processResult.stdout || ''}${processResult.stderr || ''}`.trim(),
+    reason: validatorReason(processResult.stderr || ''),
+  };
+}
+
+/** Run the same single corrective validation retry as claude-review.yml. */
+export function validateWithOneRetry({
+  reviewer, rubric, inputPath, outPath, findingsPath, model, validatePath, retryLogPath,
+}) {
+  const first = validate({ validatePath, outPath, inputPath, findingsPath });
+  if (first.processResult.status === 0 || !RETRYABLE_VALIDATION_REASONS.has(first.reason)) {
+    return { ...first, attempts: 1, reviewerFailure: null };
+  }
+
+  // The workflow's tee captures both streams in one file and passes that path
+  // back to run-reviewer. Preserve the same untrusted diagnostic envelope here.
+  writeFileSync(retryLogPath, `${first.said}\n`);
+  const retry = spawnSync(
+    process.execPath,
+    [reviewer, '--rubric', rubric, '--input', inputPath, '--out', outPath,
+      '--retry-note', retryLogPath, '--retry-reason', first.reason, '--model', model],
+    { encoding: 'utf8' },
+  );
+  if (retry.status !== 0) {
+    return { ...first, attempts: 2, reviewerFailure: retry };
+  }
+
+  const second = validate({ validatePath, outPath, inputPath, findingsPath });
+  return {
+    ...second,
+    said: [first.said, second.said].filter(Boolean).join('\n'),
+    attempts: 2,
+    reviewerFailure: null,
+  };
+}

--- a/scripts/review/rubric-eval.mjs
+++ b/scripts/review/rubric-eval.mjs
@@ -42,6 +42,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { buildPack, retrievalFailed, retrievalFailedMessage } from './build-context-pack.mjs';
+import { validateWithOneRetry, validatorReason, REVIEWER_FAULT } from './eval-validation.mjs';
 import { MAX_POSTED_FINDINGS } from './post-review.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -76,33 +77,7 @@ const CASE_DIR = join(HERE, 'eval-cases');
  * requires every reason to be classified exactly once. So a reason added there
  * cannot be silently scored as "the reviewer found nothing".
  */
-export const REVIEWER_FAULT = new Set([
-  'RAW_UNPARSEABLE',
-  'RESPONSE_TRUNCATED',
-  'SCHEMA_INVALID',
-  'VERDICT_CONTRADICTS_FINDINGS',
-  'PROOF_OF_WORK_FAILED',
-  'VALIDATION_EMPTY',
-]);
-
-export const INSTRUMENT_FAULT = new Set([
-  'BAD_ARGS',
-  'NO_RAW',
-  'NO_INPUT',
-  'NO_OUT',
-  'RAW_UNREADABLE',
-  'RAW_EMPTY',
-  'INPUT_UNREADABLE',
-  'INPUT_INVALID',
-  'OUT_UNWRITABLE',
-]);
-
-export function validatorReason(said) {
-  // [A-Z0-9_] to match the reason alphabet. Narrower here, a reason with a
-  // digit parsed as null at run time while the guard test happily classified it
-  // -- the eval would abort every case blaming the harness, with green tests.
-  return /(?:^|\n)\u274c ([A-Z0-9_]+):/.exec(String(said))?.[1] ?? null;
-}
+export { validatorReason, REVIEWER_FAULT, INSTRUMENT_FAULT } from './eval-validation.mjs';
 
 
 /**
@@ -322,15 +297,29 @@ function main() {
       // the reviewer for findings that would have been dropped for quoting a line
       // that is not in the diff.
       const findingsPath = join(tmp, `${f}.findings.json`);
-      const v = spawnSync(
-        process.execPath,
-        [join(HERE, 'validate-findings.mjs'), '--raw', outPath, '--input', inputPath, '--out', findingsPath],
-        { encoding: 'utf8' },
-      );
+      const validation = validateWithOneRetry({
+        reviewer,
+        rubric,
+        inputPath,
+        outPath,
+        findingsPath,
+        model,
+        validatePath: join(HERE, 'validate-findings.mjs'),
+        retryLogPath: join(tmp, `${f}.validate.log`),
+      });
+      const v = validation.processResult;
       // A non-zero exit is not one thing: see REVIEWER_FAULT above for which
       // refusals are the model answering badly (scored zero, the eval carries on)
       // and which mean the harness broke (stop).
-      const said = `${v.stdout || ''}${v.stderr || ''}`.trim();
+      const said = validation.said;
+      if (validation.attempts === 2) {
+        console.log(`  ${f}: ${validatorReason(validation.said) ?? 'validation failure'} on the first attempt; corrective retry ran once.`);
+      }
+      if (validation.reviewerFailure) {
+        const failed = validation.reviewerFailure;
+        console.error(`${failed.stdout || ''}${failed.stderr || ''}`.trim());
+        throw new Error(`Case ${f} corrective retry did not run; the score is not computable.`);
+      }
       if (v.status !== 0) {
         // FROM STDERR ONLY. `said` concatenates stdout, and stdout carries the
         // per-finding DROPPED warnings, which interpolate the model's own `path`
@@ -338,7 +327,7 @@ function main() {
         // line ahead of the real one, and `.exec` takes the first match -- turning
         // a reviewer fault into a fabricated instrument fault that aborts the run.
         // validate-findings prints exactly one reason line, always on stderr.
-        const reason = validatorReason(v.stderr || '');
+        const reason = validation.reason;
         if (!REVIEWER_FAULT.has(reason)) {
           console.error(said);
           throw new Error(

--- a/scripts/review/rubric-eval.test.mjs
+++ b/scripts/review/rubric-eval.test.mjs
@@ -299,6 +299,22 @@ writeFileSync(out, ${JSON.stringify(body)});
   return p;
 }
 
+function sequentialReviewer(dir, bodies) {
+  const p = join(dir, 'sequential-reviewer.mjs');
+  const count = join(dir, 'reviewer-count');
+  writeFileSync(p, `import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+const countPath = ${JSON.stringify(count)};
+const calls = existsSync(countPath) ? Number(readFileSync(countPath, 'utf8')) : 0;
+const bodies = ${JSON.stringify(bodies)};
+const out = process.argv[process.argv.indexOf('--out') + 1];
+if (calls >= bodies.length) process.exit(91);
+if (calls > 0 && (!process.argv.includes('--retry-note') || !process.argv.includes('--retry-reason'))) process.exit(92);
+writeFileSync(out, bodies[calls]);
+writeFileSync(countPath, String(calls + 1));
+`);
+  return { path: p, count };
+}
+
 const runHarness = (dir, reviewer) => spawnSync(
   process.execPath,
   // `--no-judge`, or this unit test SPAWNS THE REAL MODEL. spawnSync inherits
@@ -355,16 +371,37 @@ test('a response where NOTHING survives scores ZERO and the eval CARRIES ON', (t
   // Aborting here threw away every other case and reported a broken instrument.
   const dir = tmpCase(t);
   evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN and the comparison falls through, closing the session' }] });
-  const reviewer = stubReviewer(dir, fenced([
+  const bad = fenced([
     { path: 'src/f.ts', line: 3, quote: '  not in the diff at all', body: 'x', class: 'numeric-bound' },
-  ]));
-  const r = runHarness(dir, reviewer);
+  ]);
+  const reviewer = sequentialReviewer(dir, [bad, bad]);
+  const r = runHarness(dir, reviewer.path);
   const said = `${r.stdout}${r.stderr}`;
 
   assert.equal(r.status, 0, `the eval must finish and report a score:\n${said}`);
+  assert.equal(readFileSync(reviewer.count, 'utf8'), '2', 'a failed retry must not loop');
   assert.match(said, /VALIDATION_EMPTY/, said);
   assert.match(said, /scored ZERO/, said);
   assert.match(said, /PRODUCED NO USABLE REVIEW/, 'the recall line must say how many cases produced nothing');
+});
+
+test('#3829: a retryable validation failure gets exactly the production corrective retry', (t) => {
+  const dir = tmpCase(t);
+  evalCase(dir, { expected: [{ path: 'src/f.ts', what: 'Number(raw) returns NaN and the comparison falls through, closing the session' }] });
+  const first = fenced([
+    { path: 'src/f.ts', line: 2, quote: '  if (n > 0) return n;', body: 'Number(raw) returns NaN, so the comparison falls through and closes the session.', class: 'numeric-bound' },
+  ]);
+  const corrected = fenced([
+    { path: 'src/f.ts', line: 3, quote: '  if (n > 0) return n;', body: 'Number(raw) returns NaN, so the comparison falls through and closes the session.', class: 'numeric-bound' },
+  ]);
+  const reviewer = sequentialReviewer(dir, [first, corrected]);
+  const r = runHarness(dir, reviewer.path);
+  const said = `${r.stdout}${r.stderr}`;
+
+  assert.equal(r.status, 0, said);
+  assert.equal(readFileSync(reviewer.count, 'utf8'), '2', 'one initial call plus one bounded retry');
+  assert.match(said, /corrective retry ran once/, said);
+  assert.match(said, /RECALL of known findings: 1\/1/, said);
 });
 
 test('an EMPTY response is a HARD ERROR, because the real chain cannot produce one', (t) => {


### PR DESCRIPTION
Closes #3829

The effectiveness eval now runs the same single bounded corrective retry as the deployed review lane for `PROOF_OF_WORK_FAILED`, `RESPONSE_TRUNCATED`, and `VALIDATION_EMPTY`. It feeds the real validator transcript back through the existing fenced retry mechanism, revalidates the second response, remains fail-closed if the reviewer process fails, and scores zero if the second response still does not validate.

This repairs measurement fidelity exposed by live Opus run 33807643815: real findings in cases 3608 and 3650 were discarded for correctable off-by-one anchors without taking the production retry. It does not change the rubric, matcher, validator, or production review behavior.

Verification:
- `node --test $(rg --files scripts/review -g "*.test.mjs")`: 352/352 pass
- `pnpm exec oxlint scripts/review/rubric-eval.mjs scripts/review/eval-validation.mjs scripts/review/rubric-eval.test.mjs --deny-warnings`: pass
- `node scripts/check-test-wiring.mjs`: pass
- module sizes: rubric-eval shrinks 443 -> 432 lines; new helper is 76 lines

After merge I will rerun the same live Sonnet eval to measure the shipped pipeline.