### PR TITLE
fix(bcf): BCF 3.0 export was unwritable (no AspectRatio), DocumentReference guid missing and unstable, conformance sweep now runs 3.0

### DIFF
--- a/.changeset/bcf-30-aspect-ratio.md
+++ b/.changeset/bcf-30-aspect-ratio.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/bcf': patch
+'@ifc-lite/renderer': patch
+---
+
+Let a caller supply the viewport aspect ratio a BCF 3.0 camera requires.
+
+`v3_0/visinfo.xsd` makes `<AspectRatio>` a required child of both camera types
+and the writer refuses to invent one, but `ViewerCameraState` had no field for
+it. Every viewpoint `createViewpoint` produced was therefore unwritable as BCF
+3.0, and `writeBCF` throws for the whole archive on the first such camera, so a
+single captured viewpoint meant no export at all. `ViewerCameraState` now
+carries an optional `aspectRatio` that `cameraToPerspective`/`cameraToOrthogonal`
+pass through and `perspectiveToCamera`/`orthogonalToCamera` return, and
+`Camera.getAspect()` exposes the live viewport ratio the viewer feeds it. A
+caller that supplies nothing still gets no `AspectRatio`, as BCF 2.1 requires.

--- a/.changeset/bcf-30-aspect-ratio.md
+++ b/.changeset/bcf-30-aspect-ratio.md
@@ -1,6 +1,6 @@
 ---
 '@ifc-lite/bcf': patch
-'@ifc-lite/renderer': patch
+'@ifc-lite/renderer': minor
 ---
 
 Let a caller supply the viewport aspect ratio a BCF 3.0 camera requires.
@@ -11,6 +11,12 @@ it. Every viewpoint `createViewpoint` produced was therefore unwritable as BCF
 3.0, and `writeBCF` throws for the whole archive on the first such camera, so a
 single captured viewpoint meant no export at all. `ViewerCameraState` now
 carries an optional `aspectRatio` that `cameraToPerspective`/`cameraToOrthogonal`
-pass through and `perspectiveToCamera`/`orthogonalToCamera` return, and
-`Camera.getAspect()` exposes the live viewport ratio the viewer feeds it. A
-caller that supplies nothing still gets no `AspectRatio`, as BCF 2.1 requires.
+pass through and `perspectiveToCamera`/`orthogonalToCamera` return. A caller
+that supplies nothing still gets no `AspectRatio`, as BCF 2.1 requires.
+
+`@ifc-lite/renderer` gains `Camera.getAspect()`, which reports the ratio the
+projection is built from. That is the drawing buffer's ratio, not the CSS box's
+(the render loop floors canvas width to a multiple of 64 for WebGPU texture row
+alignment), and it is the one BCF wants: a viewpoint's snapshot PNG comes from
+the same buffer, so the written ratio describes the image actually in the
+archive.

--- a/.changeset/bcf-30-documentreference-guid.md
+++ b/.changeset/bcf-30-documentreference-guid.md
@@ -1,5 +1,7 @@
 ---
 '@ifc-lite/bcf': patch
+'@ifc-lite/encoding': minor
+'@ifc-lite/clash': patch
 ---
 
 Write the `DocumentReference/@Guid` that BCF 3.0 requires.
@@ -8,6 +10,13 @@ Write the `DocumentReference/@Guid` that BCF 3.0 requires.
 `DocumentReferenceAttributes` marks it `use="required"`, so a 3.0 topic
 carrying a document reference without one produced a `markup.bcf` that fails
 validation, and a viewer that rejects markup.bcf drops the topic entirely. A
-guid is now generated when the caller supplied none, the way a missing
-`projectId` already is; a caller-supplied guid is kept, and BCF 2.1 output is
-unchanged.
+guid is now derived when the caller supplied none, and written back onto the
+reference so the in-memory project matches the file. A caller-supplied guid is
+kept, and BCF 2.1 output is unchanged.
+
+The guid is a pure function of the topic, the document and the position, so two
+exports of one unchanged project are byte-identical. `uuidFromSeed` moved from
+`@ifc-lite/clash` to `@ifc-lite/encoding` to make that sharing possible without
+a package cycle (`@ifc-lite/clash` depends on `@ifc-lite/bcf`); it is now
+exported from `@ifc-lite/encoding`, and `@ifc-lite/clash` re-exports it from its
+existing path, so no clash caller changes.

--- a/.changeset/bcf-30-documentreference-guid.md
+++ b/.changeset/bcf-30-documentreference-guid.md
@@ -7,7 +7,7 @@ Write the `DocumentReference/@Guid` that BCF 3.0 requires.
 2.1's markup.xsd leaves the attribute optional and 3.0's
 `DocumentReferenceAttributes` marks it `use="required"`, so a 3.0 topic
 carrying a document reference without one produced a `markup.bcf` that fails
-validation — and a viewer that rejects markup.bcf drops the topic entirely. A
+validation, and a viewer that rejects markup.bcf drops the topic entirely. A
 guid is now generated when the caller supplied none, the way a missing
 `projectId` already is; a caller-supplied guid is kept, and BCF 2.1 output is
 unchanged.

--- a/.changeset/bcf-30-documentreference-guid.md
+++ b/.changeset/bcf-30-documentreference-guid.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Write the `DocumentReference/@Guid` that BCF 3.0 requires.
+
+2.1's markup.xsd leaves the attribute optional and 3.0's
+`DocumentReferenceAttributes` marks it `use="required"`, so a 3.0 topic
+carrying a document reference without one produced a `markup.bcf` that fails
+validation — and a viewer that rejects markup.bcf drops the topic entirely. A
+guid is now generated when the caller supplied none, the way a missing
+`projectId` already is; a caller-supplied guid is kept, and BCF 2.1 output is
+unchanged.

--- a/apps/viewer/src/hooks/useBCF.aspect-ratio.test.tsx
+++ b/apps/viewer/src/hooks/useBCF.aspect-ratio.test.tsx
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A viewpoint captured in the viewer must be writable as BCF 3.0 (#3612).
+ *
+ * `@ifc-lite/bcf`'s writer refuses to invent a `Camera/AspectRatio`, which
+ * v3_0/visinfo.xsd makes a required element. `writeBCF` throws on the first
+ * camera that lacks one, and it throws for the WHOLE archive — so a project
+ * exported with a single viewer-captured viewpoint produced no file at all,
+ * only the panel's "Failed to export BCF file" error.
+ *
+ * The path is not hypothetical and needs no 3.0-specific UI: `readBCF` sets
+ * `project.version` from the imported `bcf.version`, so importing another
+ * tool's 3.0 archive and adding a topic lands here.
+ *
+ * This test asserts the app-side half — `getCameraState` reads the live
+ * viewport ratio off the renderer — by driving the real `createViewpointFromState`
+ * and then actually writing the archive. Asserting only that the field is set
+ * would pass against a camera the writer still rejects.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Renderer } from '@ifc-lite/renderer';
+import { writeBCF } from '@ifc-lite/bcf';
+import type { BCFProject, BCFViewpoint } from '@ifc-lite/bcf';
+import { useViewerStore } from '@/store';
+import { useBCF } from './useBCF.js';
+
+/** 1600x900 viewport. A square one would not distinguish w/h from h/w. */
+const ASPECT = 16 / 9;
+
+const renderer = {
+  getCamera: () => ({
+    getPosition: () => ({ x: 10, y: 5, z: 20 }),
+    getTarget: () => ({ x: 1, y: 2, z: 3 }),
+    getUp: () => ({ x: 0, y: 1, z: 0 }),
+    getFOV: () => Math.PI / 4,
+    getAspect: () => ASPECT,
+    getDistance: () => 10,
+  }),
+} as unknown as Renderer;
+
+let api: ReturnType<typeof useBCF> | null = null;
+let root: Root | null = null;
+
+function Probe(): null {
+  api = useBCF({ rendererRef: { current: renderer } });
+  return null;
+}
+
+/** Wrap one viewpoint in the smallest BCF 3.0 project `writeBCF` accepts. */
+function projectAround(viewpoint: BCFViewpoint): BCFProject {
+  return {
+    version: '3.0',
+    projectId: '99999999-9999-4999-8999-999999999999',
+    name: 'Imported from another tool',
+    topics: new Map([
+      [
+        '11111111-1111-4111-8111-111111111111',
+        {
+          guid: '11111111-1111-4111-8111-111111111111',
+          title: 'Captured in the viewer',
+          topicType: 'Issue',
+          topicStatus: 'Open',
+          creationDate: '2026-01-02T03:04:05Z',
+          creationAuthor: 'author@example.invalid',
+          comments: [],
+          viewpoints: [viewpoint],
+        },
+      ],
+    ]),
+  };
+}
+
+/** Drive the real capture path and insist it produced something. */
+async function captureViewpoint(): Promise<BCFViewpoint> {
+  const captured: (BCFViewpoint | null)[] = [];
+  await act(async () => {
+    captured.push(await api!.createViewpointFromState({ includeSnapshot: false }));
+  });
+  const viewpoint = captured[0];
+  assert.ok(viewpoint, 'a viewpoint must be produced');
+  return viewpoint;
+}
+
+beforeEach(async () => {
+  useViewerStore.setState({
+    models: new Map(),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    hiddenEntities: new Set(),
+  });
+  const container = globalThis.document.createElement('div');
+  globalThis.document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'the probe must be mounted');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  api = null;
+  if (current) await act(async () => current.unmount());
+});
+
+describe('useBCF — captured viewpoints carry the viewport aspect ratio', () => {
+  it('records the live viewport ratio on the camera', async () => {
+    const viewpoint = await captureViewpoint();
+    assert.equal(
+      viewpoint.perspectiveCamera?.aspectRatio,
+      ASPECT,
+      'BUG: the captured camera has no AspectRatio, so BCF 3.0 cannot be written',
+    );
+  });
+
+  it('exports as BCF 3.0 instead of throwing away the whole archive', async () => {
+    const blob = await writeBCF(projectAround(await captureViewpoint()));
+    assert.ok(blob.size > 0, 'the export must produce an archive');
+  });
+});

--- a/apps/viewer/src/hooks/useBCF.aspect-ratio.test.tsx
+++ b/apps/viewer/src/hooks/useBCF.aspect-ratio.test.tsx
@@ -34,6 +34,17 @@ import { useBCF } from './useBCF.js';
 
 /** 1600x900 viewport. A square one would not distinguish w/h from h/w. */
 const ASPECT = 16 / 9;
