### PR TITLE
fix(review): fetch pinned eval heads before scoring

### DIFF
--- a/.github/workflows/rubric-eval.yml
+++ b/.github/workflows/rubric-eval.yml
@@ -43,18 +43,11 @@ jobs:
         with:
           lfs: false
           persist-credentials: false
-          # NO fetch-depth: 0, and the reason is worth recording so nobody adds
-          # it back. It was added here on the theory that the cases' historical
-          # head shas need full history. They are not reachable either way:
-          # measured, 0 of 18 case head shas are ancestors of origin/main -- every
-          # one was squash-merged -- refs/pull/N/head has since moved to each PR's
-          # current head, and two cases carry synthetic shas. A full-history
-          # clone of this monorepo would buy the eval nothing and cost minutes.
-          #
-          # So the eval scores siblings (retrieved with `--base HEAD`, which
-          # resolves at depth 1) and the PR description, but NOT whole-file
-          # evidence for historical heads. rubric-eval.mjs says so per case rather
-          # than reporting a number for a pack it could not assemble.
+          # NO fetch-depth: 0. Historical PR heads were squash-merged and are not
+          # ancestors of main, so a full clone still does not contain them. The
+          # scorer fetches each exact pinned 40-hex object at depth 1 instead and
+          # refuses if one remains unavailable; that supplies whole-file evidence
+          # without paying for repository history that cannot reach these tips.
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/scripts/review/eval-commit.mjs
+++ b/scripts/review/eval-commit.mjs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { execFileSync } from 'node:child_process';
+
+export class EvalCommitError extends Error {}
+
+/** Ensure a pinned squash-merged PR head is available for `git show`. */
+export function ensureEvalCommit(sha, {
+  exec = execFileSync,
+  cwd = process.cwd(),
+  remote = 'origin',
+} = {}) {
+  if (!/^[0-9a-f]{40}$/.test(String(sha))) {
+    throw new EvalCommitError(`Eval case head ${JSON.stringify(sha)} is not a 40-hex commit id.`);
+  }
+  const object = `${sha}^{commit}`;
+  try {
+    exec('git', ['cat-file', '-e', object], { cwd, stdio: 'ignore' });
+    return { fetched: false };
+  } catch {
+    // A full clone still omits an unreachable squash-merged branch tip. GitHub
+    // retains these objects, and fetching the exact committed id retrieves only
+    // the evidence this fixture pins rather than the repository's whole history.
+  }
+  try {
+    exec('git', ['fetch', '--no-tags', '--depth=1', remote, sha], { cwd, stdio: 'ignore' });
+    exec('git', ['cat-file', '-e', object], { cwd, stdio: 'ignore' });
+  } catch (error) {
+    throw new EvalCommitError(
+      `Eval case head ${sha} is unavailable after an exact fetch; refusing to score a case with no changed-file evidence.`,
+      { cause: error },
+    );
+  }
+  return { fetched: true };
+}

--- a/scripts/review/eval-commit.test.mjs
+++ b/scripts/review/eval-commit.test.mjs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ensureEvalCommit, EvalCommitError } from './eval-commit.mjs';
+
+const SHA = 'a'.repeat(40);
+
+test('#3833: a present eval head costs no fetch', () => {
+  const calls = [];
+  const result = ensureEvalCommit(SHA, { exec: (cmd, args) => calls.push([cmd, args]) });
+  assert.deepEqual(result, { fetched: false });
+  assert.deepEqual(calls, [['git', ['cat-file', '-e', `${SHA}^{commit}`]]]);
+});
+
+test('#3833: an unreachable squash head is fetched by its exact pinned id', () => {
+  const calls = [];
+  let first = true;
+  const result = ensureEvalCommit(SHA, { remote: 'upstream', exec: (cmd, args) => {
+    calls.push([cmd, args]);
+    if (first) { first = false; throw new Error('missing'); }
+  } });
+  assert.deepEqual(result, { fetched: true });
+  assert.deepEqual(calls[1], ['git', ['fetch', '--no-tags', '--depth=1', 'upstream', SHA]]);
+  assert.deepEqual(calls[2], ['git', ['cat-file', '-e', `${SHA}^{commit}`]]);
+});
+
+test('#3833: an unavailable head aborts instead of lowering recall', () => {
+  assert.throws(
+    () => ensureEvalCommit(SHA, { exec: () => { throw new Error('missing'); } }),
+    (error) => error instanceof EvalCommitError && /refusing to score/.test(error.message),
+  );
+});
+
+test('#3833: a malformed fixture id never reaches git', () => {
+  let called = false;
+  assert.throws(() => ensureEvalCommit('synthetic', { exec: () => { called = true; } }), EvalCommitError);
+  assert.equal(called, false);
+});

--- a/scripts/review/rubric-eval.mjs
+++ b/scripts/review/rubric-eval.mjs
@@ -43,6 +43,7 @@ import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
 import { buildPack, retrievalFailed, retrievalFailedMessage } from './build-context-pack.mjs';
 import { validateWithOneRetry, validatorReason, REVIEWER_FAULT } from './eval-validation.mjs';
+import { ensureEvalCommit } from './eval-commit.mjs';
 import { MAX_POSTED_FINDINGS } from './post-review.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -240,6 +241,7 @@ function main() {
     // the tree siblings are retrieved from; without it the eval measures the
     // old behaviour, which is exactly what the baseline run did.
     if (baseRef) {
+      ensureEvalCommit(c.input.headSha);
       try {
         // `body` MATTERS, and its absence was not merely an untested prompt
         // section. pr-3389's expected defect IS "the PR body describes a null


### PR DESCRIPTION
Closes #3833

The rubric evaluator now checks that each pinned historical PR head exists locally and, when it does not, fetches that exact 40-hex commit at depth one. If the object remains unavailable it aborts the instrument instead of scoring an evidence-starved case. This restores the changed-file/whole-function evidence that `build-context-pack.mjs` says is required for most of the corpus while avoiding a useless full-history checkout.

The two deliberately fabricated fixture SHAs will now fail loudly; #3834 separately replaces those stale post-fix fixtures with real defective commits. This PR intentionally makes an invalid measurement impossible before that dataset repair lands.

Verification:
- eval commit + orchestration tests: 26/26 pass
- oxlint deny-warnings: pass
- check-test-wiring: pass
- rubric-eval remains below its module-size budget (434/443 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Evaluation workflows now reliably verify that referenced commits are available before processing.
  - Missing commits are fetched individually when possible, while invalid or unavailable commit IDs are rejected with clear errors.

- **Tests**
  - Added coverage for existing, fetchable, unavailable, and malformed commit references.

- **Chores**
  - Updated workflow documentation to clarify shallow checkout and historical commit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->