### PR TITLE
fix(bcf): createBCFFromIDSReport for BCF 3.0 frames a camera from bounds or refuses at the API

### DIFF
--- a/.changeset/ids-bcf3-camera.md
+++ b/.changeset/ids-bcf3-camera.md
@@ -1,0 +1,12 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+`createBCFFromIDSReport({ version: '3.0' })` now produces a writable archive.
+Computed cameras carry an `AspectRatio` (required by BCF 3.0's `visinfo.xsd`),
+taken from a new `aspectRatio` export option that defaults to 16/9, the
+convention when no viewport exists. Per-specification grouping frames the union
+of the failing entities' bounds instead of getting no camera at all. Without
+`entityBounds` there is nothing to compute a camera from, so the export is
+refused up front, naming the topic and the option that fixes it, rather than
+failing later inside `writeBCF` with only a generated viewpoint GUID to go on.

--- a/docs/guide/bcf.md
+++ b/docs/guide/bcf.md
@@ -146,6 +146,10 @@ const blob = await writeBCF(project);
 
 The viewer's IDS panel uses this to export validation failures as BCF, with optional camera viewpoints and snapshots. See [IDS Validation](ids.md).
 
+Exporting `version: '3.0'` also needs `entityBounds`. BCF 3.0 requires exactly one camera per viewpoint, and `createBCFFromIDSReport` computes that camera only from the bounds you pass, keyed `"modelId:expressId"`. Bounds that are absent, or that cover only some of the entities a viewpoint frames, make the call throw and name the topic it could not frame, rather than write a partial view that leaves the rest off screen. With no bounds to hand, export `version: '2.1'`, or set an explicit camera on every viewpoint before writing 3.0.
+
+A computed camera gets an `AspectRatio` of 16/9, the convention for a viewpoint that never had a viewport behind it. Pass `aspectRatio` to use your own viewport's width / height instead; it must be a finite number greater than 0, since `visinfo.xsd` types `AspectRatio` as `PositiveDouble`, and the option is rejected where you set it rather than later inside `writeBCF`.
+
 ## Clash Results as BCF
 
 The clash package (`@ifc-lite/clash/bcf`) exports clash detection results as a BCF 2.1 project, one topic per clash group:

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The camera half of the IDS to BCF reporter.
+ *
+ * Split out of `ids-reporter.ts` because BCF 3.0's camera rules are a policy
+ * of their own: `v3_0/visinfo.xsd` declares `OrthogonalCamera` and
+ * `PerspectiveCamera` as an `xs:choice` with the default `minOccurs`/
+ * `maxOccurs` of 1 (exactly one camera per viewpoint, required), and makes
+ * `<AspectRatio>` a required child of both. The reporter builds its own
+ * viewpoints rather than going through `createViewpoint`, so nothing else in
+ * this package enforced either rule for it -- both violations surfaced only
+ * from `writeBCF`, whole archives at a time, with no way back to the export
+ * option that caused them (#3849).
+ */
+
+import type { BCFPerspectiveCamera, BCFProject } from './types.js';
+
+/** Bounds for an entity, used for camera computation (viewer Y-up coords) */
+export interface EntityBoundsInput {
+  min: { x: number; y: number; z: number };
+  max: { x: number; y: number; z: number };
+}
+
+/**
+ * Aspect ratio a computed camera gets when the caller names none.
+ *
+ * There is no viewport behind an IDS report -- the camera is derived from
+ * entity bounds, headlessly, and may never have been on screen. 16/9 is the
+ * convention for "no viewport existed": it is what the BCF sample files and
+ * the common desktop viewports use, and a viewer restoring the viewpoint
+ * re-frames to its own aspect anyway. This is the one place in the package
+ * that invents an aspect ratio, and it does so because a computed camera has
+ * no captured value to preserve; `writer-camera.ts` still refuses to invent
+ * one for a camera the CALLER supplied.
+ */
+export const DEFAULT_ASPECT_RATIO = 16 / 9;
+
+/**
+ * Compute a BCF perspective camera from entity bounds.
+ *
+ * Bounds are in viewer coordinates (Y-up).
+ * BCF uses Z-up, so we convert:
+ *   BCF.x = Viewer.x
+ *   BCF.y = -Viewer.z
+ *   BCF.z = Viewer.y
+ *
+ * Camera is placed at a southeast-isometric angle from the entity center,
+ * at a distance that frames the entity's bounding box with padding.
+ *
+ * @param aspectRatio - viewport ratio (width / height) written to
+ *   `AspectRatio` under BCF 3.0. 2.1 has no such element and the writer emits
+ *   none there, so one value serves both versions.
+ */
+export function computeCameraFromBounds(
+  bounds: EntityBoundsInput,
+  aspectRatio: number = DEFAULT_ASPECT_RATIO,
+): BCFPerspectiveCamera {
+  // Center in viewer coords (Y-up)
+  const cx = (bounds.min.x + bounds.max.x) / 2;
+  const cy = (bounds.min.y + bounds.max.y) / 2;
+  const cz = (bounds.min.z + bounds.max.z) / 2;
+
+  // Max extent for framing distance
+  const sx = bounds.max.x - bounds.min.x;
+  const sy = bounds.max.y - bounds.min.y;
+  const sz = bounds.max.z - bounds.min.z;
+  const maxSize = Math.max(sx, sy, sz, 0.1); // Floor to avoid zero
+
+  // Camera distance: fit maxSize into 60deg FOV with 1.5x padding
+  const fovRad = (60 * Math.PI) / 180;
+  const distance = (maxSize / 2) / Math.tan(fovRad / 2) * 1.5;
+
+  // Southeast-isometric offset in viewer coords (Y-up):
+  // camera position = center + normalized(0.6, 0.5, 0.6) * distance
+  const offsetLen = Math.sqrt(0.6 * 0.6 + 0.5 * 0.5 + 0.6 * 0.6);
+  const ox = (0.6 / offsetLen) * distance;
+  const oy = (0.5 / offsetLen) * distance;
+  const oz = (0.6 / offsetLen) * distance;
+
+  const camX = cx + ox;
+  const camY = cy + oy;
+  const camZ = cz + oz;
+
+  // Direction: from camera to center (viewer coords)
+  const dx = cx - camX;
+  const dy = cy - camY;
+  const dz = cz - camZ;
+  const dLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+  // Convert to BCF coords (Z-up)
+  // Viewer (x, y, z) → BCF (x, -z, y)
+  return {
+    cameraViewPoint: { x: camX, y: -camZ, z: camY },
+    cameraDirection: {
+      x: dx / dLen,
+      y: -dz / dLen,
+      z: dy / dLen,
+    },
+    cameraUpVector: { x: 0, y: 0, z: 1 }, // BCF Z-up
+    fieldOfView: 60,
+    aspectRatio,
+  };
+}
+
+/**
+ * The box containing every bound given, or `undefined` when none were.
+ *
+ * Per-specification grouping puts many entities in ONE viewpoint, so no single
+ * entity's box is the right frame for it. Framing the union is what lets that
+ * grouping produce a 3.0-writable camera at all -- otherwise `entityBounds`
+ * would be an option that fixes per-entity and per-requirement exports while
+ * leaving the third grouping permanently unwritable, and the refusal below
+ * would be naming a remedy that does not work for it.
+ */
+export function unionBounds(
+  boxes: readonly EntityBoundsInput[],
+): EntityBoundsInput | undefined {
+  if (boxes.length === 0) return undefined;
+  const min = { ...boxes[0].min };
+  const max = { ...boxes[0].max };
+  for (const box of boxes.slice(1)) {
+    min.x = Math.min(min.x, box.min.x);
+    min.y = Math.min(min.y, box.min.y);
+    min.z = Math.min(min.z, box.min.z);
+    max.x = Math.max(max.x, box.max.x);
+    max.y = Math.max(max.y, box.max.y);
+    max.z = Math.max(max.z, box.max.z);
+  }
+  return { min, max };
+}
+
+/**
+ * Refuse a 3.0 project whose viewpoints have no camera, naming the topic.
+ *
+ * The reporter can only give a viewpoint a camera when the caller supplied
+ * bounds for the entities in it. Without them there is nothing to compute
+ * from, and inventing a framing would assert a view of the model nobody has
+ * -- the same policy `writer-camera.ts` applies to a missing `AspectRatio`.
+ * So we refuse; the only question is WHERE.
+ *
+ * Here, rather than in `writeBCF`, because the caller's mistake is an export
+ * OPTION (`version: '3.0'` with no `entityBounds`), and `writeBCF` can only
+ * report the viewpoint GUID of whichever topic it reached first -- a GUID this
+ * function generated moments earlier, which appears in nothing the caller
+ * wrote. Naming the topic, and the option that fixes it, is the difference
+ * between an error the caller can act on and one they have to bisect.
+ */
+export function requireCamerasForVersion(project: BCFProject): void {
+  if (project.version !== '3.0') return;
+  for (const topic of project.topics.values()) {
+    for (const viewpoint of topic.viewpoints) {
+      if (viewpoint.perspectiveCamera || viewpoint.orthogonalCamera) continue;
+      throw new Error(
+        `BCF 3.0 requires exactly one camera per viewpoint, and topic ` +
+          `"${topic.title}" (${topic.guid}) has a viewpoint with none. ` +
+          `createBCFFromIDSReport computes a camera only from entityBounds, ` +
+          `so pass entityBounds covering every reported entity ` +
+          `(keyed "modelId:expressId"), or export version "2.1" and set an ` +
+          `explicit camera on each viewpoint before writing 3.0.`,
+      );
+    }
+  }
+}

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -108,6 +108,14 @@ export function computeCameraFromBounds(
 /**
  * The box containing every bound given, or `undefined` when none were.
  *
+ * CONTRACT: the caller must pass a box for EVERY entity the viewpoint frames.
+ * A union over a subset is not a smaller mistake than no camera at all -- it
+ * is a camera that looks convincing and leaves the uncovered entities off
+ * screen, with nothing in the file saying so. `buildTopicsPerSpecification`
+ * therefore passes `undefined` unless it has bounds for all of them, which
+ * makes {@link requireCamerasForVersion} refuse the 3.0 export by name rather
+ * than write a partial frame.
+ *
  * Per-specification grouping puts many entities in ONE viewpoint, so no single
  * entity's box is the right frame for it. Framing the union is what lets that
  * grouping produce a 3.0-writable camera at all -- otherwise `entityBounds`

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -38,6 +38,36 @@ export interface EntityBoundsInput {
  */
 export const DEFAULT_ASPECT_RATIO = 16 / 9;
 
+/** How {@link DEFAULT_ASPECT_RATIO} reads in an error message. */
+const DEFAULT_ASPECT_RATIO_TEXT = '16/9';
+
+/**
+ * Refuse an `aspectRatio` export option that no camera could carry.
+ *
+ * `visinfo.xsd` types `AspectRatio` as `PositiveDouble` -- `xs:double` with
+ * `minExclusive value="0"` -- so `0`, a negative number, `NaN` and `Infinity`
+ * are all invalid, and `writer-camera.ts` already rejects them. It can only
+ * name the viewpoint GUID it was writing, though: a value this package
+ * generated, for whichever topic came first, traceable to nothing the caller
+ * typed. Checking the option where the caller set it is the difference
+ * between "fix this argument" and "bisect your report".
+ *
+ * Checked for BOTH versions even though 2.1 emits no `AspectRatio`: the value
+ * is still wrong, it still lands on every camera in the project, and
+ * `readBCF` + re-export is how a 2.1 project becomes a 3.0 one.
+ */
+export function requireAspectRatioOption(aspectRatio: number): number {
+  if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+    throw new Error(
+      `createBCFFromIDSReport's aspectRatio option must be a finite number ` +
+        `greater than 0 (got ${aspectRatio}). BCF 3.0's visinfo.xsd types ` +
+        `AspectRatio as PositiveDouble, so this value could not be written; ` +
+        `omit the option to use the ${DEFAULT_ASPECT_RATIO_TEXT} default.`,
+    );
+  }
+  return aspectRatio;
+}
+
 /**
  * Compute a BCF perspective camera from entity bounds.
  *

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -155,24 +155,6 @@ export function computeCameraFromBounds(
 }
 
 /**
- * The box containing every bound given, or `undefined` when none were.
- *
- * CONTRACT: the caller must pass a box for EVERY entity the viewpoint frames.
- * A union over a subset is not a smaller mistake than no camera at all -- it
- * is a camera that looks convincing and leaves the uncovered entities off
- * screen, with nothing in the file saying so. `buildTopicsPerSpecification`
- * therefore passes `undefined` unless it has bounds for all of them, which
- * makes {@link requireCamerasForVersion} refuse the 3.0 export by name rather
- * than write a partial frame.
- *
- * Per-specification grouping puts many entities in ONE viewpoint, so no single
- * entity's box is the right frame for it. Framing the union is what lets that
- * grouping produce a 3.0-writable camera at all -- otherwise `entityBounds`
- * would be an option that fixes per-entity and per-requirement exports while
- * leaving the third grouping permanently unwritable, and the refusal below
- * would be naming a remedy that does not work for it.
- */
-/**
  * The union of the boxes for EVERY key given, or `undefined` if any key has
  * none.
  *
@@ -196,6 +178,24 @@ export function unionBoundsForEveryKey(
   return unionBounds(boxes);
 }
 
+/**
+ * The box containing every bound given, or `undefined` when none were.
+ *
+ * CONTRACT: the caller must pass a box for EVERY entity the viewpoint frames.
+ * A union over a subset is not a smaller mistake than no camera at all -- it
+ * is a camera that looks convincing and leaves the uncovered entities off
+ * screen, with nothing in the file saying so. `buildTopicsPerSpecification`
+ * therefore passes `undefined` unless it has bounds for all of them, which
+ * makes {@link requireCamerasForVersion} refuse the 3.0 export by name rather
+ * than write a partial frame.
+ *
+ * Per-specification grouping puts many entities in ONE viewpoint, so no single
+ * entity's box is the right frame for it. Framing the union is what lets that
+ * grouping produce a 3.0-writable camera at all -- otherwise `entityBounds`
+ * would be an option that fixes per-entity and per-requirement exports while
+ * leaving the third grouping permanently unwritable, and the refusal below
+ * would be naming a remedy that does not work for it.
+ */
 function unionBounds(
   boxes: readonly EntityBoundsInput[],
 ): EntityBoundsInput | undefined {

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -38,6 +38,14 @@ export interface EntityBoundsInput {
  */
 export const DEFAULT_ASPECT_RATIO = 16 / 9;
 
+/**
+ * Vertical field of view of every computed camera, in degrees.
+ *
+ * Inside BCF 3.0's `(0, 180)` exclusive facet and BCF 2.1's `[45, 60]` one, so
+ * one value is writable under both.
+ */
+const FIELD_OF_VIEW_DEGREES = 60;
+
 /** How {@link DEFAULT_ASPECT_RATIO} reads in an error message. */
 const DEFAULT_ASPECT_RATIO_TEXT = '16/9';
 
@@ -99,9 +107,20 @@ export function computeCameraFromBounds(
   const sz = bounds.max.z - bounds.min.z;
   const maxSize = Math.max(sx, sy, sz, 0.1); // Floor to avoid zero
 
-  // Camera distance: fit maxSize into 60deg FOV with 1.5x padding
-  const fovRad = (60 * Math.PI) / 180;
-  const distance = (maxSize / 2) / Math.tan(fovRad / 2) * 1.5;
+  // Camera distance: fit maxSize into the 60deg FOV with 1.5x padding.
+  //
+  // `FieldOfView` is the VERTICAL angle in BCF, and the horizontal one follows
+  // from the aspect ratio: tan(hHalf) = aspectRatio * tan(vHalf). Framing off
+  // the vertical angle alone therefore held only while the viewport was at
+  // least as wide as it is tall; at a portrait ratio the horizontal angle is
+  // the NARROWER of the two, and a wide entity was cropped by exactly the
+  // factor the ratio understated (at 9/16, by 16/9). Dividing by the narrower
+  // half-angle frames the box in whichever direction is tighter, and is inert
+  // at every ratio >= 1 -- including the 16/9 default -- because the vertical
+  // angle is the narrower one there.
+  const vHalf = (FIELD_OF_VIEW_DEGREES * Math.PI) / 360;
+  const hHalf = Math.atan(aspectRatio * Math.tan(vHalf));
+  const distance = (maxSize / 2) / Math.tan(Math.min(vHalf, hHalf)) * 1.5;
 
   // Southeast-isometric offset in viewer coords (Y-up):
   // camera position = center + normalized(0.6, 0.5, 0.6) * distance
@@ -130,7 +149,7 @@ export function computeCameraFromBounds(
       z: dy / dLen,
     },
     cameraUpVector: { x: 0, y: 0, z: 1 }, // BCF Z-up
-    fieldOfView: 60,
+    fieldOfView: FIELD_OF_VIEW_DEGREES,
     aspectRatio,
   };
 }

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -172,7 +172,31 @@ export function computeCameraFromBounds(
  * leaving the third grouping permanently unwritable, and the refusal below
  * would be naming a remedy that does not work for it.
  */
-export function unionBounds(
+/**
+ * The union of the boxes for EVERY key given, or `undefined` if any key has
+ * none.
+ *
+ * All-or-nothing for the reason {@link unionBounds} documents: the
+ * per-specification viewpoint frames a whole group of entities, and a union
+ * over the subset that happened to have bounds is a camera that leaves the
+ * rest off screen while looking entirely plausible. `undefined` leaves the
+ * viewpoint camera-less, which {@link requireCamerasForVersion} turns into a
+ * 3.0 refusal naming the topic and the missing option (#3849).
+ */
+export function unionBoundsForEveryKey(
+  keys: readonly string[],
+  entityBounds: Map<string, EntityBoundsInput> | undefined,
+): EntityBoundsInput | undefined {
+  const boxes: EntityBoundsInput[] = [];
+  for (const key of keys) {
+    const box = entityBounds?.get(key);
+    if (!box) return undefined;
+    boxes.push(box);
+  }
+  return unionBounds(boxes);
+}
+
+function unionBounds(
   boxes: readonly EntityBoundsInput[],
 ): EntityBoundsInput | undefined {
   if (boxes.length === 0) return undefined;

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -875,6 +875,34 @@ describe('IDS BCF Reporter', () => {
       expect(cam.cameraViewPoint.x).toBeGreaterThan(centerX + 5);
     });
 
+    it('refuses per-specification grouping when only some entities have bounds', () => {
+      // The viewpoint frames every failing entity at once, so a partial union
+      // is a frame that silently leaves the uncovered entity off screen.
+      const bounds = new Map<string, EntityBoundsInput>();
+      bounds.set('model-1:100', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } });
+
+      expect(() =>
+        createBCFFromIDSReport(createMockReport(), {
+          version: '3.0',
+          topicGrouping: 'per-specification',
+          entityBounds: bounds,
+        }),
+      ).toThrow(/entityBounds/);
+    });
+
+    it('leaves the per-specification camera unset when bounds are partial', () => {
+      const bounds = new Map<string, EntityBoundsInput>();
+      bounds.set('model-1:100', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } });
+
+      const project = createBCFFromIDSReport(createMockReport(), {
+        topicGrouping: 'per-specification',
+        entityBounds: bounds,
+      });
+
+      const vp = [...project.topics.values()][0].viewpoints[0];
+      expect(vp.perspectiveCamera).toBeUndefined();
+    });
+
     it('refuses a 3.0 per-requirement report with no bounds', () => {
       expect(() =>
         createBCFFromIDSReport(createMockReport(), {

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -903,6 +903,34 @@ describe('IDS BCF Reporter', () => {
       expect(vp.perspectiveCamera).toBeUndefined();
     });
 
+    for (const bad of [0, Number.NaN, -2, Number.POSITIVE_INFINITY]) {
+      it(`refuses aspectRatio ${bad} at the option boundary`, () => {
+        let thrown: Error | undefined;
+        try {
+          createBCFFromIDSReport(createMockReport(), {
+            version: '3.0',
+            aspectRatio: bad,
+            entityBounds: boundsFor('model-1:100', 'model-1:200'),
+          });
+        } catch (e) {
+          thrown = e as Error;
+        }
+        expect(thrown).toBeDefined();
+        // Named at the option the caller passed, not at a generated viewpoint
+        // GUID deep inside writeBCF.
+        expect(thrown!.message).toContain('aspectRatio');
+        expect(thrown!.message).toContain(String(bad));
+      });
+    }
+
+    it('refuses a bad aspectRatio for 2.1 too, where it is never written', () => {
+      // 2.1 emits no AspectRatio, but the option is still a number the caller
+      // got wrong, and it is what a later 3.0 re-export would carry.
+      expect(() =>
+        createBCFFromIDSReport(createMockReport(), { aspectRatio: 0 }),
+      ).toThrow(/aspectRatio/);
+    });
+
     it('refuses a 3.0 per-requirement report with no bounds', () => {
       expect(() =>
         createBCFFromIDSReport(createMockReport(), {

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -771,4 +771,109 @@ describe('IDS BCF Reporter', () => {
       expect(vp.snapshot).toBe('data:image/png;base64,BBBB');
     });
   });
+
+  // ==========================================================================
+  // BCF 3.0 writability (#3849)
+  // ==========================================================================
+
+  describe('BCF 3.0 camera policy', () => {
+    function boundsFor(...keys: string[]): Map<string, EntityBoundsInput> {
+      const map = new Map<string, EntityBoundsInput>();
+      for (const key of keys) {
+        map.set(key, { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 3, z: 1 } });
+      }
+      return map;
+    }
+
+    it('gives every computed camera the default 16/9 aspect ratio', () => {
+      const project = createBCFFromIDSReport(createMockReport(), {
+        version: '3.0',
+        entityBounds: boundsFor('model-1:100', 'model-1:200'),
+      });
+
+      const cameras = [...project.topics.values()]
+        .flatMap(t => t.viewpoints)
+        .map(vp => vp.perspectiveCamera);
+      expect(cameras.length).toBeGreaterThan(0);
+      for (const cam of cameras) {
+        expect(cam?.aspectRatio).toBeCloseTo(16 / 9, 12);
+      }
+    });
+
+    it('honours an explicit aspectRatio option', () => {
+      const project = createBCFFromIDSReport(createMockReport(), {
+        version: '3.0',
+        aspectRatio: 4 / 3,
+        entityBounds: boundsFor('model-1:100', 'model-1:200'),
+      });
+
+      const cam = [...project.topics.values()][0].viewpoints[0].perspectiveCamera!;
+      expect(cam.aspectRatio).toBeCloseTo(4 / 3, 12);
+    });
+
+    it('sets the aspect ratio on 2.1 cameras too (the writer just omits it)', () => {
+      const project = createBCFFromIDSReport(createMockReport(), {
+        entityBounds: boundsFor('model-1:100'),
+      });
+
+      const cam = [...project.topics.values()][0].viewpoints[0].perspectiveCamera!;
+      expect(cam.aspectRatio).toBeCloseTo(16 / 9, 12);
+    });
+
+    it('refuses a 3.0 report with no entityBounds, naming the topic', () => {
+      let thrown: Error | undefined;
+      try {
+        createBCFFromIDSReport(createMockReport(), { version: '3.0' });
+      } catch (e) {
+        thrown = e as Error;
+      }
+      expect(thrown).toBeDefined();
+      // The topic the caller has to act on, not just "a viewpoint".
+      expect(thrown!.message).toContain('IfcWall: Basic Wall:Generic - 200mm');
+      expect(thrown!.message).toContain('entityBounds');
+      expect(thrown!.message).toContain('BCF 3.0');
+    });
+
+    it('refuses when bounds cover only some of the failing entities', () => {
+      expect(() =>
+        createBCFFromIDSReport(createMockReport(), {
+          version: '3.0',
+          entityBounds: boundsFor('model-1:100'),
+        }),
+      ).toThrow(/IfcWall: Curtain Wall:Standard/);
+    });
+
+    it('leaves 2.1 reports without bounds alone', () => {
+      const project = createBCFFromIDSReport(createMockReport());
+      expect(project.topics.size).toBeGreaterThan(0);
+    });
+
+    it('frames the union of the failing entities in per-specification grouping', () => {
+      const bounds = new Map<string, EntityBoundsInput>();
+      bounds.set('model-1:100', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } });
+      bounds.set('model-1:200', { min: { x: 10, y: 0, z: 0 }, max: { x: 11, y: 1, z: 1 } });
+
+      const project = createBCFFromIDSReport(createMockReport(), {
+        version: '3.0',
+        topicGrouping: 'per-specification',
+        entityBounds: bounds,
+      });
+
+      const cam = [...project.topics.values()][0].viewpoints[0].perspectiveCamera!;
+      expect(cam.aspectRatio).toBeCloseTo(16 / 9, 12);
+      // Union spans x 0..11, so the camera sits far enough out to frame 11
+      // units, not the 1-unit box of either entity on its own.
+      const centerX = 5.5;
+      expect(cam.cameraViewPoint.x).toBeGreaterThan(centerX + 5);
+    });
+
+    it('refuses a 3.0 per-requirement report with no bounds', () => {
+      expect(() =>
+        createBCFFromIDSReport(createMockReport(), {
+          version: '3.0',
+          topicGrouping: 'per-requirement',
+        }),
+      ).toThrow(/BCF 3\.0/);
+    });
+  });
 });

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -6,6 +6,18 @@ import { describe, it, expect } from 'vitest';
 import { createBCFFromIDSReport } from './ids-reporter.js';
 import type { IDSReportInput, EntityBoundsInput } from './ids-reporter.js';
 
+type Vec3 = { x: number; y: number; z: number };
+const dot = (a: Vec3, b: Vec3) => a.x * b.x + a.y * b.y + a.z * b.z;
+const cross = (a: Vec3, b: Vec3): Vec3 => ({
+  x: a.y * b.z - a.z * b.y,
+  y: a.z * b.x - a.x * b.z,
+  z: a.x * b.y - a.y * b.x,
+});
+const normalize = (v: Vec3): Vec3 => {
+  const len = Math.sqrt(dot(v, v));
+  return { x: v.x / len, y: v.y / len, z: v.z / len };
+};
+
 // ============================================================================
 // Test fixtures
 // ============================================================================
@@ -929,6 +941,101 @@ describe('IDS BCF Reporter', () => {
       expect(() =>
         createBCFFromIDSReport(createMockReport(), { aspectRatio: 0 }),
       ).toThrow(/aspectRatio/);
+    });
+
+    /**
+     * Every corner of `box` sits inside the frustum `cam` describes.
+     *
+     * The check is done from the camera's OWN direction, up vector and
+     * `fieldOfView` rather than from the numbers that produced them, so a
+     * framing that agrees with itself but not with the geometry still fails.
+     */
+    function cornersOutsideFrustum(
+      cam: NonNullable<ReturnType<typeof perspectiveCameraOf>>,
+      box: EntityBoundsInput,
+      aspectRatio: number,
+    ): string[] {
+      // BCF FieldOfView is the VERTICAL angle; the horizontal one follows
+      // from the aspect ratio.
+      const halfV = (cam.fieldOfView * Math.PI) / 360;
+      const halfH = Math.atan(aspectRatio * Math.tan(halfV));
+
+      const d = cam.cameraDirection;
+      const right = normalize(cross(d, cam.cameraUpVector));
+      const up = cross(right, d);
+
+      const outside: string[] = [];
+      for (const x of [box.min.x, box.max.x]) {
+        for (const y of [box.min.y, box.max.y]) {
+          for (const z of [box.min.z, box.max.z]) {
+            // Viewer (x, y, z) -> BCF (x, -z, y), the reporter's convention.
+            const v = {
+              x: x - cam.cameraViewPoint.x,
+              y: -z - cam.cameraViewPoint.y,
+              z: y - cam.cameraViewPoint.z,
+            };
+            const depth = dot(v, d);
+            const h = Math.abs(dot(v, right)) / depth;
+            const vt = Math.abs(dot(v, up)) / depth;
+            if (depth <= 0 || h > Math.tan(halfH) || vt > Math.tan(halfV)) {
+              outside.push(`(${x}, ${y}, ${z}) h=${h.toFixed(3)} v=${vt.toFixed(3)}`);
+            }
+          }
+        }
+      }
+      return outside;
+    }
+
+    function perspectiveCameraOf(project: ReturnType<typeof createBCFFromIDSReport>) {
+      return [...project.topics.values()][0].viewpoints[0].perspectiveCamera;
+    }
+
+    function frameOneBox(box: EntityBoundsInput, aspectRatio: number) {
+      return createBCFFromIDSReport(createMockReport(), {
+        version: '3.0',
+        aspectRatio,
+        entityBounds: new Map<string, EntityBoundsInput>([
+          ['model-1:100', box],
+          ['model-1:200', box],
+        ]),
+      });
+    }
+
+    it('keeps a wide entity inside the frustum at a portrait aspect ratio', () => {
+      // fieldOfView is VERTICAL, so at 9/16 the HORIZONTAL half-angle is the
+      // narrower one. A distance derived from the vertical angle alone crops
+      // a box that is much wider than it is tall.
+      const aspectRatio = 9 / 16;
+      const box: EntityBoundsInput = {
+        min: { x: -5, y: -0.5, z: -0.5 },
+        max: { x: 5, y: 0.5, z: 0.5 },
+      };
+
+      const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
+      expect(cornersOutsideFrustum(cam, box, aspectRatio)).toEqual([]);
+    });
+
+    it('keeps a tall entity inside the frustum at a landscape aspect ratio', () => {
+      // The other direction, so a fix that merely swapped which angle is used
+      // fails here instead of passing both.
+      const aspectRatio = 16 / 9;
+      const box: EntityBoundsInput = {
+        min: { x: -0.5, y: -5, z: -0.5 },
+        max: { x: 0.5, y: 5, z: 0.5 },
+      };
+
+      const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
+      expect(cornersOutsideFrustum(cam, box, aspectRatio)).toEqual([]);
+    });
+
+    it('does not move the camera at all for a 16/9 cube', () => {
+      // The narrower half-angle at 16/9 IS the vertical one, so the widening
+      // must be inert here -- a landscape export frames exactly as before.
+      const box: EntityBoundsInput = { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 2, z: 2 } };
+      const wide = perspectiveCameraOf(frameOneBox(box, 16 / 9))!;
+      const square = perspectiveCameraOf(frameOneBox(box, 1))!;
+
+      expect(wide.cameraViewPoint).toEqual(square.cameraViewPoint);
     });
 
     it('refuses a 3.0 per-requirement report with no bounds', () => {

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -136,9 +136,17 @@ describe('IDS BCF Reporter', () => {
 
     it('should allow custom project name and version', () => {
       const report = createMockReport();
+      // 3.0 needs bounds: a viewpoint with no camera is refused outright
+      // (see "BCF 3.0 camera policy" below), so a bounds-less 3.0 export is
+      // no longer a way to check that the version option is honoured.
+      const bounds = new Map<string, EntityBoundsInput>([
+        ['model-1:100', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } }],
+        ['model-1:200', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } }],
+      ]);
       const project = createBCFFromIDSReport(report, {
         projectName: 'Custom Project',
         version: '3.0',
+        entityBounds: bounds,
       });
 
       expect(project.version).toBe('3.0');

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -28,7 +28,7 @@ import {
   computeCameraFromBounds,
   requireAspectRatioOption,
   requireCamerasForVersion,
-  unionBounds,
+  unionBoundsForEveryKey,
 } from './ids-camera.js';
 import type { EntityBoundsInput } from './ids-camera.js';
 
@@ -359,6 +359,11 @@ function addTruncationNoticeTopic(
 // Per-entity grouping (default — recommended)
 // ============================================================================
 
+/** How `entityBounds` and `entitySnapshots` are keyed. */
+function boundsKeyOf(entity: IDSEntityResultInput): string {
+  return `${entity.modelId}:${entity.expressId}`;
+}
+
 interface BuildOptions {
   author: string;
   includePassingEntities?: boolean;
@@ -428,7 +433,7 @@ function buildTopicsPerEntity(
       // Viewpoint MUST be created first so comments can reference it via viewpointGuid
       let viewpointGuid: string | undefined;
       if (entity.globalId) {
-        const boundsKey = `${entity.modelId}:${entity.expressId}`;
+        const boundsKey = boundsKeyOf(entity);
         const bounds = opts.entityBounds?.get(boundsKey);
         const snapshot = opts.entitySnapshots?.get(boundsKey);
         const viewpoint = buildEntityViewpoint(
@@ -499,7 +504,7 @@ function buildTopicsPerSpecification(
       const viewpoint = buildMultiEntityViewpoint(
         failedGuids,
         opts.failureColor,
-        boundsForEveryEntity(failedEntities, opts.entityBounds),
+        unionBoundsForEveryKey(failedEntities.map(boundsKeyOf), opts.entityBounds),
         opts.aspectRatio,
       );
       topic.viewpoints.push(viewpoint);
@@ -590,7 +595,7 @@ function buildTopicsPerRequirement(
         // Viewpoint for single entity (must be first for comment linking)
         let viewpointGuid: string | undefined;
         if (entity.globalId) {
-          const boundsKey = `${entity.modelId}:${entity.expressId}`;
+          const boundsKey = boundsKeyOf(entity);
           const bounds = opts.entityBounds?.get(boundsKey);
           const snapshot = opts.entitySnapshots?.get(boundsKey);
           const viewpoint = buildEntityViewpoint(
@@ -689,29 +694,6 @@ function buildRequirementComment(req: IDSRequirementResultInput): string {
   }
 
   return lines.join('\n');
-}
-
-/**
- * The union of the group's bounds, or `undefined` if ANY of its entities has
- * none.
- *
- * All-or-nothing because the per-specification viewpoint frames the whole
- * group: unioning whichever boxes happened to be supplied puts the rest off
- * screen and says nothing about it. Returning `undefined` instead leaves the
- * viewpoint camera-less, which `requireCamerasForVersion` turns into a 3.0
- * refusal that names the topic and the missing option (#3849).
- */
-function boundsForEveryEntity(
-  entities: readonly IDSEntityResultInput[],
-  entityBounds: Map<string, EntityBoundsInput> | undefined,
-): EntityBoundsInput | undefined {
-  const boxes: EntityBoundsInput[] = [];
-  for (const entity of entities) {
-    const box = entityBounds?.get(`${entity.modelId}:${entity.expressId}`);
-    if (!box) return undefined;
-    boxes.push(box);
-  }
-  return unionBounds(boxes);
 }
 
 // ============================================================================

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -26,6 +26,7 @@ import { generateUuid } from '@ifc-lite/encoding';
 import {
   DEFAULT_ASPECT_RATIO,
   computeCameraFromBounds,
+  requireAspectRatioOption,
   requireCamerasForVersion,
   unionBounds,
 } from './ids-camera.js';
@@ -243,10 +244,14 @@ export function createBCFFromIDSReport(
     passTopicType = DEFAULT_PASS_TOPIC_TYPE,
     maxTopics = DEFAULT_MAX_TOPICS,
     failureColor = DEFAULT_FAILURE_COLOR,
-    aspectRatio = DEFAULT_ASPECT_RATIO,
+    aspectRatio: requestedAspectRatio = DEFAULT_ASPECT_RATIO,
     entityBounds,
     entitySnapshots,
   } = options;
+
+  // Checked here, where the caller set it, rather than left to writeBCF --
+  // which can only name a viewpoint GUID this file generated (#3849).
+  const aspectRatio = requireAspectRatioOption(requestedAspectRatio);
 
   const project = createProject(projectName ?? report.title, version);
 

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -187,6 +187,11 @@ export interface IDSBCFExportOptions {
    * there is no viewport to read one from. Defaults to 16/9, the convention
    * when no viewport exists; pass the real viewport ratio when the export runs
    * beside one. 2.1 has no such element, so this changes nothing there.
+   *
+   * The viewer's own IDS export (`apps/viewer/src/hooks/useIDS.ts`, where it
+   * builds `exportOptions` for `createBCFFromIDSReport`) sets none today; it
+   * is the call site to wire `Camera.getAspect()` into if that dialog ever
+   * offers 3.0, which it currently does not.
    */
   aspectRatio?: number;
   /**

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -489,11 +489,7 @@ function buildTopicsPerSpecification(
       const viewpoint = buildMultiEntityViewpoint(
         failedGuids,
         opts.failureColor,
-        unionBounds(
-          failedEntities
-            .map((e) => opts.entityBounds?.get(`${e.modelId}:${e.expressId}`))
-            .filter((b): b is EntityBoundsInput => b !== undefined),
-        ),
+        boundsForEveryEntity(failedEntities, opts.entityBounds),
         opts.aspectRatio,
       );
       topic.viewpoints.push(viewpoint);
@@ -683,6 +679,29 @@ function buildRequirementComment(req: IDSRequirementResultInput): string {
   }
 
   return lines.join('\n');
+}
+
+/**
+ * The union of the group's bounds, or `undefined` if ANY of its entities has
+ * none.
+ *
+ * All-or-nothing because the per-specification viewpoint frames the whole
+ * group: unioning whichever boxes happened to be supplied puts the rest off
+ * screen and says nothing about it. Returning `undefined` instead leaves the
+ * viewpoint camera-less, which `requireCamerasForVersion` turns into a 3.0
+ * refusal that names the topic and the missing option (#3849).
+ */
+function boundsForEveryEntity(
+  entities: readonly IDSEntityResultInput[],
+  entityBounds: Map<string, EntityBoundsInput> | undefined,
+): EntityBoundsInput | undefined {
+  const boxes: EntityBoundsInput[] = [];
+  for (const entity of entities) {
+    const box = entityBounds?.get(`${entity.modelId}:${entity.expressId}`);
+    if (!box) return undefined;
+    boxes.push(box);
+  }
+  return unionBounds(boxes);
 }
 
 // ============================================================================

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -21,8 +21,17 @@
  * - Configurable grouping strategies
  */
 
-import type { BCFProject, BCFTopic, BCFComment, BCFViewpoint, BCFPerspectiveCamera } from './types.js';
+import type { BCFProject, BCFTopic, BCFComment, BCFViewpoint } from './types.js';
 import { generateUuid } from '@ifc-lite/encoding';
+import {
+  DEFAULT_ASPECT_RATIO,
+  computeCameraFromBounds,
+  requireCamerasForVersion,
+  unionBounds,
+} from './ids-camera.js';
+import type { EntityBoundsInput } from './ids-camera.js';
+
+export type { EntityBoundsInput } from './ids-camera.js';
 
 // ============================================================================
 // Internal BCF helpers (avoiding index.js import to prevent jszip dependency)
@@ -124,12 +133,6 @@ export interface IDSEntityResultInput {
   requirementResults: IDSRequirementResultInput[];
 }
 
-/** Bounds for an entity — used for camera computation in viewpoints (Y-up viewer coords) */
-export interface EntityBoundsInput {
-  min: { x: number; y: number; z: number };
-  max: { x: number; y: number; z: number };
-}
-
 /** Requirement result — structurally matches IDSRequirementResult */
 export interface IDSRequirementResultInput {
   status: 'pass' | 'fail' | 'not_applicable';
@@ -175,6 +178,16 @@ export interface IDSBCFExportOptions {
    * When provided, viewpoints will include a perspective camera framing the entity.
    */
   entityBounds?: Map<string, EntityBoundsInput>;
+  /**
+   * Viewport aspect ratio (width / height) for computed cameras.
+   *
+   * BCF 3.0's `visinfo.xsd` requires `<AspectRatio>` on every camera, and an
+   * IDS export is headless -- the camera is derived from entity bounds, so
+   * there is no viewport to read one from. Defaults to 16/9, the convention
+   * when no viewport exists; pass the real viewport ratio when the export runs
+   * beside one. 2.1 has no such element, so this changes nothing there.
+   */
+  aspectRatio?: number;
   /**
    * Entity snapshot map for attaching screenshots to viewpoints.
    * Key: "modelId:expressId", Value: data URL (PNG).
@@ -230,6 +243,7 @@ export function createBCFFromIDSReport(
     passTopicType = DEFAULT_PASS_TOPIC_TYPE,
     maxTopics = DEFAULT_MAX_TOPICS,
     failureColor = DEFAULT_FAILURE_COLOR,
+    aspectRatio = DEFAULT_ASPECT_RATIO,
     entityBounds,
     entitySnapshots,
   } = options;
@@ -245,6 +259,7 @@ export function createBCFFromIDSReport(
         passTopicType,
         maxTopics,
         failureColor,
+        aspectRatio,
         entityBounds,
         entitySnapshots,
       });
@@ -255,6 +270,7 @@ export function createBCFFromIDSReport(
         failureTopicType,
         maxTopics,
         failureColor,
+        aspectRatio,
         entityBounds,
         entitySnapshots,
       });
@@ -265,11 +281,16 @@ export function createBCFFromIDSReport(
         failureTopicType,
         maxTopics,
         failureColor,
+        aspectRatio,
         entityBounds,
         entitySnapshots,
       });
       break;
   }
+
+  // Refuse an unwritable 3.0 project here, where the caller can still see
+  // which option produced it, rather than leaving it to writeBCF (#3849).
+  requireCamerasForVersion(project);
 
   return project;
 }
@@ -335,6 +356,7 @@ interface BuildOptions {
   passTopicType?: string;
   maxTopics: number;
   failureColor: string;
+  aspectRatio: number;
   entityBounds?: Map<string, EntityBoundsInput>;
   entitySnapshots?: Map<string, string>;
 }
@@ -403,6 +425,7 @@ function buildTopicsPerEntity(
           entity.globalId,
           isFailed ? opts.failureColor : undefined,
           bounds,
+          opts.aspectRatio,
           snapshot,
         );
         topic.viewpoints.push(viewpoint);
@@ -463,7 +486,16 @@ function buildTopicsPerSpecification(
 
     let viewpointGuid: string | undefined;
     if (failedGuids.length > 0) {
-      const viewpoint = buildMultiEntityViewpoint(failedGuids, opts.failureColor);
+      const viewpoint = buildMultiEntityViewpoint(
+        failedGuids,
+        opts.failureColor,
+        unionBounds(
+          failedEntities
+            .map((e) => opts.entityBounds?.get(`${e.modelId}:${e.expressId}`))
+            .filter((b): b is EntityBoundsInput => b !== undefined),
+        ),
+        opts.aspectRatio,
+      );
       topic.viewpoints.push(viewpoint);
       viewpointGuid = viewpoint.guid;
     }
@@ -555,7 +587,13 @@ function buildTopicsPerRequirement(
           const boundsKey = `${entity.modelId}:${entity.expressId}`;
           const bounds = opts.entityBounds?.get(boundsKey);
           const snapshot = opts.entitySnapshots?.get(boundsKey);
-          const viewpoint = buildEntityViewpoint(entity.globalId, opts.failureColor, bounds, snapshot);
+          const viewpoint = buildEntityViewpoint(
+            entity.globalId,
+            opts.failureColor,
+            bounds,
+            opts.aspectRatio,
+            snapshot,
+          );
           topic.viewpoints.push(viewpoint);
           viewpointGuid = viewpoint.guid;
         }
@@ -648,69 +686,6 @@ function buildRequirementComment(req: IDSRequirementResultInput): string {
 }
 
 // ============================================================================
-// Helpers — Camera computation
-// ============================================================================
-
-/**
- * Compute a BCF perspective camera from entity bounds.
- *
- * Bounds are in viewer coordinates (Y-up).
- * BCF uses Z-up, so we convert:
- *   BCF.x = Viewer.x
- *   BCF.y = -Viewer.z
- *   BCF.z = Viewer.y
- *
- * Camera is placed at a southeast-isometric angle from the entity center,
- * at a distance that frames the entity's bounding box with padding.
- */
-function computeCameraFromBounds(bounds: EntityBoundsInput): BCFPerspectiveCamera {
-  // Center in viewer coords (Y-up)
-  const cx = (bounds.min.x + bounds.max.x) / 2;
-  const cy = (bounds.min.y + bounds.max.y) / 2;
-  const cz = (bounds.min.z + bounds.max.z) / 2;
-
-  // Max extent for framing distance
-  const sx = bounds.max.x - bounds.min.x;
-  const sy = bounds.max.y - bounds.min.y;
-  const sz = bounds.max.z - bounds.min.z;
-  const maxSize = Math.max(sx, sy, sz, 0.1); // Floor to avoid zero
-
-  // Camera distance: fit maxSize into 60deg FOV with 1.5x padding
-  const fovRad = (60 * Math.PI) / 180;
-  const distance = (maxSize / 2) / Math.tan(fovRad / 2) * 1.5;
-
-  // Southeast-isometric offset in viewer coords (Y-up):
-  // camera position = center + normalized(0.6, 0.5, 0.6) * distance
-  const offsetLen = Math.sqrt(0.6 * 0.6 + 0.5 * 0.5 + 0.6 * 0.6);
-  const ox = (0.6 / offsetLen) * distance;
-  const oy = (0.5 / offsetLen) * distance;
-  const oz = (0.6 / offsetLen) * distance;
-
-  const camX = cx + ox;
-  const camY = cy + oy;
-  const camZ = cz + oz;
-
-  // Direction: from camera to center (viewer coords)
-  const dx = cx - camX;
-  const dy = cy - camY;
-  const dz = cz - camZ;
-  const dLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-  // Convert to BCF coords (Z-up)
-  // Viewer (x, y, z) → BCF (x, -z, y)
-  return {
-    cameraViewPoint: { x: camX, y: -camZ, z: camY },
-    cameraDirection: {
-      x: dx / dLen,
-      y: -dz / dLen,
-      z: dy / dLen,
-    },
-    cameraUpVector: { x: 0, y: 0, z: 1 }, // BCF Z-up
-    fieldOfView: 60,
-  };
-}
-
-// ============================================================================
 // Helpers — Viewpoint builders
 // ============================================================================
 
@@ -722,7 +697,8 @@ function computeCameraFromBounds(bounds: EntityBoundsInput): BCFPerspectiveCamer
 function buildEntityViewpoint(
   globalId: string,
   failureColor: string | undefined,
-  bounds?: EntityBoundsInput,
+  bounds: EntityBoundsInput | undefined,
+  aspectRatio: number,
   snapshot?: string,
 ): BCFViewpoint {
   // Create independent component objects to prevent mutation side effects
@@ -748,7 +724,7 @@ function buildEntityViewpoint(
 
   // Compute camera from bounds (viewer Y-up → BCF Z-up)
   if (bounds) {
-    viewpoint.perspectiveCamera = computeCameraFromBounds(bounds);
+    viewpoint.perspectiveCamera = computeCameraFromBounds(bounds, aspectRatio);
   }
 
   // Attach snapshot
@@ -762,10 +738,15 @@ function buildEntityViewpoint(
 /**
  * Build a viewpoint for multiple entities: all selected and visible, colored.
  * Used by per-specification grouping where one topic covers many entities.
+ *
+ * `bounds` is the union of the entities' boxes (see `unionBounds`), so the
+ * camera frames the whole failing set rather than whichever entity came first.
  */
 function buildMultiEntityViewpoint(
   globalIds: string[],
   failureColor: string | undefined,
+  bounds: EntityBoundsInput | undefined,
+  aspectRatio: number,
 ): BCFViewpoint {
   // Use independent arrays per field to prevent mutation side effects
   const viewpoint: BCFViewpoint = {
@@ -786,6 +767,10 @@ function buildMultiEntityViewpoint(
         components: globalIds.map(id => ({ ifcGuid: id })),
       },
     ];
+  }
+
+  if (bounds) {
+    viewpoint.perspectiveCamera = computeCameraFromBounds(bounds, aspectRatio);
   }
 
   return viewpoint;

--- a/packages/bcf/src/interop-conformance.test.ts
+++ b/packages/bcf/src/interop-conformance.test.ts
@@ -75,6 +75,8 @@ import {
   createBCFTopic,
   updateTopicStatus,
 } from './index.js';
+import { createBCFFromIDSReport } from './ids-reporter.js';
+import type { EntityBoundsInput, IDSReportInput } from './ids-reporter.js';
 import type { BCFProject } from './types.js';
 
 const DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -390,5 +392,108 @@ describe('a plainly-exported archive validates entry by entry', () => {
       }
       expect(failures).toEqual([]);
     });
+  }
+});
+
+/**
+ * The other archive shape this package produces: `createBCFFromIDSReport`.
+ *
+ * `plainExport` above builds its viewpoints through `createViewpoint`, so it
+ * only ever exercises cameras the VIEWER captured. The IDS reporter builds
+ * viewpoints itself, from entity bounds, and that second path had its own
+ * 3.0 hole (#3849): the camera it computed carried no `AspectRatio`, which
+ * `visinfo.xsd` requires, so a 3.0 archive from an IDS report could not be
+ * written at all. Validating it here — against the same vendored schemas, in
+ * the same sweep — is what keeps the two paths honest about the same rules.
+ */
+describe('an IDS-derived archive validates entry by entry', () => {
+  const IDS_REPORT: IDSReportInput = {
+    title: 'Fire rating',
+    description: STRESS_TEXT,
+    specificationResults: [
+      {
+        specification: { name: 'Walls carry a fire rating', description: STRESS_TEXT },
+        status: 'fail',
+        applicableCount: 2,
+        passedCount: 0,
+        failedCount: 2,
+        entityResults: [
+          {
+            expressId: 100,
+            modelId: 'model-1',
+            entityType: 'IfcWall',
+            entityName: STRESS_TEXT,
+            globalId: '2O2Fr$t4X7Zf8NOew3FL01',
+            passed: false,
+            requirementResults: [
+              {
+                status: 'fail',
+                facetType: 'property',
+                checkedDescription: 'Pset_WallCommon.FireRating must exist',
+                failureReason: STRESS_TEXT,
+                expectedValue: 'REI 60',
+              },
+            ],
+          },
+          {
+            expressId: 200,
+            modelId: 'model-1',
+            entityType: 'IfcWall',
+            entityName: 'Curtain Wall',
+            globalId: '3P3Gs$u5Y8Ag9OPfx4GM02',
+            passed: false,
+            requirementResults: [
+              {
+                status: 'fail',
+                facetType: 'attribute',
+                checkedDescription: 'Description must be provided',
+                failureReason: 'Attribute Description is missing',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const IDS_BOUNDS = new Map<string, EntityBoundsInput>([
+    ['model-1:100', { min: { x: 0, y: 0, z: 0 }, max: { x: 4, y: 3, z: 0.2 } }],
+    ['model-1:200', { min: { x: 9, y: 0, z: 0 }, max: { x: 13, y: 3, z: 0.2 } }],
+  ]);
+
+  for (const version of ['2.1', '3.0'] as const) {
+    for (const topicGrouping of ['per-entity', 'per-specification', 'per-requirement'] as const) {
+      it(`BCF ${version} / ${topicGrouping}`, async () => {
+        const project = createBCFFromIDSReport(IDS_REPORT, {
+          version,
+          topicGrouping,
+          entityBounds: IDS_BOUNDS,
+        });
+        const entries = await entriesOf(project);
+
+        // Guard against a vacuous pass: no viewpoint entry means the camera
+        // rules this test exists for were never reached.
+        const kinds = [...entries.keys()].map((n) => n.replace(/^[^/]+\//, ''));
+        expect(kinds).toContain('bcf.version');
+        expect(kinds.filter((n) => n.endsWith('.bcfv')).length).toBeGreaterThan(0);
+
+        const failures: string[] = [];
+        for (const [name, xml] of entries) {
+          const xsd = SCHEMA_FOR_ENTRY.find(([re]) => re.test(name))![1];
+          const result = await validateXML({
+            xml: [{ fileName: 'subject.xml', contents: xml }],
+            schema: [schema(version, xsd)],
+            preload:
+              version === '3.0'
+                ? [{ fileName: 'shared-types.xsd', contents: schema('3.0', 'shared-types.xsd') }]
+                : [],
+          });
+          if (!result.valid) {
+            failures.push(`${name} [${xsd}]: ${result.errors.map((e) => e.message).join(' | ')}`);
+          }
+        }
+        expect(failures).toEqual([]);
+      });
+    }
   }
 });

--- a/packages/bcf/src/interop-conformance.test.ts
+++ b/packages/bcf/src/interop-conformance.test.ts
@@ -471,11 +471,18 @@ describe('an IDS-derived archive validates entry by entry', () => {
         });
         const entries = await entriesOf(project);
 
-        // Guard against a vacuous pass: no viewpoint entry means the camera
-        // rules this test exists for were never reached.
+        // Guard against a vacuous pass with the EXACT counts each grouping
+        // owes for this report -- one specification, two failing entities, one
+        // failing requirement each -- the way the plainExport arm above does.
+        // "At least one" is satisfied by an export that dropped a topic or its
+        // viewpoint, which is precisely how the camera rules under test would
+        // stop being reached.
+        const expectedTopics = topicGrouping === 'per-specification' ? 1 : 2;
         const kinds = [...entries.keys()].map((n) => n.replace(/^[^/]+\//, ''));
         expect(kinds).toContain('bcf.version');
-        expect(kinds.filter((n) => n.endsWith('.bcfv')).length).toBeGreaterThan(0);
+        expect(kinds).toContain('project.bcfp');
+        expect(kinds.filter((n) => n === 'markup.bcf')).toHaveLength(expectedTopics);
+        expect(kinds.filter((n) => n.endsWith('.bcfv'))).toHaveLength(expectedTopics);
 
         const failures: string[] = [];
         for (const [name, xml] of entries) {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -185,7 +185,7 @@
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
    413 apps/viewer/vite.config.ts
-   792 packages/bcf/src/ids-reporter.ts
+   788 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
    595 packages/bcf/src/viewpoint.ts


### PR DESCRIPTION
## Summary

Stacked on #3856 (base branch `fix/3612-bcf-interop`); retarget to main once that lands.

`createBCFFromIDSReport({ version: '3.0' })` produced topics the 3.0 writer refused: no camera without `entityBounds`, and no `AspectRatio` with them (#3849).

- New `packages/bcf/src/ids-camera.ts` holds the 3.0 camera policy: `computeCameraFromBounds(bounds, aspectRatio)` frames the box from a fixed isometric direction at a distance that keeps all eight corners inside the frustum for any ratio (the vertical field of view stays 60 degrees; the distance divides by the narrower half-angle, so a portrait ratio no longer crops a wide box). `aspectRatio` is a new `IDSBCFExportOptions` option, default 16/9 documented as the convention when no viewport exists, validated at the boundary (finite and positive, refused by name).
- Without bounds, or with bounds for only some of a group's entities, the call refuses before returning, naming the topic title and guid and saying 3.0 needs `entityBounds` keyed `modelId:expressId` or an explicit camera. 2.1 keeps its camera-less viewpoints. Per-specification grouping frames the union of its entities' bounds, all-or-nothing.
- The interop-conformance sweep gains an IDS-derived arm: both versions, all three groupings, every entry validated against the vendored XSDs, with exact entry counts per grouping.

Closes #3849

## Verification

- bcf 418 tests across 18 files, `pnpm typecheck`, `check-module-size` (ids-reporter.ts row ratcheted down 792 to 788): exit 0.
- RED first: 10 failing (7 camera-policy, 3 conformance arms). Mutation-checked: reverting the narrower-half-angle distance fails the 9/16 frustum test.
- Changeset: `@ifc-lite/bcf` patch.