### PR TITLE
fix(ci): enforce pipeline label authority

### DIFF
--- a/.github/workflows/label-authority.yml
+++ b/.github/workflows/label-authority.yml
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Label authority
+
+# GitHub rulesets protect branches and Git tags, not issue/PR labels. This
+# trusted-base workflow supplies the missing per-label ACL for the two labels
+# that steer the issue queue. `pull_request_target` is safe here because it
+# checks out and executes only the default branch and never PR code.
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: label-authority-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enforce:
+    name: Label authority
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          lfs: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      - name: Test the guard
+        run: node --test scripts/enforce-pipeline-labels.test.mjs
+
+      - name: Enforce protected-label authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/enforce-pipeline-labels.mjs

--- a/scripts/enforce-pipeline-labels.mjs
+++ b/scripts/enforce-pipeline-labels.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Remove a pipeline-steering label when its LabeledEvent was not created by a
+ * configured authority. GitHub rulesets protect Git refs, not issue/PR labels,
+ * and repository triage/write roles can otherwise apply every label.
+ */
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMainEntry } from './lib/is-main-entry.mjs';
+import { normaliseLogin, readConfig } from './check-issue-queue.mjs';
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG = join(ROOT, 'issue-queue.config.json');
+
+export class LabelAuthorityError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'LabelAuthorityError';
+    this.reason = reason;
+  }
+}
+
+export function decideLabelEvent(payload, cfg) {
+  if (cfg.requireLabelAuthority !== true) {
+    throw new LabelAuthorityError(
+      'BAD_CONFIG',
+      'requireLabelAuthority must be true while protected-label enforcement is installed.',
+    );
+  }
+  if (!payload || typeof payload !== 'object') {
+    throw new LabelAuthorityError('BAD_EVENT', 'The webhook payload is not an object.');
+  }
+  if (payload.action !== 'labeled') {
+    return { action: 'ignore', reason: 'NOT_LABELED' };
+  }
+  const label = payload.label?.name;
+  if (typeof label !== 'string' || label.trim() === '') {
+    throw new LabelAuthorityError('BAD_EVENT', 'A labeled event carries no label name.');
+  }
+  const protectedLabels = new Map([
+    [cfg.readyLabel.toLowerCase(), cfg.readyLabel],
+    [cfg.escapeLabel.toLowerCase(), cfg.escapeLabel],
+  ]);
+  const canonical = protectedLabels.get(label.toLowerCase());
+  if (!canonical) return { action: 'ignore', reason: 'UNPROTECTED_LABEL' };
+
+  const sender = normaliseLogin(payload.sender?.login);
+  if (sender === null) {
+    throw new LabelAuthorityError(
+      'UNKNOWN_SENDER',
+      `Protected label ${JSON.stringify(canonical)} was applied without a readable sender.`,
+    );
+  }
+  if (cfg.labelAuthorities.has(sender)) {
+    return { action: 'keep', label: canonical, sender };
+  }
+
+  const number = payload.issue?.number ?? payload.pull_request?.number ?? payload.number;
+  if (!Number.isSafeInteger(number) || number < 1) {
+    throw new LabelAuthorityError(
+      'BAD_EVENT',
+      `Protected label ${JSON.stringify(canonical)} has no positive issue or pull-request number.`,
+    );
+  }
+  return { action: 'remove', label: canonical, sender, number };
+}
+
+export function enforceLabelEvent(payload, { cfg, repo, spawn = spawnSync }) {
+  const decision = decideLabelEvent(payload, cfg);
+  if (decision.action !== 'remove') return decision;
+  if (typeof repo !== 'string' || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new LabelAuthorityError('BAD_REPO', `Invalid GITHUB_REPOSITORY ${JSON.stringify(repo)}.`);
+  }
+
+  const endpoint = `repos/${repo}/issues/${decision.number}/labels/${encodeURIComponent(decision.label)}`;
+  const result = spawn('gh', ['api', '--method', 'DELETE', endpoint], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (result.error || result.status !== 0) {
+    throw new LabelAuthorityError(
+      'REMOVE_FAILED',
+      `Could not remove ${JSON.stringify(decision.label)} from #${decision.number}: ` +
+        `${result.error?.message ?? (String(result.stderr ?? '').trim() || `exit ${result.status}`)}`,
+    );
+  }
+  return decision;
+}
+
+function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new LabelAuthorityError('BAD_EVENT', 'GITHUB_EVENT_PATH is unset.');
+  const payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  const cfg = readConfig(DEFAULT_CONFIG);
+  const decision = enforceLabelEvent(payload, {
+    cfg,
+    repo: process.env.GITHUB_REPOSITORY,
+  });
+  if (decision.action === 'remove') {
+    console.log(
+      `REMOVED: @${decision.sender} is not in labelAuthorities; protected label ` +
+        `${JSON.stringify(decision.label)} was removed from #${decision.number}.`,
+    );
+  } else if (decision.action === 'keep') {
+    console.log(`KEPT: @${decision.sender} is authorised to apply protected label ${JSON.stringify(decision.label)}.`);
+  } else {
+    console.log(`IGNORED: ${decision.reason}.`);
+  }
+}
+
+if (isMainEntry(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    if (error instanceof LabelAuthorityError) {
+      console.error(`❌ ${error.reason}: ${error.message}`);
+      process.exit(1);
+    }
+    throw error;
+  }
+}

