### PR TITLE
chore(rust): drop the stale module-size row for tokenizer.rs

### DIFF
--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -17,7 +17,6 @@
      758 rust/core/src/georef.rs
      445 rust/core/src/model_bounds.rs
      601 rust/core/src/parser/scanner.rs
-     463 rust/core/src/parser/tokenizer.rs
 # +3: Arc<Vec<AttributeValue>> so DecodedEntity clone is a refcount bump not a deep attribute-tree clone (perf/decode-churn).
     553 rust/core/src/schema_gen.rs
 # schema_helpers.rs row removed: the merged upstream #1969 split its tests into

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -57,7 +57,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// would rewrite the digest and fail CI for no reason.
 const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
-    ("rust/core", 13402756985857706732),
+    ("rust/core", 7194159970789730787),
     ("rust/export", 15791359419451037914),
     ("rust/geometry", 5850574697340138616),
     ("rust/processing", 7633784028779437211),


### PR DESCRIPTION
## Summary

The Rust module-size ratchet prints an advisory that `rust/core/src/parser/tokenizer.rs` is 308 lines (under 400) and its allowlist row should be removed. This removes the row and re-pins the `rust/core` digest in `module_size_ratchet.rs` as the test's own failure message directs.

## Verification

- `cargo test -p ifc-lite-processing --test module_size_ratchet`: 6/6 pass, no advisory note.
- `cargo clippy -p ifc-lite-processing --all-targets -- -D warnings`: clean.
- Diff touches only the allowlist row and the digest pin.