### PR TITLE
fix(server,server-client,viewer): relationship rows carry the IfcRel express id end to end

### DIFF
--- a/.changeset/tidy-donkeys-argue.md
+++ b/.changeset/tidy-donkeys-argue.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/server-client": minor
+---
+
+Decode the relationships table's new `rel_id` column: `Relationship.rel_id` carries the express id of the `IfcRel*` entity that produced the row. The field is optional and stays `undefined` against a server that does not send the column, so an older server keeps decoding unchanged.

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -20,13 +20,29 @@ fn quality_cache_suffix(quality: TessellationQuality) -> String {
     }
 }
 
-/// Request-level cache key: file hash + opening-filter suffix + quality suffix.
-pub(crate) fn request_cache_key(data: &[u8], query: &ParseQuery, quality: TessellationQuality) -> String {
+/// The seed every derived key is built on: file hash + opening-filter suffix +
+/// quality suffix. Endpoints that receive a bare hash (the cache-check and
+/// cached-geometry routes) rebuild it from the query rather than from bytes
+/// they do not have.
+pub(crate) fn cache_key_from_parts(
+    hash: &str,
+    opening_filter: OpeningFilterMode,
+    quality: TessellationQuality,
+) -> String {
     format!(
         "{}-{}{}",
-        DiskCache::generate_key(data),
-        query.opening_filter.cache_key_suffix(),
+        hash,
+        opening_filter.cache_key_suffix(),
         quality_cache_suffix(quality)
+    )
+}
+
+/// Request-level cache key: file hash + opening-filter suffix + quality suffix.
+pub(crate) fn request_cache_key(data: &[u8], query: &ParseQuery, quality: TessellationQuality) -> String {
+    cache_key_from_parts(
+        &DiskCache::generate_key(data),
+        query.opening_filter,
+        quality,
     )
 }
 
@@ -67,10 +83,8 @@ pub(crate) fn parquet_cache_key(
         // OLD blob verbatim, the columns are absent, the decoder correctly omits
         // them, and drill-to-source stays dead over the binary transport with
         // nothing saying so -- absence reading exactly like success.
-        "{}-{}{}-parquet-v5",
-        hash,
-        opening_filter.cache_key_suffix(),
-        quality_cache_suffix(quality)
+        "{}-parquet-v5",
+        cache_key_from_parts(hash, opening_filter, quality)
     )
 }
 
@@ -81,10 +95,8 @@ pub(crate) fn parquet_metadata_cache_key(
     quality: TessellationQuality,
 ) -> String {
     format!(
-        "{}-{}{}-parquet-metadata-v4",
-        hash,
-        opening_filter.cache_key_suffix(),
-        quality_cache_suffix(quality)
+        "{}-parquet-metadata-v4",
+        cache_key_from_parts(hash, opening_filter, quality)
     )
 }
 
@@ -101,6 +113,26 @@ pub(crate) fn parquet_metadata_cache_key(
 /// `RelId = 0` on every exported relationship row with nothing saying so.
 pub(crate) fn data_model_cache_key(cache_key: &str) -> String {
     format!("{cache_key}-datamodel-v6")
+}
+
+/// Whether a data model at the CURRENT payload version is cached for
+/// `cache_key`.
+///
+/// Geometry and the data model are versioned separately, so a geometry entry
+/// outlives a data-model bump. Every geometry short-circuit must ask this
+/// before returning early: without it a deployment holding pre-bump entries
+/// reports a geometry hit, the client skips the upload (or the replay path
+/// skips the parse), nothing ever writes the current data-model key, and
+/// `fetchDataModel` polls a key nobody writes until it times out — geometry on
+/// screen with no properties and no error (issue #3869). Answering `false`
+/// costs one re-parse and rewrites both entries.
+///
+/// A cache read error answers `false`: re-parsing is the safe direction.
+pub(crate) async fn has_current_data_model(cache: &DiskCache, cache_key: &str) -> bool {
+    matches!(
+        cache.get_bytes(&data_model_cache_key(cache_key)).await,
+        Ok(Some(_))
+    )
 }
 
 /// Build the symbolic-data cache key for a given file cache key.

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -88,6 +88,21 @@ pub(crate) fn parquet_metadata_cache_key(
     )
 }
 
+/// Build the data-model cache key for a given file cache key.
+///
+/// One definition for the writers (`parse_parquet`, `parse_parquet_stream`) and
+/// the reader (`get_data_model`): three separate literals could disagree, and a
+/// reader looking up a key nobody writes answers `202` forever.
+///
+/// The suffix bumps on EVERY change to the data-model payload's columns. `v6`
+/// with issue #3860: the relationships table gained `rel_id`. Without the bump
+/// a warm `CACHE_DIR` replays the pre-bump blob verbatim, the column is absent,
+/// the decoder correctly omits it, and the viewer's server path is back to
+/// `RelId = 0` on every exported relationship row with nothing saying so.
+pub(crate) fn data_model_cache_key(cache_key: &str) -> String {
+    format!("{cache_key}-datamodel-v6")
+}
+
 /// Build the symbolic-data cache key for a given file cache key.
 ///
 /// The 2D symbol stream (`IfcAnnotation` + `IfcGrid`) is cached separately
@@ -336,6 +351,26 @@ mod tests {
         assert_ne!(other, request_cache_key(data, &default_query, TessellationQuality::default()));
     }
 
+    /// The data-model payload's columns changed (issue #3860), so the suffix
+    /// must have moved off `v5`: a warm cache would otherwise serve a blob
+    /// written before the `rel_id` column existed, and absence of the column
+    /// reads to the decoder exactly like an older server — silently correct,
+    /// silently wrong.
+    #[test]
+    fn data_model_cache_key_is_versioned_and_retires_the_previous_payload() {
+        let request_key = "0ab20f4e4014-default";
+        let key = data_model_cache_key(request_key);
+        assert_eq!(key, format!("{request_key}-datamodel-v6"));
+        assert_ne!(
+            key,
+            format!("{request_key}-datamodel-v5"),
+            "the v5 entries hold a relationships table with no rel_id column"
+        );
+        assert_ne!(key, request_key);
+        assert_ne!(key, symbolic_cache_key(request_key));
+        assert_ne!(key, json_response_cache_key(request_key));
+    }
+
     /// The derived keys are all distinct namespaces over the same seed, so a
     /// parquet blob can never be served where symbolic JSON or a typed
     /// `ParseResponse` is expected.
@@ -346,6 +381,7 @@ mod tests {
             seed.to_string(),
             json_response_cache_key(seed),
             symbolic_cache_key(seed),
+            data_model_cache_key(seed),
             parquet_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
             parquet_metadata_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
         ];

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -6,7 +6,7 @@
 //! request's geometry + metadata are already cached, replay them as a
 //! three-event stream (Start / one Batch / Complete) without re-parsing.
 
-use super::cache_keys::load_cached_symbolic;
+use super::cache_keys::{has_current_data_model, load_cached_symbolic};
 use super::parquet::ParquetMetadataHeader;
 use super::parquet_stream::ParquetStreamEvent;
 use crate::error::ApiError;
@@ -46,6 +46,17 @@ pub(super) async fn try_cached_replay(
     ) else {
         return Ok(None);
     };
