### PR TITLE
fix(geometry): boolean operand drops reach diagnostics through the router

### DIFF
--- a/.changeset/boolean-operand-drops-reach-diagnostics.md
+++ b/.changeset/boolean-operand-drops-reach-diagnostics.md
@@ -1,7 +1,10 @@
 ---
 '@ifc-lite/wasm': patch
+'@ifc-lite/cli': patch
 ---
 
 Boolean-operand drops now reach `GeometryDiagnostics` instead of vanishing (#3821).
 
 `BooleanClippingProcessor::take_failures` had no caller outside tests, so everything the boolean processor recorded — an unsupported operand, an `EmptyOperand` cutter, an unknown `IfcBooleanResult` operator — accumulated in a buffer nothing read, and a load whose booleans had all degraded reported zero failures. The unsupported-first-operand case recorded nothing at all: `process_operand_with_depth` returned an empty mesh for an operand type it has no branch for, and the element's item silently disappeared from the 3D view. The router now drains its processors' logs through `take_csg_failures`, so the wasm batch path, the native pipeline and `ifc-lite diagnose-geometry` all surface these, and the unsupported operand is recorded under the new `UnsupportedOperand` reason label naming the operand's IFC type. Mesh output is unchanged — this is observability, not a geometry change.
+
+`ifc-lite diagnose-geometry` and `export --diagnostics` render `failuresByReason` verbatim, so their "Failures by reason" section gains an `UnsupportedOperand` row on affected models. `productsWithFailures` also stops counting the synthetic unattributed bucket as a product: records swept from a boolean processor's own log have no owning element, and reporting them as one product made a model with no attributed failure read as "1 product failed". Their failures still count in the totals and the reason breakdown.

--- a/.changeset/boolean-operand-drops-reach-diagnostics.md
+++ b/.changeset/boolean-operand-drops-reach-diagnostics.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Boolean-operand drops now reach `GeometryDiagnostics` instead of vanishing (#3821).
+
+`BooleanClippingProcessor::take_failures` had no caller outside tests, so everything the boolean processor recorded — an unsupported operand, an `EmptyOperand` cutter, an unknown `IfcBooleanResult` operator — accumulated in a buffer nothing read, and a load whose booleans had all degraded reported zero failures. The unsupported-first-operand case recorded nothing at all: `process_operand_with_depth` returned an empty mesh for an operand type it has no branch for, and the element's item silently disappeared from the 3D view. The router now drains its processors' logs through `take_csg_failures`, so the wasm batch path, the native pipeline and `ifc-lite diagnose-geometry` all surface these, and the unsupported operand is recorded under the new `UnsupportedOperand` reason label naming the operand's IFC type. Mesh output is unchanged — this is observability, not a geometry change.

--- a/rust/export/src/model.rs
+++ b/rust/export/src/model.rs
@@ -278,6 +278,9 @@ pub fn stream_export_model_with_options(
     // they cannot forget to ask.
     let units = resolve_unit_scales(content, project_id, &mut decoder);
 
+    // Not drained for boolean failures (#3821): `resolve_scaled_placement` is
+    // the only method called on it and it never reaches `self.processors`, so
+    // no processor here meshes anything that could record a `BoolFailure`.
     // Built with the file's scale, NOT `GeometryRouter::new()`: `new` defaults
     // `unit_scale` to 1.0 and `scale_transform` only scales when it was given
     // the real one, so the difference is silently-millimetre translations.

--- a/rust/export/src/model.rs
+++ b/rust/export/src/model.rs
@@ -278,9 +278,7 @@ pub fn stream_export_model_with_options(
     // they cannot forget to ask.
     let units = resolve_unit_scales(content, project_id, &mut decoder);
 
-    // Not drained for boolean failures (#3821): `resolve_scaled_placement` is
-    // the only method called on it and it never reaches `self.processors`, so
-    // no processor here meshes anything that could record a `BoolFailure`.
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     // Built with the file's scale, NOT `GeometryRouter::new()`: `new` defaults
     // `unit_scale` to 1.0 and `scale_transform` only scales when it was given
     // the real one, so the difference is silently-millimetre translations.

--- a/rust/geometry/src/diagnostics.rs
+++ b/rust/geometry/src/diagnostics.rs
@@ -40,6 +40,18 @@ pub fn take_pending_mapped_bool_failures() -> Vec<BoolFailure> {
     PENDING_MAPPED_BOOL_FAILURES.with(|cell| std::mem::take(&mut *cell.borrow_mut()))
 }
 
+/// Push failures from a boolean context the router cannot reach through its
+/// processor table — today `CsgSolidProcessor`, which builds a TRANSIENT
+/// `BooleanClippingProcessor` per `IfcCsgSolid.TreeRootExpression` and drops it
+/// on return, so its log has no other way out. `take_csg_failures` folds these
+/// in (bucketed under product id 0, like every other unattributed record).
+pub fn push_pending_mapped_bool_failures(failures: Vec<BoolFailure>) {
+    if failures.is_empty() {
+        return;
+    }
+    PENDING_MAPPED_BOOL_FAILURES.with(|cell| cell.borrow_mut().extend(failures));
+}
+
 /// Which boolean operation produced the failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BoolOp {
@@ -119,6 +131,17 @@ pub enum BoolFailureReason {
     /// viewers do in practice) and records this so the loss surfaces in
     /// diagnostics rather than as a silently missing element.
     DifferenceEmptiedHost,
+    /// A boolean operand's `IfcRepresentationItem` type has no meshing branch
+    /// in `BooleanClippingProcessor::process_operand_with_depth`, so the operand
+    /// resolved to an EMPTY mesh. Carries the operand's IFC type name.
+    ///
+    /// As a FIRST operand this is a real element-geometry loss: the base solid
+    /// is empty, the whole boolean result is empty, and the element renders
+    /// nothing from that item. As a SECOND operand it means "unsupported
+    /// cutter" — the host renders un-cut, and the pre-existing `EmptyOperand`
+    /// record for the same step is also emitted (one record for the cause, one
+    /// for the consequence).
+    UnsupportedOperand(String),
     /// #3440 step 2: the kernel result passed `validate_mesh` (finite,
     /// in-bounds) but failed the directed-edge closure audit
     /// (`topology_gate_reject` — same predicate `KernelError`'s step-1
@@ -153,6 +176,7 @@ impl BoolFailureReason {
             BoolFailureReason::KernelError(_) => "KernelError",
             BoolFailureReason::DifferenceEmptiedHost => "DifferenceEmptiedHost",
             BoolFailureReason::OpenTopologyRejected => "OpenTopologyRejected",
+            BoolFailureReason::UnsupportedOperand(_) => "UnsupportedOperand",
         }
     }
 }
@@ -196,6 +220,9 @@ impl fmt::Display for BoolFailureReason {
             BoolFailureReason::OpenTopologyRejected => f.write_str(
                 "CSG kernel output passed validate_mesh but failed the closure audit; rejected under csg_topology_gate (#3440)",
             ),
+            BoolFailureReason::UnsupportedOperand(ty) => {
+                write!(f, "boolean operand type '{ty}' has no processor; operand meshed empty")
+            }
         }
     }
 }

--- a/rust/geometry/src/diagnostics.rs
+++ b/rust/geometry/src/diagnostics.rs
@@ -29,7 +29,11 @@ thread_local! {
     /// special-cased `IfcMappedItem` before it could ever be reached; see the
     /// D5 dead-code sweep), so nothing pushes into this today. Kept + still
     /// drained by `take_csg_failures` in case a future non-router boolean
-    /// context needs the same escape hatch.
+    /// context needs the same escape hatch. Think twice before adding one: a
+    /// thread-local is not scoped to a router, so records a router never
+    /// drains go to whichever router drains next on that thread. A transient
+    /// processor with a router-held PARENT has a better route out — see
+    /// `CsgSolidProcessor::take_failures` (#3821).
     static PENDING_MAPPED_BOOL_FAILURES: RefCell<Vec<BoolFailure>> =
         const { RefCell::new(Vec::new()) };
 }
@@ -38,18 +42,6 @@ thread_local! {
 /// `PENDING_MAPPED_BOOL_FAILURES`).
 pub fn take_pending_mapped_bool_failures() -> Vec<BoolFailure> {
     PENDING_MAPPED_BOOL_FAILURES.with(|cell| std::mem::take(&mut *cell.borrow_mut()))
-}
-
-/// Push failures from a boolean context the router cannot reach through its
-/// processor table — today `CsgSolidProcessor`, which builds a TRANSIENT
-/// `BooleanClippingProcessor` per `IfcCsgSolid.TreeRootExpression` and drops it
-/// on return, so its log has no other way out. `take_csg_failures` folds these
-/// in (bucketed under product id 0, like every other unattributed record).
-pub fn push_pending_mapped_bool_failures(failures: Vec<BoolFailure>) {
-    if failures.is_empty() {
-        return;
-    }
-    PENDING_MAPPED_BOOL_FAILURES.with(|cell| cell.borrow_mut().extend(failures));
 }
 
 /// Which boolean operation produced the failure.

--- a/rust/geometry/src/lib.rs
+++ b/rust/geometry/src/lib.rs
@@ -216,7 +216,8 @@ pub use profiles::ProfileProcessor;
 pub use router::take_bool2d_stats;
 pub use router::{take_prism_defers, take_prism_stats};
 pub use router::{
-    aggregate_diagnostics, local_frame_set_enabled_override, ClassificationStats,
+    aggregate_diagnostics, count_attributed_products, local_frame_set_enabled_override,
+    ClassificationStats, UNATTRIBUTED_PRODUCT_ID,
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION, FACETED_BREP_DEDUP_FACE_LIMIT,
     ClassificationSummary, GeometryDiagnostics, GeometryProcessor, GeometryRouter,
     HostOpeningDiagnostic, ItemDedupCache, MappedInstancePlan, OpeningDiagnostic, OpeningKindDiag,

--- a/rust/geometry/src/processors/boolean/failures.rs
+++ b/rust/geometry/src/processors/boolean/failures.rs
@@ -30,6 +30,40 @@ impl BooleanClippingProcessor {
         self.failures.borrow_mut().extend(failures);
     }
 
+    /// A mark in the failure log, for [`Self::rewind_to`].
+    pub(super) fn failure_mark(&self) -> usize {
+        self.failures.borrow().len()
+    }
+
+    /// Discard everything recorded since `mark`.
+    ///
+    /// Only for a SPECULATIVE attempt whose work the caller is about to redo.
+    /// `try_union_polygonal_chain` is a batched attempt at a chain the
+    /// sequential walk also resolves; when it gives up, `process_with_depth`
+    /// re-meshes the same base operand and the same cutters and records the
+    /// same losses again. Its trial subtracts already dropped their own probe
+    /// failures for this reason, but the base operand did not, so one authored
+    /// unsupported operand under a deferring chain was counted TWICE — the
+    /// total inflated and the reason breakdown skewed, which is what the
+    /// viewer's "top failure reason" reads.
+    ///
+    /// NOT a way to suppress a failure that really happened: the record has to
+    /// stay reachable from somewhere, and here that somewhere is the second
+    /// walk. A failure the sequential path does NOT re-encounter (the
+    /// `CutterUnionUnavailable` the union attempt alone can see) must be
+    /// recorded AFTER the rewind, not before it.
+    pub(super) fn rewind_to(&self, mark: usize) {
+        self.failures.borrow_mut().truncate(mark);
+    }
+
+    /// [`Self::rewind_to`] plus the deferral itself, so a guard in
+    /// `try_union_polygonal_chain` reads as one line and cannot rewind without
+    /// deferring or defer without rewinding.
+    pub(super) fn defer_after(&self, mark: usize) -> crate::Result<Option<crate::Mesh>> {
+        self.rewind_to(mark);
+        Ok(None)
+    }
+
     /// Record the `EmptyOperand` consequence for a second operand that meshed
     /// empty — UNLESS [`Self::process_operand_checked`] already recorded
     /// `UnsupportedOperand` for that same operand. One dropped step, one

--- a/rust/geometry/src/processors/boolean/failures.rs
+++ b/rust/geometry/src/processors/boolean/failures.rs
@@ -9,7 +9,6 @@
 
 use super::BooleanClippingProcessor;
 use crate::diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
-use crate::ClippingProcessor;
 
 impl BooleanClippingProcessor {
     /// Drain the boolean-failure log accumulated since this processor was
@@ -22,11 +21,13 @@ impl BooleanClippingProcessor {
         self.failures.borrow_mut().push(BoolFailure::new(op, reason));
     }
 
-    /// Move every failure from `clipper` into this processor's log. Used
-    /// after a transient `ClippingProcessor` instance is about to drop.
-    pub(super) fn drain_clipper_failures(&self, clipper: &ClippingProcessor) {
-        let mut log = self.failures.borrow_mut();
-        log.extend(clipper.take_failures());
+    /// Move a drained log into this processor's log. Used after a transient
+    /// helper — a `ClippingProcessor`, or the `CsgSolidProcessor` built for an
+    /// `IfcCsgSolid` operand — is about to drop and would take its records
+    /// with it. Takes the drained `Vec` rather than the producer, so one
+    /// method covers every transient kind.
+    pub(super) fn absorb_failures(&self, failures: Vec<BoolFailure>) {
+        self.failures.borrow_mut().extend(failures);
     }
 
     /// Record the `EmptyOperand` consequence for a second operand that meshed

--- a/rust/geometry/src/processors/boolean/failures.rs
+++ b/rust/geometry/src/processors/boolean/failures.rs
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The boolean processor's own failure log: record, drain, hand off.
+//!
+//! Split out of `boolean/mod.rs` (module-size ratchet) when the one-record-
+//! per-step rule needed a home (#3821).
+
+use super::BooleanClippingProcessor;
+use crate::diagnostics::{BoolFailure, BoolFailureReason, BoolOp};
+use crate::ClippingProcessor;
+
+impl BooleanClippingProcessor {
+    /// Drain the boolean-failure log accumulated since this processor was
+    /// created (or the last `take_failures` call).
+    pub fn take_failures(&self) -> Vec<BoolFailure> {
+        std::mem::take(&mut *self.failures.borrow_mut())
+    }
+
+    pub(super) fn record_failure(&self, op: BoolOp, reason: BoolFailureReason) {
+        self.failures.borrow_mut().push(BoolFailure::new(op, reason));
+    }
+
+    /// Move every failure from `clipper` into this processor's log. Used
+    /// after a transient `ClippingProcessor` instance is about to drop.
+    pub(super) fn drain_clipper_failures(&self, clipper: &ClippingProcessor) {
+        let mut log = self.failures.borrow_mut();
+        log.extend(clipper.take_failures());
+    }
+
+    /// Record the `EmptyOperand` consequence for a second operand that meshed
+    /// empty — UNLESS [`Self::process_operand_checked`] already recorded
+    /// `UnsupportedOperand` for that same operand. One dropped step, one
+    /// record: see the flag's rationale there.
+    pub(super) fn record_empty_second_operand(&self, op: BoolOp, already_recorded: bool) {
+        if !already_recorded {
+            self.record_failure(op, BoolFailureReason::EmptyOperand);
+        }
+    }
+}

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -23,6 +23,7 @@ use super::tessellated::TriangulatedFaceSetProcessor;
 use crate::router::GeometryProcessor;
 
 mod cut_heuristics;
+mod operand;
 mod halfspace_cap;
 mod polygonal_prism;
 use cut_heuristics::{
@@ -148,70 +149,6 @@ impl BooleanClippingProcessor {
         }
         self.record_failure(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost);
         host
-    }
-
-    /// Process a solid operand with depth tracking
-    fn process_operand_with_depth(
-        &self,
-        operand: &DecodedEntity,
-        decoder: &mut EntityDecoder,
-        depth: u32,
-        quality: TessellationQuality,
-        visited: &mut OperandPath,
-    ) -> Result<Mesh> {
-        match operand.ifc_type {
-            IfcType::IfcExtrudedAreaSolid => {
-                let processor = ExtrudedAreaSolidProcessor::new(self.schema.clone());
-                processor.process(operand, decoder, &self.schema, quality)
-            }
-            IfcType::IfcFacetedBrep => {
-                let processor = FacetedBrepProcessor::new();
-                processor.process(operand, decoder, &self.schema, quality)
-            }
-            IfcType::IfcTriangulatedFaceSet => {
-                let processor = TriangulatedFaceSetProcessor::new();
-                processor.process(operand, decoder, &self.schema, quality)
-            }
-            IfcType::IfcSweptDiskSolid => {
-                let processor = SweptDiskSolidProcessor::new(self.schema.clone());
-                processor.process(operand, decoder, &self.schema, quality)
-            }
-            IfcType::IfcRevolvedAreaSolid => {
-                let processor = RevolvedAreaSolidProcessor::new(self.schema.clone());
-                processor.process(operand, decoder, &self.schema, quality)
-            }
-            IfcType::IfcBlock => {
-                BlockProcessor::new().process(operand, decoder, &self.schema, quality)
-            }
-            // `CsgSolidProcessor::process` builds a FRESH BooleanClippingProcessor
-            // for a boolean TreeRootExpression, so routing through it used to reset
-            // both `depth` and the cycle guard. `#10 IfcBooleanResult -> FirstOperand
-            // #20 IfcCsgSolid -> TreeRootExpression #10` then recursed forever with
-            // depth never passing 1, and a Rust stack overflow ABORTS (#2866).
-            // `depth` restarts at 0 here, as it did before this guard existed
-            // (the hop built a fresh processor). Carrying it would tighten
-            // MAX_BOOLEAN_DEPTH, which #960 calibrated against a per-processor
-            // reset: 8 booleans + a CsgSolid + 8 more is valid, resolves on
-            // main, and would error as "depth 11 exceeds limit 10", dropping
-            // the element. MAX_OPERAND_PATH_NODES bounds the stack across the
-            // hop instead, counting frames of both kinds.
-            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(
-                self.skip_small_cuts,
-            )
-            .process_with_boolean_cycle_guard(
-                operand,
-                decoder,
-                &self.schema,
-                0,
-                quality,
-                visited,
-            ),
-            IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
-                // Recursive case with depth tracking
-                self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality, visited)
-            }
-            _ => Ok(Mesh::new()),
-        }
     }
 
     /// Parse IfcHalfSpaceSolid to get clipping plane
@@ -989,6 +926,15 @@ impl GeometryProcessor for BooleanClippingProcessor {
 
     fn supported_types(&self) -> Vec<IfcType> {
         vec![IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult]
+    }
+
+    /// Hand this processor's failure log to the router (#3821). Same drain as
+    /// [`Self::take_failures`], which until now had no caller outside tests —
+    /// every unsupported operand, empty cutter and unknown operator recorded
+    /// here accumulated in a buffer nothing read, so the pipeline reported a
+    /// clean load for a model whose booleans had all degraded.
+    fn take_bool_failures(&self) -> Vec<BoolFailure> {
+        self.take_failures()
     }
 }
 

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -439,13 +439,13 @@ impl BooleanClippingProcessor {
                 // attempt is unique to this path — preserve its kernel
                 // failures and record the deferral, since the sequential
                 // fallback can leave seam fins the batched subtract avoids.
-                self.drain_clipper_failures(&clipper);
+                self.absorb_failures(clipper.take_failures());
                 self.record_failure(BoolOp::Union, BoolFailureReason::CutterUnionUnavailable);
                 return Ok(None);
             }
         };
         let result = clipper.subtract_mesh(&base_mesh, &combined);
-        self.drain_clipper_failures(&clipper);
+        self.absorb_failures(clipper.take_failures());
         let clipped = match result {
             Ok(m)
                 if !m.is_empty()
@@ -782,7 +782,7 @@ impl BooleanClippingProcessor {
                 ) {
                     let clipper = ClippingProcessor::new();
                     let subtract_result = clipper.subtract_mesh(&mesh, &bound_mesh);
-                    self.drain_clipper_failures(&clipper);
+                    self.absorb_failures(clipper.take_failures());
                     if let Ok(clipped) = subtract_result {
                         // The bounded-prism subtract is fragile on coincident
                         // faces: when the clip polygon spans the full host
@@ -855,7 +855,7 @@ impl BooleanClippingProcessor {
             }
             let clipper = ClippingProcessor::new();
             let result = clipper.subtract_mesh(&mesh, &second_mesh);
-            self.drain_clipper_failures(&clipper);
+            self.absorb_failures(clipper.take_failures());
             return result;
         }
 
@@ -870,7 +870,7 @@ impl BooleanClippingProcessor {
             }
             let clipper = ClippingProcessor::new();
             let result = clipper.union_mesh(&mesh, &second_mesh);
-            self.drain_clipper_failures(&clipper);
+            self.absorb_failures(clipper.take_failures());
             return result;
         }
 
@@ -885,7 +885,7 @@ impl BooleanClippingProcessor {
             }
             let clipper = ClippingProcessor::new();
             let result = clipper.intersection_mesh(&mesh, &second_mesh);
-            self.drain_clipper_failures(&clipper);
+            self.absorb_failures(clipper.take_failures());
             return result;
         }
 

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -347,6 +347,9 @@ impl BooleanClippingProcessor {
             return Ok(None);
         }
 
+        // Provisional from here: every deferral below goes through
+        // `defer_after`, which discards what this attempt recorded.
+        let mark = self.failure_mark();
         // Process the base solid (the innermost first-operand). The chain is
         // walked iteratively above, so a 12-cutter chain reaches here at the
         // SAME `depth` as a 2-cutter one — the recursion-depth limit can't drop
@@ -374,7 +377,7 @@ impl BooleanClippingProcessor {
                 // A cutter we can't build a prism for would be silently dropped
                 // here; defer to the sequential path, which records the loss as
                 // `PolygonalBoundedHalfSpaceFallback`.
-                _ => return Ok(None),
+                _ => return self.defer_after(mark),
             }
         }
 
@@ -400,12 +403,12 @@ impl BooleanClippingProcessor {
                 // fallback handles it better than a batched union would.
                 _ => {
                     let _ = clipper.take_failures();
-                    return Ok(None);
+                    return self.defer_after(mark);
                 }
             };
             if ClippingProcessor::difference_result_looks_degenerate(&base_mesh, &trial) {
                 let _ = clipper.take_failures();
-                return Ok(None);
+                return self.defer_after(mark);
             }
             let (tmn, tmx) = trial.bounds();
             tight_min = Point3::new(
@@ -439,6 +442,7 @@ impl BooleanClippingProcessor {
                 // attempt is unique to this path — preserve its kernel
                 // failures and record the deferral, since the sequential
                 // fallback can leave seam fins the batched subtract avoids.
+                self.rewind_to(mark);
                 self.absorb_failures(clipper.take_failures());
                 self.record_failure(BoolOp::Union, BoolFailureReason::CutterUnionUnavailable);
                 return Ok(None);
@@ -455,7 +459,7 @@ impl BooleanClippingProcessor {
             }
             // Kernel error or a degenerate union result — fall back to the
             // sequential per-cutter path.
-            _ => return Ok(None),
+            _ => return self.defer_after(mark),
         };
 
         // Reject a silently under-removing union: the result must fit inside the
@@ -475,7 +479,7 @@ impl BooleanClippingProcessor {
             || rmn.y < tight_min.y - tol
             || rmn.z < tight_min.z - tol;
         if under_removed {
-            return Ok(None);
+            return self.defer_after(mark);
         }
         Ok(Some(clipped))
     }
@@ -913,11 +917,7 @@ impl GeometryProcessor for BooleanClippingProcessor {
         vec![IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult]
     }
 
-    /// Hand this processor's failure log to the router (#3821). Same drain as
-    /// [`Self::take_failures`], which until now had no caller outside tests —
-    /// every unsupported operand, empty cutter and unknown operator recorded
-    /// here accumulated in a buffer nothing read, so the pipeline reported a
-    /// clean load for a model whose booleans had all degraded.
+    /// Hand the log to the router (#3821); rationale on the trait method.
     fn take_bool_failures(&self) -> Vec<BoolFailure> {
         self.take_failures()
     }

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -23,6 +23,7 @@ use super::tessellated::TriangulatedFaceSetProcessor;
 use crate::router::GeometryProcessor;
 
 mod cut_heuristics;
+mod failures;
 mod operand;
 mod halfspace_cap;
 mod polygonal_prism;
@@ -103,23 +104,6 @@ impl BooleanClippingProcessor {
             failures: RefCell::new(Vec::new()),
             skip_small_cuts,
         }
-    }
-
-    /// Drain the boolean-failure log accumulated since this processor was
-    /// created (or the last `take_failures` call).
-    pub fn take_failures(&self) -> Vec<BoolFailure> {
-        std::mem::take(&mut *self.failures.borrow_mut())
-    }
-
-    fn record_failure(&self, op: BoolOp, reason: BoolFailureReason) {
-        self.failures.borrow_mut().push(BoolFailure::new(op, reason));
-    }
-
-    /// Move every failure from `clipper` into this processor's log. Used
-    /// after a transient `ClippingProcessor` instance is about to drop.
-    fn drain_clipper_failures(&self, clipper: &ClippingProcessor) {
-        let mut log = self.failures.borrow_mut();
-        log.extend(clipper.take_failures());
     }
 
     /// If a DIFFERENCE clip emptied a non-empty host **and** the cutter's
@@ -846,10 +830,10 @@ impl BooleanClippingProcessor {
             // short-circuit here meant every CSG primitive cut (issue #780
             // bath, any `IfcCsgSolid` with a solid cutter) silently rendered
             // as the uncut host even when the operands were trivially small.
-            let second_mesh =
-                self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) =
+                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
-                self.record_failure(BoolOp::Difference, BoolFailureReason::EmptyOperand);
+                self.record_empty_second_operand(BoolOp::Difference, unsupported);
                 return Ok(mesh);
             }
             // Small-cut skip: a cutter far smaller than its host (a steel