+/** What the viewport is resized to mid-capture in the ordering test. */
+const RESIZED_ASPECT = 4 / 3;
+
+/**
+ * The live ratio, so a test can resize the viewport the way the render loop
+ * does (`Renderer.resize` -> `camera.setAspect`) and watch what the capture
+ * path reads. Reset in `beforeEach`.
+ */
+let liveAspect = ASPECT;
+/** Runs while `captureSnapshot` awaits the GPU, i.e. between the two reads. */
+let duringGpuWait: (() => void) | null = null;
 
 const renderer = {
   getCamera: () => ({
@@ -41,8 +52,15 @@ const renderer = {
     getTarget: () => ({ x: 1, y: 2, z: 3 }),
     getUp: () => ({ x: 0, y: 1, z: 0 }),
     getFOV: () => Math.PI / 4,
-    getAspect: () => ASPECT,
+    getAspect: () => liveAspect,
     getDistance: () => 10,
+  }),
+  getGPUDevice: () => ({
+    queue: {
+      onSubmittedWorkDone: async () => {
+        duringGpuWait?.();
+      },
+    },
   }),
 } as unknown as Renderer;
 
@@ -90,6 +108,8 @@ async function captureViewpoint(): Promise<BCFViewpoint> {
 }
 
 beforeEach(async () => {
+  liveAspect = ASPECT;
+  duringGpuWait = null;
   useViewerStore.setState({
     models: new Map(),
     isolatedEntities: null,
@@ -125,5 +145,46 @@ describe('useBCF — captured viewpoints carry the viewport aspect ratio', () =>
   it('exports as BCF 3.0 instead of throwing away the whole archive', async () => {
     const blob = await writeBCF(projectAround(await captureViewpoint()));
     assert.ok(blob.size > 0, 'the export must produce an archive');
+  });
+
+  /**
+   * The PNG and the `AspectRatio` describe ONE frame, so they must be read
+   * from one drawing buffer. `captureSnapshot` awaits
+   * `queue.onSubmittedWorkDone()` before `toDataURL`, and the render loop
+   * resizes the canvas and calls `camera.setAspect` inside that wait
+   * (`packages/renderer/src/index.ts`, the `dimensionsChanged` branch). Read
+   * the camera first and the viewpoint claims a ratio the image it ships does
+   * not have. Reading it after closes the window: the continuation of the
+   * `await` is a microtask, and a rAF render is a task, so nothing can resize
+   * between `toDataURL` and the camera read.
+   */
+  it('reads the camera after the snapshot, so both describe one frame', async () => {
+    const canvas = {
+      toDataURL: () => `data:image/png;base64,${Buffer.from(String(liveAspect)).toString('base64')}`,
+    } as unknown as HTMLCanvasElement;
+    api!.setCanvasRef({ current: canvas });
+    duringGpuWait = () => {
+      liveAspect = RESIZED_ASPECT;
+    };
+
+    const captured: (BCFViewpoint | null)[] = [];
+    await act(async () => {
+      captured.push(await api!.createViewpointFromState({ includeSnapshot: true }));
+    });
+    const viewpoint = captured[0];
+    assert.ok(viewpoint, 'a viewpoint must be produced');
+
+    const snapshot = viewpoint.snapshot;
+    assert.ok(snapshot, 'the viewpoint must carry the snapshot it was asked for');
+    assert.equal(
+      Buffer.from(snapshot.split(',')[1] ?? snapshot, 'base64').toString(),
+      String(RESIZED_ASPECT),
+      'fixture sanity: the PNG is encoded from the post-resize buffer',
+    );
+    assert.equal(
+      viewpoint.perspectiveCamera?.aspectRatio,
+      RESIZED_ASPECT,
+      'BUG: the camera ratio was read before the snapshot, so it describes a frame the PNG is not',
+    );
   });
 });

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -319,15 +319,13 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
         includeHidden = true,
       } = opts;
 
-      // Snapshot FIRST, camera after. The PNG and the camera's `aspectRatio`
-      // describe one frame, so they have to be read from one drawing buffer.
+      // Snapshot FIRST, camera after: the PNG and the camera's `aspectRatio`
+      // describe one frame, so they must come from one drawing buffer.
       // `captureSnapshot` awaits `queue.onSubmittedWorkDone()` before
       // `toDataURL`, and the render loop resizes the canvas and calls
-      // `camera.setAspect` inside that wait (`packages/renderer/src/index.ts`,
-      // the `dimensionsChanged` branch), so a camera read before the await can
-      // ship a ratio the image does not have. Reading it after closes the
-      // window: the continuation of an `await` is a microtask and a rAF render
-      // is a task, so nothing resizes between `toDataURL` and this read.
+      // `camera.setAspect` inside that wait (`renderer/src/index.ts`, the
+      // `dimensionsChanged` branch). Reading the camera after closes the
+      // window: an `await` resumes in a microtask, a rAF render is a task.
       let snapshot: string | undefined;
       if (includeSnapshot) {
         const captured = await captureSnapshot();

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -319,19 +319,27 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
         includeHidden = true,
       } = opts;
 
-      const cameraState = getCameraState();
-      if (!cameraState) {
-        console.warn('[useBCF] Cannot create viewpoint: no camera state');
-        return null;
-      }
-
-      // Get snapshot if requested
+      // Snapshot FIRST, camera after. The PNG and the camera's `aspectRatio`
+      // describe one frame, so they have to be read from one drawing buffer.
+      // `captureSnapshot` awaits `queue.onSubmittedWorkDone()` before
+      // `toDataURL`, and the render loop resizes the canvas and calls
+      // `camera.setAspect` inside that wait (`packages/renderer/src/index.ts`,
+      // the `dimensionsChanged` branch), so a camera read before the await can
+      // ship a ratio the image does not have. Reading it after closes the
+      // window: the continuation of an `await` is a microtask and a rAF render
+      // is a task, so nothing resizes between `toDataURL` and this read.
       let snapshot: string | undefined;
       if (includeSnapshot) {
         const captured = await captureSnapshot();
         if (captured) {
           snapshot = captured;
         }
+      }
+
+      const cameraState = getCameraState();
+      if (!cameraState) {
+        console.warn('[useBCF] Cannot create viewpoint: no camera state');
+        return null;
       }
 
       // Convert section plane state

--- a/apps/viewer/src/hooks/useBCF.ts
+++ b/apps/viewer/src/hooks/useBCF.ts
@@ -259,6 +259,11 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
     const target = camera.getTarget();
     const up = camera.getUp();
     const fov = camera.getFOV();
+    // BCF 3.0 requires <AspectRatio> on every camera and `@ifc-lite/bcf`
+    // refuses to invent one, so a viewpoint captured without it makes the
+    // WHOLE export throw -- what a user hit after importing another tool's
+    // 3.0 archive (readBCF keeps its version) and adding a topic (#3612).
+    const aspectRatio = camera.getAspect();
 
     return {
       position,
@@ -266,6 +271,7 @@ export function useBCF(options: UseBCFOptions = {}): UseBCFResult {
       up, // Use actual camera up vector
       fov,
       isOrthographic: false,
+      aspectRatio,
     };
   }, [getRenderer]);
 

--- a/docs/guide/bcf.md
+++ b/docs/guide/bcf.md
@@ -81,7 +81,7 @@ import { createViewpoint } from '@ifc-lite/bcf';
 
 // Create a viewpoint from current viewer state
 const viewpoint = createViewpoint({
-  camera: currentCameraState,   // { position, target, up, fov, isOrthographic?, orthoScale? }
+  camera: currentCameraState,   // { position, target, up, fov, aspectRatio?, isOrthographic?, orthoScale? }
   selectedGuids: selectedGuids, // IFC GlobalIds of selected entities
   hiddenGuids: hiddenGuids,     // IFC GlobalIds of hidden entities
   visibleGuids: visibleGuids,   // IFC GlobalIds for isolation mode (optional)
@@ -89,6 +89,17 @@ const viewpoint = createViewpoint({
   snapshot: base64Image,        // Screenshot as base64 (optional)
 });
 ```
+
+`aspectRatio` is the viewport's width divided by its height, and it is
+**required for BCF 3.0**. `v3_0/visinfo.xsd` makes `<AspectRatio>` a mandatory
+child of both camera types, and `@ifc-lite/bcf` will not invent one, so
+`writeBCF` throws for the whole archive on the first camera that lacks it. It
+must be finite and greater than zero. BCF 2.1 has no such element, so leave it
+unset when writing 2.1 rather than assert a viewport nobody had.
+
+Note that a project's version is not always chosen in your own code:
+`readBCF` sets `project.version` from the imported `bcf.version`, so importing
+another tool's 3.0 archive and adding a viewpoint lands on the 3.0 rule.
 
 ### Restoring Viewpoints
 

--- a/packages/bcf/README.md
+++ b/packages/bcf/README.md
@@ -62,6 +62,12 @@ const viewpoint = createViewpoint({
     target: { x: 0, y: 0, z: 0 },
     up: { x: 0, y: 0, z: 1 },
     fov: Math.PI / 3, // field of view in radians (60 degrees)
+    // Required for BCF 3.0 (viewport width / height, must be > 0). v3_0's
+    // visinfo.xsd makes `<AspectRatio>` mandatory on every camera and this
+    // package will not invent one, so `writeBCF` throws for the whole archive
+    // on the first camera that lacks it. Omit it only when writing 2.1, which
+    // has no such element.
+    aspectRatio: 16 / 9,
   },
   // Highlight specific entities by their IFC GlobalId
   selectedGuids: ['1abc2def3GhI4jKlM5nOpQ', '2bcd3efg4HiJ5kLmN6oPqR'],

--- a/packages/bcf/src/document-reference-guid.test.ts
+++ b/packages/bcf/src/document-reference-guid.test.ts
@@ -17,11 +17,19 @@
  * The remedy is to mint one rather than to refuse. A `DocumentReference`
  * guid names only itself — nothing else in the archive refers to it, unlike
  * `RelatedTopic/@Guid` or `Comment/Viewpoint/@Guid` — so a generated value
- * loses nothing, and it follows `writeProjectFile`'s existing
- * `project.projectId || generateUuid()`. Refusing, the policy used for
- * `AspectRatio` and `TopicType`, is wrong here: those assert something about
- * the view or the issue that only the caller knows, and refusing would fail
- * the whole export over a field 2.1 says is optional.
+ * loses nothing. Refusing, the policy used for `AspectRatio` and `TopicType`,
+ * is wrong here: those assert something about the view or the issue that only
+ * the caller knows, and refusing would fail the whole export over a field 2.1
+ * says is optional.
+ *
+ * The minted value must be DERIVED, not random. `generateUuid()` would make
+ * two exports of one unchanged project differ in bytes, which breaks the
+ * `bcfzip` diffing and content-addressing that a stable export supports, and
+ * it would silently mint a THIRD identity on the next write because the value
+ * was never written back. `uuidFromSeed` (shared with `@ifc-lite/clash`, which
+ * anchors its topic guids the same way) makes the guid a pure function of the
+ * topic, the document it points at, and its position, and the writer stores it
+ * back on the object so the in-memory project matches the file.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -30,7 +38,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import JSZip from 'jszip';
 import { validateXML } from 'xmllint-wasm';
-import { isValidUuid } from '@ifc-lite/encoding';
+import { isValidUuid, uuidFromSeed } from '@ifc-lite/encoding';
 import { writeBCF } from './writer.js';
 import type { BCFDocumentReference, BCFProject } from './types.js';
 
@@ -41,6 +49,8 @@ function schema(version: '2.1' | '3.0', file: string): string {
   return readFileSync(path.join(DIR, '__fixtures__', 'schemas', dir, file), 'utf8');
 }
 
+const TOPIC_GUID = '11111111-1111-4111-8111-111111111111';
+
 function projectWith(
   version: '2.1' | '3.0',
   documentReferences: BCFDocumentReference[]
@@ -50,9 +60,9 @@ function projectWith(
     projectId: '99999999-9999-4999-8999-999999999999',
     topics: new Map([
       [
-        '11111111-1111-4111-8111-111111111111',
+        TOPIC_GUID,
         {
-          guid: '11111111-1111-4111-8111-111111111111',
+          guid: TOPIC_GUID,
           title: 'Topic with an attached document',
           topicType: 'Issue',
           topicStatus: 'Open',
@@ -73,6 +83,7 @@ async function markupOf(project: BCFProject): Promise<string> {
   return zip.files[name].async('string');
 }
 
+
 async function markupErrors(version: '2.1' | '3.0', xml: string): Promise<string[]> {
   const result = await validateXML({
     xml: [{ fileName: 'subject.xml', contents: xml }],
@@ -85,18 +96,25 @@ async function markupErrors(version: '2.1' | '3.0', xml: string): Promise<string
   return result.valid ? [] : result.errors.map((e) => e.message);
 }
 
-/** No `guid` — what a caller writing to the 2.1-shaped optional field gives. */
-const WITHOUT_GUID: BCFDocumentReference = {
-  isExternal: true,
-  url: 'https://example.invalid/spec.pdf',
-  description: 'Cladding specification',
-};
+const DOC_URL = 'https://example.invalid/spec.pdf';
+
+/**
+ * No `guid` — what a caller writing to the 2.1-shaped optional field gives.
+ *
+ * A FACTORY, not a shared constant: the 3.0 writer stores the guid it minted
+ * back onto the object, so a shared literal would carry one test's guid into
+ * the next and quietly turn every later assertion into a check of the FIRST
+ * write. That is the fixture confound, not a defect in the write-back.
+ */
+function withoutGuid(): BCFDocumentReference {
+  return { isExternal: true, url: DOC_URL, description: 'Cladding specification' };
+}
 
 const CALLER_GUID = '33333333-3333-4333-8333-333333333333';
 
 describe('DocumentReference/@Guid', () => {
   it('is supplied for BCF 3.0 when the caller left it unset', async () => {
-    const xml = await markupOf(projectWith('3.0', [WITHOUT_GUID]));
+    const xml = await markupOf(projectWith('3.0', [withoutGuid()]));
     const guid = /<DocumentReference Guid="([^"]+)"/.exec(xml)?.[1];
     expect(guid, 'BUG: 3.0 requires the attribute and the writer omitted it').toBeTruthy();
     expect(isValidUuid(guid!), `generated guid ${guid} must satisfy the schema Guid type`).toBe(
@@ -106,7 +124,7 @@ describe('DocumentReference/@Guid', () => {
   });
 
   it('keeps the caller\'s own guid rather than overwriting it', async () => {
-    const xml = await markupOf(projectWith('3.0', [{ ...WITHOUT_GUID, guid: CALLER_GUID }]));
+    const xml = await markupOf(projectWith('3.0', [{ ...withoutGuid(), guid: CALLER_GUID }]));
     expect(xml).toContain(`<DocumentReference Guid="${CALLER_GUID}"`);
     expect(await markupErrors('3.0', xml)).toEqual([]);
   });
@@ -118,7 +136,7 @@ describe('DocumentReference/@Guid', () => {
    */
   it('gives two guid-less references distinct guids', async () => {
     const xml = await markupOf(
-      projectWith('3.0', [WITHOUT_GUID, { ...WITHOUT_GUID, description: 'Second document' }])
+      projectWith('3.0', [withoutGuid(), { ...withoutGuid(), description: 'Second document' }])
     );
     const guids = [...xml.matchAll(/<DocumentReference Guid="([^"]+)"/g)].map((m) => m[1]);
     expect(guids).toHaveLength(2);
@@ -132,8 +150,86 @@ describe('DocumentReference/@Guid', () => {
    * for no schema reason — and would make this fix invisible to a reader
    * trying to tell the two versions apart.
    */
+  /**
+   * Two exports of one unchanged project must be byte-identical here. A random
+   * `generateUuid()` passes every other test in this file and still fails
+   * this one, which is the whole reason it exists.
+   */
+  it('is stable across two writes of the same project', async () => {
+    const project = projectWith('3.0', [withoutGuid()]);
+    const first = await markupOf(project);
+    const second = await markupOf(project);
+    const line = (xml: string) => /<DocumentReference Guid="[^"]+"/.exec(xml)![0];
+    expect(line(second)).toBe(line(first));
+  });
+
+  /**
+   * ...and across two SEPARATE project objects built the same way, not merely
+   * across two writes of one object. Writing the guid back onto `docRef` alone
+   * would satisfy the test above while still minting a fresh identifier for
+   * every fresh in-memory project, so a second export from a reloaded file
+   * would differ.
+   */
+  it('is a pure function of the topic, the document and the position', async () => {
+    const a = await markupOf(projectWith('3.0', [withoutGuid()]));
+    const b = await markupOf(projectWith('3.0', [withoutGuid()]));
+    const guidOf = (xml: string) => /<DocumentReference Guid="([^"]+)"/.exec(xml)![1];
+    expect(guidOf(b)).toBe(guidOf(a));
+    expect(guidOf(a)).toBe(
+      uuidFromSeed(`${TOPIC_GUID}|${DOC_URL}|0`)
+    );
+  });
+
+  /**
+   * A different document under the same topic, and the same document under a
+   * different topic, must both land on different guids -- otherwise the seed
+   * is ignoring an input and every reference in a project could collide.
+   */
+  it('separates references that differ in topic, document or position', async () => {
+    const other = { ...withoutGuid(), url: 'https://example.invalid/other.pdf' };
+    const guidsOf = (xml: string) =>
+      [...xml.matchAll(/<DocumentReference Guid="([^"]+)"/g)].map((m) => m[1]);
+
+    const twoDocs = guidsOf(await markupOf(projectWith('3.0', [withoutGuid(), other])));
+    expect(new Set(twoDocs).size).toBe(2);
+
+    // Same document twice under one topic: only the index differs.
+    const sameDocTwice = guidsOf(await markupOf(projectWith('3.0', [withoutGuid(), withoutGuid()])));
+    expect(new Set(sameDocTwice).size).toBe(2);
+
+    const otherTopic = projectWith('3.0', [withoutGuid()]);
+    const topic = otherTopic.topics.get(TOPIC_GUID)!;
+    otherTopic.topics.delete(TOPIC_GUID);
+    topic.guid = '44444444-4444-4444-8444-444444444444';
+    otherTopic.topics.set(topic.guid, topic);
+    expect(guidsOf(await markupOf(otherTopic))[0]).not.toBe(twoDocs[0]);
+  });
+
+  /**
+   * The writer stores what it wrote back on the object, so the in-memory
+   * project is not left claiming a reference has no guid while the file on
+   * disk says otherwise.
+   */
+  it('writes the minted guid back onto the caller\'s document reference', async () => {
+    const docRef = withoutGuid();
+    const project = projectWith('3.0', [docRef]);
+    expect(docRef.guid, 'fixture sanity: unset before the write').toBeUndefined();
+    const xml = await markupOf(project);
+    expect(docRef.guid).toBeTruthy();
+    expect(xml).toContain(`<DocumentReference Guid="${docRef.guid}"`);
+  });
+
+  /**
+   * 2.1 mints nothing, so it must not acquire a guid by the write-back either.
+   */
+  it('leaves the caller\'s object untouched for BCF 2.1', async () => {
+    const docRef = withoutGuid();
+    await markupOf(projectWith('2.1', [docRef]));
+    expect(docRef.guid).toBeUndefined();
+  });
+
   it('is left absent for BCF 2.1, whose schema makes it optional', async () => {
-    const xml = await markupOf(projectWith('2.1', [WITHOUT_GUID]));
+    const xml = await markupOf(projectWith('2.1', [withoutGuid()]));
     expect(xml).toContain('<DocumentReference isExternal="true">');
     expect(xml).not.toMatch(/<DocumentReference Guid=/);
     expect(await markupErrors('2.1', xml)).toEqual([]);

--- a/packages/bcf/src/document-reference-guid.test.ts
+++ b/packages/bcf/src/document-reference-guid.test.ts
@@ -206,6 +206,26 @@ describe('DocumentReference/@Guid', () => {
   });
 
   /**
+   * A 3.0 reference can point at its document with `DocumentGuid` instead of a
+   * `Url` -- the writer's own body prefers it -- so the seed has to read the
+   * same field. Seeding from `url ?? referencedDocument ?? ''` alone leaves
+   * every internal reference seeded on the empty string, and then the guid is
+   * a function of the topic and the position only: two references naming
+   * DIFFERENT documents at the same position land on the same identifier.
+   */
+  it('separates references that differ only in documentGuid', async () => {
+    const guidOf = (xml: string) => /<DocumentReference Guid="([^"]+)"/.exec(xml)![1];
+    const internal = (documentGuid: string): BCFDocumentReference => ({
+      isExternal: false,
+      documentGuid,
+    });
+
+    const a = guidOf(await markupOf(projectWith('3.0', [internal('55555555-5555-4555-8555-555555555555')])));
+    const b = guidOf(await markupOf(projectWith('3.0', [internal('66666666-6666-4666-8666-666666666666')])));
+    expect(a).not.toBe(b);
+  });
+
+  /**
    * The writer stores what it wrote back on the object, so the in-memory
    * project is not left claiming a reference has no guid while the file on
    * disk says otherwise.

--- a/packages/bcf/src/document-reference-guid.test.ts
+++ b/packages/bcf/src/document-reference-guid.test.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `DocumentReference/@Guid` is OPTIONAL in BCF 2.1 and REQUIRED in BCF 3.0.
+ *
+ * 2.1's markup.xsd declares it `<xs:attribute name="Guid" type="Guid"/>` with
+ * no `use`, i.e. optional; 3.0's `DocumentReferenceAttributes` declares the
+ * same attribute `use="required"`. `BCFDocumentReference.guid` is optional to
+ * match 2.1, and the writer omitted the attribute whenever it was unset — so
+ * any 3.0 topic carrying a document reference without one produced a
+ * `markup.bcf` that fails validation ("The attribute 'Guid' is required but
+ * missing"), and `markup.bcf` IS the issue: a viewer that rejects it drops
+ * the topic entirely (#3612).
+ *
+ * The remedy is to mint one rather than to refuse. A `DocumentReference`
+ * guid names only itself — nothing else in the archive refers to it, unlike
+ * `RelatedTopic/@Guid` or `Comment/Viewpoint/@Guid` — so a generated value
+ * loses nothing, and it follows `writeProjectFile`'s existing
+ * `project.projectId || generateUuid()`. Refusing, the policy used for
+ * `AspectRatio` and `TopicType`, is wrong here: those assert something about
+ * the view or the issue that only the caller knows, and refusing would fail
+ * the whole export over a field 2.1 says is optional.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+import { validateXML } from 'xmllint-wasm';
+import { isValidUuid } from '@ifc-lite/encoding';
+import { writeBCF } from './writer.js';
+import type { BCFDocumentReference, BCFProject } from './types.js';
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function schema(version: '2.1' | '3.0', file: string): string {
+  const dir = version === '2.1' ? 'v2_1' : 'v3_0';
+  return readFileSync(path.join(DIR, '__fixtures__', 'schemas', dir, file), 'utf8');
+}
+
+function projectWith(
+  version: '2.1' | '3.0',
+  documentReferences: BCFDocumentReference[]
+): BCFProject {
+  return {
+    version,
+    projectId: '99999999-9999-4999-8999-999999999999',
+    topics: new Map([
+      [
+        '11111111-1111-4111-8111-111111111111',
+        {
+          guid: '11111111-1111-4111-8111-111111111111',
+          title: 'Topic with an attached document',
+          topicType: 'Issue',
+          topicStatus: 'Open',
+          creationDate: '2026-01-02T03:04:05Z',
+          creationAuthor: 'author@example.invalid',
+          documentReferences,
+          comments: [],
+          viewpoints: [],
+        },
+      ],
+    ]),
+  };
+}
+
+async function markupOf(project: BCFProject): Promise<string> {
+  const zip = await JSZip.loadAsync(Buffer.from(await (await writeBCF(project)).arrayBuffer()));
+  const name = Object.keys(zip.files).find((n) => n.endsWith('markup.bcf'))!;
+  return zip.files[name].async('string');
+}
+
+async function markupErrors(version: '2.1' | '3.0', xml: string): Promise<string[]> {
+  const result = await validateXML({
+    xml: [{ fileName: 'subject.xml', contents: xml }],
+    schema: [schema(version, 'markup.xsd')],
+    preload:
+      version === '3.0'
+        ? [{ fileName: 'shared-types.xsd', contents: schema('3.0', 'shared-types.xsd') }]
+        : [],
+  });
+  return result.valid ? [] : result.errors.map((e) => e.message);
+}
+
+/** No `guid` — what a caller writing to the 2.1-shaped optional field gives. */
+const WITHOUT_GUID: BCFDocumentReference = {
+  isExternal: true,
+  url: 'https://example.invalid/spec.pdf',
+  description: 'Cladding specification',
+};
+
+const CALLER_GUID = '33333333-3333-4333-8333-333333333333';
+
+describe('DocumentReference/@Guid', () => {
+  it('is supplied for BCF 3.0 when the caller left it unset', async () => {
+    const xml = await markupOf(projectWith('3.0', [WITHOUT_GUID]));
+    const guid = /<DocumentReference Guid="([^"]+)"/.exec(xml)?.[1];
+    expect(guid, 'BUG: 3.0 requires the attribute and the writer omitted it').toBeTruthy();
+    expect(isValidUuid(guid!), `generated guid ${guid} must satisfy the schema Guid type`).toBe(
+      true
+    );
+    expect(await markupErrors('3.0', xml)).toEqual([]);
+  });
+
+  it('keeps the caller\'s own guid rather than overwriting it', async () => {
+    const xml = await markupOf(projectWith('3.0', [{ ...WITHOUT_GUID, guid: CALLER_GUID }]));
+    expect(xml).toContain(`<DocumentReference Guid="${CALLER_GUID}"`);
+    expect(await markupErrors('3.0', xml)).toEqual([]);
+  });
+
+  /**
+   * Two references in one topic must not collide: a single generated guid
+   * reused for both would still validate against the attribute's type, and
+   * would still be wrong.
+   */
+  it('gives two guid-less references distinct guids', async () => {
+    const xml = await markupOf(
+      projectWith('3.0', [WITHOUT_GUID, { ...WITHOUT_GUID, description: 'Second document' }])
+    );
+    const guids = [...xml.matchAll(/<DocumentReference Guid="([^"]+)"/g)].map((m) => m[1]);
+    expect(guids).toHaveLength(2);
+    expect(new Set(guids).size).toBe(2);
+    expect(await markupErrors('3.0', xml)).toEqual([]);
+  });
+
+  /**
+   * 2.1 keeps the attribute optional. Emitting a fabricated guid there would
+   * put an identifier the caller never chose into the file a user downloads,
+   * for no schema reason — and would make this fix invisible to a reader
+   * trying to tell the two versions apart.
+   */
+  it('is left absent for BCF 2.1, whose schema makes it optional', async () => {
+    const xml = await markupOf(projectWith('2.1', [WITHOUT_GUID]));
+    expect(xml).toContain('<DocumentReference isExternal="true">');
+    expect(xml).not.toMatch(/<DocumentReference Guid=/);
+    expect(await markupErrors('2.1', xml)).toEqual([]);
+  });
+});

--- a/packages/bcf/src/interop-conformance.test.ts
+++ b/packages/bcf/src/interop-conformance.test.ts
@@ -102,6 +102,14 @@ const SCHEMA_FOR_ENTRY: ReadonlyArray<readonly [RegExp, string]> = [
 const STRESS_TEXT = `Grüße & <critical> "urgent" 'now' — 通風管 café`;
 
 /**
+ * The viewport ratio every camera below carries, mirroring what the viewer
+ * now records (`Camera.getAspect()`). 3.0's `visinfo.xsd` requires
+ * `<AspectRatio>`; 2.1 has no such element, and the writer emits none there,
+ * so one fixture value serves both arms.
+ */
+const ASPECT_RATIO = 16 / 9;
+
+/**
  * Build the archive a user downloads, using only the public helpers (plus the
  * plain-field-assignment pattern real callers already use for fields no
  * helper option reaches -- see the file-level comment above).
@@ -154,6 +162,7 @@ function plainExport(version: '2.1' | '3.0'): BCFProject {
         up: { x: 0, y: 1, z: 0 },
         fov: Math.PI / 4,
         isOrthographic: false,
+        aspectRatio: ASPECT_RATIO,
       },
       // The user's report singles out selected objects by GUID; a viewpoint
       // with no selection could not show them going missing.
@@ -252,6 +261,7 @@ function plainExport(version: '2.1' | '3.0'): BCFProject {
       fov: Math.PI / 3,
       isOrthographic: true,
       orthoScale: 5.5,
+      aspectRatio: ASPECT_RATIO,
     },
     sectionPlane: { axis: 'down', position: 40, enabled: true, flipped: false },
     bounds: { min: { x: -10, y: -10, z: -10 }, max: { x: 10, y: 10, z: 10 } },
@@ -268,6 +278,7 @@ function plainExport(version: '2.1' | '3.0'): BCFProject {
       position: { x: 3, y: 1, z: -2 },
       target: { x: 0, y: 0, z: 0 },
       up: { x: 0, y: 1, z: 0 },
+      aspectRatio: ASPECT_RATIO,
       // 50 degrees -- inside 2.1's [45, 60] FieldOfView facet, distinct from
       // plainTopic's 45-degree boundary case. (writer-camera.ts deliberately
       // does not enforce this facet on write -- see requireFieldOfViewElement
@@ -324,17 +335,21 @@ async function entriesOf(project: BCFProject): Promise<Map<string, string>> {
 }
 
 /**
- * 2.1 only, and that is the point rather than a shortcut: `createBCFProject`
- * defaults to 2.1 and every caller in this repository takes that default, so
- * 2.1 is the archive users actually get. A plain 3.0 export cannot even be
- * built through these helpers today — 3.0's `visinfo.xsd` requires
- * `AspectRatio` on both camera types, `ViewerCameraState` carries none, so
- * `createViewpoint` produces a camera the writer refuses (deliberately) rather
- * than emitting an invalid archive. `schema-validation.test.ts` covers 3.0
- * from a hand-built fixture that supplies the field.
+ * Both versions. 2.1 is what `createBCFProject` defaults to and what most
+ * callers download, but 3.0 is NOT hypothetical: `readBCF` sets
+ * `project.version` from the imported `bcf.version`, so importing another
+ * tool's 3.0 archive and adding a topic exports 3.0.
+ *
+ * The 3.0 arm was skipped until #3612 because it could not be built at all
+ * through these helpers -- `visinfo.xsd` requires `AspectRatio` on both camera
+ * types, `ViewerCameraState` carried none, and the writer refuses (rightly) to
+ * invent one, so `writeBCF` threw for the whole archive. That was read as "3.0
+ * is not what users get" when it was really "3.0 export is broken"; skipping
+ * the arm is what let it stay broken. `ViewerCameraState.aspectRatio` closes
+ * it, and running the arm is what keeps it closed.
  */
 describe('a plainly-exported archive validates entry by entry', () => {
-  for (const version of ['2.1'] as const) {
+  for (const version of ['2.1', '3.0'] as const) {
     it(`BCF ${version}`, async () => {
       const entries = await entriesOf(plainExport(version));
 
@@ -360,11 +375,14 @@ describe('a plainly-exported archive validates entry by entry', () => {
           // contain `/`; a fixed inert name keeps both out of the argv.
           xml: [{ fileName: 'subject.xml', contents: xml }],
           schema: [schema(version, xsd)],
-          // No preload needed: this sweep is 2.1-only (see the block comment
-          // above), and 2.1's schemas are self-contained. A 3.0 archive would
-          // need shared-types.xsd preloaded for its cross-schema references;
-          // `schema-validation.test.ts` covers that case.
-          preload: [],
+          // 2.1's schemas are self-contained; 3.0 pulls its simple types in
+          // with `<xs:include schemaLocation="shared-types.xsd"/>`, which
+          // xmllint resolves against its in-memory filesystem, so the include
+          // target has to be preloaded under exactly that name.
+          preload:
+            version === '3.0'
+              ? [{ fileName: 'shared-types.xsd', contents: schema('3.0', 'shared-types.xsd') }]
+              : [],
         });
         if (!result.valid) {
           failures.push(`${name} [${xsd}]: ${result.errors.map((e) => e.message).join(' | ')}`);

--- a/packages/bcf/src/viewpoint-aspect-ratio.test.ts
+++ b/packages/bcf/src/viewpoint-aspect-ratio.test.ts
@@ -24,10 +24,13 @@
  * `project.version` from the imported `bcf.version`, so importing another
  * tool's 3.0 archive, adding a topic, and exporting hit exactly this.
  *
- * The reverse direction is here for the same reason: `extractViewpointState`
- * is how a viewpoint is loaded back into the viewer, and a state that drops
- * the aspect ratio turns "apply then re-capture" into a lossy step that
- * re-creates the unwritable camera.
+ * The reverse direction is here so the conversion pair is lossless both ways.
+ * A caller that reads a viewpoint, edits the camera state and writes it back
+ * (`perspectiveToCamera` -> `cameraToPerspective`) would otherwise drop the
+ * field and produce a camera that cannot be written as BCF 3.0. This is a
+ * library-level round trip, NOT the viewer's apply path: `useBCF`'s
+ * `applyCameraState` never pushes an aspect ratio into the renderer (the
+ * viewport owns it) and `getCameraState` reads a fresh one.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -150,7 +153,7 @@ describe('viewer camera aspect ratio reaches a BCF 3.0 camera', () => {
     expect(topic?.viewpoints[0]?.perspectiveCamera?.aspectRatio).toBe(ASPECT);
   });
 
-  describe('the reverse direction keeps it, so apply-then-recapture is not lossy', () => {
+  describe('the reverse direction keeps it, so the conversion pair is lossless', () => {
     it('perspectiveToCamera returns the aspect ratio', () => {
       const bcf = cameraToPerspective(CAMERA);
       expect(perspectiveToCamera(bcf).aspectRatio).toBe(ASPECT);
@@ -161,7 +164,7 @@ describe('viewer camera aspect ratio reaches a BCF 3.0 camera', () => {
       expect(orthogonalToCamera(bcf).aspectRatio).toBe(ASPECT);
     });
 
-    it('extractViewpointState surfaces it, and re-capturing still writes', async () => {
+    it('extractViewpointState surfaces it, and re-writing that state still validates', async () => {
       const viewpoint = createViewpoint({ camera: CAMERA });
       const state = extractViewpointState(viewpoint);
       expect(state.camera?.aspectRatio).toBe(ASPECT);

--- a/packages/bcf/src/viewpoint-aspect-ratio.test.ts
+++ b/packages/bcf/src/viewpoint-aspect-ratio.test.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A BCF 3.0 camera's `<AspectRatio>` has to reach the writer from the caller.
+ *
+ * `writer-camera.ts` refuses to invent one: v3_0/visinfo.xsd declares
+ * `AspectRatio` (`PositiveDouble`) as a REQUIRED child of both camera types,
+ * and inventing a value would assert a view the caller never chose. That
+ * policy is right, and it is unenforceable unless a caller has some way to
+ * supply the number.
+ *
+ * It did not. `createViewpoint` is the only public viewpoint constructor in
+ * this package, and the app-side path (`apps/viewer`'s `useBCF`) goes through
+ * it for every viewpoint a user captures. It builds its camera from a
+ * `ViewerCameraState`, which carried no aspect ratio at all, so
+ * `cameraToPerspective`/`cameraToOrthogonal` could not set one and every
+ * viewpoint this package produced was unwritable as BCF 3.0. `writeBCF`
+ * throws on the FIRST such camera, so a single captured viewpoint made the
+ * whole archive fail: not a degraded export, no export (#3612).
+ *
+ * A 3.0 project is reachable without any 3.0-specific UI: `readBCF` sets
+ * `project.version` from the imported `bcf.version`, so importing another
+ * tool's 3.0 archive, adding a topic, and exporting hit exactly this.
+ *
+ * The reverse direction is here for the same reason: `extractViewpointState`
+ * is how a viewpoint is loaded back into the viewer, and a state that drops
+ * the aspect ratio turns "apply then re-capture" into a lossy step that
+ * re-creates the unwritable camera.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+import { validateXML } from 'xmllint-wasm';
+import {
+  cameraToOrthogonal,
+  cameraToPerspective,
+  createViewpoint,
+  extractViewpointState,
+  orthogonalToCamera,
+  perspectiveToCamera,
+  type ViewerCameraState,
+} from './viewpoint.js';
+import { writeBCF } from './writer.js';
+import { readBCF } from './reader.js';
+import type { BCFProject, BCFTopic } from './types.js';
+
+const DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** The viewport this fixture pretends to be: 1600x900, i.e. 16/9. */
+const ASPECT = 16 / 9;
+
+const CAMERA: ViewerCameraState = {
+  position: { x: 10, y: 5, z: 20 },
+  target: { x: 1, y: 2, z: 3 },
+  up: { x: 0, y: 1, z: 0 },
+  fov: Math.PI / 4,
+  aspectRatio: ASPECT,
+};
+
+function projectWith(viewpointCamera: ViewerCameraState): BCFProject {
+  const topic: BCFTopic = {
+    guid: '11111111-1111-4111-8111-111111111111',
+    title: 'Captured in the viewer',
+    topicType: 'Issue',
+    topicStatus: 'Open',
+    creationDate: '2026-01-02T03:04:05Z',
+    creationAuthor: 'author@example.invalid',
+    comments: [],
+    viewpoints: [createViewpoint({ camera: viewpointCamera })],
+  };
+  return {
+    version: '3.0',
+    projectId: '99999999-9999-4999-8999-999999999999',
+    name: 'Imported from another tool',
+    topics: new Map([[topic.guid, topic]]),
+  };
+}
+
+async function viewpointXml(project: BCFProject): Promise<string> {
+  const zip = await JSZip.loadAsync(Buffer.from(await (await writeBCF(project)).arrayBuffer()));
+  const name = Object.keys(zip.files).find((n) => n.endsWith('.bcfv'));
+  expect(name, 'archive has a viewpoint file').toBeTruthy();
+  return zip.files[name!].async('string');
+}
+
+async function validatesAgainstVisinfo(xml: string): Promise<string[]> {
+  const schema = (file: string) =>
+    readFileSync(path.join(DIR, '__fixtures__', 'schemas', 'v3_0', file), 'utf8');
+  const result = await validateXML({
+    xml: [{ fileName: 'subject.xml', contents: xml }],
+    schema: [schema('visinfo.xsd')],
+    preload: [{ fileName: 'shared-types.xsd', contents: schema('shared-types.xsd') }],
+  });
+  return result.valid ? [] : result.errors.map((e) => e.message);
+}
+
+describe('viewer camera aspect ratio reaches a BCF 3.0 camera', () => {
+  it('cameraToPerspective carries the caller-supplied aspect ratio', () => {
+    expect(cameraToPerspective(CAMERA).aspectRatio).toBe(ASPECT);
+  });
+
+  it('cameraToOrthogonal carries the caller-supplied aspect ratio', () => {
+    expect(cameraToOrthogonal(CAMERA, 42).aspectRatio).toBe(ASPECT);
+  });
+
+  /**
+   * Absent stays absent: 2.1's visinfo.xsd has no `AspectRatio` element, so a
+   * caller that supplies nothing must not acquire a fabricated one. This is
+   * the anti-mutation half — a fix that defaulted the field would pass every
+   * other assertion in this file.
+   */
+  it('leaves the aspect ratio unset when the caller supplies none', () => {
+    const { aspectRatio, ...rest } = CAMERA;
+    expect(aspectRatio).toBe(ASPECT); // fixture sanity: the field was there to remove
+    expect(cameraToPerspective(rest).aspectRatio).toBeUndefined();
+    expect(cameraToOrthogonal(rest, 42).aspectRatio).toBeUndefined();
+  });
+
+  it('writes a schema-valid BCF 3.0 perspective viewpoint', async () => {
+    const xml = await viewpointXml(projectWith(CAMERA));
+    expect(xml).toContain(`<AspectRatio>${ASPECT}</AspectRatio>`);
+    expect(await validatesAgainstVisinfo(xml)).toEqual([]);
+  });
+
+  it('writes a schema-valid BCF 3.0 orthogonal viewpoint', async () => {
+    const xml = await viewpointXml(
+      projectWith({ ...CAMERA, isOrthographic: true, orthoScale: 12.5 })
+    );
+    expect(xml).toContain('<OrthogonalCamera>');
+    expect(xml).toContain(`<AspectRatio>${ASPECT}</AspectRatio>`);
+    expect(await validatesAgainstVisinfo(xml)).toEqual([]);
+  });
+
+  /**
+   * The whole-archive property, stated at the level the user sees: a 3.0
+   * project with a viewer-authored viewpoint exports at all. Before the fix
+   * `writeBCF` rejected, so the user got no file and an error toast.
+   */
+  it('round-trips a 3.0 archive holding a viewer-authored viewpoint', async () => {
+    const project = projectWith(CAMERA);
+    const blob = await writeBCF(project);
+    const back = await readBCF(blob);
+    expect(back.version).toBe('3.0');
+    const topic = back.topics.get('11111111-1111-4111-8111-111111111111');
+    expect(topic?.viewpoints[0]?.perspectiveCamera?.aspectRatio).toBe(ASPECT);
+  });
+
+  describe('the reverse direction keeps it, so apply-then-recapture is not lossy', () => {
+    it('perspectiveToCamera returns the aspect ratio', () => {
+      const bcf = cameraToPerspective(CAMERA);
+      expect(perspectiveToCamera(bcf).aspectRatio).toBe(ASPECT);
+    });
+
+    it('orthogonalToCamera returns the aspect ratio', () => {
+      const bcf = cameraToOrthogonal(CAMERA, 42);
+      expect(orthogonalToCamera(bcf).aspectRatio).toBe(ASPECT);
+    });
+
+    it('extractViewpointState surfaces it, and re-capturing still writes', async () => {
+      const viewpoint = createViewpoint({ camera: CAMERA });
+      const state = extractViewpointState(viewpoint);
+      expect(state.camera?.aspectRatio).toBe(ASPECT);
+      const xml = await viewpointXml(projectWith(state.camera!));
+      expect(await validatesAgainstVisinfo(xml)).toEqual([]);
+    });
+
+    it('reports no aspect ratio when the source camera had none', () => {
+      const bcf = cameraToPerspective(CAMERA);
+      delete bcf.aspectRatio;
+      expect(perspectiveToCamera(bcf).aspectRatio).toBeUndefined();
+    });
+  });
+});

--- a/packages/bcf/src/viewpoint.ts
+++ b/packages/bcf/src/viewpoint.ts
@@ -247,7 +247,14 @@ export function perspectiveToCamera(
     up: viewerUp,
     fov,
     isOrthographic: false,
-    // Carried back so apply-then-recapture is not what loses it.
+    // Carried back so the conversion pair is lossless in both directions.
+    // NOT for the viewer's apply path: `useBCF`'s `applyCameraState` never
+    // pushes an aspect ratio into the renderer (the viewport owns that) and
+    // `getCameraState` reads a fresh one, so nothing there depends on this.
+    // It matters for a caller that reads a viewpoint, edits the camera state,
+    // and writes it back -- `perspectiveToCamera` -> `cameraToPerspective`
+    // would otherwise silently drop the field and make the result unwritable
+    // as BCF 3.0. The tests pin the round trip, not a viewer scenario.
     ...(camera.aspectRatio === undefined ? {} : { aspectRatio: camera.aspectRatio }),
   };
 }

--- a/packages/bcf/src/viewpoint.ts
+++ b/packages/bcf/src/viewpoint.ts
@@ -37,6 +37,16 @@ export interface ViewerCameraState {
   isOrthographic?: boolean;
   /** Orthographic scale (view-to-world) */
   orthoScale?: number;
+  /**
+   * Viewport aspect ratio (width / height). REQUIRED to write BCF 3.0:
+   * v3_0/visinfo.xsd makes `<AspectRatio>` a mandatory child of both camera
+   * types and `writer-camera.ts` refuses to invent one, so without this field
+   * no viewpoint this package produced could be written as 3.0 at all -- and
+   * `writeBCF` throws for the whole archive on the first such camera, so one
+   * captured viewpoint meant no export (#3612). Optional because 2.1 has no
+   * such element; leave it unset rather than assert a view nobody had.
+   */
+  aspectRatio?: number;
 }
 
 export interface ViewerSectionPlane {
@@ -144,6 +154,7 @@ export function cameraToPerspective(camera: ViewerCameraState): BCFPerspectiveCa
     cameraDirection: direction,
     cameraUpVector: upVector,
     fieldOfView: Math.max(1, Math.min(179, fieldOfView)), // Clamp to valid range
+    ...(camera.aspectRatio === undefined ? {} : { aspectRatio: camera.aspectRatio }),
   };
 }
 
@@ -184,6 +195,7 @@ export function cameraToOrthogonal(
     cameraDirection: direction,
     cameraUpVector: upVector,
     viewToWorldScale,
+    ...(camera.aspectRatio === undefined ? {} : { aspectRatio: camera.aspectRatio }),
   };
 }
 
@@ -235,6 +247,8 @@ export function perspectiveToCamera(
     up: viewerUp,
     fov,
     isOrthographic: false,
+    // Carried back so apply-then-recapture is not what loses it.
+    ...(camera.aspectRatio === undefined ? {} : { aspectRatio: camera.aspectRatio }),
   };
 }
 
@@ -269,6 +283,7 @@ export function orthogonalToCamera(
     fov: Math.PI / 4, // Default FOV for ortho (not used)
     isOrthographic: true,
     orthoScale: camera.viewToWorldScale,
+    ...(camera.aspectRatio === undefined ? {} : { aspectRatio: camera.aspectRatio }),
   };
 }
 

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -861,10 +861,18 @@ function writeDocumentReference(
   // one topic can name the same document, and one document can appear under
   // two topics. The result is written back onto `docRef` so the in-memory
   // project agrees with the file rather than reporting no guid at all.
+  //
+  // The "document pointed at" is read in the SAME precedence the 3.0 body
+  // below uses -- `documentGuid` first, then the url. Seeding from the url
+  // alone left every internal reference seeded on the empty string, so its
+  // guid was a function of the topic and the position only and two references
+  // naming different documents at one position collided.
   const guid =
     version === '3.0'
       ? docRef.guid ||
-        uuidFromSeed(`${topicGuid}|${docRef.url ?? docRef.referencedDocument ?? ''}|${index}`)
+        uuidFromSeed(
+          `${topicGuid}|${docRef.documentGuid ?? docRef.url ?? docRef.referencedDocument ?? ''}|${index}`
+        )
       : docRef.guid;
   if (version === '3.0' && !docRef.guid) docRef.guid = guid;
   const guidAttr = guid ? ` Guid="${escapeXml(guid)}"` : '';

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -41,7 +41,7 @@ import {
   xsdOptionalDateTime,
   xsdRequiredString,
 } from './xsd-required-string.js';
-import { generateUuid } from '@ifc-lite/encoding';
+import { generateUuid, uuidFromSeed } from '@ifc-lite/encoding';
 
 /**
  * Write a BCFProject to a .bcfzip file
@@ -353,8 +353,8 @@ function writeMarkupFile(
     // <DocumentReferences> element, while 2.1 repeats <DocumentReference>
     // directly under <Topic> (buildingSMART/BCF-XML markup.xsd, Topic).
     if (version === '3.0') content += `\n    <DocumentReferences>`;
-    for (const docRef of topic.documentReferences) {
-      content += writeDocumentReference(docRef, version);
+    for (let i = 0; i < topic.documentReferences.length; i++) {
+      content += writeDocumentReference(topic.documentReferences[i], version, topic.guid, i);
     }
     if (version === '3.0') content += `\n    </DocumentReferences>`;
   }
@@ -832,7 +832,12 @@ function writeBimSnippet(snippet: BCFBimSnippet, version: '2.1' | '3.0'): string
  * the 2.1-shaped fallback so 2.1-authored data written as 3.0 still emits
  * something.
  */
-function writeDocumentReference(docRef: BCFDocumentReference, version: '2.1' | '3.0'): string {
+function writeDocumentReference(
+  docRef: BCFDocumentReference,
+  version: '2.1' | '3.0',
+  topicGuid: string,
+  index: number,
+): string {
   // 2.1's markup.xsd declares `Guid` with no `use`, so it is optional there;
   // 3.0's `DocumentReferenceAttributes` declares it `use="required"`, so
   // omitting it made every 3.0 topic carrying a guid-less document reference
@@ -840,13 +845,28 @@ function writeDocumentReference(docRef: BCFDocumentReference, version: '2.1' | '
   // that rejects it drops the topic whole (#3612). Mint one rather than
   // refuse: this guid names only itself (nothing in the archive refers to a
   // DocumentReference the way `RelatedTopic` refers to a topic), so a
-  // generated value loses nothing, and `writeProjectFile` already fills a
-  // missing `projectId` the same way. Refusal is reserved for values that
-  // assert something only the caller knows -- `AspectRatio`, `TopicType` --
-  // and would fail the whole export over a field 2.1 says is optional. 2.1
-  // keeps the attribute absent: fabricating an identifier there buys no
-  // schema conformance at all.
-  const guid = version === '3.0' ? docRef.guid || generateUuid() : docRef.guid;
+  // generated value loses nothing. Refusal is reserved for values that assert
+  // something only the caller knows -- `AspectRatio`, `TopicType` -- and would
+  // fail the whole export over a field 2.1 says is optional. 2.1 keeps the
+  // attribute absent: fabricating an identifier there buys no schema
+  // conformance at all, and would put an identifier the caller never chose
+  // into the file a user downloads.
+  //
+  // DERIVED, not random. `generateUuid()` here would make two exports of one
+  // unchanged project differ in bytes -- and differ again on every subsequent
+  // write, because nothing kept the value. `uuidFromSeed` is the same
+  // generator `@ifc-lite/clash` anchors its topic guids with, so the guid is a
+  // pure function of the topic, the document pointed at, and the position
+  // within the topic; all three are in the seed because two references under
+  // one topic can name the same document, and one document can appear under
+  // two topics. The result is written back onto `docRef` so the in-memory
+  // project agrees with the file rather than reporting no guid at all.
+  const guid =
+    version === '3.0'
+      ? docRef.guid ||
+        uuidFromSeed(`${topicGuid}|${docRef.url ?? docRef.referencedDocument ?? ''}|${index}`)
+      : docRef.guid;
+  if (version === '3.0' && !docRef.guid) docRef.guid = guid;
   const guidAttr = guid ? ` Guid="${escapeXml(guid)}"` : '';
 
   if (version === '3.0') {

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -859,20 +859,16 @@ function writeDocumentReference(
   // pure function of the topic, the document pointed at, and the position
   // within the topic; all three are in the seed because two references under
   // one topic can name the same document, and one document can appear under
-  // two topics. The result is written back onto `docRef` so the in-memory
-  // project agrees with the file rather than reporting no guid at all.
-  //
-  // The "document pointed at" is read in the SAME precedence the 3.0 body
-  // below uses -- `documentGuid` first, then the url. Seeding from the url
-  // alone left every internal reference seeded on the empty string, so its
-  // guid was a function of the topic and the position only and two references
-  // naming different documents at one position collided.
+  // two topics. `docKey` names the document in the SAME precedence the 3.0
+  // body below uses -- seeding from the url alone left every `documentGuid`
+  // reference on the empty string, so its guid ignored the document entirely
+  // and two references naming different documents could collide. The result
+  // is written back onto `docRef` so the in-memory project agrees with the
+  // file rather than reporting no guid at all.
+  const docKey = docRef.documentGuid ?? docRef.url ?? docRef.referencedDocument ?? '';
   const guid =
     version === '3.0'
-      ? docRef.guid ||
-        uuidFromSeed(
-          `${topicGuid}|${docRef.documentGuid ?? docRef.url ?? docRef.referencedDocument ?? ''}|${index}`
-        )
+      ? docRef.guid || uuidFromSeed(`${topicGuid}|${docKey}|${index}`)
       : docRef.guid;
   if (version === '3.0' && !docRef.guid) docRef.guid = guid;
   const guidAttr = guid ? ` Guid="${escapeXml(guid)}"` : '';

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -833,7 +833,21 @@ function writeBimSnippet(snippet: BCFBimSnippet, version: '2.1' | '3.0'): string
  * something.
  */
 function writeDocumentReference(docRef: BCFDocumentReference, version: '2.1' | '3.0'): string {
-  const guidAttr = docRef.guid ? ` Guid="${escapeXml(docRef.guid)}"` : '';
+  // 2.1's markup.xsd declares `Guid` with no `use`, so it is optional there;
+  // 3.0's `DocumentReferenceAttributes` declares it `use="required"`, so
+  // omitting it made every 3.0 topic carrying a guid-less document reference
+  // write an invalid `markup.bcf` -- and markup.bcf IS the issue, so a viewer
+  // that rejects it drops the topic whole (#3612). Mint one rather than
+  // refuse: this guid names only itself (nothing in the archive refers to a
+  // DocumentReference the way `RelatedTopic` refers to a topic), so a
+  // generated value loses nothing, and `writeProjectFile` already fills a
+  // missing `projectId` the same way. Refusal is reserved for values that
+  // assert something only the caller knows -- `AspectRatio`, `TopicType` --
+  // and would fail the whole export over a field 2.1 says is optional. 2.1
+  // keeps the attribute absent: fabricating an identifier there buys no
+  // schema conformance at all.
+  const guid = version === '3.0' ? docRef.guid || generateUuid() : docRef.guid;
+  const guidAttr = guid ? ` Guid="${escapeXml(guid)}"` : '';
 
   if (version === '3.0') {
     let content = `\n    <DocumentReference${guidAttr}>`;

--- a/packages/clash/package.json
+++ b/packages/clash/package.json
@@ -39,12 +39,13 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ifc-lite/spatial": "workspace:^",
+    "@ifc-lite/bcf": "workspace:^",
+    "@ifc-lite/encoding": "workspace:^",
     "@ifc-lite/geometry": "workspace:^",
+    "@ifc-lite/ifcx": "workspace:^",
     "@ifc-lite/parser": "workspace:^",
     "@ifc-lite/query": "workspace:^",
-    "@ifc-lite/bcf": "workspace:^",
-    "@ifc-lite/ifcx": "workspace:^",
+    "@ifc-lite/spatial": "workspace:^",
     "@ifc-lite/wasm": "workspace:^"
   },
   "devDependencies": {

--- a/packages/clash/src/deterministic-uuid.ts
+++ b/packages/clash/src/deterministic-uuid.ts
@@ -3,96 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Deterministic, input-only UUID generation.
+ * Re-export of the deterministic UUID generator, which now lives in
+ * `@ifc-lite/encoding` beside `generateUuid`.
  *
- * Produces an RFC-4122-shaped identifier (8-4-4-4-12 lowercase hex) whose 128
- * bits are derived purely from a seed string. The same seed always yields the
- * same UUID, with no dependence on the system clock or any random source. This
- * is what lets a BCF topic guid be a stable function of a clash-group id, so a
- * re-run of the same coordination produces byte-identical topic guids and the
- * round-trip back to clashes stays anchored.
+ * It moved because `@ifc-lite/bcf` needs it too, to derive the
+ * `DocumentReference/@Guid` that BCF 3.0 requires (#3612), and
+ * `@ifc-lite/clash` DEPENDS ON `@ifc-lite/bcf` -- so importing it from here
+ * would have been a package cycle, and copying the algorithm would have left
+ * two implementations of one identity scheme held together by nothing but a
+ * comment. Both packages already depend on `@ifc-lite/encoding`.
  *
- * The 128 bits are filled from four 32-bit words. Each word starts from an
- * FNV-1a hash of the seed mixed with a distinct salt, then is run through a
- * short xorshift cascade so adjacent seeds (e.g. "g1" vs "g2") diffuse into
- * fully different words rather than differing in only a few low bits.
+ * This file stays so clash's own callers and its `deterministic-uuid.test.ts`
+ * keep their import path, and so the guid a clash re-run produces cannot
+ * change: the test pins exact output for fixed seeds, and it now pins the
+ * shared implementation through this path.
  */
 
-const FNV_OFFSET_BASIS = 0x811c9dc5;
-const FNV_PRIME = 0x01000193;
-
-/** 32-bit FNV-1a over the UTF-8-ish code units of `input`, seeded with `salt`. */
-function fnv1a(input: string, salt: number): number {
-  let hash = (FNV_OFFSET_BASIS ^ salt) >>> 0;
-  for (let i = 0; i < input.length; i += 1) {
-    const code = input.charCodeAt(i);
-    // Fold the full 16-bit code unit in two byte-sized steps so non-ASCII
-    // comment-free seeds still contribute every bit.
-    hash = (hash ^ (code & 0xff)) >>> 0;
-    hash = Math.imul(hash, FNV_PRIME) >>> 0;
-    hash = (hash ^ ((code >>> 8) & 0xff)) >>> 0;
-    hash = Math.imul(hash, FNV_PRIME) >>> 0;
-  }
-  return hash >>> 0;
-}
-
-/** A short xorshift cascade to diffuse a 32-bit word. */
-function xorshift32(value: number): number {
-  let x = value >>> 0;
-  x ^= x << 13;
-  x >>>= 0;
-  x ^= x >>> 17;
-  x ^= x << 5;
-  return x >>> 0;
-}
-
-/** Left-pad a non-negative 32-bit word to 8 lowercase hex chars. */
-function hex32(value: number): string {
-  return (value >>> 0).toString(16).padStart(8, '0');
-}
-
-/**
- * Stable RFC-4122-shaped UUID derived purely from `seed`.
- *
- * - 8-4-4-4-12 lowercase hex
- * - version nibble fixed to '4'
- * - variant nibble in {8, 9, a, b}
- */
-export function uuidFromSeed(seed: string): string {
-  // Four independent 32-bit words, each its own salt then xorshift-mixed.
-  const w0 = xorshift32(fnv1a(seed, 0x9e3779b1));
-  const w1 = xorshift32(fnv1a(seed, 0x85ebca77));
-  const w2 = xorshift32(fnv1a(seed, 0xc2b2ae3d));
-  const w3 = xorshift32(fnv1a(seed, 0x27d4eb2f));
-
-  // Cross-mix so each output nibble depends on the whole seed, not one word.
-  const a = xorshift32(w0 ^ Math.imul(w3, FNV_PRIME)) >>> 0;
-  const b = xorshift32(w1 ^ Math.imul(w0, FNV_PRIME)) >>> 0;
-  const c = xorshift32(w2 ^ Math.imul(w1, FNV_PRIME)) >>> 0;
-  const d = xorshift32(w3 ^ Math.imul(w2, FNV_PRIME)) >>> 0;
-
-  const hexA = hex32(a);
-  const hexB = hex32(b);
-  const hexC = hex32(c);
-  const hexD = hex32(d);
-
-  // Layout: AAAAAAAA-BBBB-4BBB-VCCC-CCCCDDDDDDDD
-  //   time_low      = hexA            (8)
-  //   time_mid      = hexB[0..4)      (4)
-  //   time_hi_ver   = '4' + hexB[4..7) (4, version nibble forced to 4)
-  //   clock_variant = variant + hexC[1..4) (4)
-  //   node          = hexC[4..8) + hexD (12)
-  const timeLow = hexA;
-  const timeMid = hexB.slice(0, 4);
-  const timeHiAndVersion = `4${hexB.slice(4, 7)}`;
-
-  // Variant nibble: high two bits must be '10' -> one of 8, 9, a, b.
-  // Derive it from the top nibble of hexC so it is still seed-dependent.
-  const variantSource = parseInt(hexC[0], 16);
-  const variantNibble = ((variantSource & 0x3) | 0x8).toString(16);
-  const clockSeqAndVariant = `${variantNibble}${hexC.slice(1, 4)}`;
-
-  const node = `${hexC.slice(4, 8)}${hexD}`;
-
-  return `${timeLow}-${timeMid}-${timeHiAndVersion}-${clockSeqAndVariant}-${node}`;
-}
+export { uuidFromSeed } from '@ifc-lite/encoding';

--- a/packages/encoding/src/deterministic-uuid.ts
+++ b/packages/encoding/src/deterministic-uuid.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Deterministic, input-only UUID generation.
+ *
+ * Produces an RFC-4122-shaped identifier (8-4-4-4-12 lowercase hex) whose 128
+ * bits are derived purely from a seed string. The same seed always yields the
+ * same UUID, with no dependence on the system clock or any random source.
+ *
+ * Two callers need exactly that, which is why this sits in `@ifc-lite/encoding`
+ * beside {@link generateUuid} rather than in either of them:
+ * - `@ifc-lite/clash` makes a BCF topic guid a stable function of a clash-group
+ *   id, so a re-run of the same coordination produces byte-identical topic
+ *   guids and the round trip back to clashes stays anchored.
+ * - `@ifc-lite/bcf` fills the `DocumentReference/@Guid` that BCF 3.0 requires
+ *   and BCF 2.1 leaves optional, so exporting one project twice yields the same
+ *   bytes instead of a fresh random identifier each time (#3612).
+ *
+ * `@ifc-lite/clash` depends on `@ifc-lite/bcf`, so sharing had to go through a
+ * package below both; a second copy of the algorithm would have been two
+ * implementations of one identity scheme, kept in step by nothing but prose.
+ *
+ * The 128 bits are filled from four 32-bit words. Each word starts from an
+ * FNV-1a hash of the seed mixed with a distinct salt, then is run through a
+ * short xorshift cascade so adjacent seeds (e.g. "g1" vs "g2") diffuse into
+ * fully different words rather than differing in only a few low bits.
+ */
+
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+const FNV_PRIME = 0x01000193;
+
+/** 32-bit FNV-1a over the UTF-8-ish code units of `input`, seeded with `salt`. */
+function fnv1a(input: string, salt: number): number {
+  let hash = (FNV_OFFSET_BASIS ^ salt) >>> 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    // Fold the full 16-bit code unit in two byte-sized steps so non-ASCII
+    // comment-free seeds still contribute every bit.
+    hash = (hash ^ (code & 0xff)) >>> 0;
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+    hash = (hash ^ ((code >>> 8) & 0xff)) >>> 0;
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/** A short xorshift cascade to diffuse a 32-bit word. */
+function xorshift32(value: number): number {
+  let x = value >>> 0;
+  x ^= x << 13;
+  x >>>= 0;
+  x ^= x >>> 17;
+  x ^= x << 5;
+  return x >>> 0;
+}
+
+/** Left-pad a non-negative 32-bit word to 8 lowercase hex chars. */
+function hex32(value: number): string {
+  return (value >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Stable RFC-4122-shaped UUID derived purely from `seed`.
+ *
+ * - 8-4-4-4-12 lowercase hex
+ * - version nibble fixed to '4'
+ * - variant nibble in {8, 9, a, b}
+ */
+export function uuidFromSeed(seed: string): string {
+  // Four independent 32-bit words, each its own salt then xorshift-mixed.
+  const w0 = xorshift32(fnv1a(seed, 0x9e3779b1));
+  const w1 = xorshift32(fnv1a(seed, 0x85ebca77));
+  const w2 = xorshift32(fnv1a(seed, 0xc2b2ae3d));
+  const w3 = xorshift32(fnv1a(seed, 0x27d4eb2f));
+
+  // Cross-mix so each output nibble depends on the whole seed, not one word.
+  const a = xorshift32(w0 ^ Math.imul(w3, FNV_PRIME)) >>> 0;
+  const b = xorshift32(w1 ^ Math.imul(w0, FNV_PRIME)) >>> 0;
+  const c = xorshift32(w2 ^ Math.imul(w1, FNV_PRIME)) >>> 0;
+  const d = xorshift32(w3 ^ Math.imul(w2, FNV_PRIME)) >>> 0;
+
+  const hexA = hex32(a);
+  const hexB = hex32(b);
+  const hexC = hex32(c);
+  const hexD = hex32(d);
+
+  // Layout: AAAAAAAA-BBBB-4BBB-VCCC-CCCCDDDDDDDD
+  //   time_low      = hexA            (8)
+  //   time_mid      = hexB[0..4)      (4)
+  //   time_hi_ver   = '4' + hexB[4..7) (4, version nibble forced to 4)
+  //   clock_variant = variant + hexC[1..4) (4)
+  //   node          = hexC[4..8) + hexD (12)
+  const timeLow = hexA;
+  const timeMid = hexB.slice(0, 4);
+  const timeHiAndVersion = `4${hexB.slice(4, 7)}`;
+
+  // Variant nibble: high two bits must be '10' -> one of 8, 9, a, b.
+  // Derive it from the top nibble of hexC so it is still seed-dependent.
+  const variantSource = parseInt(hexC[0], 16);
+  const variantNibble = ((variantSource & 0x3) | 0x8).toString(16);
+  const clockSeqAndVariant = `${variantNibble}${hexC.slice(1, 4)}`;
+
+  const node = `${hexC.slice(4, 8)}${hexD}`;
+
+  return `${timeLow}-${timeMid}-${timeHiAndVersion}-${clockSeqAndVariant}-${node}`;
+}

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -13,6 +13,7 @@ export {
   isValidUuid,
 } from './guid.js';
 export type { RandomSource } from './guid.js';
+export { uuidFromSeed } from './deterministic-uuid.js';
 export { isWhollyNumeric } from './numeric-literal.js';
 export { parsePropertyValue } from './property-value.js';
 export type { ParsedPropertyValue } from './property-value.js';

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -389,10 +389,22 @@ export class Camera {
   }
 
   /**
-   * Get the viewport aspect ratio (width / height) the projection is using.
+   * The aspect ratio (width / height) the projection is currently built from.
+   *
+   * This is the DRAWING BUFFER's ratio, not the CSS box's: the render loop
+   * floors the canvas width to a multiple of 64 for WebGPU's 256-byte texture
+   * row alignment before calling {@link setAspect}, so on a viewport whose CSS
+   * width is not a multiple of 64 the two differ by up to 63 pixels.
+   *
+   * That is the right one for BCF (#3612). A viewpoint's snapshot PNG comes
+   * from `canvas.toDataURL()`, which encodes that same drawing buffer, so the
+   * `<AspectRatio>` written beside it describes the image actually in the
+   * archive; the CSS ratio would describe an image nobody has. It is also the
+   * ratio the projection matrix used, so a viewer restoring the camera
+   * reproduces the framing rather than one 63 pixels wider.
+   *
    * Always finite and positive -- {@link setAspect} rejects anything else --
-   * which is what lets `useBCF` hand it straight to a BCF 3.0 `<AspectRatio>`,
-   * whose schema type is `PositiveDouble` (#3612).
+   * which is what BCF 3.0's `PositiveDouble` schema type requires.
    */
   getAspect(): number {
     return this.state.camera.aspect;

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -389,6 +389,16 @@ export class Camera {
   }
 
   /**
+   * Get the viewport aspect ratio (width / height) the projection is using.
+   * Always finite and positive -- {@link setAspect} rejects anything else --
+   * which is what lets `useBCF` hand it straight to a BCF 3.0 `<AspectRatio>`,
+   * whose schema type is `PositiveDouble` (#3612).
+   */
+  getAspect(): number {
+    return this.state.camera.aspect;
+  }
+
+  /**
    * Get distance from camera position to target.
    *
    * Deliberately **unsanitized**: it reports the pose as it actually is, so a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,6 +678,9 @@ importers:
       '@ifc-lite/bcf':
         specifier: workspace:^
         version: link:../bcf
+      '@ifc-lite/encoding':
+        specifier: workspace:^
+        version: link:../encoding
       '@ifc-lite/geometry':
         specifier: workspace:^
         version: link:../geometry

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1532,6 +1532,7 @@
     "isValidUuid: function",
     "isWhollyNumeric: function",
     "parsePropertyValue: function",
+    "uuidFromSeed: function",
     "uuidToIfcGuid: function"
   ],
   "@ifc-lite/export": [

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -188,8 +188,8 @@
    792 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
-   588 packages/bcf/src/viewpoint.ts
-   878 packages/bcf/src/writer.ts
+   595 packages/bcf/src/viewpoint.ts
+   896 packages/bcf/src/writer.ts
    605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts
@@ -308,7 +308,7 @@
    609 packages/provenance/src/node-hash.ts
    535 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
-   672 packages/renderer/src/camera.ts
+   684 packages/renderer/src/camera.ts
   3759 packages/renderer/src/index.ts
    756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -119,7 +119,7 @@
    458 apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
    545 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
    551 apps/viewer/src/hooks/useAnnotation2D.ts
-   678 apps/viewer/src/hooks/useBCF.ts
+   684 apps/viewer/src/hooks/useBCF.ts
   1374 apps/viewer/src/hooks/useClash.ts
    482 apps/viewer/src/hooks/useCompare.ts
   1359 apps/viewer/src/hooks/useDrawingExport.ts
@@ -188,7 +188,7 @@
    792 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
-   573 packages/bcf/src/viewpoint.ts
+   588 packages/bcf/src/viewpoint.ts
    878 packages/bcf/src/writer.ts
    605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
@@ -308,7 +308,7 @@
    609 packages/provenance/src/node-hash.ts
    535 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
-   662 packages/renderer/src/camera.ts
+   672 packages/renderer/src/camera.ts
   3759 packages/renderer/src/index.ts
    756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -119,7 +119,7 @@
    458 apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
    545 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
    551 apps/viewer/src/hooks/useAnnotation2D.ts
-   684 apps/viewer/src/hooks/useBCF.ts
+   690 apps/viewer/src/hooks/useBCF.ts
   1374 apps/viewer/src/hooks/useClash.ts
    482 apps/viewer/src/hooks/useCompare.ts
   1359 apps/viewer/src/hooks/useDrawingExport.ts
@@ -189,7 +189,7 @@
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
    595 packages/bcf/src/viewpoint.ts
-   896 packages/bcf/src/writer.ts
+   900 packages/bcf/src/writer.ts
    605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts


### PR DESCRIPTION
## Summary

Investigation of #3612 (BCF import/export in other software). The 2.1 export validates cleanly end to end against buildingSMART's XSDs since #3667, re-verified here on the archive the BCF panel actually downloads. BCF 3.0, reachable without any 3.0 setting (importing another tool's 3.0 archive keeps its version), was broken:

- `visinfo.xsd` requires `Camera/AspectRatio` in 3.0. The viewer never recorded one and the writer refuses to invent a value, so a 3.0 export threw for the whole archive. `ViewerCameraState` gains an optional `aspectRatio`, `Camera.getAspect()` exposes the renderer's ratio (the drawing-buffer ratio, which is what the snapshot PNG in the archive was rendered with; the doc says so), and `useBCF` records it on every captured viewpoint. 2.1 leaves the element absent and the 2.1 conformance arm validates that.
- `DocumentReference/@Guid` is optional in 2.1 and required in 3.0. It is now written, and derived deterministically with `uuidFromSeed(topicGuid | reference | index)` so two exports of one project are byte-identical and the value is written back onto the object. `uuidFromSeed` moved from `@ifc-lite/clash` to `@ifc-lite/encoding` (clash depends on bcf, so bcf could not import it); clash re-exports it with unchanged output.
- The interop-conformance sweep ran only its 2.1 half, skipped with "2.1 is what users get" when the real reason was that 3.0 could not be built. Both halves run now against the vendored XSDs with a real validator; enabling the 3.0 half is what found the guid bug.

Refs #3612 (kept open: the Solibri-specific rejection is still unexplained and needs the reporter's error text). Follow-ups: #3849 (IDS report to 3.0 has no camera without bounds), #3850 (unrelated solar test flake), and the orthographic capture bug filed separately.

## Verification

- bcf 18 files / 389 tests, renderer 1204, encoding and clash suites: exit 0. `pnpm typecheck`, `pnpm build`, `check-api-surface` (one new export), `check-module-size`: exit 0.
- Mutation-checked by an independent reviewer: removing the aspectRatio wire-up fails both viewer tests; restoring the random guid fails 3 of 9 guid tests and the 3.0 conformance arm.
- Changesets: `@ifc-lite/bcf` patch, `@ifc-lite/renderer` minor (new public method), `@ifc-lite/encoding` minor (new export), `@ifc-lite/clash` patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * BCF 3.0 viewpoint exports now preserve camera aspect ratios for accurate snapshots.
  * BCF 3.0 document references receive deterministic GUIDs when none is provided; existing GUIDs remain unchanged.
  * Added access to the renderer’s current camera aspect ratio.
  * Added a shared deterministic UUID utility for encoding workflows.

* **Bug Fixes**
  * Preserved existing BCF 2.1 behavior when aspect ratios or document-reference GUIDs are absent.

* **Tests**
  * Expanded coverage for BCF 2.1 and 3.0 viewpoint serialization, validation, archives, and document-reference GUID handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->