### PR TITLE
fix(docs): typecheck every published package README, and fix the 112 snippet errors that were never checked

### DIFF
--- a/.changeset/package-readme-doc-samples.md
+++ b/.changeset/package-readme-doc-samples.md
@@ -1,0 +1,28 @@
+---
+'@ifc-lite/bcf': patch
+'@ifc-lite/bcf-api': patch
+'@ifc-lite/cache': patch
+'@ifc-lite/clash': patch
+'@ifc-lite/codegen': patch
+'@ifc-lite/collab': patch
+'@ifc-lite/collab-server': patch
+'@ifc-lite/diff': patch
+'@ifc-lite/drawing-2d': patch
+'@ifc-lite/export': patch
+'@ifc-lite/extensions': patch
+'@ifc-lite/geometry': patch
+'@ifc-lite/ids': patch
+'@ifc-lite/ifcx': patch
+'@ifc-lite/lens': patch
+'@ifc-lite/lists': patch
+'@ifc-lite/merge': patch
+'@ifc-lite/mutations': patch
+'@ifc-lite/pointcloud': patch
+'@ifc-lite/renderer': patch
+'@ifc-lite/sandbox': patch
+'@ifc-lite/server-client': patch
+'@ifc-lite/spatial': patch
+'@ifc-lite/wasm': patch
+---
+
+Corrected the code samples on each package's npm landing page: the README fences are now typechecked against the package's real exports, so the snippets import what they call, declare the values they read, and no longer show removed options or renamed methods. Patch-bumping every package whose README changed so the corrections actually reach npmjs.com.

