### PR TITLE
Use Sol for the OpenAI review fallback

### DIFF
--- a/scripts/review/openai-reviewer.mjs
+++ b/scripts/review/openai-reviewer.mjs
@@ -8,7 +8,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from '../lib/is-main-entry.mjs';
 
-export const OPENAI_REVIEW_MODEL = 'gpt-5.6-terra';
+export const OPENAI_REVIEW_MODEL = 'gpt-5.6-sol';
 
 export function responseText(response) {
   if (typeof response?.output_text === 'string' && response.output_text.trim()) {


### PR DESCRIPTION
Closes #3843.

The configured OpenAI fallback authenticated and completed the real generation/validation path with Terra, but failed the unchanged planted-defect canary (run 33839537316). Sol passed the exact same forced-Claude-auth-failure drill (run 33839620698): the log records `AUTH_FAILED`, transition to the independent provider, a validated review, and the planted `timeoutMs` defect.

This changes only the fallback model. Primary Claude selection, retry classification, prompt, validator, and canary acceptance are unchanged. The temporary fault injection and diagnostic logging used for the drill are not included.

Verification:
- `node --test scripts/review/*.test.mjs` — 360/360 passed
- forced live fallback canary — passed: https://github.com/LTplus-AG/ifc-lite/actions/runs/33839620698


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI-powered review service to use the latest configured model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->