### PR TITLE
fix(scripts): mark the stdout and prompt assertions the source-text gate flags on main

### DIFF
--- a/scripts/review/rubric-eval.test.mjs
+++ b/scripts/review/rubric-eval.test.mjs
@@ -105,10 +105,10 @@ test('every eval case is well-formed, and an empty one is DECLARED, never inferr
       );
       const patch = c.input.files.find((x) => x.path === e.path)?.patch ?? '';
       for (const evidence of e.evidence ?? []) {
-        assert.ok(patch.includes(evidence), `${f}: expected defect evidence is absent: ${evidence}`);
+        assert.ok(patch.includes(evidence), `${f}: expected defect evidence is absent: ${evidence}`); // @source-text-assertion-ok `patch` is a pinned eval fixture (data), the assertion guards the fixture, not a subject
       }
       for (const fixed of e.fixedEvidence ?? []) {
-        assert.ok(!patch.includes(fixed), `${f}: fixture includes the later fix: ${fixed}`);
+        assert.ok(!patch.includes(fixed), `${f}: fixture includes the later fix: ${fixed}`); // @source-text-assertion-ok `patch` is a pinned eval fixture (data), the assertion guards the fixture, not a subject
       }
     }
   }
@@ -365,12 +365,12 @@ test('ONLY findings that survive validation are scored, and a FENCED response is
 
   assert.equal(r.status, 0, said);
   // Exactly one finding survived, it was the real one, and it was RECOGNISED.
-  assert.match(said, /VALIDATED recall before judge\/cap: 1\/1/, said);
-  assert.match(said, /POSTED recall after judge\/cap: 1\/1/, said);
-  assert.match(said, /extra findings[^:]*: 0/i, said);
+  assert.match(said, /VALIDATED recall before judge\/cap: 1\/1/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
+  assert.match(said, /POSTED recall after judge\/cap: 1\/1/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
+  assert.match(said, /extra findings[^:]*: 0/i, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
   // The drop names the FABRICATED quote, not merely the word DROPPED, which the
   // whole-output echo on the failure path also satisfies.
-  assert.match(said, /DROPPED[\s\S]*this line is nowhere in the diff/, said);
+  assert.match(said, /DROPPED[\s\S]*this line is nowhere in the diff/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
   assert.doesNotMatch(said, /a fabricated anchor/, 'a finding that failed validation must not reach the score');
 });
 
@@ -388,9 +388,9 @@ test('a response where NOTHING survives scores ZERO and the eval CARRIES ON', (t
 
   assert.equal(r.status, 0, `the eval must finish and report a score:\n${said}`);
   assert.equal(readFileSync(reviewer.count, 'utf8'), '2', 'a failed retry must not loop');
-  assert.match(said, /VALIDATION_EMPTY/, said);
-  assert.match(said, /scored ZERO/, said);
-  assert.match(said, /PRODUCED NO USABLE REVIEW/, 'the recall line must say how many cases produced nothing');
+  assert.match(said, /VALIDATION_EMPTY/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
+  assert.match(said, /scored ZERO/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
+  assert.match(said, /PRODUCED NO USABLE REVIEW/, 'the recall line must say how many cases produced nothing'); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
 });
 
 test('#3829: a retryable validation failure gets exactly the production corrective retry', (t) => {
@@ -408,8 +408,8 @@ test('#3829: a retryable validation failure gets exactly the production correcti
 
   assert.equal(r.status, 0, said);
   assert.equal(readFileSync(reviewer.count, 'utf8'), '2', 'one initial call plus one bounded retry');
-  assert.match(said, /corrective retry ran once/, said);
-  assert.match(said, /POSTED recall after judge\/cap: 1\/1/, said);
+  assert.match(said, /corrective retry ran once/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
+  assert.match(said, /POSTED recall after judge\/cap: 1\/1/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
 });
 
 test('an EMPTY response is a HARD ERROR, because the real chain cannot produce one', (t) => {
@@ -426,7 +426,7 @@ test('an EMPTY response is a HARD ERROR, because the real chain cannot produce o
   const said = `${r.stdout}${r.stderr}`;
 
   assert.notEqual(r.status, 0, `an empty response must not produce a score:\n${said}`);
-  assert.match(said, /RAW_EMPTY/, said);
+  assert.match(said, /RAW_EMPTY/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
   assert.doesNotMatch(said, /POSTED recall after judge\/cap/, 'no recall number may be printed from a run that produced nothing');
 });
 
@@ -447,7 +447,7 @@ test('a VALIDATION failure on the harness\'s own input is a HARD ERROR', (t) => 
   const said = `${r.stdout}${r.stderr}`;
 
   assert.notEqual(r.status, 0, `an INPUT_INVALID refusal must stop the run:\n${said}`);
-  assert.match(said, /INPUT_INVALID/, said);
+  assert.match(said, /INPUT_INVALID/, said); // @source-text-assertion-ok `said` is the harness process stdout+stderr, not a source file
   assert.doesNotMatch(said, /POSTED recall after judge\/cap/, 'no recall number may be printed from a run that did not happen');
 });
 

--- a/scripts/review/run-judge.test.mjs
+++ b/scripts/review/run-judge.test.mjs
@@ -235,9 +235,9 @@ test('EVERY call site passes the three flags run-judge requires', () => {
 
 test('judge rubric treats a verified untouched sibling as second-site evidence, not ownership', () => {
   const rubric = readFileSync(join(HERE, 'judge.md'), 'utf8');
-  assert.match(rubric, /verified sibling/i);
-  assert.match(rubric, /second-site defect/i);
-  assert.match(rubric, /“Already[\s\S]*owned” means a deterministic gate/i);
+  assert.match(rubric, /verified sibling/i); // @source-text-assertion-ok judge.md is the prompt handed to the judge (data, not code); the test pins that the rubric states this rule
+  assert.match(rubric, /second-site defect/i); // @source-text-assertion-ok judge.md is the prompt handed to the judge (data, not code); the test pins that the rubric states this rule
+  assert.match(rubric, /“Already[\s\S]*owned” means a deterministic gate/i); // @source-text-assertion-ok judge.md is the prompt handed to the judge (data, not code); the test pins that the rubric states this rule
 });
 
 // =================================== 6. the shipped path, which no fake can reach


### PR DESCRIPTION
## Summary

`check-source-text-assertions` exits 1 on main: Test run 33813314410 at a2230fd80 fails the step "Check for new source-text assertions", so every PR's Node-tests lane inherits the failure (#3832).

The flagged sites are not source-text assertions:

- `scripts/review/rubric-eval.test.mjs`: `said` is the harness process's stdout and stderr (11 sites), and `patch` is a pinned eval fixture whose defect evidence the test guards (2 sites). Both from #3830 and #3836.
- `scripts/review/run-judge.test.mjs`: `rubric` is `judge.md`, the prompt handed to the judge, and the test pins that the rubric states the verified-sibling rule (3 sites, from #3838).

Each site now carries the gate's own per-site `@source-text-assertion-ok <reason>` marker, which the gate lists by name in its output rather than hiding. No allowlist row is added; the gate's identity check against origin/main is unchanged.

Closes #3832

## Verification

- `node scripts/check-source-text-assertions.mjs`: exit 0, "33 allowlisted, 48 marked, 0 new", identity-checked against origin/main 3c29f55e0.
- `node --test scripts/review/run-judge.test.mjs scripts/review/rubric-eval.test.mjs`: 45 pass, 0 fail.
- Same gate on origin/main without this change: exit 1, naming exactly these 16 sites.

Sibling of #3826, which clears the module-size ratchet the same runs also fail on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Clarified that selected test assertions validate fixture or subprocess output rather than source files.
  - Test behavior and results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->