### PR TITLE
test(viewer-embed): enforce EmbedUrlParams/parser parity, and drop the hideViewCube param that never existed

### DIFF
--- a/apps/viewer-embed/src/bridge/urlParams.test.ts
+++ b/apps/viewer-embed/src/bridge/urlParams.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmbedUrlParams } from '@ifc-lite/embed-protocol';
 import { assertFetchableUrl, parseUrlParams } from './urlParams.js';
 
 function setSearch(search: string, origin = 'https://embed.example') {
@@ -259,5 +260,65 @@ describe('parseUrlParams', () => {
     expect(parseUrlParams().parentOrigin).toBe('https://host.example');
     setSearch('?parentOrigin=host.example');
     expect(parseUrlParams().parentOrigin).toBeUndefined();
+  });
+});
+
+/**
+ * Parity between `EmbedUrlParams` (the public, documented surface) and what
+ * `parseUrlParams` actually produces.
+ *
+ * #2934 was eight fields declared here, parsed, and never applied. The
+ * protocol's own doc comment states the rule in prose -- "a new field owes its
+ * own applying call site and a test that observes the effect" -- and nothing
+ * enforced the first half of it: a field could be added to `EmbedUrlParams`
+ * and the parser would simply never emit it, with no build failure and no
+ * test failure, which is how three of the eight drifted in the first place.
+ *
+ * `QUERY_FOR_FIELD` is typed `Record<keyof EmbedUrlParams, string>`, so the
+ * two directions fail differently and both fail loudly:
+ *
+ *  - a field ADDED to `EmbedUrlParams` and not parsed -> `tsc` errors on the
+ *    missing key here, naming it;
+ *  - a field listed here that the parser does not emit for its own query
+ *    string -> the runtime assertion below fails, naming it.
+ *
+ * The APPLYING half of the rule is not this file's to check; each param's
+ * effect is observed by the tests in `../components` (`EmbedViewer.urlParams`,
+ * `.autoLoad`, `.overlays`, `.modelView`), every one of which was confirmed to
+ * fail when its wiring is deleted.
+ */
+describe('EmbedUrlParams parity', () => {
+  const QUERY_FOR_FIELD: Record<keyof EmbedUrlParams, string> = {
+    modelUrl: 'modelUrl=https://cdn.example/m.ifc',
+    theme: 'theme=dark',
+    bg: 'bg=ff0000',
+    controls: 'controls=none',
+    autoLoad: 'autoLoad=false',
+    hideAxis: 'hideAxis=true',
+    hideScale: 'hideScale=true',
+    select: 'select=42',
+    isolate: 'isolate=43',
+    hideTypes: 'hideTypes=IfcSpace',
+    camera: 'camera=45,30',
+    view: 'view=front',
+  };
+
+  it('emits every field the public type declares', () => {
+    const missing: string[] = [];
+    for (const [field, query] of Object.entries(QUERY_FOR_FIELD)) {
+      setSearch(`?${query}`);
+      if (parseUrlParams()[field as keyof EmbedUrlParams] === undefined) missing.push(field);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('emits nothing the type does not declare, beyond the viewer-only security knobs', () => {
+    // `allowOrigins`/`parentOrigin` are deliberately off the public protocol
+    // (see `EmbedViewerUrlParams`), so they are the only permitted extras.
+    setSearch(`?${Object.values(QUERY_FOR_FIELD).join('&')}`);
+    const extra = Object.keys(parseUrlParams()).filter(
+      (k) => !(k in QUERY_FOR_FIELD) && k !== 'allowOrigins' && k !== 'parentOrigin',
+    );
+    expect(extra).toEqual([]);
   });
 });

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -27,9 +27,18 @@ import { Crosshair } from 'lucide-react';
 /**
  * Overlay chrome drawn on top of the 3D viewport.
  *
- * The three `hide*` props exist for the embed (`?hideViewCube=`, `?hideAxis=`,
- * `?hideScale=`): a host iframe is often too small for the full chrome. They
- * default to `false`, so the standalone viewer is unaffected.
+ * The three `hide*` props exist for the embed: a host iframe is often too
+ * small for the full chrome. They default to `false`, so the standalone
+ * viewer is unaffected.
+ *
+ * Only two of them are host-controllable. `hideAxis` and `hideScale` carry the
+ * `?hideAxis=`/`?hideScale=` URL params and INIT's `config.hideAxis`/
+ * `.hideScale` (`useEmbedRuntimeOverlays.ts`). `hideViewCube` has NO param
+ * behind it -- `urlParams.ts` never parses one and `EmbedUrlParams` never
+ * declared one -- the embed passes it unconditionally, so the ViewCube is
+ * always off there. This comment named a `?hideViewCube=` from #3316 until
+ * #2934's closing sweep; no such param has ever been parsed, so a host that
+ * sent it got exactly the silent no-op #2934 is about.
  */
 export function ViewportOverlays({
   hideViewCube = false,


### PR DESCRIPTION
## Summary

Every item #2934 names (SET_CAMERA, RESET_COLORS, ENTITY_HOVERED, and the eight URL params) is already wired on main by #3170, #3189, #3304 and #3316, none of which closed the issue. Each wiring was mutation-checked: deleting it fails a named test (details on the issue).

What was still wrong:

- `ViewportOverlays`'s doc comment claimed a `?hideViewCube=` embed URL param that `urlParams.ts` never parsed and `EmbedUrlParams` never declared (introduced by #3316). A host sending it got the exact silent no-op #2934 describes, reached from the docs. Comment corrected.
- `EmbedUrlParams`'s comment said a new field "owes its own applying call site" and admitted nothing enforced it, which is how `controls`, `hideAxis` and `hideScale` sat declared and inert. A `Record<keyof EmbedUrlParams, string>` parity test now fails in both directions: the parser dropping a field fails at runtime, a field added to the protocol without a parser fails typecheck.

Refs #2934 (closed separately with the wiring evidence).

## Verification

- `pnpm typecheck` exit 0; viewer and viewer-embed suites 44/44 tasks.
- Parity test mutation-checked both ways (drop `hideScale` from the parser: runtime failure naming it; add `hideGrid?: boolean` to the protocol: TS2741 naming it).
- No changeset: both apps are unpublished and no behaviour changes.