### PR TITLE
Protect verified sibling findings from judge suppression

### DIFF
--- a/scripts/review/run-judge.mjs
+++ b/scripts/review/run-judge.mjs
@@ -161,7 +161,13 @@ export function applyVerdicts(findings, raw) {
   const dropped = [];
   findings.forEach((f, i) => {
     const v = byIndex.get(i);
-    if (v && v.keep === false) dropped.push({ ...f, why: String(v.why ?? '').replace(/[\r\n]+/g, ' ').slice(0, 200) });
+    // A sibling reaches here only after the validator proved that its path,
+    // line and quote came from the base-tree context pack. The live judge twice
+    // inverted that evidence and called the untouched parallel site proof that
+    // the work was "already owned" (#3609, runs 33817317055/33820560852).
+    // Model prose cannot reliably protect this class from another model, so the
+    // optional precision filter is not allowed to suppress it.
+    if (v && v.keep === false && !f.sibling) dropped.push({ ...f, why: String(v.why ?? '').replace(/[\r\n]+/g, ' ').slice(0, 200) });
     else kept.push(f);
   });
   return { kept, dropped, note: null, ran: true };

--- a/scripts/review/run-judge.test.mjs
+++ b/scripts/review/run-judge.test.mjs
@@ -97,6 +97,17 @@ test('the judge removes what it rejects and keeps the rest', () => {
   assert.equal(written.counts.dropped, 1);
 });
 
+test('#3837: the optional judge cannot suppress a mechanically verified sibling finding', () => {
+  const doc = docOf(1);
+  doc.findings[0].sibling = { path: 'src/twin.ts', line: 9, quote: 'return raw;' };
+  const { written } = run(doc, spawnSaying(verdicts([
+    { index: 0, keep: false, why: 'the sibling means this is already owned' },
+  ])));
+  assert.equal(written.findings.length, 1);
+  assert.equal(written.counts.dropped, 0);
+  assert.deepEqual(written.findings[0].sibling, doc.findings[0].sibling);
+});
+
 test('a judge that emptied the list leaves the verdict alone', () => {
   // It used to rewrite `findings` -> `clean` here. Nothing reads that field:
   // post-review.mjs computes the marker's verdict from what it reads back off the


### PR DESCRIPTION
Closes #3837.

The live Haiku judge ignored the prompt rule twice and inverted verified sibling evidence. This makes the safety property deterministic: the optional precision filter may not remove a finding whose sibling path/line/quote already survived mechanical validation.

Evidence: runs 33817317055 and 33820560852 reproduced the deletion; `node --test scripts/review/*.test.mjs` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Findings with verified related results are now retained even when an optional review step recommends removing them.
  * Unverified findings may still be removed when appropriate.

* **Tests**
  * Added coverage to confirm retained findings, accurate drop counts, and preservation of related-result details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->