+
+    // Replaying skips the parse, and the parse is what writes the data model.
+    // A geometry entry that outlived a data-model version bump must therefore
+    // re-parse rather than replay (issue #3869).
+    if !has_current_data_model(&state.cache, cache_key).await {
+        tracing::info!(
+            cache_key = %cache_key,
+            "Geometry cached but the data model predates the current payload; re-parsing"
+        );
+        return Ok(None);
+    }
 
     tracing::info!(
         cache_key = %cache_key,
@@ -247,6 +258,7 @@ mod tests {
             .set_bytes(&format!("{cache_key}-parquet-v5"), &[1, 2, 3]) // < 4 bytes
             .await
             .unwrap();
+        seed_current_data_model(&state, cache_key).await;
 
         let result = try_cached_replay(&state, cache_key).await;
         assert!(
@@ -273,9 +285,55 @@ mod tests {
             .set_bytes(&format!("{cache_key}-parquet-v5"), &well_framed_blob(&[9, 9]))
             .await
             .unwrap();
+        seed_current_data_model(&state, cache_key).await;
 
         let result = try_cached_replay(&state, cache_key).await;
         assert!(result.is_err(), "unparseable cached metadata must be an error");
+    }
+
+    /// Seed a data-model entry at the CURRENT payload version.
+    async fn seed_current_data_model(state: &AppState, cache_key: &str) {
+        state
+            .cache
+            .set_bytes(
+                &crate::routes::parse::cache_keys::data_model_cache_key(cache_key),
+                b"data-model-bytes",
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Geometry and metadata both cached, but the data model beside them
+    /// predates the current payload version: replaying skips the parse, so
+    /// nothing would ever write the current data-model key and the client's
+    /// poll never resolves (issue #3869). Must be a miss, so the live parse
+    /// rewrites both.
+    #[tokio::test]
+    async fn miss_when_the_cached_data_model_predates_the_current_version() {
+        let state = test_state("miss-stale-datamodel").await;
+        let cache_key = "stale-datamodel-key";
+        let metadata_bytes = serde_json::to_vec(&sample_metadata_header(cache_key, 3)).unwrap();
+        state
+            .cache
+            .set_bytes(&format!("{cache_key}-parquet-metadata-v4"), &metadata_bytes)
+            .await
+            .unwrap();
+        state
+            .cache
+            .set_bytes(&format!("{cache_key}-parquet-v5"), &well_framed_blob(&[7, 7, 7]))
+            .await
+            .unwrap();
+        state
+            .cache
+            .set_bytes(&format!("{cache_key}-datamodel-v5"), b"pre-rel_id-parquet")
+            .await
+            .unwrap();
+
+        let result = try_cached_replay(&state, cache_key).await;
+        assert!(
+            matches!(result, Ok(None)),
+            "a geometry hit with a stale data model must re-parse, not replay"
+        );
     }
 
     #[tokio::test]
@@ -297,6 +355,8 @@ mod tests {
             .set_bytes(&format!("{cache_key}-parquet-v5"), &well_framed_blob(&geometry))
             .await
             .unwrap();
+        // A replay also requires a current data model beside the geometry (#3869).
+        seed_current_data_model(&state, cache_key).await;
 
         let result = try_cached_replay(&state, cache_key).await;
         let response = match result {

--- a/apps/server/src/routes/parse/fetch.rs
+++ b/apps/server/src/routes/parse/fetch.rs
@@ -4,7 +4,9 @@
 
 //! GET cache fetch / check endpoints.
 
-use super::cache_keys::{parquet_cache_key, parquet_metadata_cache_key, symbolic_cache_key};
+use super::cache_keys::{
+    data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key, symbolic_cache_key,
+};
 use super::ParseQuery;
 use crate::error::ApiError;
 use crate::AppState;
@@ -28,7 +30,7 @@ pub async fn get_data_model(
     State(state): State<AppState>,
     axum::extract::Path(cache_key): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let data_model_cache_key = format!("{}-datamodel-v5", cache_key);
+    let data_model_cache_key = data_model_cache_key(&cache_key);
 
     match state.cache.get_bytes(&data_model_cache_key).await? {
         Some(data_model_parquet) => {

--- a/apps/server/src/routes/parse/fetch.rs
+++ b/apps/server/src/routes/parse/fetch.rs
@@ -5,7 +5,8 @@
 //! GET cache fetch / check endpoints.
 
 use super::cache_keys::{
-    data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key, symbolic_cache_key,
+    cache_key_from_parts, data_model_cache_key, has_current_data_model, parquet_cache_key,
+    parquet_metadata_cache_key, symbolic_cache_key,
 };
 use super::ParseQuery;
 use crate::error::ApiError;
@@ -133,14 +134,16 @@ pub async fn check_cache(
     Query(query): Query<ParseQuery>,
     axum::extract::Path(hash): axum::extract::Path<String>,
 ) -> Result<Response, ApiError> {
-    let parquet_cache_key = parquet_cache_key(
-        &hash,
-        query.opening_filter,
-        query.resolved_tessellation_quality()?,
-    );
+    let quality = query.resolved_tessellation_quality()?;
+    let parquet_cache_key = parquet_cache_key(&hash, query.opening_filter, quality);
+    // A geometry entry alone is not enough: the client skips the upload on a
+    // hit, so a data model at the current payload version has to exist too, or
+    // nothing will ever write one (issue #3869).
+    let seed_cache_key = cache_key_from_parts(&hash, query.opening_filter, quality);
+    let data_model_is_current = has_current_data_model(&state.cache, &seed_cache_key).await;
 
     match state.cache.get_bytes(&parquet_cache_key).await? {
-        Some(_) => {
+        Some(_) if data_model_is_current => {
             tracing::debug!(hash = %hash, cache_key = %parquet_cache_key, "Cache check HIT");
             let response = Response::builder()
                 .status(StatusCode::OK)
@@ -148,8 +151,13 @@ pub async fn check_cache(
                 .map_err(|e| ApiError::Internal(e.to_string()))?;
             Ok(response)
         }
-        None => {
-            tracing::debug!(hash = %hash, cache_key = %parquet_cache_key, "Cache check MISS");
+        cached => {
+            tracing::debug!(
+                hash = %hash,
+                cache_key = %parquet_cache_key,
+                geometry_cached = cached.is_some(),
+                "Cache check MISS"
+            );
             let response = Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .body(Body::empty())

--- a/apps/server/src/routes/parse/fetch_tests.rs
+++ b/apps/server/src/routes/parse/fetch_tests.rs
@@ -12,7 +12,9 @@
 //! combination — these tests cover each partial-cache-state branch, not just
 //! both-present and both-absent.
 
-use super::cache_keys::{data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key};
+use super::cache_keys::{
+    cache_key_from_parts, data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key,
+};
 use crate::admission::{Admission, AdmissionCfg};
 use crate::config::Config;
 use crate::services::cache::DiskCache;
@@ -85,10 +87,73 @@ async fn check_cache_returns_200_when_parquet_cached() {
     let hash = "abc123hash";
     let key = parquet_cache_key(hash, OpeningFilterMode::Default, TessellationQuality::default());
     state.cache.set_bytes(&key, b"parquet-bytes").await.unwrap();
+    // A hit also requires a data model at the current payload version (#3869).
+    seed_current_data_model(&state, hash, OpeningFilterMode::Default).await;
 
     let response = get(&state, &format!("/api/v1/cache/check/{hash}")).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert!(body_bytes(response).await.is_empty());
+}
+
+/// Seed a data-model entry at the CURRENT payload version for `hash`.
+async fn seed_current_data_model(state: &AppState, hash: &str, filter: OpeningFilterMode) {
+    let seed = cache_key_from_parts(hash, filter, TessellationQuality::default());
+    state
+        .cache
+        .set_bytes(&data_model_cache_key(&seed), b"data-model-bytes")
+        .await
+        .unwrap();
+}
+
+/// A geometry entry outlives a data-model version bump: the geometry key is
+/// versioned separately and does not move when a data-model column is added.
+/// Reporting a hit on geometry alone makes the client skip the upload, so
+/// nothing ever writes the new data-model key and `fetchDataModel` polls a key
+/// nobody writes until it times out — geometry on screen, no properties, and
+/// no error (issue #3869). The check must miss so the file is re-parsed.
+#[tokio::test]
+async fn check_cache_misses_when_the_data_model_predates_the_current_version() {
+    let state = test_state("check-cache-stale-datamodel").await;
+    let hash = "staledmhash";
+    let geometry_key =
+        parquet_cache_key(hash, OpeningFilterMode::Default, TessellationQuality::default());
+    state
+        .cache
+        .set_bytes(&geometry_key, b"parquet-bytes")
+        .await
+        .unwrap();
+    // The data model this deployment left behind: previous payload version.
+    let seed = cache_key_from_parts(hash, OpeningFilterMode::Default, TessellationQuality::default());
+    state
+        .cache
+        .set_bytes(&format!("{seed}-datamodel-v5"), b"pre-rel_id-parquet")
+        .await
+        .unwrap();
+
+    let response = get(&state, &format!("/api/v1/cache/check/{hash}")).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "geometry alone must not report a hit when the data model is stale"
+    );
+}
+
+/// Negative control for the gate above: geometry cached with NO data model at
+/// all must also miss, so the client uploads and both get written.
+#[tokio::test]
+async fn check_cache_misses_when_no_data_model_is_cached_at_all() {
+    let state = test_state("check-cache-no-datamodel").await;
+    let hash = "nodmhash";
+    let geometry_key =
+        parquet_cache_key(hash, OpeningFilterMode::Default, TessellationQuality::default());
+    state
+        .cache
+        .set_bytes(&geometry_key, b"parquet-bytes")
+        .await
+        .unwrap();
+
+    let response = get(&state, &format!("/api/v1/cache/check/{hash}")).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 /// The cache key is filter-specific: a cached entry for `ignore_all` must NOT
@@ -104,7 +169,8 @@ async fn check_cache_is_scoped_to_opening_filter() {
     let default_response = get(&state, &format!("/api/v1/cache/check/{hash}")).await;
     assert_eq!(default_response.status(), StatusCode::NOT_FOUND);
 
-    // The matching filter must hit.
+    // The matching filter must hit (with a current data model beside it).
+    seed_current_data_model(&state, hash, OpeningFilterMode::IgnoreAll).await;
     let scoped_response = get(
         &state,
         &format!("/api/v1/cache/check/{hash}?opening_filter=ignore_all"),

--- a/apps/server/src/routes/parse/fetch_tests.rs
+++ b/apps/server/src/routes/parse/fetch_tests.rs
@@ -12,7 +12,7 @@
 //! combination — these tests cover each partial-cache-state branch, not just
 //! both-present and both-absent.
 
-use super::cache_keys::{parquet_cache_key, parquet_metadata_cache_key};
+use super::cache_keys::{data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key};
 use crate::admission::{Admission, AdmissionCfg};
 use crate::config::Config;
 use crate::services::cache::DiskCache;
@@ -207,12 +207,35 @@ async fn get_data_model_returns_202_when_not_yet_cached() {
     assert_eq!(response.status(), StatusCode::ACCEPTED);
 }
 
+/// An entry written under the PREVIOUS payload version must not be served
+/// (issue #3860). The `rel_id` column was added to the relationships table, so
+/// a `v5` blob decodes cleanly and silently restores `RelId = 0` on every
+/// relationship row of a server-loaded model. The reader must miss it and let
+/// the file be re-parsed.
+#[tokio::test]
+async fn get_data_model_ignores_an_entry_written_under_the_previous_version() {
+    let state = test_state("data-model-stale").await;
+    let cache_key = "somehash-default";
+    state
+        .cache
+        .set_bytes(&format!("{cache_key}-datamodel-v5"), b"pre-rel_id-parquet")
+        .await
+        .unwrap();
+
+    let response = get(&state, &format!("/api/v1/parse/data-model/{cache_key}")).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::ACCEPTED,
+        "a pre-bump data-model blob must not be served"
+    );
+}
+
 /// Cached data model -> 200 with the exact stored bytes as the body.
 #[tokio::test]
 async fn get_data_model_returns_200_with_cached_bytes() {
     let state = test_state("data-model-hit").await;
     let cache_key = "somehash-default";
-    let data_model_key = format!("{cache_key}-datamodel-v5");
+    let data_model_key = data_model_cache_key(cache_key);
     state
         .cache
         .set_bytes(&data_model_key, b"the-data-model-parquet")

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -4,7 +4,7 @@
 
 //! Binary Parquet parse endpoints.
 
-use super::cache_keys::{cache_symbolic_data, request_cache_key};
+use super::cache_keys::{cache_symbolic_data, data_model_cache_key, request_cache_key};
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
 use crate::services::{
@@ -182,7 +182,7 @@ pub async fn parse_parquet(
     );
 
     // Cache data model IMMEDIATELY (not in background) so it's ready when client polls
-    let data_model_cache_key = format!("{}-datamodel-v5", cache_key);
+    let data_model_cache_key = data_model_cache_key(&cache_key);
     if let Err(e) = state
         .cache
         .set_bytes(&data_model_cache_key, &data_model_parquet)

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -4,7 +4,9 @@
 
 //! Binary Parquet parse endpoints.
 
-use super::cache_keys::{cache_symbolic_data, data_model_cache_key, request_cache_key};
+use super::cache_keys::{
+    cache_symbolic_data, data_model_cache_key, has_current_data_model, request_cache_key,
+};
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
 use crate::services::{
@@ -79,9 +81,13 @@ pub async fn parse_parquet(
     let parquet_cache_key = format!("{}-parquet-v5", cache_key);
     let metadata_cache_key = format!("{}-parquet-metadata-v4", cache_key);
 
-    if let (Some(cached_parquet), Some(cached_metadata_json)) = (
+    // The cached-geometry short-circuit skips the parse, and the parse is what
+    // writes the data model. A geometry entry that outlived a data-model
+    // version bump must fall through so both get rewritten (issue #3869).
+    if let (Some(cached_parquet), Some(cached_metadata_json), true) = (
         state.cache.get_bytes(&parquet_cache_key).await?,
         state.cache.get_bytes(&metadata_cache_key).await?,
+        has_current_data_model(&state.cache, &cache_key).await,
     ) {
         tracing::info!(
             cache_key = %cache_key,

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -4,7 +4,7 @@
 
 //! SSE Parquet-batch streaming parse endpoint.
 
-use super::cache_keys::{cache_symbolic_data, request_cache_key};
+use super::cache_keys::{cache_symbolic_data, data_model_cache_key, request_cache_key};
 use super::parquet::ParquetMetadataHeader;
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
@@ -340,7 +340,7 @@ pub async fn parse_parquet_stream(
                     .await;
 
             if let Ok(Ok(parquet_data)) = serialize_result {
-                let dm_key = format!("{}-datamodel-v5", cache_key_for_dm);
+                let dm_key = data_model_cache_key(&cache_key_for_dm);
                 if let Err(e) = cache_for_dm.set_bytes(&dm_key, &parquet_data).await {
                     tracing::error!(error = %e, "Failed to cache data model from stream");
                 } else {

--- a/apps/server/src/routes/parse/parquet_tests.rs
+++ b/apps/server/src/routes/parse/parquet_tests.rs
@@ -8,7 +8,7 @@
 //! coverage in `services::parquet::parquet_tests`; this file targets the
 //! route's own cache lookup, which the service tests can't reach.
 
-use super::cache_keys::request_cache_key;
+use super::cache_keys::{data_model_cache_key, request_cache_key};
 use super::ParseQuery;
 use crate::config::Config;
 use crate::services::cache::DiskCache;
@@ -82,6 +82,13 @@ async fn parquet_cache_hit_does_not_swap_body_and_metadata() {
         .set_bytes(&metadata_key, b"METADATA-PAYLOAD")
         .await
         .expect("seed metadata cache entry");
+    // A geometry hit also requires a data model at the current payload
+    // version (#3869); this test is about which side each blob lands on.
+    state
+        .cache
+        .set_bytes(&data_model_cache_key(&cache_key), b"DATA-MODEL-PAYLOAD")
+        .await
+        .expect("seed data model cache entry");
 
     let (content_type, body) = multipart_body(content);
     let request = Request::builder()
@@ -104,4 +111,84 @@ async fn parquet_cache_hit_does_not_swap_body_and_metadata() {
 
     assert_eq!(header_value, "METADATA-PAYLOAD");
     assert_eq!(&body_bytes[..], b"GEOMETRY-PAYLOAD");
+}
+
+/// A minimal but real IFC file: the fall-through parse must actually succeed,
+/// so the assertion below is about the cache gate, not about a parse failure.
+const MINIMAL_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3869 cache-gate fixture'),'2;1');
+FILE_NAME('gate.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
+#20=IFCOPENINGELEMENT('Open00000000000000001',$,'O1',$,$,$,$,$,$);
+#40=IFCRELVOIDSELEMENT('Voi0000000000000000001',$,$,$,#10,#20);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// A deployment that already holds geometry from before the data-model version
+/// bump must still end up with a data model at the CURRENT version (issue
+/// #3869). Seeded state is what such a deployment actually looks like: a
+/// geometry entry plus a data model at the PREVIOUS version. Returning the
+/// cached geometry and stopping there leaves the client polling a key nobody
+/// writes, so the request must fall through to the live parse, which writes it.
+#[tokio::test]
+async fn a_geometry_hit_with_a_stale_data_model_still_writes_the_current_data_model() {
+    let state = test_state("stale-data-model-regenerates").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let query = ParseQuery::default();
+    let cache_key = request_cache_key(content, &query, TessellationQuality::default());
+    let current_key = data_model_cache_key(&cache_key);
+
+    state
+        .cache
+        .set_bytes(&format!("{cache_key}-parquet-v5"), b"OLD-GEOMETRY-PAYLOAD")
+        .await
+        .expect("seed geometry cache entry");
+    state
+        .cache
+        .set_bytes(&format!("{cache_key}-parquet-metadata-v4"), b"{}")
+        .await
+        .expect("seed metadata cache entry");
+    state
+        .cache
+        .set_bytes(&format!("{cache_key}-datamodel-v5"), b"PRE-BUMP-DATA-MODEL")
+        .await
+        .expect("seed previous-version data model");
+
+    // Anti-vacuity: the current key really is absent before the request.
+    assert!(
+        state.cache.get_bytes(&current_key).await.unwrap().is_none(),
+        "fixture must start with no current data model"
+    );
+
+    let (content_type, body) = multipart_body(content);
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/parse/parquet")
+        .header(header::CONTENT_TYPE, content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let response = build_router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let written = state
+        .cache
+        .get_bytes(&current_key)
+        .await
+        .unwrap()
+        .expect("the current data-model key must be written");
+    assert!(!written.is_empty(), "the written data model must not be empty");
+
+    // And the response is the freshly parsed geometry, not the seeded blob.
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_ne!(
+        &body_bytes[..],
+        b"OLD-GEOMETRY-PAYLOAD",
+        "the stale-data-model path must re-parse, not replay the cached blob"
+    );
 }

--- a/apps/server/src/services/data_model/relationships.rs
+++ b/apps/server/src/services/data_model/relationships.rs
@@ -45,7 +45,7 @@ pub(super) fn extract_relationships(
                 EntityDecoder::with_arc_index(content.as_slice(), entity_index.clone());
             let entity = local_decoder.decode_at(job.start, job.end).ok()?;
 
-            extract_relationship(&entity, &job.type_name)
+            extract_relationship(&entity, &job.type_name, job.id)
         })
         .flatten()
         .collect();
@@ -98,6 +98,9 @@ fn extract_type_property_links(
                         if let Some(set_id) = set_ref.as_entity_ref() {
                             out.push(Relationship {
                                 rel_type: "TYPEHASPROPERTYSETS".to_string(),
+                                // Synthetic: read off IfcTypeObject.HasPropertySets,
+                                // so there is no IfcRel entity to name here.
+                                rel_id: 0,
                                 relating_id: set_id,
                                 related_id: type_id,
                             });
@@ -111,7 +114,11 @@ fn extract_type_property_links(
 }
 
 /// Extract relationship from entity (may return multiple if related[] has multiple items).
-fn extract_relationship(entity: &DecodedEntity, type_name: &str) -> Option<Vec<Relationship>> {
+fn extract_relationship(
+    entity: &DecodedEntity,
+    type_name: &str,
+    rel_id: u32,
+) -> Option<Vec<Relationship>> {
     let type_upper = type_name.to_uppercase();
 
     // IfcRelVoidsElement / IfcRelFillsElement carry a SINGLE related ref, not a
@@ -125,6 +132,7 @@ fn extract_relationship(entity: &DecodedEntity, type_name: &str) -> Option<Vec<R
         let related_id = entity.get_ref(5)?;
         return Some(vec![Relationship {
             rel_type: type_name.to_string(),
+            rel_id,
             relating_id,
             related_id,
         }]);
@@ -163,6 +171,7 @@ fn extract_relationship(entity: &DecodedEntity, type_name: &str) -> Option<Vec<R
             .into_iter()
             .map(|related_id| Relationship {
                 rel_type: type_name.to_string(),
+                rel_id,
                 relating_id,
                 related_id,
             })

--- a/apps/server/src/services/data_model/tests.rs
+++ b/apps/server/src/services/data_model/tests.rs
@@ -190,6 +190,15 @@ fn extracts_type_relationship_and_resolves_typed_property_values() {
         })
     };
     assert!(type_link(210), "TYPEHASPROPERTYSETS #210->#200 missing");
+    // Synthetic edges: no IfcRel entity produced them, so `rel_id` is 0 rather
+    // than a borrowed id (issue #3860).
+    assert!(
+        dm.relationships
+            .iter()
+            .filter(|r| r.rel_type == "TYPEHASPROPERTYSETS")
+            .all(|r| r.rel_id == 0),
+        "synthetic type-set edges must not claim an IfcRel express id"
+    );
     assert!(
         type_link(220),
         "TYPEHASPROPERTYSETS #220->#200 missing (qset)"
@@ -681,4 +690,46 @@ fn buckets_contained_elements_by_the_correct_spatial_container_kind() {
     assert_eq!(sh.element_to_building.len(), 1);
     assert_eq!(sh.element_to_storey.len(), 1);
     assert_eq!(sh.element_to_space.len(), 1);
+}
+
+/// Every relationship row must carry the express id of the `IfcRel*` entity it
+/// came from (issue #3860). Without it the viewer's server path fed the
+/// relationship graph id 0 and a Parquet/DuckDB export wrote `RelId = 0` on
+/// every row, so a server-loaded model and a locally parsed one disagreed on
+/// the same relationship. The three association rels here have distinct express
+/// ids (#35 / #42 / #51) that are also distinct from their relating and related
+/// ids, so neither a constant nor a copy of a neighbouring column passes.
+#[test]
+fn relationships_carry_the_ifcrel_express_id() {
+    let dm = extract_data_model(ASSOCIATIONS_IFC);
+    let rel_id_of = |ty: &str, relating: u32, related: u32| -> u32 {
+        dm.relationships
+            .iter()
+            .find(|r| {
+                r.rel_type.eq_ignore_ascii_case(ty)
+                    && r.relating_id == relating
+                    && r.related_id == related
+            })
+            .unwrap_or_else(|| panic!("{ty} ({relating} -> {related}) missing"))
+            .rel_id
+    };
+    assert_eq!(rel_id_of("IFCRELASSOCIATESMATERIAL", 34, 28), 35);
+    assert_eq!(rel_id_of("IFCRELASSOCIATESCLASSIFICATION", 41, 28), 42);
+    assert_eq!(rel_id_of("IFCRELASSOCIATESDOCUMENT", 50, 28), 51);
+}
+
+/// The single-ref voids/fills path builds its `Relationship` in a separate arm
+/// from the list path, so it can lose `rel_id` on its own.
+#[test]
+fn voids_and_fills_carry_the_ifcrel_express_id() {
+    let dm = extract_data_model(VOID_FILL_IFC);
+    let rel_id_of = |ty: &str| -> u32 {
+        dm.relationships
+            .iter()
+            .find(|r| r.rel_type.eq_ignore_ascii_case(ty))
+            .unwrap_or_else(|| panic!("{ty} missing"))
+            .rel_id
+    };
+    assert_eq!(rel_id_of("IFCRELVOIDSELEMENT"), 40);
+    assert_eq!(rel_id_of("IFCRELFILLSELEMENT"), 50);
 }

--- a/apps/server/src/services/data_model/types.rs
+++ b/apps/server/src/services/data_model/types.rs
@@ -126,6 +126,9 @@ pub struct Quantity {
 pub struct Relationship {
     /// Relationship type (e.g., "IfcRelDefinesByProperties").
     pub rel_type: String,
+    /// Express id of the `IfcRel*` entity this row came from. `0` for the
+    /// synthetic `TYPEHASPROPERTYSETS` edges, which no IFC entity declares.
+    pub rel_id: u32,
     /// Relating entity ID.
     pub relating_id: u32,
     /// Related entity ID (one Relationship per related entity).

--- a/apps/server/src/services/parquet_data_model.rs
+++ b/apps/server/src/services/parquet_data_model.rs
@@ -494,25 +494,38 @@ fn serialize_relationships_table(
     let count = relationships.len();
 
     // Build arrays in parallel
-    let results: Vec<(String, u32, u32)> = relationships
+    let results: Vec<(String, u32, u32, u32)> = relationships
         .par_iter()
-        .map(|rel| (rel.rel_type.clone(), rel.relating_id, rel.related_id))
+        .map(|rel| {
+            (
+                rel.rel_type.clone(),
+                rel.relating_id,
+                rel.related_id,
+                rel.rel_id,
+            )
+        })
         .collect();
 
     let mut rel_types = Vec::with_capacity(count);
     let mut relating_ids = Vec::with_capacity(count);
     let mut related_ids = Vec::with_capacity(count);
+    let mut rel_ids = Vec::with_capacity(count);
 
-    for (rel_type, relating_id, related_id) in results {
+    for (rel_type, relating_id, related_id, rel_id) in results {
         rel_types.push(rel_type);
         relating_ids.push(relating_id);
         related_ids.push(related_id);
+        rel_ids.push(rel_id);
     }
 
+    // `rel_id` is appended last (data-model v6 payload, issue #3860): an older
+    // client reads the three columns it knows by name and ignores this one,
+    // and a newer client treats it as absent when an older server omits it.
     let schema = Schema::new(vec![
         Field::new("rel_type", DataType::Utf8, false),
         Field::new("relating_id", DataType::UInt32, false),
         Field::new("related_id", DataType::UInt32, false),
+        Field::new("rel_id", DataType::UInt32, false),
     ]);
 
     let batch = RecordBatch::try_new(
@@ -521,6 +534,7 @@ fn serialize_relationships_table(
             Arc::new(StringArray::from(rel_types)),
             Arc::new(UInt32Array::from(relating_ids)),
             Arc::new(UInt32Array::from(related_ids)),
+            Arc::new(UInt32Array::from(rel_ids)),
         ],
     )?;
 

--- a/apps/server/src/services/parquet_data_model_tests.rs
+++ b/apps/server/src/services/parquet_data_model_tests.rs
@@ -209,6 +209,7 @@ fn relationship_columns_do_not_swap_relating_and_related() {
     let mut dm = empty_data_model();
     dm.relationships = vec![Relationship {
         rel_type: "IfcRelAggregates".into(),
+        rel_id: 30,
         relating_id: 10,
         related_id: 20,
     }];
@@ -240,6 +241,34 @@ fn relationship_columns_do_not_swap_relating_and_related() {
 
     assert_eq!(relating.value(0), 10, "relating_id must carry the relating entity");
     assert_eq!(related.value(0), 20, "related_id must carry the related entity");
+}
+
+/// The relationships table must ship the `IfcRel*` express id (issue #3860):
+/// the client's relationship graph and every Parquet/DuckDB export downstream
+/// read `RelId` from this column, and without it a server-loaded model exports
+/// `RelId = 0` on every row. The value (30) differs from both id columns, so
+/// neither a constant nor a copy of a neighbour passes.
+#[test]
+fn relationships_table_writes_the_ifcrel_express_id() {
+    let mut dm = empty_data_model();
+    dm.relationships = vec![Relationship {
+        rel_type: "IfcRelAggregates".into(),
+        rel_id: 30,
+        relating_id: 10,
+        related_id: 20,
+    }];
+
+    let payload = serialize_data_model_to_parquet(&dm).expect("serialize");
+    let sections = split_sections(&payload);
+    let batch = read_section(&sections[3]);
+
+    let rel_ids = batch
+        .column_by_name("rel_id")
+        .expect("rel_id column (data-model v6 payload)")
+        .as_any()
+        .downcast_ref::<arrow::array::UInt32Array>()
+        .expect("u32 column");
+    assert_eq!(rel_ids.value(0), 30, "rel_id must carry the IfcRel express id");
 }
 
 /// `has_geometry` is the only boolean the entities table carries, and no test

--- a/apps/viewer/src/utils/serverDataModel.relId.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.relId.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A server-loaded model must carry the real `IfcRel*` express id on every
+ * relationship edge (issue #3860).
+ *
+ * The server payload gained a `rel_id` column; before it, the viewer's server
+ * path fed the relationship graph a hard-coded 0, so `RelId` in a Parquet or
+ * DuckDB export of a server-loaded model was 0 on every row while a locally
+ * parsed model of the same file carried the real id. `RelId` is read from the
+ * graph's `edgeRelIds`, which is exactly what the assertions below read
+ * through, so this pins the value the export writes.
+ *
+ * The fixture's rel ids (900/901/902) are disjoint from every relating and
+ * related id, so a copy of a neighbouring column fails as loudly as the old
+ * constant 0.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ServerEntityIndex, type DataModel } from '@ifc-lite/server-client';
+import { RelationshipType } from '@ifc-lite/data';
+import { convertServerDataModel, type ServerParseResult } from './serverDataModel';
+
+const parseResult: ServerParseResult = {
+  cache_key: 'rel-id',
+  metadata: { schema_version: 'IFC4' },
+  stats: { total_time_ms: 1, parse_time_ms: 1, geometry_time_ms: 0, total_vertices: 0, total_triangles: 0 },
+};
+
+/** relating -> related, and the express id of the IfcRel that declared it. */
+const EDGES = [
+  { rel_type: 'IFCRELAGGREGATES', relating_id: 1, related_id: 2, rel_id: 900 },
+  { rel_type: 'IFCRELAGGREGATES', relating_id: 2, related_id: 3, rel_id: 901 },
+  { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: 3, related_id: 4, rel_id: 902 },
+] as const;
+
+function dataModel(relationships: DataModel['relationships']): DataModel {
+  return {
+    entities: ServerEntityIndex.fromRows([
+      { entity_id: 1, type_name: 'IFCPROJECT', global_id: '0', name: 'P', has_geometry: false },
+      { entity_id: 2, type_name: 'IFCBUILDING', global_id: '1', name: 'B', has_geometry: false },
+      { entity_id: 3, type_name: 'IFCBUILDINGSTOREY', global_id: '2', name: 'S', has_geometry: false },
+      { entity_id: 4, type_name: 'IFCWALL', global_id: '3', name: 'W', has_geometry: true },
+    ]),
+    propertySets: new Map(),
+    quantitySets: new Map(),
+    relationships,
+    classifications: [],
+    materials: [],
+    documents: [],
+    spatialHierarchy: {
+      nodes: [
+        {
+          entity_id: 1,
+          parent_id: 0,
+          level: 0,
+          path: 'P',
+          type_name: 'IFCPROJECT',
+          name: 'P',
+          children_ids: [],
+          element_ids: [],
+        },
+      ],
+      project_id: 1,
+      element_to_storey: new Map(),
+      element_to_building: new Map(),
+      element_to_site: new Map(),
+      element_to_space: new Map(),
+    },
+  } as unknown as DataModel;
+}
+
+function store(relationships: DataModel['relationships']) {
+  return convertServerDataModel(dataModel(relationships), parseResult, { size: 1 }, []);
+}
+
+describe('server-loaded relationship ids', () => {
+  it('carries the IfcRel express id on every edge, in both directions', () => {
+    const { relationships } = store([...EDGES]);
+
+    for (const edge of EDGES) {
+      const between = relationships.getRelationshipsBetween(edge.relating_id, edge.related_id);
+      assert.equal(between.length, 1, `one edge ${edge.relating_id} -> ${edge.related_id}`);
+      assert.equal(
+        between[0].relationshipId,
+        edge.rel_id,
+        `RelId for ${edge.rel_type} ${edge.relating_id} -> ${edge.related_id}`,
+      );
+
+      const forward = relationships.forward
+        .getEdges(edge.relating_id)
+        .filter((e) => e.target === edge.related_id);
+      assert.equal(forward.length, 1, 'one forward edge');
+      assert.equal(forward[0].relationshipId, edge.rel_id, 'forward edge relationshipId');
+
+      const inverse = relationships.inverse
+        .getEdges(edge.related_id)
+        .filter((e) => e.target === edge.relating_id);
+      assert.equal(inverse.length, 1, 'one inverse edge');
+      assert.equal(inverse[0].relationshipId, edge.rel_id, 'inverse edge relationshipId');
+    }
+
+    // Anti-vacuity: the ids really are distinct from each other, so a single
+    // constant cannot pass. (They are disjoint from every endpoint id by
+    // construction — `as const` makes TS prove it, so no assertion here.)
+    const ids = EDGES.map((e) => e.rel_id);
+    assert.equal(new Set(ids).size, ids.length, 'rel ids must be distinct');
+    // And the edges really did map to graph types (an unmapped rel_type is
+    // dropped before it reaches an edge, which would make the loop vacuous).
+    assert.equal(relationships.forward.getEdges(1)[0].type, RelationshipType.Aggregates);
+  });
+
+  it('falls back to 0 when the server sends no rel_id (older payload)', () => {
+    // An older server omits the column, so `rel_id` is absent. The edge must
+    // still be built; it just has no id to name.
+    const older = EDGES.map(({ rel_type, relating_id, related_id }) => ({ rel_type, relating_id, related_id }));
+    const { relationships } = store(older);
+
+    const between = relationships.getRelationshipsBetween(1, 2);
+    assert.equal(between.length, 1, 'edge must still exist without a rel_id');
+    assert.equal(between[0].relationshipId, 0, 'absent rel_id reads as 0');
+  });
+});

--- a/apps/viewer/src/utils/serverDataModel.relId.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.relId.test.ts
@@ -77,6 +77,20 @@ function store(relationships: DataModel['relationships']) {
   return convertServerDataModel(dataModel(relationships), parseResult, { size: 1 }, []);
 }
 
+/** Run `fn` with `console.warn` captured, then restore it. */
+function withCapturedWarnings<T>(fn: () => T): T & { warnings: string[] } {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    return { ...fn(), warnings };
+  } finally {
+    console.warn = original;
+  }
+}
+
 describe('server-loaded relationship ids', () => {
   it('carries the IfcRel express id on every edge, in both directions', () => {
     const { relationships } = store([...EDGES]);
@@ -113,14 +127,35 @@ describe('server-loaded relationship ids', () => {
     assert.equal(relationships.forward.getEdges(1)[0].type, RelationshipType.Aggregates);
   });
 
-  it('falls back to 0 when the server sends no rel_id (older payload)', () => {
+  it('falls back to 0 when the server sends no rel_id (older payload), and says so once', () => {
     // An older server omits the column, so `rel_id` is absent. The edge must
-    // still be built; it just has no id to name.
+    // still be built; it just has no id to name. Absence has to LOOK different
+    // from success: id 0 on every row is indistinguishable from a real graph
+    // unless something names the missing column.
     const older = EDGES.map(({ rel_type, relating_id, related_id }) => ({ rel_type, relating_id, related_id }));
-    const { relationships } = store(older);
+    const { relationships, warnings } = withCapturedWarnings(() => store(older));
 
     const between = relationships.getRelationshipsBetween(1, 2);
     assert.equal(between.length, 1, 'edge must still exist without a rel_id');
     assert.equal(between[0].relationshipId, 0, 'absent rel_id reads as 0');
+
+    const named = warnings.filter((w) => w.includes('rel_id'));
+    assert.equal(named.length, 1, `exactly one warning naming rel_id, got: ${JSON.stringify(warnings)}`);
+    assert.match(named[0], /serverDataModel/, 'warning must name its source');
+  });
+
+  it('stays quiet when the server does send rel_id', () => {
+    const { warnings } = withCapturedWarnings(() => store([...EDGES]));
+    assert.deepEqual(
+      warnings.filter((w) => w.includes('rel_id')),
+      [],
+      'a v6 payload must not warn about a column it carries',
+    );
+  });
+
+  it('stays quiet when there are no relationships at all', () => {
+    // Nothing to be missing an id: an empty table must not look like an old server.
+    const { warnings } = withCapturedWarnings(() => store([]));
+    assert.deepEqual(warnings.filter((w) => w.includes('rel_id')), []);
   });
 });

--- a/apps/viewer/src/utils/serverDataModel.relationships.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.relationships.test.ts
@@ -50,17 +50,17 @@ const WALL = 3;
  * source file looks like once the server has flattened it into rows.
  */
 const RELATIONSHIPS = [
-  { rel_type: 'IFCRELAGGREGATES', relating_id: PROJECT, related_id: STOREY },
-  { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: STOREY, related_id: WALL },
-  { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: STOREY, related_id: WALL },
+  { rel_type: 'IFCRELAGGREGATES', relating_id: PROJECT, related_id: STOREY, rel_id: 900 },
+  { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: STOREY, related_id: WALL, rel_id: 901 },
+  { rel_type: 'IFCRELCONTAINEDINSPATIALSTRUCTURE', relating_id: STOREY, related_id: WALL, rel_id: 902 },
 ] as const;
 
 /** The same edges, in the same order, through the locally-parsed path's builder. */
 function referenceGraph() {
   const builder = new RelationshipGraphBuilder();
-  builder.addEdge(PROJECT, STOREY, RelationshipType.Aggregates, 0);
-  builder.addEdge(STOREY, WALL, RelationshipType.ContainsElements, 0);
-  builder.addEdge(STOREY, WALL, RelationshipType.ContainsElements, 0);
+  builder.addEdge(PROJECT, STOREY, RelationshipType.Aggregates, 900);
+  builder.addEdge(STOREY, WALL, RelationshipType.ContainsElements, 901);
+  builder.addEdge(STOREY, WALL, RelationshipType.ContainsElements, 902);
   return builder.build();
 }
 
@@ -141,6 +141,14 @@ async function exportRelationships(s: ReturnType<typeof store>): Promise<string[
   return rows.map((r) => `${Number(r.SourceId)}->${Number(r.TargetId)}:${String(r.RelType)}`);
 }
 
+/** Every exported row, RelId included. */
+async function exportRelationshipRowsWithRelId(s: ReturnType<typeof store>): Promise<string[]> {
+  const rows = decode(await new ParquetExporter(s).exportTable('relationships'));
+  return rows
+    .map((r) => `${Number(r.SourceId)}->${Number(r.TargetId)}:${String(r.RelType)}#${Number(r.RelId)}`)
+    .sort();
+}
+
 describe('server-path relationship graph', () => {
   it('anti-vacuity: the fixture really does repeat one relationship verbatim', () => {
     const seen = RELATIONSHIPS.map((r) => `${r.rel_type}:${r.relating_id}:${r.related_id}`);
@@ -184,6 +192,33 @@ describe('server-path relationship graph', () => {
       server.getRelated(STOREY, RelationshipType.ContainsElements, 'forward'),
       local.getRelated(STOREY, RelationshipType.ContainsElements, 'forward'),
       'getRelated must not count the repeat differently from the local path',
+    );
+  });
+
+  it('exports the real IfcRel express id in the RelId column', async () => {
+    // The CSR `edgeRelIds` column is what the exporter reads for RelId, so an
+    // id that reaches `getRelationshipsBetween` can still be lost on the way
+    // to an export (#3860). Assert on the exported column itself. The two
+    // repeated rows carry DIFFERENT ids, which is what a repeated
+    // relationship actually looks like: two IfcRel records, one pair.
+    const rows = await exportRelationshipRowsWithRelId(store());
+    assert.deepEqual(rows, [
+      `${PROJECT}->${STOREY}:IfcRelAggregates#900`,
+      `${STOREY}->${WALL}:IfcRelContainedInSpatialStructure#901`,
+      `${STOREY}->${WALL}:IfcRelContainedInSpatialStructure#902`,
+    ]);
+
+    // Anti-vacuity: 0 was the placeholder the server path used to write, and
+    // no fixture id equals an entity id, so a copied column fails too.
+    assert.ok(
+      rows.every((row) => !row.endsWith('#0')),
+      `no exported RelId may be the placeholder 0: ${JSON.stringify(rows)}`,
+    );
+
+    // Parity with the locally-parsed path, through the exporter.
+    assert.deepEqual(
+      rows,
+      await exportRelationshipRowsWithRelId({ ...store(), relationships: referenceGraph() }),
     );
   });
 

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -328,9 +328,9 @@ function buildRelationships(
       continue;
     }
 
-    // The server payload carries no IfcRel express id, so every edge gets 0 —
-    // the same placeholder the hand-rolled facade used.
-    graphBuilder.addEdge(rel.relating_id, rel.related_id, relType, 0);
+    // The IfcRel express id (#3860). Absent only against a server older than
+    // the column; 0 is then the placeholder every edge used to get.
+    graphBuilder.addEdge(rel.relating_id, rel.related_id, relType, rel.rel_id ?? 0);
   }
 
   if (unmappedRelTypes.size > 0) {

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -294,6 +294,8 @@ function buildRelationships(
   const typeOwnPsets = new Map<number, Array<any>>();
   const typeOwnQsets = new Map<number, Array<ServerQuantitySet>>();
   const unmappedRelTypes = new Set<string>();
+  // Whether the payload carried the rel_id column at all (#3860).
+  let sawRelId = false;
 
   // Combined loop - process relationships once for both graph building AND property mapping
   for (const rel of dataModel.relationships) {
@@ -330,11 +332,20 @@ function buildRelationships(
 
     // The IfcRel express id (#3860). Absent only against a server older than
     // the column; 0 is then the placeholder every edge used to get.
+    if (rel.rel_id !== undefined) sawRelId = true;
     graphBuilder.addEdge(rel.relating_id, rel.related_id, relType, rel.rel_id ?? 0);
   }
 
   if (unmappedRelTypes.size > 0) {
     console.warn(`[serverDataModel] Found ${unmappedRelTypes.size} unmapped relationship types: ${Array.from(unmappedRelTypes).join(', ')}`);
+  }
+
+  // Every edge then carries relationshipId 0, which looks exactly like a real
+  // graph until an export writes RelId = 0 on every row (#3860). Say it once.
+  if (!sawRelId && dataModel.relationships.length > 0) {
+    console.warn(
+      `[serverDataModel] Server sent no rel_id column: all ${dataModel.relationships.length} relationship(s) get id 0. Exported RelId will be 0 — the server predates the data-model v6 payload.`
+    );
   }
 
   // Merge each type's own (HasPropertySets) sets into its entry, FIRST and

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -409,6 +409,33 @@ interface Quantity {
 }
 ```
 
+### Relationships
+
+One row per (relating, related) pair: an `IfcRel*` record naming several
+related objects is flattened into one row each, so the same `rel_id` can appear
+on several rows.
+
+```typescript
+interface Relationship {
+  rel_type: string;      // e.g. 'IFCRELAGGREGATES', as declared in the file
+  relating_id: number;
+  related_id: number;
+  rel_id?: number;       // express id of the IfcRel entity
+}
+```
+
+`rel_id` is what a Parquet or DuckDB export writes as `RelId`, and what
+identifies the record to delete or edit. Two cases where it is not a live
+express id:
+
+- **Absent** (`undefined`) when the server predates the `datamodel-v6` payload,
+  which is where the column was added. Consumers fall back to `0`; the viewer
+  warns once naming the column, since every id reading 0 otherwise looks like a
+  normal graph.
+- **`0`** on the synthetic `TYPEHASPROPERTYSETS` rows. Those are read off
+  `IfcTypeObject.HasPropertySets` to attach a type's own property sets, and no
+  IFC entity declares them, so there is no id to carry.
+
 ### Spatial Hierarchy
 
 ```typescript

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -488,11 +488,18 @@ Cache keys are derived from file content:
 ```
 # {filter} is the opening filter (e.g. "default"); a non-default tessellation
 # quality appends a "-q{level}" suffix after it
-{SHA256}-{filter}-parquet-v4          # Geometry
+{SHA256}-{filter}-parquet-v5          # Geometry
 {SHA256}-{filter}-parquet-metadata-v4 # Metadata header
-{SHA256}-{filter}-datamodel-v2        # Properties & hierarchy
+{SHA256}-{filter}-datamodel-v6        # Properties & hierarchy
 {SHA256}-{filter}-symbolic-v1         # 2D symbol stream
 ```
+
+Each suffix is bumped whenever the payload it names changes shape: a column
+added to or removed from its tables, or a change in what an existing column
+means. Without the bump a warm cache replays the old blob, the client decodes
+it cleanly as if an older server had answered, and the change is silently
+absent. The keys above are built in `apps/server/src/routes/parse/cache_keys.rs`;
+that module is the single definition of each one.
 
 ### Cache Flow
 

--- a/packages/server-client/src/data-model-decoder.decode.test.ts
+++ b/packages/server-client/src/data-model-decoder.decode.test.ts
@@ -119,15 +119,16 @@ function relationshipsTable(
   rows: { relType: string; relatingId: number; relatedId: number; relId?: number }[],
   opts: { withRelId?: boolean } = {}
 ) {
-  const columns: Record<string, arrow.Vector> = {
+  const columns = {
     rel_type: arrow.vectorFromArray(rows.map((r) => r.relType), new arrow.Utf8()),
     relating_id: arrow.vectorFromArray(rows.map((r) => r.relatingId), new arrow.Uint32()),
     related_id: arrow.vectorFromArray(rows.map((r) => r.relatedId), new arrow.Uint32()),
   };
-  if (opts.withRelId) {
-    columns.rel_id = arrow.vectorFromArray(rows.map((r) => r.relId ?? 0), new arrow.Uint32());
-  }
-  return new arrow.Table(columns);
+  if (!opts.withRelId) return new arrow.Table(columns);
+  return new arrow.Table({
+    ...columns,
+    rel_id: arrow.vectorFromArray(rows.map((r) => r.relId ?? 0), new arrow.Uint32()),
+  });
 }
 
 function spatialNodesTable(rows: { id: number; parentId: number; level: number; path: string; type: string }[]) {

--- a/packages/server-client/src/data-model-decoder.decode.test.ts
+++ b/packages/server-client/src/data-model-decoder.decode.test.ts
@@ -113,12 +113,21 @@ function emptyQuantitiesTable() {
   });
 }
 
-function relationshipsTable(rows: { relType: string; relatingId: number; relatedId: number }[]) {
-  return new arrow.Table({
+/** `relId` is the data-model v6 column (issue #3860). Omitting it reproduces an
+ *  older server's payload, which the decoder must still accept. */
+function relationshipsTable(
+  rows: { relType: string; relatingId: number; relatedId: number; relId?: number }[],
+  opts: { withRelId?: boolean } = {}
+) {
+  const columns: Record<string, arrow.Vector> = {
     rel_type: arrow.vectorFromArray(rows.map((r) => r.relType), new arrow.Utf8()),
     relating_id: arrow.vectorFromArray(rows.map((r) => r.relatingId), new arrow.Uint32()),
     related_id: arrow.vectorFromArray(rows.map((r) => r.relatedId), new arrow.Uint32()),
-  });
+  };
+  if (opts.withRelId) {
+    columns.rel_id = arrow.vectorFromArray(rows.map((r) => r.relId ?? 0), new arrow.Uint32());
+  }
+  return new arrow.Table(columns);
 }
 
 function spatialNodesTable(rows: { id: number; parentId: number; level: number; path: string; type: string }[]) {
@@ -229,6 +238,8 @@ function buildDataModelBuffer(
     /** Raw Parquet bytes for the optional materials section; appending it
      *  also appends empty classifications/documents (positional triplet). */
     materialsBytes?: Uint8Array;
+    /** Emit the relationships table's `rel_id` column (data-model v6). */
+    withRelId?: boolean;
   } = {}
 ): ArrayBuffer {
   const entities = toParquetBytes(
@@ -238,8 +249,10 @@ function buildDataModelBuffer(
   const quantities = toParquetBytes(emptyQuantitiesTable());
   const relationships = toParquetBytes(
     opts.emptyRelationships
-      ? relationshipsTable([])
-      : relationshipsTable([{ relType: 'IfcRelAggregates', relatingId: 1, relatedId: 2 }])
+      ? relationshipsTable([], { withRelId: opts.withRelId })
+      : relationshipsTable([{ relType: 'IfcRelAggregates', relatingId: 1, relatedId: 2, relId: 7 }], {
+          withRelId: opts.withRelId,
+        })
   );
 
   const nodes =
@@ -399,6 +412,9 @@ describe('decodeDataModel — bounding controls (well-formed buffers still decod
       relating_id: 1,
       related_id: 2,
     });
+    // No `rel_id` column in this payload (older server) -> field absent, never
+    // a fabricated 0 that a caller would write into an export as a real id.
+    expect(model.relationships[0].rel_id).toBeUndefined();
 
     expect(model.spatialHierarchy.project_id).toBe(42);
     expect(model.spatialHierarchy.nodes).toHaveLength(1);
@@ -409,6 +425,21 @@ describe('decodeDataModel — bounding controls (well-formed buffers still decod
     expect(model.classifications).toEqual([]);
     expect(model.materials).toEqual([]);
     expect(model.documents).toEqual([]);
+  });
+
+  it('round-trips the relationships `rel_id` column when the server sends it (v6 payload)', async () => {
+    const buf = buildDataModelBuffer({ withRelId: true });
+    const model = await decodeDataModel(buf);
+
+    // 7 is distinct from both id columns (1, 2), so neither a copy of a
+    // neighbouring column nor the old hard-coded 0 passes.
+    expect(model.relationships).toHaveLength(1);
+    expect(model.relationships[0]).toEqual({
+      rel_type: 'IfcRelAggregates',
+      relating_id: 1,
+      related_id: 2,
+      rel_id: 7,
+    });
   });
 
   it('decodes a model with legitimately EMPTY required tables (zero quantities, zero relationships)', async () => {

--- a/packages/server-client/src/data-model-decoder.ts
+++ b/packages/server-client/src/data-model-decoder.ts
@@ -240,10 +240,9 @@ export interface Relationship {
   rel_type: string;
   relating_id: number;
   related_id: number;
-  /** Express id of the `IfcRel*` entity this row came from. Data-model v6
-   *  payload (issue #3860); `undefined` for older servers, which sent no such
-   *  column. `0` on the synthetic `TYPEHASPROPERTYSETS` rows, which no IFC
-   *  entity declares. */
+  /** Express id of the `IfcRel*` entity this row came from. v6 payload (issue
+   *  #3860); `undefined` for older servers. `0` on the synthetic
+   *  `TYPEHASPROPERTYSETS` rows, which no IFC entity declares. */
   rel_id?: number;
 }
 
@@ -554,9 +553,8 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
   const relatingIds = relationshipsArrow.getChild('relating_id')?.toArray() as Uint32Array;
   const relatedIds = relationshipsArrow.getChild('related_id')?.toArray() as Uint32Array;
   // rel_id arrives with the v6 payload (issue #3860). An older server sends no
-  // such column: leave the field absent rather than defaulting it to 0, so a
-  // caller can tell "no id on the wire" from "id 0" (the synthetic
-  // TYPEHASPROPERTYSETS rows).
+  // such column: leave the field absent rather than defaulting to 0, so a
+  // caller can tell "no id on the wire" from the genuine 0 on synthetic rows.
   const relIds = relationshipsArrow.getChild('rel_id')?.toArray() as Uint32Array | undefined;
 
   // Pre-allocate array for better performance

--- a/packages/server-client/src/data-model-decoder.ts
+++ b/packages/server-client/src/data-model-decoder.ts
@@ -240,6 +240,11 @@ export interface Relationship {
   rel_type: string;
   relating_id: number;
   related_id: number;
+  /** Express id of the `IfcRel*` entity this row came from. Data-model v6
+   *  payload (issue #3860); `undefined` for older servers, which sent no such
+   *  column. `0` on the synthetic `TYPEHASPROPERTYSETS` rows, which no IFC
+   *  entity declares. */
+  rel_id?: number;
 }
 
 export interface SpatialNode {
@@ -548,6 +553,11 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
   const relTypesArr = relationshipsArrow.getChild('rel_type')?.toArray() as string[];
   const relatingIds = relationshipsArrow.getChild('relating_id')?.toArray() as Uint32Array;
   const relatedIds = relationshipsArrow.getChild('related_id')?.toArray() as Uint32Array;
+  // rel_id arrives with the v6 payload (issue #3860). An older server sends no
+  // such column: leave the field absent rather than defaulting it to 0, so a
+  // caller can tell "no id on the wire" from "id 0" (the synthetic
+  // TYPEHASPROPERTYSETS rows).
+  const relIds = relationshipsArrow.getChild('rel_id')?.toArray() as Uint32Array | undefined;
 
   // Pre-allocate array for better performance
   const relationships: Relationship[] = new Array(relatingIds.length);
@@ -557,6 +567,7 @@ export async function decodeDataModel(data: ArrayBuffer): Promise<DataModel> {
       relating_id: relatingIds[i],
       related_id: relatedIds[i],
     };
+    if (relIds !== undefined) relationships[i].rel_id = relIds[i];
   }
 
   // Parse spatial hierarchy - format: [nodes_len][nodes_data][element_to_storey_len][element_to_storey_data]...

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -181,7 +181,7 @@
    497 apps/viewer/src/store/slices/visibilitySlice.ts
    415 apps/viewer/src/store/teardown.ts
    696 apps/viewer/src/store/types.ts
-   676 apps/viewer/src/utils/serverDataModel.ts
+   630 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
    413 apps/viewer/vite.config.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -181,7 +181,7 @@
    497 apps/viewer/src/store/slices/visibilitySlice.ts
    415 apps/viewer/src/store/teardown.ts
    696 apps/viewer/src/store/types.ts
-   665 apps/viewer/src/utils/serverDataModel.ts
+   676 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
    413 apps/viewer/vite.config.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -181,7 +181,7 @@
    497 apps/viewer/src/store/slices/visibilitySlice.ts
    415 apps/viewer/src/store/teardown.ts
    696 apps/viewer/src/store/types.ts
-   619 apps/viewer/src/utils/serverDataModel.ts
+   665 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
    413 apps/viewer/vite.config.ts
@@ -331,7 +331,7 @@
    458 packages/sdk/src/namespaces/bsdd.ts
    875 packages/sdk/src/types.ts
   1082 packages/server-client/src/client.ts
-   775 packages/server-client/src/data-model-decoder.ts
+   784 packages/server-client/src/data-model-decoder.ts
    466 packages/server-client/src/parquet-tables.ts
    627 packages/server-client/src/types.ts
    411 packages/source-dalux/src/http-client.ts


### PR DESCRIPTION
## Summary

The server's relationship payload was `{ rel_type, relating_id, related_id }`, so a server-loaded model fed `RelationshipGraphBuilder.addEdge` with relationship id 0 and every Parquet or DuckDB relationships row carried `RelId = 0` (#3860, found by Codex on #3847).

- Rust: `Relationship.rel_id: u32` populated from the IfcRel's own express id in both extraction arms (synthetic type-property links keep 0, asserted); Arrow column `rel_id` appended last (no reader indexes positionally; verified). The data-model cache key moves to `-datamodel-v6` through a single `cache_keys::data_model_cache_key` used by both writers and the reader, with a test that a blob written under v5 is not served (a warm cache would otherwise replay the old payload and restore the bug silently, the way previous column additions were handled in 564a800e9 and 7194c9500).
- Decoder: `rel_id?: number`, absent when the column is absent (older server), so a caller can tell "not on the wire" from a real 0.
- Viewer: `relationshipId = rel.rel_id ?? 0`, with one warning naming the missing column when a non-empty relationships table carries none.
- `docs/guide/server.md`: the documented cache-key suffixes were stale (v2 and v4); corrected to v6 and v5 with the rule that a suffix bumps on any payload column change.

Closes #3860

## Verification

- RED/GREEN per layer: server compile error and two rel_id tests red with `0`; decoder 1 failed then 64 pass; viewer test `expected 900, actual 0` then 4/4; cache-key test red in both directions before the call sites moved.
- `cargo test -p ifc-lite-server --no-fail-fast` 232 pass; clippy `-D warnings` clean; `pnpm typecheck`, server-client 64 tests, `check-module-size`: exit 0.
- Changeset: `@ifc-lite/server-client` minor.
- Conflict note: `scripts/module-size-allowlist.txt` conflicts with #3847 on `apps/viewer/src/utils/serverDataModel.ts` (that PR lowers the row to 619, this one raises 662 to 676). Whichever merges second must recompute the row by running `node scripts/check-module-size.mjs` against the merged file, not keep either number. The viewer's `addEdge` call in #3847 needs `rel.rel_id ?? 0` as its fourth argument; this branch's viewer test passes unchanged against #3847's file.