### PR TITLE
test(viewer): useSolarEnvironment scenario waits for the published sun direction instead of a fixed 50 ms flush

### DIFF
--- a/apps/viewer/src/hooks/useSolarEnvironment.scenario.test.tsx
+++ b/apps/viewer/src/hooks/useSolarEnvironment.scenario.test.tsx
@@ -54,10 +54,28 @@ async function mountHook(georef: SolarEnvironmentGeoref | null): Promise<Root> {
   document.body.appendChild(container);
   const root = createRoot(container);
   await act(async () => { root.render(<Harness />); });
-  // computeCesiumModelOrigin resolves proj4 (EPSG lookup + async import)
-  // before the hook's origin effect settles; flush past that.
-  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 50)); });
   return root;
+}
+
+/**
+ * The hook publishes only AFTER its origin effect settles: `origin` starts
+ * `null`, and `computeCesiumModelOrigin` awaits a proj4 EPSG lookup behind an
+ * async import. Reading the store straight after mount therefore races the
+ * effect (issue #3850: 2 of 6 runs failed on a fixed 50ms flush). Poll the
+ * published value instead, bounded, the way
+ * `useSymbolicAnnotationsForDrawing.classGate.test.tsx` waits on its harness.
+ */
+async function waitForSunDirection(timeoutMs = 10_000): Promise<readonly number[]> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const published = useViewerStore.getState().solarSunDirection;
+    if (published) return published;
+    if (Date.now() >= deadline) break;
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+  }
+  throw new Error(
+    `the hook must publish a sun direction for an enabled solar study (none within ${timeoutMs}ms)`,
+  );
 }
 
 const originalState = useViewerStore.getState();
@@ -70,8 +88,7 @@ describe('useSolarEnvironment (real hook call site, #2534 review gap)', () => {
 
     const root = await mountHook({ mapConversion, projectedCRS, coordinateInfo, lengthUnitScale: 1 });
     try {
-      const published = useViewerStore.getState().solarSunDirection;
-      assert.ok(published, 'the hook must publish a sun direction for an enabled solar study');
+      const published = await waitForSunDirection();
 
       // Independently reconstruct the origin (lat/lon/gamma) the SAME way
       // the hook's own effect does — `computeCesiumModelOrigin` already
@@ -89,11 +106,11 @@ describe('useSolarEnvironment (real hook call site, #2534 review gap)', () => {
       const dist = (a: readonly number[], b: readonly number[]) =>
         Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
       assert.ok(
-        dist(published!, authoredAxisDirection) > 0.1,
+        dist(published, authoredAxisDirection) > 0.1,
         `published direction must not match the authored-rotation prediction: published=${published}, authored=${authoredAxisDirection}`,
       );
       assert.ok(
-        dist(published!, identityAxisDirection) < 1e-6,
+        dist(published, identityAxisDirection) < 1e-6,
         `published direction must match the identity-axis (guard-neutralised) prediction: published=${published}, identity=${identityAxisDirection}`,
       );
     } finally {


### PR DESCRIPTION
## Summary

`apps/viewer/src/hooks/useSolarEnvironment.scenario.test.tsx` failed 2 of 6 runs on unmodified main with "the hook must publish a sun direction for an enabled solar study" (#3850). The hook has no synchronous fallback: `origin` starts null, the effect awaits `computeCesiumModelOrigin` (a proj4 EPSG lookup behind an async import), and the publish effect writes null until that resolves. The test flushed a fixed 50 ms timeout and then read the store synchronously, so it raced the effect.

The test now polls the store for the published direction inside `act()` with a bounded 10 s timeout, the same pattern `useSymbolicAnnotationsForDrawing.classGate.test.tsx` uses. The hook is untouched.

Closes #3850

## Verification

- Before: 6 runs, 4 pass / 2 fail. After: 10 runs, 10 pass.
- The wait is not vacuous: forcing the publish effect down its `setSolarSunDirection(null)` branch fails the test after the timeout with "(none within 10000ms)".
- `pnpm typecheck` exit 0.