--- a/scripts/enforce-pipeline-labels.mjs
+++ b/scripts/enforce-pipeline-labels.mjs
@@ -78,8 +78,40 @@ export function enforceLabelEvent(payload, { cfg, repo, spawn = spawnSync }) {
     throw new LabelAuthorityError('BAD_REPO', `Invalid GITHUB_REPOSITORY ${JSON.stringify(repo)}.`);
   }
 
-  const endpoint = `repos/${repo}/issues/${decision.number}/labels/${encodeURIComponent(decision.label)}`;
-  const result = spawn('gh', ['api', '--method', 'DELETE', endpoint], {
+  const eventsEndpoint = `repos/${repo}/issues/${decision.number}/events?per_page=100`;
+  const history = spawn('gh', ['api', '--paginate', '--slurp', eventsEndpoint], {
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (history.error || history.status !== 0) {
+    throw new LabelAuthorityError(
+      'REVALIDATE_FAILED',
+      `Could not revalidate ${JSON.stringify(decision.label)} on #${decision.number}: ` +
+        `${history.error?.message ?? (String(history.stderr ?? '').trim() || `exit ${history.status}`)}`,
+    );
+  }
+
+  let pages;
+  try {
+    pages = JSON.parse(history.stdout);
+  } catch (error) {
+    throw new LabelAuthorityError('REVALIDATE_FAILED', `Label history is not JSON: ${error.message}`);
+  }
+  if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
+    throw new LabelAuthorityError('REVALIDATE_FAILED', 'Label history does not contain paginated event arrays.');
+  }
+  const relevant = pages.flat().filter((entry) =>
+    (entry?.event === 'labeled' || entry?.event === 'unlabeled') &&
+    typeof entry.label?.name === 'string' &&
+    entry.label.name.toLowerCase() === decision.label.toLowerCase());
+  const latest = relevant.at(-1);
+  const latestActor = normaliseLogin(latest?.actor?.login);
+  if (latest?.event !== 'labeled' || latestActor !== decision.sender) {
+    return { action: 'keep-newer-state', label: decision.label, sender: decision.sender, number: decision.number };
+  }
+
+  const labelEndpoint = `repos/${repo}/issues/${decision.number}/labels/${encodeURIComponent(decision.label)}`;
+  const result = spawn('gh', ['api', '--method', 'DELETE', labelEndpoint], {
     encoding: 'utf8',
     env: process.env,
   });
@@ -109,6 +141,8 @@ function main() {
     );
   } else if (decision.action === 'keep') {
     console.log(`KEPT: @${decision.sender} is authorised to apply protected label ${JSON.stringify(decision.label)}.`);
+  } else if (decision.action === 'keep-newer-state') {
+    console.log(`KEPT: ${JSON.stringify(decision.label)} changed after @${decision.sender}'s stale event.`);
   } else {
     console.log(`IGNORED: ${decision.reason}.`);
   }

--- a/scripts/enforce-pipeline-labels.test.mjs
+++ b/scripts/enforce-pipeline-labels.test.mjs
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { decideLabelEvent, enforceLabelEvent, LabelAuthorityError } from './enforce-pipeline-labels.mjs';
+
+const cfg = {
+  readyLabel: 'ready',
+  escapeLabel: 'unqueued',
+  labelAuthorities: new Set(['louistrue']),
+  requireLabelAuthority: true,
+};
+const event = (label, sender = 'louistrue', number = 42) => ({
+  action: 'labeled',
+  label: { name: label },
+  sender: { login: sender },
+  issue: { number },
+});
+
+test('#3876: a maintainer-applied protected label remains attached', () => {
+  assert.deepEqual(decideLabelEvent(event('ready'), cfg), {
+    action: 'keep', label: 'ready', sender: 'louistrue',
+  });
+});
+
+test('#3876: an unauthorized protected label is removed from the exact issue', () => {
+  let call;
+  const result = enforceLabelEvent(event('unqueued', 'BIMvoice', 73), {
+    cfg,
+    repo: 'LTplus-AG/ifc-lite',
+    spawn: (...args) => {
+      call = args;
+      return { status: 0, stdout: '', stderr: '' };
+    },
+  });
+  assert.equal(result.action, 'remove');
+  assert.equal(result.sender, 'bimvoice');
+  assert.deepEqual(call.slice(0, 2), [
+    'gh',
+    ['api', '--method', 'DELETE', 'repos/LTplus-AG/ifc-lite/issues/73/labels/unqueued'],
+  ]);
+});
+
+test('ordinary labels are outside this narrow authority policy', () => {
+  assert.deepEqual(decideLabelEvent(event('bug', 'BIMvoice'), cfg), {
+    action: 'ignore', reason: 'UNPROTECTED_LABEL',
+  });
+});
+
+test('a malformed protected-label event fails closed', () => {
+  assert.throws(
+    () => decideLabelEvent({ action: 'labeled', label: { name: 'ready' }, sender: null }, cfg),
+    (error) => error instanceof LabelAuthorityError && error.reason === 'UNKNOWN_SENDER',
+  );
+});
+
+test('the guard cannot silently survive its authority policy being disabled', () => {
+  assert.throws(
+    () => decideLabelEvent(event('ready'), { ...cfg, requireLabelAuthority: false }),
+    (error) => error instanceof LabelAuthorityError && error.reason === 'BAD_CONFIG',
+  );
+});
+
+test('a removal API failure is visible and never reported as enforcement', () => {
+  assert.throws(
+    () => enforceLabelEvent(event('ready', 'BIMvoice'), {
+      cfg,
+      repo: 'LTplus-AG/ifc-lite',
+      spawn: () => ({ status: 1, stdout: '', stderr: 'forbidden' }),
+    }),
+    (error) => error instanceof LabelAuthorityError && error.reason === 'REMOVE_FAILED' && /forbidden/.test(error.message),
+  );
+});

--- a/scripts/enforce-pipeline-labels.test.mjs
+++ b/scripts/enforce-pipeline-labels.test.mjs
@@ -25,21 +25,42 @@ test('#3876: a maintainer-applied protected label remains attached', () => {
 });
 
 test('#3876: an unauthorized protected label is removed from the exact issue', () => {
-  let call;
+  const calls = [];
   const result = enforceLabelEvent(event('unqueued', 'BIMvoice', 73), {
     cfg,
     repo: 'LTplus-AG/ifc-lite',
     spawn: (...args) => {
-      call = args;
+      calls.push(args);
+      if (calls.length === 1) {
+        return { status: 0, stdout: '[[{"event":"labeled","label":{"name":"unqueued"},"actor":{"login":"BIMvoice"}}]]', stderr: '' };
+      }
       return { status: 0, stdout: '', stderr: '' };
     },
   });
   assert.equal(result.action, 'remove');
   assert.equal(result.sender, 'bimvoice');
-  assert.deepEqual(call.slice(0, 2), [
+  assert.deepEqual(calls[1].slice(0, 2), [
     'gh',
     ['api', '--method', 'DELETE', 'repos/LTplus-AG/ifc-lite/issues/73/labels/unqueued'],
   ]);
+});
+
+test('#3876: a stale unauthorized event cannot remove a maintainer reapplication', () => {
+  let calls = 0;
+  const result = enforceLabelEvent(event('ready', 'BIMvoice', 73), {
+    cfg,
+    repo: 'LTplus-AG/ifc-lite',
+    spawn: () => {
+      calls += 1;
+      return {
+        status: 0,
+        stdout: '[[{"event":"labeled","label":{"name":"ready"},"actor":{"login":"BIMvoice"}},{"event":"unlabeled","label":{"name":"ready"},"actor":{"login":"louistrue"}},{"event":"labeled","label":{"name":"ready"},"actor":{"login":"louistrue"}}]]',
+        stderr: '',
+      };
+    },
+  });
+  assert.equal(result.action, 'keep-newer-state');
+  assert.equal(calls, 1, 'the DELETE call must not happen');
 });
 
 test('ordinary labels are outside this narrow authority policy', () => {
@@ -63,11 +84,17 @@ test('the guard cannot silently survive its authority policy being disabled', ()
 });
 
 test('a removal API failure is visible and never reported as enforcement', () => {
+  let calls = 0;
   assert.throws(
     () => enforceLabelEvent(event('ready', 'BIMvoice'), {
       cfg,
       repo: 'LTplus-AG/ifc-lite',
-      spawn: () => ({ status: 1, stdout: '', stderr: 'forbidden' }),
+      spawn: () => {
+        calls += 1;
+        return calls === 1
+          ? { status: 0, stdout: '[[{"event":"labeled","label":{"name":"ready"},"actor":{"login":"BIMvoice"}}]]', stderr: '' }
+          : { status: 1, stdout: '', stderr: 'forbidden' };
+      },
     }),
     (error) => error instanceof LabelAuthorityError && error.reason === 'REMOVE_FAILED' && /forbidden/.test(error.message),
   );

--- a/scripts/issue-queue.config.json
+++ b/scripts/issue-queue.config.json
@@ -21,11 +21,11 @@
     "waiver\"). The earlier note here said neither existed, measured 2026-08-30, and used that",
     "to argue the gate must stay advisory; that argument is spent.",
     "",
-    "THIS GATE IS STILL NOT A REQUIRED STATUS CHECK. Measured 2026-09-02, the `main` ruleset",
-    "(id 11806334) requires exactly three contexts -- `Build + WASM + Rust + Node`, `parity",
-    "(in-tree fixtures, committed reference)` and `PR review signal`. `Issue queue` is not",
-    "among them, so `enforcing` turns the row RED and blocks no merge. Making it required is",
-    "a separate, deliberate act in repository settings, not a side effect of this file."
+    "THIS GATE IS A REQUIRED STATUS CHECK. Since 2026-09-04, the `main` ruleset (id 11806334)",
+    "requires `Issue queue` alongside `Build + WASM + Rust + Node`, `parity (in-tree fixtures,",
+    "committed reference)` and `PR review signal`. The workflow's `enforcing` mode therefore",
+    "blocks unqueued work rather than merely painting a red row. The repository ruleset is the",
+    "authoritative live state; this note records why the context belongs there."
   ],
   "$readyLabelComment": [
     "READY_LABEL: the label on an ISSUE that says the maintainer wants this built.",


### PR DESCRIPTION
Closes #3876

## What changed
- remove `ready` and `unqueued` immediately when their label event actor is not a configured maintainer
- execute only trusted default-branch code for PR label events
- fail closed on malformed events, removal failures, or disabled authority policy
- record `Issue queue` as a required ruleset context

## Verification
- `node --test scripts/enforce-pipeline-labels.test.mjs scripts/check-issue-queue.test.mjs` (53 passed)
- `node scripts/check-test-wiring.mjs`
- `pnpm exec oxlint scripts/enforce-pipeline-labels.mjs scripts/enforce-pipeline-labels.test.mjs`
- `git diff --check`

After merge I will add `Issue queue` to ruleset 11806334 and run live maintainer/unauthorized label canaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated enforcement for protected pipeline labels on issues and pull requests.
  - Authorized label applications are retained, while unauthorized applications are removed.
  - Added safeguards for invalid events and failed enforcement actions.

- **Tests**
  - Added coverage for authorized labels, unauthorized removals, ignored labels, malformed events, disabled policies, and enforcement failures.

- **Documentation**
  - Updated issue-queue configuration notes to reflect the required `main` ruleset status check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->