@@ -878,9 +862,10 @@ impl BooleanClippingProcessor {
         // Handle UNION operation — a real CSG union (overlap removed) on the
         // pure-Rust exact kernel.
         if operator == ".UNION." || operator == "UNION" {
-            let second_mesh = self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) =
+                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
-                self.record_failure(BoolOp::Union, BoolFailureReason::EmptyOperand);
+                self.record_empty_second_operand(BoolOp::Union, unsupported);
                 return Ok(mesh);
             }
             let clipper = ClippingProcessor::new();
@@ -892,10 +877,10 @@ impl BooleanClippingProcessor {
         // Handle INTERSECTION operation — a real intersection volume on the
         // pure-Rust exact kernel.
         if operator == ".INTERSECTION." || operator == "INTERSECTION" {
-            let second_mesh =
-                self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) =
+                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
-                self.record_failure(BoolOp::Intersection, BoolFailureReason::EmptyOperand);
+                self.record_empty_second_operand(BoolOp::Intersection, unsupported);
                 return Ok(Mesh::new());
             }
             let clipper = ClippingProcessor::new();

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -830,8 +830,8 @@ impl BooleanClippingProcessor {
             // short-circuit here meant every CSG primitive cut (issue #780
             // bath, any `IfcCsgSolid` with a solid cutter) silently rendered
             // as the uncut host even when the operands were trivially small.
-            let (second_mesh, unsupported) =
-                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) = self
+                .process_operand_checked(BoolOp::Difference, &second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_empty_second_operand(BoolOp::Difference, unsupported);
                 return Ok(mesh);
@@ -862,8 +862,8 @@ impl BooleanClippingProcessor {
         // Handle UNION operation — a real CSG union (overlap removed) on the
         // pure-Rust exact kernel.
         if operator == ".UNION." || operator == "UNION" {
-            let (second_mesh, unsupported) =
-                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) = self
+                .process_operand_checked(BoolOp::Union, &second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_empty_second_operand(BoolOp::Union, unsupported);
                 return Ok(mesh);
@@ -877,8 +877,8 @@ impl BooleanClippingProcessor {
         // Handle INTERSECTION operation — a real intersection volume on the
         // pure-Rust exact kernel.
         if operator == ".INTERSECTION." || operator == "INTERSECTION" {
-            let (second_mesh, unsupported) =
-                self.process_operand_checked(&second_operand, decoder, depth, quality, visited)?;
+            let (second_mesh, unsupported) = self
+                .process_operand_checked(BoolOp::Intersection, &second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_empty_second_operand(BoolOp::Intersection, unsupported);
                 return Ok(Mesh::new());

--- a/rust/geometry/src/processors/boolean/operand.rs
+++ b/rust/geometry/src/processors/boolean/operand.rs
@@ -21,6 +21,12 @@ impl BooleanClippingProcessor {
     /// Process a solid operand with depth tracking. The mesh only; callers
     /// that must not double-record an unsupported operand's consequence use
     /// [`Self::process_operand_checked`].
+    ///
+    /// Records an unsupported operand under [`BoolOp::Unknown`]: every caller
+    /// here is meshing the BASE solid at the bottom of a left spine, which is
+    /// read before any node's operator is, and whose loss empties the chain
+    /// under every operator alike. Naming one node's operator would claim an
+    /// attribution this path does not have.
     pub(super) fn process_operand_with_depth(
         &self,
         operand: &DecodedEntity,
@@ -30,7 +36,7 @@ impl BooleanClippingProcessor {
         visited: &mut OperandPath,
     ) -> Result<Mesh> {
         Ok(self
-            .process_operand_checked(operand, decoder, depth, quality, visited)?
+            .process_operand_checked(BoolOp::Unknown, operand, decoder, depth, quality, visited)?
             .0)
     }
 
@@ -44,8 +50,15 @@ impl BooleanClippingProcessor {
     /// breaks ties alphabetically, the viewer's "top failure reason" would name
     /// `EmptyOperand`, the CONSEQUENCE, over `UnsupportedOperand`, the cause.
     /// Callers pass this to [`Self::record_empty_second_operand`].
+    ///
+    /// `op` is the operation whose operand this is, and it goes into the
+    /// `UnsupportedOperand` record. Since that record is then the ONLY one for
+    /// the dropped step, recording `Unknown` for an operand of an authored
+    /// `.DIFFERENCE.` would render "UNKNOWN failed" as the whole story a
+    /// consumer of `take_csg_failures` ever gets for it.
     pub(super) fn process_operand_checked(
         &self,
+        op: BoolOp,
         operand: &DecodedEntity,
         decoder: &mut EntityDecoder,
         depth: u32,
@@ -89,17 +102,23 @@ impl BooleanClippingProcessor {
             // main, and would error as "depth 11 exceeds limit 10", dropping
             // the element. MAX_OPERAND_PATH_NODES bounds the stack across the
             // hop instead, counting frames of both kinds.
-            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(
-                self.skip_small_cuts,
-            )
-            .process_with_boolean_cycle_guard(
-                operand,
-                decoder,
-                &self.schema,
-                0,
-                quality,
-                visited,
-            ),
+            IfcType::IfcCsgSolid => {
+                // Transient, like the `ClippingProcessor`s below: it is not on
+                // any router, so its log has to come back here or it dies with
+                // it. `self` IS router-held, so this is the whole route out
+                // (#3821) — no thread-local, no cross-router leak.
+                let csg = CsgSolidProcessor::with_skip_small_cuts(self.skip_small_cuts);
+                let out = csg.process_with_boolean_cycle_guard(
+                    operand,
+                    decoder,
+                    &self.schema,
+                    0,
+                    quality,
+                    visited,
+                );
+                self.failures.borrow_mut().extend(csg.take_failures());
+                out
+            }
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
                 // Recursive case with depth tracking
                 self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality, visited)
@@ -114,10 +133,7 @@ impl BooleanClippingProcessor {
             // the only base-operand drop in the whole boolean path left no
             // trace at all, not even in a debug build.
             other => {
-                self.record_failure(
-                    BoolOp::Unknown,
-                    BoolFailureReason::UnsupportedOperand(other.to_string()),
-                );
+                self.record_failure(op, BoolFailureReason::UnsupportedOperand(other.to_string()));
                 unsupported = true;
                 Ok(Mesh::new())
             }

--- a/rust/geometry/src/processors/boolean/operand.rs
+++ b/rust/geometry/src/processors/boolean/operand.rs
@@ -18,7 +18,9 @@ use crate::{Mesh, Result, TessellationQuality};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 
 impl BooleanClippingProcessor {
-    /// Process a solid operand with depth tracking
+    /// Process a solid operand with depth tracking. The mesh only; callers
+    /// that must not double-record an unsupported operand's consequence use
+    /// [`Self::process_operand_checked`].
     pub(super) fn process_operand_with_depth(
         &self,
         operand: &DecodedEntity,
@@ -27,7 +29,31 @@ impl BooleanClippingProcessor {
         quality: TessellationQuality,
         visited: &mut OperandPath,
     ) -> Result<Mesh> {
-        match operand.ifc_type {
+        Ok(self
+            .process_operand_checked(operand, decoder, depth, quality, visited)?
+            .0)
+    }
+
+    /// Process a solid operand, reporting whether its type had NO meshing
+    /// branch here.
+    ///
+    /// The flag exists because one dropped operand must produce ONE record. An
+    /// unsupported SECOND operand meshes empty, so the `EmptyOperand` arm at
+    /// the caller would fire straight after the `UnsupportedOperand` record
+    /// below, counting the same step twice — and since the reason breakdown
+    /// breaks ties alphabetically, the viewer's "top failure reason" would name
+    /// `EmptyOperand`, the CONSEQUENCE, over `UnsupportedOperand`, the cause.
+    /// Callers pass this to [`Self::record_empty_second_operand`].
+    pub(super) fn process_operand_checked(
+        &self,
+        operand: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        depth: u32,
+        quality: TessellationQuality,
+        visited: &mut OperandPath,
+    ) -> Result<(Mesh, bool)> {
+        let mut unsupported = false;
+        let mesh = match operand.ifc_type {
             IfcType::IfcExtrudedAreaSolid => {
                 let processor = ExtrudedAreaSolidProcessor::new(self.schema.clone());
                 processor.process(operand, decoder, &self.schema, quality)
@@ -92,8 +118,11 @@ impl BooleanClippingProcessor {
                     BoolOp::Unknown,
                     BoolFailureReason::UnsupportedOperand(other.to_string()),
                 );
+                unsupported = true;
                 Ok(Mesh::new())
             }
-        }
+        }?;
+        Ok((mesh, unsupported))
     }
+
 }

--- a/rust/geometry/src/processors/boolean/operand.rs
+++ b/rust/geometry/src/processors/boolean/operand.rs
@@ -116,7 +116,7 @@ impl BooleanClippingProcessor {
                     quality,
                     visited,
                 );
-                self.failures.borrow_mut().extend(csg.take_failures());
+                self.absorb_failures(csg.take_failures());
                 out
             }
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
@@ -140,5 +140,4 @@ impl BooleanClippingProcessor {
         }?;
         Ok((mesh, unsupported))
     }
-
 }

--- a/rust/geometry/src/processors/boolean/operand.rs
+++ b/rust/geometry/src/processors/boolean/operand.rs
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! One boolean operand -> one mesh.
+//!
+//! Split out of `boolean/mod.rs` (module-size ratchet) when the unsupported-
+//! operand arm gained its diagnostic record (#3821).
+
+use super::{
+    BlockProcessor, BooleanClippingProcessor, CsgSolidProcessor, ExtrudedAreaSolidProcessor,
+    FacetedBrepProcessor, OperandPath, RevolvedAreaSolidProcessor, SweptDiskSolidProcessor,
+    TriangulatedFaceSetProcessor,
+};
+use crate::diagnostics::{BoolFailureReason, BoolOp};
+use crate::router::GeometryProcessor;
+use crate::{Mesh, Result, TessellationQuality};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
+
+impl BooleanClippingProcessor {
+    /// Process a solid operand with depth tracking
+    pub(super) fn process_operand_with_depth(
+        &self,
+        operand: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        depth: u32,
+        quality: TessellationQuality,
+        visited: &mut OperandPath,
+    ) -> Result<Mesh> {
+        match operand.ifc_type {
+            IfcType::IfcExtrudedAreaSolid => {
+                let processor = ExtrudedAreaSolidProcessor::new(self.schema.clone());
+                processor.process(operand, decoder, &self.schema, quality)
+            }
+            IfcType::IfcFacetedBrep => {
+                let processor = FacetedBrepProcessor::new();
+                processor.process(operand, decoder, &self.schema, quality)
+            }
+            IfcType::IfcTriangulatedFaceSet => {
+                let processor = TriangulatedFaceSetProcessor::new();
+                processor.process(operand, decoder, &self.schema, quality)
+            }
+            IfcType::IfcSweptDiskSolid => {
+                let processor = SweptDiskSolidProcessor::new(self.schema.clone());
+                processor.process(operand, decoder, &self.schema, quality)
+            }
+            IfcType::IfcRevolvedAreaSolid => {
+                let processor = RevolvedAreaSolidProcessor::new(self.schema.clone());
+                processor.process(operand, decoder, &self.schema, quality)
+            }
+            IfcType::IfcBlock => {
+                BlockProcessor::new().process(operand, decoder, &self.schema, quality)
+            }
+            // `CsgSolidProcessor::process` builds a FRESH BooleanClippingProcessor
+            // for a boolean TreeRootExpression, so routing through it used to reset
+            // both `depth` and the cycle guard. `#10 IfcBooleanResult -> FirstOperand
+            // #20 IfcCsgSolid -> TreeRootExpression #10` then recursed forever with
+            // depth never passing 1, and a Rust stack overflow ABORTS (#2866).
+            // `depth` restarts at 0 here, as it did before this guard existed
+            // (the hop built a fresh processor). Carrying it would tighten
+            // MAX_BOOLEAN_DEPTH, which #960 calibrated against a per-processor
+            // reset: 8 booleans + a CsgSolid + 8 more is valid, resolves on
+            // main, and would error as "depth 11 exceeds limit 10", dropping
+            // the element. MAX_OPERAND_PATH_NODES bounds the stack across the
+            // hop instead, counting frames of both kinds.
+            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(
+                self.skip_small_cuts,
+            )
+            .process_with_boolean_cycle_guard(
+                operand,
+                decoder,
+                &self.schema,
+                0,
+                quality,
+                visited,
+            ),
+            IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
+                // Recursive case with depth tracking
+                self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality, visited)
+            }
+            // No meshing branch for this operand type: the operand resolves to
+            // an EMPTY mesh. As a FIRST operand that empties the whole boolean
+            // result and the element's item renders nothing; as a SECOND
+            // operand it means an unsupported cutter and the host renders
+            // un-cut. Returning `Err` here would be wrong for the second case
+            // — it would delete the host as well — so the arm keeps returning
+            // an empty mesh and RECORDS the loss instead (#3821). Before this,
+            // the only base-operand drop in the whole boolean path left no
+            // trace at all, not even in a debug build.
+            other => {
+                self.record_failure(
+                    BoolOp::Unknown,
+                    BoolFailureReason::UnsupportedOperand(other.to_string()),
+                );
+                Ok(Mesh::new())
+            }
+        }
+    }
+}

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -12,9 +12,10 @@
 
 use super::boolean::OperandPath;
 use crate::extrusion::apply_transform;
-use crate::{Error, Mesh, Result, TessellationQuality, Vector3};
+use crate::{BoolFailure, Error, Mesh, Result, TessellationQuality, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Point3;
+use std::cell::RefCell;
 
 use super::boolean::BooleanClippingProcessor;
 use super::sphere::SphereProcessor;
@@ -103,6 +104,12 @@ pub struct CsgSolidProcessor {
     /// [`BooleanClippingProcessor`] this wraps so a CSG tree shares one scoped
     /// value (see `BooleanClippingProcessor::skip_small_cuts`).
     skip_small_cuts: bool,
+    /// Failures from the TRANSIENT [`BooleanClippingProcessor`] built per
+    /// `TreeRootExpression` and dropped on return. Held here so they leave
+    /// through [`GeometryProcessor::take_bool_failures`] — i.e. through the
+    /// router that owns THIS processor — instead of a thread-local a
+    /// different router could drain (#3821).
+    failures: RefCell<Vec<BoolFailure>>,
 }
 
 impl CsgSolidProcessor {
@@ -113,7 +120,19 @@ impl CsgSolidProcessor {
     /// Construct with the per-build small-cut skip forwarded to the boolean
     /// processor at the root of the wrapped CSG tree.
     pub fn with_skip_small_cuts(skip_small_cuts: bool) -> Self {
-        Self { skip_small_cuts }
+        Self {
+            skip_small_cuts,
+            failures: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Drain what the transient boolean processors recorded. Public so the
+    /// TRANSIENT `CsgSolidProcessor` that `BooleanClippingProcessor` builds
+    /// for an `IfcCsgSolid` OPERAND — not registered on any router — can hand
+    /// its log back to the boolean processor that built it, the same way
+    /// `drain_clipper_failures` does for a transient `ClippingProcessor`.
+    pub fn take_failures(&self) -> Vec<BoolFailure> {
+        std::mem::take(&mut *self.failures.borrow_mut())
     }
 }
 
@@ -188,17 +207,17 @@ impl CsgSolidProcessor {
         match root.ifc_type {
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
                 // This boolean processor is TRANSIENT — built per tree root and
-                // dropped on return — so it is not in the router's processor
-                // table and `drain_processor_failures` cannot reach it. Hand
-                // its log to the thread-local escape hatch, which
-                // `take_csg_failures` folds in (#3821); otherwise every
-                // diagnostic from a boolean under an `IfcCsgSolid` is lost on
-                // the way out, exactly as the router-registered one was.
+                // dropped on return — so `drain_processor_failures` cannot
+                // reach it directly. Hand its log to THIS processor, which the
+                // router does hold, so the records leave through the router
+                // that produced them (#3821); otherwise every diagnostic from
+                // a boolean under an `IfcCsgSolid` is lost on the way out,
+                // exactly as the router-registered one was.
                 let boolean =
                     BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts);
                 let out =
                     boolean.process_with_depth(&root, decoder, schema, depth, quality, visited);
-                crate::diagnostics::push_pending_mapped_bool_failures(boolean.take_failures());
+                self.failures.borrow_mut().extend(boolean.take_failures());
                 out
             }
             IfcType::IfcBlock => BlockProcessor::new().process(&root, decoder, schema, quality),
@@ -232,6 +251,10 @@ impl GeometryProcessor for CsgSolidProcessor {
 
     fn supported_types(&self) -> Vec<IfcType> {
         vec![IfcType::IfcCsgSolid]
+    }
+
+    fn take_bool_failures(&self) -> Vec<BoolFailure> {
+        self.take_failures()
     }
 }
 

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -130,7 +130,8 @@ impl CsgSolidProcessor {
     /// TRANSIENT `CsgSolidProcessor` that `BooleanClippingProcessor` builds
     /// for an `IfcCsgSolid` OPERAND — not registered on any router — can hand
     /// its log back to the boolean processor that built it, the same way
-    /// `drain_clipper_failures` does for a transient `ClippingProcessor`.
+    /// `BooleanClippingProcessor::absorb_failures` does for a transient
+    /// `ClippingProcessor`.
     pub fn take_failures(&self) -> Vec<BoolFailure> {
         std::mem::take(&mut *self.failures.borrow_mut())
     }

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -6,17 +6,18 @@
 //!
 //! Handles `IfcCsgSolid` (the solid-model wrapper around a CSG tree) and the
 //! `IfcCsgPrimitive3D` subtypes that can sit at the leaves of that tree.
-//! `IfcBlock` and `IfcSphere` are supported as standalone leaves; the rest
+//! `IfcBlock` is here; `IfcSphere` lives in the `sphere` sibling. The rest
 //! (`IfcRectangularPyramid`, `IfcRightCircularCone`, `IfcRightCircularCylinder`)
 //! are not yet implemented.
 
 use super::boolean::OperandPath;
 use crate::extrusion::apply_transform;
-use crate::{scale_segments, Error, Mesh, Result, TessellationQuality, Vector3};
+use crate::{Error, Mesh, Result, TessellationQuality, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Point3;
 
 use super::boolean::BooleanClippingProcessor;
+use super::sphere::SphereProcessor;
 use super::helpers::parse_axis2_placement_3d;
 use crate::router::GeometryProcessor;
 
@@ -186,8 +187,19 @@ impl CsgSolidProcessor {
         // CSG -> Boolean -> CSG cycle it cannot see (#2866).
         match root.ifc_type {
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
-                BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts)
-                    .process_with_depth(&root, decoder, schema, depth, quality, visited)
+                // This boolean processor is TRANSIENT — built per tree root and
+                // dropped on return — so it is not in the router's processor
+                // table and `drain_processor_failures` cannot reach it. Hand
+                // its log to the thread-local escape hatch, which
+                // `take_csg_failures` folds in (#3821); otherwise every
+                // diagnostic from a boolean under an `IfcCsgSolid` is lost on
+                // the way out, exactly as the router-registered one was.
+                let boolean =
+                    BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts);
+                let out =
+                    boolean.process_with_depth(&root, decoder, schema, depth, quality, visited);
+                crate::diagnostics::push_pending_mapped_bool_failures(boolean.take_failures());
+                out
             }
             IfcType::IfcBlock => BlockProcessor::new().process(&root, decoder, schema, quality),
             IfcType::IfcSphere => SphereProcessor::new().process(&root, decoder, schema, quality),
@@ -221,116 +233,6 @@ impl GeometryProcessor for CsgSolidProcessor {
     fn supported_types(&self) -> Vec<IfcType> {
         vec![IfcType::IfcCsgSolid]
     }
-}
-
-/// `IfcSphere` — CSG primitive: a sphere of given radius centred at the
-/// origin of its Position placement.
-///
-/// Attributes (inherits `IfcCsgPrimitive3D` → Position):
-///   0: Position (`IfcAxis2Placement3D`)
-///   1: Radius (`IfcPositiveLengthMeasure`)
-pub struct SphereProcessor;
-
-impl SphereProcessor {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for SphereProcessor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl GeometryProcessor for SphereProcessor {
-    fn process(
-        &self,
-        entity: &DecodedEntity,
-        decoder: &mut EntityDecoder,
-        _schema: &IfcSchema,
-        quality: TessellationQuality,
-    ) -> Result<Mesh> {
-        let radius = entity
-            .get_float(1)
-            .ok_or_else(|| Error::geometry("IfcSphere missing Radius".to_string()))?;
-
-        if !radius.is_finite() || radius <= 0.0 {
-            return Err(Error::geometry(format!(
-                "IfcSphere requires finite positive radius, got {radius}",
-            )));
-        }
-
-        // 24 slices × 16 stacks at Medium; scaled by quality.
-        let slices = scale_segments(24, 8, 96, quality);
-        let stacks = scale_segments(16, 4, 64, quality);
-        let mut mesh = build_uv_sphere(radius, slices, stacks);
-
-        if let Some(pos_attr) = entity.get(0) {
-            if !pos_attr.is_null() {
-                if let Some(pos_entity) = decoder.resolve_ref(pos_attr)? {
-                    if pos_entity.ifc_type == IfcType::IfcAxis2Placement3D {
-                        let transform = parse_axis2_placement_3d(&pos_entity, decoder)?;
-                        apply_transform(&mut mesh, &transform);
-                    }
-                }
-            }
-        }
-
-        Ok(mesh)
-    }
-
-    fn supported_types(&self) -> Vec<IfcType> {
-        vec![IfcType::IfcSphere]
-    }
-}
-
-/// UV-sphere tessellation. `slices` segments around the equator, `stacks`
-/// rings from pole to pole. Pole vertices are duplicated per slice so UV
-/// seams don't share normals — sphere is closed and outward-facing.
-fn build_uv_sphere(radius: f64, slices: usize, stacks: usize) -> Mesh {
-    let slices = slices.max(3);
-    let stacks = stacks.max(2);
-    let vert_count = (stacks + 1) * (slices + 1);
-    let tri_count = stacks * slices * 2;
-    let mut mesh = Mesh::with_capacity(vert_count, tri_count * 3);
-
-    for j in 0..=stacks {
-        let v = j as f64 / stacks as f64;
-        let phi = std::f64::consts::PI * v;
-        let sin_phi = phi.sin();
-        let cos_phi = phi.cos();
-        for i in 0..=slices {
-            let u = i as f64 / slices as f64;
-            let theta = std::f64::consts::TAU * u;
-            let nx = sin_phi * theta.cos();
-            let ny = sin_phi * theta.sin();
-            let nz = cos_phi;
-            mesh.add_vertex(
-                Point3::new(radius * nx, radius * ny, radius * nz),
-                Vector3::new(nx, ny, nz),
-            );
-        }
-    }
-
-    let stride = slices + 1;
-    for j in 0..stacks {
-        for i in 0..slices {
-            let a = (j * stride + i) as u32;
-            let b = a + 1;
-            let c = ((j + 1) * stride + i) as u32;
-            let d = c + 1;
-            // Skip degenerate pole triangles
-            if j != 0 {
-                mesh.add_triangle(a, c, b);
-            }
-            if j + 1 != stacks {
-                mesh.add_triangle(b, c, d);
-            }
-        }
-    }
-
-    mesh
 }
 
 /// Build an axis-aligned box from `(0,0,0)` to `(x, y, z)` with one flat

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -23,6 +23,7 @@ mod alignment;
 mod boolean;
 mod brep;
 mod csg_primitive;
+mod sphere;
 pub(crate) mod extrusion;
 mod extrusion_tapered;
 mod helpers;
@@ -42,7 +43,8 @@ pub use boolean::BooleanClippingProcessor;
 pub use brep::{
     FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, ShellBasedSurfaceModelProcessor,
 };
-pub use csg_primitive::{BlockProcessor, CsgSolidProcessor, SphereProcessor};
+pub use csg_primitive::{BlockProcessor, CsgSolidProcessor};
+pub use sphere::SphereProcessor;
 pub use extrusion::ExtrudedAreaSolidProcessor;
 pub use extrusion_tapered::ExtrudedAreaSolidTaperedProcessor;
 pub use sectioned::SectionedSolidHorizontalProcessor;

--- a/rust/geometry/src/processors/sphere.rs
+++ b/rust/geometry/src/processors/sphere.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `IfcSphere` — the UV-sphere CSG leaf primitive.
+//!
+//! Split out of `csg_primitive.rs` (module-size ratchet) when
+//! `CsgSolidProcessor` gained its boolean-failure hand-off (#3821). Moved
+//! verbatim; nothing here changed.
+
+use super::helpers::parse_axis2_placement_3d;
+use crate::extrusion::apply_transform;
+use crate::router::GeometryProcessor;
+use crate::{scale_segments, Error, Mesh, Result, TessellationQuality, Vector3};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+use nalgebra::Point3;
+
+/// `IfcSphere` — CSG primitive: a sphere of given radius centred at the
+/// origin of its Position placement.
+///
+/// Attributes (inherits `IfcCsgPrimitive3D` → Position):
+///   0: Position (`IfcAxis2Placement3D`)
+///   1: Radius (`IfcPositiveLengthMeasure`)
+pub struct SphereProcessor;
+
+impl SphereProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SphereProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GeometryProcessor for SphereProcessor {
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        _schema: &IfcSchema,
+        quality: TessellationQuality,
+    ) -> Result<Mesh> {
+        let radius = entity
+            .get_float(1)
+            .ok_or_else(|| Error::geometry("IfcSphere missing Radius".to_string()))?;
+
+        if !radius.is_finite() || radius <= 0.0 {
+            return Err(Error::geometry(format!(
+                "IfcSphere requires finite positive radius, got {radius}",
+            )));
+        }
+
+        // 24 slices × 16 stacks at Medium; scaled by quality.
+        let slices = scale_segments(24, 8, 96, quality);
+        let stacks = scale_segments(16, 4, 64, quality);
+        let mut mesh = build_uv_sphere(radius, slices, stacks);
+
+        if let Some(pos_attr) = entity.get(0) {
+            if !pos_attr.is_null() {
+                if let Some(pos_entity) = decoder.resolve_ref(pos_attr)? {
+                    if pos_entity.ifc_type == IfcType::IfcAxis2Placement3D {
+                        let transform = parse_axis2_placement_3d(&pos_entity, decoder)?;
+                        apply_transform(&mut mesh, &transform);
+                    }
+                }
+            }
+        }
+
+        Ok(mesh)
+    }
+
+    fn supported_types(&self) -> Vec<IfcType> {
+        vec![IfcType::IfcSphere]
+    }
+}
+
+/// UV-sphere tessellation. `slices` segments around the equator, `stacks`
+/// rings from pole to pole. Pole vertices are duplicated per slice so UV
+/// seams don't share normals — sphere is closed and outward-facing.
+fn build_uv_sphere(radius: f64, slices: usize, stacks: usize) -> Mesh {
+    let slices = slices.max(3);
+    let stacks = stacks.max(2);
+    let vert_count = (stacks + 1) * (slices + 1);
+    let tri_count = stacks * slices * 2;
+    let mut mesh = Mesh::with_capacity(vert_count, tri_count * 3);
+
+    for j in 0..=stacks {
+        let v = j as f64 / stacks as f64;
+        let phi = std::f64::consts::PI * v;
+        let sin_phi = phi.sin();
+        let cos_phi = phi.cos();
+        for i in 0..=slices {
+            let u = i as f64 / slices as f64;
+            let theta = std::f64::consts::TAU * u;
+            let nx = sin_phi * theta.cos();
+            let ny = sin_phi * theta.sin();
+            let nz = cos_phi;
+            mesh.add_vertex(
+                Point3::new(radius * nx, radius * ny, radius * nz),
+                Vector3::new(nx, ny, nz),
+            );
+        }
+    }
+
+    let stride = slices + 1;
+    for j in 0..stacks {
+        for i in 0..slices {
+            let a = (j * stride + i) as u32;
+            let b = a + 1;
+            let c = ((j + 1) * stride + i) as u32;
+            let d = c + 1;
+            // Skip degenerate pole triangles
+            if j != 0 {
+                mesh.add_triangle(a, c, b);
+            }
+            if j + 1 != stacks {
+                mesh.add_triangle(b, c, d);
+            }
+        }
+    }
+
+    mesh
+}

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -95,20 +95,27 @@ impl OpeningKindDiag {
 }
 
 impl GeometryRouter {
-    /// Drain the boolean / CSG failures accumulated by the void-subtraction
-    /// path since the router was created (or the last `take_csg_failures`
-    /// call). Failures are keyed by IFC product express ID — the element
-    /// whose opening / clip operation tripped a fallback.
+    /// Drain every boolean / CSG failure this router knows about since it was
+    /// created (or the last `take_csg_failures` call). The single drain point:
+    /// the native pipeline and the wasm batch path both call this and nothing
+    /// else.
     ///
-    /// Only the router-driven CSG path (multi-layer wall sub-meshes,
-    /// single-mesh `apply_voids_to_mesh`) is currently attributed. Standalone
-    /// `IfcBooleanResult` chains processed via the mapped-item path don't
-    /// yet flow their failures here.
+    /// Two kinds of record come out, distinguished by their key:
+    ///
+    ///  * Keyed by IFC product express id — the void-subtraction path
+    ///    (multi-layer wall sub-meshes, single-mesh `apply_voids_to_mesh`),
+    ///    which knows the host element whose opening / clip tripped a fallback.
+    ///  * Keyed by [`UNATTRIBUTED_PRODUCT_ID`] — the registered processors'
+    ///    own logs (swept by [`Self::drain_processor_failures`], #3821) and
+    ///    `PENDING_MAPPED_BOOL_FAILURES`. Standalone `IfcBooleanResult` chains
+    ///    DO flow here now; what they still lack is the owning product id.
+    ///    See `drain_processor_failures` for exactly what that costs.
     pub fn take_csg_failures(&self) -> FxHashMap<u32, Vec<BoolFailure>> {
-        // Fold in any failures from a context without a direct router handle
-        // (see `PENDING_MAPPED_BOOL_FAILURES`). They have no product
-        // attribution, so we bucket them under product id 0 — keeps the
-        // diagnostics surface visible without inventing a fake host id.
+        // Sweep the processors' own logs, then fold in any failures from a
+        // context with no direct router handle (`PENDING_MAPPED_BOOL_FAILURES`
+        // — today `CsgSolidProcessor`'s transient boolean processor). Neither
+        // carries a product attribution, so both land in the unattributed
+        // bucket rather than inventing a fake host id.
         self.drain_processor_failures();
         let pending = crate::diagnostics::take_pending_mapped_bool_failures();
         if !pending.is_empty() {

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -140,22 +140,16 @@ impl GeometryRouter {
         std::mem::take(&mut *self.layer_slice_diag.borrow_mut())
     }
 
-    /// Number of products with at least one recorded CSG failure, through the
-    /// same [`count_attributed_products`] rule the pipelines' scalar uses: the
-    /// synthetic [`UNATTRIBUTED_PRODUCT_ID`] bucket is not a product. A bare
-    /// `.len()` here would have made this the one surface that counts it, and
-    /// it is the obvious method to reach for.
-    ///
-    /// PEEKS: unlike [`Self::take_csg_failures`] it does not sweep the
-    /// processors' own logs first, so a record still sitting in a processor is
-    /// not counted yet.
+    /// Products with at least one recorded CSG failure, under the same
+    /// [`count_attributed_products`] rule the pipelines' scalar uses (a bare
+    /// `.len()` would make this the one surface counting the synthetic
+    /// bucket). PEEKS: no processor sweep, unlike `take_csg_failures`.
     pub fn csg_failure_product_count(&self) -> usize {
         count_attributed_products(&self.csg_failures.borrow()) as usize
     }
 
-    /// Total number of CSG failures across all products, INCLUDING the
-    /// unattributed bucket — those are real failures, only their owner is
-    /// unknown. Peeks, like [`Self::csg_failure_product_count`].
+    /// Total CSG failures, INCLUDING the unattributed bucket (real failures,
+    /// unknown owner). Peeks, like [`Self::csg_failure_product_count`].
     pub fn csg_failure_total(&self) -> usize {
         self.csg_failures.borrow().values().map(|v| v.len()).sum()
     }
@@ -292,12 +286,8 @@ impl GeometryRouter {
         entry.csg_failure_count += failures.len();
         if entry.first_failure_label.is_none() {
             // Short label for at-a-glance grouping, from the ONE home shared
-            // with the wasm console + native tracing summaries. A second copy
-            // of this match lived here and had to be extended in lockstep with
-            // every new `BoolFailureReason`; nothing but prose held them
-            // together, so a new variant could silently label differently on
-            // this surface. Full `BoolFailure` list remains in `csg_failures`
-            // for callers that want detail.
+            // with the wasm console + native tracing summaries; a second copy
+            // of this match lived here, held in lockstep by prose alone.
             let label = failures[0].reason.label();
             entry.first_failure_label = Some(label.to_string());
         }

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -109,6 +109,7 @@ impl GeometryRouter {
         // (see `PENDING_MAPPED_BOOL_FAILURES`). They have no product
         // attribution, so we bucket them under product id 0 — keeps the
         // diagnostics surface visible without inventing a fake host id.
+        self.drain_processor_failures();
         let pending = crate::diagnostics::take_pending_mapped_bool_failures();
         if !pending.is_empty() {
             self.csg_failures
@@ -273,37 +274,14 @@ impl GeometryRouter {
         let entry = log.entry(host_id).or_default();
         entry.csg_failure_count += failures.len();
         if entry.first_failure_label.is_none() {
-            // Short label for at-a-glance grouping. Full BoolFailure list
-            // remains in `csg_failures` for callers that want detail.
-            let label = match &failures[0].reason {
-                crate::diagnostics::BoolFailureReason::OperandTooLarge { .. } => "OperandTooLarge",
-                crate::diagnostics::BoolFailureReason::EmptyOperand => "EmptyOperand",
-                crate::diagnostics::BoolFailureReason::DegenerateOperand => "DegenerateOperand",
-                crate::diagnostics::BoolFailureReason::NoBoundsOverlap => "NoBoundsOverlap",
-                crate::diagnostics::BoolFailureReason::KernelOutputInvalid => "KernelOutputInvalid",
-                crate::diagnostics::BoolFailureReason::SolidSolidDifferenceSkipped => {
-                    "SolidSolidDifferenceSkipped"
-                }
-                crate::diagnostics::BoolFailureReason::PolygonalBoundedHalfSpaceFallback => {
-                    "PolygonalBoundedHalfSpaceFallback"
-                }
-                crate::diagnostics::BoolFailureReason::CutterUnionUnavailable => {
-                    "CutterUnionUnavailable"
-                }
-                crate::diagnostics::BoolFailureReason::UnknownBooleanOperator(_) => {
-                    "UnknownBooleanOperator"
-                }
-                crate::diagnostics::BoolFailureReason::ManifoldOutputDegenerate { .. } => {
-                    "ManifoldOutputDegenerate"
-                }
-                crate::diagnostics::BoolFailureReason::KernelError(_) => "KernelError",
-                crate::diagnostics::BoolFailureReason::DifferenceEmptiedHost => {
-                    "DifferenceEmptiedHost"
-                }
-                crate::diagnostics::BoolFailureReason::OpenTopologyRejected => {
-                    "OpenTopologyRejected"
-                }
-            };
+            // Short label for at-a-glance grouping, from the ONE home shared
+            // with the wasm console + native tracing summaries. A second copy
+            // of this match lived here and had to be extended in lockstep with
+            // every new `BoolFailureReason`; nothing but prose held them
+            // together, so a new variant could silently label differently on
+            // this surface. Full `BoolFailure` list remains in `csg_failures`
+            // for callers that want detail.
+            let label = failures[0].reason.label();
             entry.first_failure_label = Some(label.to_string());
         }
     }
@@ -590,6 +568,8 @@ pub fn aggregate_diagnostics(
         oversized_ref_drops,
     }
 }
+
+mod processor_failures;
 
 #[cfg(test)]
 mod diagnostics_contract_tests;

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -114,7 +114,7 @@ impl GeometryRouter {
         if !pending.is_empty() {
             self.csg_failures
                 .borrow_mut()
-                .entry(0)
+                .entry(UNATTRIBUTED_PRODUCT_ID)
                 .or_default()
                 .extend(pending);
         }
@@ -470,6 +470,29 @@ impl GeometryDiagnostics {
     }
 }
 
+/// The `csg_failures` key used for records that belong to no single product:
+/// the boolean processors' own logs (swept once per element by
+/// [`GeometryRouter::drain_processor_failures`]) and
+/// `PENDING_MAPPED_BOOL_FAILURES`. Zero is not a valid IFC express id, so it
+/// cannot collide with a real product.
+pub const UNATTRIBUTED_PRODUCT_ID: u32 = 0;
+
+/// How many REAL products have at least one failure. The synthetic
+/// [`UNATTRIBUTED_PRODUCT_ID`] bucket is excluded: it is not a product, and
+/// counting it would report "1 product failed" for a model where the only
+/// records came from an unattributed sweep. Its records still count towards
+/// the failure TOTALS — they are real failures, only their owner is unknown.
+///
+/// One home, called from `aggregate_diagnostics` and from both pipelines'
+/// legacy scalar (`ProcessingStats.products_with_failures`, the wasm console
+/// summary), so the two cannot drift.
+pub fn count_attributed_products(csg_failures: &FxHashMap<u32, Vec<BoolFailure>>) -> u64 {
+    csg_failures
+        .keys()
+        .filter(|id| **id != UNATTRIBUTED_PRODUCT_ID)
+        .count() as u64
+}
+
 /// Build a [`GeometryDiagnostics`] from drained router data. wasm-free so both
 /// the wasm/viewer path and a future native path can produce the same contract.
 /// The caller owns draining: the router accessors are destructive (`mem::take`),
@@ -483,7 +506,7 @@ pub fn aggregate_diagnostics(
     oversized_ref_drops: u64,
 ) -> GeometryDiagnostics {
     let total_csg_failures = csg_failures.values().map(Vec::len).sum::<usize>() as u64;
-    let products_with_failures = csg_failures.len() as u64;
+    let products_with_failures = count_attributed_products(csg_failures);
     let hosts_with_openings = host_diags.len() as u64;
 
     let classification = ClassificationSummary {

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -140,12 +140,22 @@ impl GeometryRouter {
         std::mem::take(&mut *self.layer_slice_diag.borrow_mut())
     }
 
-    /// Number of products with at least one recorded CSG failure.
+    /// Number of products with at least one recorded CSG failure, through the
+    /// same [`count_attributed_products`] rule the pipelines' scalar uses: the
+    /// synthetic [`UNATTRIBUTED_PRODUCT_ID`] bucket is not a product. A bare
+    /// `.len()` here would have made this the one surface that counts it, and
+    /// it is the obvious method to reach for.
+    ///
+    /// PEEKS: unlike [`Self::take_csg_failures`] it does not sweep the
+    /// processors' own logs first, so a record still sitting in a processor is
+    /// not counted yet.
     pub fn csg_failure_product_count(&self) -> usize {
-        self.csg_failures.borrow().len()
+        count_attributed_products(&self.csg_failures.borrow()) as usize
     }
 
-    /// Total number of CSG failures across all products.
+    /// Total number of CSG failures across all products, INCLUDING the
+    /// unattributed bucket — those are real failures, only their owner is
+    /// unknown. Peeks, like [`Self::csg_failure_product_count`].
     pub fn csg_failure_total(&self) -> usize {
         self.csg_failures.borrow().values().map(|v| v.len()).sum()
     }

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -105,17 +105,17 @@ impl GeometryRouter {
     ///  * Keyed by IFC product express id — the void-subtraction path
     ///    (multi-layer wall sub-meshes, single-mesh `apply_voids_to_mesh`),
     ///    which knows the host element whose opening / clip tripped a fallback.
-    ///  * Keyed by [`UNATTRIBUTED_PRODUCT_ID`] — the registered processors'
-    ///    own logs (swept by [`Self::drain_processor_failures`], #3821) and
-    ///    `PENDING_MAPPED_BOOL_FAILURES`. Standalone `IfcBooleanResult` chains
-    ///    DO flow here now; what they still lack is the owning product id.
-    ///    See `drain_processor_failures` for exactly what that costs.
+    ///  * Keyed by [`UNATTRIBUTED_PRODUCT_ID`] — the registered processors' own
+    ///    logs (swept by [`Self::drain_processor_failures`], #3821, including
+    ///    what the transient boolean under an `IfcCsgSolid` hands back to
+    ///    `CsgSolidProcessor`) and the producer-less hatch. Standalone
+    ///    `IfcBooleanResult` chains DO flow here now; what they still lack is
+    ///    the owning product id. See `drain_processor_failures` for the cost.
     pub fn take_csg_failures(&self) -> FxHashMap<u32, Vec<BoolFailure>> {
         // Sweep the processors' own logs, then fold in any failures from a
-        // context with no direct router handle (`PENDING_MAPPED_BOOL_FAILURES`
-        // — today `CsgSolidProcessor`'s transient boolean processor). Neither
-        // carries a product attribution, so both land in the unattributed
-        // bucket rather than inventing a fake host id.
+        // context with no router handle at all (`PENDING_MAPPED_BOOL_FAILURES`,
+        // which has no producer today). Neither carries a product attribution,
+        // so both land in the unattributed bucket, not a fake host id.
         self.drain_processor_failures();
         let pending = crate::diagnostics::take_pending_mapped_bool_failures();
         if !pending.is_empty() {

--- a/rust/geometry/src/router/diagnostics.rs
+++ b/rust/geometry/src/router/diagnostics.rs
@@ -477,29 +477,6 @@ impl GeometryDiagnostics {
     }
 }
 
-/// The `csg_failures` key used for records that belong to no single product:
-/// the boolean processors' own logs (swept once per element by
-/// [`GeometryRouter::drain_processor_failures`]) and
-/// `PENDING_MAPPED_BOOL_FAILURES`. Zero is not a valid IFC express id, so it
-/// cannot collide with a real product.
-pub const UNATTRIBUTED_PRODUCT_ID: u32 = 0;
-
-/// How many REAL products have at least one failure. The synthetic
-/// [`UNATTRIBUTED_PRODUCT_ID`] bucket is excluded: it is not a product, and
-/// counting it would report "1 product failed" for a model where the only
-/// records came from an unattributed sweep. Its records still count towards
-/// the failure TOTALS — they are real failures, only their owner is unknown.
-///
-/// One home, called from `aggregate_diagnostics` and from both pipelines'
-/// legacy scalar (`ProcessingStats.products_with_failures`, the wasm console
-/// summary), so the two cannot drift.
-pub fn count_attributed_products(csg_failures: &FxHashMap<u32, Vec<BoolFailure>>) -> u64 {
-    csg_failures
-        .keys()
-        .filter(|id| **id != UNATTRIBUTED_PRODUCT_ID)
-        .count() as u64
-}
-
 /// Build a [`GeometryDiagnostics`] from drained router data. wasm-free so both
 /// the wasm/viewer path and a future native path can produce the same contract.
 /// The caller owns draining: the router accessors are destructive (`mem::take`),
@@ -599,7 +576,10 @@ pub fn aggregate_diagnostics(
     }
 }
 
+mod attribution;
 mod processor_failures;
+
+pub use attribution::{count_attributed_products, UNATTRIBUTED_PRODUCT_ID};
 
 #[cfg(test)]
 mod diagnostics_contract_tests;

--- a/rust/geometry/src/router/diagnostics/attribution.rs
+++ b/rust/geometry/src/router/diagnostics/attribution.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashMap;
 
 /// The `csg_failures` key used for records that belong to no single product:
 /// the boolean processors' own logs (swept once per element by
-/// [`GeometryRouter::drain_processor_failures`]) and
+/// [`crate::GeometryRouter::drain_processor_failures`]) and
 /// `PENDING_MAPPED_BOOL_FAILURES`. Zero is not a valid IFC express id, so it
 /// cannot collide with a real product.
 pub const UNATTRIBUTED_PRODUCT_ID: u32 = 0;

--- a/rust/geometry/src/router/diagnostics/attribution.rs
+++ b/rust/geometry/src/router/diagnostics/attribution.rs
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Who a CSG failure belongs to: the synthetic bucket for records with no
+//! owner, and the one place that decides what counts as a failing PRODUCT.
+//!
+//! Split out of `router/diagnostics.rs` (module-size ratchet, #3821).
+
+use crate::BoolFailure;
+use rustc_hash::FxHashMap;
+
+/// The `csg_failures` key used for records that belong to no single product:
+/// the boolean processors' own logs (swept once per element by
+/// [`GeometryRouter::drain_processor_failures`]) and
+/// `PENDING_MAPPED_BOOL_FAILURES`. Zero is not a valid IFC express id, so it
+/// cannot collide with a real product.
+pub const UNATTRIBUTED_PRODUCT_ID: u32 = 0;
+
+/// How many REAL products have at least one failure. The synthetic
+/// [`UNATTRIBUTED_PRODUCT_ID`] bucket is excluded: it is not a product, and
+/// counting it would report "1 product failed" for a model where the only
+/// records came from an unattributed sweep. Its records still count towards
+/// the failure TOTALS — they are real failures, only their owner is unknown.
+///
+/// One home, called from `aggregate_diagnostics` and from both pipelines'
+/// legacy scalar (`ProcessingStats.products_with_failures`, the wasm console
+/// summary), so the two cannot drift.
+pub fn count_attributed_products(csg_failures: &FxHashMap<u32, Vec<BoolFailure>>) -> u64 {
+    csg_failures
+        .keys()
+        .filter(|id| **id != UNATTRIBUTED_PRODUCT_ID)
+        .count() as u64
+}

--- a/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
+++ b/rust/geometry/src/router/diagnostics/diagnostics_contract_tests.rs
@@ -287,3 +287,65 @@ fn worst_host_optional_fields_are_omitted_when_none_and_present_when_some() {
     let back: WorstHost = serde_json::from_value(legacy).unwrap();
     assert!(back.bbox.is_none() && back.triangle_count.is_none());
 }
+
+#[test]
+fn the_unattributed_bucket_counts_in_the_totals_but_is_not_a_product() {
+    // One real host plus one record swept in with no owner (a boolean
+    // processor's own log, or PENDING_MAPPED_BOOL_FAILURES). Id 0 is not a
+    // valid express id, so reporting it as a product would tell the user
+    // "2 products failed" for a model where one product failed and one failure
+    // has an unknown owner.
+    let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
+    csg.insert(
+        42,
+        vec![BoolFailure::new(BoolOp::Difference, BoolFailureReason::DifferenceEmptiedHost)],
+    );
+    csg.insert(
+        UNATTRIBUTED_PRODUCT_ID,
+        vec![BoolFailure::new(
+            BoolOp::Unknown,
+            BoolFailureReason::UnsupportedOperand("IfcSectionedSpine".to_string()),
+        )],
+    );
+
+    let d = aggregate_diagnostics(
+        ClassificationStats::default(),
+        &csg,
+        &FxHashMap::default(),
+        RectFastStats::default(),
+        16,
+        0,
+    );
+
+    assert_eq!(d.products_with_failures, 1, "the synthetic bucket is not a product");
+    assert_eq!(d.total_csg_failures, 2, "but its records still count as failures");
+    let reasons: Vec<&str> = d.failures_by_reason.iter().map(|r| r.reason.as_str()).collect();
+    assert!(
+        reasons.contains(&"UnsupportedOperand"),
+        "and still appear in the reason breakdown: {reasons:?}"
+    );
+}
+
+#[test]
+fn an_unattributed_only_pass_reports_zero_products_and_still_has_issues() {
+    // The boundary the count must not round the wrong way: failures exist, no
+    // product owns them. `has_issues` must still fire, or the pass would look
+    // clean to every caller that gates on it.
+    let mut csg: FxHashMap<u32, Vec<BoolFailure>> = FxHashMap::default();
+    csg.insert(
+        UNATTRIBUTED_PRODUCT_ID,
+        vec![BoolFailure::new(BoolOp::Union, BoolFailureReason::EmptyOperand)],
+    );
+    let d = aggregate_diagnostics(
+        ClassificationStats::default(),
+        &csg,
+        &FxHashMap::default(),
+        RectFastStats::default(),
+        16,
+        0,
+    );
+    assert_eq!(d.products_with_failures, 0);
+    assert_eq!(d.total_csg_failures, 1);
+    assert!(d.has_issues(), "an unowned failure is still a failure");
+    assert!(!d.is_empty(), "and must not be skipped as an empty diagnostic");
+}

--- a/rust/geometry/src/router/diagnostics/processor_failures.rs
+++ b/rust/geometry/src/router/diagnostics/processor_failures.rs
@@ -7,6 +7,7 @@
 //! `take_csg_failures` is the single drain point every pipeline already calls.
 
 use super::super::GeometryRouter;
+use super::UNATTRIBUTED_PRODUCT_ID;
 use crate::BoolFailure;
 
 impl GeometryRouter {
@@ -23,17 +24,23 @@ impl GeometryRouter {
     /// degraded still reported a clean load: absence was indistinguishable from
     /// success.
     ///
-    /// Bucketed under product id 0 — the same "no attribution available"
-    /// bucket `take_csg_failures` already uses for
+    /// Bucketed under [`UNATTRIBUTED_PRODUCT_ID`] — the same "no attribution
+    /// available" bucket `take_csg_failures` already uses for
     /// `PENDING_MAPPED_BOOL_FAILURES`. A processor is registered once per
     /// router and reused across every item it meshes, so at drain time its log
-    /// is not attributable to one product from in here. The native and wasm
-    /// pipelines both drain PER ELEMENT (`produce_element_meshes` takes the
-    /// router's failures after each job), so the records are still scoped to
-    /// the right element in the aggregate — only the per-product `worst_hosts`
-    /// detail is unavailable for them. Per-item attribution would mean
-    /// threading the owning product id down to every `processor.process` call
-    /// site; that is a follow-up, not a reason to keep dropping the records.
+    /// is not attributable to one product from in here.
+    ///
+    /// What that bucket does and does NOT preserve, precisely: the native and
+    /// wasm pipelines both drain PER ELEMENT (`produce_element_meshes` takes
+    /// the router's failures after each job), so a record can never be
+    /// mis-attributed to a DIFFERENT element — it is attributed to none. The
+    /// element it came from is lost, so these records do not appear in the
+    /// per-product `worst_hosts` detail and are excluded from
+    /// `products_with_failures` (see [`super::count_attributed_products`]);
+    /// they do count towards the failure totals and the reason breakdown.
+    /// Real per-product attribution would mean threading the owning product id
+    /// down to every `processor.process` call site; that is a follow-up, not a
+    /// reason to keep dropping the records.
     ///
     /// `register` stores ONE `Arc` per processor under each supported IFC type
     /// (`IfcBooleanResult` and `IfcBooleanClippingResult` share an instance),
@@ -45,7 +52,11 @@ impl GeometryRouter {
             swept.extend(processor.take_bool_failures());
         }
         if !swept.is_empty() {
-            self.csg_failures.borrow_mut().entry(0).or_default().extend(swept);
+            self.csg_failures
+                .borrow_mut()
+                .entry(UNATTRIBUTED_PRODUCT_ID)
+                .or_default()
+                .extend(swept);
         }
     }
 }

--- a/rust/geometry/src/router/diagnostics/processor_failures.rs
+++ b/rust/geometry/src/router/diagnostics/processor_failures.rs
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Split out of `router/diagnostics.rs` (module-size ratchet): the sweep that
+//! moves a processor's OWN boolean-failure log into the router's map, so
+//! `take_csg_failures` is the single drain point every pipeline already calls.
+
+use super::super::GeometryRouter;
+use crate::BoolFailure;
+
+impl GeometryRouter {
+    /// Sweep every registered processor's own boolean-failure log into this
+    /// router's map. Called by [`Self::take_csg_failures`], so a consumer that
+    /// already drains the router — the native pipeline via
+    /// `produce_element_meshes`, the wasm batch path via
+    /// `drain_and_log_csg_diagnostics` — picks these up with no second opt-in.
+    ///
+    /// Before #3821 `BooleanClippingProcessor::take_failures` was called from
+    /// tests ONLY. Everything the boolean processor recorded (an unsupported
+    /// operand, an `EmptyOperand` cutter, an unknown operator) accumulated in a
+    /// `RefCell` no production caller ever read, so a model whose booleans all
+    /// degraded still reported a clean load: absence was indistinguishable from
+    /// success.
+    ///
+    /// Bucketed under product id 0 — the same "no attribution available"
+    /// bucket `take_csg_failures` already uses for
+    /// `PENDING_MAPPED_BOOL_FAILURES`. A processor is registered once per
+    /// router and reused across every item it meshes, so at drain time its log
+    /// is not attributable to one product from in here. The native and wasm
+    /// pipelines both drain PER ELEMENT (`produce_element_meshes` takes the
+    /// router's failures after each job), so the records are still scoped to
+    /// the right element in the aggregate — only the per-product `worst_hosts`
+    /// detail is unavailable for them. Per-item attribution would mean
+    /// threading the owning product id down to every `processor.process` call
+    /// site; that is a follow-up, not a reason to keep dropping the records.
+    ///
+    /// `register` stores ONE `Arc` per processor under each supported IFC type
+    /// (`IfcBooleanResult` and `IfcBooleanClippingResult` share an instance),
+    /// so iterating the map visits the same processor twice; the second visit
+    /// drains an already-emptied log and contributes nothing. No double count.
+    pub fn drain_processor_failures(&self) {
+        let mut swept: Vec<BoolFailure> = Vec::new();
+        for processor in self.processors.values() {
+            swept.extend(processor.take_bool_failures());
+        }
+        if !swept.is_empty() {
+            self.csg_failures.borrow_mut().entry(0).or_default().extend(swept);
+        }
+    }
+}

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -23,11 +23,9 @@ pub use processor::GeometryProcessor;
 pub use transforms::local_frame_set_enabled_override;
 pub use voids::{take_bool2d_stats, take_prism_defers, take_prism_stats, RectParam};
 pub use diagnostics::{
-    GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,
-    aggregate_diagnostics, count_attributed_products, ClassificationStats,
-    ClassificationSummary, GeometryDiagnostics,
-    HostOpeningDiagnostic, OpeningDiagnostic, OpeningKindDiag, ReasonCount, RectFastSummary,
-    WorstHost, UNATTRIBUTED_PRODUCT_ID,
+    aggregate_diagnostics, count_attributed_products, ClassificationStats, ClassificationSummary,
+    GeometryDiagnostics, HostOpeningDiagnostic, OpeningDiagnostic, OpeningKindDiag, ReasonCount,
+    RectFastSummary, WorstHost, GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION, UNATTRIBUTED_PRODUCT_ID,
 };
 pub(crate) use diagnostics::ClassificationKind;
 pub(super) use rep_filter::{effective_rep_type, is_body_representation, is_direct_body_representation};
@@ -617,7 +615,11 @@ impl GeometryRouter {
     /// so they pick up the current value. Called at construction and whenever
     /// [`Self::set_skip_small_cuts`] flips the flag; `register` overwrites the
     /// existing map entries keyed by IFC type.
+    /// The processors this replaces are DROPPED, and a dropped processor takes
+    /// its failure log with it. Sweep first, so flipping the flag mid-pass can
+    /// never discard records the pipeline had not drained yet (#3821).
     fn register_skip_dependent_processors(&mut self) {
+        self.drain_processor_failures();
         self.register(Box::new(BooleanClippingProcessor::with_skip_small_cuts(
             self.skip_small_cuts,
         )));

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -13,11 +13,13 @@ mod diagnostics;
 mod instancing;
 mod layers;
 mod processing;
+mod processor;
 mod rtc_offset;
 mod textured;
 pub(crate) mod transforms;
 pub(crate) mod voids;
 
+pub use processor::GeometryProcessor;
 pub use transforms::local_frame_set_enabled_override;
 pub use voids::{take_bool2d_stats, take_prism_defers, take_prism_stats, RectParam};
 pub use diagnostics::{
@@ -50,28 +52,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-
-/// Geometry processor trait
-/// Each processor handles one type of IFC representation
-pub trait GeometryProcessor {
-    /// Process entity into mesh.
-    ///
-    /// `quality` selects tessellation detail; processors that approximate
-    /// curves derive their segment counts from it via
-    /// [`crate::tessellation::scale_segments`]. Processors with no curved
-    /// geometry ignore it. [`TessellationQuality::Medium`] reproduces the
-    /// engine's historical hardcoded behavior.
-    fn process(
-        &self,
-        entity: &DecodedEntity,
-        decoder: &mut EntityDecoder,
-        schema: &IfcSchema,
-        quality: TessellationQuality,
-    ) -> Result<Mesh>;
-
-    /// Get supported IFC types
-    fn supported_types(&self) -> Vec<IfcType>;
-}
 
 /// Shared content-dedup cache: maps a 128-bit structural item hash to the
 /// LOCAL (pre-placement, void-free, colour-free) item mesh PLUS its precomputed

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -24,9 +24,10 @@ pub use transforms::local_frame_set_enabled_override;
 pub use voids::{take_bool2d_stats, take_prism_defers, take_prism_stats, RectParam};
 pub use diagnostics::{
     GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION,
-    aggregate_diagnostics, ClassificationStats, ClassificationSummary, GeometryDiagnostics,
+    aggregate_diagnostics, count_attributed_products, ClassificationStats,
+    ClassificationSummary, GeometryDiagnostics,
     HostOpeningDiagnostic, OpeningDiagnostic, OpeningKindDiag, ReasonCount, RectFastSummary,
-    WorstHost,
+    WorstHost, UNATTRIBUTED_PRODUCT_ID,
 };
 pub(crate) use diagnostics::ClassificationKind;
 pub(super) use rep_filter::{effective_rep_type, is_body_representation, is_direct_body_representation};

--- a/rust/geometry/src/router/processor.rs
+++ b/rust/geometry/src/router/processor.rs
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The [`GeometryProcessor`] trait: one IFC representation-item family in,
+//! one mesh out, plus the diagnostics a processor accumulated while doing it.
+//!
+//! Split out of `router/mod.rs` so the drain hook below has room to carry its
+//! own rationale (module-size ratchet).
+
+use crate::tessellation::TessellationQuality;
+use crate::{BoolFailure, Mesh, Result};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+
+/// Geometry processor trait
+/// Each processor handles one type of IFC representation
+pub trait GeometryProcessor {
+    /// Process entity into mesh.
+    ///
+    /// `quality` selects tessellation detail; processors that approximate
+    /// curves derive their segment counts from it via
+    /// [`crate::tessellation::scale_segments`]. Processors with no curved
+    /// geometry ignore it. [`TessellationQuality::Medium`] reproduces the
+    /// engine's historical hardcoded behavior.
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        schema: &IfcSchema,
+        quality: TessellationQuality,
+    ) -> Result<Mesh>;
+
+    /// Get supported IFC types
+    fn supported_types(&self) -> Vec<IfcType>;
+
+    /// Drain the boolean / CSG failures this processor recorded while meshing.
+    ///
+    /// Default: none — most processors record nothing. Overridden by
+    /// [`crate::processors::BooleanClippingProcessor`], whose failure log had
+    /// no route out of the router at all before #3821: `take_failures` was
+    /// called from tests only, so an unsupported operand, an
+    /// `EmptyOperand` cutter and an unknown operator were recorded into a
+    /// buffer that nothing ever read, and the pipeline reported a clean load.
+    ///
+    /// Drained by `GeometryRouter::drain_processor_failures`, which
+    /// `take_csg_failures` calls, so every consumer of the router's CSG
+    /// diagnostics — the native pipeline and the wasm batch path alike — sees
+    /// these without a second opt-in.
+    fn take_bool_failures(&self) -> Vec<BoolFailure> {
+        Vec::new()
+    }
+}

--- a/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
+++ b/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
@@ -1,0 +1,212 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3821: the auxiliary `GeometryRouter`s are never drained for boolean
+//! failures, and this is the executable reason why.
+//!
+//! Seven production sites build a router and never call `take_csg_failures`:
+//! `processing::processor` (preprocess), `processing::stream_meta`,
+//! `processing::symbolic`, `export::model`, and the wasm `grid_lines`,
+//! `alignment_lines` and gpu-mesh `prepass`. Each uses the router only for unit
+//! scale, RTC-offset detection, placement resolution or routing-key hashing —
+//! never for meshing — so none of them can record a `BoolFailure` and draining
+//! them would always yield an empty list.
+//!
+//! That claim was seven prose comments. Prose does not fail when it stops being
+//! true, so this file replaces it: for each site, run the SAME router methods
+//! that site runs, over a model whose geometry is a boolean the processor is
+//! guaranteed to record a failure for, and assert the router drains nothing.
+//! Route a boolean through any of these methods and the matching case goes red.
+//!
+//! What this does NOT catch, stated so no one mistakes its reach: it pins the
+//! METHODS each site calls today, not the call site itself. Adding a NEW,
+//! meshing call at one of those sites is invisible here — the one-line pointer
+//! left at each site is what should send that author back to this file.
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+use ifc_lite_geometry::{GeometryRouter, MaterialLayerIndex, TessellationQuality};
+use std::sync::Arc;
+
+/// A wall whose Body item is an `IfcBooleanResult` over an operand type with no
+/// meshing branch, wrapped in an `IfcCsgSolid` for the second element. Meshing
+/// either one records `UnsupportedOperand`, so any router method that started
+/// meshing representation items would show up as a non-empty drain.
+const BOOLEAN_MODEL: &str = r"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 auxiliary-router probe'),'2;1');
+FILE_NAME('aux.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1AuxProbeBooleanWall',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#30));
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#31,#33);
+#31=IFCSECTIONEDSPINE(#32,(#34),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,1.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.0,0.2);
+#35=IFCDIRECTION((0.,0.,1.));
+#40=IFCSLAB('1AuxProbeCsgSolidSl',$,'Slab',$,$,#41,#42,$,$);
+#41=IFCLOCALPLACEMENT($,#5);
+#42=IFCPRODUCTDEFINITIONSHAPE($,$,(#43));
+#43=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#44));
+#44=IFCCSGSOLID(#45);
+#45=IFCBOOLEANRESULT(.DIFFERENCE.,#31,#33);
+ENDSEC;
+END-ISO-10303-21;
+";
+
+const ELEMENT_IDS: [u32; 2] = [10, 40];
+
+fn decoder() -> EntityDecoder<'static> {
+    let bytes = BOOLEAN_MODEL.as_bytes();
+    EntityDecoder::with_index(bytes, ifc_lite_core::build_entity_index(bytes))
+}
+
+fn jobs(decoder: &mut EntityDecoder) -> Vec<(u32, usize, usize, IfcType)> {
+    let mut scanner = ifc_lite_core::EntityScanner::new(BOOLEAN_MODEL.as_bytes());
+    let mut out = Vec::new();
+    while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        let ty = ifc_lite_core::legacy_aware_ifc_type(type_name);
+        if ty.is_subtype_of(IfcType::IfcProduct) {
+            out.push((id, start, end, ty));
+        }
+    }
+    let _ = decoder;
+    out
+}
+
+/// Everything drained after `body` ran, as stable reason labels.
+fn drained(router: &GeometryRouter) -> Vec<String> {
+    // The thread-local escape hatch is folded in by `take_csg_failures`, so a
+    // leak through `CsgSolidProcessor`'s transient processor is caught too.
+    router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .map(|f| f.reason.label().to_string())
+        .collect()
+}
+
+/// The probe's own calibration: the SAME model, meshed, must record something.
+/// Without this, every assertion below would pass just as happily against a
+/// model that has no failures to find — the emptiness would prove nothing.
+#[test]
+fn the_probe_model_really_does_record_a_failure_when_meshed() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_units(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let _ = router.process_element(&element, &mut dec);
+    }
+    let labels = drained(&router);
+    assert!(
+        labels.iter().any(|l| l == "UnsupportedOperand"),
+        "the probe model must produce a recordable failure when actually meshed, \
+         or the empty drains below prove nothing; got {labels:?}"
+    );
+}
+
+/// `rust/processing/src/processor/mod.rs` — the preprocess router: tessellation
+/// quality, material-layer index, site/building placements, RTC detection.
+#[test]
+fn the_preprocess_router_meshes_nothing() {
+    let mut dec = decoder();
+    let mut router = GeometryRouter::with_scale(1.0);
+    router.set_tessellation_quality(TessellationQuality::Medium);
+    router.set_material_layer_index(Arc::new(MaterialLayerIndex::from_spans(&[], &mut dec)));
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let _ = router.resolve_scaled_placement(&element, &mut dec);
+    }
+    let js = jobs(&mut dec);
+    let rtc = router.detect_rtc_offset_with_fallback(&js, &mut dec, BOOLEAN_MODEL.as_bytes());
+    router.set_rtc_offset(rtc);
+    let _ = router.unit_scale();
+    let _ = router.rtc_offset();
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/processing/src/stream_meta.rs` — RTC ladder plus the building-rotation
+/// placement read.
+#[test]
+fn the_stream_meta_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_scale(1.0);
+    let js = jobs(&mut dec);
+    let _ = router.detect_rtc_offset_from_jobs(&js, &mut dec);
+    let _ = router.detect_rtc_offset_with_fallback(&js, &mut dec, BOOLEAN_MODEL.as_bytes());
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let _ = router.resolve_scaled_placement(&element, &mut dec);
+    }
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/processing/src/symbolic/mod.rs` — unit scale and RTC only.
+#[test]
+fn the_symbolic_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_units(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    let _ = router.unit_scale();
+    let _ = router.detect_rtc_offset_from_first_element(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/wasm-bindings/src/api/alignment_lines.rs` — RTC only.
+#[test]
+fn the_alignment_lines_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_scale(1.0);
+    let _ = router.detect_rtc_offset_from_first_element(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/wasm-bindings/src/api/grid_lines.rs` — unit scale, RTC, grid placements.
+#[test]
+fn the_grid_lines_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_units(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    let _ = router.unit_scale();
+    let _ = router.detect_rtc_offset_from_first_element(BOOLEAN_MODEL.as_bytes(), &mut dec);
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let _ = router.resolve_scaled_placement(&element, &mut dec);
+    }
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/wasm-bindings/src/api/gpu_meshes/prepass.rs` — the affinity-key router,
+/// which hashes a representation's structure and meshes none of it.
+#[test]
+fn the_prepass_affinity_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::new();
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let key = router.geometry_routing_key(&element, &mut dec);
+        assert!(key.is_some(), "the probe elements must hash, or this proves nothing");
+    }
+    assert_eq!(drained(&router), Vec::<String>::new());
+}
+
+/// `rust/export/src/model.rs` — placement resolution only.
+#[test]
+fn the_export_model_router_meshes_nothing() {
+    let mut dec = decoder();
+    let router = GeometryRouter::with_scale(1.0);
+    for id in ELEMENT_IDS {
+        let element = dec.decode_by_id(id).expect("decode element");
+        let _ = router.resolve_scaled_placement(&element, &mut dec);
+    }
+    assert_eq!(drained(&router), Vec::<String>::new());
+}

--- a/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
+++ b/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
@@ -72,7 +72,7 @@ fn decoder() -> EntityDecoder<'static> {
     EntityDecoder::with_index(bytes, ifc_lite_core::build_entity_index(bytes))
 }
 
-fn jobs(decoder: &mut EntityDecoder) -> Vec<(u32, usize, usize, IfcType)> {
+fn jobs() -> Vec<(u32, usize, usize, IfcType)> {
     let mut scanner = ifc_lite_core::EntityScanner::new(BOOLEAN_MODEL.as_bytes());
     let mut out = Vec::new();
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
@@ -81,11 +81,10 @@ fn jobs(decoder: &mut EntityDecoder) -> Vec<(u32, usize, usize, IfcType)> {
             out.push((id, start, end, ty));
         }
     }
-    let _ = decoder;
     out
 }
 
-/// Everything drained after `body` ran, as stable reason labels.
+/// Everything the router has to hand out, as stable reason labels.
 fn drained(router: &GeometryRouter) -> Vec<String> {
     // `take_csg_failures` also sweeps the processors' own logs, so a failure
     // from `CsgSolidProcessor`'s transient boolean processor is caught too.
@@ -128,7 +127,7 @@ fn the_preprocess_router_meshes_nothing() {
         let element = dec.decode_by_id(id).expect("decode element");
         let _ = router.resolve_scaled_placement(&element, &mut dec);
     }
-    let js = jobs(&mut dec);
+    let js = jobs();
     let rtc = router.detect_rtc_offset_with_fallback(&js, &mut dec, BOOLEAN_MODEL.as_bytes());
     router.set_rtc_offset(rtc);
     let _ = router.unit_scale();
@@ -142,7 +141,7 @@ fn the_preprocess_router_meshes_nothing() {
 fn the_stream_meta_router_meshes_nothing() {
     let mut dec = decoder();
     let router = GeometryRouter::with_scale(1.0);
-    let js = jobs(&mut dec);
+    let js = jobs();
     let _ = router.detect_rtc_offset_from_jobs(&js, &mut dec);
     let _ = router.detect_rtc_offset_with_fallback(&js, &mut dec, BOOLEAN_MODEL.as_bytes());
     for id in ELEMENT_IDS {

--- a/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
+++ b/rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs
@@ -87,8 +87,8 @@ fn jobs(decoder: &mut EntityDecoder) -> Vec<(u32, usize, usize, IfcType)> {
 
 /// Everything drained after `body` ran, as stable reason labels.
 fn drained(router: &GeometryRouter) -> Vec<String> {
-    // The thread-local escape hatch is folded in by `take_csg_failures`, so a
-    // leak through `CsgSolidProcessor`'s transient processor is caught too.
+    // `take_csg_failures` also sweeps the processors' own logs, so a failure
+    // from `CsgSolidProcessor`'s transient boolean processor is caught too.
     router
         .take_csg_failures()
         .values()

--- a/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
+++ b/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
@@ -20,6 +20,17 @@ fn router_for(content: &'static str) -> (GeometryRouter, EntityDecoder<'static>)
     (router, decoder)
 }
 
+fn all_reason_labels(router: &GeometryRouter) -> Vec<String> {
+    let mut out: Vec<String> = router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .map(|f| f.reason.label().to_string())
+        .collect();
+    out.sort();
+    out
+}
+
 fn unsupported_operand_types(router: &GeometryRouter) -> Vec<String> {
     let mut out: Vec<String> = router
         .take_csg_failures()
@@ -182,5 +193,103 @@ fn draining_twice_does_not_double_count() {
     assert!(
         router.take_csg_failures().is_empty(),
         "the drain is destructive: a second take must return nothing"
+    );
+}
+
+/// The same unsupported type as the SECOND operand (an unsupported cutter).
+/// The host renders un-cut, which is correct; what must not happen is TWO
+/// records for one dropped step. Before the one-record rule, the arm recorded
+/// `UnsupportedOperand` and the caller then recorded `EmptyOperand` on top of
+/// it, inflating `total_csg_failures` and — because the reason breakdown breaks
+/// count ties alphabetically — making the viewer name `EmptyOperand`, the
+/// consequence, as the top failure reason instead of the cause.
+const UNSUPPORTED_SECOND_OPERAND: &str = r"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 unsupported cutter'),'2;1');
+FILE_NAME('g.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1UnsupportedCutter01',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#30));
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#33,#31);
+#31=IFCSECTIONEDSPINE(#32,(#34),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,3.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#35=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+";
+
+/// A cutter of a SUPPORTED type that meshes to nothing. The control for the
+/// one-record rule: suppressing the `EmptyOperand` consequence of an
+/// UNSUPPORTED operand must not suppress `EmptyOperand` where it is the only
+/// thing anyone recorded.
+const EMPTY_SUPPORTED_CUTTER: &str = r"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 empty supported cutter'),'2;1');
+FILE_NAME('h.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1EmptySupportedCut01',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#30));
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#33,#36);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,3.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#35=IFCDIRECTION((0.,0.,1.));
+#36=IFCEXTRUDEDAREASOLID(#37,#5,#35,1.0);
+#37=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#38);
+#38=IFCPOLYLINE(());
+ENDSEC;
+END-ISO-10303-21;
+";
+
+#[test]
+fn an_unsupported_cutter_yields_exactly_one_record_naming_the_cause() {
+    let (router, mut decoder) = router_for(UNSUPPORTED_SECOND_OPERAND);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let mesh = router
+        .process_element(&element, &mut decoder)
+        .expect("an unsupported cutter must not error the element");
+
+    // The host still renders, un-cut — the correct recovery, and the reason the
+    // operand arm must not return `Err`.
+    assert!(!mesh.is_empty(), "the host must survive an unsupported cutter");
+
+    assert_eq!(
+        all_reason_labels(&router),
+        vec!["UnsupportedOperand".to_string()],
+        "one dropped step must produce ONE record, naming the cause and not the \
+         EmptyOperand consequence"
+    );
+}
+
+#[test]
+fn a_genuinely_empty_cutter_still_records_emptyoperand() {
+    let (router, mut decoder) = router_for(EMPTY_SUPPORTED_CUTTER);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+    assert_eq!(
+        all_reason_labels(&router),
+        vec!["EmptyOperand".to_string()],
+        "an empty cutter of a SUPPORTED type must still record EmptyOperand"
     );
 }

--- a/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
+++ b/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
@@ -293,3 +293,23 @@ fn a_genuinely_empty_cutter_still_records_emptyoperand() {
         "an empty cutter of a SUPPORTED type must still record EmptyOperand"
     );
 }
+
+#[test]
+fn flipping_skip_small_cuts_does_not_discard_an_undrained_log() {
+    // `set_skip_small_cuts` re-registers the boolean and CSG processors, which
+    // DROPS the old ones — and a dropped processor takes its failure log with
+    // it. The viewer flips this flag on a live router, so a record made before
+    // the flip and drained after it must survive.
+    let (mut router, mut decoder) = router_for(UNSUPPORTED_BASE_OPERAND);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+
+    // Deliberately NOT drained first: that is the whole hazard.
+    router.set_skip_small_cuts(true);
+
+    assert_eq!(
+        unsupported_operand_types(&router),
+        vec!["IfcSectionedSpine".to_string()],
+        "a record made before the flag flipped must survive the re-registration"
+    );
+}

--- a/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
+++ b/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
@@ -11,7 +11,7 @@
 //! which is what made the gap invisible for so long.
 
 use ifc_lite_core::EntityDecoder;
-use ifc_lite_geometry::{BoolFailureReason, GeometryRouter};
+use ifc_lite_geometry::{BoolFailureReason, BoolOp, GeometryRouter};
 
 fn router_for(content: &'static str) -> (GeometryRouter, EntityDecoder<'static>) {
     let entity_index = ifc_lite_core::build_entity_index(content.as_bytes());
@@ -78,7 +78,8 @@ END-ISO-10303-21;
 /// The same unsupported operand, one level deeper: the Body item is an
 /// `IfcCsgSolid` whose `TreeRootExpression` is the boolean. That boolean runs
 /// on a TRANSIENT processor `CsgSolidProcessor` builds and drops, so it is not
-/// in the router's processor table and needs the thread-local hand-off.
+/// in the router's processor table and has to hand its log back to the
+/// `CsgSolidProcessor` that built it.
 const UNSUPPORTED_BASE_OPERAND_UNDER_CSGSOLID: &str = r#"ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION(('3821 csgsolid boolean'),'2;1');
@@ -311,5 +312,59 @@ fn flipping_skip_small_cuts_does_not_discard_an_undrained_log() {
         unsupported_operand_types(&router),
         vec!["IfcSectionedSpine".to_string()],
         "a record made before the flag flipped must survive the re-registration"
+    );
+}
+
+/// An unsupported SECOND operand is the only record for its step (the
+/// `EmptyOperand` consequence is suppressed by the one-record rule above), so
+/// the operation it names is the only operation a consumer of
+/// `take_csg_failures` or of `BoolFailure`'s `Display` ever sees for that step.
+/// Recording `Unknown` there renders "UNKNOWN failed: ..." for a boolean the
+/// file authored as `.DIFFERENCE.`.
+#[test]
+fn an_unsupported_cutter_names_the_containing_operation() {
+    let (router, mut decoder) = router_for(UNSUPPORTED_SECOND_OPERAND);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+
+    let ops: Vec<BoolOp> = router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .map(|f| f.op)
+        .collect();
+    assert_eq!(
+        ops,
+        vec![BoolOp::Difference],
+        "the record must name the authored .DIFFERENCE., not UNKNOWN"
+    );
+}
+
+/// Two routers, one thread. A boolean under an `IfcCsgSolid` runs on a
+/// transient processor; if its log escapes through a thread-local rather than
+/// through the router that owns the CSG processor, a router that never drains
+/// hands its records to whichever router drains next — diagnostics for the
+/// wrong model. The public router API permits exactly this order, so nothing
+/// but scoping prevents it.
+#[test]
+fn an_undrained_router_does_not_leak_into_the_next_one() {
+    let (leaky, mut leaky_decoder) = router_for(UNSUPPORTED_BASE_OPERAND_UNDER_CSGSOLID);
+    let element = leaky_decoder.decode_by_id(10).expect("decode the wall");
+    let _ = leaky.process_element(&element, &mut leaky_decoder);
+    // Deliberately NOT drained: draining is optional in the public API.
+
+    let (clean, mut clean_decoder) = router_for(CLEAN);
+    let clean_element = clean_decoder.decode_by_id(10).expect("decode the wall");
+    let _ = clean.process_element(&clean_element, &mut clean_decoder);
+    assert!(
+        clean.take_csg_failures().is_empty(),
+        "a second router on the same thread must not inherit the first router's records"
+    );
+
+    // And the records are not merely lost: the router that made them still has them.
+    assert_eq!(
+        unsupported_operand_types(&leaky),
+        vec!["IfcSectionedSpine".to_string()],
+        "the owning router must still be able to drain its own records"
     );
 }

--- a/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
+++ b/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
@@ -1,0 +1,186 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3821: the router drains its processors' own boolean-failure logs.
+//!
+//! `BooleanClippingProcessor::take_failures` had no caller outside tests, so
+//! everything it recorded sat in a `RefCell` the pipeline never read. These
+//! tests exercise the route the pipeline actually uses — build a router, mesh
+//! an element, drain the router — rather than calling `take_failures` directly,
+//! which is what made the gap invisible for so long.
+
+use ifc_lite_core::EntityDecoder;
+use ifc_lite_geometry::{BoolFailureReason, GeometryRouter};
+
+fn router_for(content: &'static str) -> (GeometryRouter, EntityDecoder<'static>) {
+    let entity_index = ifc_lite_core::build_entity_index(content.as_bytes());
+    let mut decoder = EntityDecoder::with_index(content.as_bytes(), entity_index);
+    let router = GeometryRouter::with_units(content.as_bytes(), &mut decoder);
+    (router, decoder)
+}
+
+fn unsupported_operand_types(router: &GeometryRouter) -> Vec<String> {
+    let mut out: Vec<String> = router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .filter_map(|f| match &f.reason {
+            BoolFailureReason::UnsupportedOperand(ty) => Some(ty.clone()),
+            _ => None,
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// A wall whose Body item is an `IfcBooleanResult` with an `IFCSECTIONEDSPINE`
+/// FIRST operand — no branch in the boolean operand dispatch, so the base solid
+/// meshes empty and the element's item silently disappears.
+const UNSUPPORTED_BASE_OPERAND: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 direct boolean'),'2;1');
+FILE_NAME('d.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1DirectBooleanWall001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#30));
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#31,#33);
+#31=IFCSECTIONEDSPINE(#32,(#34),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,1.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.0,0.2);
+#35=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// The same unsupported operand, one level deeper: the Body item is an
+/// `IfcCsgSolid` whose `TreeRootExpression` is the boolean. That boolean runs
+/// on a TRANSIENT processor `CsgSolidProcessor` builds and drops, so it is not
+/// in the router's processor table and needs the thread-local hand-off.
+const UNSUPPORTED_BASE_OPERAND_UNDER_CSGSOLID: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 csgsolid boolean'),'2;1');
+FILE_NAME('e.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1CsgSolidBooleanWall1',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#20));
+#20=IFCCSGSOLID(#30);
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#31,#33);
+#31=IFCSECTIONEDSPINE(#32,(#34),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,1.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.0,0.2);
+#35=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// A clean wall: one extruded solid, no booleans at all. Without this control,
+/// "the drain reported something" would not distinguish a working drain from
+/// one that manufactures records.
+const CLEAN: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 control'),'2;1');
+FILE_NAME('f.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1ControlPlainWall001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#14));
+#14=IFCEXTRUDEDAREASOLID(#34,#5,#35,3.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#35=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn unsupported_base_operand_reaches_the_routers_csg_failures() {
+    let (router, mut decoder) = router_for(UNSUPPORTED_BASE_OPERAND);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let mesh = router
+        .process_element(&element, &mut decoder)
+        .expect("an unsupported operand must not error the element");
+
+    // Behaviour is unchanged: the boolean still yields an empty mesh. Returning
+    // `Err` here would delete the host for the second-operand case, which is
+    // why the arm records instead of failing.
+    assert!(mesh.is_empty(), "the boolean result is still empty; this is observability, not a behaviour change");
+
+    assert_eq!(
+        unsupported_operand_types(&router),
+        vec!["IfcSectionedSpine".to_string()],
+        "the router must drain the boolean processor's log and name the operand type"
+    );
+}
+
+#[test]
+fn unsupported_operand_under_an_ifccsgsolid_reaches_the_router_too() {
+    let (router, mut decoder) = router_for(UNSUPPORTED_BASE_OPERAND_UNDER_CSGSOLID);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+
+    assert_eq!(
+        unsupported_operand_types(&router),
+        vec!["IfcSectionedSpine".to_string()],
+        "a boolean run on CsgSolidProcessor's transient processor must still be reported"
+    );
+}
+
+#[test]
+fn a_clean_element_drains_nothing() {
+    let (router, mut decoder) = router_for(CLEAN);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let mesh = router
+        .process_element(&element, &mut decoder)
+        .expect("the control wall meshes");
+    assert!(!mesh.is_empty(), "control wall must produce geometry");
+    assert!(
+        router.take_csg_failures().is_empty(),
+        "a model with no booleans must drain no failures"
+    );
+}
+
+#[test]
+fn draining_twice_does_not_double_count() {
+    // The boolean processor is registered under BOTH IfcBooleanResult and
+    // IfcBooleanClippingResult as one shared Arc, so the sweep visits it twice.
+    let (router, mut decoder) = router_for(UNSUPPORTED_BASE_OPERAND);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+
+    assert_eq!(unsupported_operand_types(&router).len(), 1, "one drop, one record");
+    assert!(
+        router.take_csg_failures().is_empty(),
+        "the drain is destructive: a second take must return nothing"
+    );
+}

--- a/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
+++ b/rust/geometry/tests/issue_3821_router_drains_bool_failures.rs
@@ -368,3 +368,85 @@ fn an_undrained_router_does_not_leak_into_the_next_one() {
         "the owning router must still be able to drain its own records"
     );
 }
+
+/// A DIFFERENCE chain of two `IfcPolygonalBoundedHalfSpace` cutters over a base
+/// that itself records a failure, with the SECOND cutter's `PolygonalBoundary`
+/// authored as an `IfcCircle` instead of an `IfcPolyline`.
+///
+/// The batched-chain attempt (`try_union_polygonal_chain`) meshes the base,
+/// then fails to build that cutter's prism and defers to the sequential walk —
+/// which re-meshes the same base and records the same `UnsupportedOperand`
+/// again. Two walks over one authored step.
+const DEFERRED_PBHS_CHAIN_OVER_A_FAILING_BASE: &str = r"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('3821 deferred chain'),'2;1');
+FILE_NAME('c.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1DeferredChainWall00001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#30));
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#40,#70);
+#40=IFCBOOLEANRESULT(.DIFFERENCE.,#50,#60);
+#50=IFCBOOLEANRESULT(.DIFFERENCE.,#33,#31);
+#31=IFCSECTIONEDSPINE(#32,(#34),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#35,2.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,1.0);
+#35=IFCDIRECTION((0.,0.,1.));
+#60=IFCPOLYGONALBOUNDEDHALFSPACE(#61,.F.,#63,#64);
+#61=IFCPLANE(#62);
+#62=IFCAXIS2PLACEMENT3D(#67,$,$);
+#63=IFCAXIS2PLACEMENT3D(#67,$,$);
+#64=IFCPOLYLINE((#65,#66,#68,#69,#65));
+#65=IFCCARTESIANPOINT((-0.4,-0.4));
+#66=IFCCARTESIANPOINT((0.4,-0.4));
+#67=IFCCARTESIANPOINT((-1.5,0.,0.5));
+#68=IFCCARTESIANPOINT((0.4,0.4));
+#69=IFCCARTESIANPOINT((-0.4,0.4));
+#70=IFCPOLYGONALBOUNDEDHALFSPACE(#71,.F.,#73,#74);
+#71=IFCPLANE(#72);
+#72=IFCAXIS2PLACEMENT3D(#77,$,$);
+#73=IFCAXIS2PLACEMENT3D(#77,$,$);
+#74=IFCCIRCLE(#75,0.4);
+#75=IFCAXIS2PLACEMENT2D(#76,$);
+#76=IFCCARTESIANPOINT((0.,0.));
+#77=IFCCARTESIANPOINT((1.5,0.,0.5));
+ENDSEC;
+END-ISO-10303-21;
+";
+
+/// A speculative attempt that DEFERS must not leave its records behind for the
+/// walk that redoes the work to record again.
+///
+/// `try_union_polygonal_chain` is a batched attempt at a chain the sequential
+/// walk can also resolve; when it gives up, everything it meshed is meshed
+/// again. Its trial subtracts already discarded their own probe failures for
+/// this reason, but the base operand it meshed first did not, so one authored
+/// unsupported operand under a deferring chain was counted TWICE — inflating
+/// `total_csg_failures` and skewing the reason breakdown the viewer's "top
+/// failure reason" reads.
+///
+/// The calibration is the assertion itself: 0 would mean the fixture never
+/// reached the failing base at all, so the count has to be exactly 1.
+#[test]
+fn a_deferred_batched_chain_does_not_record_the_base_operand_twice() {
+    let (router, mut decoder) = router_for(DEFERRED_PBHS_CHAIN_OVER_A_FAILING_BASE);
+    let element = decoder.decode_by_id(10).expect("decode the wall");
+    let _ = router.process_element(&element, &mut decoder);
+
+    assert_eq!(
+        unsupported_operand_types(&router),
+        vec!["IfcSectionedSpine".to_string()],
+        "the deferring batched attempt and the sequential walk that redoes its \
+         work must yield ONE record for the one authored operand, not two"
+    );
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1517,7 +1517,7 @@ pub fn process_geometry_streaming_filtered_with_options(
         .into_inner()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let total_csg_failures: usize = csg_failures.values().map(Vec::len).sum();
-    let products_with_failures = csg_failures.len();
+    let products_with_failures = ifc_lite_geometry::count_attributed_products(&csg_failures);
     let backstop_dropped = backstop_collector.into_inner();
     // #3421/#3752: refused, not wrapped; surfaced below via GeometryDiagnostics.
     let oversized_ref_drops = oversized_ref_drop_collector.into_inner();
@@ -1640,7 +1640,7 @@ pub fn process_geometry_streaming_filtered_with_options(
             total_time_ms: total_time.as_millis() as u64,
             from_cache: false,
             total_csg_failures: total_csg_failures as u64,
-            products_with_failures: products_with_failures as u64,
+            products_with_failures,
             degenerate_triangles_dropped: backstop_dropped,
             point_cache_hits,
             point_cache_misses,

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1041,6 +1041,7 @@ pub fn process_geometry_streaming_filtered_with_options(
         unit_scales.length_unit_scale,
         unit_scales.plane_angle_to_radians,
     );
+    // Placements + RTC only; never reaches `self.processors`, so it meshes nothing and has no boolean failures to drain (#3821).
     let mut router = GeometryRouter::with_scale(unit_scales.length_unit_scale);
     router.set_tessellation_quality(options.tessellation_quality);
     // Build the #563 material-layer index from the IfcRelAssociatesMaterial spans

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1041,7 +1041,7 @@ pub fn process_geometry_streaming_filtered_with_options(
         unit_scales.length_unit_scale,
         unit_scales.plane_angle_to_radians,
     );
-    // Placements + RTC only; never reaches `self.processors`, so it meshes nothing and has no boolean failures to drain (#3821).
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     let mut router = GeometryRouter::with_scale(unit_scales.length_unit_scale);
     router.set_tessellation_quality(options.tessellation_quality);
     // Build the #563 material-layer index from the IfcRelAssociatesMaterial spans

--- a/rust/processing/src/stream_meta.rs
+++ b/rust/processing/src/stream_meta.rs
@@ -99,12 +99,7 @@ pub fn resolve_stream_meta(
     let length_unit_scale = unit_scales.length_unit_scale;
     decoder.seed_unit_scales(length_unit_scale, unit_scales.plane_angle_to_radians);
 
-    // #3821: this router is NOT drained for boolean failures, and that is
-    // correct rather than an oversight. It is used only for RTC-offset detection and the building-rotation placement read; none of
-    // those methods touches `self.processors`, so no processor here ever
-    // meshes a representation item and none can record a `BoolFailure`.
-    // Draining it would always yield an empty list. The routers that DO mesh
-    // are the per-element ones, drained through `take_csg_failures`.
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     let router = GeometryRouter::with_scale(length_unit_scale);
 
     let rtc_offset = match mode {

--- a/rust/processing/src/stream_meta.rs
+++ b/rust/processing/src/stream_meta.rs
@@ -99,6 +99,12 @@ pub fn resolve_stream_meta(
     let length_unit_scale = unit_scales.length_unit_scale;
     decoder.seed_unit_scales(length_unit_scale, unit_scales.plane_angle_to_radians);
 
+    // #3821: this router is NOT drained for boolean failures, and that is
+    // correct rather than an oversight. It is used only for RTC-offset detection and the building-rotation placement read; none of
+    // those methods touches `self.processors`, so no processor here ever
+    // meshes a representation item and none can record a `BoolFailure`.
+    // Draining it would always yield an empty list. The routers that DO mesh
+    // are the per-element ones, drained through `take_csg_failures`.
     let router = GeometryRouter::with_scale(length_unit_scale);
 
     let rtc_offset = match mode {

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -127,6 +127,12 @@ where
     let mut decoder = EntityDecoder::with_index(content, entity_index);
 
     // Reuse the geometry router for both unit-scale and the RTC offset.
+    // #3821: this router is NOT drained for boolean failures, and that is
+    // correct rather than an oversight. It is used only for the unit scale and RTC-offset detection; none of
+    // those methods touches `self.processors`, so no processor here ever
+    // meshes a representation item and none can record a `BoolFailure`.
+    // Draining it would always yield an empty list. The routers that DO mesh
+    // are the per-element ones, drained through `take_csg_failures`.
     let router = ifc_lite_geometry::GeometryRouter::with_units(content, &mut decoder);
     let unit_scale = router.unit_scale() as f32;
 

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -127,12 +127,7 @@ where
     let mut decoder = EntityDecoder::with_index(content, entity_index);
 
     // Reuse the geometry router for both unit-scale and the RTC offset.
-    // #3821: this router is NOT drained for boolean failures, and that is
-    // correct rather than an oversight. It is used only for the unit scale and RTC-offset detection; none of
-    // those methods touches `self.processors`, so no processor here ever
-    // meshes a representation item and none can record a `BoolFailure`.
-    // Draining it would always yield an empty list. The routers that DO mesh
-    // are the per-element ones, drained through `take_csg_failures`.
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     let router = ifc_lite_geometry::GeometryRouter::with_units(content, &mut decoder);
     let unit_scale = router.unit_scale() as f32;
 

--- a/rust/processing/tests/issue_3821_boolean_failure_drain.rs
+++ b/rust/processing/tests/issue_3821_boolean_failure_drain.rs
@@ -159,8 +159,36 @@ fn a_clean_model_records_no_boolean_failures_on_either_entry_point() {
     }
 }
 
+/// Parse `IFC_LITE_REQUIRE_FIXTURES` the way `rust/export/src/test_support.rs`
+/// documents it — that module is the canonical home, but it is private to the
+/// export crate and unreachable from here.
+///
+/// Unset, empty or `"0"` = off (skip a missing fixture, the local default).
+/// `"1"` = on (a missing fixture is a hard failure; CI sets this for
+/// `cargo test --workspace`). Anything else PANICS rather than falling through
+/// to "off": treating a typo like `true` as off would recreate the silent pass
+/// the variable exists to close.
+fn require_fixtures() -> bool {
+    match std::env::var("IFC_LITE_REQUIRE_FIXTURES") {
+        Err(std::env::VarError::NotPresent) => false,
+        Ok(v) if v.is_empty() || v == "0" => false,
+        Ok(v) if v == "1" => true,
+        other => panic!(
+            "IFC_LITE_REQUIRE_FIXTURES must be unset, \"\", \"0\" or \"1\"; got {other:?}"
+        ),
+    }
+}
+
 /// Streaming-vs-native parity on a real model, not just the synthetic fixture:
 /// the batch size must not change what the pass reports.
+///
+/// NOT load-bearing on its own. The fixture is not committed, so without it
+/// this returns early and passes having asserted nothing — it stayed green
+/// under every mutation of the code it covers. The two synthetic tests above
+/// are what actually pin the behaviour; this one adds breadth over real
+/// geometry when the fixture is present. `IFC_LITE_REQUIRE_FIXTURES=1` (which
+/// CI sets) turns the silent skip into a hard failure, so fixture drift shows
+/// up as a failure rather than as a quietly smaller suite.
 #[test]
 fn streaming_and_native_report_identical_diagnostics_on_a_real_fixture() {
     const FIXTURE: &str = "tests/models/ara3d/AC20-FZK-Haus.ifc";
@@ -168,10 +196,17 @@ fn streaming_and_native_report_identical_diagnostics_on_a_real_fixture() {
         .join("..")
         .join("..")
         .join(FIXTURE);
-    // ara3d fixtures are not committed; skip cleanly when absent (AGENTS.md).
-    let Ok(bytes) = std::fs::read(&path) else {
-        eprintln!("{FIXTURE} missing - skipping");
-        return;
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            assert!(
+                !require_fixtures(),
+                "IFC_LITE_REQUIRE_FIXTURES=1 but {FIXTURE} is missing ({e}) — \
+                 run `pnpm fixtures` (sha256 in tests/models/manifest.json)"
+            );
+            eprintln!("{FIXTURE} missing - skipping");
+            return;
+        }
     };
 
     let native = process_geometry(&bytes);

--- a/rust/processing/tests/issue_3821_boolean_failure_drain.rs
+++ b/rust/processing/tests/issue_3821_boolean_failure_drain.rs
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3821: `BooleanClippingProcessor`'s failure log reaches `GeometryDiagnostics`.
+//!
+//! `take_failures` was called from tests ONLY. Every record the boolean
+//! processor made — an unsupported operand, an `EmptyOperand` cutter, an
+//! unknown operator — went into a `RefCell` no production caller read, so a
+//! model whose booleans had all degraded reported a clean load. The base-operand
+//! arm was worse still: it returned an empty mesh and recorded nothing at all.
+//!
+//! Both native entry points funnel into
+//! `process_geometry_streaming_filtered_with_options`, differing only in batch
+//! size, so the parity assertions below pin that a per-batch drain cannot start
+//! reporting a different total from a single-batch one.
+
+use ifc_lite_processing::{process_geometry, process_geometry_streaming};
+
+/// A wall with one ordinary extruded solid AND one `IfcBooleanResult` whose
+/// FIRST operand is `IFCSECTIONEDSPINE` — a representation-item type the
+/// boolean operand dispatch has no branch for. The base solid meshes empty, so
+/// the whole boolean item contributes nothing; the wall still renders from its
+/// other item, which is exactly why the loss is invisible without a diagnostic.
+const UNSUPPORTED_BASE_OPERAND_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3821 unsupported base operand'),'2;1');
+FILE_NAME('b3821.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+
+#10=IFCWALL('1BoolUnsupportedBase01',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#14,#30));
+#14=IFCEXTRUDEDAREASOLID(#15,#5,#16,3.0);
+#15=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#16=IFCDIRECTION((0.,0.,1.));
+
+#30=IFCBOOLEANRESULT(.DIFFERENCE.,#31,#33);
+#31=IFCSECTIONEDSPINE(#32,(#15),(#5));
+#32=IFCCOMPOSITECURVE((),$);
+#33=IFCEXTRUDEDAREASOLID(#34,#5,#16,1.0);
+#34=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.0,0.2);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// The same wall WITHOUT the boolean item. The control for every assertion
+/// below: a clean model must stay clean, or "diagnostics appeared" would only
+/// mean "this pipeline emits diagnostics for everything".
+const CLEAN_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3821 control'),'2;1');
+FILE_NAME('c3821.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+
+#10=IFCWALL('1BoolCleanControl0001',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','SweptSolid',(#14));
+#14=IFCEXTRUDEDAREASOLID(#15,#5,#16,3.0);
+#15=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,4.0,0.3);
+#16=IFCDIRECTION((0.,0.,1.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn unsupported_operand_count(diag: &ifc_lite_geometry::GeometryDiagnostics) -> u64 {
+    diag.failures_by_reason
+        .iter()
+        .find(|r| r.reason == "UnsupportedOperand")
+        .map_or(0, |r| r.count)
+}
+
+#[test]
+fn unsupported_first_operand_reaches_both_entry_points_with_the_same_count() {
+    // Non-streaming: one batch of everything.
+    let native = process_geometry(UNSUPPORTED_BASE_OPERAND_IFC);
+    // Streaming: batch size 1, so each element is finalized on its own.
+    let streaming =
+        process_geometry_streaming(UNSUPPORTED_BASE_OPERAND_IFC.as_bytes(), 1, |_, _, _| {});
+
+    // The element still renders (the loss is one item, not the whole wall) —
+    // which is precisely why nothing but a diagnostic can reveal it.
+    assert!(!native.meshes.is_empty(), "the wall's other item must still mesh");
+    assert_eq!(native.meshes.len(), streaming.meshes.len());
+
+    let native_diag = native
+        .stats
+        .geometry_diagnostics
+        .as_ref()
+        .expect("a dropped boolean operand must attach geometry_diagnostics");
+    let streaming_diag = streaming
+        .stats
+        .geometry_diagnostics
+        .as_ref()
+        .expect("the streaming entry point must attach the same diagnostics");
+
+    assert_eq!(
+        unsupported_operand_count(native_diag),
+        1,
+        "the unsupported base operand must be recorded exactly once: {:?}",
+        native_diag.failures_by_reason
+    );
+    assert_eq!(
+        native_diag.total_csg_failures, 1,
+        "one drop, one failure: {native_diag:?}"
+    );
+    assert_eq!(
+        native_diag.total_csg_failures, streaming_diag.total_csg_failures,
+        "streaming and non-streaming must report the SAME count for the same file"
+    );
+    assert_eq!(
+        unsupported_operand_count(streaming_diag),
+        unsupported_operand_count(native_diag),
+        "…and the same per-reason breakdown"
+    );
+    // The legacy scalar the server has always exposed agrees with the contract.
+    assert_eq!(native.stats.total_csg_failures, 1);
+    assert_eq!(streaming.stats.total_csg_failures, 1);
+}
+
+#[test]
+fn a_clean_model_records_no_boolean_failures_on_either_entry_point() {
+    for (label, result) in [
+        ("non-streaming", process_geometry(CLEAN_IFC)),
+        (
+            "streaming",
+            process_geometry_streaming(CLEAN_IFC.as_bytes(), 1, |_, _, _| {}),
+        ),
+    ] {
+        assert!(!result.meshes.is_empty(), "{label}: control wall must mesh");
+        assert_eq!(
+            result.stats.total_csg_failures, 0,
+            "{label}: a model with no booleans must record no boolean failures"
+        );
+        let unsupported = result
+            .stats
+            .geometry_diagnostics
+            .as_ref()
+            .map_or(0, unsupported_operand_count);
+        assert_eq!(unsupported, 0, "{label}: no spurious UnsupportedOperand");
+    }
+}
+
+/// Streaming-vs-native parity on a real model, not just the synthetic fixture:
+/// the batch size must not change what the pass reports.
+#[test]
+fn streaming_and_native_report_identical_diagnostics_on_a_real_fixture() {
+    const FIXTURE: &str = "tests/models/ara3d/AC20-FZK-Haus.ifc";
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join(FIXTURE);
+    // ara3d fixtures are not committed; skip cleanly when absent (AGENTS.md).
+    let Ok(bytes) = std::fs::read(&path) else {
+        eprintln!("{FIXTURE} missing - skipping");
+        return;
+    };
+
+    let native = process_geometry(&bytes);
+    let streaming = process_geometry_streaming(&bytes, 8, |_, _, _| {});
+
+    assert_eq!(
+        native.stats.total_csg_failures, streaming.stats.total_csg_failures,
+        "batch size must not change the boolean-failure total"
+    );
+    assert_eq!(
+        native.stats.products_with_failures, streaming.stats.products_with_failures,
+        "batch size must not change the product-failure count"
+    );
+
+    let native_reasons = native
+        .stats
+        .geometry_diagnostics
+        .as_ref()
+        .map(|d| d.failures_by_reason.clone())
+        .unwrap_or_default();
+    let streaming_reasons = streaming
+        .stats
+        .geometry_diagnostics
+        .as_ref()
+        .map(|d| d.failures_by_reason.clone())
+        .unwrap_or_default();
+    let as_pairs = |v: Vec<ifc_lite_geometry::ReasonCount>| {
+        v.into_iter()
+            .map(|r| (r.reason, r.count))
+            .collect::<std::collections::BTreeMap<_, _>>()
+    };
+    assert_eq!(
+        as_pairs(native_reasons),
+        as_pairs(streaming_reasons),
+        "batch size must not change the per-reason breakdown"
+    );
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -144,12 +144,14 @@
 # per-processor reset, and a valid 8-CsgSolid-8 chain that resolves on main
 # would have been dropped with "depth 11 exceeds limit 10". Caught in review,
 # so the note is the record of a regression avoided rather than commentary.
-    1005 rust/geometry/src/processors/boolean/mod.rs
+# -54: #3821 split process_operand_with_depth (and its new unsupported-operand
+# record) out to the operand.rs sibling; 1005 -> 951.
+     951 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
-# +20: #2866 — the Boolean<->CSG cycle guard, with the module's tests moved to a
-# sibling csg_primitive_tests.rs (402 -> 422). The guard costs more than the
-# test split paid back, so this is a LOOSENING and is recorded as one.
-     422 rust/geometry/src/processors/csg_primitive.rs
+# csg_primitive.rs row REMOVED: #3821 moved IfcSphere (processor + UV-sphere
+# tessellation, verbatim) to the sphere.rs sibling to make room for the
+# CsgSolid boolean-failure hand-off; 422 -> 324, under the 400 limit. That
+# repays the #2866 loosening this row recorded.
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs
      598 rust/geometry/src/profiles/curves_2d.rs
@@ -179,7 +181,11 @@
      706 rust/geometry/src/profiles/simplify.rs
 # +26: cap the fast-path opening count (O(N^3) DoS guard) + regression test.
      807 rust/geometry/src/rect_fast.rs
-     595 rust/geometry/src/router/diagnostics.rs
+# -21: #3821 replaced the second, hand-maintained copy of the BoolFailureReason
+# label match with a call to BoolFailureReason::label(), and put the new
+# processor-failure sweep in the diagnostics/processor_failures.rs sibling;
+# 585 -> 565.
+     565 rust/geometry/src/router/diagnostics.rs
 # +26: #2866 — item_has_identity_position chases IfcBooleanResult.FirstOperand,
 # a file-supplied reference, so one self-referential entity aborted the process
 # (stack overflow = abort in Rust, not a catchable panic). The walk is now
@@ -202,7 +208,9 @@
 # +42: #1623 Phase 3 batch-local template mode — instancing_batch_local flag + instanced_sources_materialized tracker fields + set_/getter/mark_source_materialized_if_first methods (browser per-batch don't-bake).
 # +1: #1293 dedup rep_identity: build_dedup_extra_enabled/set_build_dedup_extra_override gate + DEDUP_EXTRA_OVERRIDE static; net +1 after the ItemDedupCache doc consolidation.
 # +1: #1781 `mod textured;` — texture channel split OUT of processing.rs (that file drops ~90 lines below its budget; crate trends down).
-     749 rust/geometry/src/router/mod.rs
+# -20: #3821 moved the GeometryProcessor trait to the router/processor.rs
+# sibling so its new take_bool_failures drain hook has room; 749 -> 729.
+     729 rust/geometry/src/router/mod.rs
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
 # +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -151,7 +151,7 @@
      486 rust/geometry/src/processors/brep/faceted.rs
 # csg_primitive.rs row REMOVED: #3821 moved IfcSphere (processor + UV-sphere
 # tessellation, verbatim) to the sphere.rs sibling to make room for the
-# CsgSolid boolean-failure hand-off; 422 -> 324, under the 400 limit. That
+# CsgSolid boolean-failure hand-off; 422 -> 347, under the 400 limit. That
 # repays the #2866 loosening this row recorded.
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -182,13 +182,15 @@
      706 rust/geometry/src/profiles/simplify.rs
 # +26: cap the fast-path opening count (O(N^3) DoS guard) + regression test.
      807 rust/geometry/src/rect_fast.rs
-# -3: #3821 replaced the second, hand-maintained copy of the BoolFailureReason
+# -10: #3821 replaced the second, hand-maintained copy of the BoolFailureReason
 # label match with a call to BoolFailureReason::label(), and put the new
 # processor-failure sweep in the diagnostics/processor_failures.rs sibling;
 # that paid for count_attributed_products and the reworked take_csg_failures
 # doc, and the id-0 bucket rules moved on to diagnostics/attribution.rs.
-# 586 -> 575.
-     575 rust/geometry/src/router/diagnostics.rs
+# The baseline moved under this PR: #3863 grew the file to 595 without moving
+# the row, and #3881 re-measured the row to match. Measured after the rebase
+# onto that: 595 -> 585.
+     585 rust/geometry/src/router/diagnostics.rs
 # +26: #2866 — item_has_identity_position chases IfcBooleanResult.FirstOperand,
 # a file-supplied reference, so one self-referential entity aborted the process
 # (stack overflow = abort in Rust, not a catchable panic). The walk is now

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -151,7 +151,7 @@
      486 rust/geometry/src/processors/brep/faceted.rs
 # csg_primitive.rs row REMOVED: #3821 moved IfcSphere (processor + UV-sphere
 # tessellation, verbatim) to the sphere.rs sibling to make room for the
-# CsgSolid boolean-failure hand-off; 422 -> 347, under the 400 limit. That
+# CsgSolid boolean-failure hand-off; 422 -> 348, under the 400 limit. That
 # repays the #2866 loosening this row recorded.
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -144,9 +144,10 @@
 # per-processor reset, and a valid 8-CsgSolid-8 chain that resolves on main
 # would have been dropped with "depth 11 exceeds limit 10". Caught in review,
 # so the note is the record of a regression avoided rather than commentary.
-# -54: #3821 split process_operand_with_depth (and its new unsupported-operand
-# record) out to the operand.rs sibling; 1005 -> 951.
-     951 rust/geometry/src/processors/boolean/mod.rs
+# -69: #3821 split process_operand_with_depth (with its new unsupported-operand
+# record) out to the operand.rs sibling and the failure-log methods out to
+# failures.rs; 1005 -> 936.
+     936 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
 # csg_primitive.rs row REMOVED: #3821 moved IfcSphere (processor + UV-sphere
 # tessellation, verbatim) to the sphere.rs sibling to make room for the
@@ -181,11 +182,13 @@
      706 rust/geometry/src/profiles/simplify.rs
 # +26: cap the fast-path opening count (O(N^3) DoS guard) + regression test.
      807 rust/geometry/src/rect_fast.rs
-# -21: #3821 replaced the second, hand-maintained copy of the BoolFailureReason
+# -3: #3821 replaced the second, hand-maintained copy of the BoolFailureReason
 # label match with a call to BoolFailureReason::label(), and put the new
 # processor-failure sweep in the diagnostics/processor_failures.rs sibling;
-# 585 -> 565.
-     565 rust/geometry/src/router/diagnostics.rs
+# that paid for count_attributed_products and the reworked take_csg_failures
+# doc, and the id-0 bucket rules moved on to diagnostics/attribution.rs.
+# 586 -> 575.
+     575 rust/geometry/src/router/diagnostics.rs
 # +26: #2866 — item_has_identity_position chases IfcBooleanResult.FirstOperand,
 # a file-supplied reference, so one self-referential entity aborted the process
 # (stack overflow = abort in Rust, not a catchable panic). The walk is now
@@ -208,9 +211,10 @@
 # +42: #1623 Phase 3 batch-local template mode — instancing_batch_local flag + instanced_sources_materialized tracker fields + set_/getter/mark_source_materialized_if_first methods (browser per-batch don't-bake).
 # +1: #1293 dedup rep_identity: build_dedup_extra_enabled/set_build_dedup_extra_override gate + DEDUP_EXTRA_OVERRIDE static; net +1 after the ItemDedupCache doc consolidation.
 # +1: #1781 `mod textured;` — texture channel split OUT of processing.rs (that file drops ~90 lines below its budget; crate trends down).
-# -20: #3821 moved the GeometryProcessor trait to the router/processor.rs
-# sibling so its new take_bool_failures drain hook has room; 749 -> 729.
-     729 rust/geometry/src/router/mod.rs
+# -17: #3821 moved the GeometryProcessor trait to the router/processor.rs
+# sibling, which paid for its new take_bool_failures drain hook and for the
+# sweep that stops set_skip_small_cuts discarding an undrained log; 749 -> 732.
+     732 rust/geometry/src/router/mod.rs
 # +65: #1623 Phase 2 don't-bake — the top-level mapped-item intercept (template retag + instance placeholder) + the public/impl process_element_with_submeshes split; the two eligibility/ensure helpers were extracted to router/instancing.rs (new, 92 lines) to hold the net down.
 # +7: #858 palette guard — exclude an indexed-colour single-solid source from the don't-bake decision (one .filter on the resolved solid id + explanatory comment) so its per-triangle palette survives the flat split.
 # +16: #1623 Phase 3 — thread the batch-local vs global template decision through the mapped-item intercept (is_template match arm + retag guard).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 218310759456605933),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 10803330618731922689),
+    ("rust/geometry", 7515871353102465711),
     ("rust/processing", 7633784028779437211),
     ("rust/wasm-bindings", 11372642225568989008),
 ];

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 218310759456605933),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 7515871353102465711),
+    ("rust/geometry", 12363772718172929708),
     ("rust/processing", 7633784028779437211),
     ("rust/wasm-bindings", 11372642225568989008),
 ];

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 218310759456605933),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 2973351381616537576),
+    ("rust/geometry", 10803330618731922689),
     ("rust/processing", 7633784028779437211),
     ("rust/wasm-bindings", 11372642225568989008),
 ];

--- a/rust/wasm-bindings/src/api/alignment_lines.rs
+++ b/rust/wasm-bindings/src/api/alignment_lines.rs
@@ -70,12 +70,7 @@ pub(crate) fn extract_alignment_line_vertices(content: &str) -> Vec<f32> {
     // RTC offset (metres) — `detect_rtc_offset_from_first_element` returns
     // (0,0,0) for models within 10 km of the origin, so this is a no-op for
     // local files and a true shift for georeferenced infrastructure.
-    // #3821: this router is NOT drained for boolean failures, and that is
-    // correct rather than an oversight. It is used only for RTC-offset detection; none of
-    // those methods touches `self.processors`, so no processor here ever
-    // meshes a representation item and none can record a `BoolFailure`.
-    // Draining it would always yield an empty list. The routers that DO mesh
-    // are the per-element ones, drained through `take_csg_failures`.
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     let router = GeometryRouter::with_scale(unit_scale);
     let rtc = router.detect_rtc_offset_from_first_element(content, &mut decoder);
 

--- a/rust/wasm-bindings/src/api/alignment_lines.rs
+++ b/rust/wasm-bindings/src/api/alignment_lines.rs
@@ -70,6 +70,12 @@ pub(crate) fn extract_alignment_line_vertices(content: &str) -> Vec<f32> {
     // RTC offset (metres) — `detect_rtc_offset_from_first_element` returns
     // (0,0,0) for models within 10 km of the origin, so this is a no-op for
     // local files and a true shift for georeferenced infrastructure.
+    // #3821: this router is NOT drained for boolean failures, and that is
+    // correct rather than an oversight. It is used only for RTC-offset detection; none of
+    // those methods touches `self.processors`, so no processor here ever
+    // meshes a representation item and none can record a `BoolFailure`.
+    // Draining it would always yield an empty list. The routers that DO mesh
+    // are the per-element ones, drained through `take_csg_failures`.
     let router = GeometryRouter::with_scale(unit_scale);
     let rtc = router.detect_rtc_offset_from_first_element(content, &mut decoder);
 

--- a/rust/wasm-bindings/src/api/csg_diagnostics.rs
+++ b/rust/wasm-bindings/src/api/csg_diagnostics.rs
@@ -71,7 +71,7 @@ pub(super) fn drain_and_log_csg_diagnostics(
         );
     }
 
-    let products_with_failures = csg_failures.len();
+    let products_with_failures = ifc_lite_geometry::count_attributed_products(&csg_failures);
 
     if total_failures > 0 || !host_diags.is_empty() {
         // Per-reason breakdown for the warn line.

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -710,7 +710,7 @@ impl IfcAPI {
         {
             let mut akey_decoder =
                 EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
-            let akey_router = GeometryRouter::new(); // hashes routing keys only: meshes nothing, so no boolean failures to drain (#3821)
+            let akey_router = GeometryRouter::new(); // not drained: meshes nothing (issue_3821_auxiliary_routers_mesh_nothing.rs)
             let rest = &buffered_jobs[first_n..];
             let mut affinity: Vec<u32> = Vec::with_capacity(rest.len());
             for &(id, _s, _e, _t) in rest {

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -710,7 +710,7 @@ impl IfcAPI {
         {
             let mut akey_decoder =
                 EntityDecoder::with_arc_columnar_index(content, entity_index_arc.clone());
-            let akey_router = GeometryRouter::new();
+            let akey_router = GeometryRouter::new(); // hashes routing keys only: meshes nothing, so no boolean failures to drain (#3821)
             let rest = &buffered_jobs[first_n..];
             let mut affinity: Vec<u32> = Vec::with_capacity(rest.len());
             for &(id, _s, _e, _t) in rest {

--- a/rust/wasm-bindings/src/api/grid_lines.rs
+++ b/rust/wasm-bindings/src/api/grid_lines.rs
@@ -51,12 +51,7 @@ pub(crate) fn extract_grid_axes(content: &str) -> Vec<GridAxis3D> {
 
     // Reuse the geometry router for both unit-scale and the placement resolver,
     // exactly like the mesh pipeline (and the symbolic builder).
-    // #3821: this router is NOT drained for boolean failures, and that is
-    // correct rather than an oversight. It is used only for the unit scale, RTC-offset detection and grid placements; none of
-    // those methods touches `self.processors`, so no processor here ever
-    // meshes a representation item and none can record a `BoolFailure`.
-    // Draining it would always yield an empty list. The routers that DO mesh
-    // are the per-element ones, drained through `take_csg_failures`.
+    // Not drained: meshes nothing. Pinned by rust/geometry/tests/issue_3821_auxiliary_routers_mesh_nothing.rs.
     let router = GeometryRouter::with_units(content, &mut decoder);
     let unit_scale = router.unit_scale();
 

--- a/rust/wasm-bindings/src/api/grid_lines.rs
+++ b/rust/wasm-bindings/src/api/grid_lines.rs
@@ -51,6 +51,12 @@ pub(crate) fn extract_grid_axes(content: &str) -> Vec<GridAxis3D> {
 
     // Reuse the geometry router for both unit-scale and the placement resolver,
     // exactly like the mesh pipeline (and the symbolic builder).
+    // #3821: this router is NOT drained for boolean failures, and that is
+    // correct rather than an oversight. It is used only for the unit scale, RTC-offset detection and grid placements; none of
+    // those methods touches `self.processors`, so no processor here ever
+    // meshes a representation item and none can record a `BoolFailure`.
+    // Draining it would always yield an empty list. The routers that DO mesh
+    // are the per-element ones, drained through `take_csg_failures`.
     let router = GeometryRouter::with_units(content, &mut decoder);
     let unit_scale = router.unit_scale();
 


### PR DESCRIPTION
## Summary

`BooleanClippingProcessor::take_failures` was called only from tests, never by the router, so an unsupported boolean operand never reached `geometry_diagnostics`; the base-operand arm `_ => Ok(Mesh::new())` reported nothing; and the non-streaming native entry point reported 0 dropped items where streaming reported N (#3821).

- A defaulted `GeometryProcessor::take_bool_failures` hook, overridden by `BooleanClippingProcessor`, is swept by `GeometryRouter::drain_processor_failures` from `take_csg_failures`, so the native pipeline and the wasm batch path both pick it up. `CsgSolidProcessor`'s transient boolean processor hands its log to the same thread-local hatch.
- The base-operand arm records `BoolFailureReason::UnsupportedOperand(type)` and still returns an empty mesh (an `Err` there would delete the host). An unsupported cutter yields exactly one record naming the cause: the `EmptyOperand` consequence is suppressed for the same operand, and a genuinely empty supported cutter still records `EmptyOperand`.
- Records without a product owner sit in a synthetic bucket that is counted in totals and the reason breakdown but excluded from `products_with_failures` (one home for that count, used by the aggregate, `ProcessingStats` and the wasm console summary).
- `set_skip_small_cuts` drains the outgoing processor before re-registering, so a mid-batch flip cannot discard records.
- The routers built at prepass, grid, alignment, symbolic, stream-meta, export and `processor/mod.rs` are pinned by a structural test that runs each site's real workload on a model whose boolean is guaranteed to record and asserts the drain is empty, with a calibration test proving the same model does record when meshed.
- The real-fixture parity test is gated on `IFC_LITE_REQUIRE_FIXTURES` and its doc names the synthetic tests as the load-bearing ones.

Ratchet: split, not raised (`boolean/failures.rs`, `router/diagnostics/attribution.rs`, `router/processor.rs`, `boolean/operand.rs`, `processors/sphere.rs`); every row is at or below its value on main and the `csg_primitive.rs` row is deleted.

Closes #3821

## Verification

- `cargo test -p ifc-lite-geometry -p ifc-lite-processing --no-fail-fast`: exit 0, 1452 passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0. `module_size_ratchet`: 6/6.
- Mutation-checked by an independent reviewer: reverting the operand arm fails four named tests; removing the sweep fails two and the clean control stays green; forcing or suppressing the cutter record fails the cause test or the control respectively.
- Changeset: `@ifc-lite/wasm` patch and `@ifc-lite/cli` patch (`diagnose-geometry` gains an `UnsupportedOperand` row and `productsWithFailures` no longer counts the unowned bucket). No `GEOMETRY_DIAGNOSTICS_SCHEMA_VERSION` bump: the reason list is open and no field is renamed or re-counted. #3691 (open) bumps it to 3 and touches `router/mod.rs`; a conflict there is expected and mechanical.