### PR TITLE
feat(geometry): the watertightness census reads enclosed volume, so an over-cut on a closed host needs a bless

### DIFF
--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -740,10 +740,21 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
                 std::cmp::Ordering::Greater => {
                     c.volume_moved.push(format!("{msg} (fewer triangles, more enclosed volume)"))
                 }
-                std::cmp::Ordering::Equal => c
+                // ZERO is not a volume that can be unchanged. A watertight
+                // host reading 0 cm³ is a sheet, a doubled surface or a pair
+                // of cancelling shells — the signed balance certifies it and
+                // the divergence sum has nothing to say — so a triangle drop
+                // there carries exactly as much information as it did before
+                // this column existed, which is the `worse_counts` verdict.
+                // Without this guard a doubled sheet that loses half its
+                // triangles reads "enclosed volume unchanged" and files as a
+                // friendly re-tessellation.
+                std::cmp::Ordering::Equal if a != 0 => c
                     .retessellated
                     .push(format!("{msg} (fewer triangles, enclosed volume unchanged)")),
-                std::cmp::Ordering::Less => c.worse_counts.push(format!("{msg} (geometry lost)")),
+                std::cmp::Ordering::Equal | std::cmp::Ordering::Less => {
+                    c.worse_counts.push(format!("{msg} (geometry lost)"))
+                }
             },
             None if r.open < g.open && g.open_is_comparable() && r.open_is_comparable() => {
                 c.retessellated.push(format!("{msg} (fewer triangles, less torn)"))

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -386,7 +386,10 @@ pub struct Diff {
     /// reading a triangle count as damage. The volume dimension cannot reach
     /// it either: `vol` is not taken on a torn host (see [`HostRow::vol`]).
     /// What would close it is the tear being fixed, at which point the host
-    /// gains a reading.
+    /// gains a reading. The gap is pinned as a KNOWN GAP, asserting the
+    /// wrong-but-current verdict, by
+    /// `a_torn_host_that_loses_half_its_mesh_is_still_called_a_re_tessellation`
+    /// below, which also names the #3219 population it applies to.
     pub retessellated: Vec<Delta>,
     /// Enclosed volume differs between two WATERTIGHT readings of the same host
     /// (#3422), and nothing outranked it. Requires a bless, is never a
@@ -405,6 +408,20 @@ pub struct Diff {
     /// `improved`; before this bucket the census read both as green. See
     /// `an_over_cut_on_a_watertight_host_requires_a_bless`
     /// in `triangulation_invariance.rs` for the measurement.
+    ///
+    /// What it does NOT catch, stated here so a reader landing on the bucket
+    /// does not over-read it:
+    ///
+    /// - The SAME over-cut on a TORN host. There is no reading on either side,
+    ///   so the pair is decided by the pre-#3422 rules and the
+    ///   [`Diff::retessellated`] over-fire is untouched. That is not a corner:
+    ///   all 32 hosts the candidate #3219 fix moves are torn. Pinned as a known
+    ///   gap by
+    ///   `a_torn_host_that_loses_half_its_mesh_is_still_called_a_re_tessellation`.
+    /// - The DEFECT THAT IS ALREADY THERE. A host over-cut on main today is
+    ///   blessed at its over-cut volume, the same way every other column blessed
+    ///   the state it found. This bucket makes the NEXT move in either direction
+    ///   cost a bless; it says nothing about whether today's number is right.
     pub volume_moved: Vec<Delta>,
     /// Strictly better. Reported, never a failure.
     ///
@@ -1790,6 +1807,65 @@ mod tests {
         let d = diff(std::slice::from_ref(&g), &[row("a.ifc", 1, 0, 600)], &swept(&["a.ifc"]));
         assert!(d.volume_moved.is_empty(), "one reading is not a comparison");
         assert_eq!(d.changed.len(), 1);
+    }
+
+    /// KNOWN GAP (#3422). The volume dimension does NOT close the
+    /// `Diff::retessellated` over-fire on a TORN host, and this test asserts
+    /// the wrong-but-known verdict rather than the right one, so that the day
+    /// it is fixed this test fails and has to be rewritten deliberately.
+    ///
+    /// The population is not hypothetical. Running the candidate #3219 cap fix
+    /// through the census moves 32 hosts, 23 regressed and 9 re-tessellated,
+    /// and EVERY one of the 32 is torn, with open counts from 11 to 1125. Not
+    /// one watertight host is among them. That is the exact population the
+    /// #3219 bless has to judge, and `vol` is deliberately not taken there, for
+    /// the reason [`HostRow::vol`] gives: on an open surface the divergence sum
+    /// is not a volume, so two readings compared say nothing about material.
+    /// #3422's own framing of this ("translation-variant, changing if the model
+    /// moved") does not hold against
+    /// `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh` in
+    /// `kernel/mesh_volume.rs`, which pins an OPEN reading stable across a
+    /// 10 km offset because the sum is AABB-centred. The conclusion is the same
+    /// and the reason is not, so the reason is corrected here rather than
+    /// inherited.
+    ///
+    /// What the gap costs, concretely: a host that loses HALF its mesh while
+    /// its tearing improves is filed as a re-tessellation and described as
+    /// "less torn". That is a bless-requiring bucket, so the event is not
+    /// silent, but it is misdescribed, and the exposure is a wrong bless by a
+    /// reviewer reading "less torn" and approving it.
+    ///
+    /// Closing it needs the tear fixed, at which point the host gains a
+    /// reading. Do NOT close it with a proportionality heuristic on `tris`:
+    /// that is a second magnitude rule on a vocabulary with no magnitude in it,
+    /// which is the mistake `Diff::retessellated` already documents.
+    #[test]
+    fn a_torn_host_that_loses_half_its_mesh_is_still_called_a_re_tessellation() {
+        let g = row("a.ifc", 1, 40, 800);
+        assert_eq!(g.vol, None, "torn, so there is no volume to adjudicate with");
+        let halved = row("a.ifc", 1, 2, 400);
+        assert_eq!(halved.vol, None, "still torn on the run side, so still no reading");
+
+        let d = diff(std::slice::from_ref(&g), &[halved], &swept(&["a.ifc"]));
+        // The WRONG verdict, pinned as the current behaviour. Half the mesh is
+        // gone; the census says the host got less torn.
+        assert_eq!(d.regressed.len(), 0, "KNOWN GAP #3422: this SHOULD be a regression");
+        assert_eq!(d.retessellated.len(), 1, "and is filed as a re-tessellation instead");
+        assert!(d.volume_moved.is_empty(), "no volume on either side, so nothing to compare");
+        let reasons = d.retessellated[0].reasons.join("; ");
+        assert!(reasons.contains("triangles 800 -> 400 (fewer triangles, less torn)"), "{reasons}");
+        // The one thing that is right about it: it is not GREEN. A reviewer is
+        // asked, with the wrong description.
+        assert!(d.requires_bless(), "the misdescribed event must at least require a bless");
+
+        // The same shrink on a WATERTIGHT host IS caught, which is what the
+        // column bought and what makes the gap a population boundary rather
+        // than a hole in the rule. Same 800 -> 400, volume falls with it.
+        let wg = row("a.ifc", 1, 0, 800);
+        let wr = HostRow { tris: 400, vol: Some(27_000), ..wg.clone() };
+        let d = diff(std::slice::from_ref(&wg), &[wr], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "watertight, so the volume says material left");
+        assert!(d.regressed[0].reasons.join("; ").contains("geometry lost"));
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -929,7 +929,46 @@ pub fn render(rows: &[HostRow]) -> String {
     out
 }
 
-pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
+/// Why a golden could not be read. TWO classes, because a bless treats them
+/// differently and treating them alike loses rows silently (#3422).
+///
+/// [`ParseError::Schema`] is the file a column-adding change leaves on disk:
+/// every row is intact under the OLD schema and short of the new column. Its
+/// rows cannot be reused without inventing that column, so a bless discards
+/// them deliberately and says so. That is the sanctioned path.
+///
+/// [`ParseError::Malformed`] is anything else — a bad number, an unreadable
+/// flag, a truncated write, a merge that mangled one line. It is NOT a
+/// sanctioned bless input, and a bless must not treat it as an empty golden.
+/// The heavy lane is where that distinction has teeth: its two fixtures share
+/// one file and each blesses only its own model's rows, so a bless of
+/// ISSUE_053 against a file with one corrupt ISSUE_068 row would, under a
+/// single error class, silently drop all 363 of that model's rows and write a
+/// golden missing them. The next heavy run would then read them as 363
+/// `added` hosts and demand another bless, and the tear pin would be gone.
+#[derive(Debug)]
+pub enum ParseError {
+    /// A row has the wrong number of columns. Carries the line so a stale
+    /// golden names the schema it is on.
+    Schema { line: usize, expected: usize, got: usize },
+    /// A field the schema DOES have could not be read.
+    Malformed(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Wording preserved from when this was a bare String, because
+            // `read_golden`'s bless line and three tests match on it.
+            Self::Schema { line, expected, got } => {
+                write!(f, "line {line}: expected {expected} columns, got {got}")
+            }
+            Self::Malformed(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+pub fn parse(text: &str) -> Result<Vec<HostRow>, ParseError> {
     let mut out = Vec::new();
     for (n, line) in text.lines().enumerate() {
         // Skip comments, the column header and blank lines. `model\t` catches
@@ -944,30 +983,29 @@ pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
         // host that was never measured. A bad merge of this golden is then loud
         // instead of silently under-gated.
         if f.len() != 11 {
-            return Err(format!("line {}: expected 11 columns, got {}", n + 1, f.len()));
+            return Err(ParseError::Schema { line: n + 1, expected: 11, got: f.len() });
         }
-        let num = |i: usize| -> Result<usize, String> {
-            f[i].parse::<usize>().map_err(|_| format!("line {}: bad number {:?}", n + 1, f[i]))
+        // Every failure below is a field the schema HAS that could not be
+        // read, so all of them are `Malformed` and none is a bless input.
+        let bad = |m: String| ParseError::Malformed(format!("line {}: {m}", n + 1));
+        let num = |i: usize| -> Result<usize, ParseError> {
+            f[i].parse::<usize>().map_err(|_| bad(format!("bad number {:?}", f[i])))
         };
         out.push(HostRow {
             model: f[0].to_string(),
-            id: f[1].parse().map_err(|_| format!("line {}: bad id {:?}", n + 1, f[1]))?,
+            id: f[1].parse().map_err(|_| bad(format!("bad id {:?}", f[1])))?,
             rep: f[2].to_string(),
             open: num(3)?,
             tris: num(4)?,
-            collapsed: parse_flag(f[5]).map_err(|e| format!("line {}: {e}", n + 1))?,
-            far: parse_flag(f[6]).map_err(|e| format!("line {}: {e}", n + 1))?,
+            collapsed: parse_flag(f[5]).map_err(bad)?,
+            far: parse_flag(f[6]).map_err(bad)?,
             alt: if f[7] == "x" { None } else { Some(num(7)?) },
-            pre: parse_pre(f[8]).map_err(|e| format!("line {}: {e}", n + 1))?,
+            pre: parse_pre(f[8]).map_err(bad)?,
             strict: num(9)?,
             vol: if f[10] == "-" {
                 None
             } else {
-                Some(
-                    f[10]
-                        .parse::<i64>()
-                        .map_err(|_| format!("line {}: bad volume {:?}", n + 1, f[10]))?,
-                )
+                Some(f[10].parse::<i64>().map_err(|_| bad(format!("bad volume {:?}", f[10])))?)
             },
         });
     }
@@ -2438,27 +2476,46 @@ mod tests {
     #[test]
     fn a_truncated_row_is_an_error_not_a_silently_short_golden() {
         let header = "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\tvol\n";
-        let err = parse(&format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"))
-            .expect_err("a 7-column row must not parse");
-        assert!(err.contains("expected 11 columns"), "{err}");
-
+        // Matched on the VARIANT, not on the message. The two classes are what
+        // `read_golden` branches on in bless mode (#3422), so a test that only
+        // read the text would stay green if a row-shape failure started
+        // reporting as `Malformed` — which would make a column-adding bless
+        // fatal — or, far worse, if a corrupt field started reporting as
+        // `Schema`, which is the arm a bless treats as an empty golden.
+        let short = |text: String, what: &str| match parse(&text) {
+            Err(ParseError::Schema { expected, got, .. }) => {
+                assert_eq!(expected, 11, "{what}");
+                got
+            }
+            other => panic!("{what} must be a Schema error, got {other:?}"),
+        };
+        assert_eq!(short(format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"), "a 7-column row"), 7);
         // And a COMPLETE pre-#3397 or pre-#3422 row is a truncation too, not a
         // row with an implied strict count or volume. Defaulting either would
         // fabricate a clean-looking host for every line of a stale golden,
         // which is the one way a column could go dark across the whole corpus
         // at once.
-        let old = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"))
-            .expect_err("a 9-column pre-#3397 row must not parse");
-        assert!(old.contains("expected 11 columns"), "{old}");
-        let ten = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n"))
-            .expect_err("a 10-column pre-#3422 row must not parse");
-        assert!(ten.contains("expected 11 columns"), "{ten}");
+        assert_eq!(
+            short(format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"), "a pre-#3397 row"),
+            9
+        );
+        assert_eq!(
+            short(
+                format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n"),
+                "a pre-#3422 row"
+            ),
+            10
+        );
 
-        // A volume token that is neither `-` nor an integer is a bad row, not
-        // a missing reading.
+        // A volume token that is neither `-` nor an integer is a CORRUPT row,
+        // not a missing reading and not an older schema: the column is there
+        // and unreadable. `Malformed` is what keeps a bless from swallowing it.
         let bad = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t1.5\n"))
             .expect_err("a float volume must not parse");
-        assert!(bad.contains("bad volume"), "{bad}");
+        assert!(
+            matches!(bad, ParseError::Malformed(ref m) if m.contains("bad volume")),
+            "{bad:?}"
+        );
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -583,6 +583,53 @@ fn fall_note(g: &HostRow, r: &HostRow) -> &'static str {
     }
 }
 
+/// How far two readings of the same host may differ before the difference is a
+/// real move (#3422). Whichever is larger of 1 cm³ and 1e-6 of the golden's
+/// magnitude.
+///
+/// WHY A TOLERANCE AT ALL, given the column exists to compare exactly. The
+/// reading is a divergence sum over f32 positions that `mesh_to_tris` has
+/// already snapped to the kernel's 1/65536 m grid. That snap normally swallows
+/// the whole difference between one platform's fused multiply-add and
+/// another's: two builds of the same mesh land on the same grid points and so
+/// on the same integer. It swallows it EXCEPT on a boundary, where two
+/// coordinates a hair either side of a grid step round opposite ways and one
+/// vertex moves 15.26 µm. The goldens in this repo are blessed on arm64 and the
+/// census lane runs on x86_64, so a single such vertex is enough to red the
+/// lane on a change that touched no geometry.
+///
+/// WHY THESE TWO TERMS. The absolute one covers a small host, where 1e-6 of the
+/// magnitude is under the cm³ quantum and would be no tolerance at all. The
+/// relative one covers a large host, where a handful of boundary vertices can
+/// move more than a single cm³: at the corpus's largest readings (a few million
+/// cm³) it is a few cm³, still far under one grid step's worth of a real face.
+///
+/// WHAT IT DOES NOT COST. Every move this column exists to catch is orders of
+/// magnitude above it: the 1.4x over-cut fixture moves 50000 cm³ against a
+/// tolerance of 1. A tolerance that admitted a real over-cut would have to be
+/// four decades wider than this one.
+fn volume_tolerance_cm3(golden: i64) -> i64 {
+    ((golden.unsigned_abs() as f64) * 1.0e-6).ceil().max(1.0) as i64
+}
+
+/// Did the reading move, beyond [`volume_tolerance_cm3`]? SIGNED, so a winding
+/// flip at equal magnitude is still a move.
+fn volume_reading_moved(from: i64, to: i64) -> bool {
+    to.saturating_sub(from).saturating_abs() > volume_tolerance_cm3(from)
+}
+
+/// Which way the MAGNITUDE moved, under the same tolerance. `Equal` means "the
+/// same volume as far as this reading can tell", which is what the
+/// re-tessellation verdict below rests on.
+fn volume_magnitude_cmp(from: i64, to: i64) -> std::cmp::Ordering {
+    let (a, b) = (from.abs(), to.abs());
+    if !volume_reading_moved(a, b) {
+        std::cmp::Ordering::Equal
+    } else {
+        b.cmp(&a)
+    }
+}
+
 /// How a volume reading moved, as a percentage of the golden's MAGNITUDE.
 /// From zero there is no percentage to give, so it says so instead of
 /// dividing by it.
@@ -670,7 +717,7 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
     // which is what "more" and "less" mean below.
     let vol = g.vol.zip(r.vol);
     if let Some((a, b)) = vol {
-        if a != b {
+        if volume_reading_moved(a, b) {
             c.volume_moved.push(format!(
                 "enclosed volume {a} -> {b} cm³ ({}){}",
                 volume_delta(a, b),
@@ -687,14 +734,17 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
         // and the volume says whether material left with the triangles; where
         // one side is torn, an open count that fell is the repair reading.
         // Everything else is loss.
-        match vol.map(|(a, b)| (a.abs(), b.abs())) {
+        match vol {
             _ if r.tris == 0 => c.worse_counts.push(format!("{msg} (geometry lost)")),
-            Some((a, b)) if b > a => {
-                c.volume_moved.push(format!("{msg} (fewer triangles, more enclosed volume)"))
-            }
-            Some((a, b)) if b == a => {
-                c.retessellated.push(format!("{msg} (fewer triangles, enclosed volume unchanged)"))
-            }
+            Some((a, b)) => match volume_magnitude_cmp(a, b) {
+                std::cmp::Ordering::Greater => {
+                    c.volume_moved.push(format!("{msg} (fewer triangles, more enclosed volume)"))
+                }
+                std::cmp::Ordering::Equal => c
+                    .retessellated
+                    .push(format!("{msg} (fewer triangles, enclosed volume unchanged)")),
+                std::cmp::Ordering::Less => c.worse_counts.push(format!("{msg} (geometry lost)")),
+            },
             None if r.open < g.open && g.open_is_comparable() && r.open_is_comparable() => {
                 c.retessellated.push(format!("{msg} (fewer triangles, less torn)"))
             }
@@ -1928,6 +1978,52 @@ mod tests {
         let d = diff(std::slice::from_ref(&g), &[collapsed], &swept(&["a.ifc"]));
         assert_eq!(d.regressed.len(), 1, "a gained collapse outranks the volume");
         assert!(d.regressed[0].reasons.join("; ").contains("enclosed volume 55000 -> 47200"));
+    }
+
+    #[test]
+    fn a_reading_that_moves_by_less_than_the_platform_noise_is_not_a_move() {
+        // #3422. The goldens are blessed on arm64 and the census lane runs on
+        // x86_64. The 1/65536 m snap normally makes the two agree exactly, but
+        // a vertex sitting on a grid boundary can round the other way and move
+        // 15.26 µm, which is a real cm³ or two on a large host and no defect at
+        // all. Bounded by `volume_tolerance_cm3`: 1 cm³, or 1e-6 of the
+        // golden's magnitude, whichever is larger.
+        let all = swept(&["a.ifc"]);
+
+        // The boundary, both sides of it, on a small host where the absolute
+        // term rules: tolerance 1.
+        let g = HostRow { vol: Some(55_000), ..row("a.ifc", 1, 0, 800) };
+        assert_eq!(volume_tolerance_cm3(55_000), 1);
+        let d = diff(std::slice::from_ref(&g), &[HostRow { vol: Some(55_001), ..g.clone() }], &all);
+        assert!(d.volume_moved.is_empty(), "1 cm³ is inside the noise floor");
+        assert!(!d.requires_bless(), "and must not cost a bless");
+        let d = diff(std::slice::from_ref(&g), &[HostRow { vol: Some(55_002), ..g.clone() }], &all);
+        assert_eq!(d.volume_moved.len(), 1, "2 cm³ is outside it");
+
+        // And on a large host, where the relative term rules: 3 000 000 cm³
+        // gives a tolerance of 3.
+        let big = HostRow { vol: Some(3_000_000), ..row("a.ifc", 1, 0, 800) };
+        assert_eq!(volume_tolerance_cm3(3_000_000), 3);
+        let more = HostRow { vol: Some(3_000_003), ..big.clone() };
+        let d = diff(std::slice::from_ref(&big), &[more], &all);
+        assert!(d.volume_moved.is_empty(), "3 cm³ of 3 m³ is inside the noise floor");
+        let more = HostRow { vol: Some(3_000_004), ..big.clone() };
+        let d = diff(std::slice::from_ref(&big), &[more], &all);
+        assert_eq!(d.volume_moved.len(), 1, "4 cm³ of 3 m³ is outside it");
+
+        // The same tolerance decides the ROUTING of a triangle drop, not only
+        // whether the move is reported. A watertight shrink whose volume held
+        // to within the noise floor is a re-tessellation, and would otherwise
+        // be called geometry lost by a platform difference.
+        let shrank = HostRow { tris: 600, vol: Some(54_999), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[shrank], &all);
+        assert!(d.regressed.is_empty(), "1 cm³ of drift must not read as geometry lost");
+        assert_eq!(d.retessellated.len(), 1);
+        assert!(d.retessellated[0].reasons.join("; ").contains("enclosed volume unchanged"));
+
+        // What the tolerance costs, stated as a measurement: nothing this
+        // column exists to catch. The over-cut fixture moves 50 000 cm³.
+        assert!(volume_tolerance_cm3(550_000) < 50, "the tolerance must stay negligible");
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -630,6 +630,25 @@ fn volume_magnitude_cmp(from: i64, to: i64) -> std::cmp::Ordering {
     }
 }
 
+/// The winding, said out loud (#3422). `vol` is SIGNED because IFC winding is
+/// not reliably outward and the sweep does not orient the host, so a negative
+/// reading is an inward-wound solid and not a negative volume.
+///
+/// Without this the only cue is a minus sign inside a number, and the two
+/// readings a reviewer most needs to tell apart look nearly identical in a
+/// bucket listing: `55000 -> -55000` is the SAME solid re-wound, a topological
+/// change with no material moved, while `55000 -> -47200` is a re-winding AND
+/// an over-cut. The percentage cannot say it either, since it is taken on the
+/// magnitude.
+fn winding_note(from: i64, to: i64) -> &'static str {
+    match (from < 0, to < 0) {
+        (false, true) => "; WINDING INVERTED (the host is now inward-wound)",
+        (true, false) => "; winding righted (the host is now outward-wound)",
+        (true, true) => "; both readings negative, so the host is inward-wound throughout",
+        (false, false) => "",
+    }
+}
+
 /// How a volume reading moved, as a percentage of the golden's MAGNITUDE.
 /// From zero there is no percentage to give, so it says so instead of
 /// dividing by it.
@@ -719,8 +738,9 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
     if let Some((a, b)) = vol {
         if volume_reading_moved(a, b) {
             c.volume_moved.push(format!(
-                "enclosed volume {a} -> {b} cm³ ({}){}",
+                "enclosed volume {a} -> {b} cm³ ({}){}{}",
                 volume_delta(a, b),
+                winding_note(a, b),
                 if g.far || r.far { "; far-field, so the reading is f32-quantized" } else { "" }
             ));
         }
@@ -2035,6 +2055,50 @@ mod tests {
         // What the tolerance costs, stated as a measurement: nothing this
         // column exists to catch. The over-cut fixture moves 50 000 cm³.
         assert!(volume_tolerance_cm3(550_000) < 50, "the tolerance must stay negligible");
+    }
+
+    #[test]
+    fn a_negative_reading_says_the_winding_is_inverted() {
+        // #3422. `vol` is signed because IFC winding is not reliably outward,
+        // so a negative reading is an inward-wound solid, not a negative
+        // volume. A minus sign inside a number is not a legible cue for that
+        // in a bucket listing, and the two readings a reviewer most needs to
+        // separate look nearly alike without one.
+        let all = swept(&["a.ifc"]);
+        let g = row("a.ifc", 1, 0, 800); // vol Some(55_000)
+
+        // The same solid, re-wound: no material moved at all.
+        let flipped = HostRow { vol: Some(-55_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[flipped], &all);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("55000 -> -55000"), "{reasons}");
+        assert!(reasons.contains("WINDING INVERTED"), "{reasons}");
+        // And the percentage still reads on the magnitude, which is 0%: the
+        // two cues together are what say "re-wound, nothing removed".
+        assert!(reasons.contains("(+0.00%)"), "{reasons}");
+
+        // Re-wound AND over-cut: the pair the cue exists to separate from the
+        // one above. Same sign change, a real magnitude drop with it.
+        let both = HostRow { vol: Some(-47_200), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[both], &all);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("WINDING INVERTED"), "{reasons}");
+        assert!(reasons.contains("(-14.18%)"), "{reasons}");
+
+        // Coming back the other way is not alarming, and does not shout.
+        let inward = HostRow { vol: Some(-55_000), ..row("a.ifc", 1, 0, 800) };
+        let d = diff(std::slice::from_ref(&inward), std::slice::from_ref(&g), &all);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("winding righted"), "{reasons}");
+        assert!(!reasons.contains("INVERTED"), "{reasons}");
+
+        // A host inward-wound on BOTH sides says so once, rather than reading
+        // as a flip on every row of a model that is wound that way throughout.
+        let deeper = HostRow { vol: Some(-47_200), ..inward.clone() };
+        let d = diff(std::slice::from_ref(&inward), &[deeper], &all);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("inward-wound throughout"), "{reasons}");
+        assert!(!reasons.contains("INVERTED"), "{reasons}");
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -916,11 +916,14 @@ pub fn diff(golden: &[HostRow], run: &[HostRow], swept_models: &BTreeSet<String>
         // re-tessellation. Under, because both are "review, then re-bless"
         // verdicts and a relabel changes what the volume is a volume OF; above,
         // because a shrink at unchanged volume is the friendly reading and a
-        // shrink with the volume moving is not. The two lists are exclusive by
-        // construction today — `retessellated` fires on a torn host, where
-        // there is no volume, or on a watertight one at EQUAL volume — but the
-        // order is still stated so that adding a route does not decide it by
-        // accident.
+        // shrink with the volume moving is not. The two lists are NOT
+        // exclusive, and the order is what decides between them: a SIGN FLIP at
+        // equal magnitude fills both, since `volume_moved` is read on the
+        // signed integer and the shrink's routing on the magnitude, so
+        // `55000 -> -55000` with fewer triangles is "winding inverted" AND
+        // "enclosed volume unchanged". Filing it as a volume move is the right
+        // answer — the re-winding is the bigger news — and the re-tessellation
+        // reason rides along in the same text.
         if !c.worse_counts.is_empty() {
             out.regressed.push(delta(
                 [
@@ -2505,6 +2508,13 @@ mod tests {
         let mut retessellated = 0usize;
         let mut improved = 0usize;
         let mut unchanged = 0usize;
+        // The expected bucket counts when exactly bucket `i` fired. Captures
+        // nothing, so it is built once rather than per pair.
+        let only = |i: usize| {
+            let mut e = [0usize; 5];
+            e[i] = 1;
+            e
+        };
         for g in &vs {
             for r in &vs {
                 let c = classify(g, r);
@@ -2521,11 +2531,6 @@ mod tests {
                     d.retessellated.len(),
                     d.improved.len(),
                 ];
-                let only = |i: usize| {
-                    let mut e = [0usize; 5];
-                    e[i] = 1;
-                    e
-                };
                 assert!(d.added.is_empty() && d.missing.is_empty(), "{g:?} -> {r:?}");
                 if !c.worse_counts.is_empty() {
                     assert_eq!(got, only(0), "a worsened count must regress: {g:?} -> {r:?}");

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -635,11 +635,32 @@ fn fall_note(g: &HostRow, r: &HostRow) -> &'static str {
 /// move more than a single cm³: at the corpus's largest readings (a few million
 /// cm³) it is a few cm³, still far under one grid step's worth of a real face.
 ///
+/// AND IT DOES NOT COVER ONE FLIPPED VERTEX, which the paragraph above is
+/// wrong about and this one corrects (raised in review, then measured). The
+/// shift from moving one vertex by one grid step is the incident triangle area
+/// times the step over three, so it grows with the FACE, not with the host's
+/// volume, and the 1e-6 relative term does not track it. Measured on this PR's
+/// own over-cut fixture — a 2.0 x 0.1 x 3.0 m panel reading 550034 cm³, 108
+/// vertices, each nudged one step on each axis in turn — the worst single
+/// vertex moves the reading by 8 cm³ against a tolerance of 1. (A UNIFORM
+/// one-step shift of every vertex moves it by 0: a grid-aligned translation is
+/// exact, so only INDEPENDENT re-rounding costs anything.)
+///
+/// So the tolerance is not sized for the platform difference its first
+/// paragraph invokes, and if arm64 and x86_64 do disagree on a boundary vertex
+/// this column reds the census lane rather than absorbing it. That is left
+/// as-is deliberately: widening the gate to a measured worst case would have to
+/// be roughly two decades wider, and a gate that is too NARROW fails loudly on
+/// a run a reviewer can look at, while one that is too WIDE fails silently on
+/// the small real moves the column exists to catch. It has never been observed
+/// to fire — these goldens have not yet been read back on x86_64 at all — so
+/// the first CI run is the measurement, not this doc.
+///
 /// WHAT IT DOES NOT COST. Every move this column exists to catch is orders of
 /// magnitude above it: the 1.4x over-cut fixture moves 50000 cm³ against a
 /// tolerance of 1. A tolerance that admitted a real over-cut would have to be
 /// four decades wider than this one.
-fn volume_tolerance_cm3(golden: i64) -> i64 {
+pub fn volume_tolerance_cm3(golden: i64) -> i64 {
     ((golden.unsigned_abs() as f64) * 1.0e-6).ceil().max(1.0) as i64
 }
 
@@ -725,9 +746,32 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
         ));
     }
 
+    // The one magnitude in the row (#3422). Read where BOTH sides are
+    // watertight, which is the only place either side has it, and reported
+    // whichever way it moved: see `Diff::volume_moved` for why neither
+    // direction is a verdict. Compared on the SIGNED integer, so a sign flip at
+    // equal magnitude is still a difference, and described on the magnitude,
+    // which is what "more" and "less" mean below.
+    let vol = g.vol.zip(r.vol);
+    if let Some((a, b)) = vol {
+        if volume_reading_moved(a, b) {
+            c.volume_moved.push(format!(
+                "enclosed volume {a} -> {b} cm³ ({}){}{}",
+                volume_delta(a, b),
+                winding_note(a, b),
+                if g.far || r.far { "; far-field, so the reading is f32-quantized" } else { "" }
+            ));
+        }
+    }
+
     // Triangles shrinking is the loss direction ONLY when the tearing did not
     // improve with it. An empty mesh is always a loss: it still returns `Ok` and
     // still reports `open == 0`, so nothing else here would catch it.
+    //
+    // Everything from here to the `if r.tris < g.tris` below describes the TORN
+    // route, the `None` arm of the match: where neither side carries a volume,
+    // the open counts are all there is and the paragraphs below are the rules
+    // for reading them. A watertight pair never reaches any of it.
     //
     // And only where both open counts are COMPARABLE, because `g.open` and
     // `r.open` only read as repair if each one measures the same kind of thing.
@@ -759,24 +803,18 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
     // Carrying the degenerate COUNT instead of a flag would
     // let the axis fire on an increase and is the better fix, but it changes the
     // golden's schema and so needs its own re-bless.
-    // The one magnitude in the row (#3422). Read where BOTH sides are
-    // watertight, which is the only place either side has it, and reported
-    // whichever way it moved: see `Diff::volume_moved` for why neither
-    // direction is a verdict. Compared on the SIGNED integer, so a sign flip at
-    // equal magnitude is still a difference, and described on the magnitude,
-    // which is what "more" and "less" mean below.
-    let vol = g.vol.zip(r.vol);
-    if let Some((a, b)) = vol {
-        if volume_reading_moved(a, b) {
-            c.volume_moved.push(format!(
-                "enclosed volume {a} -> {b} cm³ ({}){}{}",
-                volume_delta(a, b),
-                winding_note(a, b),
-                if g.far || r.far { "; far-field, so the reading is f32-quantized" } else { "" }
-            ));
-        }
-    }
-
+    //
+    // #3422 LOOSENED that collapse guard on the watertight route, deliberately
+    // and without a comment until now. A host `coll=1` on BOTH sides that
+    // shrinks at `open 0 -> 0` used to be geometry lost, because
+    // `open_is_comparable` is false on a collapse and the old chain fell
+    // through; it now files as a re-tessellation, because the volume arm never
+    // asks. That is the right adjudicator on this route — `edge_stats` skips
+    // degenerate triangles, so they enclose nothing and cannot move the
+    // divergence sum — but it IS a change in verdict for the rows that are
+    // watertight AND collapsed (16 of 1005 in the default golden, 11 of 624 in
+    // the heavy one, counted at this commit), and it is a change the volume,
+    // not the collapse flag, is now answering for.
     if r.tris < g.tris {
         let msg = format!("triangles {} -> {}", g.tris, r.tris);
         // A vanished mesh is always a loss, whatever else moved: it still
@@ -881,9 +919,15 @@ pub fn diff(golden: &[HostRow], run: &[HostRow], swept_models: &BTreeSet<String>
         // alternate triangulator: the divergence decides (regressed), but
         // dropping the shrink from the text makes the failure less informative
         // than it was before the retessellated split existed. A gained COLLAPSE
-        // is not the example any more, because `r.collapsed` now disqualifies
-        // the re-tessellation outright, so that pair cannot occur. `better` rides
-        // along for the same reason and not as good
+        // is the example again since #3422. It stopped being one while the only
+        // route into `c.retessellated` ran through `open_is_comparable`, which
+        // `r.collapsed` disqualifies; the watertight arm added below routes on
+        // the VOLUME and never consults it, so `open 0 -> 0` with fewer
+        // triangles at unchanged volume fills `worse_counts` ("gained
+        // snap-collapsed triangles") and `c.retessellated` at the same time.
+        // The verdict is unaffected — a worsened count outranks — but the
+        // shrink reason has to ride along, which is what this paragraph is
+        // about. `better` rides along for the same reason and not as good
         // news: the shrink reason SAYS "less torn", and the open-edge numbers
         // are the only thing in the output that lets a reviewer check it.
         //

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -1013,10 +1013,12 @@ pub fn render(rows: &[HostRow]) -> String {
 /// Why a golden could not be read. TWO classes, because a bless treats them
 /// differently and treating them alike loses rows silently (#3422).
 ///
-/// [`ParseError::Schema`] is the file a column-adding change leaves on disk:
-/// every row is intact under the OLD schema and short of the new column. Its
-/// rows cannot be reused without inventing that column, so a bless discards
-/// them deliberately and says so. That is the sanctioned path.
+/// [`ParseError::Schema`] is the file a column-adding change leaves on disk,
+/// POSITIVELY identified rather than assumed from any row-shape failure: EVERY
+/// data row exactly one column short, which is the only shape such a change
+/// produces. Those rows are intact under the OLD schema and cannot be reused
+/// without inventing the new column, so a bless discards them deliberately and
+/// says so. That is the sanctioned path.
 ///
 /// [`ParseError::Malformed`] is anything else — a bad number, an unreadable
 /// flag, a truncated write, a merge that mangled one line. It is NOT a
@@ -1029,8 +1031,9 @@ pub fn render(rows: &[HostRow]) -> String {
 /// `added` hosts and demand another bless, and the tear pin would be gone.
 #[derive(Debug)]
 pub enum ParseError {
-    /// A row has the wrong number of columns. Carries the line so a stale
-    /// golden names the schema it is on.
+    /// EVERY data row is exactly one column short. Carries the first such line
+    /// so a stale golden names the schema it is on. An arbitrary wrong column
+    /// count is [`Self::Malformed`], not this.
     Schema { line: usize, expected: usize, got: usize },
     /// A field the schema DOES have could not be read.
     Malformed(String),
@@ -1049,26 +1052,51 @@ impl std::fmt::Display for ParseError {
     }
 }
 
+/// Columns a current row has. A pre-#3397 nine-column or pre-#3422 ten-column
+/// row is an ERROR, not a row with an implied strict count or volume: accepting
+/// one would have to invent the missing value, and a fabricated value is a
+/// clean-looking host that was never measured.
+pub const COLUMNS: usize = 11;
+
 pub fn parse(text: &str) -> Result<Vec<HostRow>, ParseError> {
-    let mut out = Vec::new();
-    for (n, line) in text.lines().enumerate() {
-        // Skip comments, the column header and blank lines. `model\t` catches
-        // the header without also swallowing a fixture literally named "model".
-        if line.is_empty() || line.starts_with('#') || line.starts_with("model\t") {
-            continue;
+    // Data rows, paired with their 1-based line number. Comments, blank lines
+    // and the column header are skipped; `model\t` catches the header without
+    // also swallowing a fixture literally named "model".
+    let rows: Vec<(usize, Vec<&str>)> = text
+        .lines()
+        .enumerate()
+        .filter(|(_, l)| !(l.is_empty() || l.starts_with('#') || l.starts_with("model\t")))
+        .map(|(n, l)| (n + 1, l.split('\t').collect()))
+        .collect();
+
+    // The file's SHAPE, decided over ALL rows before any field is read, because
+    // the two error classes are decided by shape and a bless treats them
+    // differently. `Schema` — the arm a bless tolerates as an empty golden — is
+    // reserved for the one file a column-adding change leaves: every data row
+    // exactly one column short. Classifying an ARBITRARY wrong count that way
+    // would hand a bless the very loss the split exists to prevent: a truncated
+    // write, a mangled merge or one stray tab would read as "obsolete schema",
+    // and in the heavy lane, where two fixtures share one file and each blesses
+    // only its own model's rows, the golden would come back missing the other
+    // model entirely. Uniformity is part of the identification: a single short
+    // row among current-schema rows is a mangled file, not a migration.
+    let odd: Vec<(usize, usize)> =
+        rows.iter().map(|(n, f)| (*n, f.len())).filter(|&(_, len)| len != COLUMNS).collect();
+    if let Some(&(line, got)) = odd.first() {
+        if odd.len() == rows.len() && odd.iter().all(|&(_, len)| len + 1 == COLUMNS) {
+            return Err(ParseError::Schema { line, expected: COLUMNS, got });
         }
-        let f: Vec<&str> = line.split('\t').collect();
-        // Exactly 11. A pre-#3397 nine-column or pre-#3422 ten-column row is an
-        // ERROR, not a row with an implied strict count or volume: accepting it
-        // would have to invent one, and a fabricated value is a clean-looking
-        // host that was never measured. A bad merge of this golden is then loud
-        // instead of silently under-gated.
-        if f.len() != 11 {
-            return Err(ParseError::Schema { line: n + 1, expected: 11, got: f.len() });
-        }
+        return Err(ParseError::Malformed(format!(
+            "line {line}: expected {COLUMNS} columns, got {got}; this is a MANGLED file, \
+             not the uniformly one-column-short golden a column-adding change leaves"
+        )));
+    }
+
+    let mut out = Vec::with_capacity(rows.len());
+    for (n, f) in rows {
         // Every failure below is a field the schema HAS that could not be
         // read, so all of them are `Malformed` and none is a bless input.
-        let bad = |m: String| ParseError::Malformed(format!("line {}: {m}", n + 1));
+        let bad = |m: String| ParseError::Malformed(format!("line {n}: {m}"));
         let num = |i: usize| -> Result<usize, ParseError> {
             f[i].parse::<usize>().map_err(|_| bad(format!("bad number {:?}", f[i])))
         };
@@ -2645,48 +2673,74 @@ mod tests {
     }
 
     #[test]
-    fn a_truncated_row_is_an_error_not_a_silently_short_golden() {
+    fn only_a_uniformly_one_column_short_golden_is_a_schema_error() {
         let header = "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\tvol\n";
         // Matched on the VARIANT, not on the message. The two classes are what
         // `read_golden` branches on in bless mode (#3422), so a test that only
         // read the text would stay green if a row-shape failure started
         // reporting as `Malformed` — which would make a column-adding bless
-        // fatal — or, far worse, if a corrupt field started reporting as
+        // fatal — or, far worse, if a mangled row started reporting as
         // `Schema`, which is the arm a bless treats as an empty golden.
-        let short = |text: String, what: &str| match parse(&text) {
+        let schema = |text: String, what: &str| match parse(&text) {
             Err(ParseError::Schema { expected, got, .. }) => {
-                assert_eq!(expected, 11, "{what}");
+                assert_eq!(expected, COLUMNS, "{what}");
                 got
             }
             other => panic!("{what} must be a Schema error, got {other:?}"),
         };
-        assert_eq!(short(format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"), "a 7-column row"), 7);
-        // And a COMPLETE pre-#3397 or pre-#3422 row is a truncation too, not a
-        // row with an implied strict count or volume. Defaulting either would
-        // fabricate a clean-looking host for every line of a stale golden,
-        // which is the one way a column could go dark across the whole corpus
-        // at once.
+        let malformed = |text: String, what: &str| match parse(&text) {
+            Err(ParseError::Malformed(m)) => m,
+            other => panic!("{what} must be a Malformed error, got {other:?}"),
+        };
+
+        // The ONE tolerated shape, and the only one a bless may treat as an
+        // empty golden: EVERY data row exactly one column short, which is what
+        // a column-adding change leaves on disk and nothing else produces.
         assert_eq!(
-            short(format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"), "a pre-#3397 row"),
-            9
-        );
-        assert_eq!(
-            short(
-                format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n"),
-                "a pre-#3422 row"
+            schema(
+                format!(
+                    "{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n\
+                     a.ifc\t2\tCSG\t0\t12\t0\t0\t0\t-\t0\n"
+                ),
+                "a pre-#3422 golden"
             ),
             10
+        );
+
+        // Every OTHER column count is a MANGLED file, not an older schema, and
+        // so is fatal in bless mode too. A truncated write, a mangled merge or
+        // a stray tab lands here, and treating any of them as an empty golden
+        // is the loss this split exists to prevent: in the heavy lane the two
+        // fixtures share one file and each blesses only its own model's rows.
+        malformed(format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"), "a 7-column row");
+        // Two schemas stale is not the sanctioned migration either. Its rows
+        // would need TWO columns invented, and a bless that discarded them
+        // silently would be indistinguishable from the mangled cases above.
+        malformed(format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"), "a pre-#3397 row");
+        malformed(
+            format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t55\t7\n"),
+            "a row one column too many"
+        );
+        // The heavy lane's actual hazard: ONE truncated row among rows that are
+        // on the current schema. Not uniform, so not a migration — and under a
+        // rule that only looked at the FIRST bad row's count it would have been
+        // one, taking the other model's rows with it.
+        malformed(
+            format!(
+                "{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t55\n\
+                 b.ifc\t2\tCSG\t0\t12\t0\t0\t0\t-\t0\n"
+            ),
+            "one short row among current-schema rows"
         );
 
         // A volume token that is neither `-` nor an integer is a CORRUPT row,
         // not a missing reading and not an older schema: the column is there
         // and unreadable. `Malformed` is what keeps a bless from swallowing it.
-        let bad = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t1.5\n"))
-            .expect_err("a float volume must not parse");
-        assert!(
-            matches!(bad, ParseError::Malformed(ref m) if m.contains("bad volume")),
-            "{bad:?}"
+        let bad = malformed(
+            format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t1.5\n"),
+            "a float volume"
         );
+        assert!(bad.contains("bad volume"), "{bad}");
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -137,8 +137,39 @@ pub struct HostRow {
     /// translation-variant — `mesh_volume` sums about the mesh's own AABB
     /// centre, and `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh`
     /// pins that even an open reading holds to the snap-grid noise floor across
-    /// a 10 km offset. On a closed surface it IS a real volume, and it answers
-    /// the question no count in this row can:
+    /// a 10 km offset.
+    ///
+    /// CLOSED HERE MEANS CLOSED AT THE CENSUS SNAP, which is weaker than closed
+    /// at the resolution the divergence sum runs at, and the gap is a real
+    /// exposure rather than a rounding detail (raised in review on #3867).
+    /// `edge_stats` pairs edges on a 1 mm position GRID; `mesh_volume`
+    /// integrates positions `mesh_to_tris` snapped to 1/65536 m. A crack under
+    /// half a snap bucket therefore lands both its sides in one cell, reads
+    /// `open == 0`, and still leaves the surface handed to the sum open, so the
+    /// reading carries that crack as an offset — measured, not asserted, by
+    /// `a_sub_millimetre_crack_reads_watertight_but_shifts_the_volume`, which
+    /// also pins where the blind spot ends.
+    ///
+    /// It is tolerable because this column is only ever read DIFFERENTIALLY:
+    /// golden against run, same host, same code path, through
+    /// `volume_reading_moved` and `volume_magnitude_cmp` and never as a claim
+    /// about the host's true volume. An unchanged crack cancels; a changed one
+    /// is a real change in the mesh, and it is REPORTED rather than absorbed.
+    ///
+    /// Gating on closure at the sum's own resolution is NOT the remedy, and the
+    /// reason is the same f32 limit `far` and `F32_SAFE_MAGNITUDE` are about.
+    /// `Mesh.positions` is f32, whose step is already ~0.12 mm at this census's
+    /// magnitude ceiling and ~3 cm at UTM scale — coarser than 1/65536 m either
+    /// way — so vertices meant to coincide cannot be relied on to agree any
+    /// closer than that. A 15 µm pairing rule would therefore read hosts as
+    /// torn for the storage format's reasons rather than the boolean's and take
+    /// the column dark on the population it exists to measure. (A derivation
+    /// from the f32 step, not a sweep: the corpus is not fetched here.) The
+    /// 1 mm grid is the finest topology these positions carry, which is why the
+    /// edge walk uses it and why the gate is stated at that resolution.
+    ///
+    /// On a surface closed at that resolution it is a real volume, and it
+    /// answers the question no count in this row can:
     /// at `open 0 -> 0` a triangle drop is loss or a cut that stopped
     /// over-removing, and an opening cut larger than authored — the #3219
     /// shape — moves no count at all, or only grows `tris`, which is green.

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -125,9 +125,46 @@ pub struct HostRow {
     /// See [`PreVoid`]. Diagnostic: carried so the origin split and the
     /// closed-solid expectation are derivable from the golden, never compared.
     pub pre: PreVoid,
+    /// Signed enclosed volume in whole cm³ (#3422), the one MAGNITUDE the row
+    /// carries. `None` where the host is torn.
+    ///
+    /// Taken only where `open == 0`, the mirror of `pre`, which is taken only
+    /// where it is not. The divergence theorem the sum implements requires a
+    /// closed surface, so on a torn host the number is not a volume at all: it
+    /// is a function of where the boundary happens to be, and two such readings
+    /// compared say nothing about whether material left. Checking one in would
+    /// be bless churn with no interpretable verdict. NOT because it would be
+    /// translation-variant — `mesh_volume` sums about the mesh's own AABB
+    /// centre, and `mesh_volume_is_stable_far_from_the_world_origin_for_an_open_mesh`
+    /// pins that even an open reading holds to the snap-grid noise floor across
+    /// a 10 km offset. On a closed surface it IS a real volume, and it answers
+    /// the question no count in this row can:
+    /// at `open 0 -> 0` a triangle drop is loss or a cut that stopped
+    /// over-removing, and an opening cut larger than authored — the #3219
+    /// shape — moves no count at all, or only grows `tris`, which is green.
+    ///
+    /// SIGNED because IFC winding is not reliably outward and the sweep does
+    /// not orient the host; an inward-wound solid reads negative. The magnitude
+    /// comparisons in `classify` use the absolute value, and a sign flip alone
+    /// is still a difference the golden must absorb.
+    ///
+    /// A whole cm³ rather than a float, so two platforms that produce the same
+    /// mesh produce the same integer and the golden diffs exactly. The reading
+    /// comes off `kernel::mesh_volume`, which sums about the mesh's own AABB
+    /// centre over the same f32 positions the edge walk reads, so on a
+    /// far-field host it carries that host's f32 quantization and nothing
+    /// else; `far` is named in the reason where it applies.
+    pub vol: Option<i64>,
 }
 
 impl HostRow {
+    /// The #3422 wiring rule, in one place: the volume reading exists exactly
+    /// where the host is watertight. `sweep` asserts it on every row it
+    /// produces, and the golden pin below asserts it on every row checked in.
+    pub fn volume_is_wired(&self) -> bool {
+        self.vol.is_some() == (self.open == 0)
+    }
+
     /// Does this host's watertightness depend on the triangulator's diagonal
     /// choice? A failed alternate pass counts as divergence — it is a difference
     /// in outcome, and the old census counted it as one too.
@@ -326,14 +363,18 @@ pub struct Diff {
     /// baking its centre into f32: 86 of 1170 rows are eligible, 17 of them
     /// far-field. 1005 have `open == 0` and at `0 -> 0` open cannot fall; of
     /// the 165 that are torn, 35 are open shells whose boundary edges are
-    /// structural. A shrink anywhere else still reads as geometry loss. The row
-    /// vocabulary genuinely cannot tell a
-    /// healed over-cut from a vanished component on a watertight host, and red
-    /// is the right answer while that is true. Separating those needs a volume
-    /// dimension the golden does not carry yet.
+    /// structural.
     ///
-    /// It over-fires in the other direction too, and for the same missing
-    /// dimension. A torn host that loses a whole solid item can land here: at
+    /// On a WATERTIGHT host the shrink is read against [`HostRow::vol`]
+    /// instead (#3422): at unchanged enclosed volume it files here as a plain
+    /// re-tessellation, with MORE enclosed volume it files under
+    /// [`Diff::volume_moved`] as a cut that removes less, and only with LESS
+    /// enclosed volume does it keep the "geometry lost" verdict. That is the
+    /// magnitude the triangle count was standing in for, and the 1005 rows
+    /// above are where it is read.
+    ///
+    /// On a TORN host there is no such reading, and this bucket still over-fires
+    /// there. A torn host that loses a whole solid item can land here: at
     /// golden `open=40 tris=800`, a run of `open=2 tris=400` has dropped half
     /// the mesh, yet tris is non-zero and open did fall, so it is filed as a
     /// re-tessellation and described as "less torn". Only the total vanish
@@ -342,8 +383,29 @@ pub struct Diff {
     /// event deserves and the exposure is a wrong BLESS. Do not add a
     /// proportionality heuristic to patch it: that is a second magnitude rule
     /// on a vocabulary with no magnitude in it, which is the same mistake as
-    /// reading a triangle count as damage. The volume dimension is the fix.
+    /// reading a triangle count as damage. The volume dimension cannot reach
+    /// it either: `vol` is not taken on a torn host (see [`HostRow::vol`]).
+    /// What would close it is the tear being fixed, at which point the host
+    /// gains a reading.
     pub retessellated: Vec<Delta>,
+    /// Enclosed volume differs between two WATERTIGHT readings of the same host
+    /// (#3422), and nothing outranked it. Requires a bless, is never a
+    /// regression on its own, and is never good news on its own.
+    ///
+    /// Volume has no direction. Less volume is an over-cut growing, or a void
+    /// that was silently skipped now applying; more is a healed over-cut, or a
+    /// void that stopped applying. Each pair holds one defect and one fix, so
+    /// the bucket says HOW MUCH and which way and leaves the verdict to the
+    /// reviewer, the same way a reclassification does.
+    ///
+    /// What it catches that no count could: an opening cut larger than
+    /// authored in its own plane, the #3219 shape. Measured on a watertight
+    /// panel, a 1.4x cut leaves `open`, `strict`, `tris` and `coll` exactly
+    /// where they were, and a 1.6x cut only GROWS `tris`, which files under
+    /// `improved`; before this bucket the census read both as green. See
+    /// `an_over_cut_on_a_watertight_host_requires_a_bless`
+    /// in `triangulation_invariance.rs` for the measurement.
+    pub volume_moved: Vec<Delta>,
     /// Strictly better. Reported, never a failure.
     ///
     /// So the golden is a CEILING per host, not an equality snapshot, and a fix
@@ -362,7 +424,10 @@ pub struct Diff {
     /// pairs that reached `c.retessellated`, so the eligibility rules still
     /// apply. A shell whose 40 boundary edges became 12 while it shrank is NOT
     /// here, because that fall is not repair; nor is a total vanish. Those are
-    /// geometry loss and are counted as regressions.
+    /// geometry loss and are counted as regressions. Since #3422 the name is
+    /// one case short: a WATERTIGHT host that shrank at unchanged enclosed
+    /// volume reaches `c.retessellated` too, with nothing to heal, and is
+    /// counted here for the same reason.
     ///
     /// `retessellated` only holds the ones where nothing outranked it, and a
     /// reclassification does. A wall-cut change is what flips
@@ -382,6 +447,7 @@ impl Diff {
             || !self.added.is_empty()
             || !self.changed.is_empty()
             || !self.retessellated.is_empty()
+            || !self.volume_moved.is_empty()
     }
 }
 
@@ -461,10 +527,16 @@ struct Classified {
     /// without any count moving, and calling that a geometry regression would
     /// be the same misattribution in the opposite direction.
     worse_gated: Vec<String>,
-    /// The tris drop came with an open-edge drop. Routed here rather than to
-    /// `worse_counts`; see [`Diff::retessellated`] for why that distinction
-    /// exists and where it cannot fire.
+    /// The tris drop came with an open-edge drop, or with an unchanged enclosed
+    /// volume. Routed here rather than to `worse_counts`; see
+    /// [`Diff::retessellated`] for why that distinction exists and where it
+    /// cannot fire.
     retessellated: Vec<String>,
+    /// Both sides carry an enclosed-volume reading and they differ. See
+    /// [`Diff::volume_moved`]. A tris drop that came with MORE volume joins it
+    /// here rather than in `worse_counts`, because more material is not what
+    /// losing geometry looks like.
+    volume_moved: Vec<String>,
     better: Vec<String>,
 }
 
@@ -491,6 +563,18 @@ fn fall_note(g: &HostRow, r: &HostRow) -> &'static str {
         "improved; far-field, so the count is an f32 artifact"
     } else {
         "improved"
+    }
+}
+
+/// How a volume reading moved, as a percentage of the golden's MAGNITUDE.
+/// From zero there is no percentage to give, so it says so instead of
+/// dividing by it.
+fn volume_delta(from: i64, to: i64) -> String {
+    let (a, b) = (from.abs(), to.abs());
+    if a == 0 {
+        "from empty".to_string()
+    } else {
+        format!("{:+.2}%", (b - a) as f64 / a as f64 * 100.0)
     }
 }
 
@@ -561,16 +645,43 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
     // Carrying the degenerate COUNT instead of a flag would
     // let the axis fire on an increase and is the better fix, but it changes the
     // golden's schema and so needs its own re-bless.
+    // The one magnitude in the row (#3422). Read where BOTH sides are
+    // watertight, which is the only place either side has it, and reported
+    // whichever way it moved: see `Diff::volume_moved` for why neither
+    // direction is a verdict. Compared on the SIGNED integer, so a sign flip at
+    // equal magnitude is still a difference, and described on the magnitude,
+    // which is what "more" and "less" mean below.
+    let vol = g.vol.zip(r.vol);
+    if let Some((a, b)) = vol {
+        if a != b {
+            c.volume_moved.push(format!(
+                "enclosed volume {a} -> {b} cm³ ({}){}",
+                volume_delta(a, b),
+                if g.far || r.far { "; far-field, so the reading is f32-quantized" } else { "" }
+            ));
+        }
+    }
+
     if r.tris < g.tris {
         let msg = format!("triangles {} -> {}", g.tris, r.tris);
-        if r.tris == 0
-            || r.open >= g.open
-            || !g.open_is_comparable()
-            || !r.open_is_comparable()
-        {
-            c.worse_counts.push(format!("{msg} (geometry lost)"));
-        } else {
-            c.retessellated.push(format!("{msg} (fewer triangles, less torn)"));
+        // A vanished mesh is always a loss, whatever else moved: it still
+        // returns `Ok`, still reports `open == 0`, and reads a volume of 0.
+        // Otherwise, where both sides are watertight `open` cannot have fallen
+        // and the volume says whether material left with the triangles; where
+        // one side is torn, an open count that fell is the repair reading.
+        // Everything else is loss.
+        match vol.map(|(a, b)| (a.abs(), b.abs())) {
+            _ if r.tris == 0 => c.worse_counts.push(format!("{msg} (geometry lost)")),
+            Some((a, b)) if b > a => {
+                c.volume_moved.push(format!("{msg} (fewer triangles, more enclosed volume)"))
+            }
+            Some((a, b)) if b == a => {
+                c.retessellated.push(format!("{msg} (fewer triangles, enclosed volume unchanged)"))
+            }
+            None if r.open < g.open && g.open_is_comparable() && r.open_is_comparable() => {
+                c.retessellated.push(format!("{msg} (fewer triangles, less torn)"))
+            }
+            _ => c.worse_counts.push(format!("{msg} (geometry lost)")),
         }
     } else if r.tris > g.tris {
         c.better.push(format!("triangles {} -> {} (improved)", g.tris, r.tris));
@@ -671,13 +782,34 @@ pub fn diff(golden: &[HostRow], run: &[HostRow], swept_models: &BTreeSet<String>
         // reclassification would be the real change of meaning, filing a pure
         // relabel as a geometry regression — the misattribution #3366 landed to
         // stop, pinned by the reclassification tests below.
+        //
+        // A volume move (#3422) sits under the reclassification and above the
+        // re-tessellation. Under, because both are "review, then re-bless"
+        // verdicts and a relabel changes what the volume is a volume OF; above,
+        // because a shrink at unchanged volume is the friendly reading and a
+        // shrink with the volume moving is not. The two lists are exclusive by
+        // construction today — `retessellated` fires on a torn host, where
+        // there is no volume, or on a watertight one at EQUAL volume — but the
+        // order is still stated so that adding a route does not decide it by
+        // accident.
         if !c.worse_counts.is_empty() {
             out.regressed.push(delta(
-                [c.worse_counts, c.worse_gated, c.retessellated, reclassified, c.better].concat(),
+                [
+                    c.worse_counts,
+                    c.worse_gated,
+                    c.volume_moved,
+                    c.retessellated,
+                    reclassified,
+                    c.better,
+                ]
+                .concat(),
             ));
         } else if !reclassified.is_empty() {
-            out.changed
-                .push(delta([reclassified, c.worse_gated, c.retessellated, c.better].concat()));
+            out.changed.push(delta(
+                [reclassified, c.worse_gated, c.volume_moved, c.retessellated, c.better].concat(),
+            ));
+        } else if !c.volume_moved.is_empty() {
+            out.volume_moved.push(delta([c.volume_moved, c.retessellated, c.better].concat()));
         } else if !c.retessellated.is_empty() {
             out.retessellated.push(delta([c.retessellated, c.better].concat()));
         } else if !c.better.is_empty() {
@@ -719,7 +851,10 @@ const HEADER: &str = "\
 # strict: undirected edges NOT used exactly once forward and once reverse. Always
 #        >= open, and sees what open cannot: a doubled sheet nets to zero on the
 #        signed balance. Gated as its own count; the defect population is open's.
-model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict";
+# vol:   signed enclosed volume in whole cm^3, or - if not taken. Taken only where
+#        open is 0: an open surface has no volume to read. A change here requires a
+#        bless in either direction; the reason says how much and which way.
+model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\tvol";
 
 fn pre_token(p: PreVoid) -> String {
     match p {
@@ -751,12 +886,15 @@ pub fn render(rows: &[HostRow]) -> String {
     let mut out = String::from(HEADER);
     for r in rows {
         let alt = r.alt.map(|v| v.to_string()).unwrap_or_else(|| "x".to_string());
-        // `strict` is appended LAST rather than beside `open`, so `cut -f1-9`
-        // over this file still reproduces the pre-#3397 row byte for byte. That
-        // is what made the bless diff for the commit that added it readable:
-        // every existing column had to hold, and a moved one had to be visible.
+        // Each new column is appended LAST rather than beside the count it
+        // qualifies, so `cut -f1-9` over this file still reproduces the
+        // pre-#3397 row and `cut -f1-10` the pre-#3422 row, byte for byte.
+        // That is what makes the bless diff for the commit adding a column
+        // readable: every existing column had to hold, and a moved one had to
+        // be visible.
+        let vol = r.vol.map(|v| v.to_string()).unwrap_or_else(|| "-".to_string());
         out.push_str(&format!(
-            "\n{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "\n{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             r.model,
             r.id,
             r.rep,
@@ -767,6 +905,7 @@ pub fn render(rows: &[HostRow]) -> String {
             alt,
             pre_token(r.pre),
             r.strict,
+            vol,
         ));
     }
     out.push('\n');
@@ -782,12 +921,13 @@ pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
             continue;
         }
         let f: Vec<&str> = line.split('\t').collect();
-        // Exactly 10. A pre-#3397 nine-column row is an ERROR, not a row with
-        // an implied strict count: accepting it would have to invent one, and a
-        // fabricated zero is a clean-looking host that was never measured. A bad
-        // merge of this golden is then loud instead of silently under-gated.
-        if f.len() != 10 {
-            return Err(format!("line {}: expected 10 columns, got {}", n + 1, f.len()));
+        // Exactly 11. A pre-#3397 nine-column or pre-#3422 ten-column row is an
+        // ERROR, not a row with an implied strict count or volume: accepting it
+        // would have to invent one, and a fabricated value is a clean-looking
+        // host that was never measured. A bad merge of this golden is then loud
+        // instead of silently under-gated.
+        if f.len() != 11 {
+            return Err(format!("line {}: expected 11 columns, got {}", n + 1, f.len()));
         }
         let num = |i: usize| -> Result<usize, String> {
             f[i].parse::<usize>().map_err(|_| format!("line {}: bad number {:?}", n + 1, f[i]))
@@ -803,6 +943,15 @@ pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
             alt: if f[7] == "x" { None } else { Some(num(7)?) },
             pre: parse_pre(f[8]).map_err(|e| format!("line {}: {e}", n + 1))?,
             strict: num(9)?,
+            vol: if f[10] == "-" {
+                None
+            } else {
+                Some(
+                    f[10]
+                        .parse::<i64>()
+                        .map_err(|_| format!("line {}: bad volume {:?}", n + 1, f[10]))?,
+                )
+            },
         });
     }
     Ok(out)
@@ -835,6 +984,10 @@ mod tests {
             // base geometry alone: two rows of the same host normally agree
             // here even when their void-applied counts differ.
             pre: if open == 0 { PreVoid::NotTaken } else { PreVoid::Open(7) },
+            // Taken if and only if `open == 0`, exactly as the sweep does, and
+            // FIXED for the same reason `pre` is: a reading, not a function of
+            // the counts. Tests that need it to move set it.
+            vol: if open == 0 { Some(55_000) } else { None },
         }
     }
 
@@ -1508,6 +1661,238 @@ mod tests {
         assert!(d2.requires_bless(), "a probe starting to run must also require a bless");
     }
 
+    #[test]
+    fn a_volume_move_with_every_count_unchanged_requires_a_bless() {
+        // #3422, the shape no count can see: an opening cut larger than
+        // authored in its own plane, the #3219 shape, which on a watertight
+        // host can leave open, strict, tris and coll exactly where they were
+        // (measured at 1.4x on the pipeline in `triangulation_invariance.rs`).
+        // Before this column such a pair was an IDENTICAL row.
+        let g = row("a.ifc", 1, 0, 800);
+        let r = HostRow { vol: Some(47_200), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[r], &swept(&["a.ifc"]));
+        assert_eq!(d.volume_moved.len(), 1, "a volume move must be filed as one");
+        assert!(d.regressed.is_empty(), "and is not a regression on its own");
+        assert!(d.improved.is_empty(), "nor an improvement");
+        assert!(d.requires_bless(), "but the golden must absorb it explicitly");
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("enclosed volume 55000 -> 47200 cm³ (-14.18%)"), "{reasons}");
+
+        // The same pair without the column is the pre-#3422 census, and it
+        // sees NOTHING. Pinned so the claim above stays a measurement.
+        let blind_g = HostRow { vol: None, ..g.clone() };
+        let blind_r = HostRow { vol: None, ..g };
+        let blind = diff(&[blind_g], &[blind_r], &swept(&["a.ifc"]));
+        assert!(!blind.requires_bless(), "without a volume the over-cut is invisible");
+    }
+
+    #[test]
+    fn volume_has_no_direction_so_both_ways_require_a_bless_and_neither_improves() {
+        // Less volume is an over-cut growing OR a skipped void now applying;
+        // more is a healed over-cut OR a void that stopped applying. Each
+        // direction holds a defect and a fix, so neither may file as
+        // `improved` (green) and neither as `regressed` on its own.
+        // Less is `a_volume_move_with_every_count_unchanged_requires_a_bless`
+        // above; this is the other direction, then the sign.
+        let g = row("a.ifc", 1, 0, 800);
+        let more = HostRow { vol: Some(60_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[more], &swept(&["a.ifc"]));
+        assert_eq!(d.volume_moved.len(), 1);
+        assert!(d.improved.is_empty() && d.regressed.is_empty(), "more volume is not a verdict");
+        assert!(d.requires_bless());
+        // A sign flip at equal magnitude is still a difference: the host was
+        // wound the other way, and the golden must say so before absorbing it.
+        let flipped = HostRow { vol: Some(-55_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[flipped], &swept(&["a.ifc"]));
+        assert_eq!(d.volume_moved.len(), 1, "a sign flip is a volume move");
+        assert!(d.volume_moved[0].reasons.join("; ").contains("55000 -> -55000"));
+    }
+
+    #[test]
+    fn a_watertight_shrink_is_read_against_the_volume_not_called_loss_by_default() {
+        // The `Diff::retessellated` blind spot as documented before #3422: at
+        // `open 0 -> 0` a triangle drop read as geometry loss whether a cut
+        // stopped over-removing or a component vanished. The volume is what
+        // separates the three cases, and each gets its own verdict.
+        let g = row("a.ifc", 1, 0, 800);
+
+        // MORE enclosed volume with fewer triangles: material came back, which
+        // is not what losing geometry looks like. Bless-requiring, not red as
+        // a regression.
+        let healed = HostRow { tris: 600, vol: Some(62_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[healed], &swept(&["a.ifc"]));
+        assert!(d.regressed.is_empty(), "more volume is not geometry lost");
+        assert_eq!(d.volume_moved.len(), 1);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("fewer triangles, more enclosed volume"), "{reasons}");
+        assert!(reasons.contains("enclosed volume 55000 -> 62000"), "{reasons}");
+        assert!(!reasons.contains("geometry lost"), "{reasons}");
+
+        // UNCHANGED volume with fewer triangles: the surface is the same
+        // surface, triangulated differently. The friendly bucket, still red.
+        let retess = HostRow { tris: 600, ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[retess], &swept(&["a.ifc"]));
+        assert!(d.regressed.is_empty(), "same volume is not geometry lost");
+        assert_eq!(d.retessellated.len(), 1);
+        let reasons = d.retessellated[0].reasons.join("; ");
+        assert!(reasons.contains("enclosed volume unchanged"), "{reasons}");
+        assert!(d.requires_bless());
+
+        // LESS enclosed volume with fewer triangles: something left. The
+        // original verdict, and the volume rides along as the evidence.
+        let lost = HostRow { tris: 600, vol: Some(30_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[lost], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "less volume with fewer triangles is loss");
+        let reasons = d.regressed[0].reasons.join("; ");
+        assert!(reasons.contains("geometry lost"), "{reasons}");
+        assert!(reasons.contains("enclosed volume 55000 -> 30000"), "{reasons}");
+
+        // And a vanished mesh is loss whatever the volume column says: it
+        // reads 0 there, which is "less", but the `tris == 0` rule decides it
+        // before the volume is consulted, exactly as on a torn host.
+        let gone = HostRow { tris: 0, vol: Some(0), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[gone], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+        assert!(d.regressed[0].reasons[0].contains("geometry lost"));
+    }
+
+    #[test]
+    fn more_triangles_with_less_volume_is_no_longer_an_improvement() {
+        // The other silent case: an over-cut that grows can ADD triangles (a
+        // cutter now exits through one more face), and a grown `tris` filed
+        // under `improved`, green, with no bless. The volume outranks it.
+        let g = row("a.ifc", 1, 0, 800);
+        let r = HostRow { tris: 820, vol: Some(40_000), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[r], &swept(&["a.ifc"]));
+        assert!(d.improved.is_empty(), "a volume move must not read as a triangle gain");
+        assert_eq!(d.volume_moved.len(), 1);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        // The triangle gain is still REPORTED, as evidence beside the volume.
+        assert!(reasons.contains("triangles 800 -> 820"), "{reasons}");
+        assert!(reasons.contains("enclosed volume 55000 -> 40000"), "{reasons}");
+    }
+
+    #[test]
+    fn a_torn_host_carries_no_volume_and_keeps_its_pre_3422_verdicts() {
+        // The reading is not taken on an open surface, so nothing on a torn
+        // host changes: the shrink-and-heal rule still decides, and its stated
+        // over-fire (`Diff::retessellated`) is still there. Pinned so a later
+        // "improvement" cannot start reading a translation-variant number.
+        let g = row("a.ifc", 1, 40, 800);
+        assert_eq!(g.vol, None, "the helper mirrors the sweep: torn means not taken");
+        let d = diff(std::slice::from_ref(&g), &[row("a.ifc", 1, 12, 600)], &swept(&["a.ifc"]));
+        assert_eq!(d.retessellated.len(), 1);
+        assert!(d.volume_moved.is_empty());
+
+        // A torn golden against a watertight run: one side has no reading, so
+        // there is nothing to compare, and the pair is decided by the forced
+        // `pre` transition exactly as before.
+        let d = diff(std::slice::from_ref(&g), &[row("a.ifc", 1, 0, 600)], &swept(&["a.ifc"]));
+        assert!(d.volume_moved.is_empty(), "one reading is not a comparison");
+        assert_eq!(d.changed.len(), 1);
+    }
+
+    #[test]
+    fn a_volume_move_outranks_a_shrink_and_yields_to_a_reclassification() {
+        // Chain order, pinned per arm. A relabel changes what the volume is a
+        // volume OF, so it decides; the volume reason still has to reach the
+        // text, or the reviewer sees a relabel with no evidence of what moved.
+        let g = row("a.ifc", 1, 0, 800);
+        let relabelled = HostRow { rep: "Clipping".to_string(), vol: Some(47_200), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[relabelled], &swept(&["a.ifc"]));
+        assert_eq!(d.changed.len(), 1, "the relabel decides");
+        assert!(d.volume_moved.is_empty());
+        let reasons = d.changed[0].reasons.join("; ");
+        assert!(reasons.contains("representation SweptSolid -> Clipping"), "{reasons}");
+        assert!(reasons.contains("enclosed volume 55000 -> 47200"), "{reasons}");
+
+        // And a worsened count outranks the volume, with the volume carried.
+        let torn = HostRow { open: 3, strict: 3, vol: None, ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[torn], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+        let collapsed = HostRow { collapsed: true, vol: Some(47_200), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[collapsed], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "a gained collapse outranks the volume");
+        assert!(d.regressed[0].reasons.join("; ").contains("enclosed volume 55000 -> 47200"));
+    }
+
+    #[test]
+    fn a_far_field_volume_move_names_its_quantization() {
+        // `far` is reported, never gated, and a volume read off absolute f32
+        // positions past that magnitude carries the f32 step. The move still
+        // requires a bless; the reason says what the number is worth.
+        let g = HostRow { far: true, ..row("a.ifc", 1, 0, 800) };
+        let r = HostRow { vol: Some(55_900), ..g.clone() };
+        let d = diff(std::slice::from_ref(&g), &[r], &swept(&["a.ifc"]));
+        assert_eq!(d.volume_moved.len(), 1);
+        let reasons = d.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains("f32-quantized"), "{reasons}");
+        assert!(reasons.contains("+1.64%"), "{reasons}");
+    }
+
+    #[test]
+    fn a_volume_move_from_an_empty_golden_has_no_percentage() {
+        // `volume_delta`'s zero guard: 83 watertight golden rows are empty
+        // meshes reading 0 cm³, and a host that gains material from there has
+        // no base to divide by.
+        let empty = HostRow { vol: Some(0), ..row("a.ifc", 1, 0, 800) };
+        let d = diff(&[empty], &[row("a.ifc", 1, 0, 800)], &swept(&["a.ifc"]));
+        assert!(d.volume_moved[0].reasons.join("; ").contains("(from empty)"));
+    }
+
+    #[test]
+    fn the_checked_in_golden_carries_a_volume_wherever_open_is_zero_and_nowhere_else() {
+        // The sweep-wiring property no synthetic row can carry (#3422), the
+        // same way `strict` is pinned above: `vol: None` everywhere, or
+        // `Some(0)` everywhere, would leave every routing test in this module
+        // green and the census green too, since a reading that never moves
+        // never requires a bless. A re-bless lands the dark column here.
+        //
+        // Both goldens: the heavy lane blesses its own file by hand and is
+        // `#[ignore]`d, so without this it would be the one place a dark
+        // column could be checked in with nothing reading it.
+        //
+        // The floors are DARKNESS floors, not population pins: a dark column
+        // reads 0 non-zero volumes, so they sit far below what each file
+        // actually carries (1170 rows / 920 non-zero, and the heavy figures
+        // below: 652 rows, 624 watertight, 623 non-zero) rather than one row
+        // under it. Pinning the population here
+        // would red the lane on any legitimate coverage change, which
+        // `MIN_VOID_HOSTS` and the heavy lane's own floors already gate.
+        for (name, text, min_rows, min_nonzero) in [
+            (
+                "watertightness_census.tsv",
+                include_str!("../manifests/watertightness_census.tsv"),
+                1000,
+                700,
+            ),
+            (
+                "watertightness_census_heavy.tsv",
+                include_str!("../manifests/watertightness_census_heavy.tsv"),
+                600,
+                400,
+            ),
+        ] {
+            let rows = parse(text).unwrap_or_else(|e| panic!("{name} must parse: {e}"));
+            assert!(rows.len() > min_rows, "{name} is under-populated: {} rows", rows.len());
+            for r in &rows {
+                assert!(
+                    r.volume_is_wired(),
+                    "{name} {} #{}: vol {:?} with open {}",
+                    r.model,
+                    r.id,
+                    r.vol,
+                    r.open
+                );
+            }
+            let nonzero = rows.iter().filter(|r| matches!(r.vol, Some(v) if v != 0)).count();
+            assert!(
+                nonzero > min_nonzero,
+                "{name}: only {nonzero} watertight rows carry a non-zero volume; the column is dark"
+            );
+        }
+    }
+
     /// Every `HostRow` shape that matters, for the exhaustive invariant below.
     fn variants() -> Vec<HostRow> {
         let mut out = Vec::new();
@@ -1530,18 +1915,29 @@ mod tests {
                                         PreVoid::Open(0),
                                         PreVoid::Open(2),
                                     ] {
-                                        out.push(HostRow {
-                                            model: "a.ifc".to_string(),
-                                            id: 1,
-                                            rep: rep.to_string(),
-                                            open,
-                                            strict,
-                                            tris,
-                                            collapsed,
-                                            far,
-                                            alt,
-                                            pre,
-                                        });
+                                        // Taken only where `open == 0`, as the
+                                        // sweep does; two values there so the
+                                        // cross product builds a move both
+                                        // ways, and `None` on a torn row, which
+                                        // is the only value the sweep can give
+                                        // it.
+                                        let vols: &[Option<i64>] =
+                                            if open == 0 { &[Some(100), Some(160)] } else { &[None] };
+                                        for &vol in vols {
+                                            out.push(HostRow {
+                                                model: "a.ifc".to_string(),
+                                                id: 1,
+                                                rep: rep.to_string(),
+                                                open,
+                                                strict,
+                                                tris,
+                                                collapsed,
+                                                far,
+                                                alt,
+                                                pre,
+                                                vol,
+                                            });
+                                        }
                                     }
                                 }
                             }
@@ -1614,6 +2010,15 @@ mod tests {
         // no shrink is ever checked, because every shrink requires a bless. The
         // additions are further growth pairs and equal-`tris` pairs. The exact
         // count is asserted below rather than described here.
+        //
+        // #3422 moved all three, and `detected` closes exactly. Every `open == 0`
+        // variant now carries two `vol` values, and a WATERTIGHT shrink at equal
+        // volume is detected as a re-tessellation where it used to file as
+        // geometry lost: 768 watertight variants become 1536, half of the
+        // 1536 x 1536 pairs agree on `vol`, and one `tris` combination in nine
+        // is the `5 -> 3` shrink, so 131072 new detections. The old 2304 healing
+        // pairs all land on a watertight run side and so double to 4608. Sum
+        // 135680. `checked` and `landed` are asserted as measured.
         let vs = variants();
         let all = swept(&["a.ifc"]);
         let mut checked = 0usize;
@@ -1642,12 +2047,12 @@ mod tests {
         }
         // Guard against the loop vacuously skipping everything.
         assert!(checked > vs.len(), "only {checked} clean pairs of {}", vs.len() * vs.len());
-        assert_eq!(checked, 37440, "clean pairs swept");
+        assert_eq!(checked, 63648, "clean pairs swept");
         // The two counts the comment above quotes, asserted rather than
         // recorded. The gap between them is the whole reason
         // `shrank_while_healing` exists, so it must not drift unnoticed.
-        assert_eq!(detected, 2304, "pairs DETECTED as a re-tessellation");
-        assert_eq!(landed, 312, "pairs that LAND in the retessellated bucket");
+        assert_eq!(detected, 135680, "pairs DETECTED as a re-tessellation");
+        assert_eq!(landed, 4368, "pairs that LAND in the retessellated bucket");
     }
 
     #[test]
@@ -1743,31 +2148,48 @@ mod tests {
         // `improved`.
         let vs = variants();
         let all = swept(&["a.ifc"]);
-        let (mut regressed, mut changed, mut retessellated, mut improved, mut unchanged) =
-            (0usize, 0, 0, 0, 0);
+        let mut regressed = 0usize;
+        let mut changed = 0usize;
+        let mut volume_moved = 0usize;
+        let mut retessellated = 0usize;
+        let mut improved = 0usize;
+        let mut unchanged = 0usize;
         for g in &vs {
             for r in &vs {
                 let c = classify(g, r);
                 let reclassified = reclassifications(g, r);
                 let d = diff(std::slice::from_ref(g), std::slice::from_ref(r), &all);
-                let got =
-                    (d.regressed.len(), d.changed.len(), d.retessellated.len(), d.improved.len());
+                // Exactly one bucket, and it is number `i`. An array rather
+                // than a tuple literal per arm, so adding a bucket is one
+                // edit here and a mistyped zero cannot pass for the wrong
+                // reason.
+                let got = [
+                    d.regressed.len(),
+                    d.changed.len(),
+                    d.volume_moved.len(),
+                    d.retessellated.len(),
+                    d.improved.len(),
+                ];
+                let only = |i: usize| {
+                    let mut e = [0usize; 5];
+                    e[i] = 1;
+                    e
+                };
                 assert!(d.added.is_empty() && d.missing.is_empty(), "{g:?} -> {r:?}");
                 if !c.worse_counts.is_empty() {
-                    assert_eq!(got, (1, 0, 0, 0), "a worsened count must regress: {g:?} -> {r:?}");
+                    assert_eq!(got, only(0), "a worsened count must regress: {g:?} -> {r:?}");
                     regressed += 1;
                 } else if !reclassified.is_empty() {
-                    assert_eq!(got, (0, 1, 0, 0), "a reclassification must change: {g:?} -> {r:?}");
+                    assert_eq!(got, only(1), "a reclassification must change: {g:?} -> {r:?}");
                     changed += 1;
+                } else if !c.volume_moved.is_empty() {
+                    assert_eq!(got, only(2), "a volume move must file as one: {g:?} -> {r:?}");
+                    volume_moved += 1;
                 } else if !c.retessellated.is_empty() {
-                    assert_eq!(
-                        got,
-                        (0, 0, 1, 0),
-                        "a shrink that healed must re-tessellate: {g:?} -> {r:?}"
-                    );
+                    assert_eq!(got, only(3), "a shrink that healed must re-tessellate: {g:?} -> {r:?}");
                     retessellated += 1;
                 } else if !c.better.is_empty() {
-                    assert_eq!(got, (0, 0, 0, 1), "an improvement must improve: {g:?} -> {r:?}");
+                    assert_eq!(got, only(4), "an improvement must improve: {g:?} -> {r:?}");
                     improved += 1;
                 } else {
                     // Deleting the gated arm made this `else` a SILENT DROP for
@@ -1794,13 +2216,14 @@ mod tests {
                         c.worse_gated.is_empty(),
                         "a gated flip with nothing else moving would land in NO bucket: {g:?} -> {r:?}"
                     );
-                    assert_eq!(got, (0, 0, 0, 0), "an identical pair moves nothing: {g:?} -> {r:?}");
+                    assert_eq!(got, [0; 5], "an identical pair moves nothing: {g:?} -> {r:?}");
                     unchanged += 1;
                 }
             }
         }
         assert!(regressed > 0, "no pair reaches the regressed arm");
         assert!(changed > 0, "no pair reaches the changed arm");
+        assert!(volume_moved > 0, "no pair reaches the volume_moved arm");
         assert!(retessellated > 0, "no pair reaches the retessellated arm");
         assert!(improved > 0, "no pair reaches the improved arm");
         assert!(unchanged > 0, "no pair leaves the chain without a delta");
@@ -1897,6 +2320,7 @@ mod tests {
                 far: false,
                 alt: None,
                 pre: PreVoid::Open(3),
+                vol: None,
             },
             HostRow {
                 model: "vendor/a.ifc".to_string(),
@@ -1913,6 +2337,9 @@ mod tests {
                 far: true,
                 alt: Some(0),
                 pre: PreVoid::Failed,
+                // NEGATIVE, so the serializer is pinned on the sign the column
+                // is documented to carry and not only on a magnitude.
+                vol: Some(-1234),
             },
         ];
         let text = render(&rows);
@@ -1927,18 +2354,28 @@ mod tests {
 
     #[test]
     fn a_truncated_row_is_an_error_not_a_silently_short_golden() {
-        let header = "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\n";
+        let header = "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\tvol\n";
         let err = parse(&format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"))
             .expect_err("a 7-column row must not parse");
-        assert!(err.contains("expected 10 columns"), "{err}");
+        assert!(err.contains("expected 11 columns"), "{err}");
 
-        // And a COMPLETE pre-#3397 row is a truncation too, not a row with an
-        // implied strict count. Defaulting it would fabricate a clean-looking
-        // host for every line of a stale golden, which is the one way this
-        // column could go dark across the whole corpus at once.
+        // And a COMPLETE pre-#3397 or pre-#3422 row is a truncation too, not a
+        // row with an implied strict count or volume. Defaulting either would
+        // fabricate a clean-looking host for every line of a stale golden,
+        // which is the one way a column could go dark across the whole corpus
+        // at once.
         let old = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"))
             .expect_err("a 9-column pre-#3397 row must not parse");
-        assert!(old.contains("expected 10 columns"), "{old}");
+        assert!(old.contains("expected 11 columns"), "{old}");
+        let ten = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n"))
+            .expect_err("a 10-column pre-#3422 row must not parse");
+        assert!(ten.contains("expected 11 columns"), "{ten}");
+
+        // A volume token that is neither `-` nor an integer is a bad row, not
+        // a missing reading.
+        let bad = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\t1.5\n"))
+            .expect_err("a float volume must not parse");
+        assert!(bad.contains("bad volume"), "{bad}");
     }
 
     #[test]

--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -1928,25 +1928,32 @@ mod tests {
         // `#[ignore]`d, so without this it would be the one place a dark
         // column could be checked in with nothing reading it.
         //
-        // The floors are DARKNESS floors, not population pins: a dark column
-        // reads 0 non-zero volumes, so they sit far below what each file
-        // actually carries (1170 rows / 920 non-zero, and the heavy figures
-        // below: 652 rows, 624 watertight, 623 non-zero) rather than one row
-        // under it. Pinning the population here
-        // would red the lane on any legitimate coverage change, which
+        // The floors are DARKNESS floors, not population pins. A dark column
+        // reads ZERO non-zero volumes, so each floor sits far enough below the
+        // file's real population that a legitimate coverage change cannot
+        // reach it and a dark column cannot miss it. Measured at this commit:
+        // the default golden carries 1170 rows / 1005 watertight / 920
+        // non-zero, the heavy one 652 / 624 / 623. The floors below are set at
+        // roughly half of each, not one row under it. Pinning the population
+        // here would red the lane on any legitimate coverage change, which
         // `MIN_VOID_HOSTS` and the heavy lane's own floors already gate.
+        //
+        // The heavy floor was 600 in the commit that added it, against 652
+        // actual. That contradicted this paragraph: a 53-row coverage change
+        // would have redded the lane and said "the column is dark", which is
+        // the wrong diagnosis by a wide margin (a dark column reads 0).
         for (name, text, min_rows, min_nonzero) in [
             (
                 "watertightness_census.tsv",
                 include_str!("../manifests/watertightness_census.tsv"),
-                1000,
-                700,
+                600,
+                500,
             ),
             (
                 "watertightness_census_heavy.tsv",
                 include_str!("../manifests/watertightness_census_heavy.tsv"),
-                600,
-                400,
+                300,
+                300,
             ),
         ] {
             let rows = parse(text).unwrap_or_else(|e| panic!("{name} must parse: {e}"));

--- a/rust/geometry/tests/manifests/watertightness_census.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census.tsv
@@ -15,1174 +15,1177 @@
 # strict: undirected edges NOT used exactly once forward and once reverse. Always
 #        >= open, and sees what open cannot: a doubled sheet nets to zero on the
 #        signed balance. Gated as its own count; the defect population is open's.
-model	id	rep	open	tris	coll	far	alt	pre	strict
-ara3d/AC20-FZK-Haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0
-ara3d/AC20-FZK-Haus.ifc	60012	Clipping	0	204	0	0	18	-	0
-ara3d/AC20-FZK-Haus.ifc	67828	Clipping	0	196	0	0	18	-	0
-ara3d/C20-Institute-Var-2.ifc	31190	SweptSolid	0	320	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	35819	SweptSolid	0	324	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	40505	SweptSolid	0	600	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	47404	SweptSolid	0	116	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	50078	SweptSolid	0	130	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	52075	SweptSolid	0	52	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	55353	SweptSolid	0	42	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	56404	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	57708	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	72946	SweptSolid	0	80	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	81755	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	82662	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	83555	SweptSolid	0	320	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	87784	SweptSolid	0	70	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	90339	SweptSolid	0	320	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	94567	SweptSolid	0	324	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	99022	SweptSolid	0	100	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	100667	SweptSolid	0	72	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	101958	SweptSolid	0	120	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	104309	SweptSolid	0	64	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	107811	SweptSolid	0	328	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	112277	SweptSolid	0	36	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	113099	SweptSolid	0	42	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	114155	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	114727	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	125284	SweptSolid	0	80	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	135395	SweptSolid	0	320	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	139845	SweptSolid	0	324	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	144069	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	144635	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	145201	SweptSolid	0	948	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	154762	SweptSolid	0	116	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	157112	SweptSolid	0	120	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	159462	SweptSolid	0	192	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	165435	SweptSolid	0	34	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	166266	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	167338	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	178044	SweptSolid	0	64	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	188155	SweptSolid	0	320	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	192605	SweptSolid	0	324	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	196829	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	197395	SweptSolid	0	32	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	197961	SweptSolid	0	948	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	207522	SweptSolid	0	116	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	209872	SweptSolid	0	120	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	212222	SweptSolid	0	182	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	218661	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	219733	SweptSolid	0	40	0	0	0	-	0
-ara3d/C20-Institute-Var-2.ifc	220884	SweptSolid	0	64	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	26448	SweptSolid	0	72	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	26635	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	30660	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	30826	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	31022	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	40974	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	52867	SweptSolid	0	34	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	53112	SweptSolid	0	34	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	61530	SweptSolid	0	48	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	67415	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	67562	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	67758	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	77712	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	89640	SweptSolid	0	34	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	89885	SweptSolid	0	34	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	90210	SweptSolid	0	48	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	99281	SweptSolid	0	72	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	100158	SweptSolid	0	168	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	100207	SweptSolid	0	186	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	106167	Clipping	0	48	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	106259	SweptSolid	0	40	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	106951	SweptSolid	0	100	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	136983	SweptSolid	0	80	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	137547	Clipping	0	60	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	138037	Clipping	12	301	1	0	21	0	12
-ara3d/FM_ARC_DigitalHub.ifc	138279	SweptSolid	0	60	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	138767	Clipping	0	80	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	139288	Clipping	9	300	1	0	9	0	9
-ara3d/FM_ARC_DigitalHub.ifc	139605	Clipping	9	300	1	0	9	0	9
-ara3d/FM_ARC_DigitalHub.ifc	139864	Clipping	0	184	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	139985	Clipping	9	300	1	0	18	0	9
-ara3d/FM_ARC_DigitalHub.ifc	140227	SweptSolid	0	184	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	140337	SweptSolid	0	496	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	146777	SweptSolid	0	222	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	149094	SweptSolid	0	668	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	155733	SweptSolid	0	282	0	0	11	-	0
-ara3d/FM_ARC_DigitalHub.ifc	187843	SweptSolid	0	172	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	188186	SweptSolid	0	32	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	188235	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	188333	SweptSolid	0	74	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	188424	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	196863	SweptSolid	0	112	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	196912	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	196961	SweptSolid	0	132	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	197010	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	197353	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	197794	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	200204	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	200253	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	200449	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	200645	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	216340	SweptSolid	0	68	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	216561	SweptSolid	0	44	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	216762	SweptSolid	0	28	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	217867	SweptSolid	0	72	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	218038	SweptSolid	0	32	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	218227	SweptSolid	0	72	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	218398	SweptSolid	0	32	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	218587	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	218718	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	219094	SweptSolid	0	52	0	0	0	-	0
-ara3d/FM_ARC_DigitalHub.ifc	219225	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_005_haus.ifc	60012	Clipping	0	204	0	0	18	-	0
-ara3d/ISSUE_005_haus.ifc	67828	Clipping	0	196	0	0	18	-	0
-ara3d/ISSUE_126_model.ifc	40983	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	43236	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	49197	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	49964	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	50658	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	50766	SweptSolid	0	58	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	52352	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	56758	SweptSolid	0	30	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	73237	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	73349	SweptSolid	0	264	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	77438	SweptSolid	0	80	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	78232	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	78975	SweptSolid	0	264	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	82108	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	82925	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	83323	SweptSolid	0	66	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	83694	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	84442	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	86446	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	86609	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	98282	SweptSolid	26	220	0	0	26	0	26
-ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-	0
-ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0	27
-ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	34	422	0	0	18	6	34
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1119	1157	0	1	931	0	1124
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	0	30	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	723	824	1	1	717	0	774
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	0	192	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	2106	2332	1	1	1811	0	2119
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	260	1536	0	1	144	0	264
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	493	725	1	1	571	0	493
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	458	882	0	1	375	0	469
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	26	160	0	0	24	12	26
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	6	190	0	0	0	0	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	0	118	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	6	282	0	0	0	0	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	1723	1764	0	1	2008	0	1730
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	34	131	1	0	34	0	34
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	0	151	1	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	743	1429	1	1	768	3	752
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	0	126	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	0	182	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	0	6	0	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68263	Clipping	0	84	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68943	Clipping	0	192	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69569	Clipping	0	46	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69961	Clipping	0	180	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81223	Clipping	0	166	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81562	Clipping	0	238	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81869	Clipping	0	28	0	0	0	-	15
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	83043	Clipping	0	46	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138693	Clipping	0	108	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138919	Clipping	0	76	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139190	SweptSolid	6	174	0	0	6	0	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139364	Clipping	0	182	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139571	SweptSolid	0	304	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSolid	37	161	0	0	0	0	37
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	20	180	0	0	0	6	20
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	0	118	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	0	190	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	519	1008	0	1	388	0	527
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	0	100	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	356	562	0	1	312	0	359
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	214	993	0	1	284	0	240
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	148	174	0	1	129	0	152
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	92	83	0	1	101	0	92
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	403	639	0	1	340	0	416
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	0	229	1	0	0	-	1
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	9	93	0	0	9	0	9
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	7	244	1	0	7	0	7
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	3	200	1	0	3	0	3
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	622	473	1	1	515	0	629
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	621	572	1	1	553	0	633
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	6	12	0	0	6	0	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	279	649	0	1	250	0	281
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	222	387	0	1	129	0	224
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0	63
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1326	1347	1	1	1209	6	1339
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	1110	1095	1	1	1334	0	1115
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	29	125	0	0	29	0	29
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	0	74	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	18	30	0	1	18	0	18
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	54	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	34	44	0	1	34	0	34
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	0	160	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	0	46	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360821	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360966	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	361107	SweptSolid	0	38	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4380	SweptSolid	6	94	0	0	0	0	6
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4630	SweptSolid	0	38	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4732	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4834	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4940	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	6012	Clipping	6	144	0	0	6	0	6
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	8511	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27148	SweptSolid	3	117	1	0	0	0	3
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27562	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27770	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	28290	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	34099	SweptSolid	35	259	0	0	30	0	35
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	37094	SweptSolid	0	64	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46565	SweptSolid	0	100	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46667	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46769	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46871	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	47807	SweptSolid	0	168	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	49773	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63308	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63516	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	64036	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	76544	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78513	SweptSolid	0	156	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78918	Clipping	12	106	0	0	0	0	12
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79070	Clipping	0	50	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79197	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79969	AdvancedBrep	0	80	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	80101	Clipping	0	80	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	81274	Clipping	12	140	0	0	12	0	12
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	83292	Clipping	0	52	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87331	Clipping	0	132	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87839	Clipping	0	44	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88116	Clipping	0	46	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88776	Clipping	0	76	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	92201	Clipping	17	141	0	0	20	0	17
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	94199	Clipping	0	66	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95188	Clipping	6	96	0	0	6	0	6
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95332	Clipping	0	44	0	0	3	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95459	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95605	Clipping	0	80	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	96778	Clipping	12	132	0	0	12	0	12
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	98786	Clipping	0	48	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100558	Clipping	0	44	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100835	Clipping	0	46	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	101495	Clipping	0	76	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	103251	Clipping	0	78	1	0	3	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	105519	SweptSolid	0	156	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119816	SweptSolid	6	62	0	0	0	0	6
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119924	SweptSolid	3	63	1	0	0	0	3
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120028	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120132	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120448	SweptSolid	0	96	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	121490	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	122695	SweptSolid	12	144	1	0	0	0	12
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123117	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123329	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123859	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	124711	SweptSolid	0	204	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	127658	SweptSolid	0	54	1	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128193	SweptSolid	3	97	1	0	0	0	3
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128297	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128401	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128505	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	129459	SweptSolid	0	120	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	131443	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132587	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132799	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	133329	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	134472	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	135938	SweptSolid	0	128	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	137886	SweptSolid	0	112	0	0	0	-	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	139140	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	61	SweptSolid	0	114	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	528	SweptSolid	0	64	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	733	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	880	SweptSolid	0	64	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1085	SweptSolid	0	72	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1290	SweptSolid	0	58	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1512	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1812	SweptSolid	0	58	0	0	0	-	0
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	2017	SweptSolid	0	68	0	0	0	-	0
-ara3d/IfcOpenHouse_IFC4.ifc	40	SweptSolid	0	56	0	0	0	-	0
-ara3d/IfcOpenHouse_IFC4.ifc	268	Clipping	0	40	0	0	0	-	0
-ara3d/IfcOpenHouse_IFC4.ifc	281	Clipping	0	42	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	65	SweptSolid	0	92	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	71	SweptSolid	0	308	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	76	SweptSolid	0	140	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	81	SweptSolid	0	312	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	82	SweptSolid	0	32	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	83	SweptSolid	0	292	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	88	SweptSolid	0	60	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	97	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	100	SweptSolid	0	152	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	101	SweptSolid	0	164	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	102	SweptSolid	0	140	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	104	SweptSolid	0	92	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	105	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	106	SweptSolid	0	172	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	130	SweptSolid	0	76	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	134	SweptSolid	0	92	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	139	SweptSolid	0	76	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	143	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	156	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	161	SweptSolid	0	60	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	164	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	165	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	166	SweptSolid	0	100	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	175	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	178	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	179	SweptSolid	0	60	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	183	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	185	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	188	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	191	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	193	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	195	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	196	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	197	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	198	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	223	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	224	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	227	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	228	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	234	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	238	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	239	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	242	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	246	SweptSolid	0	60	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	247	SweptSolid	0	44	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	248	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	277	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	282	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	288	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	307	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	314	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	326	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	351	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	354	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	361	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	363	SweptSolid	0	28	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	364	SweptSolid	0	180	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	417	SweptSolid	0	122	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	429	SweptSolid	0	32	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	607	SweptSolid	0	122	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	684	SweptSolid	0	122	0	0	0	-	0
-ara3d/Office_A_20110811.ifc	1028	SweptSolid	0	678	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	4172	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	5434	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	6155	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	14416	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	35182	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	36567	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	43442	SweptSolid	0	80	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	48600	SweptSolid	0	44	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	49149	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89022	unknown	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89141	SweptSolid	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89264	SweptSolid	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89384	SweptSolid	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89504	SweptSolid	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	89624	SweptSolid	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	90617	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	91291	CSG	3	46	1	0	3	6	3
-ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12	13
-ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	4	160	0	0	4	4	4
-ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6	6
-ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164	90
-ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78	78
-ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51	51
-ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503263	unknown	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503302	SweptSolid	0	172	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503345	SweptSolid	0	172	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503385	SweptSolid	0	172	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503425	SweptSolid	0	172	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	503482	SweptSolid	0	172	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	543063	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	639833	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	670546	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	701210	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	704150	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	719862	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	722750	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	723436	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	724125	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	724811	CSG	3	81	0	0	3	3	3
-ara3d/S_Office_Integrated Design Archi.ifc	725497	CSG	7	185	0	0	7	12	7
-ara3d/S_Office_Integrated Design Archi.ifc	726183	CSG	0	212	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	726869	CSG	0	212	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	730647	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	753197	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	763256	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	763898	CSG	0	122	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	108	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	769740	CSG	0	280	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	770504	CSG	0	100	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	771268	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	772032	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	803290	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	832090	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	832800	CSG	0	224	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	833513	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	834223	CSG	0	200	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	834933	CSG	0	100	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	835643	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	836353	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857637	unknown	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857676	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857719	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857759	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857799	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	857839	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	866873	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	867376	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	868018	CSG	0	122	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	108	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	904620	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6	6
-ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	212	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	909877	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	910230	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	910609	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	912366	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	918017	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	918355	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	929798	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	930704	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	951036	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3	3
-ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	13	225	0	0	4	7	13
-ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	970645	CSG	0	224	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	971358	CSG	0	216	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	972068	CSG	0	200	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	972778	CSG	0	100	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	973488	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974198	CSG	0	196	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974760	unknown	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974799	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974842	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974882	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974922	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	112	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	108	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	998325	SweptSolid	0	52	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	1001521	SweptSolid	0	32	0	0	0	-	0
-ara3d/S_Office_Integrated Design Archi.ifc	1001906	SweptSolid	0	32	0	0	0	-	0
-ara3d/advanced_model.ifc	552611	SweptSolid	0	158	0	0	0	-	0
-ara3d/advanced_model.ifc	552761	SweptSolid	0	168	0	0	0	-	0
-ara3d/advanced_model.ifc	552894	SweptSolid	0	104	0	0	0	-	0
-ara3d/advanced_model.ifc	553010	Clipping	0	82	0	0	0	-	0
-ara3d/advanced_model.ifc	555082	SweptSolid	0	88	0	0	0	-	0
-ara3d/advanced_model.ifc	555224	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	555268	SweptSolid	0	124	0	0	0	-	0
-ara3d/advanced_model.ifc	555433	SweptSolid	0	172	0	0	0	-	0
-ara3d/advanced_model.ifc	555613	Clipping	0	90	0	0	0	-	0
-ara3d/advanced_model.ifc	555770	Clipping	0	56	0	0	0	-	0
-ara3d/advanced_model.ifc	555985	SweptSolid	0	184	0	0	0	-	0
-ara3d/advanced_model.ifc	556264	SweptSolid	0	192	0	0	0	-	0
-ara3d/advanced_model.ifc	559034	SweptSolid	0	88	0	0	0	-	0
-ara3d/advanced_model.ifc	559171	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	559270	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	559314	SweptSolid	0	52	0	0	0	-	0
-ara3d/advanced_model.ifc	561445	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	563598	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	563980	SweptSolid	0	156	0	0	0	-	0
-ara3d/advanced_model.ifc	612062	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	612150	SweptSolid	0	124	0	0	0	-	0
-ara3d/advanced_model.ifc	612315	SweptSolid	0	128	0	0	0	-	0
-ara3d/advanced_model.ifc	612436	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	632450	Clipping	0	126	0	0	0	-	0
-ara3d/advanced_model.ifc	636693	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	636774	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	636818	SweptSolid	0	52	0	0	0	-	0
-ara3d/advanced_model.ifc	636995	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	637271	SweptSolid	0	76	0	0	0	-	0
-ara3d/advanced_model.ifc	637377	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	637697	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	637785	SweptSolid	0	60	0	0	0	-	0
-ara3d/advanced_model.ifc	637873	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	637917	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	646621	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	646665	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	650657	SweptSolid	0	68	0	0	0	-	0
-ara3d/advanced_model.ifc	650761	SweptSolid	0	76	0	0	0	-	0
-ara3d/advanced_model.ifc	650893	SweptSolid	0	56	0	0	0	-	0
-ara3d/advanced_model.ifc	651604	SweptSolid	0	76	0	0	0	-	0
-ara3d/advanced_model.ifc	674148	SweptSolid	0	76	0	0	0	-	0
-ara3d/advanced_model.ifc	679345	SweptSolid	0	140	0	0	0	-	0
-ara3d/advanced_model.ifc	694436	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	737480	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	737716	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	737804	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	737892	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	737936	SweptSolid	0	156	0	0	0	-	0
-ara3d/advanced_model.ifc	738205	SweptSolid	0	92	0	0	0	-	0
-ara3d/advanced_model.ifc	738433	SweptSolid	0	1860	0	0	0	-	0
-ara3d/advanced_model.ifc	739014	SweptSolid	0	1832	0	0	0	-	0
-ara3d/advanced_model.ifc	797099	SweptSolid	0	192	0	0	0	-	0
-ara3d/advanced_model.ifc	797102	SweptSolid	0	192	0	0	0	-	0
-ara3d/advanced_model.ifc	797108	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	797111	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	797114	SweptSolid	0	464	0	0	0	-	0
-ara3d/advanced_model.ifc	797120	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	797123	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	797126	SweptSolid	0	604	0	0	0	-	0
-ara3d/advanced_model.ifc	797129	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	798479	SweptSolid	0	612	0	0	0	-	0
-ara3d/advanced_model.ifc	798926	SweptSolid	0	2900	0	0	0	-	0
-ara3d/advanced_model.ifc	799400	SweptSolid	0	604	0	0	0	-	0
-ara3d/advanced_model.ifc	799566	SweptSolid	0	604	0	0	0	-	0
-ara3d/advanced_model.ifc	799732	SweptSolid	0	604	0	0	0	-	0
-ara3d/advanced_model.ifc	800371	SweptSolid	0	604	0	0	0	-	0
-ara3d/advanced_model.ifc	800374	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800377	SweptSolid	0	464	0	0	0	-	0
-ara3d/advanced_model.ifc	800380	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800383	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800389	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800395	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800398	SweptSolid	0	308	0	0	0	-	0
-ara3d/advanced_model.ifc	800410	SweptSolid	0	340	0	0	0	-	0
-ara3d/advanced_model.ifc	800413	SweptSolid	0	160	0	0	0	-	0
-ara3d/advanced_model.ifc	800416	SweptSolid	0	372	0	0	0	-	0
-ara3d/advanced_model.ifc	800422	SweptSolid	0	324	0	0	0	-	0
-ara3d/advanced_model.ifc	801940	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	801984	SweptSolid	0	44	0	0	0	-	0
-ara3d/advanced_model.ifc	806064	SweptSolid	0	28	0	0	0	-	0
-ara3d/advanced_model.ifc	806149	SweptSolid	0	508	0	0	0	-	0
-ara3d/advanced_model.ifc	815104	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	94	SweptSolid	0	232	0	0	0	-	0
-ara3d/dental_clinic.ifc	95	SweptSolid	0	172	0	0	0	-	0
-ara3d/dental_clinic.ifc	101	SweptSolid	0	128	0	0	0	-	0
-ara3d/dental_clinic.ifc	146	SweptSolid	0	192	0	0	0	-	0
-ara3d/dental_clinic.ifc	156	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	157	SweptSolid	0	92	0	0	0	-	0
-ara3d/dental_clinic.ifc	159	SweptSolid	0	108	0	0	0	-	0
-ara3d/dental_clinic.ifc	163	SweptSolid	0	128	0	0	0	-	0
-ara3d/dental_clinic.ifc	166	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	167	Clipping	10	192	0	0	10	0	10
-ara3d/dental_clinic.ifc	169	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	175	Clipping	0	168	0	0	0	-	0
-ara3d/dental_clinic.ifc	180	Clipping	0	168	0	0	0	-	0
-ara3d/dental_clinic.ifc	184	SweptSolid	0	92	0	0	0	-	0
-ara3d/dental_clinic.ifc	195	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	196	SweptSolid	0	64	0	0	0	-	0
-ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0	8
-ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	215	SweptSolid	0	68	0	0	0	-	0
-ara3d/dental_clinic.ifc	216	SweptSolid	0	92	0	0	0	-	0
-ara3d/dental_clinic.ifc	217	SweptSolid	0	26	0	0	0	-	0
-ara3d/dental_clinic.ifc	218	SweptSolid	0	20	0	0	0	-	0
-ara3d/dental_clinic.ifc	231	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	232	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	233	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	234	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	235	SweptSolid	0	112	0	0	0	-	0
-ara3d/dental_clinic.ifc	236	SweptSolid	0	72	0	0	0	-	0
-ara3d/dental_clinic.ifc	248	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	249	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	262	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	263	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	264	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	265	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	266	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	269	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	270	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	271	Clipping	0	72	0	0	0	-	0
-ara3d/dental_clinic.ifc	272	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	273	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	284	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	285	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	286	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	287	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	288	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	297	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	298	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	299	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	300	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	301	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	302	SweptSolid	0	72	0	0	0	-	0
-ara3d/dental_clinic.ifc	303	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	319	Clipping	0	38	0	0	0	-	0
-ara3d/dental_clinic.ifc	320	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	321	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	322	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	323	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	324	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	325	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	326	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	327	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	329	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	349	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	350	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	351	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	352	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	353	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	354	SweptSolid	0	60	0	0	0	-	0
-ara3d/dental_clinic.ifc	355	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	356	SweptSolid	0	52	0	0	0	-	0
-ara3d/dental_clinic.ifc	357	SweptSolid	0	20	0	0	0	-	0
-ara3d/dental_clinic.ifc	360	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	361	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	375	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	376	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	377	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	378	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	379	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	380	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	381	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	424	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	425	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	426	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	427	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	428	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	429	SweptSolid	0	104	0	0	0	-	0
-ara3d/dental_clinic.ifc	430	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	431	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	432	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	434	SweptSolid	0	12	0	0	0	-	0
-ara3d/dental_clinic.ifc	437	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	438	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	439	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	475	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	481	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	482	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	483	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	484	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	488	SweptSolid	0	20	0	0	0	-	0
-ara3d/dental_clinic.ifc	490	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	491	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	507	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	522	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	523	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	524	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	525	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	526	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	527	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	528	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	529	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	530	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	531	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	532	Clipping	0	22	0	0	0	-	0
-ara3d/dental_clinic.ifc	542	Clipping	0	22	0	0	0	-	0
-ara3d/dental_clinic.ifc	545	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	584	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	590	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	591	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	592	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	593	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	594	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	595	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	596	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	597	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	598	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	599	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	600	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	601	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	627	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	628	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	675	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	686	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	696	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	697	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	698	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	699	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	700	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	701	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	702	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	703	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	704	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	736	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	804	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	825	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	827	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	828	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	829	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	830	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	831	Clipping	0	64	0	0	0	-	0
-ara3d/dental_clinic.ifc	872	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	931	SweptSolid	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	964	Clipping	0	30	0	0	0	-	0
-ara3d/dental_clinic.ifc	965	Clipping	0	30	0	0	0	-	0
-ara3d/dental_clinic.ifc	966	Clipping	0	30	0	0	0	-	0
-ara3d/dental_clinic.ifc	973	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	974	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	975	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	976	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	977	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	978	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	979	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	980	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	981	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	982	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	983	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	984	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	985	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	986	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	987	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	988	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	989	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	990	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	991	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	992	SweptSolid	0	54	0	0	0	-	0
-ara3d/dental_clinic.ifc	993	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	994	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	995	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	996	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	997	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	998	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	999	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1003	Clipping	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1022	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1085	Clipping	0	32	0	0	0	-	0
-ara3d/dental_clinic.ifc	1093	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1094	SweptSolid	0	36	0	0	0	-	0
-ara3d/dental_clinic.ifc	1096	SweptSolid	0	36	0	0	0	-	0
-ara3d/dental_clinic.ifc	1183	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1194	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1195	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-	0
-ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0	10
-ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-	0
-ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-	0
-ara3d/dental_clinic.ifc	1673	Clipping	9	32	1	0	9	0	10
-ara3d/dental_clinic.ifc	1757	Clipping	3	28	1	0	3	0	6
-ara3d/dental_clinic.ifc	1831	SweptSolid	0	24	0	0	0	-	0
-ara3d/dental_clinic.ifc	1832	SweptSolid	0	24	0	0	0	-	0
-ara3d/dental_clinic.ifc	2093	SweptSolid	0	28	0	0	0	-	0
-ara3d/dental_clinic.ifc	2268	SweptSolid	0	48	0	0	0	-	0
-ara3d/dental_clinic.ifc	2269	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2270	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2275	SweptSolid	0	64	0	0	0	-	0
-ara3d/dental_clinic.ifc	2276	SweptSolid	0	76	0	0	0	-	0
-ara3d/dental_clinic.ifc	2278	SweptSolid	0	72	0	0	0	-	0
-ara3d/dental_clinic.ifc	2279	SweptSolid	0	68	0	0	0	-	0
-ara3d/dental_clinic.ifc	2280	SweptSolid	0	68	0	0	0	-	0
-ara3d/dental_clinic.ifc	2285	SweptSolid	0	548	0	0	0	-	0
-ara3d/dental_clinic.ifc	2286	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2287	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0	19
-ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2296	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2297	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-	0
-ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-	0
-ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0	6
-ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0	7
-ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2307	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2308	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2309	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2310	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2311	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2312	SweptSolid	0	56	0	0	0	-	0
-ara3d/dental_clinic.ifc	2313	SweptSolid	0	56	0	0	0	-	0
-ara3d/duplex.ifc	3797	SweptSolid	0	48	0	0	0	-	0
-ara3d/duplex.ifc	3999	SweptSolid	0	48	0	0	0	-	0
-ara3d/duplex.ifc	4043	SweptSolid	0	48	0	0	0	-	0
-ara3d/duplex.ifc	4087	SweptSolid	0	48	0	0	0	-	0
-ara3d/duplex.ifc	4219	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	4508	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	5448	SweptSolid	0	142	0	0	0	-	0
-ara3d/duplex.ifc	5498	SweptSolid	0	218	0	0	0	-	0
-ara3d/duplex.ifc	5548	SweptSolid	0	164	0	0	0	-	0
-ara3d/duplex.ifc	5598	SweptSolid	0	226	0	0	0	-	0
-ara3d/duplex.ifc	5642	SweptSolid	0	32	0	0	0	-	0
-ara3d/duplex.ifc	5687	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	5731	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	5903	SweptSolid	0	32	0	0	0	-	0
-ara3d/duplex.ifc	5948	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	5992	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	12574	SurfaceModel	89	292	0	0	89	70	89
-ara3d/duplex.ifc	12976	SurfaceModel	84	292	0	0	85	70	84
-ara3d/duplex.ifc	13331	SurfaceModel	89	292	0	0	89	70	89
-ara3d/duplex.ifc	13685	SurfaceModel	84	292	0	0	85	70	84
-ara3d/duplex.ifc	14040	SurfaceModel	89	292	0	0	89	70	89
-ara3d/duplex.ifc	14394	SurfaceModel	85	292	0	0	86	70	85
-ara3d/duplex.ifc	14749	SurfaceModel	89	292	0	0	89	70	89
-ara3d/duplex.ifc	15103	SurfaceModel	85	292	0	0	86	70	85
-ara3d/duplex.ifc	16261	SweptSolid	0	68	0	0	0	-	0
-ara3d/duplex.ifc	16802	SweptSolid	3	727	0	0	3	0	3
-ara3d/duplex.ifc	22475	unknown	0	0	0	0	0	-	0
-ara3d/duplex.ifc	22492	SweptSolid	0	60	0	0	0	-	0
-ara3d/duplex.ifc	35199	SweptSolid	0	28	0	0	0	-	0
-ara3d/duplex.ifc	35357	SweptSolid	0	28	0	0	0	-	0
-ara3d/schependomlaan.ifc	46535	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	49281	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	52348	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	72010	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	76629	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	80335	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	99074	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	101868	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	112392	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	115669	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	119854	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	125502	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	133655	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	136076	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	140907	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	143594	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	154792	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	159728	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	163917	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	169275	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	171696	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	178863	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	186163	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	188256	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	263912	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	270253	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	271891	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	311100	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	313863	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	315576	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	325984	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	338352	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	340160	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	345463	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	368479	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	401470	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	404402	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	409878	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	411995	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	415563	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	422700	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	424453	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	426206	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	435307	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	472665	SweptSolid	0	80	0	0	0	-	0
-ara3d/schependomlaan.ifc	534371	SweptSolid	0	12	0	0	0	-	0
-ara3d/schependomlaan.ifc	558010	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	562146	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	597457	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	605031	SweptSolid	0	40	0	0	0	-	0
-ara3d/schependomlaan.ifc	618431	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	640164	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	643860	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	668602	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	711509	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	717596	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	753581	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	766683	SweptSolid	0	12	0	0	0	-	0
-ara3d/schependomlaan.ifc	778605	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	783014	SweptSolid	0	40	0	0	0	-	0
-ara3d/schependomlaan.ifc	787207	SweptSolid	0	48	0	0	0	-	0
-ara3d/schependomlaan.ifc	820735	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	822589	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	826337	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	829534	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	876846	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	878050	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	879248	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	880446	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	967617	SweptSolid	0	0	0	0	0	-	0
-ara3d/schependomlaan.ifc	969938	SweptSolid	0	0	0	0	0	-	0
-ara3d/tested_sample_project.ifc	186	SweptSolid	0	192	0	0	0	-	0
-ara3d/tested_sample_project.ifc	294	SweptSolid	0	28	0	0	0	-	0
-buildingsmart/wall-with-opening-and-window.ifc	45	unknown	0	32	0	0	0	-	0
-ifc5/Hello_Wall_hello-wall.ifc	1222	SweptSolid	0	68	0	0	0	-	0
-ifcopenshell/faceted_brep_csg.ifc	1096640	CSG	0	58	0	0	0	-	0
-issues/1007_roof_brep_opening_winding.ifc	1112	Brep	0	98	0	0	0	-	0
-issues/218_IFC-test-lite.ifc	417	SweptSolid	8	72	0	0	8	8	24
-issues/821_TallBuilding.ifc	615	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	810	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	887	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	964	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	1297	Clipping	0	44	0	0	0	-	0
-issues/821_TallBuilding.ifc	1850	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	1926	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	2002	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	2078	Clipping	0	52	0	0	0	-	0
-issues/821_TallBuilding.ifc	2401	Clipping	0	68	0	0	0	-	0
-issues/821_TallBuilding.ifc	2477	Clipping	0	72	0	0	0	-	0
-issues/821_TallBuilding.ifc	11462	Clipping	0	44	0	0	0	-	0
-issues/832_opening_representations.ifc	50	SweptSolid	0	32	0	0	0	-	0
-issues/832_opening_representations.ifc	89	SweptSolid	0	36	0	0	0	-	0
-issues/832_opening_representations.ifc	128	SweptSolid	0	32	0	0	0	-	0
-issues/832_opening_representations.ifc	175	SweptSolid	0	28	0	0	0	-	0
-issues/832_opening_representations.ifc	222	SweptSolid	0	28	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	96	SweptSolid	0	96	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	144	SweptSolid	0	28	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	192	SweptSolid	0	68	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	240	SweptSolid	0	32	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	336	SweptSolid	0	174	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	384	SweptSolid	0	322	1	0	0	-	3
-issues/841_house_stack_overflow.ifc	432	SweptSolid	0	338	1	0	0	-	0
-issues/841_house_stack_overflow.ifc	528	SweptSolid	0	60	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	576	SweptSolid	0	28	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	768	SweptSolid	0	48	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	914	SweptSolid	0	32	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1020	SweptSolid	0	40	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1070	SweptSolid	0	58	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1118	SweptSolid	0	60	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1166	SweptSolid	0	36	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1362	Clipping	0	92	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	1878	Clipping	0	114	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	2152	Clipping	55	236	1	0	6	4	55
-issues/841_house_stack_overflow.ifc	2797	Clipping	0	44	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	3698	Clipping	0	68	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	4148	Clipping	0	142	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	4219	Clipping	0	52	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	4267	SweptSolid	0	30	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	4374	Clipping	0	62	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	4897	Clipping	0	130	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	5904	Clipping	0	124	0	0	0	-	0
-issues/841_house_stack_overflow.ifc	13928	SweptSolid	0	28	0	0	0	-	0
-issues/845_wall_elemented_case.ifc	130	SweptSolid	0	224	0	0	0	-	0
-issues/845_wall_elemented_case.ifc	133	SweptSolid	0	392	0	0	0	-	31
-issues/845_wall_elemented_case.ifc	145	SweptSolid	0	224	0	0	0	-	56
-issues/845_wall_elemented_case.ifc	146	SweptSolid	0	200	0	0	0	-	7
-issues/845_wall_elemented_case.ifc	148	unknown	0	0	0	0	0	-	0
-issues/853_slab_pocket.ifc	303	SweptSolid	0	260	0	0	0	-	0
-issues/953_trimmed_curve_cartesian_arc.ifc	1112	Brep	0	98	0	0	0	-	0
-issues/960_house_segmented_roof_clip.ifc	2152	Clipping	55	236	1	0	6	4	55
-issues/960_house_segmented_roof_clip.ifc	2797	Clipping	0	44	0	0	0	-	0
-issues/960_house_segmented_roof_clip.ifc	4148	Clipping	0	142	0	0	0	-	0
-issues/960_house_segmented_roof_clip.ifc	4374	Clipping	0	62	0	0	0	-	0
-issues/960_house_segmented_roof_clip.ifc	5904	Clipping	0	124	0	0	0	-	0
-issues/964_slab_arbitrary_profile_voids.ifc	6443	SweptSolid	111	322	0	0	113	64	111
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	430	SweptSolid	0	280	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	654	SweptSolid	0	284	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	857	SweptSolid	0	52	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1029	SweptSolid	0	128	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1183	SweptSolid	0	172	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1369	SweptSolid	0	204	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1536	SweptSolid	0	92	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1649	SweptSolid	0	32	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1691	SweptSolid	0	76	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1789	SweptSolid	0	496	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1992	SweptSolid	0	32	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	2036	SweptSolid	0	588	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	2411	SweptSolid	0	1406	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3051	SweptSolid	0	48	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3110	SweptSolid	0	112	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3394	Clipping	0	32	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	25758	SweptSolid	40	308	0	0	40	50	40
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	26830	SweptSolid	0	32	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	27921	Clipping	0	32	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45444	SweptSolid	0	64	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45708	SweptSolid	0	176	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45774	Clipping	0	40	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	71367	SweptSolid	0	216	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	81962	SweptSolid	136	784	0	0	136	158	136
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	100256	SweptSolid	0	84	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	100536	SweptSolid	0	176	0	0	0	-	0
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	124547	SweptSolid	0	968	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	74	SweptSolid	0	52	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	75	SweptSolid	0	76	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	77	SweptSolid	0	524	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	78	SweptSolid	0	240	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	90	SweptSolid	0	340	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	91	SweptSolid	0	84	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	92	SweptSolid	0	52	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	93	SweptSolid	0	58	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	94	SweptSolid	0	52	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	103	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	104	SweptSolid	0	48	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	105	SweptSolid	0	250	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	106	SweptSolid	0	84	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	107	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	108	SweptSolid	0	476	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	109	SweptSolid	0	158	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	110	SweptSolid	0	96	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	111	SweptSolid	0	28	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	112	SweptSolid	0	56	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	113	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	114	SweptSolid	0	164	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	115	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	116	SweptSolid	0	68	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	136	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	137	SweptSolid	0	128	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	138	SweptSolid	0	180	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	139	SweptSolid	0	48	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	140	SweptSolid	0	194	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	141	SweptSolid	0	28	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	142	SweptSolid	0	56	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	143	SweptSolid	0	120	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	144	SweptSolid	0	172	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	145	SweptSolid	0	94	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	146	SweptSolid	0	40	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	179	SweptSolid	0	136	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	180	SweptSolid	0	124	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	181	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	182	SweptSolid	0	128	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	183	SweptSolid	0	28	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	214	SweptSolid	0	32	0	0	0	-	0
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	276	SweptSolid	0	72	0	0	0	-	0
-various/issue-604-door.ifc	55	SweptSolid	0	28	0	0	0	-	0
-various/rvt01.ifc	5941	Tessellation	58	281	0	0	61	11	93
-various/rvt01.ifc	6073	Tessellation	8	290	0	0	34	0	39
-various/rvt01.ifc	6163	SweptSolid	13	79	0	0	13	0	19
-various/rvt01.ifc	6243	SweptSolid	29	146	0	0	36	8	51
-various/rvt01.ifc	6305	SweptSolid	30	266	1	0	67	8	60
-various/rvt01.ifc	6420	SweptSolid	31	163	0	0	28	6	43
-various/rvt01.ifc	6511	SweptSolid	22	190	0	0	13	6	30
-various/rvt01.ifc	6588	SweptSolid	8	134	0	0	8	0	26
-various/rvt01.ifc	6724	SweptSolid	32	211	0	0	36	8	46
-various/rvt01.ifc	6810	SweptSolid	97	293	1	0	99	27	125
-various/rvt01.ifc	6934	SweptSolid	0	100	0	0	6	-	6
-various/rvt01.ifc	7013	SweptSolid	32	221	0	0	29	8	61
-various/rvt01.ifc	7075	SweptSolid	51	264	0	0	37	8	80
-various/rvt01.ifc	7137	SweptSolid	18	164	0	0	25	0	29
-various/rvt01.ifc	7216	SweptSolid	15	157	0	0	18	0	28
-various/rvt01.ifc	7295	SweptSolid	53	160	1	0	39	6	58
-various/rvt01.ifc	7403	Tessellation	11	41	0	0	11	3	18
-various/rvt01.ifc	7544	SweptSolid	76	239	1	0	56	8	102
-various/rvt01.ifc	7700	SweptSolid	41	161	0	0	39	0	43
-various/rvt01.ifc	7834	SweptSolid	90	241	0	0	81	16	128
-various/rvt01.ifc	8881	SweptSolid	56	221	1	0	36	8	73
-various/rvt01.ifc	8997	SweptSolid	54	218	0	0	43	26	74
-various/rvt01.ifc	9058	SweptSolid	44	214	0	0	48	8	59
-various/rvt01.ifc	9229	SweptSolid	31	222	0	0	25	8	58
-various/rvt01.ifc	9400	SweptSolid	32	204	0	0	29	0	44
-various/rvt01.ifc	9730	SweptSolid	20	136	1	0	20	8	36
-various/rvt01.ifc	9901	SweptSolid	18	110	0	0	21	8	34
-various/rvt01.ifc	10191	Tessellation	13	31	0	0	14	0	13
-various/rvt01.ifc	10335	Tessellation	3	11	0	0	4	0	3
-various/rvt01.ifc	10526	Tessellation	13	103	0	0	13	0	24
-various/rvt01.ifc	10632	Tessellation	11	167	1	0	5	0	11
-various/rvt01.ifc	11110	Tessellation	0	4	0	0	3	-	0
-various/rvt01.ifc	11168	Tessellation	4	78	0	0	6	0	4
-various/rvt01.ifc	11232	Tessellation	0	64	0	0	0	-	2
-various/rvt01.ifc	11304	Tessellation	0	32	0	0	0	-	0
-various/rvt01.ifc	11477	Tessellation	0	0	0	0	7	-	0
-various/rvt01.ifc	11563	Tessellation	23	18	0	1	26	0	23
-various/rvt01.ifc	11627	Tessellation	63	63	0	1	54	3	65
-various/rvt01.ifc	11690	Tessellation	72	93	0	1	56	6	73
-various/rvt01.ifc	11753	Tessellation	10	4	0	1	16	0	10
-various/rvt01.ifc	11803	SweptSolid	22	65	0	0	12	0	23
-various/rvt01.ifc	12235	SweptSolid	15	59	0	0	15	0	16
-various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0	12
-various/rvt01.ifc	12449	Tessellation	16	168	1	0	31	9	19
-various/rvt01.ifc	13735	SweptSolid	35	213	0	0	19	8	63
-various/rvt01.ifc	13797	Tessellation	131	508	1	0	119	42	213
-various/rvt01.ifc	14014	SweptSolid	44	214	1	0	41	8	66
-various/rvt01.ifc	14132	SweptSolid	30	210	0	0	29	8	50
-various/rvt01.ifc	14194	SweptSolid	34	202	0	0	34	8	57
-various/rvt01.ifc	14256	SweptSolid	32	200	0	0	35	0	54
-various/rvt01.ifc	14447	SweptSolid	3	255	1	0	7	0	48
-various/rvt01.ifc	14638	SweptSolid	21	191	0	0	21	8	45
-various/rvt01.ifc	14797	SweptSolid	17	151	0	0	17	0	31
-various/rvt01.ifc	15020	SweptSolid	25	201	0	0	21	8	49
-various/rvt01.ifc	15301	SweptSolid	42	193	0	0	32	8	60
-various/rvt01.ifc	15857	SweptSolid	31	201	1	0	35	12	48
-various/rvt01.ifc	15917	SweptSolid	43	250	1	0	55	16	76
-various/rvt01.ifc	16231	SweptSolid	45	170	1	0	30	0	53
-various/rvt01.ifc	16286	SweptSolid	46	192	1	0	40	8	58
-various/rvt01.ifc	16805	SweptSolid	26	116	1	0	15	8	41
-various/rvt01.ifc	17553	Tessellation	4	10	0	0	4	0	7
-various/rvt01.ifc	17615	Tessellation	0	56	0	0	0	-	0
-various/rvt01.ifc	17919	Tessellation	0	48	0	0	0	-	6
-various/rvt01.ifc	17985	Tessellation	27	59	0	0	25	0	27
-various/rvt01.ifc	18169	SweptSolid	42	186	1	0	29	8	58
-various/rvt01.ifc	21999	SweptSolid	0	40	0	1	0	-	20
-various/rvt01.ifc	25694	Tessellation	3	111	0	0	3	0	3
-various/rvt01.ifc	25914	SweptSolid	12	176	0	0	13	0	35
-various/rvt01.ifc	26166	Tessellation	8	100	0	0	0	0	16
-various/rvt01.ifc	26300	Tessellation	41	207	1	0	8	0	53
-various/rvt01.ifc	26610	Tessellation	3	63	0	0	3	0	3
-various/rvt01.ifc	26681	Tessellation	0	174	0	0	4	-	6
-various/rvt01.ifc	26832	Tessellation	0	22	0	0	0	-	0
-various/rvt01.ifc	30054	Tessellation	0	48	0	0	0	-	0
-various/rvt01.ifc	30125	Tessellation	0	44	0	0	6	-	0
-various/rvt01.ifc	30518	Tessellation	7	257	0	0	0	0	8
-various/rvt01.ifc	31083	Tessellation	25	55	0	0	15	0	25
-various/rvt01.ifc	31156	Tessellation	3	173	0	0	0	0	3
-various/rvt01.ifc	31323	Tessellation	0	8	0	0	0	-	3
-various/rvt01.ifc	31430	Tessellation	0	50	0	0	0	-	2
-various/rvt01.ifc	31577	Tessellation	0	48	0	0	0	-	0
-various/rvt01.ifc	31648	Tessellation	0	44	0	0	6	-	0
-various/rvt01.ifc	32081	SweptSolid	31	213	1	0	31	0	48
-various/rvt01.ifc	33639	SweptSolid	122	308	0	1	157	24	135
-various/rvt01.ifc	37278	Tessellation	4	16	0	0	5	0	4
-various/rvt01.ifc	37347	Tessellation	39	169	1	0	38	0	63
-various/rvt01.ifc	37455	Tessellation	20	164	0	0	15	3	25
-various/rvt01.ifc	37570	SweptSolid	0	76	0	0	0	-	12
-various/rvt01.ifc	38680	Tessellation	28	150	1	0	27	0	35
-various/rvt01.ifc	38745	SweptSolid	4	54	0	0	4	0	8
-various/rvt01.ifc	38800	SweptSolid	39	246	1	0	41	14	81
+# vol:   signed enclosed volume in whole cm^3, or - if not taken. Taken only where
+#        open is 0: an open surface has no volume to read. A change here requires a
+#        bless in either direction; the reason says how much and which way.
+model	id	rep	open	tris	coll	far	alt	pre	strict	vol
+ara3d/AC20-FZK-Haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0	2914954
+ara3d/AC20-FZK-Haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0	3412238
+ara3d/AC20-FZK-Haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0	5808017
+ara3d/AC20-FZK-Haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0	6604926
+ara3d/AC20-FZK-Haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0	6417058
+ara3d/AC20-FZK-Haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0	7317067
+ara3d/AC20-FZK-Haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0	19968257
+ara3d/AC20-FZK-Haus.ifc	60012	Clipping	0	204	0	0	18	-	0	5550386
+ara3d/AC20-FZK-Haus.ifc	67828	Clipping	0	196	0	0	18	-	0	5550388
+ara3d/C20-Institute-Var-2.ifc	31190	SweptSolid	0	320	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	35819	SweptSolid	0	324	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	40505	SweptSolid	0	600	0	0	0	-	0	24777211
+ara3d/C20-Institute-Var-2.ifc	47404	SweptSolid	0	116	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	50078	SweptSolid	0	130	0	0	0	-	0	20826168
+ara3d/C20-Institute-Var-2.ifc	52075	SweptSolid	0	52	0	0	0	-	0	3519022
+ara3d/C20-Institute-Var-2.ifc	55353	SweptSolid	0	42	0	0	0	-	0	5400322
+ara3d/C20-Institute-Var-2.ifc	56404	SweptSolid	0	40	0	0	0	-	0	4293030
+ara3d/C20-Institute-Var-2.ifc	57708	SweptSolid	0	40	0	0	0	-	0	4293039
+ara3d/C20-Institute-Var-2.ifc	72946	SweptSolid	0	80	0	0	0	-	0	156421594
+ara3d/C20-Institute-Var-2.ifc	81755	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	82662	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	83555	SweptSolid	0	320	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	87784	SweptSolid	0	70	0	0	0	-	0	2217015
+ara3d/C20-Institute-Var-2.ifc	90339	SweptSolid	0	320	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	94567	SweptSolid	0	324	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	99022	SweptSolid	0	100	0	0	0	-	0	11817094
+ara3d/C20-Institute-Var-2.ifc	100667	SweptSolid	0	72	0	0	0	-	0	12447102
+ara3d/C20-Institute-Var-2.ifc	101958	SweptSolid	0	120	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	104309	SweptSolid	0	64	0	0	0	-	0	13077111
+ara3d/C20-Institute-Var-2.ifc	107811	SweptSolid	0	328	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	112277	SweptSolid	0	36	0	0	0	-	0	8221564
+ara3d/C20-Institute-Var-2.ifc	113099	SweptSolid	0	42	0	0	0	-	0	8221574
+ara3d/C20-Institute-Var-2.ifc	114155	SweptSolid	0	32	0	0	0	-	0	958510
+ara3d/C20-Institute-Var-2.ifc	114727	SweptSolid	0	32	0	0	0	-	0	958510
+ara3d/C20-Institute-Var-2.ifc	125284	SweptSolid	0	80	0	0	0	-	0	158521615
+ara3d/C20-Institute-Var-2.ifc	135395	SweptSolid	0	320	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	139845	SweptSolid	0	324	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	144069	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	144635	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	145201	SweptSolid	0	948	0	0	0	-	0	21177175
+ara3d/C20-Institute-Var-2.ifc	154762	SweptSolid	0	116	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	157112	SweptSolid	0	120	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	159462	SweptSolid	0	192	0	0	0	-	0	29124241
+ara3d/C20-Institute-Var-2.ifc	165435	SweptSolid	0	34	0	0	0	-	0	1955963
+ara3d/C20-Institute-Var-2.ifc	166266	SweptSolid	0	40	0	0	0	-	0	4293030
+ara3d/C20-Institute-Var-2.ifc	167338	SweptSolid	0	40	0	0	0	-	0	4293039
+ara3d/C20-Institute-Var-2.ifc	178044	SweptSolid	0	64	0	0	0	-	0	150121530
+ara3d/C20-Institute-Var-2.ifc	188155	SweptSolid	0	320	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	192605	SweptSolid	0	324	0	0	0	-	0	9180077
+ara3d/C20-Institute-Var-2.ifc	196829	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	197395	SweptSolid	0	32	0	0	0	-	0	9072082
+ara3d/C20-Institute-Var-2.ifc	197961	SweptSolid	0	948	0	0	0	-	0	21177175
+ara3d/C20-Institute-Var-2.ifc	207522	SweptSolid	0	116	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	209872	SweptSolid	0	120	0	0	0	-	0	10557078
+ara3d/C20-Institute-Var-2.ifc	212222	SweptSolid	0	182	0	0	0	-	0	29124241
+ara3d/C20-Institute-Var-2.ifc	218661	SweptSolid	0	40	0	0	0	-	0	4293030
+ara3d/C20-Institute-Var-2.ifc	219733	SweptSolid	0	40	0	0	0	-	0	4293039
+ara3d/C20-Institute-Var-2.ifc	220884	SweptSolid	0	64	0	0	0	-	0	150121530
+ara3d/FM_ARC_DigitalHub.ifc	26448	SweptSolid	0	72	0	0	0	-	0	281396940
+ara3d/FM_ARC_DigitalHub.ifc	26635	SweptSolid	0	52	0	0	0	-	0	295821951
+ara3d/FM_ARC_DigitalHub.ifc	30660	SweptSolid	0	28	0	0	0	-	0	4275877
+ara3d/FM_ARC_DigitalHub.ifc	30826	SweptSolid	0	28	0	0	0	-	0	12168983
+ara3d/FM_ARC_DigitalHub.ifc	31022	SweptSolid	0	28	0	0	0	-	0	5781494
+ara3d/FM_ARC_DigitalHub.ifc	40974	SweptSolid	0	28	0	0	0	-	0	2541161
+ara3d/FM_ARC_DigitalHub.ifc	52867	SweptSolid	0	34	0	0	0	-	0	2197456
+ara3d/FM_ARC_DigitalHub.ifc	53112	SweptSolid	0	34	0	0	0	-	0	1859966
+ara3d/FM_ARC_DigitalHub.ifc	61530	SweptSolid	0	48	0	0	0	-	0	648690
+ara3d/FM_ARC_DigitalHub.ifc	67415	SweptSolid	0	28	0	0	0	-	0	4275877
+ara3d/FM_ARC_DigitalHub.ifc	67562	SweptSolid	0	28	0	0	0	-	0	12168983
+ara3d/FM_ARC_DigitalHub.ifc	67758	SweptSolid	0	28	0	0	0	-	0	5781494
+ara3d/FM_ARC_DigitalHub.ifc	77712	SweptSolid	0	28	0	0	0	-	0	2541161
+ara3d/FM_ARC_DigitalHub.ifc	89640	SweptSolid	0	34	0	0	0	-	0	2197463
+ara3d/FM_ARC_DigitalHub.ifc	89885	SweptSolid	0	34	0	0	0	-	0	1859973
+ara3d/FM_ARC_DigitalHub.ifc	90210	SweptSolid	0	48	0	0	0	-	0	648690
+ara3d/FM_ARC_DigitalHub.ifc	99281	SweptSolid	0	72	0	0	0	-	0	158367337
+ara3d/FM_ARC_DigitalHub.ifc	100158	SweptSolid	0	168	0	0	0	-	0	26911553
+ara3d/FM_ARC_DigitalHub.ifc	100207	SweptSolid	0	186	0	0	0	-	0	26443934
+ara3d/FM_ARC_DigitalHub.ifc	106167	Clipping	0	48	0	0	0	-	0	1233071
+ara3d/FM_ARC_DigitalHub.ifc	106259	SweptSolid	0	40	0	0	0	-	0	1228671
+ara3d/FM_ARC_DigitalHub.ifc	106951	SweptSolid	0	100	0	0	0	-	0	128392921
+ara3d/FM_ARC_DigitalHub.ifc	136983	SweptSolid	0	80	0	0	0	-	0	8286552
+ara3d/FM_ARC_DigitalHub.ifc	137547	Clipping	0	60	0	0	0	-	0	4659365
+ara3d/FM_ARC_DigitalHub.ifc	138037	Clipping	12	301	1	0	21	0	12	-
+ara3d/FM_ARC_DigitalHub.ifc	138279	SweptSolid	0	60	0	0	0	-	0	4659365
+ara3d/FM_ARC_DigitalHub.ifc	138767	Clipping	0	80	0	0	0	-	0	8286552
+ara3d/FM_ARC_DigitalHub.ifc	139288	Clipping	9	300	1	0	9	0	9	-
+ara3d/FM_ARC_DigitalHub.ifc	139605	Clipping	9	300	1	0	9	0	9	-
+ara3d/FM_ARC_DigitalHub.ifc	139864	Clipping	0	184	0	0	0	-	0	12700602
+ara3d/FM_ARC_DigitalHub.ifc	139985	Clipping	9	300	1	0	18	0	9	-
+ara3d/FM_ARC_DigitalHub.ifc	140227	SweptSolid	0	184	0	0	0	-	0	12700602
+ara3d/FM_ARC_DigitalHub.ifc	140337	SweptSolid	0	496	0	0	0	-	0	88860205
+ara3d/FM_ARC_DigitalHub.ifc	146777	SweptSolid	0	222	0	0	0	-	0	33511756
+ara3d/FM_ARC_DigitalHub.ifc	149094	SweptSolid	0	668	0	0	0	-	0	91218199
+ara3d/FM_ARC_DigitalHub.ifc	155733	SweptSolid	0	282	0	0	11	-	0	33511740
+ara3d/FM_ARC_DigitalHub.ifc	187843	SweptSolid	0	172	0	0	0	-	0	31679430
+ara3d/FM_ARC_DigitalHub.ifc	188186	SweptSolid	0	32	0	0	0	-	0	3361126
+ara3d/FM_ARC_DigitalHub.ifc	188235	SweptSolid	0	52	0	0	0	-	0	7023358
+ara3d/FM_ARC_DigitalHub.ifc	188333	SweptSolid	0	74	0	0	0	-	0	10340341
+ara3d/FM_ARC_DigitalHub.ifc	188424	SweptSolid	0	28	0	0	0	-	0	266515
+ara3d/FM_ARC_DigitalHub.ifc	196863	SweptSolid	0	112	0	0	0	-	0	21212811
+ara3d/FM_ARC_DigitalHub.ifc	196912	SweptSolid	0	52	0	0	0	-	0	3791878
+ara3d/FM_ARC_DigitalHub.ifc	196961	SweptSolid	0	132	0	0	0	-	0	20878464
+ara3d/FM_ARC_DigitalHub.ifc	197010	SweptSolid	0	52	0	0	0	-	0	3791878
+ara3d/FM_ARC_DigitalHub.ifc	197353	SweptSolid	0	52	0	0	0	-	0	6968619
+ara3d/FM_ARC_DigitalHub.ifc	197794	SweptSolid	0	52	0	0	0	-	0	6886488
+ara3d/FM_ARC_DigitalHub.ifc	200204	SweptSolid	0	52	0	0	0	-	0	2507369
+ara3d/FM_ARC_DigitalHub.ifc	200253	SweptSolid	0	52	0	0	0	-	0	2671622
+ara3d/FM_ARC_DigitalHub.ifc	200449	SweptSolid	0	52	0	0	0	-	0	1795665
+ara3d/FM_ARC_DigitalHub.ifc	200645	SweptSolid	0	52	0	0	0	-	0	1713547
+ara3d/FM_ARC_DigitalHub.ifc	216340	SweptSolid	0	68	0	0	0	-	0	391187637
+ara3d/FM_ARC_DigitalHub.ifc	216561	SweptSolid	0	44	0	0	0	-	0	8625487
+ara3d/FM_ARC_DigitalHub.ifc	216762	SweptSolid	0	28	0	0	0	-	0	8733493
+ara3d/FM_ARC_DigitalHub.ifc	217867	SweptSolid	0	72	0	0	0	-	0	307785
+ara3d/FM_ARC_DigitalHub.ifc	218038	SweptSolid	0	32	0	0	0	-	0	473892
+ara3d/FM_ARC_DigitalHub.ifc	218227	SweptSolid	0	72	0	0	0	-	0	322928
+ara3d/FM_ARC_DigitalHub.ifc	218398	SweptSolid	0	32	0	0	0	-	0	473892
+ara3d/FM_ARC_DigitalHub.ifc	218587	SweptSolid	0	52	0	0	0	-	0	227101
+ara3d/FM_ARC_DigitalHub.ifc	218718	SweptSolid	0	52	0	0	0	-	0	227101
+ara3d/FM_ARC_DigitalHub.ifc	219094	SweptSolid	0	52	0	0	0	-	0	227101
+ara3d/FM_ARC_DigitalHub.ifc	219225	SweptSolid	0	52	0	0	0	-	0	227101
+ara3d/ISSUE_005_haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0	2914954
+ara3d/ISSUE_005_haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0	3412238
+ara3d/ISSUE_005_haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0	5808017
+ara3d/ISSUE_005_haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0	6604926
+ara3d/ISSUE_005_haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0	6417058
+ara3d/ISSUE_005_haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0	7317067
+ara3d/ISSUE_005_haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0	19968257
+ara3d/ISSUE_005_haus.ifc	60012	Clipping	0	204	0	0	18	-	0	5550386
+ara3d/ISSUE_005_haus.ifc	67828	Clipping	0	196	0	0	18	-	0	5550388
+ara3d/ISSUE_126_model.ifc	40983	SweptSolid	0	52	0	0	0	-	0	907580
+ara3d/ISSUE_126_model.ifc	43236	SweptSolid	0	20	0	0	0	-	0	201577
+ara3d/ISSUE_126_model.ifc	49197	SweptSolid	0	20	0	0	0	-	0	180119
+ara3d/ISSUE_126_model.ifc	49964	SweptSolid	0	20	0	0	0	-	0	127069
+ara3d/ISSUE_126_model.ifc	50658	SweptSolid	0	54	0	0	0	-	0	613821
+ara3d/ISSUE_126_model.ifc	50766	SweptSolid	0	58	0	0	0	-	0	141910
+ara3d/ISSUE_126_model.ifc	52352	SweptSolid	0	34	0	0	0	-	0	38325
+ara3d/ISSUE_126_model.ifc	56758	SweptSolid	0	30	0	0	0	-	0	312981
+ara3d/ISSUE_126_model.ifc	73237	SweptSolid	0	28	0	0	0	-	0	696566
+ara3d/ISSUE_126_model.ifc	73349	SweptSolid	0	264	0	0	0	-	0	5861784
+ara3d/ISSUE_126_model.ifc	77438	SweptSolid	0	80	0	0	0	-	0	86496
+ara3d/ISSUE_126_model.ifc	78232	SweptSolid	0	52	0	0	0	-	0	471427
+ara3d/ISSUE_126_model.ifc	78975	SweptSolid	0	264	0	0	0	-	0	4301247
+ara3d/ISSUE_126_model.ifc	82108	SweptSolid	0	28	0	0	0	-	0	173347
+ara3d/ISSUE_126_model.ifc	82925	SweptSolid	0	34	0	0	0	-	0	38318
+ara3d/ISSUE_126_model.ifc	83323	SweptSolid	0	66	0	0	0	-	0	840110
+ara3d/ISSUE_126_model.ifc	83694	SweptSolid	0	20	0	0	0	-	0	59590
+ara3d/ISSUE_126_model.ifc	84442	SweptSolid	0	34	0	0	0	-	0	38318
+ara3d/ISSUE_126_model.ifc	86446	SweptSolid	0	54	0	0	0	-	0	141887
+ara3d/ISSUE_126_model.ifc	86609	SweptSolid	0	28	0	0	0	-	0	862544
+ara3d/ISSUE_126_model.ifc	98282	SweptSolid	26	220	0	0	26	0	26	-
+ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-	0	474969
+ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0	27	-
+ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-	0	660647
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	34	422	0	0	18	6	34	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1119	1157	0	1	931	0	1124	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	0	0	-	0	11869873
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	0	30	0	0	0	-	0	5875039
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	723	824	1	1	717	0	774	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	0	192	0	0	0	-	0	6974662
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	2106	2332	1	1	1811	0	2119	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	260	1536	0	1	144	0	264	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	493	725	1	1	571	0	493	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	458	882	0	1	375	0	469	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	26	160	0	0	24	12	26	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	6	190	0	0	0	0	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	0	118	0	0	0	-	0	10178345
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	6	282	0	0	0	0	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	1723	1764	0	1	2008	0	1730	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	34	131	1	0	34	0	34	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	0	151	1	0	0	-	0	3242613
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	0	0	-	0	1570711
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	743	1429	1	1	768	3	752	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	0	126	0	0	0	-	0	383526
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	0	182	0	0	0	-	0	7063377
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	0	6	0	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68263	Clipping	0	84	0	0	0	-	0	2517475
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68943	Clipping	0	192	0	0	0	-	0	4592372
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69569	Clipping	0	46	0	0	0	-	0	1816337
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69961	Clipping	0	180	0	0	0	-	0	182772
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81223	Clipping	0	166	0	0	0	-	0	4091089
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81562	Clipping	0	238	0	0	0	-	0	4188817
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81869	Clipping	0	28	0	0	0	-	15	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	83043	Clipping	0	46	0	0	0	-	0	1727547
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138693	Clipping	0	108	0	0	0	-	0	4638831
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138919	Clipping	0	76	0	0	0	-	0	19504171
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139190	SweptSolid	6	174	0	0	6	0	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139364	Clipping	0	182	0	0	0	-	0	50793066
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139571	SweptSolid	0	304	0	0	0	-	0	14738995
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSolid	37	161	0	0	0	0	37	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	20	180	0	0	0	6	20	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	0	118	0	0	0	-	0	33362947
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	0	190	0	0	0	-	0	1187154
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	519	1008	0	1	388	0	527	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	0	100	0	0	0	-	0	66527568
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	356	562	0	1	312	0	359	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	214	993	0	1	284	0	240	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	148	174	0	1	129	0	152	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	92	83	0	1	101	0	92	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-	0	19407023
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	403	639	0	1	340	0	416	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	0	229	1	0	0	-	1	1986684
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	9	93	0	0	9	0	9	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	7	244	1	0	7	0	7	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	3	200	1	0	3	0	3	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	622	473	1	1	515	0	629	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	621	572	1	1	553	0	633	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-	0	216919038
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	6	12	0	0	6	0	6	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	279	649	0	1	250	0	281	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	222	387	0	1	129	0	224	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0	63	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1326	1347	1	1	1209	6	1339	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	1110	1095	1	1	1334	0	1115	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	29	125	0	0	29	0	29	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	54	0	0	0	-	0	9952879
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	0	74	0	0	0	-	0	5662539
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	18	30	0	1	18	0	18	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	54	0	0	0	-	0	9952879
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	54	0	0	0	-	0	9952879
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	34	44	0	1	34	0	34	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	0	160	0	0	0	-	0	2021562
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	0	46	0	0	0	-	0	2662478
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	0	0	-	0	391568
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360821	SweptSolid	0	32	0	0	0	-	0	269625
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360966	SweptSolid	0	44	0	0	0	-	0	385157
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	361107	SweptSolid	0	38	0	0	0	-	0	398517
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4380	SweptSolid	6	94	0	0	0	0	6	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4630	SweptSolid	0	38	1	0	0	-	0	4716266
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4732	SweptSolid	0	28	0	0	0	-	0	4295328
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4834	SweptSolid	0	44	0	0	0	-	0	12662791
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4940	SweptSolid	0	44	0	0	0	-	0	1567238
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	6012	Clipping	6	144	0	0	6	0	6	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	8511	SweptSolid	0	36	0	0	0	-	0	3597847
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27148	SweptSolid	3	117	1	0	0	0	3	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27562	SweptSolid	0	28	0	0	0	-	0	764373
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27770	SweptSolid	0	28	0	0	0	-	0	353129
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	28290	SweptSolid	0	44	0	0	0	-	0	1773116
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	34099	SweptSolid	35	259	0	0	30	0	35	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	37094	SweptSolid	0	64	1	0	0	-	0	2914418
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46565	SweptSolid	0	100	0	0	0	-	0	6617037
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46667	SweptSolid	0	32	0	0	0	-	0	4716265
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46769	SweptSolid	0	28	0	0	0	-	0	4295328
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46871	SweptSolid	0	44	0	0	0	-	0	1567238
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	47807	SweptSolid	0	168	0	0	0	-	0	5288329
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	49773	SweptSolid	0	36	0	0	0	-	0	3597847
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63308	SweptSolid	0	28	0	0	0	-	0	764373
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63516	SweptSolid	0	28	0	0	0	-	0	353129
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	64036	SweptSolid	0	44	0	0	0	-	0	1773116
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	76544	SweptSolid	0	60	0	0	0	-	0	2155557
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78513	SweptSolid	0	156	0	0	0	-	0	59583457
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78918	Clipping	12	106	0	0	0	0	12	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79070	Clipping	0	50	1	0	0	-	0	3444646
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79197	Clipping	0	44	0	0	0	-	0	6406640
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79969	AdvancedBrep	0	80	0	0	0	-	0	21521856
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	80101	Clipping	0	80	0	0	0	-	0	2427536
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	81274	Clipping	12	140	0	0	12	0	12	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	83292	Clipping	0	52	0	0	0	-	0	2126638
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87331	Clipping	0	132	0	0	0	-	0	8850339
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87839	Clipping	0	44	1	0	0	-	0	1298858
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88116	Clipping	0	46	1	0	0	-	0	659910
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88776	Clipping	0	76	1	0	0	-	0	2773015
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	92201	Clipping	17	141	0	0	20	0	17	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	94199	Clipping	0	66	1	0	0	-	0	3861856
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95188	Clipping	6	96	0	0	6	0	6	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95332	Clipping	0	44	0	0	3	-	0	3444640
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95459	Clipping	0	44	0	0	0	-	0	6406640
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95605	Clipping	0	80	0	0	0	-	0	2427536
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	96778	Clipping	12	132	0	0	12	0	12	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	98786	Clipping	0	48	0	0	0	-	0	2126635
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100558	Clipping	0	44	1	0	0	-	0	1298862
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100835	Clipping	0	46	1	0	0	-	0	659910
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	101495	Clipping	0	76	1	0	0	-	0	2773019
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	103251	Clipping	0	78	1	0	3	-	0	2589260
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	105519	SweptSolid	0	156	0	0	0	-	0	59583457
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119816	SweptSolid	6	62	0	0	0	0	6	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119924	SweptSolid	3	63	1	0	0	0	3	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120028	SweptSolid	0	28	0	0	0	-	0	4295328
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120132	SweptSolid	0	44	0	0	0	-	0	12662791
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120448	SweptSolid	0	96	0	0	0	-	0	5397823
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	121490	SweptSolid	0	60	0	0	0	-	0	2633659
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	122695	SweptSolid	12	144	1	0	0	0	12	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123117	SweptSolid	0	28	0	0	0	-	0	764373
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123329	SweptSolid	0	28	0	0	0	-	0	353129
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123859	SweptSolid	0	44	0	0	0	-	0	1773116
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	124711	SweptSolid	0	204	0	0	0	-	0	5592146
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	127658	SweptSolid	0	54	1	0	0	-	0	2735389
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128193	SweptSolid	3	97	1	0	0	0	3	-
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128297	SweptSolid	0	32	0	0	0	-	0	4716265
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128401	SweptSolid	0	28	0	0	0	-	0	4295328
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128505	SweptSolid	0	44	0	0	0	-	0	1567238
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	129459	SweptSolid	0	120	0	0	0	-	0	4736424
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	131443	SweptSolid	0	36	0	0	0	-	0	2837500
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132587	SweptSolid	0	28	0	0	0	-	0	764373
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132799	SweptSolid	0	28	0	0	0	-	0	353129
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	133329	SweptSolid	0	44	0	0	0	-	0	1773116
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	134472	SweptSolid	0	60	0	0	0	-	0	1598747
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	135938	SweptSolid	0	128	0	0	0	-	0	61497697
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	137886	SweptSolid	0	112	0	0	0	-	0	1797398
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	139140	SweptSolid	0	36	0	0	0	-	0	440689
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	61	SweptSolid	0	114	0	0	0	-	0	3310373
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	528	SweptSolid	0	64	0	0	0	-	0	4276653
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	733	SweptSolid	0	32	0	0	0	-	0	1704918
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	880	SweptSolid	0	64	0	0	0	-	0	3792153
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1085	SweptSolid	0	72	0	0	0	-	0	3273592
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1290	SweptSolid	0	58	0	0	0	-	0	4276647
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1512	SweptSolid	0	36	0	0	0	-	0	1029006
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1812	SweptSolid	0	58	0	0	0	-	0	2285017
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	2017	SweptSolid	0	68	0	0	0	-	0	1977110
+ara3d/IfcOpenHouse_IFC4.ifc	40	SweptSolid	0	56	0	0	0	-	0	6560365
+ara3d/IfcOpenHouse_IFC4.ifc	268	Clipping	0	40	0	0	0	-	0	6858013
+ara3d/IfcOpenHouse_IFC4.ifc	281	Clipping	0	42	0	0	0	-	0	6604566
+ara3d/Office_A_20110811.ifc	65	SweptSolid	0	92	0	0	0	-	0	21215311
+ara3d/Office_A_20110811.ifc	71	SweptSolid	0	308	0	0	0	-	0	55971753
+ara3d/Office_A_20110811.ifc	76	SweptSolid	0	140	0	0	0	-	0	11159801
+ara3d/Office_A_20110811.ifc	81	SweptSolid	0	312	0	0	0	-	0	47331434
+ara3d/Office_A_20110811.ifc	82	SweptSolid	0	32	0	0	0	-	0	64518573
+ara3d/Office_A_20110811.ifc	83	SweptSolid	0	292	0	0	0	-	0	48208635
+ara3d/Office_A_20110811.ifc	88	SweptSolid	0	60	0	0	0	-	0	7903807
+ara3d/Office_A_20110811.ifc	97	SweptSolid	0	44	0	0	0	-	0	5424824
+ara3d/Office_A_20110811.ifc	100	SweptSolid	0	152	0	0	0	-	0	36529589
+ara3d/Office_A_20110811.ifc	101	SweptSolid	0	164	0	0	0	-	0	42227279
+ara3d/Office_A_20110811.ifc	102	SweptSolid	0	140	0	0	0	-	0	41904420
+ara3d/Office_A_20110811.ifc	104	SweptSolid	0	92	0	0	0	-	0	9626495
+ara3d/Office_A_20110811.ifc	105	SweptSolid	0	28	0	0	0	-	0	7792587
+ara3d/Office_A_20110811.ifc	106	SweptSolid	0	172	0	0	0	-	0	35652372
+ara3d/Office_A_20110811.ifc	130	SweptSolid	0	76	0	0	0	-	0	9424142
+ara3d/Office_A_20110811.ifc	134	SweptSolid	0	92	0	0	0	-	0	6847247
+ara3d/Office_A_20110811.ifc	139	SweptSolid	0	76	0	0	0	-	0	5540300
+ara3d/Office_A_20110811.ifc	143	SweptSolid	0	44	0	0	0	-	0	6079177
+ara3d/Office_A_20110811.ifc	156	SweptSolid	0	44	0	0	0	-	0	5941736
+ara3d/Office_A_20110811.ifc	161	SweptSolid	0	60	0	0	0	-	0	3681439
+ara3d/Office_A_20110811.ifc	164	SweptSolid	0	44	0	0	0	-	0	5728091
+ara3d/Office_A_20110811.ifc	165	SweptSolid	0	44	0	0	0	-	0	4372460
+ara3d/Office_A_20110811.ifc	166	SweptSolid	0	100	0	0	0	-	0	6119792
+ara3d/Office_A_20110811.ifc	175	SweptSolid	0	28	0	0	0	-	0	3014310
+ara3d/Office_A_20110811.ifc	178	SweptSolid	0	44	0	0	0	-	0	4489165
+ara3d/Office_A_20110811.ifc	179	SweptSolid	0	60	0	0	0	-	0	3185935
+ara3d/Office_A_20110811.ifc	183	SweptSolid	0	44	0	0	0	-	0	4516183
+ara3d/Office_A_20110811.ifc	185	SweptSolid	0	44	0	0	0	-	0	1783184
+ara3d/Office_A_20110811.ifc	188	SweptSolid	0	44	0	0	0	-	0	6933307
+ara3d/Office_A_20110811.ifc	191	SweptSolid	0	28	0	0	0	-	0	2838687
+ara3d/Office_A_20110811.ifc	193	SweptSolid	0	28	0	0	0	-	0	1156511
+ara3d/Office_A_20110811.ifc	195	SweptSolid	0	28	0	0	0	-	0	894925
+ara3d/Office_A_20110811.ifc	196	SweptSolid	0	44	0	0	0	-	0	4355994
+ara3d/Office_A_20110811.ifc	197	SweptSolid	0	28	0	0	0	-	0	3848983
+ara3d/Office_A_20110811.ifc	198	SweptSolid	0	28	0	0	0	-	0	3015905
+ara3d/Office_A_20110811.ifc	223	SweptSolid	0	28	0	0	0	-	0	1078091
+ara3d/Office_A_20110811.ifc	224	SweptSolid	0	44	0	0	0	-	0	1105407
+ara3d/Office_A_20110811.ifc	227	SweptSolid	0	44	0	0	0	-	0	4736946
+ara3d/Office_A_20110811.ifc	228	SweptSolid	0	44	0	0	0	-	0	2755798
+ara3d/Office_A_20110811.ifc	234	SweptSolid	0	28	0	0	0	-	0	2620328
+ara3d/Office_A_20110811.ifc	238	SweptSolid	0	28	0	0	0	-	0	795942
+ara3d/Office_A_20110811.ifc	239	SweptSolid	0	44	0	0	0	-	0	3708624
+ara3d/Office_A_20110811.ifc	242	SweptSolid	0	28	0	0	0	-	0	612343
+ara3d/Office_A_20110811.ifc	246	SweptSolid	0	60	0	0	0	-	0	4752768
+ara3d/Office_A_20110811.ifc	247	SweptSolid	0	44	0	0	0	-	0	1401456
+ara3d/Office_A_20110811.ifc	248	SweptSolid	0	28	0	0	0	-	0	1579376
+ara3d/Office_A_20110811.ifc	277	SweptSolid	0	28	0	0	0	-	0	1378644
+ara3d/Office_A_20110811.ifc	282	SweptSolid	0	28	0	0	0	-	0	3314428
+ara3d/Office_A_20110811.ifc	288	SweptSolid	0	28	0	0	0	-	0	2613332
+ara3d/Office_A_20110811.ifc	307	SweptSolid	0	28	0	0	0	-	0	2738884
+ara3d/Office_A_20110811.ifc	314	SweptSolid	0	28	0	0	0	-	0	544967
+ara3d/Office_A_20110811.ifc	326	SweptSolid	0	28	0	0	0	-	0	899361
+ara3d/Office_A_20110811.ifc	351	SweptSolid	0	28	0	0	0	-	0	3696712
+ara3d/Office_A_20110811.ifc	354	SweptSolid	0	28	0	0	0	-	0	1879550
+ara3d/Office_A_20110811.ifc	361	SweptSolid	0	28	0	0	0	-	0	544963
+ara3d/Office_A_20110811.ifc	363	SweptSolid	0	28	0	0	0	-	0	3229168
+ara3d/Office_A_20110811.ifc	364	SweptSolid	0	180	0	0	0	-	0	45103
+ara3d/Office_A_20110811.ifc	417	SweptSolid	0	122	0	0	0	-	0	34063
+ara3d/Office_A_20110811.ifc	429	SweptSolid	0	32	0	0	0	-	0	153723
+ara3d/Office_A_20110811.ifc	607	SweptSolid	0	122	0	0	0	-	0	39305
+ara3d/Office_A_20110811.ifc	684	SweptSolid	0	122	0	0	0	-	0	35629
+ara3d/Office_A_20110811.ifc	1028	SweptSolid	0	678	0	0	0	-	0	64167
+ara3d/S_Office_Integrated Design Archi.ifc	4172	SweptSolid	0	32	0	0	0	-	0	4747495
+ara3d/S_Office_Integrated Design Archi.ifc	5434	SweptSolid	0	36	0	0	0	-	0	1282516
+ara3d/S_Office_Integrated Design Archi.ifc	6155	SweptSolid	0	32	0	0	0	-	0	126110038
+ara3d/S_Office_Integrated Design Archi.ifc	14416	SweptSolid	0	52	0	0	0	-	0	148113
+ara3d/S_Office_Integrated Design Archi.ifc	35182	SweptSolid	0	32	0	0	0	-	0	1708818
+ara3d/S_Office_Integrated Design Archi.ifc	36567	SweptSolid	0	52	0	0	0	-	0	292564
+ara3d/S_Office_Integrated Design Archi.ifc	43442	SweptSolid	0	80	0	0	0	-	0	1048077
+ara3d/S_Office_Integrated Design Archi.ifc	48600	SweptSolid	0	44	0	0	0	-	0	1679670
+ara3d/S_Office_Integrated Design Archi.ifc	49149	SweptSolid	0	52	0	0	0	-	0	1192160
+ara3d/S_Office_Integrated Design Archi.ifc	89022	unknown	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	89141	SweptSolid	0	232	0	0	0	-	0	7738711
+ara3d/S_Office_Integrated Design Archi.ifc	89264	SweptSolid	0	232	0	0	0	-	0	383689
+ara3d/S_Office_Integrated Design Archi.ifc	89384	SweptSolid	0	232	0	0	0	-	0	17023984
+ara3d/S_Office_Integrated Design Archi.ifc	89504	SweptSolid	0	232	0	0	0	-	0	3866404
+ara3d/S_Office_Integrated Design Archi.ifc	89624	SweptSolid	0	232	0	0	0	-	0	9674865
+ara3d/S_Office_Integrated Design Archi.ifc	90617	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	91291	CSG	3	46	1	0	3	6	3	-
+ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-	0	76182
+ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12	13	-
+ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-	0	1124166
+ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-	0	124089
+ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	4	160	0	0	4	4	4	-
+ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-	0	920535
+ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-	0	1758145
+ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-	0	5896872
+ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-	0	128252029
+ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6	6	-
+ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164	90	-
+ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78	78	-
+ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51	51	-
+ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-	0	5896872
+ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-	0	6031243
+ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-	0	68368125
+ara3d/S_Office_Integrated Design Archi.ifc	503263	unknown	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	503302	SweptSolid	0	172	0	0	0	-	0	8390248
+ara3d/S_Office_Integrated Design Archi.ifc	503345	SweptSolid	0	172	0	0	0	-	0	415992
+ara3d/S_Office_Integrated Design Archi.ifc	503385	SweptSolid	0	172	0	0	0	-	0	24748350
+ara3d/S_Office_Integrated Design Archi.ifc	503425	SweptSolid	0	172	0	0	0	-	0	4191924
+ara3d/S_Office_Integrated Design Archi.ifc	503482	SweptSolid	0	172	0	0	0	-	0	4191924
+ara3d/S_Office_Integrated Design Archi.ifc	543063	SweptSolid	0	36	0	0	0	-	0	1623766
+ara3d/S_Office_Integrated Design Archi.ifc	639833	SweptSolid	0	52	0	0	0	-	0	148111
+ara3d/S_Office_Integrated Design Archi.ifc	670546	SweptSolid	0	32	0	0	0	-	0	1248362
+ara3d/S_Office_Integrated Design Archi.ifc	701210	SweptSolid	0	52	0	0	0	-	0	1192160
+ara3d/S_Office_Integrated Design Archi.ifc	704150	SweptSolid	0	32	0	0	0	-	0	1381495
+ara3d/S_Office_Integrated Design Archi.ifc	719862	SweptSolid	0	32	0	0	0	-	0	1375078
+ara3d/S_Office_Integrated Design Archi.ifc	722750	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	723436	CSG	0	216	0	0	0	-	0	55347
+ara3d/S_Office_Integrated Design Archi.ifc	724125	CSG	0	216	0	0	0	-	0	55954
+ara3d/S_Office_Integrated Design Archi.ifc	724811	CSG	3	81	0	0	3	3	3	-
+ara3d/S_Office_Integrated Design Archi.ifc	725497	CSG	7	185	0	0	7	12	7	-
+ara3d/S_Office_Integrated Design Archi.ifc	726183	CSG	0	212	0	0	0	-	0	79838
+ara3d/S_Office_Integrated Design Archi.ifc	726869	CSG	0	212	0	0	0	-	0	78771
+ara3d/S_Office_Integrated Design Archi.ifc	730647	SweptSolid	0	32	0	0	0	-	0	1239586
+ara3d/S_Office_Integrated Design Archi.ifc	753197	SweptSolid	0	52	0	0	0	-	0	292564
+ara3d/S_Office_Integrated Design Archi.ifc	763256	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	763898	CSG	0	122	0	0	0	-	0	75231
+ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-	0	75640
+ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-	0	116307
+ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-	0	899738
+ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-	0	99193
+ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	108	0	0	0	-	0	98168
+ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-	0	58476
+ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-	0	59521
+ara3d/S_Office_Integrated Design Archi.ifc	769740	CSG	0	280	0	0	0	-	0	92429
+ara3d/S_Office_Integrated Design Archi.ifc	770504	CSG	0	100	0	0	0	-	0	835195
+ara3d/S_Office_Integrated Design Archi.ifc	771268	CSG	0	196	0	0	0	-	0	91977
+ara3d/S_Office_Integrated Design Archi.ifc	772032	CSG	0	196	0	0	0	-	0	91674
+ara3d/S_Office_Integrated Design Archi.ifc	803290	SweptSolid	0	52	0	0	0	-	0	68358351
+ara3d/S_Office_Integrated Design Archi.ifc	832090	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	832800	CSG	0	224	0	0	0	-	0	58845
+ara3d/S_Office_Integrated Design Archi.ifc	833513	CSG	0	216	0	0	0	-	0	59893
+ara3d/S_Office_Integrated Design Archi.ifc	834223	CSG	0	200	0	0	0	-	0	92992
+ara3d/S_Office_Integrated Design Archi.ifc	834933	CSG	0	100	0	0	0	-	0	835195
+ara3d/S_Office_Integrated Design Archi.ifc	835643	CSG	0	196	0	0	0	-	0	91977
+ara3d/S_Office_Integrated Design Archi.ifc	836353	CSG	0	196	0	0	0	-	0	91674
+ara3d/S_Office_Integrated Design Archi.ifc	857637	unknown	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	857676	SweptSolid	0	156	0	0	0	-	0	8345841
+ara3d/S_Office_Integrated Design Archi.ifc	857719	SweptSolid	0	156	0	0	0	-	0	420477
+ara3d/S_Office_Integrated Design Archi.ifc	857759	SweptSolid	0	156	0	0	0	-	0	24636157
+ara3d/S_Office_Integrated Design Archi.ifc	857799	SweptSolid	0	156	0	0	0	-	0	4172920
+ara3d/S_Office_Integrated Design Archi.ifc	857839	SweptSolid	0	156	0	0	0	-	0	4172920
+ara3d/S_Office_Integrated Design Archi.ifc	866873	SweptSolid	0	36	0	0	0	-	0	1623759
+ara3d/S_Office_Integrated Design Archi.ifc	867376	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	868018	CSG	0	122	0	0	0	-	0	75231
+ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-	0	75640
+ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-	0	116307
+ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-	0	899741
+ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-	0	99193
+ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	108	0	0	0	-	0	98168
+ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-	0	6031220
+ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-	0	292564
+ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-	0	1239586
+ara3d/S_Office_Integrated Design Archi.ifc	904620	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-	0	55347
+ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-	0	55954
+ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6	6	-
+ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-	0	726273
+ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	212	0	0	0	-	0	79465
+ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-	0	78400
+ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-	0	1381495
+ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-	0	1390266
+ara3d/S_Office_Integrated Design Archi.ifc	909877	SweptSolid	0	52	0	0	0	-	0	1192160
+ara3d/S_Office_Integrated Design Archi.ifc	910230	SweptSolid	0	52	0	0	0	-	0	148111
+ara3d/S_Office_Integrated Design Archi.ifc	910609	SweptSolid	0	32	0	0	0	-	0	1248362
+ara3d/S_Office_Integrated Design Archi.ifc	912366	SweptSolid	0	52	0	0	0	-	0	68358351
+ara3d/S_Office_Integrated Design Archi.ifc	918017	SweptSolid	0	52	0	0	0	-	0	1192160
+ara3d/S_Office_Integrated Design Archi.ifc	918355	SweptSolid	0	32	0	0	0	-	0	1381495
+ara3d/S_Office_Integrated Design Archi.ifc	929798	SweptSolid	0	52	0	0	0	-	0	148113
+ara3d/S_Office_Integrated Design Archi.ifc	930704	SweptSolid	0	32	0	0	0	-	0	1390266
+ara3d/S_Office_Integrated Design Archi.ifc	951036	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-	0	55347
+ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-	0	55954
+ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3	3	-
+ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-	0	726268
+ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	13	225	0	0	4	7	13	-
+ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-	0	78399
+ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-	0	1239586
+ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	970645	CSG	0	224	0	0	0	-	0	58846
+ara3d/S_Office_Integrated Design Archi.ifc	971358	CSG	0	216	0	0	0	-	0	59893
+ara3d/S_Office_Integrated Design Archi.ifc	972068	CSG	0	200	0	0	0	-	0	92993
+ara3d/S_Office_Integrated Design Archi.ifc	972778	CSG	0	100	0	0	0	-	0	835195
+ara3d/S_Office_Integrated Design Archi.ifc	973488	CSG	0	196	0	0	0	-	0	91977
+ara3d/S_Office_Integrated Design Archi.ifc	974198	CSG	0	196	0	0	0	-	0	91674
+ara3d/S_Office_Integrated Design Archi.ifc	974760	unknown	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	974799	SweptSolid	0	156	0	0	0	-	0	8390397
+ara3d/S_Office_Integrated Design Archi.ifc	974842	SweptSolid	0	156	0	0	0	-	0	422400
+ara3d/S_Office_Integrated Design Archi.ifc	974882	SweptSolid	0	156	0	0	0	-	0	24742390
+ara3d/S_Office_Integrated Design Archi.ifc	974922	SweptSolid	0	156	0	0	0	-	0	4198398
+ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-	0	4191998
+ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-	0	0
+ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-	0	75232
+ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-	0	75641
+ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	112	0	0	0	-	0	116308
+ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	32	0	0	0	-	0	899738
+ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-	0	99194
+ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	108	0	0	0	-	0	98168
+ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-	0	5804378
+ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-	0	1248362
+ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-	0	1550644
+ara3d/S_Office_Integrated Design Archi.ifc	998325	SweptSolid	0	52	0	0	0	-	0	292564
+ara3d/S_Office_Integrated Design Archi.ifc	1001521	SweptSolid	0	32	0	0	0	-	0	145815370
+ara3d/S_Office_Integrated Design Archi.ifc	1001906	SweptSolid	0	32	0	0	0	-	0	9042842
+ara3d/advanced_model.ifc	552611	SweptSolid	0	158	0	0	0	-	0	16942752
+ara3d/advanced_model.ifc	552761	SweptSolid	0	168	0	0	0	-	0	16396664
+ara3d/advanced_model.ifc	552894	SweptSolid	0	104	0	0	0	-	0	15793901
+ara3d/advanced_model.ifc	553010	Clipping	0	82	0	0	0	-	0	16546783
+ara3d/advanced_model.ifc	555082	SweptSolid	0	88	0	0	0	-	0	11065032
+ara3d/advanced_model.ifc	555224	SweptSolid	0	28	0	0	0	-	0	4761893
+ara3d/advanced_model.ifc	555268	SweptSolid	0	124	0	0	0	-	0	11277539
+ara3d/advanced_model.ifc	555433	SweptSolid	0	172	0	0	0	-	0	6486471
+ara3d/advanced_model.ifc	555613	Clipping	0	90	0	0	0	-	0	10415403
+ara3d/advanced_model.ifc	555770	Clipping	0	56	0	0	0	-	0	16841522
+ara3d/advanced_model.ifc	555985	SweptSolid	0	184	0	0	0	-	0	464669601
+ara3d/advanced_model.ifc	556264	SweptSolid	0	192	0	0	0	-	0	465354628
+ara3d/advanced_model.ifc	559034	SweptSolid	0	88	0	0	0	-	0	475201221
+ara3d/advanced_model.ifc	559171	SweptSolid	0	92	0	0	0	-	0	4550446
+ara3d/advanced_model.ifc	559270	SweptSolid	0	44	0	0	0	-	0	2690508
+ara3d/advanced_model.ifc	559314	SweptSolid	0	52	0	0	0	-	0	4646966
+ara3d/advanced_model.ifc	561445	SweptSolid	0	28	0	0	0	-	0	543976
+ara3d/advanced_model.ifc	563598	SweptSolid	0	28	0	0	0	-	0	2942267
+ara3d/advanced_model.ifc	563980	SweptSolid	0	156	0	0	0	-	0	13854456
+ara3d/advanced_model.ifc	612062	SweptSolid	0	92	0	0	0	-	0	7634639
+ara3d/advanced_model.ifc	612150	SweptSolid	0	124	0	0	0	-	0	1982795
+ara3d/advanced_model.ifc	612315	SweptSolid	0	128	0	0	0	-	0	4132150
+ara3d/advanced_model.ifc	612436	SweptSolid	0	28	0	0	0	-	0	923079
+ara3d/advanced_model.ifc	632450	Clipping	0	126	0	0	0	-	0	27791587
+ara3d/advanced_model.ifc	636693	SweptSolid	0	92	0	0	0	-	0	4165478
+ara3d/advanced_model.ifc	636774	SweptSolid	0	44	0	0	0	-	0	2485619
+ara3d/advanced_model.ifc	636818	SweptSolid	0	52	0	0	0	-	0	4366134
+ara3d/advanced_model.ifc	636995	SweptSolid	0	28	0	0	0	-	0	489952
+ara3d/advanced_model.ifc	637271	SweptSolid	0	76	0	0	0	-	0	4702484
+ara3d/advanced_model.ifc	637377	SweptSolid	0	28	0	0	0	-	0	516196
+ara3d/advanced_model.ifc	637697	SweptSolid	0	28	0	0	0	-	0	1760229
+ara3d/advanced_model.ifc	637785	SweptSolid	0	60	0	0	0	-	0	1058069
+ara3d/advanced_model.ifc	637873	SweptSolid	0	44	0	0	0	-	0	432922
+ara3d/advanced_model.ifc	637917	SweptSolid	0	44	0	0	0	-	0	1211448
+ara3d/advanced_model.ifc	646621	SweptSolid	0	28	0	0	0	-	0	646382
+ara3d/advanced_model.ifc	646665	SweptSolid	0	28	0	0	0	-	0	2737689
+ara3d/advanced_model.ifc	650657	SweptSolid	0	68	0	0	0	-	0	480029
+ara3d/advanced_model.ifc	650761	SweptSolid	0	76	0	0	0	-	0	1596600
+ara3d/advanced_model.ifc	650893	SweptSolid	0	56	0	0	0	-	0	2925353
+ara3d/advanced_model.ifc	651604	SweptSolid	0	76	0	0	0	-	0	269460
+ara3d/advanced_model.ifc	674148	SweptSolid	0	76	0	0	0	-	0	7372931
+ara3d/advanced_model.ifc	679345	SweptSolid	0	140	0	0	0	-	0	13122132
+ara3d/advanced_model.ifc	694436	SweptSolid	0	92	0	0	0	-	0	7476704
+ara3d/advanced_model.ifc	737480	SweptSolid	0	92	0	0	0	-	0	14279567
+ara3d/advanced_model.ifc	737716	SweptSolid	0	28	0	0	0	-	0	552941
+ara3d/advanced_model.ifc	737804	SweptSolid	0	28	0	0	0	-	0	603577
+ara3d/advanced_model.ifc	737892	SweptSolid	0	28	0	0	0	-	0	573946
+ara3d/advanced_model.ifc	737936	SweptSolid	0	156	0	0	0	-	0	11582287
+ara3d/advanced_model.ifc	738205	SweptSolid	0	92	0	0	0	-	0	7125859
+ara3d/advanced_model.ifc	738433	SweptSolid	0	1860	0	0	0	-	0	63249158
+ara3d/advanced_model.ifc	739014	SweptSolid	0	1832	0	0	0	-	0	64723193
+ara3d/advanced_model.ifc	797099	SweptSolid	0	192	0	0	0	-	0	5186723
+ara3d/advanced_model.ifc	797102	SweptSolid	0	192	0	0	0	-	0	4661930
+ara3d/advanced_model.ifc	797108	SweptSolid	0	308	0	0	0	-	0	11506046
+ara3d/advanced_model.ifc	797111	SweptSolid	0	308	0	0	0	-	0	4623244
+ara3d/advanced_model.ifc	797114	SweptSolid	0	464	0	0	0	-	0	11827963
+ara3d/advanced_model.ifc	797120	SweptSolid	0	308	0	0	0	-	0	11814764
+ara3d/advanced_model.ifc	797123	SweptSolid	0	308	0	0	0	-	0	9365455
+ara3d/advanced_model.ifc	797126	SweptSolid	0	604	0	0	0	-	0	11725223
+ara3d/advanced_model.ifc	797129	SweptSolid	0	308	0	0	0	-	0	9329744
+ara3d/advanced_model.ifc	798479	SweptSolid	0	612	0	0	0	-	0	22668799
+ara3d/advanced_model.ifc	798926	SweptSolid	0	2900	0	0	0	-	0	95966880
+ara3d/advanced_model.ifc	799400	SweptSolid	0	604	0	0	0	-	0	6274816
+ara3d/advanced_model.ifc	799566	SweptSolid	0	604	0	0	0	-	0	6274816
+ara3d/advanced_model.ifc	799732	SweptSolid	0	604	0	0	0	-	0	6274816
+ara3d/advanced_model.ifc	800371	SweptSolid	0	604	0	0	0	-	0	14186663
+ara3d/advanced_model.ifc	800374	SweptSolid	0	308	0	0	0	-	0	9384127
+ara3d/advanced_model.ifc	800377	SweptSolid	0	464	0	0	0	-	0	13675423
+ara3d/advanced_model.ifc	800380	SweptSolid	0	308	0	0	0	-	0	9433899
+ara3d/advanced_model.ifc	800383	SweptSolid	0	308	0	0	0	-	0	6984590
+ara3d/advanced_model.ifc	800389	SweptSolid	0	308	0	0	0	-	0	4603726
+ara3d/advanced_model.ifc	800395	SweptSolid	0	308	0	0	0	-	0	6984590
+ara3d/advanced_model.ifc	800398	SweptSolid	0	308	0	0	0	-	0	4568014
+ara3d/advanced_model.ifc	800410	SweptSolid	0	340	0	0	0	-	0	8518967
+ara3d/advanced_model.ifc	800413	SweptSolid	0	160	0	0	0	-	0	1983272
+ara3d/advanced_model.ifc	800416	SweptSolid	0	372	0	0	0	-	0	3412709
+ara3d/advanced_model.ifc	800422	SweptSolid	0	324	0	0	0	-	0	11416759
+ara3d/advanced_model.ifc	801940	SweptSolid	0	44	0	0	0	-	0	97142
+ara3d/advanced_model.ifc	801984	SweptSolid	0	44	0	0	0	-	0	97142
+ara3d/advanced_model.ifc	806064	SweptSolid	0	28	0	0	0	-	0	764756
+ara3d/advanced_model.ifc	806149	SweptSolid	0	508	0	0	0	-	0	23186859
+ara3d/advanced_model.ifc	815104	SweptSolid	0	28	0	0	0	-	0	304712
+ara3d/dental_clinic.ifc	94	SweptSolid	0	232	0	0	0	-	0	60044252
+ara3d/dental_clinic.ifc	95	SweptSolid	0	172	0	0	0	-	0	15752049
+ara3d/dental_clinic.ifc	101	SweptSolid	0	128	0	0	0	-	0	52295834
+ara3d/dental_clinic.ifc	146	SweptSolid	0	192	0	0	0	-	0	44169023
+ara3d/dental_clinic.ifc	156	SweptSolid	0	60	0	0	0	-	0	8231844
+ara3d/dental_clinic.ifc	157	SweptSolid	0	92	0	0	0	-	0	6941948
+ara3d/dental_clinic.ifc	159	SweptSolid	0	108	0	0	0	-	0	10300887
+ara3d/dental_clinic.ifc	163	SweptSolid	0	128	0	0	0	-	0	8898936
+ara3d/dental_clinic.ifc	166	SweptSolid	0	76	0	0	0	-	0	5718352
+ara3d/dental_clinic.ifc	167	Clipping	10	192	0	0	10	0	10	-
+ara3d/dental_clinic.ifc	169	SweptSolid	0	28	0	0	0	-	0	9630151
+ara3d/dental_clinic.ifc	175	Clipping	0	168	0	0	0	-	0	8568865
+ara3d/dental_clinic.ifc	180	Clipping	0	168	0	0	0	-	0	8568865
+ara3d/dental_clinic.ifc	184	SweptSolid	0	92	0	0	0	-	0	8930960
+ara3d/dental_clinic.ifc	195	SweptSolid	0	44	0	0	0	-	0	40826665
+ara3d/dental_clinic.ifc	196	SweptSolid	0	64	0	0	0	-	0	20378147
+ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-	0	3726179
+ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-	0	6285996
+ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-	0	5407859
+ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-	0	24013649
+ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0	8	-
+ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-	0	6076059
+ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-	0	4086273
+ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-	0	6479706
+ara3d/dental_clinic.ifc	215	SweptSolid	0	68	0	0	0	-	0	14986377
+ara3d/dental_clinic.ifc	216	SweptSolid	0	92	0	0	0	-	0	18694928
+ara3d/dental_clinic.ifc	217	SweptSolid	0	26	0	0	0	-	0	235593
+ara3d/dental_clinic.ifc	218	SweptSolid	0	20	0	0	0	-	0	354594
+ara3d/dental_clinic.ifc	231	SweptSolid	0	60	0	0	0	-	0	3537529
+ara3d/dental_clinic.ifc	232	SweptSolid	0	44	0	0	0	-	0	2355584
+ara3d/dental_clinic.ifc	233	SweptSolid	0	76	0	0	0	-	0	7486129
+ara3d/dental_clinic.ifc	234	SweptSolid	0	60	0	0	0	-	0	6276229
+ara3d/dental_clinic.ifc	235	SweptSolid	0	112	0	0	0	-	0	22209498
+ara3d/dental_clinic.ifc	236	SweptSolid	0	72	0	0	0	-	0	16582426
+ara3d/dental_clinic.ifc	248	SweptSolid	0	44	0	0	0	-	0	2717268
+ara3d/dental_clinic.ifc	249	SweptSolid	0	60	0	0	0	-	0	3636558
+ara3d/dental_clinic.ifc	262	SweptSolid	0	76	0	0	0	-	0	5793675
+ara3d/dental_clinic.ifc	263	SweptSolid	0	44	0	0	0	-	0	2904592
+ara3d/dental_clinic.ifc	264	SweptSolid	0	28	0	0	0	-	0	3486852
+ara3d/dental_clinic.ifc	265	SweptSolid	0	44	0	0	0	-	0	3443074
+ara3d/dental_clinic.ifc	266	SweptSolid	0	60	0	0	0	-	0	3929443
+ara3d/dental_clinic.ifc	269	SweptSolid	0	60	0	0	0	-	0	5700065
+ara3d/dental_clinic.ifc	270	SweptSolid	0	60	0	0	0	-	0	3434812
+ara3d/dental_clinic.ifc	271	Clipping	0	72	0	0	0	-	0	3921719
+ara3d/dental_clinic.ifc	272	SweptSolid	0	60	0	0	0	-	0	5027262
+ara3d/dental_clinic.ifc	273	SweptSolid	0	60	0	0	0	-	0	1473069
+ara3d/dental_clinic.ifc	284	SweptSolid	0	28	0	0	0	-	0	3589349
+ara3d/dental_clinic.ifc	285	SweptSolid	0	28	0	0	0	-	0	1943972
+ara3d/dental_clinic.ifc	286	SweptSolid	0	60	0	0	0	-	0	3466876
+ara3d/dental_clinic.ifc	287	SweptSolid	0	28	0	0	0	-	0	7792851
+ara3d/dental_clinic.ifc	288	SweptSolid	0	32	0	0	0	-	0	15298258
+ara3d/dental_clinic.ifc	297	SweptSolid	0	60	0	0	0	-	0	4045275
+ara3d/dental_clinic.ifc	298	SweptSolid	0	28	0	0	0	-	0	5200528
+ara3d/dental_clinic.ifc	299	SweptSolid	0	28	0	0	0	-	0	5644684
+ara3d/dental_clinic.ifc	300	SweptSolid	0	28	0	0	0	-	0	3629200
+ara3d/dental_clinic.ifc	301	SweptSolid	0	44	0	0	0	-	0	3097365
+ara3d/dental_clinic.ifc	302	SweptSolid	0	72	0	0	0	-	0	12085999
+ara3d/dental_clinic.ifc	303	SweptSolid	0	44	0	0	0	-	0	3007646
+ara3d/dental_clinic.ifc	319	Clipping	0	38	0	0	0	-	0	4350591
+ara3d/dental_clinic.ifc	320	SweptSolid	0	28	0	0	0	-	0	3060279
+ara3d/dental_clinic.ifc	321	SweptSolid	0	28	0	0	0	-	0	1906295
+ara3d/dental_clinic.ifc	322	SweptSolid	0	28	0	0	0	-	0	3715325
+ara3d/dental_clinic.ifc	323	SweptSolid	0	28	0	0	0	-	0	5572104
+ara3d/dental_clinic.ifc	324	SweptSolid	0	28	0	0	0	-	0	2120402
+ara3d/dental_clinic.ifc	325	SweptSolid	0	28	0	0	0	-	0	2900924
+ara3d/dental_clinic.ifc	326	SweptSolid	0	28	0	0	0	-	0	6113184
+ara3d/dental_clinic.ifc	327	SweptSolid	0	28	0	0	0	-	0	4360006
+ara3d/dental_clinic.ifc	329	SweptSolid	0	28	0	0	0	-	0	2185907
+ara3d/dental_clinic.ifc	349	SweptSolid	0	44	0	0	0	-	0	2988799
+ara3d/dental_clinic.ifc	350	SweptSolid	0	44	0	0	0	-	0	3780301
+ara3d/dental_clinic.ifc	351	SweptSolid	0	44	0	0	0	-	0	2632584
+ara3d/dental_clinic.ifc	352	SweptSolid	0	28	0	0	0	-	0	2247553
+ara3d/dental_clinic.ifc	353	SweptSolid	0	28	0	0	0	-	0	5644003
+ara3d/dental_clinic.ifc	354	SweptSolid	0	60	0	0	0	-	0	3193796
+ara3d/dental_clinic.ifc	355	SweptSolid	0	28	0	0	0	-	0	4361448
+ara3d/dental_clinic.ifc	356	SweptSolid	0	52	0	0	0	-	0	10882700
+ara3d/dental_clinic.ifc	357	SweptSolid	0	20	0	0	0	-	0	2007909
+ara3d/dental_clinic.ifc	360	SweptSolid	0	28	0	0	0	-	0	2108516
+ara3d/dental_clinic.ifc	361	SweptSolid	0	32	0	0	0	-	0	6160524
+ara3d/dental_clinic.ifc	375	SweptSolid	0	28	0	0	0	-	0	3209384
+ara3d/dental_clinic.ifc	376	SweptSolid	0	44	0	0	0	-	0	2889071
+ara3d/dental_clinic.ifc	377	SweptSolid	0	28	0	0	0	-	0	1813220
+ara3d/dental_clinic.ifc	378	SweptSolid	0	28	0	0	0	-	0	789857
+ara3d/dental_clinic.ifc	379	SweptSolid	0	28	0	0	0	-	0	3788139
+ara3d/dental_clinic.ifc	380	SweptSolid	0	28	0	0	0	-	0	7456786
+ara3d/dental_clinic.ifc	381	SweptSolid	0	28	0	0	0	-	0	644291
+ara3d/dental_clinic.ifc	424	SweptSolid	0	44	0	0	0	-	0	843005
+ara3d/dental_clinic.ifc	425	SweptSolid	0	28	0	0	0	-	0	1930671
+ara3d/dental_clinic.ifc	426	SweptSolid	0	44	0	0	0	-	0	1237455
+ara3d/dental_clinic.ifc	427	SweptSolid	0	28	0	0	0	-	0	712983
+ara3d/dental_clinic.ifc	428	SweptSolid	0	28	0	0	0	-	0	1338199
+ara3d/dental_clinic.ifc	429	SweptSolid	0	104	0	0	0	-	0	798150
+ara3d/dental_clinic.ifc	430	SweptSolid	0	28	0	0	0	-	0	4134391
+ara3d/dental_clinic.ifc	431	SweptSolid	0	44	0	0	0	-	0	1559862
+ara3d/dental_clinic.ifc	432	SweptSolid	0	32	0	0	0	-	0	7156206
+ara3d/dental_clinic.ifc	434	SweptSolid	0	12	0	0	0	-	0	500664
+ara3d/dental_clinic.ifc	437	SweptSolid	0	44	0	0	0	-	0	2657230
+ara3d/dental_clinic.ifc	438	SweptSolid	0	28	0	0	0	-	0	1476142
+ara3d/dental_clinic.ifc	439	SweptSolid	0	44	0	0	0	-	0	3066374
+ara3d/dental_clinic.ifc	475	SweptSolid	0	28	0	0	0	-	0	1070586
+ara3d/dental_clinic.ifc	481	SweptSolid	0	28	0	0	0	-	0	3679652
+ara3d/dental_clinic.ifc	482	SweptSolid	0	28	0	0	0	-	0	1415391
+ara3d/dental_clinic.ifc	483	SweptSolid	0	44	0	0	0	-	0	4171560
+ara3d/dental_clinic.ifc	484	SweptSolid	0	28	0	0	0	-	0	1073069
+ara3d/dental_clinic.ifc	488	SweptSolid	0	20	0	0	0	-	0	1988039
+ara3d/dental_clinic.ifc	490	SweptSolid	0	28	0	0	0	-	0	2247553
+ara3d/dental_clinic.ifc	491	SweptSolid	0	28	0	0	0	-	0	2791924
+ara3d/dental_clinic.ifc	507	SweptSolid	0	28	0	0	0	-	0	1396465
+ara3d/dental_clinic.ifc	522	SweptSolid	0	28	0	0	0	-	0	1289150
+ara3d/dental_clinic.ifc	523	SweptSolid	0	28	0	0	0	-	0	2210227
+ara3d/dental_clinic.ifc	524	SweptSolid	0	44	0	0	0	-	0	2689644
+ara3d/dental_clinic.ifc	525	SweptSolid	0	44	0	0	0	-	0	4117309
+ara3d/dental_clinic.ifc	526	SweptSolid	0	44	0	0	0	-	0	2896835
+ara3d/dental_clinic.ifc	527	SweptSolid	0	44	0	0	0	-	0	6154342
+ara3d/dental_clinic.ifc	528	SweptSolid	0	44	0	0	0	-	0	3092395
+ara3d/dental_clinic.ifc	529	SweptSolid	0	28	0	0	0	-	0	1394677
+ara3d/dental_clinic.ifc	530	SweptSolid	0	28	0	0	0	-	0	1306983
+ara3d/dental_clinic.ifc	531	SweptSolid	0	28	0	0	0	-	0	1086769
+ara3d/dental_clinic.ifc	532	Clipping	0	22	0	0	0	-	0	2022307
+ara3d/dental_clinic.ifc	542	Clipping	0	22	0	0	0	-	0	1973241
+ara3d/dental_clinic.ifc	545	SweptSolid	0	44	0	0	0	-	0	2722942
+ara3d/dental_clinic.ifc	584	SweptSolid	0	28	0	0	0	-	0	1235697
+ara3d/dental_clinic.ifc	590	SweptSolid	0	56	0	0	0	-	0	1539726
+ara3d/dental_clinic.ifc	591	SweptSolid	0	28	0	0	0	-	0	1225993
+ara3d/dental_clinic.ifc	592	SweptSolid	0	28	0	0	0	-	0	1473078
+ara3d/dental_clinic.ifc	593	SweptSolid	0	28	0	0	0	-	0	1157295
+ara3d/dental_clinic.ifc	594	SweptSolid	0	28	0	0	0	-	0	695805
+ara3d/dental_clinic.ifc	595	SweptSolid	0	28	0	0	0	-	0	1930924
+ara3d/dental_clinic.ifc	596	SweptSolid	0	28	0	0	0	-	0	793864
+ara3d/dental_clinic.ifc	597	SweptSolid	0	28	0	0	0	-	0	2114045
+ara3d/dental_clinic.ifc	598	SweptSolid	0	44	0	0	0	-	0	1272904
+ara3d/dental_clinic.ifc	599	SweptSolid	0	28	0	0	0	-	0	2245851
+ara3d/dental_clinic.ifc	600	SweptSolid	0	28	0	0	0	-	0	620694
+ara3d/dental_clinic.ifc	601	SweptSolid	0	28	0	0	0	-	0	3158823
+ara3d/dental_clinic.ifc	627	SweptSolid	0	32	0	0	0	-	0	3334502
+ara3d/dental_clinic.ifc	628	SweptSolid	0	44	0	0	0	-	0	1949727
+ara3d/dental_clinic.ifc	675	SweptSolid	0	28	0	0	0	-	0	1410870
+ara3d/dental_clinic.ifc	686	SweptSolid	0	28	0	0	0	-	0	1026837
+ara3d/dental_clinic.ifc	696	SweptSolid	0	28	0	0	0	-	0	512889
+ara3d/dental_clinic.ifc	697	SweptSolid	0	28	0	0	0	-	0	2251991
+ara3d/dental_clinic.ifc	698	SweptSolid	0	28	0	0	0	-	0	2045349
+ara3d/dental_clinic.ifc	699	SweptSolid	0	28	0	0	0	-	0	1424751
+ara3d/dental_clinic.ifc	700	SweptSolid	0	28	0	0	0	-	0	6675679
+ara3d/dental_clinic.ifc	701	SweptSolid	0	28	0	0	0	-	0	567343
+ara3d/dental_clinic.ifc	702	SweptSolid	0	28	0	0	0	-	0	798943
+ara3d/dental_clinic.ifc	703	SweptSolid	0	28	0	0	0	-	0	798943
+ara3d/dental_clinic.ifc	704	SweptSolid	0	28	0	0	0	-	0	799190
+ara3d/dental_clinic.ifc	736	SweptSolid	0	28	0	0	0	-	0	866326
+ara3d/dental_clinic.ifc	804	SweptSolid	0	32	0	0	0	-	0	1050464
+ara3d/dental_clinic.ifc	825	SweptSolid	0	28	0	0	0	-	0	1374974
+ara3d/dental_clinic.ifc	827	SweptSolid	0	28	0	0	0	-	0	1640754
+ara3d/dental_clinic.ifc	828	SweptSolid	0	28	0	0	0	-	0	798952
+ara3d/dental_clinic.ifc	829	SweptSolid	0	28	0	0	0	-	0	883748
+ara3d/dental_clinic.ifc	830	SweptSolid	0	28	0	0	0	-	0	834135
+ara3d/dental_clinic.ifc	831	Clipping	0	64	0	0	0	-	0	776597
+ara3d/dental_clinic.ifc	872	SweptSolid	0	28	0	0	0	-	0	947666
+ara3d/dental_clinic.ifc	931	SweptSolid	0	32	0	0	0	-	0	1499485
+ara3d/dental_clinic.ifc	964	Clipping	0	30	0	0	0	-	0	1835400
+ara3d/dental_clinic.ifc	965	Clipping	0	30	0	0	0	-	0	1832545
+ara3d/dental_clinic.ifc	966	Clipping	0	30	0	0	0	-	0	1831852
+ara3d/dental_clinic.ifc	973	SweptSolid	0	28	0	0	0	-	0	1052030
+ara3d/dental_clinic.ifc	974	SweptSolid	0	28	0	0	0	-	0	705227
+ara3d/dental_clinic.ifc	975	SweptSolid	0	28	0	0	0	-	0	1949505
+ara3d/dental_clinic.ifc	976	SweptSolid	0	28	0	0	0	-	0	695805
+ara3d/dental_clinic.ifc	977	SweptSolid	0	28	0	0	0	-	0	1332364
+ara3d/dental_clinic.ifc	978	SweptSolid	0	28	0	0	0	-	0	622130
+ara3d/dental_clinic.ifc	979	SweptSolid	0	28	0	0	0	-	0	622130
+ara3d/dental_clinic.ifc	980	SweptSolid	0	28	0	0	0	-	0	705222
+ara3d/dental_clinic.ifc	981	SweptSolid	0	28	0	0	0	-	0	705222
+ara3d/dental_clinic.ifc	982	SweptSolid	0	28	0	0	0	-	0	773931
+ara3d/dental_clinic.ifc	983	SweptSolid	0	28	0	0	0	-	0	705222
+ara3d/dental_clinic.ifc	984	SweptSolid	0	28	0	0	0	-	0	682734
+ara3d/dental_clinic.ifc	985	SweptSolid	0	28	0	0	0	-	0	1338446
+ara3d/dental_clinic.ifc	986	SweptSolid	0	28	0	0	0	-	0	695805
+ara3d/dental_clinic.ifc	987	SweptSolid	0	28	0	0	0	-	0	705222
+ara3d/dental_clinic.ifc	988	SweptSolid	0	28	0	0	0	-	0	705227
+ara3d/dental_clinic.ifc	989	SweptSolid	0	28	0	0	0	-	0	709253
+ara3d/dental_clinic.ifc	990	SweptSolid	0	28	0	0	0	-	0	728547
+ara3d/dental_clinic.ifc	991	SweptSolid	0	28	0	0	0	-	0	2175468
+ara3d/dental_clinic.ifc	992	SweptSolid	0	54	0	0	0	-	0	424069
+ara3d/dental_clinic.ifc	993	SweptSolid	0	28	0	0	0	-	0	728547
+ara3d/dental_clinic.ifc	994	SweptSolid	0	28	0	0	0	-	0	728547
+ara3d/dental_clinic.ifc	995	SweptSolid	0	28	0	0	0	-	0	1835456
+ara3d/dental_clinic.ifc	996	SweptSolid	0	28	0	0	0	-	0	3678012
+ara3d/dental_clinic.ifc	997	SweptSolid	0	28	0	0	0	-	0	1295598
+ara3d/dental_clinic.ifc	998	SweptSolid	0	28	0	0	0	-	0	495813
+ara3d/dental_clinic.ifc	999	SweptSolid	0	28	0	0	0	-	0	748109
+ara3d/dental_clinic.ifc	1003	Clipping	0	28	0	0	0	-	0	277496
+ara3d/dental_clinic.ifc	1022	SweptSolid	0	28	0	0	0	-	0	294711
+ara3d/dental_clinic.ifc	1085	Clipping	0	32	0	0	0	-	0	164901
+ara3d/dental_clinic.ifc	1093	SweptSolid	0	28	0	0	0	-	0	705222
+ara3d/dental_clinic.ifc	1094	SweptSolid	0	36	0	0	0	-	0	47576
+ara3d/dental_clinic.ifc	1096	SweptSolid	0	36	0	0	0	-	0	41318
+ara3d/dental_clinic.ifc	1183	SweptSolid	0	28	0	0	0	-	0	2127495
+ara3d/dental_clinic.ifc	1194	SweptSolid	0	28	0	0	0	-	0	1961954
+ara3d/dental_clinic.ifc	1195	SweptSolid	0	28	0	0	0	-	0	1961956
+ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-	0	1945789
+ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-	0	2018855
+ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-	0	2018853
+ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-	0	315746
+ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0	10	-
+ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-	0	409703
+ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-	0	137144
+ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-	0	1739830
+ara3d/dental_clinic.ifc	1673	Clipping	9	32	1	0	9	0	10	-
+ara3d/dental_clinic.ifc	1757	Clipping	3	28	1	0	3	0	6	-
+ara3d/dental_clinic.ifc	1831	SweptSolid	0	24	0	0	0	-	0	24406
+ara3d/dental_clinic.ifc	1832	SweptSolid	0	24	0	0	0	-	0	22682
+ara3d/dental_clinic.ifc	2093	SweptSolid	0	28	0	0	0	-	0	172387
+ara3d/dental_clinic.ifc	2268	SweptSolid	0	48	0	0	0	-	0	34204
+ara3d/dental_clinic.ifc	2269	SweptSolid	0	44	0	0	0	-	0	32588
+ara3d/dental_clinic.ifc	2270	SweptSolid	0	56	0	0	0	-	0	48747
+ara3d/dental_clinic.ifc	2275	SweptSolid	0	64	0	0	0	-	0	66469
+ara3d/dental_clinic.ifc	2276	SweptSolid	0	76	0	0	0	-	0	126536
+ara3d/dental_clinic.ifc	2278	SweptSolid	0	72	0	0	0	-	0	104317
+ara3d/dental_clinic.ifc	2279	SweptSolid	0	68	0	0	0	-	0	81794
+ara3d/dental_clinic.ifc	2280	SweptSolid	0	68	0	0	0	-	0	82139
+ara3d/dental_clinic.ifc	2285	SweptSolid	0	548	0	0	0	-	0	22203
+ara3d/dental_clinic.ifc	2286	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2287	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0	19	-
+ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-	0	32319
+ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-	0	32319
+ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2296	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2297	SweptSolid	0	44	0	0	0	-	0	32319
+ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-	0	32317
+ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-	0	67331
+ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0	6	-
+ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0	7	-
+ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-	0	56842
+ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-	0	56845
+ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-	0	56842
+ara3d/dental_clinic.ifc	2307	SweptSolid	0	56	0	0	0	-	0	56842
+ara3d/dental_clinic.ifc	2308	SweptSolid	0	56	0	0	0	-	0	56845
+ara3d/dental_clinic.ifc	2309	SweptSolid	0	56	0	0	0	-	0	56845
+ara3d/dental_clinic.ifc	2310	SweptSolid	0	56	0	0	0	-	0	56842
+ara3d/dental_clinic.ifc	2311	SweptSolid	0	56	0	0	0	-	0	56845
+ara3d/dental_clinic.ifc	2312	SweptSolid	0	56	0	0	0	-	0	56847
+ara3d/dental_clinic.ifc	2313	SweptSolid	0	56	0	0	0	-	0	56842
+ara3d/duplex.ifc	3797	SweptSolid	0	48	0	0	0	-	0	5676032
+ara3d/duplex.ifc	3999	SweptSolid	0	48	0	0	0	-	0	20734888
+ara3d/duplex.ifc	4043	SweptSolid	0	48	0	0	0	-	0	5137010
+ara3d/duplex.ifc	4087	SweptSolid	0	48	0	0	0	-	0	20195851
+ara3d/duplex.ifc	4219	SweptSolid	0	28	0	0	0	-	0	819973
+ara3d/duplex.ifc	4508	SweptSolid	0	28	0	0	0	-	0	819973
+ara3d/duplex.ifc	5448	SweptSolid	0	142	0	0	0	-	0	6546078
+ara3d/duplex.ifc	5498	SweptSolid	0	218	0	0	0	-	0	16741903
+ara3d/duplex.ifc	5548	SweptSolid	0	164	0	0	0	-	0	6546087
+ara3d/duplex.ifc	5598	SweptSolid	0	226	0	0	0	-	0	16741895
+ara3d/duplex.ifc	5642	SweptSolid	0	32	0	0	0	-	0	659872
+ara3d/duplex.ifc	5687	SweptSolid	0	28	0	0	0	-	0	1732672
+ara3d/duplex.ifc	5731	SweptSolid	0	28	0	0	0	-	0	488880
+ara3d/duplex.ifc	5903	SweptSolid	0	32	0	0	0	-	0	659872
+ara3d/duplex.ifc	5948	SweptSolid	0	28	0	0	0	-	0	1732672
+ara3d/duplex.ifc	5992	SweptSolid	0	28	0	0	0	-	0	488884
+ara3d/duplex.ifc	12574	SurfaceModel	89	292	0	0	89	70	89	-
+ara3d/duplex.ifc	12976	SurfaceModel	84	292	0	0	85	70	84	-
+ara3d/duplex.ifc	13331	SurfaceModel	89	292	0	0	89	70	89	-
+ara3d/duplex.ifc	13685	SurfaceModel	84	292	0	0	85	70	84	-
+ara3d/duplex.ifc	14040	SurfaceModel	89	292	0	0	89	70	89	-
+ara3d/duplex.ifc	14394	SurfaceModel	85	292	0	0	86	70	85	-
+ara3d/duplex.ifc	14749	SurfaceModel	89	292	0	0	89	70	89	-
+ara3d/duplex.ifc	15103	SurfaceModel	85	292	0	0	86	70	85	-
+ara3d/duplex.ifc	16261	SweptSolid	0	68	0	0	0	-	0	80792
+ara3d/duplex.ifc	16802	SweptSolid	3	727	0	0	3	0	3	-
+ara3d/duplex.ifc	22475	unknown	0	0	0	0	0	-	0	0
+ara3d/duplex.ifc	22492	SweptSolid	0	60	0	0	0	-	0	60747162
+ara3d/duplex.ifc	35199	SweptSolid	0	28	0	0	0	-	0	356003
+ara3d/duplex.ifc	35357	SweptSolid	0	28	0	0	0	-	0	356006
+ara3d/schependomlaan.ifc	46535	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	49281	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	52348	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	72010	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	76629	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	80335	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	99074	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	101868	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	112392	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	115669	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	119854	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	125502	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	133655	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	136076	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	140907	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	143594	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	154792	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	159728	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	163917	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	169275	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	171696	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	178863	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	186163	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	188256	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	263912	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	270253	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	271891	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	311100	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	313863	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	315576	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	325984	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	338352	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	340160	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	345463	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	368479	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	401470	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	404402	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	409878	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	411995	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	415563	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	422700	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	424453	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	426206	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	435307	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	472665	SweptSolid	0	80	0	0	0	-	0	2147922
+ara3d/schependomlaan.ifc	534371	SweptSolid	0	12	0	0	0	-	0	13751
+ara3d/schependomlaan.ifc	558010	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	562146	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	597457	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	605031	SweptSolid	0	40	0	0	0	-	0	1333330
+ara3d/schependomlaan.ifc	618431	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	640164	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	643860	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	668602	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	711509	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	717596	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	753581	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	766683	SweptSolid	0	12	0	0	0	-	0	13751
+ara3d/schependomlaan.ifc	778605	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	783014	SweptSolid	0	40	0	0	0	-	0	1333669
+ara3d/schependomlaan.ifc	787207	SweptSolid	0	48	0	0	0	-	0	106150
+ara3d/schependomlaan.ifc	820735	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	822589	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	826337	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	829534	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	876846	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	878050	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	879248	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	880446	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	967617	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/schependomlaan.ifc	969938	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/tested_sample_project.ifc	186	SweptSolid	0	192	0	0	0	-	0	2995683
+ara3d/tested_sample_project.ifc	294	SweptSolid	0	28	0	0	0	-	0	2022122
+buildingsmart/wall-with-opening-and-window.ifc	45	unknown	0	32	0	0	0	-	0	1500015
+ifc5/Hello_Wall_hello-wall.ifc	1222	SweptSolid	0	68	0	0	0	-	0	2784170
+ifcopenshell/faceted_brep_csg.ifc	1096640	CSG	0	58	0	0	0	-	0	8535046
+issues/1007_roof_brep_opening_winding.ifc	1112	Brep	0	98	0	0	0	-	0	179976376
+issues/218_IFC-test-lite.ifc	417	SweptSolid	8	72	0	0	8	8	24	-
+issues/821_TallBuilding.ifc	615	Clipping	0	52	0	0	0	-	0	5644588
+issues/821_TallBuilding.ifc	810	Clipping	0	52	0	0	0	-	0	5890594
+issues/821_TallBuilding.ifc	887	Clipping	0	52	0	0	0	-	0	5890594
+issues/821_TallBuilding.ifc	964	Clipping	0	52	0	0	0	-	0	5890594
+issues/821_TallBuilding.ifc	1297	Clipping	0	44	0	0	0	-	0	5379299
+issues/821_TallBuilding.ifc	1850	Clipping	0	52	0	0	0	-	0	5490558
+issues/821_TallBuilding.ifc	1926	Clipping	0	52	0	0	0	-	0	5730563
+issues/821_TallBuilding.ifc	2002	Clipping	0	52	0	0	0	-	0	5730563
+issues/821_TallBuilding.ifc	2078	Clipping	0	52	0	0	0	-	0	5730563
+issues/821_TallBuilding.ifc	2401	Clipping	0	68	0	0	0	-	0	4708764
+issues/821_TallBuilding.ifc	2477	Clipping	0	72	0	0	0	-	0	5235641
+issues/821_TallBuilding.ifc	11462	Clipping	0	44	0	0	0	-	0	5459284
+issues/832_opening_representations.ifc	50	SweptSolid	0	32	0	0	0	-	0	1600098
+issues/832_opening_representations.ifc	89	SweptSolid	0	36	0	0	0	-	0	1700104
+issues/832_opening_representations.ifc	128	SweptSolid	0	32	0	0	0	-	0	1600098
+issues/832_opening_representations.ifc	175	SweptSolid	0	28	0	0	0	-	0	1699997
+issues/832_opening_representations.ifc	222	SweptSolid	0	28	0	0	0	-	0	1699997
+issues/841_house_stack_overflow.ifc	96	SweptSolid	0	96	0	0	0	-	0	10067844
+issues/841_house_stack_overflow.ifc	144	SweptSolid	0	28	0	0	0	-	0	4127946
+issues/841_house_stack_overflow.ifc	192	SweptSolid	0	68	0	0	0	-	0	5595916
+issues/841_house_stack_overflow.ifc	240	SweptSolid	0	32	0	0	0	-	0	4757945
+issues/841_house_stack_overflow.ifc	336	SweptSolid	0	174	0	0	0	-	0	935989
+issues/841_house_stack_overflow.ifc	384	SweptSolid	0	322	1	0	0	-	3	1895964
+issues/841_house_stack_overflow.ifc	432	SweptSolid	0	338	1	0	0	-	0	936016
+issues/841_house_stack_overflow.ifc	528	SweptSolid	0	60	0	0	0	-	0	3929954
+issues/841_house_stack_overflow.ifc	576	SweptSolid	0	28	0	0	0	-	0	2500062
+issues/841_house_stack_overflow.ifc	768	SweptSolid	0	48	0	0	0	-	0	4901915
+issues/841_house_stack_overflow.ifc	914	SweptSolid	0	32	0	0	0	-	0	2412059
+issues/841_house_stack_overflow.ifc	1020	SweptSolid	0	40	0	0	0	-	0	2519974
+issues/841_house_stack_overflow.ifc	1070	SweptSolid	0	58	0	0	0	-	0	1031908
+issues/841_house_stack_overflow.ifc	1118	SweptSolid	0	60	0	0	0	-	0	569540
+issues/841_house_stack_overflow.ifc	1166	SweptSolid	0	36	0	0	0	-	0	1914121
+issues/841_house_stack_overflow.ifc	1362	Clipping	0	92	0	0	0	-	0	6379215
+issues/841_house_stack_overflow.ifc	1878	Clipping	0	114	0	0	0	-	0	13371611
+issues/841_house_stack_overflow.ifc	2152	Clipping	55	236	1	0	6	4	55	-
+issues/841_house_stack_overflow.ifc	2797	Clipping	0	44	0	0	0	-	0	5717671
+issues/841_house_stack_overflow.ifc	3698	Clipping	0	68	0	0	0	-	0	5599761
+issues/841_house_stack_overflow.ifc	4148	Clipping	0	142	0	0	0	-	0	9474529
+issues/841_house_stack_overflow.ifc	4219	Clipping	0	52	0	0	0	-	0	4105196
+issues/841_house_stack_overflow.ifc	4267	SweptSolid	0	30	0	0	0	-	0	3649551
+issues/841_house_stack_overflow.ifc	4374	Clipping	0	62	0	0	0	-	0	3266357
+issues/841_house_stack_overflow.ifc	4897	Clipping	0	130	0	0	0	-	0	986400
+issues/841_house_stack_overflow.ifc	5904	Clipping	0	124	0	0	0	-	0	13960888
+issues/841_house_stack_overflow.ifc	13928	SweptSolid	0	28	0	0	0	-	0	18321124
+issues/845_wall_elemented_case.ifc	130	SweptSolid	0	224	0	0	0	-	0	30972
+issues/845_wall_elemented_case.ifc	133	SweptSolid	0	392	0	0	0	-	31	122855
+issues/845_wall_elemented_case.ifc	145	SweptSolid	0	224	0	0	0	-	56	106539
+issues/845_wall_elemented_case.ifc	146	SweptSolid	0	200	0	0	0	-	7	106412
+issues/845_wall_elemented_case.ifc	148	unknown	0	0	0	0	0	-	0	0
+issues/853_slab_pocket.ifc	303	SweptSolid	0	260	0	0	0	-	0	1185753
+issues/953_trimmed_curve_cartesian_arc.ifc	1112	Brep	0	98	0	0	0	-	0	179976376
+issues/960_house_segmented_roof_clip.ifc	2152	Clipping	55	236	1	0	6	4	55	-
+issues/960_house_segmented_roof_clip.ifc	2797	Clipping	0	44	0	0	0	-	0	5717671
+issues/960_house_segmented_roof_clip.ifc	4148	Clipping	0	142	0	0	0	-	0	9474529
+issues/960_house_segmented_roof_clip.ifc	4374	Clipping	0	62	0	0	0	-	0	3266357
+issues/960_house_segmented_roof_clip.ifc	5904	Clipping	0	124	0	0	0	-	0	13960888
+issues/964_slab_arbitrary_profile_voids.ifc	6443	SweptSolid	111	322	0	0	113	64	111	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	430	SweptSolid	0	280	0	0	0	-	0	18269443
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	654	SweptSolid	0	284	0	0	0	-	0	14174385
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	857	SweptSolid	0	52	0	0	0	-	0	2982099
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1029	SweptSolid	0	128	0	0	0	-	0	11792867
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1183	SweptSolid	0	172	0	0	0	-	0	10606105
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1369	SweptSolid	0	204	0	0	0	-	0	21434985
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1536	SweptSolid	0	92	0	0	0	-	0	25035112
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1649	SweptSolid	0	32	0	0	0	-	0	12560962
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1691	SweptSolid	0	76	0	0	0	-	0	52218262
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1789	SweptSolid	0	496	0	0	0	-	0	49389302
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1992	SweptSolid	0	32	0	0	0	-	0	10751989
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2036	SweptSolid	0	588	0	0	0	-	0	49426659
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2411	SweptSolid	0	1406	0	0	0	-	0	16172277
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3051	SweptSolid	0	48	0	0	0	-	0	17064424
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3110	SweptSolid	0	112	0	0	0	-	0	15343750
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3394	Clipping	0	32	0	0	0	-	0	23838922
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	25758	SweptSolid	40	308	0	0	40	50	40	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	26830	SweptSolid	0	32	0	0	0	-	0	1908287
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	27921	Clipping	0	32	0	0	0	-	0	3589668
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45444	SweptSolid	0	64	0	0	0	-	0	60715441
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45708	SweptSolid	0	176	0	0	0	-	0	94347540
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45774	Clipping	0	40	0	0	0	-	0	6060437
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	71367	SweptSolid	0	216	0	0	0	-	0	100102011
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	81962	SweptSolid	136	784	0	0	136	158	136	-
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100256	SweptSolid	0	84	0	0	0	-	0	109010502
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100536	SweptSolid	0	176	0	0	0	-	0	94377035
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	124547	SweptSolid	0	968	0	0	0	-	0	13250360
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	74	SweptSolid	0	52	0	0	0	-	0	3454738
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	75	SweptSolid	0	76	0	0	0	-	0	1263583
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	77	SweptSolid	0	524	0	0	0	-	0	7703208
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	78	SweptSolid	0	240	0	0	0	-	0	6971520
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	90	SweptSolid	0	340	0	0	0	-	0	110461292
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	91	SweptSolid	0	84	0	0	0	-	0	1811592
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	92	SweptSolid	0	52	0	0	0	-	0	1920290
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	93	SweptSolid	0	58	0	0	0	-	0	1032567
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	94	SweptSolid	0	52	0	0	0	-	0	1391129
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	103	SweptSolid	0	32	0	0	0	-	0	517630
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	104	SweptSolid	0	48	0	0	0	-	0	669792
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	105	SweptSolid	0	250	0	0	0	-	0	1317982
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	106	SweptSolid	0	84	0	0	0	-	0	2215403
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	107	SweptSolid	0	32	0	0	0	-	0	2158165
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	108	SweptSolid	0	476	0	0	0	-	0	5621115
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	109	SweptSolid	0	158	0	0	0	-	0	1162383
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	110	SweptSolid	0	96	0	0	0	-	0	1483294
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	111	SweptSolid	0	28	0	0	0	-	0	561787
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	112	SweptSolid	0	56	0	0	0	-	0	1320682
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	113	SweptSolid	0	32	0	0	0	-	0	692488
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	114	SweptSolid	0	164	0	0	0	-	0	8454958
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	115	SweptSolid	0	32	0	0	0	-	0	383416
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	116	SweptSolid	0	68	0	0	0	-	0	561791
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	136	SweptSolid	0	32	0	0	0	-	0	1907446
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	137	SweptSolid	0	128	0	0	0	-	0	540030
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	138	SweptSolid	0	180	0	0	0	-	0	1889965
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	139	SweptSolid	0	48	0	0	0	-	0	1588706
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	140	SweptSolid	0	194	0	0	0	-	0	1759893
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	141	SweptSolid	0	28	0	0	0	-	0	150656
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	142	SweptSolid	0	56	0	0	0	-	0	555607
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	143	SweptSolid	0	120	0	0	0	-	0	3130562
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	144	SweptSolid	0	172	0	0	0	-	0	2016039
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	145	SweptSolid	0	94	0	0	0	-	0	1904675
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	146	SweptSolid	0	40	0	0	0	-	0	3123294
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	179	SweptSolid	0	136	0	0	0	-	0	68234684
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	180	SweptSolid	0	124	0	0	0	-	0	1035251
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	181	SweptSolid	0	32	0	0	0	-	0	1907442
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	182	SweptSolid	0	128	0	0	0	-	0	549994
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	183	SweptSolid	0	28	0	0	0	-	0	360023
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	214	SweptSolid	0	32	0	0	0	-	0	2719651
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	276	SweptSolid	0	72	0	0	0	-	0	79259689
+various/issue-604-door.ifc	55	SweptSolid	0	28	0	0	0	-	0	843048
+various/rvt01.ifc	5941	Tessellation	58	281	0	0	61	11	93	-
+various/rvt01.ifc	6073	Tessellation	8	290	0	0	34	0	39	-
+various/rvt01.ifc	6163	SweptSolid	13	79	0	0	13	0	19	-
+various/rvt01.ifc	6243	SweptSolid	29	146	0	0	36	8	51	-
+various/rvt01.ifc	6305	SweptSolid	30	266	1	0	67	8	60	-
+various/rvt01.ifc	6420	SweptSolid	31	163	0	0	28	6	43	-
+various/rvt01.ifc	6511	SweptSolid	22	190	0	0	13	6	30	-
+various/rvt01.ifc	6588	SweptSolid	8	134	0	0	8	0	26	-
+various/rvt01.ifc	6724	SweptSolid	32	211	0	0	36	8	46	-
+various/rvt01.ifc	6810	SweptSolid	97	293	1	0	99	27	125	-
+various/rvt01.ifc	6934	SweptSolid	0	100	0	0	6	-	6	3571807
+various/rvt01.ifc	7013	SweptSolid	32	221	0	0	29	8	61	-
+various/rvt01.ifc	7075	SweptSolid	51	264	0	0	37	8	80	-
+various/rvt01.ifc	7137	SweptSolid	18	164	0	0	25	0	29	-
+various/rvt01.ifc	7216	SweptSolid	15	157	0	0	18	0	28	-
+various/rvt01.ifc	7295	SweptSolid	53	160	1	0	39	6	58	-
+various/rvt01.ifc	7403	Tessellation	11	41	0	0	11	3	18	-
+various/rvt01.ifc	7544	SweptSolid	76	239	1	0	56	8	102	-
+various/rvt01.ifc	7700	SweptSolid	41	161	0	0	39	0	43	-
+various/rvt01.ifc	7834	SweptSolid	90	241	0	0	81	16	128	-
+various/rvt01.ifc	8881	SweptSolid	56	221	1	0	36	8	73	-
+various/rvt01.ifc	8997	SweptSolid	54	218	0	0	43	26	74	-
+various/rvt01.ifc	9058	SweptSolid	44	214	0	0	48	8	59	-
+various/rvt01.ifc	9229	SweptSolid	31	222	0	0	25	8	58	-
+various/rvt01.ifc	9400	SweptSolid	32	204	0	0	29	0	44	-
+various/rvt01.ifc	9730	SweptSolid	20	136	1	0	20	8	36	-
+various/rvt01.ifc	9901	SweptSolid	18	110	0	0	21	8	34	-
+various/rvt01.ifc	10191	Tessellation	13	31	0	0	14	0	13	-
+various/rvt01.ifc	10335	Tessellation	3	11	0	0	4	0	3	-
+various/rvt01.ifc	10526	Tessellation	13	103	0	0	13	0	24	-
+various/rvt01.ifc	10632	Tessellation	11	167	1	0	5	0	11	-
+various/rvt01.ifc	11110	Tessellation	0	4	0	0	3	-	0	651
+various/rvt01.ifc	11168	Tessellation	4	78	0	0	6	0	4	-
+various/rvt01.ifc	11232	Tessellation	0	64	0	0	0	-	2	38443
+various/rvt01.ifc	11304	Tessellation	0	32	0	0	0	-	0	36281
+various/rvt01.ifc	11477	Tessellation	0	0	0	0	7	-	0	0
+various/rvt01.ifc	11563	Tessellation	23	18	0	1	26	0	23	-
+various/rvt01.ifc	11627	Tessellation	63	63	0	1	54	3	65	-
+various/rvt01.ifc	11690	Tessellation	72	93	0	1	56	6	73	-
+various/rvt01.ifc	11753	Tessellation	10	4	0	1	16	0	10	-
+various/rvt01.ifc	11803	SweptSolid	22	65	0	0	12	0	23	-
+various/rvt01.ifc	12235	SweptSolid	15	59	0	0	15	0	16	-
+various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0	12	-
+various/rvt01.ifc	12449	Tessellation	16	168	1	0	31	9	19	-
+various/rvt01.ifc	13735	SweptSolid	35	213	0	0	19	8	63	-
+various/rvt01.ifc	13797	Tessellation	131	508	1	0	119	42	213	-
+various/rvt01.ifc	14014	SweptSolid	44	214	1	0	41	8	66	-
+various/rvt01.ifc	14132	SweptSolid	30	210	0	0	29	8	50	-
+various/rvt01.ifc	14194	SweptSolid	34	202	0	0	34	8	57	-
+various/rvt01.ifc	14256	SweptSolid	32	200	0	0	35	0	54	-
+various/rvt01.ifc	14447	SweptSolid	3	255	1	0	7	0	48	-
+various/rvt01.ifc	14638	SweptSolid	21	191	0	0	21	8	45	-
+various/rvt01.ifc	14797	SweptSolid	17	151	0	0	17	0	31	-
+various/rvt01.ifc	15020	SweptSolid	25	201	0	0	21	8	49	-
+various/rvt01.ifc	15301	SweptSolid	42	193	0	0	32	8	60	-
+various/rvt01.ifc	15857	SweptSolid	31	201	1	0	35	12	48	-
+various/rvt01.ifc	15917	SweptSolid	43	250	1	0	55	16	76	-
+various/rvt01.ifc	16231	SweptSolid	45	170	1	0	30	0	53	-
+various/rvt01.ifc	16286	SweptSolid	46	192	1	0	40	8	58	-
+various/rvt01.ifc	16805	SweptSolid	26	116	1	0	15	8	41	-
+various/rvt01.ifc	17553	Tessellation	4	10	0	0	4	0	7	-
+various/rvt01.ifc	17615	Tessellation	0	56	0	0	0	-	0	14264
+various/rvt01.ifc	17919	Tessellation	0	48	0	0	0	-	6	1
+various/rvt01.ifc	17985	Tessellation	27	59	0	0	25	0	27	-
+various/rvt01.ifc	18169	SweptSolid	42	186	1	0	29	8	58	-
+various/rvt01.ifc	21999	SweptSolid	0	40	0	1	0	-	20	120311
+various/rvt01.ifc	25694	Tessellation	3	111	0	0	3	0	3	-
+various/rvt01.ifc	25914	SweptSolid	12	176	0	0	13	0	35	-
+various/rvt01.ifc	26166	Tessellation	8	100	0	0	0	0	16	-
+various/rvt01.ifc	26300	Tessellation	41	207	1	0	8	0	53	-
+various/rvt01.ifc	26610	Tessellation	3	63	0	0	3	0	3	-
+various/rvt01.ifc	26681	Tessellation	0	174	0	0	4	-	6	64718
+various/rvt01.ifc	26832	Tessellation	0	22	0	0	0	-	0	4651
+various/rvt01.ifc	30054	Tessellation	0	48	0	0	0	-	0	31649
+various/rvt01.ifc	30125	Tessellation	0	44	0	0	6	-	0	23968
+various/rvt01.ifc	30518	Tessellation	7	257	0	0	0	0	8	-
+various/rvt01.ifc	31083	Tessellation	25	55	0	0	15	0	25	-
+various/rvt01.ifc	31156	Tessellation	3	173	0	0	0	0	3	-
+various/rvt01.ifc	31323	Tessellation	0	8	0	0	0	-	3	0
+various/rvt01.ifc	31430	Tessellation	0	50	0	0	0	-	2	9770
+various/rvt01.ifc	31577	Tessellation	0	48	0	0	0	-	0	27745
+various/rvt01.ifc	31648	Tessellation	0	44	0	0	6	-	0	20841
+various/rvt01.ifc	32081	SweptSolid	31	213	1	0	31	0	48	-
+various/rvt01.ifc	33639	SweptSolid	122	308	0	1	157	24	135	-
+various/rvt01.ifc	37278	Tessellation	4	16	0	0	5	0	4	-
+various/rvt01.ifc	37347	Tessellation	39	169	1	0	38	0	63	-
+various/rvt01.ifc	37455	Tessellation	20	164	0	0	15	3	25	-
+various/rvt01.ifc	37570	SweptSolid	0	76	0	0	0	-	12	37498
+various/rvt01.ifc	38680	Tessellation	28	150	1	0	27	0	35	-
+various/rvt01.ifc	38745	SweptSolid	4	54	0	0	4	0	8	-
+various/rvt01.ifc	38800	SweptSolid	39	246	1	0	41	14	81	-

--- a/rust/geometry/tests/manifests/watertightness_census_heavy.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census_heavy.tsv
@@ -15,656 +15,659 @@
 # strict: undirected edges NOT used exactly once forward and once reverse. Always
 #        >= open, and sees what open cannot: a doubled sheet nets to zero on the
 #        signed balance. Gated as its own count; the defect population is open's.
-model	id	rep	open	tris	coll	far	alt	pre	strict
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	38320	SweptSolid	0	1116	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	88827	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91103	SweptSolid	0	50	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91296	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91480	SweptSolid	0	48	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	93675	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	96393	SweptSolid	0	1150	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	100042	SweptSolid	0	660	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1712335	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1714558	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1717336	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1717504	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1721929	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1725768	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1727101	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1730412	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1774883	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1777087	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906369	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906553	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906786	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906954	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1907320	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1907855	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1908156	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1908692	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1909321	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1909498	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2022997	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023181	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023414	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023582	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023948	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2024483	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2024784	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2025320	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2025949	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2026126	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2139609	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2139793	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140026	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140194	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140560	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141095	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141396	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141932	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2142561	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2142738	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257369	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257553	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257786	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257954	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2258320	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2258855	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2259156	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2259692	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260321	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260498	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260673	SweptSolid	0	0	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2377840	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378024	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378257	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378425	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378791	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2379326	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2379627	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380163	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380792	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380969	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494452	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494636	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494869	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495037	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495403	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495938	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2496239	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2496775	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2497404	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2497581	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611064	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611248	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611481	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611649	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612015	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612550	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612851	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2613387	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2614016	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2614193	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2727676	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2727860	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728093	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728261	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728627	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729162	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729463	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729999	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2730628	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2730805	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844288	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844472	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844705	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844873	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2845239	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2845774	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2846075	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2846611	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2847240	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2847417	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2960900	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961084	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961317	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961485	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961851	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2962386	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2962687	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2963223	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2963852	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2964029	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077512	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077696	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077929	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078097	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078463	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078998	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3079299	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3079835	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3080464	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3080641	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194124	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194308	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194541	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194709	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195075	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195610	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195911	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3196447	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3197076	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3197253	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3310736	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3310920	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311153	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311321	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311687	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3312222	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3312523	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313059	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313688	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313865	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427348	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427532	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427765	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427933	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3428299	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3428834	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3429135	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3429671	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3430300	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3430477	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3543960	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544144	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544377	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544545	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544911	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3545446	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3545747	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3546283	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3546912	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3547089	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660572	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660756	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660989	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3661157	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3661523	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662058	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662359	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662895	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3663524	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3663701	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777184	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777368	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777601	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777769	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778135	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778670	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778971	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3779507	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3780136	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3780313	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3893796	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3893980	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894213	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894381	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894747	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3895282	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3895583	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896119	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896748	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896925	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010408	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010592	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010825	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010993	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4011359	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4011894	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4012195	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4012731	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4013360	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4013537	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127020	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127204	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127437	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127605	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127971	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4128506	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4128807	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4129343	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4129972	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4130149	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4243632	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4243816	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244049	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244217	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244583	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245118	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245419	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245955	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4246584	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4246761	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360244	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360428	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360661	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360829	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4361195	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4361730	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4362031	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4362567	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4363196	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4363373	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4476856	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477040	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477273	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477441	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477807	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4478342	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4478643	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479179	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479808	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479985	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593468	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593652	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593885	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594053	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594419	SweptSolid	0	162	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594954	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4595255	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4595791	SweptSolid	0	110	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4596420	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4596597	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4688035	SweptSolid	0	74	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5405105	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5405951	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5406788	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490434	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490623	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490812	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501531	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501720	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501909	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512584	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512773	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512962	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5523637	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5523826	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5524015	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5534690	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5534879	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5535068	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5545743	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5545932	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5546121	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5556796	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5556985	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5557174	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5567849	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568038	SweptSolid	0	42	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568227	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5578837	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5603607	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	43810	SweptSolid	40	1362	1	0	40	0	45
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	45388	SweptSolid	0	16	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52001	SweptSolid	0	232	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52476	SweptSolid	0	112	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52944	SweptSolid	0	554	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53237	Clipping	0	76	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53374	SweptSolid	32	254	0	0	32	0	32
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53592	SweptSolid	0	212	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53772	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53921	SweptSolid	0	318	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	54410	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	54549	SweptSolid	0	1170	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	55343	Clipping	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	55682	Clipping	0	208	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	68413	SweptSolid	0	608	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	135558	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	138279	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	138391	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143268	SweptSolid	0	96	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143491	SweptSolid	0	318	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143664	SweptSolid	0	360	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143837	SweptSolid	7	1073	1	0	7	0	8
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144344	SweptSolid	3	114	1	0	3	0	4
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144568	SweptSolid	22	224	0	0	22	0	22
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144736	SweptSolid	0	80	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	145112	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	145365	Clipping	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146378	Clipping	0	236	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146493	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146648	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146927	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	147047	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	147364	Clipping	0	112	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	150496	Clipping	0	52	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	150761	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	153999	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	154144	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	159350	Clipping	0	346	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	159858	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	170082	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	172652	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	177953	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	178601	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	179215	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	181747	Clipping	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185465	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185602	SweptSolid	0	76	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185845	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	186004	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	186252	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	204518	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	207468	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	214819	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227639	Clipping	0	138	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227792	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227888	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227985	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	230709	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	230824	Clipping	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	231186	Clipping	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	231389	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234207	Clipping	0	492	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234364	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234511	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234624	Clipping	0	66	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	247094	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252316	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252437	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252544	Clipping	0	98	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	255443	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	263471	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	268623	Clipping	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	273537	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	276078	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	278702	Clipping	0	120	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	278819	Clipping	0	90	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	295719	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	300934	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	308566	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	311038	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	311129	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	319210	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321693	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321799	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321916	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	338662	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	338986	Clipping	0	1316	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	341599	Clipping	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	346502	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	346870	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	349479	Clipping	12	1280	1	0	12	0	17
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	349767	SweptSolid	6	432	1	0	6	0	6
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350159	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350351	SweptSolid	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350469	Clipping	0	744	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350768	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	351103	Clipping	0	322	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	351200	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352017	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352171	Clipping	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352391	Clipping	0	110	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	358726	Clipping	0	244	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	358944	Clipping	3	899	1	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359140	Clipping	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359248	Clipping	0	547	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359479	Clipping	0	244	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359792	Clipping	0	126	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360030	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360382	Clipping	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360652	Clipping	0	374	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360795	SweptSolid	6	294	0	0	6	0	7
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360926	Clipping	0	276	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	364300	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	391643	Clipping	0	258	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	406997	Clipping	0	86	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	409492	Clipping	0	72	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	421473	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	422918	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	423069	Clipping	15	382	1	0	15	0	19
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426240	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426336	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426679	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426780	SweptSolid	0	24	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	431974	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	442318	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	448086	Clipping	0	76	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	448926	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449133	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449245	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449359	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	450171	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	450285	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	455526	Clipping	0	68	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	456370	Clipping	0	84	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	457851	Clipping	0	82	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	457965	Clipping	0	288	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458076	Clipping	0	134	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458188	Clipping	0	84	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458306	Clipping	0	188	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	461422	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	464348	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	464445	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	477457	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480514	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480859	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480954	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	481062	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	509974	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515088	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515286	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515966	Clipping	0	66	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519013	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519208	SweptSolid	0	124	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519360	Clipping	0	102	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519482	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519583	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	521473	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	531006	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	531219	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	542299	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	542982	Clipping	0	70	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544450	SweptSolid	0	248	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544676	SweptSolid	0	158	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544860	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	548651	Clipping	0	184	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	549140	Clipping	0	90	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	556478	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	556796	Clipping	0	96	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	558537	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	587069	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	616469	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627292	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627564	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627923	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628153	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628418	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628727	SweptSolid	3	17	0	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628996	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629259	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629443	SweptSolid	6	15	1	0	6	0	6
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629795	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632229	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632492	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632761	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633029	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633296	SweptSolid	0	38	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633563	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	637986	SweptSolid	3	17	1	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638255	SweptSolid	0	38	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638524	SweptSolid	0	48	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638793	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639075	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639344	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639525	SweptSolid	9	15	0	0	9	0	9
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639794	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639976	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640160	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640343	SweptSolid	0	274	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640479	SweptSolid	4	366	0	0	4	0	4
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640787	SweptSolid	0	50	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641056	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641240	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641424	SweptSolid	6	15	1	0	6	0	6
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641695	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641955	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642224	SweptSolid	0	34	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642493	SweptSolid	9	15	0	0	9	0	9
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642763	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643033	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643300	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643484	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	645145	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	649824	SweptSolid	0	17	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650006	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650267	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650449	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650717	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651337	SweptSolid	0	26	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651602	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651868	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	652136	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	652444	SweptSolid	0	18	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	873655	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	874469	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882182	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882681	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882777	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	885733	SweptSolid	0	18	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886311	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886572	SweptSolid	9	16	1	0	9	0	9
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886833	SweptSolid	0	26	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	887388	Clipping	0	76	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	887561	Clipping	0	266	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888120	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888459	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888576	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888861	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889283	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889391	Clipping	0	114	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889525	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889728	Clipping	0	48	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889824	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889988	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890242	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890360	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890480	Clipping	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890707	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890860	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891016	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891221	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891553	SweptSolid	6	84	0	0	6	0	6
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891721	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892212	Brep	0	252	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892717	Brep	19	433	0	0	20	29	19
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892891	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	893133	SweptSolid	20	234	1	0	20	0	20
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	896693	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	896784	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	901491	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	911379	Clipping	0	232	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	923985	SweptSolid	3	17	0	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	924293	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	933132	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	983282	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	988781	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991529	Clipping	0	76	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991636	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991977	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	994080	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1166069	SweptSolid	0	64	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1168164	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1168271	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169015	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169133	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169685	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1184767	SweptSolid	0	130	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1184857	SweptSolid	8	40	0	0	8	0	8
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1185151	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1185916	SweptSolid	0	56	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1186976	SweptSolid	0	60	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1194412	SweptSolid	0	180	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1203700	Clipping	0	78	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1203850	Clipping	0	294	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204373	Clipping	0	52	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204637	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204858	Clipping	3	329	1	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1205157	Clipping	0	108	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1206496	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1206592	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1207081	SweptSolid	0	78	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1246694	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247003	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247270	SweptSolid	0	30	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247537	SweptSolid	0	18	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247720	SweptSolid	9	15	0	0	9	0	9
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1256100	Clipping	0	82	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1265258	Brep	8	272	0	0	0	23	8
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1280178	Clipping	0	120	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1287307	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1293702	SweptSolid	0	96	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1307364	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1307542	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1320084	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1320395	SweptSolid	0	40	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1328896	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340435	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340547	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340775	Clipping	0	152	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340889	Clipping	0	144	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341003	Clipping	0	370	0	0	0	-	1
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341220	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341310	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341401	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341513	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341625	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1342032	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1359333	SweptSolid	0	52	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364381	SweptSolid	0	20	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364584	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364691	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375064	SweptSolid	0	24	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375195	SweptSolid	0	246	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375458	SweptSolid	0	150	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375635	SweptSolid	0	24	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375725	SweptSolid	0	24	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375821	SweptSolid	0	138	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380129	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380479	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380592	Clipping	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1388779	SweptSolid	0	12	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1397967	SweptSolid	0	116	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1398327	Brep	0	226	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399367	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399725	SweptSolid	3	22	1	0	3	0	3
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400126	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400391	SweptSolid	0	48	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400573	SweptSolid	0	450	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400840	SweptSolid	0	30	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401021	SweptSolid	0	182	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401204	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401471	SweptSolid	0	48	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401653	SweptSolid	0	150	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401920	SweptSolid	0	14	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1402102	SweptSolid	0	36	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1402572	SweptSolid	0	58	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1458827	SweptSolid	0	16	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1459395	SweptSolid	0	19	1	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1459594	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1483180	Clipping	0	328	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1485236	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1499878	Clipping	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1507348	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1507445	SweptSolid	0	32	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1520374	SweptSolid	0	44	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1577983	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1578551	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1579028	SweptSolid	0	148	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1579408	SweptSolid	8	279	1	0	8	0	12
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580067	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580605	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580912	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1581134	SweptSolid	0	28	0	0	0	-	0
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1581884	SweptSolid	0	28	0	0	0	-	0
+# vol:   signed enclosed volume in whole cm^3, or - if not taken. Taken only where
+#        open is 0: an open surface has no volume to read. A change here requires a
+#        bless in either direction; the reason says how much and which way.
+model	id	rep	open	tris	coll	far	alt	pre	strict	vol
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	38320	SweptSolid	0	1116	0	0	0	-	0	239015427
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	88827	SweptSolid	0	52	0	0	0	-	0	2275210
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91103	SweptSolid	0	50	0	0	0	-	0	1186175
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91296	SweptSolid	0	52	0	0	0	-	0	2275213
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	91480	SweptSolid	0	48	0	0	0	-	0	1186331
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	93675	SweptSolid	0	28	0	0	0	-	0	1993917
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	96393	SweptSolid	0	1150	0	0	0	-	0	138319992
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	100042	SweptSolid	0	660	0	0	0	-	0	91059812
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1712335	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1714558	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1717336	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1717504	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1721929	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1725768	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1727101	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1730412	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1774883	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1777087	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906369	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906553	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906786	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1906954	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1907320	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1907855	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1908156	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1908692	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1909321	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	1909498	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2022997	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023181	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023414	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023582	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2023948	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2024483	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2024784	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2025320	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2025949	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2026126	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2139609	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2139793	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140026	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140194	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2140560	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141095	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141396	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2141932	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2142561	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2142738	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257369	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257553	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257786	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2257954	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2258320	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2258855	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2259156	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2259692	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260321	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260498	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2260673	SweptSolid	0	0	0	0	0	-	0	0
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2377840	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378024	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378257	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378425	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2378791	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2379326	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2379627	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380163	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380792	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2380969	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494452	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494636	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2494869	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495037	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495403	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2495938	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2496239	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2496775	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2497404	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2497581	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611064	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611248	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611481	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2611649	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612015	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612550	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2612851	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2613387	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2614016	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2614193	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2727676	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2727860	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728093	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728261	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2728627	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729162	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729463	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2729999	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2730628	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2730805	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844288	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844472	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844705	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2844873	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2845239	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2845774	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2846075	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2846611	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2847240	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2847417	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2960900	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961084	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961317	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961485	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2961851	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2962386	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2962687	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2963223	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2963852	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	2964029	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077512	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077696	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3077929	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078097	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078463	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3078998	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3079299	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3079835	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3080464	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3080641	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194124	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194308	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194541	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3194709	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195075	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195610	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3195911	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3196447	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3197076	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3197253	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3310736	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3310920	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311153	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311321	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3311687	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3312222	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3312523	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313059	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313688	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3313865	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427348	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427532	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427765	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3427933	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3428299	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3428834	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3429135	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3429671	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3430300	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3430477	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3543960	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544144	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544377	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544545	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3544911	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3545446	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3545747	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3546283	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3546912	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3547089	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660572	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660756	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3660989	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3661157	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3661523	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662058	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662359	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3662895	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3663524	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3663701	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777184	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777368	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777601	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3777769	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778135	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778670	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3778971	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3779507	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3780136	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3780313	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3893796	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3893980	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894213	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894381	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3894747	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3895282	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3895583	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896119	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896748	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	3896925	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010408	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010592	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010825	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4010993	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4011359	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4011894	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4012195	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4012731	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4013360	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4013537	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127020	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127204	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127437	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127605	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4127971	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4128506	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4128807	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4129343	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4129972	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4130149	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4243632	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4243816	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244049	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244217	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4244583	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245118	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245419	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4245955	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4246584	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4246761	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360244	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360428	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360661	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4360829	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4361195	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4361730	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4362031	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4362567	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4363196	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4363373	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4476856	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477040	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477273	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477441	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4477807	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4478342	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4478643	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479179	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479808	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4479985	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593468	SweptSolid	0	40	0	0	0	-	0	3704925
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593652	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4593885	SweptSolid	0	28	0	0	0	-	0	3418279
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594053	SweptSolid	0	60	0	0	0	-	0	3342637
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594419	SweptSolid	0	162	0	0	0	-	0	1559929
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4594954	SweptSolid	0	56	0	0	0	-	0	1229935
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4595255	SweptSolid	0	76	0	0	0	-	0	1560063
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4595791	SweptSolid	0	110	0	0	0	-	0	996403
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4596420	SweptSolid	0	28	0	0	0	-	0	1368911
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4596597	SweptSolid	0	28	0	0	0	-	0	1368908
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	4688035	SweptSolid	0	74	0	0	0	-	0	8210577
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5405105	SweptSolid	0	36	0	0	0	-	0	5484619
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5405951	SweptSolid	0	44	0	0	0	-	0	7424520
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5406788	SweptSolid	0	52	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490434	SweptSolid	0	36	0	0	0	-	0	5484619
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490623	SweptSolid	0	44	0	0	0	-	0	7424520
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5490812	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501531	SweptSolid	0	36	0	0	0	-	0	5484619
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501720	SweptSolid	0	44	0	0	0	-	0	7424520
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5501909	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512584	SweptSolid	0	36	0	0	0	-	0	5484619
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512773	SweptSolid	0	44	0	0	0	-	0	7424520
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5512962	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5523637	SweptSolid	0	36	0	0	0	-	0	5484619
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5523826	SweptSolid	0	44	0	0	0	-	0	7424520
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5524015	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5534690	SweptSolid	0	36	0	0	0	-	0	5484623
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5534879	SweptSolid	0	44	0	0	0	-	0	7424524
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5535068	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5545743	SweptSolid	0	36	0	0	0	-	0	5484623
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5545932	SweptSolid	0	44	0	0	0	-	0	7424524
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5546121	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5556796	SweptSolid	0	36	0	0	0	-	0	5484623
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5556985	SweptSolid	0	44	0	0	0	-	0	7424524
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5557174	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5567849	SweptSolid	0	36	0	0	0	-	0	5484623
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568038	SweptSolid	0	42	0	0	0	-	0	7457524
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568227	SweptSolid	0	36	0	0	0	-	0	5463711
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5578837	SweptSolid	0	36	0	0	0	-	0	5516518
+ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5603607	SweptSolid	0	36	0	0	0	-	0	5516518
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	43810	SweptSolid	40	1362	1	0	40	0	45	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	45388	SweptSolid	0	16	0	0	0	-	0	399170
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52001	SweptSolid	0	232	0	0	0	-	0	2994143
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52476	SweptSolid	0	112	0	0	0	-	0	2466211
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52944	SweptSolid	0	554	0	0	0	-	0	46764732
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53237	Clipping	0	76	0	0	0	-	0	1783502
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53374	SweptSolid	32	254	0	0	32	0	32	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53592	SweptSolid	0	212	0	0	0	-	0	49209257
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53772	SweptSolid	0	44	0	0	0	-	0	1307831
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	53921	SweptSolid	0	318	0	0	0	-	0	48791156
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	54410	Clipping	0	44	0	0	0	-	0	1400984
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	54549	SweptSolid	0	1170	1	0	0	-	0	92445457
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	55343	Clipping	0	124	0	0	0	-	0	1959848
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	55682	Clipping	0	208	0	0	0	-	0	1206494
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	68413	SweptSolid	0	608	0	0	0	-	0	109863387
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	135558	Clipping	0	44	0	0	0	-	0	2573164
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	138279	Clipping	0	28	0	0	0	-	0	699596
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	138391	Clipping	0	28	0	0	0	-	0	1341257
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143268	SweptSolid	0	96	0	0	0	-	0	13675596
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143491	SweptSolid	0	318	0	0	0	-	0	37224348
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143664	SweptSolid	0	360	0	0	0	-	0	35579690
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	143837	SweptSolid	7	1073	1	0	7	0	8	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144344	SweptSolid	3	114	1	0	3	0	4	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144568	SweptSolid	22	224	0	0	22	0	22	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	144736	SweptSolid	0	80	0	0	0	-	0	19490873
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	145112	SweptSolid	0	28	0	0	0	-	0	739814
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	145365	Clipping	0	20	0	0	0	-	0	675604
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146378	Clipping	0	236	0	0	0	-	0	4517182
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146493	Clipping	0	28	0	0	0	-	0	600361
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146648	Clipping	0	28	0	0	0	-	0	1847441
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	146927	Clipping	0	28	0	0	0	-	0	1030406
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	147047	Clipping	0	60	0	0	0	-	0	1394460
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	147364	Clipping	0	112	0	0	0	-	0	1118004
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	150496	Clipping	0	52	0	0	0	-	0	13630280
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	150761	Clipping	0	28	0	0	0	-	0	526660
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	153999	Clipping	0	44	0	0	0	-	0	1252199
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	154144	Clipping	0	44	0	0	0	-	0	2816037
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	159350	Clipping	0	346	1	0	0	-	0	2046042
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	159858	Clipping	0	44	0	0	0	-	0	2592458
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	170082	Clipping	0	44	0	0	0	-	0	693702
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	172652	Clipping	0	44	0	0	0	-	0	2233290
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	177953	SweptSolid	0	44	0	0	0	-	0	10055314
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	178601	SweptSolid	0	28	0	0	0	-	0	5296597
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	179215	Clipping	0	28	0	0	0	-	0	2276661
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	181747	Clipping	0	20	0	0	0	-	0	2075954
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185465	SweptSolid	0	28	0	0	0	-	0	572726
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185602	SweptSolid	0	76	0	0	0	-	0	4059378
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	185845	Clipping	0	28	0	0	0	-	0	1338053
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	186004	Clipping	0	28	0	0	0	-	0	785369
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	186252	Clipping	0	28	0	0	0	-	0	1543897
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	204518	SweptSolid	0	28	0	0	0	-	0	474197
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	207468	SweptSolid	0	28	0	0	0	-	0	1205113
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	214819	SweptSolid	0	28	0	0	0	-	0	1855762
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227639	Clipping	0	138	0	0	0	-	0	6866328
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227792	Clipping	0	28	0	0	0	-	0	1467239
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227888	SweptSolid	0	28	0	0	0	-	0	872365
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	227985	SweptSolid	0	28	0	0	0	-	0	1535782
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	230709	Clipping	0	60	0	0	0	-	0	2816882
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	230824	Clipping	0	36	0	0	0	-	0	1314559
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	231186	Clipping	0	36	0	0	0	-	0	2278631
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	231389	Clipping	0	44	0	0	0	-	0	1730123
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234207	Clipping	0	492	0	0	0	-	0	4318954
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234364	Clipping	0	44	0	0	0	-	0	1107031
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234511	Clipping	0	44	0	0	0	-	0	1106882
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	234624	Clipping	0	66	0	0	0	-	0	1538402
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	247094	Clipping	0	28	0	0	0	-	0	405083
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252316	Clipping	0	44	0	0	0	-	0	1793627
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252437	Clipping	0	28	0	0	0	-	0	1193243
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	252544	Clipping	0	98	0	0	0	-	0	910982
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	255443	Clipping	0	28	0	0	0	-	0	5194987
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	263471	SweptSolid	0	32	0	0	0	-	0	4080909
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	268623	Clipping	0	36	0	0	0	-	0	1256534
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	273537	Clipping	0	44	0	0	0	-	0	738474
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	276078	SweptSolid	0	28	0	0	0	-	0	739814
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	278702	Clipping	0	120	0	0	0	-	0	549871
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	278819	Clipping	0	90	0	0	0	-	0	582558
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	295719	SweptSolid	0	28	0	0	0	-	0	551414
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	300934	SweptSolid	0	52	0	0	0	-	0	453972
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	308566	Clipping	0	44	0	0	0	-	0	906627
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	311038	SweptSolid	0	28	0	0	0	-	0	841543
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	311129	SweptSolid	0	28	0	0	0	-	0	570976
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	319210	SweptSolid	0	28	0	0	0	-	0	986646
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321693	Clipping	0	28	0	0	0	-	0	1388288
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321799	Clipping	0	44	0	0	0	-	0	724314
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	321916	Clipping	0	28	0	0	0	-	0	3306910
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	338662	Clipping	0	28	0	0	0	-	0	554598
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	338986	Clipping	0	1316	1	0	0	-	0	3723635
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	341599	Clipping	0	36	0	0	0	-	0	587561
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	346502	SweptSolid	0	44	0	0	0	-	0	2602305
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	346870	Clipping	0	44	0	0	0	-	0	2534277
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	349479	Clipping	12	1280	1	0	12	0	17	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	349767	SweptSolid	6	432	1	0	6	0	6	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350159	Clipping	0	28	0	0	0	-	0	1587242
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350351	SweptSolid	0	124	0	0	0	-	0	4426221
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350469	Clipping	0	744	0	0	0	-	0	4298807
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	350768	SweptSolid	0	44	0	0	0	-	0	2650739
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	351103	Clipping	0	322	1	0	0	-	0	7565067
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	351200	SweptSolid	0	44	0	0	0	-	0	2650739
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352017	Clipping	0	60	0	0	0	-	0	1581778
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352171	Clipping	0	124	0	0	0	-	0	554591
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	352391	Clipping	0	110	0	0	0	-	0	554595
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	358726	Clipping	0	244	0	0	0	-	0	1368810
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	358944	Clipping	3	899	1	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359140	Clipping	0	124	0	0	0	-	0	888221
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359248	Clipping	0	547	1	0	0	-	0	2378369
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359479	Clipping	0	244	1	0	0	-	0	4353924
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	359792	Clipping	0	126	0	0	0	-	0	1736365
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360030	Clipping	0	44	0	0	0	-	0	1276867
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360382	Clipping	0	124	0	0	0	-	0	3736492
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360652	Clipping	0	374	0	0	0	-	0	8242181
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360795	SweptSolid	6	294	0	0	6	0	7	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	360926	Clipping	0	276	0	0	0	-	0	2548637
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	364300	Clipping	0	44	0	0	0	-	0	920460
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	391643	Clipping	0	258	0	0	0	-	0	999321
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	406997	Clipping	0	86	0	0	0	-	0	6524020
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	409492	Clipping	0	72	0	0	0	-	0	904770
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	421473	SweptSolid	0	20	0	0	0	-	0	2452340
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	422918	SweptSolid	0	28	0	0	0	-	0	1775400
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	423069	Clipping	15	382	1	0	15	0	19	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426240	Clipping	0	60	0	0	0	-	0	1112557
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426336	SweptSolid	0	28	0	0	0	-	0	2991634
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426679	Clipping	0	28	0	0	0	-	0	554606
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	426780	SweptSolid	0	24	0	0	0	-	0	242855
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	431974	SweptSolid	0	28	0	0	0	-	0	3434047
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	442318	Clipping	0	44	0	0	0	-	0	597241
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	448086	Clipping	0	76	0	0	0	-	0	2180168
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	448926	Clipping	0	44	0	0	0	-	0	2250631
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449133	Clipping	0	28	0	0	0	-	0	840346
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449245	Clipping	0	28	0	0	0	-	0	840346
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	449359	Clipping	0	44	0	0	0	-	0	902533
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	450171	SweptSolid	0	44	0	0	0	-	0	4801348
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	450285	Clipping	0	60	0	0	0	-	0	1160313
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	455526	Clipping	0	68	0	0	0	-	0	6277383
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	456370	Clipping	0	84	0	0	0	-	0	1892526
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	457851	Clipping	0	82	0	0	0	-	0	503100
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	457965	Clipping	0	288	0	0	0	-	0	1183281
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458076	Clipping	0	134	0	0	0	-	0	770863
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458188	Clipping	0	84	0	0	0	-	0	824203
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	458306	Clipping	0	188	0	0	0	-	0	2258498
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	461422	Clipping	0	28	0	0	0	-	0	660798
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	464348	Clipping	0	28	0	0	0	-	0	897308
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	464445	SweptSolid	0	28	0	0	0	-	0	525997
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	477457	Clipping	0	28	0	0	0	-	0	816022
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480514	Clipping	0	28	0	0	0	-	0	1307268
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480859	Clipping	0	28	0	0	0	-	0	2203457
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	480954	SweptSolid	0	60	0	0	0	-	0	3734667
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	481062	Clipping	0	28	0	0	0	-	0	923962
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	509974	Clipping	0	28	0	0	0	-	0	986654
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515088	Clipping	0	44	0	0	0	-	0	589539
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515286	SweptSolid	0	28	0	0	0	-	0	3141511
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	515966	Clipping	0	66	0	0	0	-	0	789516
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519013	Clipping	0	44	0	0	0	-	0	643174
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519208	SweptSolid	0	124	0	0	0	-	0	4062492
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519360	Clipping	0	102	0	0	0	-	0	1110699
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519482	Clipping	0	28	0	0	0	-	0	1112132
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	519583	SweptSolid	0	28	0	0	0	-	0	1500110
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	521473	SweptSolid	0	36	0	0	0	-	0	1128568
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	531006	Clipping	0	28	0	0	0	-	0	454861
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	531219	Clipping	0	28	0	0	0	-	0	445496
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	542299	SweptSolid	0	28	0	0	0	-	0	997094
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	542982	Clipping	0	70	0	0	0	-	0	817232
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544450	SweptSolid	0	248	0	0	0	-	0	4122567
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544676	SweptSolid	0	158	0	0	0	-	0	8730838
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	544860	SweptSolid	0	32	0	0	0	-	0	11539248
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	548651	Clipping	0	184	0	0	0	-	0	1196787
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	549140	Clipping	0	90	0	0	0	-	0	582542
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	556478	SweptSolid	0	36	0	0	0	-	0	1604106
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	556796	Clipping	0	96	0	0	0	-	0	491013
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	558537	Clipping	0	28	0	0	0	-	0	1000314
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	587069	SweptSolid	0	32	0	0	0	-	0	9022196
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	616469	Clipping	0	28	0	0	0	-	0	1079530
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627292	SweptSolid	0	12	0	0	0	-	0	293690
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627564	SweptSolid	0	12	0	0	0	-	0	1076573
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	627923	SweptSolid	0	12	0	0	0	-	0	298188
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628153	SweptSolid	0	20	0	0	0	-	0	1162434
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628418	SweptSolid	0	12	0	0	0	-	0	302699
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628727	SweptSolid	3	17	0	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	628996	SweptSolid	0	12	0	0	0	-	0	302699
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629259	SweptSolid	0	12	0	0	0	-	0	527013
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629443	SweptSolid	6	15	1	0	6	0	6	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	629795	SweptSolid	0	12	0	0	0	-	0	924267
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632229	SweptSolid	0	12	0	0	0	-	0	932896
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632492	SweptSolid	0	34	0	0	0	-	0	302694
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	632761	SweptSolid	0	12	0	0	0	-	0	372967
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633029	SweptSolid	0	34	0	0	0	-	0	1292804
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633296	SweptSolid	0	38	0	0	0	-	0	550777
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	633563	SweptSolid	0	12	0	0	0	-	0	632156
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	637986	SweptSolid	3	17	1	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638255	SweptSolid	0	38	0	0	0	-	0	302704
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638524	SweptSolid	0	48	0	0	0	-	0	526201
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	638793	SweptSolid	0	12	0	0	0	-	0	302630
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639075	SweptSolid	0	20	0	0	0	-	0	302702
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639344	SweptSolid	0	12	0	0	0	-	0	302556
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639525	SweptSolid	9	15	0	0	9	0	9	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639794	SweptSolid	0	12	0	0	0	-	0	302561
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	639976	SweptSolid	0	12	0	0	0	-	0	302561
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640160	SweptSolid	0	12	0	0	0	-	0	609169
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640343	SweptSolid	0	274	0	0	0	-	0	21656779
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640479	SweptSolid	4	366	0	0	4	0	4	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	640787	SweptSolid	0	50	1	0	0	-	0	1093277
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641056	SweptSolid	0	28	0	0	0	-	0	304075
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641240	SweptSolid	0	12	0	0	0	-	0	919780
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641424	SweptSolid	6	15	1	0	6	0	6	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641695	SweptSolid	0	12	0	0	0	-	0	682117
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	641955	SweptSolid	0	12	0	0	0	-	0	933267
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642224	SweptSolid	0	34	0	0	0	-	0	302694
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642493	SweptSolid	9	15	0	0	9	0	9	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	642763	SweptSolid	0	12	0	0	0	-	0	302699
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643033	SweptSolid	0	12	0	0	0	-	0	632679
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643300	SweptSolid	0	12	0	0	0	-	0	300891
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	643484	SweptSolid	0	12	0	0	0	-	0	552820
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	645145	SweptSolid	0	28	0	0	0	-	0	739816
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	649824	SweptSolid	0	17	1	0	0	-	0	220120
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650006	SweptSolid	0	12	0	0	0	-	0	702427
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650267	SweptSolid	0	12	0	0	0	-	0	220041
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650449	SweptSolid	0	12	0	0	0	-	0	250381
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	650717	SweptSolid	0	12	0	0	0	-	0	402156
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651337	SweptSolid	0	26	0	0	0	-	0	1192781
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651602	SweptSolid	0	12	0	0	0	-	0	1066669
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	651868	SweptSolid	0	12	0	0	0	-	0	607202
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	652136	SweptSolid	0	12	0	0	0	-	0	183455
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	652444	SweptSolid	0	18	0	0	0	-	0	277705
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	873655	SweptSolid	0	12	0	0	0	-	0	620477
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	874469	SweptSolid	0	44	0	0	0	-	0	1275133
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882182	SweptSolid	0	28	0	0	0	-	0	651219
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882681	Clipping	0	44	0	0	0	-	0	1320579
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	882777	SweptSolid	0	28	0	0	0	-	0	1667925
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	885733	SweptSolid	0	18	0	0	0	-	0	305306
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886311	SweptSolid	0	12	0	0	0	-	0	302693
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886572	SweptSolid	9	16	1	0	9	0	9	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	886833	SweptSolid	0	26	0	0	0	-	0	302705
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	887388	Clipping	0	76	0	0	0	-	0	936235
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	887561	Clipping	0	266	0	0	0	-	0	1507253
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888120	Clipping	0	44	0	0	0	-	0	3787755
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888459	Clipping	0	28	0	0	0	-	0	566970
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888576	Clipping	0	44	0	0	0	-	0	1502221
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	888861	Clipping	0	28	0	0	0	-	0	923811
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889283	SweptSolid	0	60	0	0	0	-	0	1305299
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889391	Clipping	0	114	0	0	0	-	0	549797
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889525	SweptSolid	0	28	0	0	0	-	0	469134
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889728	Clipping	0	48	0	0	0	-	0	3143359
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889824	SweptSolid	0	28	0	0	0	-	0	2002009
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	889988	Clipping	0	44	0	0	0	-	0	1020980
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890242	SweptSolid	0	28	0	0	0	-	0	493891
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890360	Clipping	0	28	0	0	0	-	0	1039414
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890480	Clipping	0	60	0	0	0	-	0	1323235
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890707	Clipping	0	28	0	0	0	-	0	897342
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	890860	Clipping	0	28	0	0	0	-	0	1673807
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891016	Clipping	0	28	0	0	0	-	0	660649
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891221	SweptSolid	0	40	0	0	0	-	0	2767953
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891553	SweptSolid	6	84	0	0	6	0	6	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891721	SweptSolid	0	28	0	0	0	-	0	1264342
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892212	Brep	0	252	0	0	0	-	0	21624994
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892717	Brep	19	433	0	0	20	29	19	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892891	SweptSolid	0	52	0	0	0	-	0	26320657
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	893133	SweptSolid	20	234	1	0	20	0	20	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	896693	SweptSolid	0	28	0	0	0	-	0	708425
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	896784	SweptSolid	0	28	0	0	0	-	0	1506744
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	901491	SweptSolid	0	28	0	0	0	-	0	2356826
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	911379	Clipping	0	232	0	0	0	-	0	8403213
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	923985	SweptSolid	3	17	0	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	924293	SweptSolid	0	12	0	0	0	-	0	315786
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	933132	SweptSolid	0	28	0	0	0	-	0	805092
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	983282	SweptSolid	0	28	0	0	0	-	0	1014968
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	988781	Clipping	0	28	0	0	0	-	0	676000
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991529	Clipping	0	76	0	0	0	-	0	2787197
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991636	Clipping	0	28	0	0	0	-	0	1163909
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	991977	SweptSolid	0	12	0	0	0	-	0	378374
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	994080	SweptSolid	0	28	0	0	0	-	0	1772680
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1166069	SweptSolid	0	64	0	0	0	-	0	219188347
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1168164	Clipping	0	44	0	0	0	-	0	1912883
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1168271	Clipping	0	28	0	0	0	-	0	526668
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169015	SweptSolid	0	28	0	0	0	-	0	614785
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169133	Clipping	0	28	0	0	0	-	0	418706
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1169685	Clipping	0	28	0	0	0	-	0	903203
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1184767	SweptSolid	0	130	0	0	0	-	0	134168
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1184857	SweptSolid	8	40	0	0	8	0	8	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1185151	Clipping	0	44	0	0	0	-	0	614841
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1185916	SweptSolid	0	56	0	0	0	-	0	83734603
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1186976	SweptSolid	0	60	0	0	0	-	0	169381
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1194412	SweptSolid	0	180	0	0	0	-	0	1499037
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1203700	Clipping	0	78	0	0	0	-	0	2636832
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1203850	Clipping	0	294	0	0	0	-	0	3780936
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204373	Clipping	0	52	0	0	0	-	0	307548
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204637	Clipping	0	28	0	0	0	-	0	1091755
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1204858	Clipping	3	329	1	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1205157	Clipping	0	108	0	0	0	-	0	493923
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1206496	SweptSolid	0	28	0	0	0	-	0	1169915
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1206592	SweptSolid	0	32	0	0	0	-	0	690614
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1207081	SweptSolid	0	78	0	0	0	-	0	2226910
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1246694	SweptSolid	0	12	0	0	0	-	0	183458
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247003	SweptSolid	0	12	0	0	0	-	0	183458
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247270	SweptSolid	0	30	0	0	0	-	0	220240
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247537	SweptSolid	0	18	0	0	0	-	0	180184
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1247720	SweptSolid	9	15	0	0	9	0	9	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1256100	Clipping	0	82	0	0	0	-	0	1671538
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1265258	Brep	8	272	0	0	0	23	8	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1280178	Clipping	0	120	0	0	0	-	0	2415844
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1287307	SweptSolid	0	28	0	0	0	-	0	365360
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1293702	SweptSolid	0	96	0	0	0	-	0	496113710
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1307364	SweptSolid	0	32	0	0	0	-	0	7364147
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1307542	SweptSolid	0	32	0	0	0	-	0	7434181
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1320084	SweptSolid	0	32	0	0	0	-	0	1414412
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1320395	SweptSolid	0	40	0	0	0	-	0	2147294
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1328896	Clipping	0	44	0	0	0	-	0	1202550
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340435	Clipping	0	44	0	0	0	-	0	1202550
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340547	Clipping	0	28	0	0	0	-	0	1871459
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340775	Clipping	0	152	0	0	0	-	0	958753
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1340889	Clipping	0	144	0	0	0	-	0	915033
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341003	Clipping	0	370	0	0	0	-	1	1773228
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341220	Clipping	0	44	0	0	0	-	0	1360462
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341310	SweptSolid	0	44	0	0	0	-	0	1309585
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341401	SweptSolid	0	44	0	0	0	-	0	1311383
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341513	Clipping	0	44	0	0	0	-	0	729378
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1341625	Clipping	0	44	0	0	0	-	0	729371
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1342032	SweptSolid	0	28	0	0	0	-	0	1517871
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1359333	SweptSolid	0	52	0	0	0	-	0	3129339
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364381	SweptSolid	0	20	0	0	0	-	0	1266836
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364584	Clipping	0	44	0	0	0	-	0	1148429
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1364691	Clipping	0	44	0	0	0	-	0	763110
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375064	SweptSolid	0	24	0	0	0	-	0	209850
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375195	SweptSolid	0	246	0	0	0	-	0	5729120
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375458	SweptSolid	0	150	0	0	0	-	0	9113375
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375635	SweptSolid	0	24	0	0	0	-	0	209836
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375725	SweptSolid	0	24	0	0	0	-	0	209836
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1375821	SweptSolid	0	138	0	0	0	-	0	7654318
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380129	SweptSolid	0	28	0	0	0	-	0	1135403
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380479	Clipping	0	44	0	0	0	-	0	1046006
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1380592	Clipping	0	44	0	0	0	-	0	1232330
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1388779	SweptSolid	0	12	0	0	0	-	0	302699
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1397967	SweptSolid	0	116	0	0	0	-	0	10351251
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1398327	Brep	0	226	0	0	0	-	0	7144232
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399367	SweptSolid	0	28	0	0	0	-	0	1144544
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399725	SweptSolid	3	22	1	0	3	0	3	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400126	SweptSolid	0	36	0	0	0	-	0	25347
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400391	SweptSolid	0	48	0	0	0	-	0	23232
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400573	SweptSolid	0	450	1	0	0	-	0	25340
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400840	SweptSolid	0	30	0	0	0	-	0	22704
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401021	SweptSolid	0	182	0	0	0	-	0	26920
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401204	SweptSolid	0	36	0	0	0	-	0	25347
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401471	SweptSolid	0	48	0	0	0	-	0	30097
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401653	SweptSolid	0	150	0	0	0	-	0	25606
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401920	SweptSolid	0	14	1	0	0	-	0	23110
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1402102	SweptSolid	0	36	0	0	0	-	0	25346
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1402572	SweptSolid	0	58	0	0	0	-	0	3303297
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1458827	SweptSolid	0	16	0	0	0	-	0	57094
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1459395	SweptSolid	0	19	1	0	0	-	0	312498
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1459594	SweptSolid	0	32	0	0	0	-	0	809389
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1483180	Clipping	0	328	0	0	0	-	0	1249718
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1485236	SweptSolid	0	28	0	0	0	-	0	252205
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1499878	Clipping	0	28	0	0	0	-	0	439558
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1507348	SweptSolid	0	32	0	0	0	-	0	1666741
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1507445	SweptSolid	0	32	0	0	0	-	0	1535393
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1520374	SweptSolid	0	44	0	0	0	-	0	670381
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1577983	SweptSolid	0	28	0	0	0	-	0	92601
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1578551	SweptSolid	0	28	0	0	0	-	0	28471
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1579028	SweptSolid	0	148	0	0	0	-	0	21311
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1579408	SweptSolid	8	279	1	0	8	0	12	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580067	SweptSolid	0	28	0	0	0	-	0	20657
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580605	SweptSolid	0	28	0	0	0	-	0	67669
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1580912	SweptSolid	0	28	0	0	0	-	0	72097
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1581134	SweptSolid	0	28	0	0	0	-	0	66370
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1581884	SweptSolid	0	28	0	0	0	-	0	40389

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -1318,6 +1318,58 @@ fn unit_cube() -> Mesh {
 /// makes it a doubling rather than a hole: a copy that drifted would leave the
 /// superset test below asserting `strict >= open` over some other mesh, and
 /// passing.
+/// `n` disjoint doubled sheets: one triangle and its reverse, side by side.
+///
+/// The shape the volume column cannot read (#3422). The signed balance
+/// certifies it watertight — every undirected edge is used once forward and
+/// once reverse — and the divergence sum over a surface that encloses nothing
+/// is exactly 0, so a census row for it carries `open = 0`, `strict = 0` and
+/// `vol = Some(0)`. Real hosts of this shape exist: a wall modelled as a
+/// zero-thickness face, a duplicated shell that cancels itself.
+fn doubled_sheets(n: usize) -> Mesh {
+    let mut m = Mesh::default();
+    for i in 0..n {
+        let (b, x) = ((m.positions.len() / 3) as u32, i as f32 * 4.0);
+        m.positions.extend_from_slice(&[x, 0.0, 0.0, x + 1.0, 0.0, 0.0, x, 1.0, 0.0]);
+        m.indices.extend_from_slice(&[b, b + 1, b + 2, b, b + 2, b + 1]);
+    }
+    m
+}
+
+/// #3422, the zero-volume hole in the volume column's own routing. A host that
+/// loses HALF its sheets is watertight on both sides and reads 0 cm³ on both,
+/// so "the enclosed volume did not change" is true and says nothing. Routing
+/// the triangle drop on it filed a vanished component as a friendly
+/// re-tessellation.
+///
+/// Measured through `row_from_mesh`, the sweep's own row builder, so the zero
+/// is the reading the sweep would take and not a synthetic one.
+#[test]
+fn a_watertight_host_reading_zero_volume_is_not_re_tessellated_when_it_shrinks() {
+    let swept: BTreeSet<String> = ["sheets.ifc".to_string()].into_iter().collect();
+    let row = |m: &Mesh| {
+        let s = edge_stats(m);
+        row_from_mesh("sheets.ifc", 1, "Brep".into(), m, &s, Some(s.open), PreVoid::NotTaken)
+    };
+    let (before, after) = (row(&doubled_sheets(2)), row(&doubled_sheets(1)));
+
+    // The premise: watertight by both rules on both sides, and zero volume on
+    // both, with half the mesh gone.
+    for (what, r) in [("before", &before), ("after", &after)] {
+        assert_eq!(r.open, 0, "{what}: the signed balance certifies a doubled sheet");
+        assert_eq!(r.strict, 0, "{what}: and so does the strict rule, on disjoint sheets");
+        assert_eq!(r.vol, Some(0), "{what}: a surface enclosing nothing reads 0 cm³");
+    }
+    assert_eq!((before.tris, after.tris), (4, 2), "half the mesh must be gone");
+
+    let d = census_golden::diff(&[before], &[after], &swept);
+    assert_eq!(d.regressed.len(), 1, "a vanished sheet is geometry lost");
+    assert!(d.retessellated.is_empty(), "not a re-tessellation: there is no volume to be unchanged");
+    assert!(d.volume_moved.is_empty(), "and 0 -> 0 is not a move either");
+    let reasons = d.regressed[0].reasons.join("; ");
+    assert!(reasons.contains("triangles 4 -> 2 (geometry lost)"), "{reasons}");
+}
+
 fn doubled_face_cube() -> Mesh {
     let mut m = unit_cube();
     m.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -1680,6 +1680,60 @@ fn an_over_cut_on_a_watertight_host_requires_a_bless() {
     }
 }
 
+/// What ONE vertex rounding the other way costs the reading (#3422), measured
+/// rather than argued. `census_golden::volume_tolerance_cm3`'s doc invokes this
+/// difference to justify a tolerance, and the number it originally quoted ("a
+/// real cm³ or two") is an order of magnitude under what the shape actually
+/// gives, so the figure is pinned here instead of asserted there.
+///
+/// The shift from moving one vertex by one snap step is the incident triangle
+/// area times the step over three: it grows with the FACE, not with the host's
+/// volume, which is why the tolerance's 1e-6 relative term does not track it.
+///
+/// The second arm is the part that makes the first one meaningful: shifting
+/// EVERY vertex by the same step moves the reading by nothing, because a
+/// grid-aligned translation is exact. Only independent re-rounding costs
+/// anything, which is exactly the platform-difference case.
+#[test]
+fn one_vertex_rounding_the_other_way_moves_the_reading_by_more_than_the_tolerance() {
+    const STEP: f32 = 1.0 / 65536.0;
+    let ifc = over_cut_fixture(1.4);
+    let voids = void_index(&ifc);
+    let mesh = process(&ifc, 50, &voids).expect("authored wall meshes");
+    let base = volume_cm3(&mesh);
+
+    let mut worst = 0i64;
+    for v in 0..mesh.positions.len() / 3 {
+        for axis in 0..3 {
+            let mut m = mesh.clone();
+            m.positions[v * 3 + axis] += STEP;
+            worst = worst.max((volume_cm3(&m) - base).abs());
+        }
+    }
+    // The measurement, bounded on BOTH sides. Too small and the claim above is
+    // wrong in the other direction; too large and the panel has changed shape.
+    assert!(
+        (4..=40).contains(&worst),
+        "one vertex, one snap step, on a {base} cm³ panel: expected a shift of \
+         a few cm³, got {worst}"
+    );
+    // The point of the number: it is well OVER the tolerance the column diffs
+    // at, so this really is a way for the census lane to red with no defect.
+    assert!(
+        worst > census_golden::volume_tolerance_cm3(base),
+        "a single flipped vertex ({worst} cm³) must exceed the tolerance ({}) for the \
+         doc's correction to be the right one",
+        census_golden::volume_tolerance_cm3(base)
+    );
+
+    // A uniform shift is a translation, and the grid is closed under it.
+    let mut all = mesh.clone();
+    for x in all.positions.iter_mut() {
+        *x += STEP;
+    }
+    assert_eq!(volume_cm3(&all), base, "a grid-aligned translation must be exact");
+}
+
 /* -------------------------------------------------------------------- *
  * The heavy lane (#3434). See the module doc's "heavy lane" section.   *
  * -------------------------------------------------------------------- */

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -523,7 +523,6 @@ fn volume_cm3(mesh: &Mesh) -> i64 {
 /// metres above the walls' top edge, so the surface carries a slit of that
 /// width all the way round. The one shape that separates the census's
 /// watertightness reading from the closure `mesh_volume` actually needs.
-#[cfg(test)]
 fn cracked_cube(crack: f32) -> Mesh {
     let base = [[0.0f32, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
     let mut positions: Vec<f32> = Vec::new();
@@ -717,7 +716,9 @@ fn a_bless_refuses_a_corrupt_golden_instead_of_treating_it_as_empty() {
     let _ = std::fs::remove_file(&path);
 
     for (mode, outcome) in [("measuring", measuring), ("blessing", blessing)] {
-        let err = outcome.expect_err("a corrupt golden must be fatal in {mode} mode");
+        let Err(err) = outcome else {
+            panic!("a corrupt golden must be fatal in {mode} mode");
+        };
         let text = err.downcast_ref::<String>().cloned().unwrap_or_default();
         assert!(text.contains("is CORRUPT, not merely on an older schema"), "{mode}: {text}");
         assert!(text.contains("bad volume"), "{mode}: {text}");
@@ -1384,16 +1385,6 @@ fn unit_cube() -> Mesh {
     m
 }
 
-/// [`unit_cube`] with one existing face triangle re-emitted AND its reverse.
-///
-/// Every position is already in the mesh, so this adds no boundary at all: the
-/// three affected edges go from 1 forward / 1 reverse to 2 forward / 2 reverse.
-/// That is the exact shape the signed balance cancels to zero on.
-///
-/// ONE fixture rather than a copy per test, because the six indices are what
-/// makes it a doubling rather than a hole: a copy that drifted would leave the
-/// superset test below asserting `strict >= open` over some other mesh, and
-/// passing.
 /// `n` disjoint doubled sheets: one triangle and its reverse, side by side.
 ///
 /// The shape the volume column cannot read (#3422). The signed balance
@@ -1446,6 +1437,16 @@ fn a_watertight_host_reading_zero_volume_is_not_re_tessellated_when_it_shrinks()
     assert!(reasons.contains("triangles 4 -> 2 (geometry lost)"), "{reasons}");
 }
 
+/// [`unit_cube`] with one existing face triangle re-emitted AND its reverse.
+///
+/// Every position is already in the mesh, so this adds no boundary at all: the
+/// three affected edges go from 1 forward / 1 reverse to 2 forward / 2 reverse.
+/// That is the exact shape the signed balance cancels to zero on.
+///
+/// ONE fixture rather than a copy per test, because the six indices are what
+/// makes it a doubling rather than a hole: a copy that drifted would leave the
+/// superset test below asserting `strict >= open` over some other mesh, and
+/// passing.
 fn doubled_face_cube() -> Mesh {
     let mut m = unit_cube();
     m.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -551,8 +551,12 @@ fn row_from_mesh(
 /// that carried on would be measuring against nothing.
 ///
 /// In bless mode exactly ONE failure is tolerated, and it is the one a
-/// column-adding change creates: [`census_golden::ParseError::Schema`], the
-/// file on disk having one column fewer than `parse` demands (#3397, #3422).
+/// column-adding change creates: [`census_golden::ParseError::Schema`], EVERY
+/// row on disk having exactly one column fewer than `parse` demands (#3397,
+/// #3422). `parse` identifies that shape positively rather than inferring it
+/// from any row-shape failure, so an arbitrary wrong column count — a
+/// truncated write, a mangled merge, one stray tab — is `Malformed` and stays
+/// fatal here.
 /// Its rows are intact but cannot be reused without inventing the new column,
 /// so the lane discards them and says so; every swept model is rewritten from
 /// this run, and a model NOT swept has no rows to keep, which the bless line's

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -547,20 +547,31 @@ fn row_from_mesh(
 
 /// The golden a lane compares against, or that a bless overwrites.
 ///
-/// Outside a bless an unreadable golden is fatal: a lane that carried on would
-/// be measuring against nothing. In bless mode it is expected exactly once per
-/// schema change — the file on disk has one column fewer than `parse` demands
-/// (#3397, #3422), and its rows cannot be reused without inventing that column
-/// — so it is treated as empty and the lane says so. Every swept model is then
-/// rewritten from this run, and a model NOT swept has no rows to keep, which
-/// the bless line's `kept` count shows. Before this the only way past the
-/// parse was the run report under `target/`, which the heavy lane does not
-/// write.
+/// Outside a bless an unreadable golden is fatal, whatever the reason: a lane
+/// that carried on would be measuring against nothing.
+///
+/// In bless mode exactly ONE failure is tolerated, and it is the one a
+/// column-adding change creates: [`census_golden::ParseError::Schema`], the
+/// file on disk having one column fewer than `parse` demands (#3397, #3422).
+/// Its rows are intact but cannot be reused without inventing the new column,
+/// so the lane discards them and says so; every swept model is rewritten from
+/// this run, and a model NOT swept has no rows to keep, which the bless line's
+/// `kept` count shows. Before this the only way past the parse was the run
+/// report under `target/`, which the heavy lane does not write.
+///
+/// Every OTHER failure — a bad number, an unreadable flag, a truncated write,
+/// a mangled merge — is fatal in bless mode too. Treating it as an empty
+/// golden would be the absence-reads-as-success shape: in the heavy lane the
+/// two fixtures share one file and each blesses only its own model's rows, so
+/// a bless of ISSUE_053 against a file carrying one corrupt ISSUE_068 row
+/// would silently write a golden missing all 363 of that model's rows, taking
+/// the #3435 tear pin with them. `parse` separates the two classes so this
+/// function can refuse the second one.
 fn read_golden(path: &std::path::Path, bless: bool) -> Vec<HostRow> {
     let text = std::fs::read_to_string(path).unwrap_or_default();
     match census_golden::parse(&text) {
         Ok(rows) => rows,
-        Err(e) if bless => {
+        Err(e @ census_golden::ParseError::Schema { .. }) if bless => {
             println!(
                 "\nBLESS WITHOUT COMPARISON: {} does not parse under the current golden \
                  schema ({e}). Its rows cannot be compared or kept, so every swept model \
@@ -569,6 +580,12 @@ fn read_golden(path: &std::path::Path, bless: bool) -> Vec<HostRow> {
             );
             Vec::new()
         }
+        Err(e @ census_golden::ParseError::Malformed(_)) => panic!(
+            "{} is CORRUPT, not merely on an older schema ({e}). A bless will not treat \
+             this as an empty golden: the rows it would silently drop include every model \
+             this run does not sweep. Fix or restore the file first.",
+            path.display()
+        ),
         Err(e) => panic!("{} is unreadable: {e}", path.display()),
     }
 }
@@ -596,6 +613,42 @@ fn a_golden_one_column_short_kills_a_measuring_run_and_is_kept_by_no_bless() {
     assert!(text.contains("expected 11 columns, got 10"), "{text}");
     let rows = blessing.expect("a bless must tolerate a golden one column short");
     assert!(rows.is_empty(), "an old-schema row was kept: {rows:?}");
+}
+
+/// The other half of the same rule (#3422). A golden that is CORRUPT rather
+/// than merely on an older schema is fatal in BOTH modes: the rows a bless
+/// would discard include every model this run does not sweep, and in the heavy
+/// lane, where two fixtures share one file, that is 363 rows and the #3435
+/// tear pin.
+///
+/// The fixture is the schema-short row from the test above with the new column
+/// present and unreadable, so the ONLY difference between the two is the class
+/// of failure, not the file's shape. Without the split in
+/// `census_golden::ParseError` this test passes an empty `Vec` back and writes
+/// a golden missing the other model.
+#[test]
+fn a_bless_refuses_a_corrupt_golden_instead_of_treating_it_as_empty() {
+    let path =
+        std::env::temp_dir().join(format!("ifc-lite-3422-corrupt-{}.tsv", std::process::id()));
+    std::fs::write(
+        &path,
+        "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\tvol\n\
+         a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\tnot-a-number\n",
+    )
+    .expect("write the corrupt golden");
+    let measuring = std::panic::catch_unwind(|| read_golden(&path, false));
+    let blessing = std::panic::catch_unwind(|| read_golden(&path, true));
+    let _ = std::fs::remove_file(&path);
+
+    for (mode, outcome) in [("measuring", measuring), ("blessing", blessing)] {
+        let err = outcome.expect_err("a corrupt golden must be fatal in {mode} mode");
+        let text = err.downcast_ref::<String>().cloned().unwrap_or_default();
+        assert!(text.contains("is CORRUPT, not merely on an older schema"), "{mode}: {text}");
+        assert!(text.contains("bad volume"), "{mode}: {text}");
+        // And it must NOT be described as a schema change, or the reader
+        // reaches for the bless command that would destroy the file.
+        assert!(!text.contains("BLESS WITHOUT COMPARISON"), "{mode}: {text}");
+    }
 }
 
 /// The host, then the reasons that moved it. The one definition of that shape

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -506,6 +506,34 @@ fn max_abs_coord(mesh: &Mesh) -> f64 {
     mesh.positions.iter().fold(0.0f64, |m, &v| m.max((v as f64).abs()))
 }
 
+/// One census row from a host's void-applied mesh. Every column that is a
+/// reading OF THAT MESH is derived here and nowhere else, so a test that builds
+/// a row from a mesh cannot drift from the sweep; `alt` and `pre` are second
+/// processing passes and stay with the caller, which has already read `stats`
+/// to decide whether `pre` is taken.
+fn row_from_mesh(
+    model: &str,
+    id: u32,
+    rep: String,
+    mesh: &Mesh,
+    stats: &EdgeStats,
+    alt: Option<usize>,
+    pre: PreVoid,
+) -> HostRow {
+    HostRow {
+        model: model.to_string(),
+        id,
+        rep,
+        open: stats.open,
+        strict: stats.strict,
+        tris: mesh.indices.len() / 3,
+        collapsed: stats.degenerate > 0,
+        far: max_abs_coord(mesh) >= F32_SAFE_MAGNITUDE,
+        alt,
+        pre,
+    }
+}
+
 /// The host, then the reasons that moved it. The one definition of that shape
 /// for the four buckets that carry a [`Delta`], so their print lines and their
 /// failure texts cannot drift apart. `missing` and `added` carry a bare
@@ -578,18 +606,15 @@ fn sweep(models: &[(String, PathBuf)]) -> (Vec<HostRow>, BTreeSet<String>) {
                     None => PreVoid::Failed,
                 }
             };
-            rows.push(HostRow {
-                model: rel.clone(),
+            rows.push(row_from_mesh(
+                rel,
                 id,
-                rep: representation_type(&content, &lines, id),
-                open,
-                strict: stats.strict,
-                tris: base.indices.len() / 3,
-                collapsed: stats.degenerate > 0,
-                far: max_abs_coord(&base) >= F32_SAFE_MAGNITUDE,
-                alt: alt.as_ref().map(open_boundary_edges),
+                representation_type(&content, &lines, id),
+                &base,
+                &stats,
+                alt.as_ref().map(open_boundary_edges),
                 pre,
-            });
+            ));
         }
     }
 
@@ -1193,6 +1218,130 @@ fn a_snap_collapsed_triangle_is_skipped_by_both_readings() {
     assert_eq!(s.degenerate, 1, "the collapsed triangle is counted");
     assert_eq!(s.open, 0, "and contributes no unbalanced edge");
     assert_eq!(s.strict, 0, "nor any strict violation, or every far-field host would gain some");
+}
+
+/// One 2.0 x 0.1 x 3.0 m panel with one rectangular opening through it, twice:
+/// wall #50 with the opening as authored (0.5 x 1.0 m), wall #150 with the
+/// SAME opening scaled by `scale` in its own plane, centre unmoved. That is
+/// the #3219 shape as a fixture: an opening cut larger than authored, on a
+/// host that is watertight either way.
+fn over_cut_fixture(scale: f64) -> String {
+    let (w, h) = (0.5 * scale, 1.0 * scale);
+    let z0 = 1.5 - h / 2.0;
+    format!(
+        r##"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('#3422 over-cut census probe'),'2;1');
+FILE_NAME('overcut.ifc','2026-09-03T00:00:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#2=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCDIRECTION((0.,0.,1.));
+#7=IFCDIRECTION((1.,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#5,#6,#7);
+#10=IFCUNITASSIGNMENT((#11));
+#11=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#8,$);
+#1=IFCPROJECT('0proj0000000000000001',#2,'P',$,$,$,$,(#20),#10);
+#30=IFCLOCALPLACEMENT($,#8);
+#40=IFCCARTESIANPOINT((0.,0.));
+#41=IFCDIRECTION((1.,0.));
+#42=IFCAXIS2PLACEMENT2D(#40,#41);
+/* --- wall #50: the panel, opening as authored --- */
+#43=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,2.,0.1);
+#44=IFCEXTRUDEDAREASOLID(#43,#8,#6,3.);
+#45=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#44));
+#46=IFCPRODUCTDEFINITIONSHAPE($,$,(#45));
+#50=IFCWALLSTANDARDCASE('authoredwall00000001',#2,'wall',$,$,#30,#46,'t1');
+/* opening 0.5 wide x 0.3 deep, z from 1.0 to 2.0: centre (0, 0, 1.5) */
+#60=IFCCARTESIANPOINT((0.,0.,1.));
+#61=IFCAXIS2PLACEMENT3D(#60,#6,#7);
+#62=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,0.5,0.3);
+#63=IFCEXTRUDEDAREASOLID(#62,#61,#6,1.);
+#64=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#63));
+#65=IFCPRODUCTDEFINITIONSHAPE($,$,(#64));
+#66=IFCOPENINGELEMENT('authoredopening00001',#2,'op',$,$,#30,#65,'t2');
+#70=IFCRELVOIDSELEMENT('authoredvoid0000001',#2,$,$,#50,#66);
+/* --- wall #150: the same panel, opening scaled about its centre --- */
+#143=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,2.,0.1);
+#144=IFCEXTRUDEDAREASOLID(#143,#8,#6,3.);
+#145=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#144));
+#146=IFCPRODUCTDEFINITIONSHAPE($,$,(#145));
+#150=IFCWALLSTANDARDCASE('overcutwall000000001',#2,'wall',$,$,#30,#146,'t3');
+#160=IFCCARTESIANPOINT((0.,0.,{z0:?}));
+#161=IFCAXIS2PLACEMENT3D(#160,#6,#7);
+#162=IFCRECTANGLEPROFILEDEF(.AREA.,'',#42,{w:?},0.3);
+#163=IFCEXTRUDEDAREASOLID(#162,#161,#6,{h:?});
+#164=IFCSHAPEREPRESENTATION(#20,'Body','SweptSolid',(#163));
+#165=IFCPRODUCTDEFINITIONSHAPE($,$,(#164));
+#166=IFCOPENINGELEMENT('overcutopening000001',#2,'op',$,$,#30,#165,'t4');
+#170=IFCRELVOIDSELEMENT('overcutvoid00000001',#2,$,$,#150,#166);
+ENDSEC;
+END-ISO-10303-21;"##
+    )
+}
+
+/// #3422. The census row vocabulary (`open`, `strict`, `tris`, `coll`, `far`,
+/// `alt`, `pre`) is COUNTS and FLAGS over topology, and the golden is a
+/// ceiling: a host may get better for free. An opening cut larger than
+/// authored on a watertight host, the #3219 shape, reads one of two ways under
+/// that vocabulary, and both are green:
+///
+/// - at 1.4x every count holds and the pair is an IDENTICAL row;
+/// - at 1.6x the cutter emits MORE triangles, and a grown `tris` files under
+///   `improved`, which requires no bless.
+///
+/// Measured on the pipeline rather than on synthetic rows: both walls go
+/// through the `process` / `edge_stats` / `max_abs_coord` path the sweep uses,
+/// via `row_from_mesh`, and the two rows are then diffed as golden and run.
+///
+/// Runs in the default `cargo test`: it needs no fixture and no alternate
+/// triangulator.
+#[test]
+fn an_over_cut_on_a_watertight_host_requires_a_bless() {
+    let swept: BTreeSet<String> = ["overcut.ifc".to_string()].into_iter().collect();
+
+    for (scale, tris_grow) in [(1.4, false), (1.6, true)] {
+        let ifc = over_cut_fixture(scale);
+        let voids = void_index(&ifc);
+        let authored = process(&ifc, 50, &voids).expect("authored wall meshes");
+        let over_cut = process(&ifc, 150, &voids).expect("over-cut wall meshes");
+
+        let (a, b) = (edge_stats(&authored), edge_stats(&over_cut));
+        // The rows exactly as the sweep records a host, through the same
+        // builder, so this test measures the sweep's own row and not a copy.
+        let wired_a =
+            row_from_mesh("overcut.ifc", 1, "SweptSolid".into(), &authored, &a, Some(a.open), PreVoid::NotTaken);
+        let wired_b =
+            row_from_mesh("overcut.ifc", 1, "SweptSolid".into(), &over_cut, &b, Some(b.open), PreVoid::NotTaken);
+        // Both must be WATERTIGHT, or this probes the torn-host rules instead.
+        assert_eq!(wired_a.open, 0, "{scale}x: authored wall must be watertight");
+        assert_eq!(wired_b.open, 0, "{scale}x: over-cut wall must be watertight");
+        assert_eq!(wired_a.strict, wired_b.strict, "{scale}x: strict");
+        assert_eq!(wired_a.collapsed, wired_b.collapsed, "{scale}x: collapsed");
+        assert_eq!(wired_a.far, wired_b.far, "{scale}x: far");
+        // The one count that CAN move, pinned per scale so the test says which
+        // green reading it is exercising. If either arm flips, the fixture has
+        // stopped demonstrating that reading and the test must say so rather
+        // than pass on the other one.
+        let (ta, tb) = (wired_a.tris, wired_b.tris);
+        if tris_grow {
+            assert!(tb > ta, "{scale}x: expected MORE triangles, got {ta} -> {tb}");
+        } else {
+            assert_eq!(ta, tb, "{scale}x: expected the same triangle count");
+        }
+
+        // The over-cut removed material the authored opening did not, and the
+        // census must say so. Nothing in the row vocabulary above can: this is
+        // the blind spot, and it is what the volume column closes.
+        let d = census_golden::diff(&[wired_a], &[wired_b], &swept);
+        assert!(
+            d.requires_bless(),
+            "{scale}x: an opening cut larger than authored left the census green"
+        );
+    }
 }
 
 /* -------------------------------------------------------------------- *

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -126,6 +126,7 @@ mod census_golden;
 
 use census_golden::{is_closed_solid, totals, Delta, HostRow, PreVoid};
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::kernel::mesh_volume::mesh_volume;
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 use std::collections::BTreeSet;
@@ -506,11 +507,18 @@ fn max_abs_coord(mesh: &Mesh) -> f64 {
     mesh.positions.iter().fold(0.0f64, |m, &v| m.max((v as f64).abs()))
 }
 
+/// Signed enclosed volume in whole cm³, for [`HostRow::vol`] (#3422), which
+/// says where it is taken and why it is an integer. `kernel::mesh_volume`
+/// reads the same f32 positions `edge_stats` does, so one mesh is one integer.
+fn volume_cm3(mesh: &Mesh) -> i64 {
+    (mesh_volume(mesh) * 1.0e6).round() as i64
+}
+
 /// One census row from a host's void-applied mesh. Every column that is a
-/// reading OF THAT MESH is derived here and nowhere else, so a test that builds
-/// a row from a mesh cannot drift from the sweep; `alt` and `pre` are second
-/// processing passes and stay with the caller, which has already read `stats`
-/// to decide whether `pre` is taken.
+/// reading OF THAT MESH is derived here and nowhere else, so a test that
+/// builds a row from a mesh cannot drift from the sweep; `alt` and `pre` are
+/// second processing passes and stay with the caller, which has already read
+/// `stats` to decide whether `pre` is taken.
 fn row_from_mesh(
     model: &str,
     id: u32,
@@ -531,7 +539,63 @@ fn row_from_mesh(
         far: max_abs_coord(mesh) >= F32_SAFE_MAGNITUDE,
         alt,
         pre,
+        // The mirror of `pre`: taken exactly where that one is not. Same
+        // SIGNED trigger, for the same reason.
+        vol: (stats.open == 0).then(|| volume_cm3(mesh)),
     }
+}
+
+/// The golden a lane compares against, or that a bless overwrites.
+///
+/// Outside a bless an unreadable golden is fatal: a lane that carried on would
+/// be measuring against nothing. In bless mode it is expected exactly once per
+/// schema change — the file on disk has one column fewer than `parse` demands
+/// (#3397, #3422), and its rows cannot be reused without inventing that column
+/// — so it is treated as empty and the lane says so. Every swept model is then
+/// rewritten from this run, and a model NOT swept has no rows to keep, which
+/// the bless line's `kept` count shows. Before this the only way past the
+/// parse was the run report under `target/`, which the heavy lane does not
+/// write.
+fn read_golden(path: &std::path::Path, bless: bool) -> Vec<HostRow> {
+    let text = std::fs::read_to_string(path).unwrap_or_default();
+    match census_golden::parse(&text) {
+        Ok(rows) => rows,
+        Err(e) if bless => {
+            println!(
+                "\nBLESS WITHOUT COMPARISON: {} does not parse under the current golden \
+                 schema ({e}). Its rows cannot be compared or kept, so every swept model \
+                 is written from this run alone.",
+                path.display()
+            );
+            Vec::new()
+        }
+        Err(e) => panic!("{} is unreadable: {e}", path.display()),
+    }
+}
+
+/// A golden one column short — the file every column-adding change leaves on
+/// disk. A measuring run must die on it (comparing against nothing certifies
+/// nothing); a bless must keep none of its rows, which cannot be reused
+/// without inventing the missing column. One fixture for both arms, so they
+/// cannot drift onto different inputs, removed before either assertion so a
+/// failure does not leak it.
+#[test]
+fn a_golden_one_column_short_kills_a_measuring_run_and_is_kept_by_no_bless() {
+    let path = std::env::temp_dir().join(format!("ifc-lite-3422-{}.tsv", std::process::id()));
+    std::fs::write(
+        &path,
+        "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\na.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\t0\n",
+    )
+    .expect("write the old-schema golden");
+    let measuring = std::panic::catch_unwind(|| read_golden(&path, false));
+    let blessing = std::panic::catch_unwind(|| read_golden(&path, true));
+    let _ = std::fs::remove_file(&path);
+
+    let err = measuring.expect_err("a measuring run must die on a golden one column short");
+    let text = err.downcast_ref::<String>().cloned().unwrap_or_default();
+    assert!(text.contains("expected 11 columns, got 10"), "{text}");
+    let rows = blessing.expect("a bless must tolerate a golden one column short");
+    assert!(rows.is_empty(), "an old-schema row was kept: {rows:?}");
 }
 
 /// The host, then the reasons that moved it. The one definition of that shape
@@ -545,6 +609,33 @@ fn fmt_delta(d: &Delta) -> String {
 /// One indented line per delta, for a failure message.
 fn fmt_deltas(ds: &[Delta]) -> String {
     ds.iter().map(|d| format!("  {}", fmt_delta(d))).collect::<Vec<_>>().join("\n")
+}
+
+/// Every bucket, each host named, in one place for both lanes: the census
+/// lane's comment above its call says why every bucket prints before any
+/// assert. One definition so adding a bucket is one edit, not one per lane.
+fn print_buckets(diff: &census_golden::Diff) {
+    for d in &diff.improved {
+        println!("  IMPROVED  {}", fmt_delta(d));
+    }
+    for d in &diff.regressed {
+        println!("  REGRESSED  {}", fmt_delta(d));
+    }
+    for r in &diff.missing {
+        println!("  COVERAGE LOSS  {}", fmt_host(r));
+    }
+    for d in &diff.retessellated {
+        println!("  RETESSELLATED  {}", fmt_delta(d));
+    }
+    for d in &diff.volume_moved {
+        println!("  VOLUME MOVED  {}", fmt_delta(d));
+    }
+    for r in &diff.added {
+        println!("  ADDED  {}", fmt_host(r));
+    }
+    for d in &diff.changed {
+        println!("  RECLASSIFIED  {}", fmt_delta(d));
+    }
 }
 
 fn fmt_host(r: &HostRow) -> String {
@@ -616,6 +707,24 @@ fn sweep(models: &[(String, PathBuf)]) -> (Vec<HostRow>, BTreeSet<String>) {
                 pre,
             ));
         }
+    }
+
+    // #3422: the wiring rule, asserted on every row this walk produces so both
+    // lanes inherit it. A sweep that stopped taking the reading would diff
+    // `Some` against `None`, which `classify` reads as "one reading is not a
+    // comparison", so every watertight host would read unchanged and the
+    // column would go dark with nothing failing; the golden pin in
+    // `census_golden` only proves the reading was taken once.
+    for r in &rows {
+        assert!(
+            r.volume_is_wired(),
+            "{} #{}: vol {:?} with open {} — the sweep takes the reading exactly where \
+             the host is watertight",
+            r.model,
+            r.id,
+            r.vol,
+            r.open
+        );
     }
 
     (rows, swept_models)
@@ -862,16 +971,13 @@ fn watertightness_census_and_triangulator_invariance() {
         run.hosts
     );
 
-    let golden_path = crate_dir().join(GOLDEN_PATH);
-    let golden_text = std::fs::read_to_string(&golden_path).unwrap_or_default();
-    let golden = census_golden::parse(&golden_text)
-        .unwrap_or_else(|e| panic!("{} is unreadable: {e}", golden_path.display()));
-
     let bless = census_golden::bless_mode(
         std::env::var_os(BLESS_ENV).is_some(),
         std::env::var_os("CI").is_some_and(|v| !v.is_empty() && v != "0" && v != "false"),
     )
     .unwrap_or_else(|e| panic!("{e}"));
+    let golden_path = crate_dir().join(GOLDEN_PATH);
+    let golden = read_golden(&golden_path, bless);
 
     if bless {
         // Preserve the rows of models this run did NOT sweep, so blessing on a
@@ -929,36 +1035,22 @@ fn watertightness_census_and_triangulator_invariance() {
         "  ... called a re-tessellation, in any bucket: {}",
         diff.shrank_while_healing
     );
+    println!(
+        "volume moved (watertight both sides, enclosed volume differs): {}",
+        diff.volume_moved.len()
+    );
     println!("improved  : {}", diff.improved.len());
     // EVERY bucket names its hosts HERE, before any assert, `regressed`
     // included even though its assert happens to run first. The asserts run
-    // regressed -> missing -> retessellated -> added -> changed and the FIRST
-    // failure panics, so any bucket that only names its hosts inside its own
-    // assert is a bare count whenever an earlier one fails. Keeping all six in
-    // this block means reordering the asserts cannot silently cost a bucket its
-    // host names.
+    // one bucket at a time and the FIRST failure panics, so any bucket that
+    // only names its hosts inside its own assert is a bare count whenever an
+    // earlier one fails. Keeping every bucket in `print_buckets` means
+    // reordering the asserts cannot silently cost a bucket its host names.
     //
     // The run that motivated this is the one where several buckets are
     // non-empty at once: whatever stays in `regressed` panics first, and every
     // host that shrank while healing would otherwise show up only as a count.
-    for d in &diff.improved {
-        println!("  IMPROVED  {}", fmt_delta(d));
-    }
-    for d in &diff.regressed {
-        println!("  REGRESSED  {}", fmt_delta(d));
-    }
-    for r in &diff.missing {
-        println!("  COVERAGE LOSS  {}", fmt_host(r));
-    }
-    for d in &diff.retessellated {
-        println!("  RETESSELLATED  {}", fmt_delta(d));
-    }
-    for r in &diff.added {
-        println!("  ADDED  {}", fmt_host(r));
-    }
-    for d in &diff.changed {
-        println!("  RECLASSIFIED  {}", fmt_delta(d));
-    }
+    print_buckets(&diff);
 
     // Not a failure: `MIN_MODELS` sits under the corpus precisely so a failed
     // fixture fetch does not red the build, and a model that did not load has no
@@ -1025,12 +1117,28 @@ fn watertightness_census_and_triangulator_invariance() {
     // able to tell "this tore" from "this shrank while healing".
     assert!(
         diff.retessellated.is_empty(),
-        "{} host(s) RE-TESSELLATED: fewer triangles AND fewer open edges. Usually \
-         a cut that stopped over-extending, but the test is magnitude-blind - a \
-         near-total loss on a torn host also lands here, so CHECK THE SHRINK \
-         before blessing. If the shrink is intended, re-bless:\n  {BLESS_CMD}\n{}",
+        "{} host(s) RE-TESSELLATED: fewer triangles with fewer open edges on a \
+         torn host, or at unchanged enclosed volume on a watertight one. Usually \
+         a cut that stopped over-extending or a mesher change. On a TORN host the \
+         test is magnitude-blind - a near-total loss also lands here, so CHECK \
+         THE SHRINK before blessing. If the shrink is intended, re-bless:\n  \
+         {BLESS_CMD}\n{}",
         diff.retessellated.len(),
         fmt_deltas(&diff.retessellated)
+    );
+
+    // Separated from both of the above (#3422): the enclosed volume of a
+    // watertight host moved, which no count sees when the topology holds. The
+    // message carries why neither direction is a verdict.
+    assert!(
+        diff.volume_moved.is_empty(),
+        "{} host(s) moved in ENCLOSED VOLUME while watertight on both sides. \
+         Neither direction is a verdict: less volume is an over-cut growing or a \
+         void that was silently skipped now applying; more is a healed over-cut \
+         or a void that stopped applying. Read the percentage against what the \
+         change was meant to do, then re-bless:\n  {BLESS_CMD}\n{}",
+        diff.volume_moved.len(),
+        fmt_deltas(&diff.volume_moved)
     );
 
     assert!(
@@ -1283,11 +1391,11 @@ END-ISO-10303-21;"##
     )
 }
 
-/// #3422. The census row vocabulary (`open`, `strict`, `tris`, `coll`, `far`,
-/// `alt`, `pre`) is COUNTS and FLAGS over topology, and the golden is a
-/// ceiling: a host may get better for free. An opening cut larger than
-/// authored on a watertight host, the #3219 shape, reads one of two ways under
-/// that vocabulary, and both are green:
+/// #3422. The census row vocabulary before this change (`open`, `strict`,
+/// `tris`, `coll`, `far`, `alt`, `pre`) is COUNTS and FLAGS over topology, and
+/// the golden is a ceiling: a host may get better for free. An opening cut
+/// larger than authored on a watertight host, the #3219 shape, reads one of
+/// two ways under that vocabulary, and both are green:
 ///
 /// - at 1.4x every count holds and the pair is an IDENTICAL row;
 /// - at 1.6x the cutter emits MORE triangles, and a grown `tris` files under
@@ -1295,7 +1403,9 @@ END-ISO-10303-21;"##
 ///
 /// Measured on the pipeline rather than on synthetic rows: both walls go
 /// through the `process` / `edge_stats` / `max_abs_coord` path the sweep uses,
-/// via `row_from_mesh`, and the two rows are then diffed as golden and run.
+/// and the two rows are then diffed as golden and run. Only the enclosed
+/// volume separates them, and only the volume column makes the pair require a
+/// bless.
 ///
 /// Runs in the default `cargo test`: it needs no fixture and no alternate
 /// triangulator.
@@ -1312,10 +1422,10 @@ fn an_over_cut_on_a_watertight_host_requires_a_bless() {
         let (a, b) = (edge_stats(&authored), edge_stats(&over_cut));
         // The rows exactly as the sweep records a host, through the same
         // builder, so this test measures the sweep's own row and not a copy.
-        let wired_a =
-            row_from_mesh("overcut.ifc", 1, "SweptSolid".into(), &authored, &a, Some(a.open), PreVoid::NotTaken);
-        let wired_b =
-            row_from_mesh("overcut.ifc", 1, "SweptSolid".into(), &over_cut, &b, Some(b.open), PreVoid::NotTaken);
+        let row = |mesh: &Mesh, s: &EdgeStats| {
+            row_from_mesh("overcut.ifc", 1, "SweptSolid".into(), mesh, s, Some(s.open), PreVoid::NotTaken)
+        };
+        let (wired_a, wired_b) = (row(&authored, &a), row(&over_cut, &b));
         // Both must be WATERTIGHT, or this probes the torn-host rules instead.
         assert_eq!(wired_a.open, 0, "{scale}x: authored wall must be watertight");
         assert_eq!(wired_b.open, 0, "{scale}x: over-cut wall must be watertight");
@@ -1333,14 +1443,58 @@ fn an_over_cut_on_a_watertight_host_requires_a_bless() {
             assert_eq!(ta, tb, "{scale}x: expected the same triangle count");
         }
 
-        // The over-cut removed material the authored opening did not, and the
-        // census must say so. Nothing in the row vocabulary above can: this is
-        // the blind spot, and it is what the volume column closes.
-        let d = census_golden::diff(&[wired_a], &[wired_b], &swept);
+        // The volume is what differs. Panel 2.0 x 0.1 x 3.0 = 0.6 m³, less the
+        // opening 0.5 x 0.1 x 1.0 = 0.05 m³ authored and 0.05 * scale² over-cut.
+        // Read to within the primitive's documented quantization floor —
+        // `mesh_to_tris` snaps every coordinate to 1/65536 m, so the reading
+        // drifts by up to surface_area * SNAP_GRID, about 14 m² * 15.3 µm =
+        // 210 cm³ here — never to the exact figure, which the 0.05 m faces
+        // (not grid-representable) would miss by a few tens of cm³.
+        const SNAP_NOISE_CM3: i64 = 250;
+        let (va, vb) = (
+            wired_a.vol.expect("watertight, so the sweep takes the reading"),
+            wired_b.vol.expect("watertight, so the sweep takes the reading"),
+        );
+        assert_eq!(va.signum(), vb.signum(), "{scale}x: both walls wound the same way");
         assert!(
-            d.requires_bless(),
+            (va.abs() - 550_000).abs() <= SNAP_NOISE_CM3,
+            "{scale}x: authored 0.55 m³, read {va} cm³"
+        );
+        let want_drop = (50_000.0 * (scale * scale - 1.0)) as i64;
+        let drop = va.abs() - vb.abs();
+        assert!(
+            (drop - want_drop).abs() <= SNAP_NOISE_CM3,
+            "{scale}x: over-cut removes {want_drop} cm³ more, read {drop}"
+        );
+
+        // The pre-#3422 census: the over-cut requires no bless either way.
+        let blind = census_golden::diff(
+            &[HostRow { vol: None, ..wired_a.clone() }],
+            &[HostRow { vol: None, ..wired_b.clone() }],
+            &swept,
+        );
+        assert!(
+            !blind.requires_bless(),
+            "{scale}x: without a volume column the census sees nothing to bless"
+        );
+        if tris_grow {
+            assert_eq!(blind.improved.len(), 1, "{scale}x: and calls the over-cut an improvement");
+            let reasons = blind.improved[0].reasons.join("; ");
+            assert!(reasons.contains("(improved)"), "{reasons}");
+        } else {
+            assert!(blind.improved.is_empty(), "{scale}x: the over-cut is an identical row");
+        }
+
+        // With the column, the pair is a volume move and the golden must absorb it.
+        let seen = census_golden::diff(&[wired_a], &[wired_b], &swept);
+        assert!(
+            seen.requires_bless(),
             "{scale}x: an opening cut larger than authored left the census green"
         );
+        assert_eq!(seen.volume_moved.len(), 1, "{scale}x: the over-cut files as a volume move");
+        assert!(seen.regressed.is_empty() && seen.improved.is_empty(), "{scale}x");
+        let reasons = seen.volume_moved[0].reasons.join("; ");
+        assert!(reasons.contains(&format!("enclosed volume {va} -> {vb} cm³")), "{reasons}");
     }
 }
 
@@ -1524,16 +1678,13 @@ fn run_heavy_lane(model: &str, min_hosts: usize) -> Option<census_golden::Totals
         run.hosts
     );
 
-    let golden_path = crate_dir().join(HEAVY_GOLDEN_PATH);
-    let golden_text = std::fs::read_to_string(&golden_path).unwrap_or_default();
-    let golden = census_golden::parse(&golden_text)
-        .unwrap_or_else(|e| panic!("{} is unreadable: {e}", golden_path.display()));
-
     let bless = census_golden::bless_mode(
         std::env::var_os(BLESS_ENV).is_some(),
         std::env::var_os("CI").is_some_and(|v| !v.is_empty() && v != "0" && v != "false"),
     )
     .unwrap_or_else(|e| panic!("{e}"));
+    let golden_path = crate_dir().join(HEAVY_GOLDEN_PATH);
+    let golden = read_golden(&golden_path, bless);
 
     if bless {
         // Keeping the rows of models this run did not sweep is what lets the
@@ -1577,25 +1728,9 @@ fn run_heavy_lane(model: &str, min_hosts: usize) -> Option<census_golden::Totals
     // bucket can read 0 on the very run it exists for, when a reclassification
     // outranks it, and this tally is the only thing that says so.
     println!("  of which shrank while healing: {}", diff.shrank_while_healing);
+    println!("volume moved: {}", diff.volume_moved.len());
     println!("improved  : {}", diff.improved.len());
-    for d in &diff.improved {
-        println!("  IMPROVED  {}", fmt_delta(d));
-    }
-    for d in &diff.regressed {
-        println!("  REGRESSED  {}", fmt_delta(d));
-    }
-    for r in &diff.missing {
-        println!("  COVERAGE LOSS  {}", fmt_host(r));
-    }
-    for d in &diff.retessellated {
-        println!("  RETESSELLATED  {}", fmt_delta(d));
-    }
-    for r in &diff.added {
-        println!("  ADDED  {}", fmt_host(r));
-    }
-    for d in &diff.changed {
-        println!("  RECLASSIFIED  {}", fmt_delta(d));
-    }
+    print_buckets(&diff);
 
     assert!(
         diff.regressed.is_empty(),
@@ -1612,9 +1747,8 @@ fn run_heavy_lane(model: &str, min_hosts: usize) -> Option<census_golden::Totals
     );
     assert!(
         !diff.requires_bless(),
-        "the diff against {HEAVY_GOLDEN_PATH} requires a bless (added, reclassified, or \
-         re-tessellated rows present) — review the buckets printed above, then:\n  \
-         {HEAVY_BLESS_CMD}"
+        "the diff against {HEAVY_GOLDEN_PATH} requires a bless — review the buckets \
+         printed above, then:\n  {HEAVY_BLESS_CMD}"
     );
 
     Some(run)

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -510,8 +510,80 @@ fn max_abs_coord(mesh: &Mesh) -> f64 {
 /// Signed enclosed volume in whole cm³, for [`HostRow::vol`] (#3422), which
 /// says where it is taken and why it is an integer. `kernel::mesh_volume`
 /// reads the same f32 positions `edge_stats` does, so one mesh is one integer.
+///
+/// The two do NOT read them at the same resolution, and
+/// [`a_sub_millimetre_crack_reads_watertight_but_shifts_the_volume`] measures
+/// what that costs. See [`HostRow::vol`] for why it is tolerable and why
+/// tightening the gate is not the remedy.
 fn volume_cm3(mesh: &Mesh) -> i64 {
     (mesh_volume(mesh) * 1.0e6).round() as i64
+}
+
+/// A unit cube whose lid is a SEPARATE set of vertices, raised by `crack`
+/// metres above the walls' top edge, so the surface carries a slit of that
+/// width all the way round. The one shape that separates the census's
+/// watertightness reading from the closure `mesh_volume` actually needs.
+#[cfg(test)]
+fn cracked_cube(crack: f32) -> Mesh {
+    let base = [[0.0f32, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+    let mut positions: Vec<f32> = Vec::new();
+    for z in [0.0, 1.0, 1.0 + crack] {
+        for v in base {
+            positions.extend([v[0], v[1], z]);
+        }
+    }
+    let mut indices: Vec<u32> = vec![0, 2, 1, 0, 3, 2]; // floor, wound down
+    for k in 0..4u32 {
+        let (a, b) = (k, (k + 1) % 4);
+        indices.extend([a, b, b + 4, a, b + 4, a + 4]); // walls
+    }
+    indices.extend([8, 9, 10, 8, 10, 11]); // lid, off the RAISED copies
+    Mesh { positions, indices, ..Default::default() }
+}
+
+/// The blind spot [`HostRow::vol`]'s gate has, measured rather than asserted
+/// (#3422, raised in review on #3867).
+///
+/// `stats.open == 0` is the gate, and it is read off a walk that quantizes
+/// positions to a 1 mm GRID. `mesh_volume` integrates positions `mesh_to_tris`
+/// snapped to 1/65536 m. So a crack under half a snap bucket lands both of its
+/// sides in one grid cell, the edges pair, the host reads watertight — and the
+/// surface handed to the divergence sum is still open. The reading then carries
+/// the crack as an offset, and this test pins its size against the column's own
+/// 1 cm³ tolerance so nobody has to take the claim on trust.
+///
+/// The second arm is where the blind spot ENDS: at 0.9 mm the two sides fall in
+/// different cells, the walk sees the tear, and no volume is taken at all. The
+/// gap between the arms is the whole of the exposure — sub-half-bucket cracks,
+/// nothing wider.
+#[test]
+fn a_sub_millimetre_crack_reads_watertight_but_shifts_the_volume() {
+    let sealed = cracked_cube(0.0);
+    assert_eq!(edge_stats(&sealed).open, 0, "the sealed cube must be watertight");
+    let truth = volume_cm3(&sealed);
+    assert_eq!(truth, 1_000_000, "a unit cube is 1 m³");
+
+    // Under half the 1 mm bucket: invisible to the gate, visible in the sum.
+    let cracked = cracked_cube(0.0004);
+    assert_eq!(
+        edge_stats(&cracked).open,
+        0,
+        "a 0.4 mm slit is inside one snap bucket, so the census reads it watertight"
+    );
+    let off = (volume_cm3(&cracked) - truth).abs();
+    // Bounded ABOVE by the naive band term (the slit width times the lid area,
+    // 4e-4 m³ = 400 cm³), and far above the 1 cm³ tolerance this column diffs
+    // at — so the offset is real, not rounding, and its scale is the crack's.
+    assert!(
+        (100..=400).contains(&off),
+        "a 0.4 mm slit should shift the reading by ~a third of the 400 cm³ band term, got {off}"
+    );
+
+    // Over half the bucket: the gate catches it and takes no reading.
+    assert!(
+        edge_stats(&cracked_cube(0.0009)).open > 0,
+        "a 0.9 mm slit crosses the snap bucket, so the census must see it as torn"
+    );
 }
 
 /// One census row from a host's void-applied mesh. Every column that is a


### PR DESCRIPTION
## Summary

The geometry census compared triangle, open-edge and collision counts, so an opening cut larger than authored on a watertight host was invisible: at 1.4x every count is identical, at 1.6x only `tris` grows, which files as improved (#3422).

- A `vol` column (whole cm3, signed, taken only at `open == 0`, summed about the operand's own AABB centre) joins the census rows; `Diff::volume_moved` ranks between reclassification and re-tessellation and requires a bless. Tolerance is 1 cm3 or 1e-6 of the golden's magnitude, whichever is larger, since the goldens are blessed on arm64 and CI runs x86_64 and the snap grid swallows ULP divergence except on a boundary. The reason line names a winding flip (`WINDING INVERTED`, "winding righted", "inward-wound throughout") so `55000 -> -55000` is not misread as material moving.
- Both goldens re-blessed from a local sweep at this base; columns 1 to 10 are byte-identical to the previous files in the same order (verified with `cut -f1-10 | diff`), only the new column and three header lines changed. A schema-short golden is accepted in bless mode; a corrupt one fails loudly in both modes rather than being silently treated as empty.
- What it does not catch is stated and pinned: the same over-cut on a torn host (no volume is taken, so the pre-#3422 rules and the #3219 re-tessellation over-fire stand; a test asserts the current wrong verdict with the issue named so it fails loudly when fixed), and a zero-volume watertight host loses triangles falls through to `worse_counts` instead of reading as "volume unchanged".
- The prior branch's justification for not reading torn hosts ("the sum is translation-variant") was refuted: `signed_volume6` sums about the AABB centre and a test pins an open reading stable across a 10 km offset. The real reason is that the divergence theorem needs a closed surface.

Closes #3422

## Verification

- RED at the pin commit: "an opening cut larger than authored left the census green"; GREEN with the column.
- `cargo test -p ifc-lite-processing -p ifc-lite-geometry --no-fail-fast` exit 0 (161 suites); the census in measuring mode with `--features triangulation-alt`: 60 passed, `volume moved: 0`, golden test passes; clippy `-D warnings` exit 0; the ratchet needs no row (tests are exempt).
- Mutation-checked: deleting the classify volume branch fails 9 of 56; a `vol: None` sweep trips the run-side guard on the first watertight host; perturbing one checked-in golden volume by 100000 cm3 reds the census end to end; tolerance replaced by 0 fails only the boundary test; the zero-volume guard relaxed fails only its test.
- `.github/workflows/test.yml` unchanged: no column-count or schema coupling exists in either census workflow (checked).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added validation for enclosed-volume changes in watertight geometry.
  - Classifies results as unchanged, increased, or decreased volume to better identify re-tessellation, movement, and geometry loss.
  - Added coverage for cracks, zero-volume meshes, over-cut geometry, rounding, and winding-related diagnostics.
  - Improved golden-file validation by distinguishing outdated schemas from malformed or corrupted data.
  - Updated standard and heavy test reporting to include volume-related outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->