### PR TITLE
fix(server-client)!: decode through parquet-wasm 0.7's entry point instead of the arrow2 path dropped in 0.6

### DIFF
--- a/.changeset/create-ifc-lite-parquet-wasm-peer-pin.md
+++ b/.changeset/create-ifc-lite-parquet-wasm-peer-pin.md
@@ -1,0 +1,5 @@
+---
+'create-ifc-lite': patch
+---
+
+The `server` and `server-native` scaffolds pinned `parquet-wasm: ^0.6.0` as an optional dependency, which falls outside `@ifc-lite/server-client`'s narrowed `^0.7.2` peer range. A strict package manager rejects the generated project's install; a permissive one installs a decoder the SDK no longer supports, so the first Parquet decode fails at runtime. Both templates now scaffold `^0.7.2`, and a test asserts the scaffolded pin stays inside the peer range that `packages/server-client/package.json` declares.

--- a/.changeset/server-client-parquet-wasm-07-entry.md
+++ b/.changeset/server-client-parquet-wasm-07-entry.md
@@ -1,7 +1,7 @@
 ---
-'@ifc-lite/server-client': minor
+'@ifc-lite/server-client': major
 ---
 
-`parquet-decoder.ts` imported `parquet-wasm/esm/arrow2.js`, an entry point parquet-wasm removed in 0.6, while `peerDependencies` advertised `parquet-wasm >=0.5.0`. In-repo that range auto-installed 0.5.0, where the path still existed, so nothing here failed; a consumer who installed 0.7 (what the rest of this workspace pins) got a missing module the first time any Parquet decode ran. The decoder now imports the package entry point `parquet-wasm` and lets its export map pick the build, the same shape `@ifc-lite/export` already uses, and the peer range is narrowed to `^0.7.0`, the version range that entry point is verified against. A new test decodes a payload written by the resolved parquet-wasm, so the dropped entry point cannot come back unnoticed.
+`parquet-decoder.ts` imported `parquet-wasm/esm/arrow2.js`, an entry point parquet-wasm removed in 0.6, while `peerDependencies` advertised `parquet-wasm >=0.5.0`. In-repo that range auto-installed 0.5.0, where the path still existed, so nothing here failed; a consumer who installed 0.7 (what the rest of this workspace pins) got a missing module the first time any Parquet decode ran. The decoder now imports the package entry point `parquet-wasm` and lets its export map pick the build, the same shape `@ifc-lite/export` already uses, and the peer range narrows to `^0.7.2`, the version that entry point is verified against. A new test decodes a payload written by the resolved parquet-wasm, so the dropped entry point cannot come back unnoticed.
 
-Minor rather than patch: narrowing the peer range means an installation pinned to parquet-wasm 0.5 or 0.6 that resolved cleanly before will now report an unmet peer dependency.
+**Breaking:** this drops support for parquet-wasm 0.5 and 0.6. parquet-wasm 0.5 declares no `exports` and no `main`, so under Node the new bare `import('parquet-wasm')` fails outright with `ERR_MODULE_NOT_FOUND` (verified against 0.5.0). A consumer still on 0.5 whose Parquet decoding worked before gets a hard failure, not a peer-dependency warning: upgrade to `parquet-wasm@^0.7.2` alongside this release.

--- a/.changeset/server-client-parquet-wasm-07-entry.md
+++ b/.changeset/server-client-parquet-wasm-07-entry.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/server-client': minor
+---
+
+`parquet-decoder.ts` imported `parquet-wasm/esm/arrow2.js`, an entry point parquet-wasm removed in 0.6, while `peerDependencies` advertised `parquet-wasm >=0.5.0`. In-repo that range auto-installed 0.5.0, where the path still existed, so nothing here failed; a consumer who installed 0.7 (what the rest of this workspace pins) got a missing module the first time any Parquet decode ran. The decoder now imports the package entry point `parquet-wasm` and lets its export map pick the build, the same shape `@ifc-lite/export` already uses, and the peer range is narrowed to `^0.7.0`, the version range that entry point is verified against. A new test decodes a payload written by the resolved parquet-wasm, so the dropped entry point cannot come back unnoticed.
+
+Minor rather than patch: narrowing the peer range means an installation pinned to parquet-wasm 0.5 or 0.6 that resolved cleanly before will now report an unmet peer dependency.

--- a/packages/create-ifc-lite/src/templates/server-native.ts
+++ b/packages/create-ifc-lite/src/templates/server-native.ts
@@ -39,7 +39,7 @@ export function createServerNativeTemplate(targetDir: string, projectName: strin
       '@types/node': '^20.0.0',
     },
     optionalDependencies: {
-      'parquet-wasm': '^0.6.0',
+      'parquet-wasm': '^0.7.2',
       'apache-arrow': '^17.0.0',
     },
   }, null, 2));