--- a/packages/bcf-api/README.md
+++ b/packages/bcf-api/README.md
@@ -46,6 +46,16 @@ const { project, warnings } = await fetchProjectAsBCF(client, projects[0].projec
 ## Direct endpoint access
 
 ```ts
+import { BcfApiClient } from '@ifc-lite/bcf-api';
+
+const client = new BcfApiClient({
+  baseUrl: 'https://example.com/bcf/2.1',
+  getAccessToken: () => 'your-access-token',
+});
+const projectId = 'my-project-guid';
+const topicGuid = 'my-topic-guid';
+const viewpointGuid = 'my-viewpoint-guid';
+
 await client.getVersions();
 await client.getCurrentUser();
 await client.getExtensions(projectId);

--- a/packages/bcf/README.md
+++ b/packages/bcf/README.md
@@ -54,7 +54,12 @@ const url = URL.createObjectURL(blob);
 ## Add a viewpoint with selection
 
 ```typescript
-import { createViewpoint, addViewpointToTopic } from '@ifc-lite/bcf';
+import { createBCFTopic, createViewpoint, addViewpointToTopic } from '@ifc-lite/bcf';
+
+const topic = createBCFTopic({
+  title: 'Missing fire rating on east-facade walls',
+  author: 'reviewer@example.com',
+});
 
 const viewpoint = createViewpoint({
   camera: {

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -15,28 +15,59 @@ import {
   xxhash64Hex,
   BinaryCacheReader,
   BinaryCacheWriter,
+  SchemaVersion,
+  type CacheDataStore,
 } from '@ifc-lite/cache';
+import { IfcParser } from '@ifc-lite/parser';
+import { GeometryProcessor } from '@ifc-lite/geometry';
 
-const ifcBuffer = await file.arrayBuffer();
-const cacheKey = xxhash64Hex(ifcBuffer);
+// Your own persistence layer: IndexedDB, fs, S3, ...
+declare const myStorage: {
+  get(key: string): Promise<ArrayBuffer | undefined>;
+  put(key: string, value: ArrayBuffer): Promise<void>;
+};
 
-// Try cache first
-const cached = await myStorage.get(cacheKey); // your IndexedDB / fs / S3 lookup
-if (cached) {
-  const reader = new BinaryCacheReader();
-  const { geometry } = await reader.read(cached);
-  renderer.loadGeometry(geometry?.meshes ?? []);
-  return; // first triangles in milliseconds
+async function loadWithCache(file: File) {
+  const ifcBuffer = await file.arrayBuffer();
+  const cacheKey = xxhash64Hex(ifcBuffer);
+
+  // Try cache first
+  const cached = await myStorage.get(cacheKey);
+  if (cached) {
+    const reader = new BinaryCacheReader();
+    const { geometry } = await reader.read(cached);
+    renderer.loadGeometry(geometry?.meshes ?? []);
+    return; // first triangles in milliseconds
+  }
+
+  // Cold path — full parse + tessellation, then write the cache.
+  const dataStore = await new IfcParser().parseColumnar(ifcBuffer);
+  const geometry = await new GeometryProcessor().process(new Uint8Array(ifcBuffer));
+
+  // The writer takes the cache-format view of the parsed store.
+  const cacheDataStore: CacheDataStore = {
+    schema:
+      dataStore.schemaVersion === 'IFC4'
+        ? SchemaVersion.IFC4
+        : dataStore.schemaVersion === 'IFC4X3'
+          ? SchemaVersion.IFC4X3
+          : SchemaVersion.IFC2X3,
+    entityCount: dataStore.entityCount,
+    strings: dataStore.strings,
+    entities: dataStore.entities,
+    properties: dataStore.properties,
+    quantities: dataStore.quantities,
+    relationships: dataStore.relationships,
+    spatialHierarchy: dataStore.spatialHierarchy,
+    entityIndex: dataStore.entityIndex,
+  };
+
+  const writer = new BinaryCacheWriter();
+  const cacheBuffer = await writer.write(cacheDataStore, geometry, ifcBuffer, {
+    includeGeometry: true,
+  });
+  await myStorage.put(cacheKey, cacheBuffer);
 }
-
-// Cold path — full parse + tessellation, then write the cache.
-// dataStore comes from the parser; process() returns a GeometryResult.
-const dataStore = await parser.parseColumnar(new Uint8Array(ifcBuffer));
-const geometry = await geometryProcessor.process(new Uint8Array(ifcBuffer));
-
-const writer = new BinaryCacheWriter();
-const cacheBuffer = await writer.write(dataStore, geometry, ifcBuffer, { includeGeometry: true });
-await myStorage.put(cacheKey, cacheBuffer);
 ```
 
 ## Pure GLB read
@@ -46,11 +77,13 @@ If you already have a GLB blob (from a server, S3, etc.), skip the binary cache 
 ```typescript
 import { loadGLBToMeshData, parseGLB } from '@ifc-lite/cache';
 
-const meshes = loadGLBToMeshData(new Uint8Array(glbBuffer)); // synchronous
+declare const glbBytes: Uint8Array; // e.g. new Uint8Array(await res.arrayBuffer())
+
+const glbMeshes = loadGLBToMeshData(glbBytes); // synchronous
 // MeshData[] ready to feed into @ifc-lite/renderer
 
 // Or get the parsed GLB structure if you need lower-level access
-const { json, bin } = parseGLB(glbBuffer);
+const { json, bin } = parseGLB(glbBytes);
 ```
 
 ## Hashing utilities
@@ -75,8 +108,17 @@ The binary layout is versioned via the exported `FORMAT_VERSION` constant. Reade
 By default the header stores the full-file `xxhash64` of the source in `sourceHash`, and `reader.validate()` / `read({ sourceBuffer })` compare against it. Hashing a large source can be a multi-second main-thread cost, so a caller that validates the source **another way** (e.g. an application-layer content hash plus a file modified-time guard, as the viewer's source-decoupled cache tier does) can pass `omitSourceHash: true`:
 
 ```typescript
+import { BinaryCacheWriter, type CacheDataStore } from '@ifc-lite/cache';
+import type { GeometryResult } from '@ifc-lite/geometry';
+
+declare const cacheDataStore: CacheDataStore;
+declare const geometry: GeometryResult;
+declare const ifcBuffer: ArrayBuffer;
+
+const writer = new BinaryCacheWriter();
+
 // Skip the full-file hash; validate the source at the application layer instead.
-const cacheBuffer = await writer.write(dataStore, geometry, ifcBuffer, {
+const cacheBuffer = await writer.write(cacheDataStore, geometry, ifcBuffer, {
   includeGeometry: true,
   omitSourceHash: true,
 });

--- a/packages/clash/README.md
+++ b/packages/clash/README.md
@@ -38,6 +38,11 @@ space (as the viewer's loader does for every model past the first) while the
 can address the store correctly:
 
 ```ts
+import { elementsFromStep, type FederationLike } from '@ifc-lite/clash/step';
+
+declare const federation: FederationLike; // e.g. the renderer's FederationRegistry
+declare const model: { idOffset: number };
+
 elementsFromStep({ store, meshes, modelId, federation, meshIdOffset: model.idOffset });
 ```
 

--- a/packages/codegen/README.md
+++ b/packages/codegen/README.md
@@ -65,6 +65,8 @@ END_ENTITY;
 
 You get a TypeScript interface with full inheritance:
 
+<!-- Reason: shows generator OUTPUT; IfcBuildingElement and IfcWallTypeEnum only exist in the emitted files. -->
+<!-- docs-check: skip -->
 ```typescript
 export interface IfcWall extends IfcBuildingElement {
   PredefinedType?: IfcWallTypeEnum;
@@ -73,6 +75,8 @@ export interface IfcWall extends IfcBuildingElement {
 
 Plus runtime metadata for the same entity:
 
+<!-- Reason: shows generator OUTPUT; SCHEMA_REGISTRY lives in the emitted schema-registry.ts. -->
+<!-- docs-check: skip -->
 ```typescript
 SCHEMA_REGISTRY.IfcWall = {
   parent: 'IfcBuildingElement',

--- a/packages/collab-server/README.md
+++ b/packages/collab-server/README.md
@@ -38,6 +38,10 @@ Environment variables:
 ```ts
 import { startCollabServer } from '@ifc-lite/collab-server';
 
+// Your own credential check — a JWT verify, a session lookup, whatever you
+// already run. (`createRoomTokenAuthenticator` ships one if you want ours.)
+declare function verify(token: string | undefined): boolean;
+
 const server = await startCollabServer({
   port: 4444,
   authenticate: async (token, room) => {

--- a/packages/collab/README.md
+++ b/packages/collab/README.md
@@ -55,6 +55,8 @@ const ifcx = snapshotToIfcx(session.doc, { author: 'louis' });
 
 ## Public API
 
+<!-- Reason: signature listing, not runnable code - bare member paths and `→` arrows. -->
+<!-- docs-check: skip -->
 ```ts
 createCollabSession(opts) → CollabSession
 session.doc            // Y.Doc

--- a/packages/diff/README.md
+++ b/packages/diff/README.md
@@ -18,12 +18,13 @@ npm install @ifc-lite/diff
 ## Usage
 
 ```ts
-import {
-  diffModels,
-  buildDataFingerprint,
-  identityMapFromContentMatches,
-  type EntityFingerprint,
-} from '@ifc-lite/diff';
+import { diffModels, type EntityFingerprint } from '@ifc-lite/diff';
+
+// Your adapter walks a store and emits one fingerprint per entity, per model.
+declare function extractFingerprints(model: unknown): EntityFingerprint<number>[];
+declare const baseModel: unknown;
+declare const headModel: unknown;
+declare const gid: string; // the GlobalId you picked in the viewer
 
 // One fingerprint per entity, per model. `key` is the stable cross-revision
 // identity (the IFC GlobalId). `dataHash` comes from buildDataFingerprint;
@@ -109,11 +110,13 @@ same `{ base, here, reason }` vocabulary a published layer carries in its
 provenance manifest:
 
 ```ts
+import { diffModels, identityMapFromContentMatches } from '@ifc-lite/diff';
+
 const first = diffModels(base, head, { matchUnpairedByContent: true });
 const claims = identityMapFromContentMatches(first.contentMatches);
 // [{ base: 'oldGid', here: 'newGid', reason: 'content-match:renamed' }]
 
-const aliases = new Map(claims.map((c) => [c.here, c.base]));
+const aliases = new Map(claims.map((c) => [c.here, c.base] as const));
 const second = diffModels(base, head, { matchUnpairedByContent: true, keyAliases: aliases });
 second.appliedKeyAliases; // what actually took effect
 ```
@@ -146,9 +149,20 @@ type assignments, so collection ordering never produces a spurious diff. Feed it
 a plain `DataFingerprintInput` extracted from your store:
 
 ```ts
+import { buildDataFingerprint, type DataFingerprintInput } from '@ifc-lite/diff';
+
+// Whatever your store hands back for one entity.
+declare const entity: DataFingerprintInput;
+
 const dataHash = buildDataFingerprint({
-  ifcType, name, description, objectType, predefinedType,
-  propertySets, quantitySets, typeAssignments,
+  ifcType: entity.ifcType,
+  name: entity.name,
+  description: entity.description,
+  objectType: entity.objectType,
+  predefinedType: entity.predefinedType,
+  propertySets: entity.propertySets,
+  quantitySets: entity.quantitySets,
+  typeAssignments: entity.typeAssignments,
 });
 ```
 

--- a/packages/drawing-2d/README.md
+++ b/packages/drawing-2d/README.md
@@ -16,7 +16,7 @@ import { generateFloorPlan, exportToSVG, PAPER_SIZES, COMMON_SCALES } from '@ifc
 // Cut at 1.2 m above floor level (standard architectural plan height)
 const drawing = await generateFloorPlan(meshes, 1.2, {
   includeHiddenLines: true,
-  includeMaterialHatching: true,
+  includeProjection: true,
 });
 
 const svg = exportToSVG(drawing, {
@@ -39,7 +39,7 @@ import { generateSection, exportToSVG } from '@ifc-lite/drawing-2d';
 // Vertical section through plane x = 5
 const drawing = await generateSection(meshes, 'x', 5, {
   includeHiddenLines: false,
-  includeProjectionLines: true,
+  includeProjection: true,
 });
 
 const svg = exportToSVG(drawing);
@@ -56,8 +56,12 @@ await generator.initialize();
 const config = createSectionConfig('y', 2.5, { projectionDepth: 5, scale: 50 });
 const drawing = await generator.generate(meshes, config, {
   includeHiddenLines: true,
-  includeMaterialHatching: true,
+  includeEdges: true,
 });
+
+// Hatching for the cut polygons is a separate pass; `exportToSVG`'s
+// `showHatching` option draws the lines it returns.
+const hatchLines = generator.generateHatching(drawing);
 
 generator.dispose();
 ```
@@ -85,7 +89,7 @@ const custom = createOverrideEngine([
     enabled: true,
     priority: 10,
     criteria: ifcTypeCriterion(['IfcWall', 'IfcWallStandardCase']),
-    style: { strokeColor: '#d62828', strokeWidth: 0.7 },
+    style: { strokeColor: '#d62828', lineWeight: 0.7 },
   },
 ]);
 
@@ -132,6 +136,7 @@ Import an existing DXF drawing (site plan, survey, coordination set) as a refere
 ```typescript
 import { importDxf, exportToSVG } from '@ifc-lite/drawing-2d';
 
+const dxfFileText = await fetch('site-plan.dxf').then((r) => r.text());
 const underlay = importDxf(dxfFileText, 'site-plan.dxf');
 // underlay.layers[n].paths / .fills / .texts, underlay.bounds, underlay.warnings
 

--- a/packages/drawing-2d/README.md
+++ b/packages/drawing-2d/README.md
@@ -59,9 +59,13 @@ const drawing = await generator.generate(meshes, config, {
   includeEdges: true,
 });
 
-// Hatching for the cut polygons is a separate pass; `exportToSVG`'s
-// `showHatching` option draws the lines it returns.
+// Hatching is a separate pass, for callers rendering the drawing themselves:
+// it returns the cut polygons' hatch as DrawingLine[]. `exportToSVG`'s
+// `showHatching` does NOT consume these — it derives its own hatching layer
+// from `drawing.cutPolygons` (svg-exporter.ts:151), so passing both just
+// draws the same hatch twice.
 const hatchLines = generator.generateHatching(drawing);
+console.log(`${hatchLines.length} hatch lines`);
 
 generator.dispose();
 ```

--- a/packages/export/README.md
+++ b/packages/export/README.md
@@ -117,6 +117,8 @@ argument to drop overlay-deleted entities (and every row that references one) fr
 `Entities`, `Properties`, `Quantities` and `Relationships`:
 
 ```typescript
+import { ParquetExporter } from '@ifc-lite/export';
+
 const exporter = new ParquetExporter(store, geometryResult, mutationView);
 ```
 
@@ -158,7 +160,7 @@ const bytes = new Uint8Array(await file.arrayBuffer());
 const lod0 = await generateLod0(bytes);
 
 // LOD1 — meshes simplified to bounding boxes / convex hulls, returned as GLB
-const lod1 = await generateLod1(bytes, { quality: 'medium' });
+const lod1 = await generateLod1(bytes);
 //   { glb: Uint8Array, meta: { failedElements, mapping, ... } }
 
 // Falls back gracefully to box geometry if a complex element fails to mesh

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -62,12 +62,12 @@ import { loadBundleFromDirectory } from '@ifc-lite/extensions/node';
 // Validate a manifest
 const manifestJson: unknown = await fetch('/my-extension/manifest.json').then((r) => r.json());
 const result = validateManifest(manifestJson);
-if (result.ok === false) {
+if (result.ok === true) {
+  console.log(result.value.id);
+} else {
   for (const err of result.errors) {
     console.error(`${err.path}: ${err.message}`);
   }
-} else {
-  console.log(result.value.id);
 }
 ```
 

--- a/packages/extensions/README.md
+++ b/packages/extensions/README.md
@@ -60,13 +60,14 @@ import {
 import { loadBundleFromDirectory } from '@ifc-lite/extensions/node';
 
 // Validate a manifest
+const manifestJson: unknown = await fetch('/my-extension/manifest.json').then((r) => r.json());
 const result = validateManifest(manifestJson);
-if (result.ok) {
-  console.log(result.value.id);
-} else {
+if (result.ok === false) {
   for (const err of result.errors) {
     console.error(`${err.path}: ${err.message}`);
   }
+} else {
+  console.log(result.value.id);
 }
 ```
 

--- a/packages/geometry/README.md
+++ b/packages/geometry/README.md
@@ -26,9 +26,11 @@ console.log(`${result.meshes.length} meshes, ${result.totalTriangles} triangles`
 ## Stream geometry (recommended for large models)
 
 ```typescript
+const buffer = new Uint8Array(await file.arrayBuffer());
+
 for await (const event of processor.processStreaming(buffer)) {
   if (event.type === 'batch') {
-    renderer.appendMeshes(event.meshes);
+    renderer.addMeshes(event.meshes, true);
     console.log(`Loaded ${event.totalSoFar} meshes so far`);
   } else if (event.type === 'complete') {
     console.log(`Done: ${event.totalMeshes} meshes`);
@@ -54,8 +56,7 @@ Unset / `'medium'` reproduces the engine's historical densities byte-for-byte. L
 ## Coordinate handling
 
 ```typescript
-import { CoordinateHandler } from '@ifc-lite/geometry';
-
+const buffer = new Uint8Array(await file.arrayBuffer());
 const result = await processor.process(buffer);
 
 // Models with large world coordinates (geo-referenced) get auto-shifted
@@ -92,6 +93,8 @@ If your bundler can't transform
 wasm URLs through the `processAdaptive` / `processParallel` `wasmUrls`
 option:
 
+<!-- Reason: Vite-only `?url` import specifier, unresolvable by tsc. -->
+<!-- docs-check: skip -->
 ```ts
 // Vite's `?url` suffix yields a fully-resolved URL string at build time.
 // `@ifc-lite/wasm` exposes the binary at the `./ifc-lite_bg.wasm` subpath

--- a/packages/ids/README.md
+++ b/packages/ids/README.md
@@ -48,6 +48,9 @@ for (const spec of report.specificationResults) {
 Reports translate automatically. Supported languages: English (`en`), German (`de`), French (`fr`).
 
 ```typescript
+import { parseIDS, validateIDS, createTranslationService } from '@ifc-lite/ids';
+
+const idsSpec = parseIDS(idsXml);
 const de = createTranslationService('de');
 const report = await validateIDS(idsSpec, accessor, modelInfo, { translator: de });
 // Failures now read: "Anforderung 'FireRating' nicht erfüllt..."
@@ -69,6 +72,8 @@ for (const issue of audit.issues) {
 ## Inspect an IDS specification
 
 ```typescript
+import { parseIDS } from '@ifc-lite/ids';
+
 const idsSpec = parseIDS(idsXml);
 
 for (const spec of idsSpec.specifications) {

--- a/packages/ifcx/README.md
+++ b/packages/ifcx/README.md
@@ -31,7 +31,8 @@ renderer.loadGeometry(result.meshes);
 ## Auto-detect format
 
 ```typescript
-import { detectFormat } from '@ifc-lite/ifcx';
+import { detectFormat, parseIfcx } from '@ifc-lite/ifcx';
+import { IfcParser } from '@ifc-lite/parser';
 
 const format = detectFormat(buffer);
 // 'ifcx' | 'ifc' | 'glb' | 'unknown'
@@ -39,7 +40,7 @@ const format = detectFormat(buffer);
 if (format === 'ifcx') {
   await parseIfcx(buffer);
 } else if (format === 'ifc') {
-  await ifcParser.parse(buffer); // @ifc-lite/parser
+  await new IfcParser().parse(buffer);
 }
 ```
 
@@ -49,6 +50,12 @@ IFCX supports overlays — a base file with the geometry, plus one or more layer
 
 ```typescript
 import { parseFederatedIfcx } from '@ifc-lite/ifcx';
+
+const [baseBytes, psetOverlayBytes, scheduleOverlayBytes] = await Promise.all(
+  ['architecture.ifcx', 'fire-safety-overlay.ifcx', 'construction-schedule.ifcx'].map(
+    (name) => fetch(name).then((r) => r.arrayBuffer()),
+  ),
+);
 
 const result = await parseFederatedIfcx([
   { buffer: baseBytes, name: 'architecture.ifcx' },

--- a/packages/lens/README.md
+++ b/packages/lens/README.md
@@ -14,7 +14,10 @@ npm install @ifc-lite/lens
 import { evaluateLens, BUILTIN_LENSES } from '@ifc-lite/lens';
 import type { LensDataProvider } from '@ifc-lite/lens';
 
-const provider: LensDataProvider = createMyProvider(myData);
+// Bridge your data source (IfcDataStore, a server API, IndexedDB, ...)
+// to the engine by implementing LensDataProvider.
+declare const provider: LensDataProvider;
+
 const result = evaluateLens(BUILTIN_LENSES[0], provider);
 // result.colorMap   - Map<globalId, RGBAColor>
 // result.hiddenIds  - Set<globalId>

--- a/packages/lists/README.md
+++ b/packages/lists/README.md
@@ -14,7 +14,9 @@ npm install @ifc-lite/lists
 import { executeList, listResultToCSV, LIST_PRESETS } from '@ifc-lite/lists';
 import type { ListDataProvider } from '@ifc-lite/lists';
 
-const provider: ListDataProvider = createMyProvider(myData);
+// Bridge your data source (IfcDataStore, a server API, IndexedDB, ...)
+// to the engine by implementing ListDataProvider.
+declare const provider: ListDataProvider;
 
 // LIST_PRESETS includes ready-made schedules (for example a Wall Schedule)
 const result = executeList(LIST_PRESETS[0], provider);

--- a/packages/merge/README.md
+++ b/packages/merge/README.md
@@ -8,6 +8,7 @@ editing a wall's placement and an agent editing `Pset_FireSafety` on the
 same wall is *not* a conflict.
 
 ```ts
+import type { IfcxFile } from '@ifc-lite/ifcx';
 import {
   planThreeWayMerge,
   applyResolutions,
@@ -16,6 +17,14 @@ import {
 
 // A = the candidate layer's base, O = the target ref's state,
 // T = the candidate applied to A (all ordered weakest-first).
+declare const ancestor: readonly IfcxFile[];
+declare const ours: readonly IfcxFile[];
+declare const theirs: readonly IfcxFile[];
+// Content hash of the stack the merge applies on top of, and the id of
+// the candidate layer being merged.
+declare const stackHash: string;
+declare const candidate: string;
+
 const plan = planThreeWayMerge({ ancestor, ours, theirs });
 // plan.autoOps   — apply cleanly on top of `ours`
 // plan.conflicts — explicit records: concurrent-edit, delete-vs-modify,

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -69,6 +69,10 @@ is unambiguously REAL-backed, a whole-number value is serialized with the
 decimal point automatically, so the natural call just works:
 
 ```typescript
+const profile = editor.addEntity('IfcRectangleProfileDef', [
+  '.AREA.', null, '#34', 0.6, 0.4,
+]);
+
 editor.setPositionalAttribute(profile.expressId, 3, 1);  // XDim → 1.  (dotted)
 ```
 
@@ -77,6 +81,8 @@ For the rare slot that a bare value genuinely can't disambiguate — a
 the number in the write-only `{ real }` marker to force a REAL literal:
 
 ```typescript
+const unitRef = '#34';  // STEP reference to an IfcNamedUnit
+
 editor.addEntity('IfcQuantityLength', ['L', null, unitRef, { real: 3 }]); // → IFCLENGTHMEASURE-safe 3.
 ```
 
@@ -88,6 +94,12 @@ type-QUALIFIED — `IFCBOOLEAN(.T.)`, not a bare `.T.`, in an
 the member is unambiguous, so the natural call just works:
 
 ```typescript
+// IfcBoundaryNodeCondition: Name, TranslationalStiffnessX/Y/Z,
+//                           RotationalStiffnessX/Y/Z
+const condition = editor.addEntity('IfcBoundaryNodeCondition', [
+  'Pinned', null, null, null, null, null, null,
+]);
+
 // TranslationalStiffnessX : SELECT(IfcBoolean, IfcLinearStiffnessMeasure)
 editor.setPositionalAttribute(condition.expressId, 1, true);  // → IFCBOOLEAN(.T.)
 editor.setPositionalAttribute(condition.expressId, 1, 1000);  // → IFCLINEARSTIFFNESSMEASURE(1000.)
@@ -146,6 +158,8 @@ To carry a created entity across, call `restoreNewEntity()` with its
 view) **before** calling `importMutations`:
 
 ```typescript
+const json = view.exportMutations();
+
 const created = view.getNewEntity(expressId)!;
 mutationView.restoreNewEntity(created);
 mutationView.importMutations(json); // dependent property/attribute/quantity mutations now replay
@@ -188,7 +202,23 @@ console.log(`Updated ${result.affectedEntityCount} walls`);
 Preview without applying:
 
 ```typescript
-const preview = engine.preview(query);
+import { BulkQueryEngine, type BulkQuery } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+
+const engine = new BulkQueryEngine(store.entities, view);
+
+const bulkQuery: BulkQuery = {
+  select: { propertyFilters: [{ propName: 'IsExternal', operator: '=', value: true }] },
+  action: {
+    type: 'SET_PROPERTY',
+    psetName: 'Pset_WallCommon',
+    propName: 'ThermalTransmittance',
+    value: 0.18,
+    valueType: PropertyValueType.Real,
+  },
+};
+
+const preview = engine.preview(bulkQuery);
 console.log(`Would update ${preview.matchedCount} entities`);
 ```
 
@@ -201,6 +231,8 @@ import { CsvConnector } from '@ifc-lite/mutations';
 import { PropertyValueType } from '@ifc-lite/data';
 
 const connector = new CsvConnector(store.entities, view);
+
+const csvText = await file.text();  // or any string of CSV
 
 const stats = connector.import(csvText, {
   matchStrategy: { type: 'globalId', column: 'GlobalId' },

--- a/packages/mutations/README.md
+++ b/packages/mutations/README.md
@@ -207,8 +207,17 @@ import { PropertyValueType } from '@ifc-lite/data';
 
 const engine = new BulkQueryEngine(store.entities, view);
 
+// The same query the execute example above runs.
 const bulkQuery: BulkQuery = {
-  select: { propertyFilters: [{ propName: 'IsExternal', operator: '=', value: true }] },
+  select: {
+    entityTypes: [/* IfcWall enum value */],
+    propertyFilters: [{
+      psetName: 'Pset_WallCommon',
+      propName: 'IsExternal',
+      operator: '=',
+      value: true,
+    }],
+  },
   action: {
     type: 'SET_PROPERTY',
     psetName: 'Pset_WallCommon',

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -19,6 +19,9 @@ npm install @ifc-lite/pointcloud
 ```ts
 import { decodeIfcxPointAttribute } from '@ifc-lite/pointcloud';
 
+// One IFCX node's attribute map, e.g. from a parsed .ifcx document
+const node: { attributes: ReadonlyMap<string, unknown> } = { attributes: new Map() };
+
 const chunk = decodeIfcxPointAttribute(node.attributes);
 if (chunk) {
   console.log(`${chunk.pointCount} points`, chunk.bbox);

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -20,7 +20,7 @@ npm install @ifc-lite/pointcloud
 import { decodeIfcxPointAttribute } from '@ifc-lite/pointcloud';
 
 // One IFCX node's attribute map, e.g. from a parsed .ifcx document
-const node: { attributes: ReadonlyMap<string, unknown> } = { attributes: new Map() };
+declare const node: { attributes: ReadonlyMap<string, unknown> };
 
 const chunk = decodeIfcxPointAttribute(node.attributes);
 if (chunk) {

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -88,6 +88,10 @@ renderer.requestRender();
 ```typescript
 import { federationRegistry } from '@ifc-lite/renderer';
 
+// The highest expressId in each model decides the offset spacing
+const maxArchExpressId = 500_000;
+const maxStructExpressId = 250_000;
+
 // Register each model with a unique ID offset
 federationRegistry.registerModel('arch', maxArchExpressId);
 federationRegistry.registerModel('struct', maxStructExpressId);

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -12,9 +12,12 @@ npm install @ifc-lite/sandbox
 
 ```ts
 import { createSandbox } from '@ifc-lite/sandbox';
-import { createBimContext } from '@ifc-lite/sdk';
+import { createBimContext, type BimBackend } from '@ifc-lite/sdk';
 
-const bim = createBimContext({ backend: myBackend });
+// Your BimBackend — the viewer's store adapter, a server client, ...
+declare const backend: BimBackend;
+
+const bim = createBimContext({ backend });
 const sandbox = await createSandbox(bim, {
   permissions: { mutate: true },
   limits: { timeoutMs: 10_000 },
@@ -39,7 +42,10 @@ A script that exhausts the memory limit inside a *drained promise job* — the p
 **`dispose()` can throw, and that throw is the run's verdict.** It rejects with `SandboxAbortError`. The `eval()` that caused it already resolved normally — the reproducer returns `"started"` — so teardown is the *only* place the failure is observable. Treat a throwing `dispose()` as that run having failed, and settle the run's outcome after teardown rather than before it:
 
 ```ts
-import { SandboxAbortError, type ScriptResult } from '@ifc-lite/sandbox';
+import { SandboxAbortError, type Sandbox, type ScriptResult } from '@ifc-lite/sandbox';
+
+declare const sandbox: Sandbox;
+declare const code: string;
 
 let result: ScriptResult | null = await sandbox.eval(code);
 try {
@@ -54,6 +60,11 @@ try {
 **A long-lived sandbox must be discarded once `moduleRetired` is true.** The abort poisons the whole WASM module, so this package retires it and builds the next sandbox on a fresh one — 1-5 ms, no page reload, and nothing for a caller to do. But a host that *keeps* one sandbox across many runs (an extension runtime, a REPL) can be holding one whose module was retired by some other sandbox's abort. That sandbox still executes scripts, yet emscripten's `ABORT` latch is per module and has already fired on it: its own teardown can no longer report a failure, and it will silently leak whatever `JS_FreeRuntime` does not reach. Check before running, and replace rather than reuse:
 
 ```ts
+import { createSandbox, type Sandbox, type SandboxConfig } from '@ifc-lite/sandbox';
+
+declare let sandbox: Sandbox;
+declare const config: SandboxConfig;
+
 if (sandbox.moduleRetired) {
   sandbox.dispose();
   sandbox = await createSandbox(bim, config); // built on a fresh module

--- a/packages/server-client/README.md
+++ b/packages/server-client/README.md
@@ -31,7 +31,19 @@ for await (const event of client.parseStream(file)) {
       console.log(`${event.processed}/${event.total}`);
       break;
     case 'batch':
-      renderer.appendMeshes(event.meshes); // first triangles ~300ms in
+      // Server meshes are snake_case; map them onto the renderer's MeshData.
+      renderer.addMeshes(
+        event.meshes.map((m) => ({
+          expressId: m.express_id,
+          ifcType: m.ifc_type,
+          positions: m.positions,
+          normals: m.normals,
+          indices: m.indices,
+          color: m.color,
+          origin: m.origin,
+        })),
+        true, // streaming: throttle batch rebuilds — first triangles ~300ms in
+      );
       break;
     case 'complete':
       console.log(`Done: ${event.stats.total_meshes} meshes`);

--- a/packages/server-client/README.md
+++ b/packages/server-client/README.md
@@ -25,23 +25,38 @@ console.log(`${result.metadata.entity_count} entities, ${result.meshes.length} m
 ## Stream a large file
 
 ```typescript
+import type { MeshData as ServerMeshData } from '@ifc-lite/server-client';
+import type { MeshData } from '@ifc-lite/geometry';
+
+// Server meshes are the snake_case wire shape. Converting them is a real seam,
+// not a rename: `origin` and `geometryClass` must be OMITTED rather than
+// stamped when absent or zero, so a world-baked mesh decodes identically over
+// every transport, and the two disjoint source ids are tested against
+// `undefined` rather than for truthiness. The viewer keeps the tested copy at
+// apps/viewer/src/utils/serverMesh.ts (issue #1841, #3199); keep yours in step.
+function convertServerMesh(m: ServerMeshData): MeshData {
+  return {
+    expressId: m.express_id,
+    ifcType: m.ifc_type,
+    positions: new Float32Array(m.positions),
+    normals: m.normals ? new Float32Array(m.normals) : new Float32Array(0),
+    indices: new Uint32Array(m.indices),
+    color: m.color,
+    ...(m.origin?.some((v) => v !== 0) ? { origin: m.origin } : {}),
+    ...(m.geometry_class ? { geometryClass: m.geometry_class } : {}),
+    ...(m.geometry_item_id !== undefined ? { geometryItemId: m.geometry_item_id } : {}),
+    ...(m.material_id !== undefined ? { materialId: m.material_id } : {}),
+  };
+}
+
 for await (const event of client.parseStream(file)) {
   switch (event.type) {
     case 'progress':
       console.log(`${event.processed}/${event.total}`);
       break;
     case 'batch':
-      // Server meshes are snake_case; map them onto the renderer's MeshData.
       renderer.addMeshes(
-        event.meshes.map((m) => ({
-          expressId: m.express_id,
-          ifcType: m.ifc_type,
-          positions: m.positions,
-          normals: m.normals,
-          indices: m.indices,
-          color: m.color,
-          origin: m.origin,
-        })),
+        event.meshes.map(convertServerMesh),
         true, // streaming: throttle batch rebuilds — first triangles ~300ms in
       );
       break;

--- a/packages/spatial/README.md
+++ b/packages/spatial/README.md
@@ -24,6 +24,10 @@ const indexAsync = await buildSpatialIndexAsync(meshes);
 ## Raycast (entity picking)
 
 ```typescript
+import { buildSpatialIndex } from '@ifc-lite/spatial';
+
+const index = buildSpatialIndex(meshes);
+
 const origin: [number, number, number] = [0, 5, 10];
 const direction: [number, number, number] = [0, -1, 0];
 
@@ -38,10 +42,14 @@ if (hits.length > 0) {
 ## AABB query (region select)
 
 ```typescript
-const region = {
+import { buildSpatialIndex, type AABB } from '@ifc-lite/spatial';
+
+const index = buildSpatialIndex(meshes);
+
+const region: AABB = {
   min: [-5, 0, -5],
   max: [5, 3, 5],
-} as const;
+};
 
 const hits = index.queryAABB(region);
 // → expressIds of every mesh whose bounds intersect the box
@@ -52,9 +60,12 @@ console.log(`${hits.length} entities in region`);
 ## Frustum culling
 
 ```typescript
-import { FrustumUtils } from '@ifc-lite/spatial';
+import { buildSpatialIndex, FrustumUtils } from '@ifc-lite/spatial';
+
+const index = buildSpatialIndex(meshes);
 
 // Build a frustum from a view-projection matrix (column-major 4×4)
+const viewProjMatrix = new Float32Array(16); // from your camera
 const frustum = FrustumUtils.fromViewProjMatrix(viewProjMatrix);
 
 const visible = index.queryFrustum(frustum);

--- a/packages/spatial/README.md
+++ b/packages/spatial/README.md
@@ -64,8 +64,9 @@ import { buildSpatialIndex, FrustumUtils } from '@ifc-lite/spatial';
 
 const index = buildSpatialIndex(meshes);
 
-// Build a frustum from a view-projection matrix (column-major 4×4)
-const viewProjMatrix = new Float32Array(16); // from your camera
+// Your camera's view-projection matrix (column-major 4×4)
+declare const viewProjMatrix: Float32Array;
+
 const frustum = FrustumUtils.fromViewProjMatrix(viewProjMatrix);
 
 const visible = index.queryFrustum(frustum);

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -45,7 +45,8 @@ import init, { IfcAPI } from '@ifc-lite/wasm';
 
 await init();
 const api = new IfcAPI();
-const bytes = new Uint8Array(await fetch('model.ifc').then(r => r.arrayBuffer()));
+const modelBuffer = await fetch('model.ifc').then(r => r.arrayBuffer());
+const bytes = new Uint8Array(modelBuffer);
 
 const pre = api.buildPrePassOnce(bytes);
 // Large-coordinate models: pre.needsShift / pre.rtcOffset give the RTC origin.
@@ -61,7 +62,9 @@ for (let start = 0; start < pre.totalJobs; start += 100) {
   );
   for (let i = 0; i < collection.length; i++) {
     const mesh = collection.get(i);
-    scene.add(toThreeMesh(mesh)); // mesh.expressId, .ifcType, .positions, .normals, .indices, .color
+    // mesh.expressId, .ifcType, .positions, .normals, .indices, .color —
+    // hand these to your renderer of choice before freeing the mesh.
+    console.log(mesh.expressId, mesh.ifcType, mesh.positions.length / 3);
     mesh.free();
   }
   collection.free();

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -43,6 +43,10 @@ plus unit scale, RTC offset, void/style indices) followed by
 ```typescript
 import init, { IfcAPI } from '@ifc-lite/wasm';
 
+// Your renderer, and your own adapter from a wasm mesh to its mesh type.
+declare const scene: { add(m: unknown): void };
+declare function toThreeMesh(mesh: unknown): unknown;
+
 await init();
 const api = new IfcAPI();
 const modelBuffer = await fetch('model.ifc').then(r => r.arrayBuffer());
@@ -62,9 +66,7 @@ for (let start = 0; start < pre.totalJobs; start += 100) {
   );
   for (let i = 0; i < collection.length; i++) {
     const mesh = collection.get(i);
-    // mesh.expressId, .ifcType, .positions, .normals, .indices, .color —
-    // hand these to your renderer of choice before freeing the mesh.
-    console.log(mesh.expressId, mesh.ifcType, mesh.positions.length / 3);
+    scene.add(toThreeMesh(mesh)); // mesh.expressId, .ifcType, .positions, .normals, .indices, .color
     mesh.free();
   }
   collection.free();

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -61,6 +61,7 @@ import {
   readdirSync,
   writeFileSync,
   existsSync,
+  statSync,
   rmSync,
 } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
@@ -74,25 +75,71 @@ const GLOBALS_SRC = join(HERE, 'doc-samples-globals.d.ts');
 const EXTERNALS_SRC = join(HERE, 'doc-samples-externals.d.ts');
 
 /**
+ * Lower bound on how many published-package READMEs must reach the typecheck.
+ * The sibling of check-package-readmes.mjs's CHECKED_FLOOR, set to the same
+ * 25 against the same measured 43, and here for the same reason: every way
+ * this walk can go blind - a wrong ROOT, a restructured `packages/`, a read
+ * that stops resolving - collapses the count towards zero rather than to 24,
+ * and a gate that quietly stopped covering package READMEs is exactly the
+ * #3846 defect coming back.
+ */
+const PACKAGE_README_FLOOR = 25;
+
+function fail(message) {
+  console.error(`\n❌ ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * Does this path exist? Refuses when the answer is UNKNOWABLE.
+ *
+ * Same body and same reason as check-package-readmes.mjs's: `existsSync`
+ * answers false for EACCES and ENOTDIR too, and "absent" here means "skip
+ * this package", which is how one leaves the audit without leaving a trace.
+ * Not the shared scripts/lib/ helper, for the reason that gate documents -
+ * both files are copied alone into synthetic trees by their harnesses, so
+ * neither may import outside node builtins.
+ */
+function existsOrFail(path, what) {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    fail(
+      `cannot read ${what} ${path} (${err.code || err.message}). ` +
+        'Refusing to treat an unreadable path as an absent one - that is how a ' +
+        'package drops out of this audit without anyone noticing.',
+    );
+  }
+}
+
+/**
  * Every published package under `packages/`, as `{ dir, pkg }`.
  *
  * "Published" is decided exactly as check-package-readmes.mjs decides it -
- * a non-dotfile directory carrying a package.json whose `private` is not
- * `true` - so the set of READMEs that gate REQUIRES to exist is the set this
- * gate TYPECHECKS. Restated rather than imported: both gates are copied
- * file-by-file into synthetic trees by their regression harnesses, so
- * neither may import outside node builtins (see `existsOrFail` there).
+ * a non-dotfile directory carrying a readable package.json whose `private`
+ * is not `true` - so the set of READMEs that gate REQUIRES to exist is the
+ * set this gate TYPECHECKS. check-doc-samples.test.mjs drives both rules
+ * over the real packages/ layout and asserts the two sets are equal.
+ *
+ * Deliberately NOT filtered on `pkg.name`: the sibling does not filter on it,
+ * and a nameless manifest that silently left this set would be a package
+ * whose README stopped being checked. buildPaths() drops it instead, where
+ * the name is what is actually needed.
  */
 function publishedPackages() {
   const packagesDir = join(ROOT, 'packages');
   const out = [];
   for (const dir of readdirSync(packagesDir).sort()) {
-    // As check-package-readmes.mjs: `packages/*` never matches a leading dot.
+    // As check-package-readmes.mjs: `packages/*` never matches a leading dot,
+    // and statting `.DS_Store/package.json` raises the ENOTDIR that
+    // existsOrFail refuses by design.
     if (dir.startsWith('.')) continue;
     const pkgJson = join(packagesDir, dir, 'package.json');
-    if (!existsSync(pkgJson)) continue;
+    if (!existsOrFail(pkgJson, 'package manifest')) continue;
     const pkg = JSON.parse(readFileSync(pkgJson, 'utf-8'));
-    if (pkg.private === true || !pkg.name) continue;
+    if (pkg.private === true) continue;
     out.push({ dir, pkg });
   }
   return out;
@@ -115,11 +162,25 @@ function targetDocs() {
       if (f.endsWith('.md')) files.push(join('docs', dir, f));
     }
   }
+  let packageReadmes = 0;
   for (const { dir } of publishedPackages()) {
     const rel = join('packages', dir, 'README.md');
     // A missing README is check-package-readmes.mjs's verdict, not this
     // gate's, which would only crash on the unreadable path.
-    if (existsSync(join(ROOT, rel))) files.push(rel);
+    if (!existsOrFail(join(ROOT, rel), 'package README')) continue;
+    files.push(rel);
+    packageReadmes += 1;
+  }
+  if (packageReadmes < PACKAGE_README_FLOOR) {
+    fail(
+      `only ${packageReadmes} published-package README(s) reached the doc-samples ` +
+        `typecheck under ${join(ROOT, 'packages')}, expected at least ` +
+        `${PACKAGE_README_FLOOR}. Refusing a vacuous pass: this gate found almost ` +
+        'no package READMEs to check, which is a failure of discovery, not a clean ' +
+        'tree, and leaving them unchecked is the #3846 defect. If packages/ ' +
+        'genuinely shrank this far, lower PACKAGE_README_FLOOR in this file - ' +
+        'deliberately, in a reviewable diff.',
+    );
   }
   return files;
 }
@@ -169,6 +230,9 @@ function buildPaths() {
   const paths = {};
   const packagesDir = join(ROOT, 'packages');
   for (const { dir, pkg } of publishedPackages()) {
+    // A manifest with no `name` is not in the published set's business, but it
+    // is in this map's: the name IS the key here (#3846 review).
+    if (!pkg.name) continue;
     // @ifc-lite/wasm ships a committed .d.ts (no src/index.ts).
     if (pkg.name === '@ifc-lite/wasm') {
       paths['@ifc-lite/wasm'] = ['packages/wasm/pkg/ifc-lite.d.ts'];

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -11,7 +11,8 @@
  *
  * How it works:
  *   1. Extract every fenced ts/typescript block from a fixed list of
- *      docs (README + guides + tutorials).
+ *      docs (README + guides + tutorials + every published package's
+ *      README).
  *   2. Write each block to a temp dir as its own module.
  *   3. Typecheck them all with the workspace TypeScript, resolving
  *      `@ifc-lite/*` to each package's `src/` via tsconfig `paths` so no
@@ -73,23 +74,20 @@ const GLOBALS_SRC = join(HERE, 'doc-samples-globals.d.ts');
 const EXTERNALS_SRC = join(HERE, 'doc-samples-externals.d.ts');
 
 /**
- * Every published (non-private) package under `packages/`, as
- * `{ dir, pkg }`.
+ * Every published package under `packages/`, as `{ dir, pkg }`.
  *
- * "Published" is decided exactly as check-package-readmes.mjs decides it —
+ * "Published" is decided exactly as check-package-readmes.mjs decides it -
  * a non-dotfile directory carrying a package.json whose `private` is not
- * `true` — so the set of READMEs that gate REQUIRES to exist is the same
- * set this gate TYPECHECKS. The rule is restated rather than imported:
- * both gates are copied file-by-file into synthetic trees by their
- * regression harnesses, so neither may import outside node builtins (see
- * the note on `existsOrFail` in check-package-readmes.mjs).
+ * `true` - so the set of READMEs that gate REQUIRES to exist is the set this
+ * gate TYPECHECKS. Restated rather than imported: both gates are copied
+ * file-by-file into synthetic trees by their regression harnesses, so
+ * neither may import outside node builtins (see `existsOrFail` there).
  */
 function publishedPackages() {
   const packagesDir = join(ROOT, 'packages');
   const out = [];
   for (const dir of readdirSync(packagesDir).sort()) {
-    // Same reason as check-package-readmes.mjs: `packages/*` never matches a
-    // leading dot, and statting `.DS_Store/package.json` raises ENOTDIR.
+    // As check-package-readmes.mjs: `packages/*` never matches a leading dot.
     if (dir.startsWith('.')) continue;
     const pkgJson = join(packagesDir, dir, 'package.json');
     if (!existsSync(pkgJson)) continue;
@@ -104,10 +102,10 @@ function publishedPackages() {
  * Docs whose ts/typescript snippets are typechecked: the root README, the
  * guides and tutorials, and every published package's README.
  *
- * The package READMEs were absent from this list until #3846, which is how
+ * The package READMEs were missing here until #3846, which is how
  * packages/cache/README.md shipped a quickstart with two TS2345 errors
- * (#3759). A package README is the npm landing page — the single most
- * copy-pasted code in the repo — so it is checked exactly like a guide.
+ * (#3759). A package README is an npm landing page, so it is checked
+ * exactly like a guide.
  */
 function targetDocs() {
   const files = ['README.md'];
@@ -119,8 +117,8 @@ function targetDocs() {
   }
   for (const { dir } of publishedPackages()) {
     const rel = join('packages', dir, 'README.md');
-    // A missing README is check-package-readmes.mjs's verdict to report,
-    // not this gate's; it would fail here as an unreadable path instead.
+    // A missing README is check-package-readmes.mjs's verdict, not this
+    // gate's, which would only crash on the unreadable path.
     if (existsSync(join(ROOT, rel))) files.push(rel);
   }
   return files;

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -72,7 +72,43 @@ const ROOT = join(HERE, '..', '..');
 const GLOBALS_SRC = join(HERE, 'doc-samples-globals.d.ts');
 const EXTERNALS_SRC = join(HERE, 'doc-samples-externals.d.ts');
 
-/** Docs whose ts/typescript snippets are typechecked. */
+/**
+ * Every published (non-private) package under `packages/`, as
+ * `{ dir, pkg }`.
+ *
+ * "Published" is decided exactly as check-package-readmes.mjs decides it —
+ * a non-dotfile directory carrying a package.json whose `private` is not
+ * `true` — so the set of READMEs that gate REQUIRES to exist is the same
+ * set this gate TYPECHECKS. The rule is restated rather than imported:
+ * both gates are copied file-by-file into synthetic trees by their
+ * regression harnesses, so neither may import outside node builtins (see
+ * the note on `existsOrFail` in check-package-readmes.mjs).
+ */
+function publishedPackages() {
+  const packagesDir = join(ROOT, 'packages');
+  const out = [];
+  for (const dir of readdirSync(packagesDir).sort()) {
+    // Same reason as check-package-readmes.mjs: `packages/*` never matches a
+    // leading dot, and statting `.DS_Store/package.json` raises ENOTDIR.
+    if (dir.startsWith('.')) continue;
+    const pkgJson = join(packagesDir, dir, 'package.json');
+    if (!existsSync(pkgJson)) continue;
+    const pkg = JSON.parse(readFileSync(pkgJson, 'utf-8'));
+    if (pkg.private === true || !pkg.name) continue;
+    out.push({ dir, pkg });
+  }
+  return out;
+}
+
+/**
+ * Docs whose ts/typescript snippets are typechecked: the root README, the
+ * guides and tutorials, and every published package's README.
+ *
+ * The package READMEs were absent from this list until #3846, which is how
+ * packages/cache/README.md shipped a quickstart with two TS2345 errors
+ * (#3759). A package README is the npm landing page — the single most
+ * copy-pasted code in the repo — so it is checked exactly like a guide.
+ */
 function targetDocs() {
   const files = ['README.md'];
   for (const dir of ['guide', 'tutorials']) {
@@ -80,6 +116,12 @@ function targetDocs() {
     for (const f of readdirSync(abs).sort()) {
       if (f.endsWith('.md')) files.push(join('docs', dir, f));
     }
+  }
+  for (const { dir } of publishedPackages()) {
+    const rel = join('packages', dir, 'README.md');
+    // A missing README is check-package-readmes.mjs's verdict to report,
+    // not this gate's; it would fail here as an unreadable path instead.
+    if (existsSync(join(ROOT, rel))) files.push(rel);
   }
   return files;
 }
@@ -128,11 +170,7 @@ function extractBlocks(relPath) {
 function buildPaths() {
   const paths = {};
   const packagesDir = join(ROOT, 'packages');
-  for (const dir of readdirSync(packagesDir).sort()) {
-    const pkgJson = join(packagesDir, dir, 'package.json');
-    if (!existsSync(pkgJson)) continue;
-    const pkg = JSON.parse(readFileSync(pkgJson, 'utf-8'));
-    if (pkg.private === true || !pkg.name) continue;
+  for (const { dir, pkg } of publishedPackages()) {
     // @ifc-lite/wasm ships a committed .d.ts (no src/index.ts).
     if (pkg.name === '@ifc-lite/wasm') {
       paths['@ifc-lite/wasm'] = ['packages/wasm/pkg/ifc-lite.d.ts'];

--- a/scripts/docs/check-doc-samples.test.mjs
+++ b/scripts/docs/check-doc-samples.test.mjs
@@ -49,7 +49,7 @@ const README = ['# Sample', '', '```ts', 'const n: number = 1;', '```', ''].join
  * snippet, and `node_modules/.bin/tsc` written from `tscShim` (pass `null` to
  * leave the binary out entirely).
  */
-function makeTree(tscShim, { readme = README } = {}) {
+function makeTree(tscShim, { readme = README, packages = [] } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'doc-samples-'));
   mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
   mkdirSync(join(root, 'docs', 'guide'), { recursive: true });
@@ -65,6 +65,20 @@ function makeTree(tscShim, { readme = README } = {}) {
     copyFileSync(join(HERE, f), join(root, 'scripts', 'docs', f));
   }
   writeFileSync(join(root, 'README.md'), readme, 'utf8');
+
+  // `packages` entries are `{ dir, name, private?, readme? }`. A package with
+  // no `readme` ships none at all, which is check-package-readmes.mjs's
+  // verdict to report, not this gate's.
+  for (const p of packages) {
+    const dir = join(root, 'packages', p.dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      `${JSON.stringify({ name: p.name, version: '0.0.0', private: p.private === true })}\n`,
+      'utf8',
+    );
+    if (p.readme !== undefined) writeFileSync(join(dir, 'README.md'), p.readme, 'utf8');
+  }
 
   if (tscShim !== null) {
     const bin = join(root, 'node_modules', '.bin', 'tsc');
@@ -274,6 +288,108 @@ test('a non-zero exit with only out-of-scope diagnostics is still a clean run', 
       status: 2,
     }),
   );
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 0, `expected exit 0, got ${status}: ${out}`);
+    assert.match(out, /Doc code samples typecheck clean \(1 snippet compiled/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #3846: package READMEs are in the target set.
+//
+// `targetDocs()` used to return the root README plus docs/guide and
+// docs/tutorials only, so every packages/*/README.md - the npm landing pages,
+// the most copy-pasted code in the repo - was the one class of docs with no
+// typecheck at all. That is how packages/cache/README.md shipped a quickstart
+// with two TS2345 errors (#3759): check-package-readmes.mjs asserted the file
+// EXISTED and nothing looked inside it.
+//
+// These three drive the gate over a synthetic tree holding a package, rather
+// than asserting on the shape of `targetDocs()`, because inclusion in the list
+// is not the property that matters - being COMPILED is, and the gate reports
+// on the files tsc named, not the files it wrote (see #3200 above).
+// ---------------------------------------------------------------------------
+
+/** A package README with a snippet whose error the shim will report. */
+const PKG_README = ['# @scope/thing', '', '```ts', 'const s: string = 1;', '```', ''].join('\n');
+
+test("a published package's README is compiled, not merely required to exist", () => {
+  // A tsc that exits 0 having compiled nothing names every snippet the gate
+  // put in the program, so this is a positive assertion about MEMBERSHIP: had
+  // targetDocs() left package READMEs out, the package snippet would not be
+  // among the ones reported never-compiled, and the count would be 1, not 2.
+  const root = makeTree('#!/bin/sh\nexit 0\n', {
+    packages: [{ dir: 'thing', name: '@scope/thing', readme: PKG_README }],
+  });
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /confirmed only 0 of 2 snippets/);
+    assert.match(
+      out,
+      /never compiled: packages[/\\]thing[/\\]README\.md:4 \(fence #0\)/,
+      'the package README must be in the program at all',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a broken snippet in a package README is REPORTED against that README", () => {
+  // The gate's whole purpose, aimed at the file class it used to skip. The
+  // root README's snippet is snippet-000; the package README's is snippet-001,
+  // because targetDocs() appends packages after the root README and the guides.
+  const root = makeTree(
+    workingTsc({
+      extraLines: [
+        "__TMP__/snippet-001.ts(1,7): error TS2322: Type 'number' is not assignable to type 'string'.",
+      ],
+      status: 2,
+    }),
+    { packages: [{ dir: 'thing', name: '@scope/thing', readme: PKG_README }] },
+  );
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /failed to typecheck \(1 error\)/);
+    assert.match(out, /packages[/\\]thing[/\\]README\.md:4 \(fence #0\)/);
+    assert.match(out, /TS2322/);
+    assert.doesNotMatch(out, /typecheck clean/, 'a rejected snippet must never read as clean');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a PRIVATE package\'s README is not in the target set', () => {
+  // Pins the half of the rule that says which READMEs are in scope. It is
+  // check-package-readmes.mjs's rule verbatim - `private: true` is not
+  // published - and the two gates must cover the same set: a README that gate
+  // does not require to exist is not one this gate can insist compiles.
+  // Without this, "include every packages/*/README.md" would look identical.
+  const root = makeTree('#!/bin/sh\nexit 0\n', {
+    packages: [{ dir: 'inner', name: '@scope/inner', private: true, readme: PKG_README }],
+  });
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /confirmed only 0 of 1 snippets/, 'only the root README snippet is in scope');
+    assert.doesNotMatch(out, /packages[/\\]inner/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a published package with no README is left to check-package-readmes', () => {
+  // targetDocs() must not hand a nonexistent path to extractBlocks: that would
+  // be an ENOENT stack trace from this gate over a condition the README gate
+  // reports properly, and a crash here reads as "the docs check is broken"
+  // rather than "a package is missing its landing page".
+  const root = makeTree(workingTsc(), {
+    packages: [{ dir: 'bare', name: '@scope/bare' }],
+  });
   try {
     const { status, out } = run(root);
     assert.equal(status, 0, `expected exit 0, got ${status}: ${out}`);

--- a/scripts/docs/check-doc-samples.test.mjs
+++ b/scripts/docs/check-doc-samples.test.mjs
@@ -34,7 +34,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  copyFileSync,
+  chmodSync,
+  rmSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -49,7 +58,7 @@ const README = ['# Sample', '', '```ts', 'const n: number = 1;', '```', ''].join
  * snippet, and `node_modules/.bin/tsc` written from `tscShim` (pass `null` to
  * leave the binary out entirely).
  */
-function makeTree(tscShim, { readme = README, packages = [] } = {}) {
+function makeTree(tscShim, { readme = README, packages = [], fillFloor = true } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'doc-samples-'));
   mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
   mkdirSync(join(root, 'docs', 'guide'), { recursive: true });
@@ -65,6 +74,22 @@ function makeTree(tscShim, { readme = README, packages = [] } = {}) {
     copyFileSync(join(HERE, f), join(root, 'scripts', 'docs', f));
   }
   writeFileSync(join(root, 'README.md'), readme, 'utf8');
+
+  // PACKAGE_README_FLOOR published READMEs, so the floor never fires in a test
+  // that is about something else. Their READMEs carry NO ts fence, so every
+  // snippet count asserted below still counts only the docs the test wrote.
+  if (fillFloor) {
+    for (let i = 0; i < 25; i++) {
+      const dir = join(root, 'packages', `filler${i}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, 'package.json'),
+        `${JSON.stringify({ name: `@filler/p${i}`, version: '0.0.0' })}\n`,
+        'utf8',
+      );
+      writeFileSync(join(dir, 'README.md'), `# filler${i}\n\nNo code here.\n`, 'utf8');
+    }
+  }
 
   // `packages` entries are `{ dir, name, private?, readme? }`. A package with
   // no `readme` ships none at all, which is check-package-readmes.mjs's
@@ -394,6 +419,167 @@ test('a published package with no README is left to check-package-readmes', () =
     const { status, out } = run(root);
     assert.equal(status, 0, `expected exit 0, got ${status}: ${out}`);
     assert.match(out, /Doc code samples typecheck clean \(1 snippet compiled/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// #3846 review: the published-package rule must MATCH check-package-readmes.mjs
+// and must refuse to go quiet.
+// ---------------------------------------------------------------------------
+
+test('a package manifest that cannot be READ is fatal, not silently dropped', () => {
+  // The sibling gate's finding, one gate over: `existsSync` answers false for
+  // ENOTDIR and EACCES as well as ENOENT, so an unreadable package left the
+  // walk and its README's snippets left with it — a clean tick over docs
+  // nothing looked at, which is the whole #3846 subject.
+  const root = makeTree(workingTsc());
+  try {
+    // A FILE where a package directory belongs: statting its package.json is
+    // ENOTDIR.
+    writeFileSync(join(root, 'packages', 'locked'), 'not a directory', 'utf8');
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /cannot read package manifest .*locked[/\\]package\.json \(ENOTDIR\)/);
+    assert.match(out, /without anyone noticing/);
+    assert.doesNotMatch(out, /typecheck clean/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('too few package READMEs reaching the typecheck is refused, not reported clean', () => {
+  // Without the floor, a walk that stopped finding package READMEs at all —
+  // wrong ROOT, restructured packages/ — reports the guides as a clean run and
+  // says nothing about the class of docs it stopped covering. That silence IS
+  // the pre-#3846 behaviour, so it must not be reachable by accident again.
+  const root = makeTree(workingTsc(), { fillFloor: false });
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /only 0 published-package README\(s\) reached the doc-samples typecheck/);
+    assert.match(out, /expected at least 25/);
+    // The remedy must NAME the constant, as the sibling gate's does.
+    assert.match(out, /lower PACKAGE_README_FLOOR in this file/);
+    assert.doesNotMatch(out, /typecheck clean/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+/**
+ * A tree that mirrors the REAL `packages/` layout: one directory per real
+ * package, carrying that package's real manifest (so `private` and `name` are
+ * the real ones), and a one-snippet README wherever the real package has one.
+ *
+ * Both gates derive ROOT from their own location, so copying both into this
+ * tree runs both REAL rules over the real package set without either gate
+ * growing a scan-root flag.
+ */
+function mirrorRealPackages() {
+  const repoPackages = join(HERE, '..', '..', 'packages');
+  const root = mkdtempSync(join(tmpdir(), 'doc-samples-parity-'));
+  mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
+  mkdirSync(join(root, 'docs', 'guide'), { recursive: true });
+  mkdirSync(join(root, 'docs', 'tutorials'), { recursive: true });
+  mkdirSync(join(root, 'packages'), { recursive: true });
+  mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true });
+  for (const f of [
+    'check-doc-samples.mjs',
+    'check-package-readmes.mjs',
+    'doc-samples-globals.d.ts',
+    'doc-samples-externals.d.ts',
+  ]) {
+    copyFileSync(join(HERE, f), join(root, 'scripts', 'docs', f));
+  }
+  writeFileSync(join(root, 'README.md'), README, 'utf8');
+
+  const withReadme = [];
+  for (const dir of readdirSync(repoPackages).sort()) {
+    if (dir.startsWith('.')) continue;
+    const manifest = join(repoPackages, dir, 'package.json');
+    let text;
+    try {
+      text = readFileSync(manifest, 'utf8');
+    } catch {
+      continue;
+    }
+    mkdirSync(join(root, 'packages', dir), { recursive: true });
+    writeFileSync(join(root, 'packages', dir, 'package.json'), text, 'utf8');
+    let hasReadme = true;
+    try {
+      readFileSync(join(repoPackages, dir, 'README.md'), 'utf8');
+    } catch {
+      hasReadme = false;
+    }
+    if (hasReadme) {
+      writeFileSync(join(root, 'packages', dir, 'README.md'), README, 'utf8');
+      withReadme.push(dir);
+    }
+  }
+  return { root, withReadme };
+}
+
+test('both gates agree on which packages/* are published', () => {
+  // The two gates are only as aligned as their two copies of one rule. This
+  // drives BOTH real rules over the real package layout and compares the sets:
+  // the READMEs check-package-readmes REQUIRES to exist must be exactly the
+  // READMEs check-doc-samples TYPECHECKS. Drift either way is silent — a
+  // README nobody requires, or a landing page nobody compiles.
+  const { root, withReadme } = mirrorRealPackages();
+  try {
+    // Set A: every doc check-doc-samples put in its program. A tsc that
+    // reports an error against EVERY snippet makes the gate print one line per
+    // snippet with its doc path, which the truncated never-compiled listing
+    // could not give.
+    writeFileSync(
+      join(root, 'node_modules', '.bin', 'tsc'),
+      `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const i = process.argv.indexOf('-p');
+const cfg = JSON.parse(fs.readFileSync(process.argv[i + 1], 'utf8'));
+let out = '';
+if (process.argv.includes('--listFiles')) for (const f of cfg.files) out += f + '\\n';
+for (const f of cfg.files) {
+  if (/snippet-\\d+\\.ts$/.test(f)) out += f + "(1,7): error TS2322: parity probe.\\n";
+}
+fs.writeSync(1, out);
+process.exitCode = 2;
+`,
+      'utf8',
+    );
+    chmodSync(join(root, 'node_modules', '.bin', 'tsc'), 0o755);
+
+    const samples = run(root);
+    assert.equal(samples.status, 1, samples.out);
+    const typechecked = new Set(
+      [...samples.out.matchAll(/packages[/\\]([^/\\]+)[/\\]README\.md:/g)].map((m) => m[1]),
+    );
+
+    // Set B: check-package-readmes' own published set. Read out by removing
+    // every package README first — the list it then reports as MISSING is
+    // exactly the set it audits, named by that gate rather than restated here.
+    for (const dir of withReadme) rmSync(join(root, 'packages', dir, 'README.md'));
+    const readmes = spawnSync(
+      process.execPath,
+      [join(root, 'scripts', 'docs', 'check-package-readmes.mjs')],
+      { cwd: root, encoding: 'utf8' },
+    );
+    const out = `${readmes.stdout ?? ''}${readmes.stderr ?? ''}`;
+    assert.equal(readmes.status, 1, out);
+    const required = new Set(
+      [...out.matchAll(/\(packages[/\\]([^/\\]+)[/\\]README\.md\)/g)].map((m) => m[1]),
+    );
+
+    assert.ok(required.size >= 25, `expected the real tree to hold 25+ published packages, got ${required.size}`);
+    // Stated as sorted arrays so a mismatch names the packages that drifted.
+    assert.deepEqual(
+      [...typechecked].sort(),
+      [...required].sort(),
+      'check-doc-samples and check-package-readmes disagree on the published set',
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -357,6 +357,7 @@
    612 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
+   435 scripts/docs/check-doc-samples.mjs
    506 scripts/generate-bim-globals.mjs
    423 scripts/generate-epsg-index.ts
    403 scripts/lib/ci-path-coverage.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -357,7 +357,7 @@
    612 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
-   435 scripts/docs/check-doc-samples.mjs
+   499 scripts/docs/check-doc-samples.mjs
    506 scripts/generate-bim-globals.mjs
    423 scripts/generate-epsg-index.ts
    403 scripts/lib/ci-path-coverage.mjs


### PR DESCRIPTION
## Summary

`scripts/docs/check-doc-samples.mjs` only targeted the root README and the guides, so package README snippets were never typechecked. That is how `packages/cache/README.md` shipped a quickstart with two type errors (#3759, #3846).

- `targetDocs()` now covers the 43 published package READMEs (84 docs, up from 41). "Published" is decided by the same rule `check-package-readmes.mjs` uses, restated because both gates are copied file-by-file into synthetic trees by their harnesses; a parity test copies both gates into a tree mirroring `packages/` and asserts they agree on the set, a floor refuses a run that discovers almost no package READMEs, and an unreadable manifest fails loudly instead of silently shrinking the set.
- 112 errors across 24 READMEs fixed. Real documentation defects among them: drawing-2d named options that do not exist (`includeMaterialHatching`, `includeProjectionLines`, `strokeWidth` for `lineWeight`); geometry and server-client called a `renderer.appendMeshes()` that does not exist (`addMeshes(meshes, isStreaming)`), and server-client's snake_case mapping now carries `geometryClass` and omits a zero origin exactly as the viewer's seam does (#1841); cache passed the parser's store to a writer that takes `CacheDataStore`; export used a `quality` option `GenerateLod1Options` does not have; wasm called a `toThreeMesh` that exists nowhere. Everything else was missing imports or undeclared free variables.
- 4 new skip markers, each with its reason (a collab signature listing, two codegen fences whose types only exist in emitted output, a Vite `?url` specifier).
- No snippet was weakened to compile: no `any`, no casts, no deleted code. Where a fence needs a value the README does not construct, it uses `declare const` with the real type.

Closes #3846

## Verification

- `node scripts/docs/check-doc-samples.mjs`: 380 snippets compiled across 84 docs, 9 skipped, exit 0. On main without the checker change, adding `packages/cache/README.md` alone reproduces both #3759 errors.
- `node --test scripts/docs/*.test.mjs`: 24 pass (each guard mutation-checked: skipping a package fails only the parity test, disabling the floor fails only the floor test, reverting to `existsSync` fails only the unreadable-manifest test).
- `check-test-wiring`, `check-package-readmes`, `check-module-size`: exit 0. The checker's own row is raised to its measured count; it cannot be split because its test harness copies the single file into a synthetic tree.
- Follow-up worth its own PR: exporting the server-client mesh converter so the README can call it instead of restating the viewer's logic.