### PR TITLE
fix(viewer): a moved file and a lost GPU join their families instead of filing fresh issues

### DIFF
--- a/apps/viewer/src/components/viewer/device-loss-report.test.ts
+++ b/apps/viewer/src/components/viewer/device-loss-report.test.ts
@@ -100,6 +100,33 @@ describe('reportDeviceLost', () => {
     );
   });
 
+  it('groups every device loss under one fingerprint, whatever the driver said (#3767)', () => {
+    // Without a capture-site fingerprint PostHog groups by type + message +
+    // STACK, and both halves of that vary: the driver text is Dawn's (a D3D12
+    // hang, a Vulkan VRAM exhaustion, a Metal timeout all word themselves
+    // differently) and the stack names the hashed bundle, so it changes on
+    // every deploy. #3767 and #3774 are the demonstration - the SAME
+    // DXGI_ERROR_DEVICE_HUNG message, six hours apart, filed as two separate
+    // GitHub issues. `stampFingerprint` in analytics-scrub cannot help: it only
+    // fingerprints kinds `classifyLoadError` recognises, and a GPU loss is not
+    // one, so the fingerprint has to be chosen here.
+    const d3d12 = 'ID3D12Device::GetDeviceRemovedReason failed with DXGI_ERROR_DEVICE_HUNG (0x887A0006)';
+    const vulkan = 'vkAllocateMemory failed with VK_ERROR_OUT_OF_DEVICE_MEMORY';
+
+    reportDeviceLost({ message: d3d12, reason: 'unknown' });
+    const first = scrubEvent({ event: '$exception', properties: { ...(captures[0].props ?? {}) } });
+    resetDeviceLossReportForTests();
+    reportDeviceLost({ message: vulkan, reason: 'unknown' });
+    const second = scrubEvent({ event: '$exception', properties: { ...(captures[1].props ?? {}) } });
+
+    assert.equal(first?.properties?.$exception_fingerprint, 'ifc-lite:device_lost');
+    assert.equal(second?.properties?.$exception_fingerprint, 'ifc-lite:device_lost');
+    // The driver text is not lost to the grouping - it stays queryable inside
+    // the one issue, which is the whole trade.
+    assert.equal(first?.properties?.device_lost_detail, d3d12);
+    assert.equal(second?.properties?.device_lost_detail, vulkan);
+  });
+
   it('carries the GPU detail THROUGH the real privacy scrubber, not just to the capture call', () => {
     // The trap this pins: every captured event passes `scrubEvent`
     // (`before_send`), which DELETES any property whose key contains `message`
@@ -244,6 +271,12 @@ describe('reportPersistentRenderDegradation (#2417)', () => {
     assert.doesNotThrow(() => reportPersistentRenderDegradation(DEGRADED));
   });
 
+  it('groups persistent degradation under its OWN fingerprint, separate from a loss', () => {
+    reportPersistentRenderDegradation(DEGRADED);
+    const sent = scrubEvent({ event: '$exception', properties: { ...(captures[0].props ?? {}) } });
+    assert.equal(sent?.properties?.$exception_fingerprint, 'ifc-lite:render_degraded');
+  });
+
   it('carries the GPU detail THROUGH the real privacy scrubber', () => {
     // Same trap as `device_lost_detail`: `scrubEvent` DELETES any property key
     // containing `message` as a `_`-delimited word, and a test that stubs
@@ -336,7 +369,7 @@ describe('subscribeViewportHealth wires every way the view can stop', () => {
     const props = captures[0].props ?? {};
     assert.deepEqual(
       Object.keys(props).sort(),
-      ['context', 'device_lost_detail', 'device_lost_reason'],
+      ['$exception_fingerprint', 'context', 'device_lost_detail', 'device_lost_reason'],
       'base fields intact, and a throwing builder contributes no context fields',
     );
     assert.equal(props.context, 'device_lost');

--- a/apps/viewer/src/components/viewer/device-loss-report.test.ts
+++ b/apps/viewer/src/components/viewer/device-loss-report.test.ts
@@ -119,12 +119,40 @@ describe('reportDeviceLost', () => {
     reportDeviceLost({ message: vulkan, reason: 'unknown' });
     const second = scrubEvent({ event: '$exception', properties: { ...(captures[1].props ?? {}) } });
 
-    assert.equal(first?.properties?.$exception_fingerprint, 'ifc-lite:device_lost');
-    assert.equal(second?.properties?.$exception_fingerprint, 'ifc-lite:device_lost');
+    assert.equal(first?.properties?.$exception_fingerprint, 'ifc-lite:device_lost:unknown');
+    assert.equal(second?.properties?.$exception_fingerprint, 'ifc-lite:device_lost:unknown');
     // The driver text is not lost to the grouping - it stays queryable inside
     // the one issue, which is the whole trade.
     assert.equal(first?.properties?.device_lost_detail, d3d12);
     assert.equal(second?.properties?.device_lost_detail, vulkan);
+  });
+
+  it('separates loss reasons, and caps how many groups an engine can mint', () => {
+    // The reason discriminates: a driver-side loss and Safari's synchronous
+    // frame throw are different bugs with different fixes.
+    reportDeviceLost({ message: SAFARI_LOST, reason: 'render-exception' });
+    const safari = scrubEvent({ event: '$exception', properties: { ...(captures[0].props ?? {}) } });
+    assert.equal(safari?.properties?.$exception_fingerprint, 'ifc-lite:device_lost:render-exception');
+
+    // But `info.reason` is half browser-supplied, and an unbounded fingerprint
+    // is the bug this whole change exists to fix. Anything off the allowlist -
+    // a future spec value, a non-conforming engine, a vendor putting driver
+    // text where a reason belongs - folds into one bucket instead of minting a
+    // group per wording.
+    resetDeviceLossReportForTests();
+    reportDeviceLost({ message: SAFARI_LOST, reason: 'GPUDevice was removed: 0x887A0006 (vendor text)' });
+    const rogue = scrubEvent({ event: '$exception', properties: { ...(captures[1].props ?? {}) } });
+    assert.equal(rogue?.properties?.$exception_fingerprint, 'ifc-lite:device_lost:other');
+    assert.doesNotMatch(
+      String(rogue?.properties?.$exception_fingerprint),
+      /887A0006|vendor text/,
+      'no engine-supplied text may ever reach a fingerprint',
+    );
+    // The raw reason still travels, so the fold costs nothing to triage.
+    assert.equal(
+      rogue?.properties?.device_lost_reason,
+      'GPUDevice was removed: 0x887A0006 (vendor text)',
+    );
   });
 
   it('carries the GPU detail THROUGH the real privacy scrubber, not just to the capture call', () => {

--- a/apps/viewer/src/components/viewer/device-loss-report.ts
+++ b/apps/viewer/src/components/viewer/device-loss-report.ts
@@ -27,6 +27,45 @@ import {
  * than as raw stack frames nobody can attribute.
  */
 
+/**
+ * The reasons a device loss can carry, and the ONLY strings allowed into a
+ * fingerprint.
+ *
+ * Two sources feed `info.reason`, and only one of them is ours. The WebGPU spec
+ * bounds `GPUDeviceLostInfo.reason` to `'unknown'` and `'destroyed'` (and
+ * `device.ts` never forwards a `'destroyed'` teardown), while `Renderer`
+ * synthesises `'render-exception'` / `'render-encode-exception'` for the
+ * synchronous-throw path Safari takes instead of resolving `device.lost`.
+ *
+ * The point of the allowlist is that a fingerprint must have a CEILING. The
+ * browser-supplied half is a string we do not control: a future spec value, a
+ * non-conforming engine, or a vendor that puts driver text where a reason
+ * belongs would each mint a new issue group per wording, which is exactly the
+ * unbounded grouping that made #3767 and #3774 two issues for one failure.
+ * Anything not on this list folds into `other`, so the ceiling is five groups
+ * whatever an engine hands us, and no vendor or driver text can ever reach a
+ * fingerprint. The raw reason is not lost: it stays on the event as
+ * `device_lost_reason`, queryable inside whichever group it landed in.
+ *
+ * A single `ifc-lite:device_lost` would have been simpler and is what one
+ * reading of the review asks for, but it merges failures with different fixes:
+ * a driver-side loss on Windows and a Safari frame throwing a DOMException are
+ * not the same bug, and that is the same argument that keeps `render_degraded`
+ * out of the loss group below.
+ */
+const DEVICE_LOST_FINGERPRINT_REASONS: ReadonlySet<string> = new Set([
+  'unknown',
+  'destroyed',
+  'render-exception',
+  'render-encode-exception',
+]);
+
+/** Bounded fingerprint for a device loss. Never carries engine-supplied text. */
+function deviceLostFingerprint(reason: string): string {
+  const bucket = DEVICE_LOST_FINGERPRINT_REASONS.has(reason) ? reason : 'other';
+  return `ifc-lite:device_lost:${bucket}`;
+}
+
 // Session-scoped latch. Module state is deliberate: the loss is a property of
 // the device, not of a component instance, so a remount must not re-toast.
 let reported = false;
@@ -78,25 +117,28 @@ export function reportDeviceLost(
         // scrub-path test in device-loss-report.test.ts, which runs the real
         // `scrubEvent` so this cannot regress unnoticed.
         device_lost_detail: info.message,
-        // ONE issue for the whole family, chosen here because nothing
-        // downstream can choose it. PostHog groups an exception by type +
-        // message + stack unless the client supplies this, and both halves
-        // vary for a device loss: the message is Dawn's driver text (a D3D12
-        // hang, a Vulkan VRAM exhaustion and a Metal timeout word themselves
-        // differently) and the stack names the hashed bundle, so it moves on
-        // every deploy — the same reason #2354's fixed-string WebGL report
-        // still minted a fresh issue per release. What was OBSERVED: #3767 and
-        // #3774 carry the same DXGI_ERROR_DEVICE_HUNG text six hours apart and
-        // were filed as two separate GitHub issues, with a dozen merges to
-        // main (so several viewer deploys) in between; #3207's Vulkan loss is
-        // a third issue for the same family. The
-        // `stampFingerprint` pass in lib/analytics-scrub.ts cannot cover this:
-        // it fingerprints only the kinds `classifyLoadError` recognises, and a
-        // GPU loss is deliberately not one of them. It DOES honour a
-        // fingerprint set at the capture site, which is what this is.
-        // Nothing is lost to the grouping — the reason, the driver text and
-        // the whole enrichment block stay queryable inside the one issue.
-        $exception_fingerprint: 'ifc-lite:device_lost',
+        // One issue per LOSS REASON, chosen here because nothing downstream
+        // can choose it. PostHog groups an exception by type + message + stack
+        // unless the client supplies this, and both halves vary for a device
+        // loss: the message is Dawn's driver text (a D3D12 hang, a Vulkan VRAM
+        // exhaustion and a Metal timeout word themselves differently) and the
+        // stack names the hashed bundle, so it moves on every deploy — the
+        // same reason #2354's fixed-string WebGL report still minted a fresh
+        // issue per release. What was OBSERVED: #3767 and #3774 carry the same
+        // DXGI_ERROR_DEVICE_HUNG text six hours apart and were filed as two
+        // separate GitHub issues, with a dozen merges to main (so several
+        // viewer deploys) in between; #3207's Vulkan loss is a third issue for
+        // the same family. The `stampFingerprint` pass in
+        // lib/analytics-scrub.ts cannot cover this: it fingerprints only the
+        // kinds `classifyLoadError` recognises, and a GPU loss is deliberately
+        // not one of them. It DOES honour a fingerprint set at the capture
+        // site, which is what this is.
+        //
+        // The reason, and NOTHING else, discriminates — see
+        // `DEVICE_LOST_FINGERPRINT_REASONS` for why it is allowlisted rather
+        // than interpolated raw. The driver text and the whole enrichment
+        // block stay queryable inside whichever group they landed in.
+        $exception_fingerprint: deviceLostFingerprint(info.reason),
       },
     );
   } catch (err) {

--- a/apps/viewer/src/components/viewer/device-loss-report.ts
+++ b/apps/viewer/src/components/viewer/device-loss-report.ts
@@ -78,6 +78,25 @@ export function reportDeviceLost(
         // scrub-path test in device-loss-report.test.ts, which runs the real
         // `scrubEvent` so this cannot regress unnoticed.
         device_lost_detail: info.message,
+        // ONE issue for the whole family, chosen here because nothing
+        // downstream can choose it. PostHog groups an exception by type +
+        // message + stack unless the client supplies this, and both halves
+        // vary for a device loss: the message is Dawn's driver text (a D3D12
+        // hang, a Vulkan VRAM exhaustion and a Metal timeout word themselves
+        // differently) and the stack names the hashed bundle, so it moves on
+        // every deploy — the same reason #2354's fixed-string WebGL report
+        // still minted a fresh issue per release. What was OBSERVED: #3767 and
+        // #3774 carry the same DXGI_ERROR_DEVICE_HUNG text six hours apart and
+        // were filed as two separate GitHub issues, with a dozen merges to
+        // main (so several viewer deploys) in between; #3207's Vulkan loss is
+        // a third issue for the same family. The
+        // `stampFingerprint` pass in lib/analytics-scrub.ts cannot cover this:
+        // it fingerprints only the kinds `classifyLoadError` recognises, and a
+        // GPU loss is deliberately not one of them. It DOES honour a
+        // fingerprint set at the capture site, which is what this is.
+        // Nothing is lost to the grouping — the reason, the driver text and
+        // the whole enrichment block stay queryable inside the one issue.
+        $exception_fingerprint: 'ifc-lite:device_lost',
       },
     );
   } catch (err) {
@@ -162,6 +181,11 @@ export function reportPersistentRenderDegradation(
         // scrub-path test in device-loss-report.test.ts runs the real
         // `scrubEvent` over these keys so that cannot regress unnoticed.
         render_degraded_detail: info.detail,
+        // Its own fingerprint, not the loss's — see the note there. A live
+        // device that stopped drawing and a dead device are different bugs
+        // with different fixes, so they must not share an issue even though
+        // they share this module and their user-visible outcome.
+        $exception_fingerprint: 'ifc-lite:render_degraded',
       },
     );
   } catch (err) {

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -439,7 +439,7 @@ export function useIfcLoader() {
       // analytics — the retry only gives the user a shot at a result first.
       posthog.captureException(err, {
         context,
-        ...errorCaptureProps(err),
+        ...errorCaptureProps(err, context),
         load_stage: loadStage,
         is_retry: options?.isResourceRetry === true,
         resource_retry: retryTier,
@@ -2050,11 +2050,11 @@ export function useIfcLoader() {
                   // registered on success via finalizeModel→addModel), so
                   // updateModel would no-op and the failure would vanish —
                   // addModel just returns null. Surface it to the user instead.
-                  toast.error(formatLoadError(err, file.name));
+                  toast.error(formatLoadError(err, file.name, 'geometry_processing'));
                 } else {
                   updateModel(modelId, {
                     loadState: 'error',
-                    loadError: formatLoadError(err, file.name),
+                    loadError: formatLoadError(err, file.name, 'geometry_processing'),
                   });
                 }
               });
@@ -2077,16 +2077,16 @@ export function useIfcLoader() {
         // A WASM engine-load failure (e.g. the geometry binary 404'd) surfaces
         // here as a cryptic `compile on 'WebAssembly'` TypeError — humanise it
         // and tag the captured exception so it is filterable in error tracking.
-        const kind = classifyLoadError(err);
+        const kind = classifyLoadError(err, 'geometry_processing');
         // The stall / worker-crash / OOM failures land HERE, not in the outer
         // catch — retry once at lower detail before surfacing a dead end.
         if (await tryResourceRetry(err, kind, 'geometry_processing')) return;
-        setError(formatLoadError(err, file.name));
+        setError(formatLoadError(err, file.name, 'geometry_processing'));
         // Flat properties: posthog-js spreads this object onto the event, so a
         // wrapper key would bury `error_kind` in an unfilterable nested blob.
         posthog.captureException(err, {
           context: 'geometry_processing',
-          ...errorCaptureProps(err),
+          ...errorCaptureProps(err, 'geometry_processing'),
           load_stage: loadStage,
           is_retry: options?.isResourceRetry === true,
         });
@@ -2198,14 +2198,14 @@ export function useIfcLoader() {
     } catch (err) {
       console.error(`[useIfc] loadFile THREW (session=${currentSession}, current=${loadSessionRef.current}):`, err);
       if (loadSessionRef.current !== currentSession) return;
-      const kind = classifyLoadError(err);
+      const kind = classifyLoadError(err, 'ifc_model_load');
 
       // Resource-limit recovery — see tryResourceRetry. A failure that reaches
       // this outer catch (rather than the streaming loop's inner one) still
       // qualifies, e.g. an allocation failure outside the stream.
       if (await tryResourceRetry(err, kind, 'ifc_model_load')) return;
 
-      const friendly = formatLoadError(err, file.name);
+      const friendly = formatLoadError(err, file.name, 'ifc_model_load');
       updateModel(modelId, {
         loadState: 'error',
         loadError: friendly,
@@ -2217,7 +2217,7 @@ export function useIfcLoader() {
       // signal there is. See errorCaptureProps in ../lib/load-errors.ts.
       posthog.captureException(err, {
         context: 'ifc_model_load',
-        ...errorCaptureProps(err),
+        ...errorCaptureProps(err, 'ifc_model_load'),
         load_stage: loadStage,
         is_retry: options?.isResourceRetry === true,
       });

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -411,12 +411,6 @@ const tagErrorKind = (
   if (typeof event.properties.error_kind === 'string') return;
   const message = exceptionMessage(event.properties);
   if (message === undefined) return;
-  // The event's own `context` travels into the classifier. All it gates is the
-  // one WebKit wording that a message cannot settle on its own ("The object can
-  // not be found here." is Safari's text for BOTH a vanished file and the
-  // removeChild/insertBefore reconciler crash). Autocaptured exceptions carry
-  // no context, so they keep the honest `unknown` and stay out of the
-  // file-picker issue.
   const kind = classifyLoadError(message, event.properties.context);
   // Only tag recognised families — never stamp `unknown` onto an unrelated
   // exception (that would mislabel it as a triaged load error).
@@ -560,19 +554,9 @@ const stampFingerprint = (
 // with it. If a WebGLRenderer is ever constructed outside that guard again, the
 // throw would arrive here benign; the guard is the thing keeping this honest.
 //
-// `file_unreadable` meets the same bar and joins them: the file the user picked
-// moved, was renamed, deleted or evicted by a cloud-sync client between the
-// pick and the read, which is user-side and transient, nothing in the app
-// failed, the toast already says to select the file again, and no code change
-// of ours can alter it. It stays captured, kept and fingerprinted, so a spike
-// is still a real signal about (say) a sync client evicting files mid-load; it
-// just stops competing with genuine breakage on an error-level list.
-//
-// This is only safe BECAUSE of the load-context gate on the WebKit wording:
-// while "The object can not be found here." was claimed unconditionally, a
-// Safari React reconciler crash classified as `file_unreadable`, and a downgrade
-// would have hidden a hard crash behind a warning. It classifies `unknown` now
-// and keeps its `error` level, which the severity test pins alongside this.
+// `file_unreadable` meets the same bar and joins them, and is safe here ONLY
+// because the ambiguous WebKit wording is context-gated -- the argument, and
+// what breaks without it, are in ./file-not-found-errors.ts.
 const BENIGN_ERROR_KINDS = new Set<string>([
   'network_unavailable', 'cancelled', 'webgl_unavailable', 'file_unreadable',
 ]);

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -411,7 +411,13 @@ const tagErrorKind = (
   if (typeof event.properties.error_kind === 'string') return;
   const message = exceptionMessage(event.properties);
   if (message === undefined) return;
-  const kind = classifyLoadError(message);
+  // The event's own `context` travels into the classifier. All it gates is the
+  // one WebKit wording that a message cannot settle on its own ("The object can
+  // not be found here." is Safari's text for BOTH a vanished file and the
+  // removeChild/insertBefore reconciler crash). Autocaptured exceptions carry
+  // no context, so they keep the honest `unknown` and stay out of the
+  // file-picker issue.
+  const kind = classifyLoadError(message, event.properties.context);
   // Only tag recognised families — never stamp `unknown` onto an unrelated
   // exception (that would mislabel it as a triaged load error).
   if (kind === 'unknown') return;

--- a/apps/viewer/src/lib/analytics-scrub.ts
+++ b/apps/viewer/src/lib/analytics-scrub.ts
@@ -559,8 +559,22 @@ const stampFingerprint = (
 // `isThreeContextRefusal` in ./webgl-unavailable.ts) and they inherit this severity
 // with it. If a WebGLRenderer is ever constructed outside that guard again, the
 // throw would arrive here benign; the guard is the thing keeping this honest.
+//
+// `file_unreadable` meets the same bar and joins them: the file the user picked
+// moved, was renamed, deleted or evicted by a cloud-sync client between the
+// pick and the read, which is user-side and transient, nothing in the app
+// failed, the toast already says to select the file again, and no code change
+// of ours can alter it. It stays captured, kept and fingerprinted, so a spike
+// is still a real signal about (say) a sync client evicting files mid-load; it
+// just stops competing with genuine breakage on an error-level list.
+//
+// This is only safe BECAUSE of the load-context gate on the WebKit wording:
+// while "The object can not be found here." was claimed unconditionally, a
+// Safari React reconciler crash classified as `file_unreadable`, and a downgrade
+// would have hidden a hard crash behind a warning. It classifies `unknown` now
+// and keeps its `error` level, which the severity test pins alongside this.
 const BENIGN_ERROR_KINDS = new Set<string>([
-  'network_unavailable', 'cancelled', 'webgl_unavailable',
+  'network_unavailable', 'cancelled', 'webgl_unavailable', 'file_unreadable',
 ]);
 
 const downgradeBenignExceptions = (

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -665,6 +665,36 @@ describe('scrubEvent — issue grouping', () => {
     assert.equal(oom?.properties?.$exception_fingerprint, 'ifc-lite:out_of_memory');
   });
 
+  it('collapses the file-moved NotFoundError onto the file_unreadable fingerprint (#3731)', () => {
+    // Four PostHog issues carried this condition (#2546, #2860, #3324, #3731),
+    // each a fresh GitHub issue, because an unclassified message keeps
+    // PostHog's default type+message+stack grouping and the stack names the
+    // hashed bundle it came from. Both engine wordings, and the
+    // NotReadableError sibling, must land on ONE fingerprint.
+    const chromium = scrubEvent(exceptionEvent(
+      'A requested file or directory could not be found at the time an operation was processed.',
+    ));
+    const webkit = scrubEvent(exceptionEvent('The object can not be found here.'));
+    const unreadable = scrubEvent(exceptionEvent(
+      'NotReadableError: The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.',
+    ));
+    assert.equal(chromium?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
+    assert.equal(webkit?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
+    assert.equal(unreadable?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
+    assert.equal(chromium?.properties?.error_kind, 'file_unreadable');
+  });
+
+  it('keeps the DOM-mutation NotFoundError out of the file_unreadable group', () => {
+    // Same DOMException name, different failure entirely (#1229/#1230/#1232,
+    // the family harden-dom-mutations.ts suppresses). Grouping it with a moved
+    // file would bury a React-reconciler crash under a file-picker message.
+    const out = scrubEvent(exceptionEvent(
+      "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+    ));
+    assert.equal(out?.properties?.$exception_fingerprint, undefined);
+    assert.equal(out?.properties?.error_kind, undefined);
+  });
+
   it('leaves unrecognised exceptions on PostHog default grouping', () => {
     const out = scrubEvent(exceptionEvent("Cannot read properties of undefined (reading 'toLowerCase')"));
     assert.equal(out?.properties?.$exception_fingerprint, undefined);

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -674,7 +674,9 @@ describe('scrubEvent — issue grouping', () => {
     const chromium = scrubEvent(exceptionEvent(
       'A requested file or directory could not be found at the time an operation was processed.',
     ));
-    const webkit = scrubEvent(exceptionEvent('The object can not be found here.'));
+    const webkit = scrubEvent(exceptionEvent('The object can not be found here.', {
+      context: 'ifc_model_load',
+    }));
     const unreadable = scrubEvent(exceptionEvent(
       'NotReadableError: The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.',
     ));
@@ -682,6 +684,17 @@ describe('scrubEvent — issue grouping', () => {
     assert.equal(webkit?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
     assert.equal(unreadable?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
     assert.equal(chromium?.properties?.error_kind, 'file_unreadable');
+  });
+
+  it('keeps a Safari reconciler crash out of the file_unreadable group (no load context)', () => {
+    // WebKit words the removeChild/insertBefore failure with its generic
+    // NotFoundError text, the same string a vanished file gets, so the message
+    // alone cannot separate them. A reconciler crash is UNCAUGHT and reaches
+    // PostHog with no `context`; that absence is what keeps it out of the
+    // file-picker issue and off the "your file moved" message.
+    const out = scrubEvent(exceptionEvent('The object can not be found here.'));
+    assert.equal(out?.properties?.error_kind, undefined);
+    assert.equal(out?.properties?.$exception_fingerprint, undefined);
   });
 
   it('keeps the DOM-mutation NotFoundError out of the file_unreadable group', () => {

--- a/apps/viewer/src/lib/analytics.test.ts
+++ b/apps/viewer/src/lib/analytics.test.ts
@@ -569,6 +569,42 @@ describe('scrubEvent — the noise filter never drops on a substring', () => {
     assert.equal(out?.properties?.$exception_fingerprint, 'ifc-lite:webgl_unavailable');
   });
 
+  it('downgrades a moved file to warning, but not the Safari crash that shares its wording', () => {
+    // A file that moved between the pick and the read is user-side, transient
+    // and unfixable from here - the same bar `cancelled` and
+    // `webgl_unavailable` clear - so it is kept, classified and fingerprinted,
+    // just not competing with real breakage at error level.
+    const moved = scrubEvent(exceptionEvent(
+      'A requested file or directory could not be found at the time an operation was processed.',
+      { $exception_level: 'error' },
+    ));
+    assert.notEqual(moved, null);
+    assert.equal(moved?.properties?.error_kind, 'file_unreadable');
+    assert.equal(moved?.properties?.$exception_level, 'warning');
+    assert.equal(moved?.properties?.$exception_fingerprint, 'ifc-lite:file_unreadable');
+
+    // And the reason the downgrade is safe: WebKit gives a reconciler crash the
+    // SAME text as a vanished file, and an uncontextualised occurrence is not
+    // claimed as a load failure. If it were, this downgrade would be hiding a
+    // hard React crash behind a warning.
+    const safariCrash = scrubEvent(exceptionEvent(
+      'The object can not be found here.',
+      { $exception_level: 'error' },
+    ));
+    assert.notEqual(safariCrash, null);
+    assert.equal(safariCrash?.properties?.error_kind, undefined);
+    assert.equal(safariCrash?.properties?.$exception_level, 'error');
+    assert.equal(safariCrash?.properties?.$exception_fingerprint, undefined);
+
+    // The same wording INSIDE a load is the real thing, and is downgraded.
+    const safariLoad = scrubEvent(exceptionEvent(
+      'The object can not be found here.',
+      { $exception_level: 'error', context: 'ifc_model_load' },
+    ));
+    assert.equal(safariLoad?.properties?.error_kind, 'file_unreadable');
+    assert.equal(safariLoad?.properties?.$exception_level, 'warning');
+  });
+
   it('KEEPS a Cesium-shaped stringification whose key list is really a sentence', () => {
     // The `^`-only arm's exact escape (CodeRabbit, round two of this PR): the
     // three key names are all present and the value starts correctly, so every

--- a/apps/viewer/src/lib/file-not-found-errors.ts
+++ b/apps/viewer/src/lib/file-not-found-errors.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `NotFoundError` half of the `file_unreadable` family (the kind is
+ * declared, with the rest of the taxonomy, in ./load-errors.ts).
+ *
+ * TWO DOMException names map to `file_unreadable`, not one. `NotReadableError`
+ * — the file still at its path but unreadable — stays in ./load-errors.ts,
+ * because its matcher is a pattern and nothing more. `NotFoundError` is the
+ * file whose bytes are GONE by read time: moved, renamed, deleted, or rewritten
+ * in place by the authoring tool between `getFile()` and the read, which is
+ * exactly what the Refresh flow (#1345) invites. Its two engine wordings carry
+ * far more rationale than pattern, and each has a DIFFERENT safety argument, so
+ * they live here rather than lengthening the classifier — the same split, for
+ * the same reason, as ./webgl-unavailable.ts and
+ * ./cancelled-and-network-errors.ts.
+ *
+ * The whole family lives here so the SET is visible in one read: a third engine
+ * wording adds an arm to {@link isFileNotFoundMessage}, rather than a matcher
+ * somewhere else that nobody thinks to group. Only that one predicate is
+ * exported; the per-engine arms and the load-context set are private, because
+ * the ORDER the buckets are tried in stays the classifier's business.
+ *
+ * WHY THIS MODULE CARRIES THE SEVERITY ARGUMENT. `file_unreadable` is in
+ * `BENIGN_ERROR_KINDS` (./analytics-scrub.ts), so it is captured, kept and
+ * fingerprinted — a spike is still a real signal about, say, a sync client
+ * evicting files mid-load — but reported at `warning` rather than `error`: the
+ * file the user picked moved, was renamed, deleted or evicted between the pick
+ * and the read, nothing in the app failed, the toast already says to select the
+ * file again, and no code change of ours can alter it.
+ *
+ * That downgrade is safe ONLY because of the context gate in
+ * {@link isWebkitGenericNotFoundMessage} below. While the WebKit wording was
+ * claimed unconditionally, a Safari React reconciler crash classified as
+ * `file_unreadable` and the downgrade would have hidden a hard crash behind a
+ * warning. Uncontextualised, that string classifies `unknown` and keeps its
+ * `error` level. Loosen the gate and the severity rule stops being safe, so the
+ * two have to be read together — which is why they sit in one file.
+ */
+
+/**
+ * The `context` property a model-load capture site stamps on its exception.
+ *
+ * Only these two mean "this exception was thrown while reading and processing a
+ * file the user picked" — `useIfcLoader`'s outer catch and its geometry-stream
+ * catch. Every other context in the app (`ids_validation`, `clash_detection`,
+ * `export_glb`, `device_lost`, …) is some other operation entirely, and an
+ * exception with NO context at all is an uncaught one PostHog autocaptured,
+ * which by definition nobody attributed to a load.
+ *
+ * It exists for exactly one arm: {@link isWebkitGenericNotFoundMessage}.
+ * Nothing else here needs to know who was calling, and nothing else should
+ * start to — a classifier that consults the caller for its ordinary buckets is
+ * a classifier that gives two answers for one error.
+ */
+const LOAD_CONTEXTS: ReadonlySet<string> = new Set(['ifc_model_load', 'geometry_processing']);
+
+/**
+ * Whether a capture-site `context` marks a model-load failure. Deliberately
+ * takes `unknown`: the analytics path reads it straight off an event's
+ * properties, where it is whatever the capture site put there.
+ */
+function isLoadContext(context: unknown): boolean {
+  return typeof context === 'string' && LOAD_CONTEXTS.has(context);
+}
+
+/**
+ * Chromium's wording, and the one the field reports actually carry (#2546,
+ * #2860, #3324, #3731: four separate PostHog issues over four weeks, every one
+ * of them classified `unknown`, so the user was shown the raw DOM sentence and
+ * each occurrence spawned its own GitHub issue).
+ *
+ * What is CONFIRMED is the wording and that it keeps arriving; the mechanism
+ * behind it is read off Blink rather than reproduced here, and is recorded as
+ * the inference it is: a blob read fails with `NotFoundError` once the backing
+ * file no longer matches the snapshot taken when the `File` was handed out.
+ * Either way the user guidance is identical to `NotReadableError`'s, which is
+ * why both map to `file_unreadable`: the file the user picked is not there to
+ * be read.
+ *
+ * ANCHORED on the whole message, never a substring test, and that is
+ * load-bearing rather than stylistic: `NotFoundError` is also what
+ * `removeChild` / `insertBefore` throw when a translation extension re-parents
+ * a node React owns (the family `harden-dom-mutations.ts` exists to suppress —
+ * #1229 / #1230 / #1232). A search for "could not be found" would sweep those
+ * in and tell that user their file had moved, which is a lie. Matching by
+ * `.name` alone would do the same, so the name is deliberately NOT used here.
+ *
+ * What makes anchoring SUFFICIENT here is a property of Blink, and it is worth
+ * stating precisely because the obvious reading is wrong: this string does not
+ * name files because Blink reserved it for file failures. It is Blink's generic
+ * description for the `NotFoundError` NAME, handed to any throw that supplies
+ * no message of its own. The safety comes from the other side — Blink's DOM
+ * sites all DO supply a message, the `Failed to execute '…' on '…'` form, so
+ * they never reach this text and the anchor excludes them. That is a fact about
+ * Blink's DOM bindings, not about this string, and if it ever stopped being
+ * true this arm would need the same context gate its WebKit sibling has.
+ *
+ * An optional `NotFoundError: ` prefix is tolerated for the stringified form —
+ * `analytics-scrub.ts` classifies from the message text alone, where all that
+ * survives is `String(err)`.
+ */
+function isChromiumFileNotFoundMessage(message: string): boolean {
+  return /^(?:NotFoundError: )?A requested file or directory could not be found at the time an operation was processed\.?$/i
+    .test(message.trim());
+}
+
+/**
+ * WebKit's wording for the same DOMException (#2860) — and the arm that CANNOT
+ * stand on the message alone, which is why the predicate takes a context.
+ *
+ * "The object can not be found here." is WebKit's GENERIC description for the
+ * `NotFoundError` name, and unlike Blink, WebKit does NOT supply a per-site
+ * message for the DOM mutation failures: `removeChild` / `insertBefore` against
+ * a parent that no longer holds the node throw a bare `NotFoundError` carrying
+ * exactly this text. So on Safari the string is genuinely ambiguous between
+ * "the file the user picked is gone" and "a translation extension re-parented a
+ * node React owns and the reconciler crashed" (#1229 / #1230 / #1232). The
+ * anchoring that separates the two families on Chromium separates nothing here.
+ *
+ * Getting it wrong is not cosmetic in either direction. Claimed unconditionally,
+ * a Safari reconciler crash is shown to the user as "your file may have been
+ * moved… select the file again" and, because `analytics-scrub.ts` runs the
+ * classifier over EVERY `$exception`, is fingerprinted into
+ * `ifc-lite:file_unreadable` and buried in a file-picker issue. Dropped
+ * entirely, the Safari half of the family it was added for goes back to being
+ * an unclassified one-off.
+ *
+ * The capture-site `context` is what actually distinguishes them, and it is
+ * already on the event: a load failure is caught by `useIfcLoader` and captured
+ * as `ifc_model_load` / `geometry_processing`, while a reconciler crash is
+ * uncaught and reaches PostHog with no context at all. So this wording counts
+ * only inside a load. An uncontextualised occurrence stays `unknown`, which is
+ * the honest answer: on this engine, with this string and nothing else, we do
+ * not know which failure it was.
+ */
+function isWebkitGenericNotFoundMessage(message: string): boolean {
+  return /^(?:NotFoundError: )?The object can ?not be found here\.?$/i.test(message.trim());
+}
+
+/**
+ * Whether a message says the picked file was GONE by read time.
+ *
+ * `context` is the capture site's own `context` property, where one exists. It
+ * gates the WebKit arm alone: that engine's wording is ambiguous, so it counts
+ * only inside a load. Omitting the context can therefore only cost that one
+ * Safari wording its kind — it can never turn a non-match into a match.
+ */
+export function isFileNotFoundMessage(message: string, context?: unknown): boolean {
+  return (
+    isChromiumFileNotFoundMessage(message) ||
+    (isLoadContext(context) && isWebkitGenericNotFoundMessage(message))
+  );
+}

--- a/apps/viewer/src/lib/load-error-message.ts
+++ b/apps/viewer/src/lib/load-error-message.ts
@@ -25,9 +25,14 @@ import {
  * never hide useful detail.
  *
  * @param fileName Optional file name to attribute the failure to.
+ * @param context  The capture site's `context`, where the caller has one. Only
+ *   one WebKit wording depends on it (see `isWebkitGenericNotFoundMessage` in
+ *   ./load-errors.ts); omitting it costs that string its guidance and nothing
+ *   else. A caller that is NOT a model load should omit it rather than invent
+ *   one, because that is precisely the case the gate exists to exclude.
  */
-export function formatLoadError(err: unknown, fileName?: string): string {
-  const kind = classifyLoadError(err);
+export function formatLoadError(err: unknown, fileName?: string, context?: unknown): string {
+  const kind = classifyLoadError(err, context);
   const subject = fileName ? `"${fileName}"` : 'the model';
   switch (kind) {
     case 'wasm_engine_load':

--- a/apps/viewer/src/lib/load-error-message.ts
+++ b/apps/viewer/src/lib/load-error-message.ts
@@ -26,8 +26,8 @@ import {
  *
  * @param fileName Optional file name to attribute the failure to.
  * @param context  The capture site's `context`, where the caller has one. Only
- *   one WebKit wording depends on it (see `isWebkitGenericNotFoundMessage` in
- *   ./load-errors.ts); omitting it costs that string its guidance and nothing
+ *   one WebKit wording depends on it (see `isFileNotFoundMessage` in
+ *   ./file-not-found-errors.ts); omitting it costs that string its guidance and nothing
  *   else. A caller that is NOT a model load should omit it rather than invent
  *   one, because that is precisely the case the gate exists to exclude.
  */

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -138,6 +138,56 @@ describe('classifyLoadError', () => {
     );
   });
 
+  it('classifies the file-moved NotFoundError as file_unreadable, not as unknown (#3731)', () => {
+    // The SIBLING of NotReadableError, and the one the field reports actually
+    // carry. Chromium throws NotReadableError when the file is still there but
+    // unreadable (permissions), and NotFoundError when the bytes are gone --
+    // the file was moved, renamed, deleted, or rewritten in place by the
+    // authoring tool between `getFile()` and the read. Four PostHog issues
+    // (#2546, #2860, #3324, #3731) carried this wording and every one of them
+    // classified as `unknown`, so the user was shown the raw DOM sentence and
+    // each occurrence spawned its own GitHub issue.
+    assert.equal(
+      classifyLoadError(new Error(
+        'A requested file or directory could not be found at the time an operation was processed.',
+      )),
+      'file_unreadable',
+    );
+    // Stringified name-first, the shape `String(err)` produces.
+    assert.equal(
+      classifyLoadError(new Error(
+        'NotFoundError: A requested file or directory could not be found at the time an operation was processed.',
+      )),
+      'file_unreadable',
+    );
+    // WebKit's wording for the same DOMException (#2860).
+    assert.equal(
+      classifyLoadError(new Error('The object can not be found here.')),
+      'file_unreadable',
+    );
+  });
+
+  it('leaves the DOM-mutation NotFoundError alone - it is not a file failure', () => {
+    // `harden-dom-mutations.ts` exists because a translation extension makes
+    // React's reconciler call removeChild/insertBefore against a parent that no
+    // longer holds the node. Those are NotFoundErrors too, and telling that
+    // user their file was moved would be a lie. The two families are separated
+    // by wording, which is why the matcher above is anchored on the whole
+    // message instead of searching for "could not be found".
+    assert.equal(
+      classifyLoadError(new Error(
+        "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+      )),
+      'unknown',
+    );
+    assert.equal(
+      classifyLoadError(new Error(
+        "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      )),
+      'unknown',
+    );
+  });
+
   it('classifies a DOMException by its stable .name, whatever the message says', () => {
     // `.message` is engine-specific prose that need not repeat the name — only
     // `.name` is stable, and `messageOf` alone would never see it.
@@ -612,6 +662,17 @@ describe('formatLoadError', () => {
     assert.match(msg, /select the file again/i);
     // Must NOT tell them to close tabs / shrink the model — nothing is too big.
     assert.doesNotMatch(msg, /memory|too large|smaller/i);
+  });
+
+  it('tells the user to re-pick a file that moved out from under the browser (#3731)', () => {
+    const msg = formatLoadError(
+      new Error('A requested file or directory could not be found at the time an operation was processed.'),
+      'tower.ifc',
+    );
+    assert.match(msg, /"tower\.ifc"/);
+    assert.match(msg, /select the file again/i);
+    // The raw DOM sentence is what four field reports put in front of a user.
+    assert.doesNotMatch(msg, /at the time an operation was processed/i);
   });
 
   it('preserves the raw message for unknown failures', () => {

--- a/apps/viewer/src/lib/load-errors.test.ts
+++ b/apps/viewer/src/lib/load-errors.test.ts
@@ -160,9 +160,42 @@ describe('classifyLoadError', () => {
       )),
       'file_unreadable',
     );
-    // WebKit's wording for the same DOMException (#2860).
+    // WebKit's wording for the same DOMException (#2860) needs the load
+    // context to be safe - see the Safari test below.
     assert.equal(
-      classifyLoadError(new Error('The object can not be found here.')),
+      classifyLoadError(new Error('The object can not be found here.'), 'ifc_model_load'),
+      'file_unreadable',
+    );
+  });
+
+  it('only trusts the WebKit NotFoundError wording inside a load context', () => {
+    // "The object can not be found here." is WebKit's GENERIC description for
+    // the NotFoundError name, and WebKit - unlike Blink - gives removeChild and
+    // insertBefore no message of their own, so a Safari reconciler crash
+    // (#1229/#1230/#1232) carries this EXACT string. Message-only, the two are
+    // indistinguishable, and claiming it unconditionally shows a user whose
+    // React tree just died a note about re-picking their file.
+    const webkit = new Error('The object can not be found here.');
+
+    assert.equal(
+      classifyLoadError(webkit),
+      'unknown',
+      'no context: the honest answer, because on this engine the string does not say which failure it was',
+    );
+    assert.equal(
+      classifyLoadError(webkit, 'export_glb'),
+      'unknown',
+      'a context that is not a load is as disqualifying as none',
+    );
+    assert.equal(classifyLoadError(webkit, 'ifc_model_load'), 'file_unreadable');
+    assert.equal(classifyLoadError(webkit, 'geometry_processing'), 'file_unreadable');
+
+    // The Chromium wording needs no context: Blink words its DOM failures
+    // "Failed to execute '...' on '...'", so they never reach this text.
+    assert.equal(
+      classifyLoadError(new Error(
+        'A requested file or directory could not be found at the time an operation was processed.',
+      )),
       'file_unreadable',
     );
   });

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -61,7 +61,8 @@ export type LoadErrorKind =
    * whose bytes are gone by read time — moved, renamed, deleted, or rewritten
    * in place by the authoring tool between `getFile()` and the read, which is
    * exactly what the Refresh flow (#1345) invites. See
-   * {@link isFileNotFoundMessage}.
+   * {@link isChromiumFileNotFoundMessage} and, for the wording that needs a
+   * load context to be safe, {@link isWebkitGenericNotFoundMessage}.
    */
   | 'file_unreadable'
   /**
@@ -175,6 +176,32 @@ function isFileUnreadableError(message: string): boolean {
 }
 
 /**
+ * The `context` property a model-load capture site stamps on its exception.
+ *
+ * Only these two mean "this exception was thrown while reading and processing a
+ * file the user picked" — `useIfcLoader`'s outer catch and its geometry-stream
+ * catch. Every other context in the app (`ids_validation`, `clash_detection`,
+ * `export_glb`, `device_lost`, …) is some other operation entirely, and an
+ * exception with NO context at all is an uncaught one PostHog autocaptured,
+ * which by definition nobody attributed to a load.
+ *
+ * It exists for exactly one matcher: {@link isWebkitGenericNotFoundMessage}.
+ * Nothing else here needs to know who was calling, and nothing else should
+ * start to — a classifier that consults the caller for its ordinary buckets is
+ * a classifier that gives two answers for one error.
+ */
+const LOAD_CONTEXTS: ReadonlySet<string> = new Set(['ifc_model_load', 'geometry_processing']);
+
+/**
+ * Whether a capture-site `context` marks a model-load failure. Deliberately
+ * takes `unknown`: the analytics path reads it straight off an event's
+ * properties, where it is whatever the capture site put there.
+ */
+export function isLoadContext(context: unknown): boolean {
+  return typeof context === 'string' && LOAD_CONTEXTS.has(context);
+}
+
+/**
  * The picked file is GONE, not merely unreadable — the sibling of
  * `NotReadableError` above, and the one the field reports actually carry
  * (#2546, #2860, #3324, #3731: four separate PostHog issues over four weeks,
@@ -190,34 +217,68 @@ function isFileUnreadableError(message: string): boolean {
  * guidance is identical to `NotReadableError`'s, which is why both map to
  * `file_unreadable`: the file the user picked is not there to be read.
  *
+ * This is Chromium's wording only (#2546, #3324, #3731); WebKit's is a
+ * different string with a different safety argument, and lives in
+ * {@link isWebkitGenericNotFoundMessage}.
+ *
  * ANCHORED on the whole message, never a substring test, and that is
  * load-bearing rather than stylistic: `NotFoundError` is also what
  * `removeChild` / `insertBefore` throw when a translation extension re-parents
  * a node React owns (the family `harden-dom-mutations.ts` exists to suppress —
- * #1229 / #1230 / #1232). Those carry `Failed to execute '…' on 'Node': …`, so
- * anchoring keeps them out; a search for "could not be found" would sweep them
+ * #1229 / #1230 / #1232). A search for "could not be found" would sweep those
  * in and tell that user their file had moved, which is a lie. Matching by
  * `.name` alone would do the same, so the name is deliberately NOT used here.
  *
- * Both engine wordings, because both have been observed:
- *  - Chromium: "A requested file or directory could not be found at the time an
- *    operation was processed." (#2546, #3324, #3731). Blink's fixed text for
- *    FileErrorCode::kNotFoundErr — it names files and directories outright, so
- *    claiming it for this family is safe.
- *  - WebKit:   "The object can not be found here." (#2860). WEAKER, and worth
- *    knowing before trusting the kind: this is WebKit's DEFAULT description for
- *    NotFoundError, emitted by any internal throw that supplies no message of
- *    its own, so it is file-specific only by where it can arise in THIS app.
- *    Kept because the viewer's only other NotFoundError surface is the DOM pair
- *    above, which words itself distinctly; drop this arm the day a Safari
- *    NotFoundError from somewhere else shows up misfiled.
+ * What makes anchoring SUFFICIENT here is a property of Blink, and it is worth
+ * stating precisely because the obvious reading is wrong: this string does not
+ * name files because Blink reserved it for file failures. It is Blink's generic
+ * description for the `NotFoundError` NAME, handed to any throw that supplies
+ * no message of its own. The safety comes from the other side — Blink's DOM
+ * sites all DO supply a message, the `Failed to execute '…' on '…'` form, so
+ * they never reach this text and the anchor excludes them. That is a fact about
+ * Blink's DOM bindings, not about this string, and if it ever stopped being
+ * true this matcher would need the same context gate its WebKit sibling has.
+ *
  * An optional `NotFoundError: ` prefix is tolerated for the stringified form —
  * `analytics-scrub.ts` classifies from the message text alone, where all that
  * survives is `String(err)`.
  */
-function isFileNotFoundMessage(message: string): boolean {
-  return /^(?:NotFoundError: )?(?:A requested file or directory could not be found at the time an operation was processed\.?|The object can ?not be found here\.?)$/i
+function isChromiumFileNotFoundMessage(message: string): boolean {
+  return /^(?:NotFoundError: )?A requested file or directory could not be found at the time an operation was processed\.?$/i
     .test(message.trim());
+}
+
+/**
+ * WebKit's wording for the same DOMException (#2860) — and the arm that CANNOT
+ * stand on the message alone, which is why it takes a context.
+ *
+ * "The object can not be found here." is WebKit's GENERIC description for the
+ * `NotFoundError` name, and unlike Blink, WebKit does NOT supply a per-site
+ * message for the DOM mutation failures: `removeChild` / `insertBefore` against
+ * a parent that no longer holds the node throw a bare `NotFoundError` carrying
+ * exactly this text. So on Safari the string is genuinely ambiguous between
+ * "the file the user picked is gone" and "a translation extension re-parented a
+ * node React owns and the reconciler crashed" (#1229 / #1230 / #1232). The
+ * anchoring that separates the two families on Chromium separates nothing here.
+ *
+ * Getting it wrong is not cosmetic in either direction. Claimed unconditionally,
+ * a Safari reconciler crash is shown to the user as "your file may have been
+ * moved… select the file again" and, because `analytics-scrub.ts` runs this
+ * classifier over EVERY `$exception`, is fingerprinted into
+ * `ifc-lite:file_unreadable` and buried in a file-picker issue. Dropped
+ * entirely, the Safari half of the family it was added for goes back to being
+ * an unclassified one-off.
+ *
+ * The capture-site `context` is what actually distinguishes them, and it is
+ * already on the event: a load failure is caught by `useIfcLoader` and captured
+ * as `ifc_model_load` / `geometry_processing`, while a reconciler crash is
+ * uncaught and reaches PostHog with no context at all. So this wording counts
+ * only inside a load. An uncontextualised occurrence stays `unknown`, which is
+ * the honest answer: on this engine, with this string and nothing else, we do
+ * not know which failure it was.
+ */
+function isWebkitGenericNotFoundMessage(message: string): boolean {
+  return /^(?:NotFoundError: )?The object can ?not be found here\.?$/i.test(message.trim());
 }
 
 /**
@@ -276,8 +337,16 @@ function isWasmRuntimeCrashError(err: unknown, message: string): boolean {
   );
 }
 
-/** Classify a load failure into a stable analytics bucket. */
-export function classifyLoadError(err: unknown): LoadErrorKind {
+/**
+ * Classify a load failure into a stable analytics bucket.
+ *
+ * `context` is the capture site's own `context` property, where one exists. It
+ * is consulted by exactly one matcher — {@link isWebkitGenericNotFoundMessage},
+ * whose string is ambiguous on WebKit — and ignored by every other bucket, so
+ * omitting it can only cost that one Safari wording its kind. It can never
+ * change any other answer.
+ */
+export function classifyLoadError(err: unknown, context?: unknown): LoadErrorKind {
   const message = messageOf(err);
   // Checked before the memory/worker buckets: a NotReadableError says nothing
   // about the model or this device's capacity, and its message ("...could not
@@ -289,7 +358,8 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   if (
     name === 'NotReadableError' ||
     isFileUnreadableError(message) ||
-    isFileNotFoundMessage(message)
+    isChromiumFileNotFoundMessage(message) ||
+    (isLoadContext(context) && isWebkitGenericNotFoundMessage(message))
   ) {
     return 'file_unreadable';
   }
@@ -330,6 +400,9 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
  *
  * - `error_kind`  the classified family (see {@link classifyLoadError}); drives
  *                 `$exception_fingerprint` grouping and the severity downgrade.
+ *                 Pass the same `context` the call site stamps on the event:
+ *                 one WebKit wording is only classifiable inside a load, and a
+ *                 kind set here wins over the analytics-path re-classification.
  * - `error_type`  the throwable's own identity — a DOMException's stable
  *                 `.name`, else the constructor name. The one property that
  *                 survives when the message is two words and the stack empty.
@@ -337,10 +410,10 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
  *                 be told apart from a failure of ours. Omitted where the
  *                 browser doesn't expose it (Node tests).
  */
-export function errorCaptureProps(err: unknown): Record<string, unknown> {
+export function errorCaptureProps(err: unknown, context?: unknown): Record<string, unknown> {
   const name = errorNameOf(err);
   const props: Record<string, unknown> = {
-    error_kind: classifyLoadError(err),
+    error_kind: classifyLoadError(err, context),
     // `name` is set on every Error and DOMException; the constructor fallback
     // covers a thrown non-Error (posthog stringifies those, losing even this).
     error_type: name || (err as { constructor?: { name?: string } })?.constructor?.name || typeof err,

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -5,9 +5,10 @@
 /**
  * Classification of model-load failures. This module owns the taxonomy and the
  * ORDER the buckets are tried in; the user-facing humanisation lives in
- * ./load-error-message.ts, and the two families whose matchers carry more
+ * ./load-error-message.ts, and the families whose matchers carry more
  * rationale than pattern have their own modules (./webgl-unavailable.ts,
- * ./cancelled-and-network-errors.ts) rather than a longer file here.
+ * ./cancelled-and-network-errors.ts, ./file-not-found-errors.ts) rather than a
+ * longer file here.
  *
  * Despite the name, this is the viewer's ONLY error-family classifier —
  * `analytics-scrub.ts` runs it over every captured `$exception` — so a non-load
@@ -25,6 +26,7 @@
  */
 
 import { isCancelledError, isNetworkUnavailableError } from './cancelled-and-network-errors.js';
+import { isFileNotFoundMessage } from './file-not-found-errors.js';
 import { isWebglUnavailable } from './webgl-unavailable.js';
 
 /** Stable, analytics-friendly classification of a load failure. */
@@ -60,9 +62,9 @@ export type LoadErrorKind =
    * that is still at its path but cannot be read; `NotFoundError` is the file
    * whose bytes are gone by read time — moved, renamed, deleted, or rewritten
    * in place by the authoring tool between `getFile()` and the read, which is
-   * exactly what the Refresh flow (#1345) invites. See
-   * {@link isChromiumFileNotFoundMessage} and, for the wording that needs a
-   * load context to be safe, {@link isWebkitGenericNotFoundMessage}.
+   * exactly what the Refresh flow (#1345) invites. Both engine wordings, and
+   * the load context one of them needs to be safe, live in
+   * ./file-not-found-errors.ts.
    */
   | 'file_unreadable'
   /**
@@ -176,112 +178,6 @@ function isFileUnreadableError(message: string): boolean {
 }
 
 /**
- * The `context` property a model-load capture site stamps on its exception.
- *
- * Only these two mean "this exception was thrown while reading and processing a
- * file the user picked" — `useIfcLoader`'s outer catch and its geometry-stream
- * catch. Every other context in the app (`ids_validation`, `clash_detection`,
- * `export_glb`, `device_lost`, …) is some other operation entirely, and an
- * exception with NO context at all is an uncaught one PostHog autocaptured,
- * which by definition nobody attributed to a load.
- *
- * It exists for exactly one matcher: {@link isWebkitGenericNotFoundMessage}.
- * Nothing else here needs to know who was calling, and nothing else should
- * start to — a classifier that consults the caller for its ordinary buckets is
- * a classifier that gives two answers for one error.
- */
-const LOAD_CONTEXTS: ReadonlySet<string> = new Set(['ifc_model_load', 'geometry_processing']);
-
-/**
- * Whether a capture-site `context` marks a model-load failure. Deliberately
- * takes `unknown`: the analytics path reads it straight off an event's
- * properties, where it is whatever the capture site put there.
- */
-export function isLoadContext(context: unknown): boolean {
-  return typeof context === 'string' && LOAD_CONTEXTS.has(context);
-}
-
-/**
- * The picked file is GONE, not merely unreadable — the sibling of
- * `NotReadableError` above, and the one the field reports actually carry
- * (#2546, #2860, #3324, #3731: four separate PostHog issues over four weeks,
- * every one of them classified `unknown`, so the user was shown the raw DOM
- * sentence and each occurrence spawned its own GitHub issue).
- *
- * What is CONFIRMED is the wording and that it keeps arriving; the mechanism
- * behind it is read off Blink rather than reproduced here, and is recorded as
- * the inference it is: a blob read fails with `NotFoundError` once the backing
- * file no longer matches the snapshot taken when the `File` was handed out —
- * moved, renamed, deleted, or (the likely one for this app) rewritten in place
- * by the authoring tool between `getFile()` and the read. Either way the user
- * guidance is identical to `NotReadableError`'s, which is why both map to
- * `file_unreadable`: the file the user picked is not there to be read.
- *
- * This is Chromium's wording only (#2546, #3324, #3731); WebKit's is a
- * different string with a different safety argument, and lives in
- * {@link isWebkitGenericNotFoundMessage}.
- *
- * ANCHORED on the whole message, never a substring test, and that is
- * load-bearing rather than stylistic: `NotFoundError` is also what
- * `removeChild` / `insertBefore` throw when a translation extension re-parents
- * a node React owns (the family `harden-dom-mutations.ts` exists to suppress —
- * #1229 / #1230 / #1232). A search for "could not be found" would sweep those
- * in and tell that user their file had moved, which is a lie. Matching by
- * `.name` alone would do the same, so the name is deliberately NOT used here.
- *
- * What makes anchoring SUFFICIENT here is a property of Blink, and it is worth
- * stating precisely because the obvious reading is wrong: this string does not
- * name files because Blink reserved it for file failures. It is Blink's generic
- * description for the `NotFoundError` NAME, handed to any throw that supplies
- * no message of its own. The safety comes from the other side — Blink's DOM
- * sites all DO supply a message, the `Failed to execute '…' on '…'` form, so
- * they never reach this text and the anchor excludes them. That is a fact about
- * Blink's DOM bindings, not about this string, and if it ever stopped being
- * true this matcher would need the same context gate its WebKit sibling has.
- *
- * An optional `NotFoundError: ` prefix is tolerated for the stringified form —
- * `analytics-scrub.ts` classifies from the message text alone, where all that
- * survives is `String(err)`.
- */
-function isChromiumFileNotFoundMessage(message: string): boolean {
-  return /^(?:NotFoundError: )?A requested file or directory could not be found at the time an operation was processed\.?$/i
-    .test(message.trim());
-}
-
-/**
- * WebKit's wording for the same DOMException (#2860) — and the arm that CANNOT
- * stand on the message alone, which is why it takes a context.
- *
- * "The object can not be found here." is WebKit's GENERIC description for the
- * `NotFoundError` name, and unlike Blink, WebKit does NOT supply a per-site
- * message for the DOM mutation failures: `removeChild` / `insertBefore` against
- * a parent that no longer holds the node throw a bare `NotFoundError` carrying
- * exactly this text. So on Safari the string is genuinely ambiguous between
- * "the file the user picked is gone" and "a translation extension re-parented a
- * node React owns and the reconciler crashed" (#1229 / #1230 / #1232). The
- * anchoring that separates the two families on Chromium separates nothing here.
- *
- * Getting it wrong is not cosmetic in either direction. Claimed unconditionally,
- * a Safari reconciler crash is shown to the user as "your file may have been
- * moved… select the file again" and, because `analytics-scrub.ts` runs this
- * classifier over EVERY `$exception`, is fingerprinted into
- * `ifc-lite:file_unreadable` and buried in a file-picker issue. Dropped
- * entirely, the Safari half of the family it was added for goes back to being
- * an unclassified one-off.
- *
- * The capture-site `context` is what actually distinguishes them, and it is
- * already on the event: a load failure is caught by `useIfcLoader` and captured
- * as `ifc_model_load` / `geometry_processing`, while a reconciler crash is
- * uncaught and reaches PostHog with no context at all. So this wording counts
- * only inside a load. An uncontextualised occurrence stays `unknown`, which is
- * the honest answer: on this engine, with this string and nothing else, we do
- * not know which failure it was.
- */
-function isWebkitGenericNotFoundMessage(message: string): boolean {
-  return /^(?:NotFoundError: )?The object can ?not be found here\.?$/i.test(message.trim());
-}
-
-/**
  * The geometry stream watchdog timed out (see `useIfcLoader`'s `Promise.race`).
  * Matched on the stable prefix only — the message must NOT carry the file name
  * (it would leak a confidential model name into error tracking), so we never
@@ -341,10 +237,10 @@ function isWasmRuntimeCrashError(err: unknown, message: string): boolean {
  * Classify a load failure into a stable analytics bucket.
  *
  * `context` is the capture site's own `context` property, where one exists. It
- * is consulted by exactly one matcher — {@link isWebkitGenericNotFoundMessage},
- * whose string is ambiguous on WebKit — and ignored by every other bucket, so
- * omitting it can only cost that one Safari wording its kind. It can never
- * change any other answer.
+ * is consulted by exactly one matcher — the WebKit arm of
+ * {@link isFileNotFoundMessage}, whose string is ambiguous on that engine — and
+ * ignored by every other bucket, so omitting it can only cost that one Safari
+ * wording its kind. It can never change any other answer.
  */
 export function classifyLoadError(err: unknown, context?: unknown): LoadErrorKind {
   const message = messageOf(err);
@@ -358,8 +254,7 @@ export function classifyLoadError(err: unknown, context?: unknown): LoadErrorKin
   if (
     name === 'NotReadableError' ||
     isFileUnreadableError(message) ||
-    isChromiumFileNotFoundMessage(message) ||
-    (isLoadContext(context) && isWebkitGenericNotFoundMessage(message))
+    isFileNotFoundMessage(message, context)
   ) {
     return 'file_unreadable';
   }

--- a/apps/viewer/src/lib/load-errors.ts
+++ b/apps/viewer/src/lib/load-errors.ts
@@ -55,6 +55,13 @@ export type LoadErrorKind =
    * evicted it, removable media was unplugged, or an AV/permission change
    * locked it. Nothing about the model is wrong and nothing in the app failed;
    * the user just needs to pick the file again.
+   *
+   * TWO DOMException names land here, not one. `NotReadableError` is the file
+   * that is still at its path but cannot be read; `NotFoundError` is the file
+   * whose bytes are gone by read time — moved, renamed, deleted, or rewritten
+   * in place by the authoring tool between `getFile()` and the read, which is
+   * exactly what the Refresh flow (#1345) invites. See
+   * {@link isFileNotFoundMessage}.
    */
   | 'file_unreadable'
   /**
@@ -168,6 +175,52 @@ function isFileUnreadableError(message: string): boolean {
 }
 
 /**
+ * The picked file is GONE, not merely unreadable — the sibling of
+ * `NotReadableError` above, and the one the field reports actually carry
+ * (#2546, #2860, #3324, #3731: four separate PostHog issues over four weeks,
+ * every one of them classified `unknown`, so the user was shown the raw DOM
+ * sentence and each occurrence spawned its own GitHub issue).
+ *
+ * What is CONFIRMED is the wording and that it keeps arriving; the mechanism
+ * behind it is read off Blink rather than reproduced here, and is recorded as
+ * the inference it is: a blob read fails with `NotFoundError` once the backing
+ * file no longer matches the snapshot taken when the `File` was handed out —
+ * moved, renamed, deleted, or (the likely one for this app) rewritten in place
+ * by the authoring tool between `getFile()` and the read. Either way the user
+ * guidance is identical to `NotReadableError`'s, which is why both map to
+ * `file_unreadable`: the file the user picked is not there to be read.
+ *
+ * ANCHORED on the whole message, never a substring test, and that is
+ * load-bearing rather than stylistic: `NotFoundError` is also what
+ * `removeChild` / `insertBefore` throw when a translation extension re-parents
+ * a node React owns (the family `harden-dom-mutations.ts` exists to suppress —
+ * #1229 / #1230 / #1232). Those carry `Failed to execute '…' on 'Node': …`, so
+ * anchoring keeps them out; a search for "could not be found" would sweep them
+ * in and tell that user their file had moved, which is a lie. Matching by
+ * `.name` alone would do the same, so the name is deliberately NOT used here.
+ *
+ * Both engine wordings, because both have been observed:
+ *  - Chromium: "A requested file or directory could not be found at the time an
+ *    operation was processed." (#2546, #3324, #3731). Blink's fixed text for
+ *    FileErrorCode::kNotFoundErr — it names files and directories outright, so
+ *    claiming it for this family is safe.
+ *  - WebKit:   "The object can not be found here." (#2860). WEAKER, and worth
+ *    knowing before trusting the kind: this is WebKit's DEFAULT description for
+ *    NotFoundError, emitted by any internal throw that supplies no message of
+ *    its own, so it is file-specific only by where it can arise in THIS app.
+ *    Kept because the viewer's only other NotFoundError surface is the DOM pair
+ *    above, which words itself distinctly; drop this arm the day a Safari
+ *    NotFoundError from somewhere else shows up misfiled.
+ * An optional `NotFoundError: ` prefix is tolerated for the stringified form —
+ * `analytics-scrub.ts` classifies from the message text alone, where all that
+ * survives is `String(err)`.
+ */
+function isFileNotFoundMessage(message: string): boolean {
+  return /^(?:NotFoundError: )?(?:A requested file or directory could not be found at the time an operation was processed\.?|The object can ?not be found here\.?)$/i
+    .test(message.trim());
+}
+
+/**
  * The geometry stream watchdog timed out (see `useIfcLoader`'s `Promise.race`).
  * Matched on the stable prefix only — the message must NOT carry the file name
  * (it would leak a confidential model name into error tracking), so we never
@@ -233,7 +286,11 @@ export function classifyLoadError(err: unknown): LoadErrorKind {
   // browser worded `.message`; the message match covers the analytics path,
   // where all we have is the already-stringified value.
   const name = errorNameOf(err);
-  if (name === 'NotReadableError' || isFileUnreadableError(message)) {
+  if (
+    name === 'NotReadableError' ||
+    isFileUnreadableError(message) ||
+    isFileNotFoundMessage(message)
+  ) {
     return 'file_unreadable';
   }
   // Same stable-`.name` argument as NotReadableError above: an aborted fetch

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -131,7 +131,7 @@
    436 apps/viewer/src/hooks/useIfcServer.ts
    488 apps/viewer/src/hooks/useKeyboardShortcuts.ts
    496 apps/viewer/src/hooks/useSymbolicAnnotations.ts
-   629 apps/viewer/src/lib/analytics-scrub.ts
+   633 apps/viewer/src/lib/analytics-scrub.ts
    651 apps/viewer/src/lib/clash/persistence.ts
    427 apps/viewer/src/lib/collab/geometry-sync.ts
    445 apps/viewer/src/lib/compare/buildFingerprints.ts


### PR DESCRIPTION
## Summary

Triage of the auto-filed crash reports #3731 (NotFoundError) and #3767 (GPU device lost). Neither is closed by this PR; both issues carry the analysis and what is still needed from PostHog.

- **NotFoundError (#3731, and #2546, #2860, #3324 before it):** the file `NotFoundError` wording (a file moved, renamed, deleted or unloaded by a cloud-sync client between `getFile()` and the byte read) fell through `classifyLoadError` to `unknown`, so the user saw the raw engine text instead of the existing `file_unreadable` message, and each occurrence filed its own issue. Both engine wordings now map to `file_unreadable`. The Blink wording is anchored on the whole message (every Blink DOM site supplies an explicit "Failed to execute" message, which the anchor excludes). The WebKit wording is WebKit's generic `NotFoundError` description, which a Safari reconciler crash also carries, so it is honoured only under a load context (`ifc_model_load`, `geometry_processing`) threaded through `classifyLoadError`, `formatLoadError`, `errorCaptureProps` and `tagErrorKind`. `file_unreadable` is benign (captured and fingerprinted, warning level), which is safe only because of that gate; a test pins all three arms.
- **Device lost (#3767, #3774, #3207):** a device loss carried no `error_kind`, so occurrences grouped by driver text plus hashed bundle stack and filed separately. The capture sites now set `$exception_fingerprint` themselves: `ifc-lite:device_lost:<reason>` with reason bounded to `destroyed`, `unknown`, `render-exception`, `render-encode-exception` (anything else folds to `other`, so no engine text can mint a group), and `ifc-lite:render_degraded` for the degradation report.

Refs #3731, #3767.

## Verification

- `pnpm typecheck` exit 0; the touched viewer test files (load-errors, analytics, device-loss-report, device-loss-context, resource-retry, file-system-access, useIfcLoader.*) 228 tests, 0 fail.
- Mutation-checked: reverting the classifier fails two tests; dropping the context gate fails both Safari tests; removing the benign membership fails its test; reverting the fingerprint fails three.
- Not reproduced: a real `FileSystemFileHandle` whose backing file changes mid-read, or a driver TDR. Both mechanisms are read off the engines and the comments say so.
- No changeset: viewer only.