--- a/packages/create-ifc-lite/src/templates/server.ts
+++ b/packages/create-ifc-lite/src/templates/server.ts
@@ -197,7 +197,7 @@ cache
       '@types/node': '^20.0.0',
     },
     optionalDependencies: {
-      'parquet-wasm': '^0.6.0',
+      'parquet-wasm': '^0.7.2',
       'apache-arrow': '^17.0.0',
     },
   }, null, 2));

--- a/packages/create-ifc-lite/test/template-peer-ranges.test.ts
+++ b/packages/create-ifc-lite/test/template-peer-ranges.test.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The server templates scaffold `parquet-wasm` as an optional dependency, and
+ * @ifc-lite/server-client declares the same package as an optional peer. A
+ * scaffold that pins a version outside that peer range is rejected outright by
+ * strict peer resolution, and under a permissive package manager it silently
+ * installs a decoder the SDK does not support. The pins are written by hand in
+ * two separate files, so nothing but this test keeps them inside the contract.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+const TEMPLATES = [
+  'packages/create-ifc-lite/src/templates/server.ts',
+  'packages/create-ifc-lite/src/templates/server-native.ts',
+];
+
+type Caret = { major: number; minor: number; patch: number };
+
+/**
+ * Parse `^X.Y.Z`. Anything else throws, so a range format this test cannot
+ * reason about fails loudly instead of passing vacuously.
+ */
+function parseCaret(range: string, what: string): Caret {
+  const match = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(range);
+  if (!match) {
+    throw new Error(`${what} is "${range}", which this test can only check in ^X.Y.Z form.`);
+  }
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+/**
+ * Does the floor of a caret range fall inside another caret range? A caret on a
+ * 0.x version pins the minor too, so `^0.7.2` excludes 0.8.0 while `^1.7.2`
+ * includes 1.8.0.
+ */
+function floorSatisfies(candidate: Caret, allowed: Caret): boolean {
+  if (candidate.major !== allowed.major) return false;
+  if (allowed.major === 0 && candidate.minor !== allowed.minor) return false;
+  if (candidate.minor !== allowed.minor) return candidate.minor > allowed.minor;
+  return candidate.patch >= allowed.patch;
+}
+
+function readPeerRange(): string {
+  const pkg = JSON.parse(
+    readFileSync(resolve(REPO_ROOT, 'packages/server-client/package.json'), 'utf-8')
+  );
+  const range = pkg.peerDependencies?.['parquet-wasm'];
+  if (typeof range !== 'string') {
+    throw new Error('@ifc-lite/server-client no longer declares a parquet-wasm peer dependency.');
+  }
+  return range;
+}
+
+function readTemplatePin(relativePath: string): string {
+  const source = readFileSync(resolve(REPO_ROOT, relativePath), 'utf-8');
+  const match = /'parquet-wasm':\s*'([^']+)'/.exec(source);
+  if (!match) {
+    throw new Error(`${relativePath} no longer pins parquet-wasm in a scaffolded package.json.`);
+  }
+  return match[1];
+}
+
+describe('server template dependency pins', () => {
+  it.each(TEMPLATES)('%s scaffolds a parquet-wasm inside the server-client peer range', (template) => {
+    const peerRange = readPeerRange();
+    const templateRange = readTemplatePin(template);
+
+    const peer = parseCaret(peerRange, 'The @ifc-lite/server-client parquet-wasm peer range');
+    const pinned = parseCaret(templateRange, `The parquet-wasm pin in ${template}`);
+
+    expect(
+      floorSatisfies(pinned, peer),
+      `${template} pins parquet-wasm ${templateRange}, outside the server-client peer range ${peerRange}.`
+    ).toBe(true);
+  });
+});

--- a/packages/server-client/package.json
+++ b/packages/server-client/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "apache-arrow": ">=14.0.0",
-    "parquet-wasm": "^0.7.0"
+    "parquet-wasm": "^0.7.2"
   },
   "peerDependenciesMeta": {
     "apache-arrow": {

--- a/packages/server-client/package.json
+++ b/packages/server-client/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "apache-arrow": ">=14.0.0",
-    "parquet-wasm": ">=0.5.0"
+    "parquet-wasm": "^0.7.0"
   },
   "peerDependenciesMeta": {
     "apache-arrow": {
@@ -31,6 +31,7 @@
     }
   },
   "devDependencies": {
+    "parquet-wasm": "^0.7.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   },

--- a/packages/server-client/src/data-model-decoder.decode.test.ts
+++ b/packages/server-client/src/data-model-decoder.decode.test.ts
@@ -19,7 +19,6 @@
  */
 
 import { describe, it, expect, beforeAll } from 'vitest';
-import { createRequire } from 'node:module';
 import { readFileSync } from 'node:fs';
 import { decodeDataModel } from './data-model-decoder.js';
 
@@ -31,22 +30,38 @@ let arrow: any;
 let parquet: any;
 
 beforeAll(async () => {
-  // `decodeDataModel` boots parquet-wasm via `ensureParquetInit()`, which
-  // fetches the .wasm asset by URL — a Vite/browser-only path that has no
-  // static server under plain `vitest run`. `initSync` with the wasm file's
-  // own bytes initializes the SAME cached module instance (parquet-wasm
-  // memoizes on its internal `wasm` binding, see arrow2.js's `__wbg_init`),
-  // so `ensureParquetInit()`'s later `parquet.default(url)` call short-
-  // circuits on the existing instance instead of re-fetching.
-  const require = createRequire(import.meta.url);
-  const jsPath = require.resolve('parquet-wasm/esm/arrow2.js');
-  const wasmPath = jsPath.replace(/arrow2\.js$/, 'arrow2_bg.wasm');
-  const wasmBytes = readFileSync(wasmPath);
-  parquet = await import('parquet-wasm/esm/arrow2.js');
-  parquet.initSync(wasmBytes);
+  // Same import `ensureParquetInit()` makes: the bare package entry, whose
+  // export map picks the self-initializing Node build under `vitest run`.
+  // (This used to deep-import `parquet-wasm/esm/arrow2.js` and hand-run
+  // `initSync` on the .wasm bytes, because that build initializes by
+  // FETCHING its asset, which has no server here. The deep path was dropped
+  // in parquet-wasm 0.6, see #3845 and `parquet-decoder.entry.test.ts`.)
+  parquet = await import('parquet-wasm');
 
   arrow = await import('apache-arrow');
 });
+
+/**
+ * Re-stamp every field of a table as nullable.
+ *
+ * `new arrow.Table({ col: vector })` always marks its fields NON-nullable,
+ * even for a vector that carries nulls. parquet-wasm 0.7's writer rejects
+ * that mismatch outright (`Column 'name' is declared as non-nullable but
+ * contains null values`), where 0.5 accepted it and silently wrote the nulls
+ * away. Only tables with genuinely nullable columns need this.
+ */
+function nullableTable(columns: Record<string, unknown>) {
+  const table = new arrow.Table(columns);
+  const schema = new arrow.Schema(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    table.schema.fields.map((f: any) => arrow.Field.new(f.name, f.type, true))
+  );
+  return new arrow.Table(
+    schema,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    table.batches.map((b: any) => new arrow.RecordBatch(schema, b.data))
+  );
+}
 
 /** Serialize an Arrow-JS Table to Parquet bytes via parquet-wasm, mirroring
  *  the server's writer path (packages/export/src/parquet-exporter.ts). */
@@ -123,7 +138,7 @@ function relationshipsTable(rows: { relType: string; relatingId: number; related
 
 function spatialNodesTable(rows: { id: number; parentId: number; level: number; path: string; type: string }[]) {
   const listType = new arrow.List(arrow.Field.new('item', new arrow.Uint32(), true));
-  return new arrow.Table({
+  return nullableTable({
     entity_id: arrow.vectorFromArray(rows.map((r) => r.id), new arrow.Uint32()),
     parent_id: arrow.vectorFromArray(rows.map((r) => r.parentId), new arrow.Uint32()),
     level: arrow.vectorFromArray(rows.map((r) => r.level), new arrow.Uint16()),
@@ -179,13 +194,15 @@ function emptyDocumentsTable() {
  * `__fixtures__/nodes-nullable-elevation.parquet` and
  * `__fixtures__/materials-nullable-thickness.parquet` are authored by
  * DuckDB (an independent Parquet writer, not this repo's own code), NOT via
- * this file's `toParquetBytes` helper: the locked `parquet-wasm@0.5.0`'s
- * `writeParquet` silently drops null-ness for a nullable Float64 column
- * written through the `apache-arrow` Table -> IPC -> `Table.fromIPCStream`
- * bridge (confirmed against DuckDB reading its own output back: the byte a
- * "null" row lands on decodes as a real `0`, not a null). That is a
- * write-side bug in the pinned `parquet-wasm` version, orthogonal to the
- * read-side bug under test here, and DuckDB's own writer does not share it.
+ * this file's `toParquetBytes` helper: when these fixtures were written the
+ * package resolved `parquet-wasm@0.5.0`, whose `writeParquet` silently drops
+ * null-ness for a nullable Float64 column written through the `apache-arrow`
+ * Table -> IPC -> `Table.fromIPCStream` bridge (confirmed against DuckDB
+ * reading its own output back: the byte a "null" row lands on decodes as a
+ * real `0`, not a null). 0.7.2 (what the package resolves now, see #3845)
+ * does round-trip those nulls, but the fixtures stay DuckDB-authored: an
+ * independent writer is the stronger oracle for a read-side bug, and it is
+ * the writer real payloads come from.
  *
  * Regenerate with DuckDB (`npm i --prefix /tmp/pq duckdb`, not a repo dep):
  *   COPY (SELECT CAST(row_id AS UINTEGER) entity_id, CAST(0 AS UINTEGER)

--- a/packages/server-client/src/parquet-decoder.entry.test.ts
+++ b/packages/server-client/src/parquet-decoder.entry.test.ts
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/**
+ * The decoder is loaded against the parquet-wasm version this package
+ * actually resolves, so the dead entry point cannot come back (#3845).
+ *
+ * `parquet-decoder.ts` imported `parquet-wasm/esm/arrow2.js`, a path
+ * parquet-wasm dropped in 0.6, while the peer range said `>=0.5.0`. In-repo
+ * that range auto-installed 0.5.0, where the path still existed, so every
+ * existing test passed while any consumer on the version the rest of the
+ * workspace pins (0.7.x) got a missing module at import time.
+ *
+ * The two halves below pin both directions of that mismatch:
+ *  - the resolved version satisfies the declared peer range, and the dropped
+ *    path is genuinely absent from it (a downgrade back to 0.5 fails here);
+ *  - `decodeParquetGeometry` reads a real Parquet payload written by that same
+ *    resolved version (re-introducing the deep import fails here, because the
+ *    dynamic import inside `ensureParquetInit` no longer resolves).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { decodeParquetGeometry } from './parquet-decoder.js';
+
+const require = createRequire(import.meta.url);
+
+// apache-arrow's browser export map hides the `.d.ts` from TS's strict
+// resolver, same as the modules under test.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let arrow: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let parquet: any;
+
+beforeAll(async () => {
+  // The bare specifier is the point of this file: under Node the export map
+  // picks the self-initializing Node build, which is exactly what
+  // `ensureParquetInit()` imports.
+  parquet = await import('parquet-wasm');
+  arrow = await import('apache-arrow');
+});
+
+function readJson(relative: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(new URL(relative, import.meta.url), 'utf8'));
+}
+
+/** Minimal caret check, enough for the `^X.Y.Z` ranges this repo writes and
+ *  for 0.x semantics (a caret on 0.x is pinned to the minor). */
+function satisfiesCaret(version: string, range: string): boolean {
+  const [rMajor, rMinor, rPatch] = range.replace(/^\^/, '').split('.').map(Number);
+  const [vMajor, vMinor, vPatch] = version.split('.').map(Number);
+  if (vMajor !== rMajor) return false;
+  if (rMajor === 0 && vMinor !== rMinor) return false;
+  if (vMinor !== rMinor) return vMinor > rMinor;
+  return vPatch >= rPatch;
+}
+
+describe('parquet-wasm entry point', () => {
+  it('resolves a version that satisfies the declared peer range', () => {
+    const pkg = readJson('../package.json');
+    const range = (pkg.peerDependencies as Record<string, string>)['parquet-wasm'];
+    const installed = readJson('../node_modules/parquet-wasm/package.json').version as string;
+    expect(satisfiesCaret(installed, range)).toBe(true);
+  });
+
+  it('resolves the package entry point, not the arrow2 path dropped in 0.6', () => {
+    expect(() => require.resolve('parquet-wasm/esm/arrow2.js')).toThrow();
+    expect(typeof parquet.readParquet).toBe('function');
+  });
+});
+
+/** Serialize an Arrow-JS Table to Parquet bytes via the resolved parquet-wasm,
+ *  mirroring the server's writer path (packages/export/src/parquet-exporter.ts). */
+function toParquetBytes(table: unknown): Uint8Array {
+  const ipc = arrow.tableToIPC(table, 'stream');
+  return new Uint8Array(parquet.writeParquet(parquet.Table.fromIPCStream(ipc)));
+}
+
+function u32le(n: number): Uint8Array {
+  const b = new Uint8Array(4);
+  new DataView(b.buffer).setUint32(0, n, true);
+  return b;
+}
+
+function frame(sections: Uint8Array[]): ArrayBuffer {
+  const chunks = sections.flatMap((bytes) => [u32le(bytes.length), bytes]);
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out.buffer;
+}
+
+/** One unit triangle, in the three-table standard geometry layout. */
+function oneTriangleGeometry(): ArrayBuffer {
+  const u32 = (values: number[]) => arrow.vectorFromArray(values, new arrow.Uint32());
+  const f32 = (values: number[]) => arrow.vectorFromArray(values, new arrow.Float32());
+
+  const meshTable = new arrow.Table({
+    express_id: u32([42]),
+    ifc_type: arrow.vectorFromArray(['IfcWall'], new arrow.Utf8()),
+    vertex_start: u32([0]),
+    vertex_count: u32([3]),
+    index_start: u32([0]),
+    index_count: u32([3]),
+    color_r: f32([0.25]),
+    color_g: f32([0.5]),
+    color_b: f32([0.75]),
+    color_a: f32([1]),
+  });
+
+  const vertexTable = new arrow.Table({
+    x: f32([0, 1, 0]),
+    y: f32([0, 0, 1]),
+    z: f32([0, 0, 0]),
+    nx: f32([0, 0, 0]),
+    ny: f32([0, 0, 0]),
+    nz: f32([1, 1, 1]),
+  });
+
+  const indexTable = new arrow.Table({ i0: u32([0]), i1: u32([1]), i2: u32([2]) });
+
+  return frame([
+    toParquetBytes(meshTable),
+    toParquetBytes(vertexTable),
+    toParquetBytes(indexTable),
+  ]);
+}
+
+describe('decodeParquetGeometry against the resolved parquet-wasm', () => {
+  it('decodes a payload written by that same version', async () => {
+    const meshes = await decodeParquetGeometry(oneTriangleGeometry());
+
+    expect(meshes).toHaveLength(1);
+    const mesh = meshes[0];
+    expect(mesh.express_id).toBe(42);
+    expect(mesh.ifc_type).toBe('IfcWall');
+    expect(Array.from(mesh.positions)).toEqual([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    expect(Array.from(mesh.indices)).toEqual([0, 1, 2]);
+    expect(mesh.color).toEqual([0.25, 0.5, 0.75, 1]);
+  });
+});

--- a/packages/server-client/src/parquet-decoder.entry.test.ts
+++ b/packages/server-client/src/parquet-decoder.entry.test.ts
@@ -22,6 +22,7 @@
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import { readFileSync } from 'node:fs';
 import { decodeParquetGeometry } from './parquet-decoder.js';
 
@@ -42,27 +43,37 @@ beforeAll(async () => {
   arrow = await import('apache-arrow');
 });
 
-function readJson(relative: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(new URL(relative, import.meta.url), 'utf8'));
+function readJson(path: string | URL): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, 'utf8'));
 }
 
-/** Minimal caret check, enough for the `^X.Y.Z` ranges this repo writes and
- *  for 0.x semantics (a caret on 0.x is pinned to the minor). */
-function satisfiesCaret(version: string, range: string): boolean {
+/**
+ * `^0.Y.Z` is pinned to the minor. That is the only shape this package's
+ * parquet-wasm peer range takes (a 0.x caret), and the test below asserts
+ * the range still has that shape rather than quietly mis-reading a `^1.x`.
+ */
+function satisfiesZeroMajorCaret(version: string, range: string): boolean {
   const [rMajor, rMinor, rPatch] = range.replace(/^\^/, '').split('.').map(Number);
   const [vMajor, vMinor, vPatch] = version.split('.').map(Number);
-  if (vMajor !== rMajor) return false;
-  if (rMajor === 0 && vMinor !== rMinor) return false;
-  if (vMinor !== rMinor) return vMinor > rMinor;
-  return vPatch >= rPatch;
+  return vMajor === rMajor && vMinor === rMinor && vPatch >= rPatch;
 }
 
 describe('parquet-wasm entry point', () => {
   it('resolves a version that satisfies the declared peer range', () => {
-    const pkg = readJson('../package.json');
+    const pkg = readJson(new URL('../package.json', import.meta.url));
     const range = (pkg.peerDependencies as Record<string, string>)['parquet-wasm'];
-    const installed = readJson('../node_modules/parquet-wasm/package.json').version as string;
-    expect(satisfiesCaret(installed, range)).toBe(true);
+    expect(range.startsWith('^0.')).toBe(true);
+
+    // Ask the resolver, not a hard-coded node_modules path: this resolves
+    // the very entry point `import('parquet-wasm')` in the decoder gets.
+    // Its manifest is read relatively because 0.7's export map does not
+    // expose `./package.json` (resolving that subpath throws
+    // ERR_PACKAGE_PATH_NOT_EXPORTED), and every build entry it does expose
+    // sits one directory below the package root (bundler/, esm/, node/).
+    const manifest = readJson(new URL('../package.json', pathToFileURL(require.resolve('parquet-wasm'))));
+    expect(manifest.name).toBe('parquet-wasm');
+    const installed = manifest.version as string;
+    expect(satisfiesZeroMajorCaret(installed, range)).toBe(true);
   });
 
   it('resolves the package entry point, not the arrow2 path dropped in 0.6', () => {

--- a/packages/server-client/src/parquet-decoder.ts
+++ b/packages/server-client/src/parquet-decoder.ts
@@ -12,7 +12,8 @@
 import type { MeshData } from './types.js';
 import { buildMeshesFromTables, buildMeshesFromOptimizedTables } from './parquet-tables.js';
 
-// Ambient types in vendor-types.d.ts cover parquet-wasm and apache-arrow APIs.
+// Ambient types in vendor-types.d.ts cover the apache-arrow APIs used here.
+// parquet-wasm ships its own types, one set per build.
 
 // WASM initialization state. The in-flight promise is cached too, so
 // concurrent decodes share one init instead of racing two.
@@ -47,8 +48,14 @@ async function loadParquet(): Promise<ParquetModule> {
   // itself on import and exposes no default init, hence the guard rather
   // than an unconditional call. Same shape as
   // packages/export/src/columns-to-parquet.ts.
-  if (typeof parquet.default === 'function') {
-    await parquet.default();
+  //
+  // The cast is the price of that guard: TypeScript resolves the export map
+  // under the `node` condition, so it only ever sees the Node build's types,
+  // where `default` is the CommonJS namespace object and not callable. Which
+  // build actually loads is a runtime question, so ask at runtime.
+  const init = (parquet as { default?: unknown }).default;
+  if (typeof init === 'function') {
+    await (init as () => Promise<unknown>)();
   }
 
   if (typeof parquet.readParquet !== 'function') {

--- a/packages/server-client/src/parquet-decoder.ts
+++ b/packages/server-client/src/parquet-decoder.ts
@@ -14,93 +14,51 @@ import { buildMeshesFromTables, buildMeshesFromOptimizedTables } from './parquet
 
 // Ambient types in vendor-types.d.ts cover parquet-wasm and apache-arrow APIs.
 
-// WASM initialization state
-let parquetInitialized = false;
-let parquetModule: typeof import('parquet-wasm/esm/arrow2.js') | null = null;
+// WASM initialization state. The in-flight promise is cached too, so
+// concurrent decodes share one init instead of racing two.
+type ParquetModule = typeof import('parquet-wasm');
+let parquetInit: Promise<ParquetModule> | null = null;
 
 /**
  * Ensure parquet-wasm WASM module is initialized.
  * This MUST be called before using any parquet functions.
- * 
+ *
  * @returns Initialized parquet-wasm module
  */
-export async function ensureParquetInit() {
-  if (parquetInitialized && parquetModule) {
-    return parquetModule;
+export async function ensureParquetInit(): Promise<ParquetModule> {
+  parquetInit ??= loadParquet().catch((err) => {
+    // Do not cache a failed init: a later call (e.g. after the WASM asset
+    // becomes reachable) should be able to try again.
+    parquetInit = null;
+    throw err;
+  });
+  return parquetInit;
+}
+
+async function loadParquet(): Promise<ParquetModule> {
+  // Import the package entry point and let its export map choose the build.
+  // Deep-importing a build (this module used `parquet-wasm/esm/arrow2.js`)
+  // breaks on parquet-wasm 0.6+, where that path no longer exists (#3845).
+  const parquet = await import('parquet-wasm');
+
+  // The browser/bundler ESM build does nothing until its default export is
+  // awaited; without it every call throws `Cannot read properties of
+  // undefined (reading '__wbindgen_malloc')`. The Node build initializes
+  // itself on import and exposes no default init, hence the guard rather
+  // than an unconditional call. Same shape as
+  // packages/export/src/columns-to-parquet.ts.
+  if (typeof parquet.default === 'function') {
+    await parquet.default();
   }
 
-  console.log('[parquet-decoder] Starting WASM initialization...');
-
-  let parquet: typeof import('parquet-wasm/esm/arrow2.js') | undefined;
-
-  // Strategy 1: Try ESM build with explicit WASM URL (works with Vite)
-  try {
-    parquet = await import('parquet-wasm/esm/arrow2.js');
-    console.log('[parquet-decoder] Imported ESM build');
-
-    // ESM build requires calling init (default export) to load WASM
-    if (typeof parquet.default === 'function') {
-      console.log('[parquet-decoder] Calling ESM init to load WASM...');
-
-      // Get the WASM file URL - Vite handles this with ?url suffix
-      const wasmModule = await import('parquet-wasm/esm/arrow2_bg.wasm?url');
-      const wasmUrl = wasmModule.default;
-      console.log('[parquet-decoder] Loading WASM from:', wasmUrl);
-
-      // Pass the URL to init so it can fetch the WASM correctly
-      await parquet.default(wasmUrl);
-      console.log('[parquet-decoder] ESM WASM initialized');
-    }
-
-    if (typeof parquet.readParquet === 'function') {
-      parquetModule = parquet;
-      parquetInitialized = true;
-      console.log('[parquet-decoder] ESM build ready with readParquet');
-      return parquet;
-    } else {
-      console.warn('[parquet-decoder] ESM build initialized but readParquet not found');
-    }
-  } catch (e) {
-    console.warn('[parquet-decoder] ESM import failed:', e);
+  if (typeof parquet.readParquet !== 'function') {
+    throw new Error(
+      'parquet-wasm: module loaded but readParquet is missing. ' +
+        'Install a supported parquet-wasm version (see this package\'s peerDependencies).'
+    );
   }
 
-  // Strategy 2: Try web build with fetch (alternative for browsers)
-  try {
-    parquet = await import('parquet-wasm/esm/arrow2.js');
-
-    if (typeof parquet.default === 'function') {
-      console.log('[parquet-decoder] Trying web init with node_modules path...');
-
-      // Try common paths where WASM might be served
-      const wasmPaths = [
-        '/node_modules/parquet-wasm/esm/arrow2_bg.wasm',
-        './node_modules/parquet-wasm/esm/arrow2_bg.wasm',
-      ];
-
-      for (const wasmPath of wasmPaths) {
-        try {
-          const response = await fetch(wasmPath);
-          if (response.ok) {
-            console.log('[parquet-decoder] Found WASM at:', wasmPath);
-            await parquet.default(response);
-
-            if (typeof parquet.readParquet === 'function') {
-              parquetModule = parquet;
-              parquetInitialized = true;
-              console.log('[parquet-decoder] Web init successful');
-              return parquet;
-            }
-          }
-        } catch {
-          // Try next path
-        }
-      }
-    }
-  } catch (e2) {
-    console.warn('[parquet-decoder] Web init failed:', e2);
-  }
-
-  throw new Error('parquet-wasm: Could not load WASM module. Ensure parquet-wasm is installed and WASM files are accessible.');
+  return parquet;
 }
 
 /**

--- a/packages/server-client/src/vendor-types.d.ts
+++ b/packages/server-client/src/vendor-types.d.ts
@@ -11,16 +11,18 @@
 
 // ── parquet-wasm ──
 
-declare module 'parquet-wasm/esm/arrow2.js' {
-  /** Initialize WASM module. Pass a URL or Response to load from. */
+// The package's own entry point (`parquet-wasm`), not a build-specific deep
+// path: `esm/arrow2.js` was dropped in parquet-wasm 0.6, so importing it
+// broke for any consumer on the version the rest of this workspace pins
+// (#3845). The bare specifier lets the package's export map pick the build:
+// the Node build (auto-initializing, no default export) under Node, the
+// wasm-bindgen ESM build (whose default export must be awaited before any
+// other call) in a browser or bundler.
+declare module 'parquet-wasm' {
+  /** Initialize WASM module. Browser/bundler build only; absent on Node. */
   export default function init(wasmUrlOrResponse?: string | Response): Promise<void>;
   /** Read a Parquet buffer and return an Arrow IPC-compatible table. */
   export function readParquet(data: Uint8Array): ParquetTable;
-}
-
-declare module 'parquet-wasm/esm/arrow2_bg.wasm?url' {
-  const url: string;
-  export default url;
 }
 
 interface ParquetTable {

--- a/packages/server-client/src/vendor-types.d.ts
+++ b/packages/server-client/src/vendor-types.d.ts
@@ -3,32 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Minimal ambient type declarations for parquet-wasm and apache-arrow.
+ * Minimal ambient type declarations for apache-arrow.
  *
  * These cover only the API surface actually used in this package,
  * avoiding the need for @ts-ignore on every call site.
+ *
+ * parquet-wasm is NOT declared here: it ships its own `.d.ts` per build and
+ * they resolve fine from this package's tsconfig. An ambient stub would
+ * shadow them (#3845). See `parquet-decoder.ts` for the one place the real
+ * types need help: they describe whichever build the resolver picked, and
+ * the runtime may be the other one.
  */
-
-// ── parquet-wasm ──
-
-// The package's own entry point (`parquet-wasm`), not a build-specific deep
-// path: `esm/arrow2.js` was dropped in parquet-wasm 0.6, so importing it
-// broke for any consumer on the version the rest of this workspace pins
-// (#3845). The bare specifier lets the package's export map pick the build:
-// the Node build (auto-initializing, no default export) under Node, the
-// wasm-bindgen ESM build (whose default export must be awaited before any
-// other call) in a browser or bundler.
-declare module 'parquet-wasm' {
-  /** Initialize WASM module. Browser/bundler build only; absent on Node. */
-  export default function init(wasmUrlOrResponse?: string | Response): Promise<void>;
-  /** Read a Parquet buffer and return an Arrow IPC-compatible table. */
-  export function readParquet(data: Uint8Array): ParquetTable;
-}
-
-interface ParquetTable {
-  /** Convert to Arrow IPC stream bytes for use with apache-arrow. */
-  intoIPCStream(): Uint8Array;
-}
 
 // ── apache-arrow ──
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4879,9 +4879,6 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
-  parquet-wasm@0.5.0:
-    resolution: {integrity: sha512-XN3EW+3xf915QgpxCvfCdVYsxDLXz+BckKLDlMo41cbipSYD8x+F/3lGcrWtxdY6uJgAmtb+SX3tS+9PPsplQA==}
-
   parquet-wasm@0.7.2:
     resolution: {integrity: sha512-XfzVFW7REEYzt/MF5pG2fVjF0lyArXkk4x7m4wuE7R5OEoUfXq5wdI5DQi/UsB8wWW3ncx2z6xMjq5dM9qTYgg==}
 
@@ -8941,8 +8938,6 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
-
-  parquet-wasm@0.5.0: {}
 
   parquet-wasm@0.7.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1460,10 +1460,10 @@ importers:
       apache-arrow:
         specifier: '>=14.0.0'
         version: 14.0.2
-      parquet-wasm:
-        specifier: '>=0.5.0'
-        version: 0.5.0
     devDependencies:
+      parquet-wasm:
+        specifier: ^0.7.2
+        version: 0.7.2
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

`packages/server-client/src/parquet-decoder.ts` imported `parquet-wasm/esm/arrow2.js`, an entry removed in parquet-wasm 0.6, behind a `>=0.5.0` peer range, while `packages/export` and `apps/viewer` pin `^0.7.2` (#3845, surfaced by #2931). In-repo it resolved to 0.5.0 so nothing failed here; a downstream consumer on 0.7 got a missing module at first decode, and the viewer (which bundles server-client from source and resolves 0.7.2) had its Parquet decode broken behind the generic "Could not load WASM module" catch.

- The decoder now does `await import('parquet-wasm')` and lets the export map pick the build, with the same init guard `packages/export` ships (the Node build's `default` is the CJS namespace, the browser build's is the awaited init function; the type is read through a narrow cast because `nodenext` types only the Node condition). Init is a cached promise; a failed init is not cached.
- Peer range `^0.7.2`, dev dependency `parquet-wasm@^0.7.2`; the ambient stub that shadowed parquet-wasm's published types is deleted (apache-arrow keeps its block, its browser export map really hides its types).
- `pnpm-lock.yaml`: the offline metadata mirror could not resolve parquet-wasm, so the server-client importer block was edited by hand and the orphaned 0.5.0 entries removed. `pnpm install --frozen-lockfile --offline` passes and `--lockfile-only --offline` rewrites nothing.
- Tests: the decode test boots via the bare entry (its spatial-nodes fixture needed an explicitly nullable Arrow schema, since 0.7's writer rejects nulls in non-nullable fields that 0.5 silently dropped; the DuckDB fixtures stay the independent oracle). New `parquet-decoder.entry.test.ts` asserts the resolved version satisfies the peer range, the dead subpath no longer resolves, and a one-triangle payload written by the resolved parquet-wasm decodes.

**Breaking** for `@ifc-lite/server-client`: on parquet-wasm 0.5 or 0.6 under Node, `import('parquet-wasm')` is a hard `ERR_MODULE_NOT_FOUND` (0.5 has no `exports` or `main`), so consumers pinned there must upgrade to `^0.7.2` alongside this release. The changeset is `major` and says so.

Closes #3845

## Verification

- `pnpm typecheck` exit 0; server-client 66 tests and export 1102 tests pass.
- RED proven: restoring the deep import fails the entry test at load; setting the peer range to `^0.6.0` fails the range assertion.
- `check-changeset-bump`, `check-changesets`, `check-unused-locals` exit 0. `check-module-size` still fails on the three script rows red on main (#3826).
- Not proven: the browser init path was not driven in a running viewer; it is the same call shape `packages/export` already ships there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Parquet decoding compatibility across browser and Node environments.
  * Added retry support when Parquet initialization fails.
  * Preserved nullable fields when writing Parquet data.
  * Removed compatibility with parquet-wasm versions 0.5 and 0.6; version 0.7.2 or later is now required.

* **Tests**
  * Added coverage for package entry-point resolution, geometry decoding, version compatibility, and independent Parquet fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->