### PR TITLE
ci(geometry): a lane that builds and tests the two CSG accept gates, with the topology gate's red targets pinned

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,6 +251,11 @@ jobs:
               - 'rust/processing/**'
               - 'apps/server/Cargo.toml'
               - 'Cargo.lock'
+              # Workspace inputs the feature builds inherit: a root manifest or
+              # toolchain change can break the off-by-default gate builds that
+              # only the csg-accept-gates lane compiles.
+              - 'Cargo.toml'
+              - 'rust-toolchain.toml'
               - '.github/workflows/test.yml'
               # The watertightness census sweeps the fixture set named here, so a
               # corpus change moves its pinned counts even with no code change.
@@ -1647,6 +1652,11 @@ jobs:
         run: cargo clippy -p ifc-lite-geometry --features csg_manifold_gate --all-targets -- -D warnings
       - name: Clippy (csg_topology_gate)
         run: cargo clippy -p ifc-lite-geometry --features csg_topology_gate --all-targets -- -D warnings
+      # The combined build selects code behind cfg(all(...)) that neither
+      # single-feature pass compiles, and `cargo test` does not make warnings
+      # fatal, so it needs its own -D warnings pass.
+      - name: Clippy (both gates)
+        run: cargo clippy -p ifc-lite-geometry --features csg_manifold_gate,csg_topology_gate --all-targets -- -D warnings
 
       # `IFC_LITE_REQUIRE_FIXTURES` for the same reason rust-tests sets it:
       # fixtures are fetched and verified above, so a missing one here is drift,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1571,6 +1571,106 @@ jobs:
           name: watertightness-census-rows
           path: target/watertightness_census.run.tsv
           if-no-files-found: warn
+  # The boolean accept gates' feature builds (#3871).
+  #
+  # `csg_manifold_gate` (#3440) and `csg_topology_gate` (#3717) are off by
+  # default and enabled by NOTHING downstream, so `cargo test --workspace` in
+  # `rust-tests` never COMPILES either gate, let alone runs it. That is the same
+  # dead-but-maintained shape the `parquet-bos` step in that job exists to
+  # reject, and it had already happened: `csg_topology_gate` was red on three
+  # targets from the day #3717 landed and no lane said so. This is the lane that
+  # says so.
+  #
+  # NOT on the aggregate `test` gate's `needs:` list, deliberately, and this is
+  # the one thing about this job that must not drift. What it asserts are pinned
+  # MEASUREMENTS of a fallback path known to be worse than the tear it replaces
+  # (issue_098_v5c, issue_960_segmented_roof_clip), for a configuration nothing
+  # ships. A number moving there is a thing to look at, not a thing to block a
+  # merge on. Adding this job to that `needs:` list, or to the `results` map
+  # beside it, turns a report into a gate.
+  #
+  # `geometry`, not `rust`: the same scope argument geometry-census above spells
+  # out. The gates live in rust/geometry, they sit downstream of rust/core's
+  # parse path, and the per-fixture numbers they pin move with the fixture
+  # corpus, so `tests/models/manifest.json` is in that filter too.
+  #
+  # PR-only, like geometry-census and viewer-e2e: three feature builds of the
+  # geometry crate and its test targets are not free, and a PR lane already
+  # catches the flip before it reaches main.
+  #
+  # ONE STEP PER FEATURE COMBINATION, not one `--all-features` run. The two
+  # gates read different defect classes and reject different hosts, so each
+  # combination lands on its own numbers -- issue_098_v5c measures 416 / 124 /
+  # 552 unpaired edges under manifold-only / topology-only / both. A single
+  # combined run would attribute every flip to whichever gate fired first, and
+  # would leave the other two combinations' pins asserted by nothing.
+  csg-accept-gates:
+    name: CSG accept gates (feature builds)
+    needs: changes
+    if: needs.changes.outputs.geometry == 'true' && github.event_name == 'pull_request'
+    # This lane must not consume metered runner minutes.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup Rust (pinned by rust-toolchain.toml)
+        run: rustup show
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          prefix-key: ci-rust-csg-gates
+      - name: Cache test fixtures
+        id: fixtures-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/models
+          key: ci-fixtures-${{ runner.os }}-${{ hashFiles('tests/models/manifest.json') }}
+      - name: Fetch fixtures
+        if: steps.fixtures-cache.outputs.cache-hit != 'true'
+        run: node scripts/fixtures/fetch-fixtures.mjs
+
+      # Unconditional, for the reason spelled out in rust-tests: on a cache hit
+      # nothing else confirms the restored tree still matches the manifest, and
+      # every pin below is fixture-gated. A partial cache would make them all
+      # skip and report ok, which is precisely the absence this job exists to
+      # make visible.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
+
+      # Clippy first: a lint failure is cheaper to find than a 20-minute test
+      # run, and `--all-targets` type-checks the test targets the steps below
+      # then run.
+      - name: Clippy (csg_manifold_gate)
+        run: cargo clippy -p ifc-lite-geometry --features csg_manifold_gate --all-targets -- -D warnings
+      - name: Clippy (csg_topology_gate)
+        run: cargo clippy -p ifc-lite-geometry --features csg_topology_gate --all-targets -- -D warnings
+
+      # `IFC_LITE_REQUIRE_FIXTURES` for the same reason rust-tests sets it:
+      # fixtures are fetched and verified above, so a missing one here is drift,
+      # not a legitimate local skip, and every pinned number in these targets is
+      # measured from a fixture.
+      - name: Rust tests (csg_manifold_gate)
+        env:
+          IFC_LITE_REQUIRE_FIXTURES: "1"
+        run: cargo test -p ifc-lite-geometry --features csg_manifold_gate --no-fail-fast
+      - name: Rust tests (csg_topology_gate)
+        env:
+          IFC_LITE_REQUIRE_FIXTURES: "1"
+        run: cargo test -p ifc-lite-geometry --features csg_topology_gate --no-fail-fast
+
+      # The combined build, because the third set of pins is asserted by nothing
+      # else: under both gates issue_098_v5c measures 552 unpaired edges and
+      # 24.103 m3, neither of which either single-feature leg above visits. It
+      # is also the configuration a census that has to attribute a rejection to
+      # one gate rather than the other runs in.
+      - name: Rust tests (both gates)
+        env:
+          IFC_LITE_REQUIRE_FIXTURES: "1"
+        run: cargo test -p ifc-lite-geometry --features csg_manifold_gate,csg_topology_gate --no-fail-fast
+
 
   # Plato clash-math single-source freshness gate. The clash narrow-phase math
   # is written once in Plato and transpiled to Rust + TypeScript; the committed

--- a/rust/geometry/tests/geometry_correctness_harness.rs
+++ b/rust/geometry/tests/geometry_correctness_harness.rs
@@ -616,21 +616,23 @@ fn geometry_correctness_harness() {
     // vendored, so every snapshot is asserted there. Accept intentional
     // changes with `cargo insta review` (or `INSTA_UPDATE=auto`).
     //
-    // #3440: under `csg_manifold_gate` the boolean accept seam rejects torn
-    // kernel results and the router falls back, so some fixtures emit
-    // different geometry - `218_IFC-test-lite` measured 3492 tris / 21 spike
-    // triangles against the default build's 3340 / 19. These snapshots are a
-    // per-fixture baseline for the DEFAULT build; blessing a second set under
-    // the feature would be a second golden to keep true, for a configuration
-    // nothing ships. The hard invariants above (no NaN, no parse failure, no
-    // empty-when-expected) still run in both builds, so the feature build is
-    // not unguarded here - it is unpinned on tessellation detail only. The
-    // per-fixture regression numbers the feature DOES need pinned live in
-    // `issue_098_reveal_wall`, `issue_098_v5c` and
-    // `issue_960_segmented_roof_clip`, which assert them directly.
-    if cfg!(feature = "csg_manifold_gate") {
+    // #3440/#3871: under either accept gate (`csg_manifold_gate`,
+    // `csg_topology_gate`) the boolean accept seam rejects torn kernel results
+    // and the router falls back, so some fixtures emit different geometry -
+    // `218_IFC-test-lite` measured 3492 tris / 21 spike triangles under each
+    // gate alone and under both together, against the default build's 3340 /
+    // 19. These snapshots are a per-fixture baseline for the DEFAULT build;
+    // blessing a second set per feature combination would be three more
+    // goldens to keep true, for configurations nothing ships. The hard
+    // invariants above (no NaN, no parse failure, no empty-when-expected)
+    // still run in every build, so a gated build is not unguarded here - it is
+    // unpinned on tessellation detail only. The per-fixture regression numbers
+    // the gates DO need pinned live in `issue_098_reveal_wall`,
+    // `issue_098_v5c` and `issue_960_segmented_roof_clip`, which assert them
+    // directly, per feature combination.
+    if cfg!(any(feature = "csg_manifold_gate", feature = "csg_topology_gate")) {
         println!(
-            "[harness] csg_manifold_gate build: {} fixture snapshot(s) not asserted (#3440)",
+            "[harness] accept-gate build: {} fixture snapshot(s) not asserted (#3440, #3871)",
             reports.iter().filter(|r| r.fixture_found).count()
         );
         return;

--- a/rust/geometry/tests/issue_098_reveal_wall.rs
+++ b/rust/geometry/tests/issue_098_reveal_wall.rs
@@ -139,6 +139,28 @@ fn dump_wall_mesh() {
     }
 }
 
+// #3440/#3871: under an accept gate (`csg_manifold_gate`, `csg_topology_gate`)
+// the boolean accept seam REJECTS a kernel result carrying a torn or
+// non-manifold edge, and the router falls back. On this fixture that fallback
+// is measurably WORSE than the tear it replaces, which is precisely why both
+// features are off by default. Where it regresses, the assertion below is not
+// relaxed - it is REPLACED by the measured value, so the gated build stays
+// green while still failing the moment the number moves in either direction.
+// The thing to fix is the FALLBACK path (the #635 AABB box-cut the void router
+// reaches when the exact cut is discarded), not the bar; when it is fixed,
+// these pins should go and the default bar apply to every build.
+//
+// `None` means the real bar still holds in that configuration and is left to do
+// its job. `csg_topology_gate` alone measures 22 unpaired edges here, BETTER
+// than the default build's ~42, so it keeps the bar rather than pinning a
+// number that is not a regression.
+#[cfg(not(feature = "csg_manifold_gate"))]
+const PINNED_OPEN_EDGES: Option<i64> = None;
+#[cfg(all(feature = "csg_manifold_gate", not(feature = "csg_topology_gate")))]
+const PINNED_OPEN_EDGES: Option<i64> = Some(380);
+#[cfg(all(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
+const PINNED_OPEN_EDGES: Option<i64> = Some(352);
+
 #[test]
 fn reveal_wall_openings_do_not_leave_flaps() {
     let voided = voided_wall();
@@ -158,24 +180,15 @@ fn reveal_wall_openings_do_not_leave_flaps() {
     // + weld-for-batching fixes bring it to ~42 (5 of 7 windows fully watertight,
     // the reveals preserved). Guard against regression past that.
     let _ = mx;
-    // #3440: under `csg_manifold_gate` the boolean accept seam REJECTS a kernel
-    // result carrying a non-manifold or reversed-winding edge, and the router
-    // falls back. On this fixture that fallback is measurably WORSE than the tear
-    // it replaces, which is precisely why the feature is off by default. The
-    // assertion is not relaxed - it is REPLACED by the measured regression, so the
-    // feature build stays green while still failing the moment the number moves in
-    // either direction. The thing to fix is the FALLBACK path (the #635 AABB
-    // box-cut the void router reaches when the exact cut is discarded), not this
-    // bar; when it is fixed, this branch should go and the default bar apply to
-    // both builds.
-    #[cfg(not(feature = "csg_manifold_gate"))]
-    assert!(open < 60, "cut re-fragmented: {open} unpaired edges (was ~42)");
-    #[cfg(feature = "csg_manifold_gate")]
-    assert_eq!(
-        open, 380,
-        "known regression under csg_manifold_gate: the rejected cut falls back \
-         to a result with 380 unpaired edges against the default build's ~42. \
-         A different number means the gate or the fallback moved and the \
-         regression needs re-measuring, not re-pinning."
-    );
+    match PINNED_OPEN_EDGES {
+        None => assert!(open < 60, "cut re-fragmented: {open} unpaired edges (was ~42)"),
+        Some(pinned) => assert_eq!(
+            open, pinned,
+            "known regression under the accept gate(s) this build enables: the \
+             rejected cut falls back to a result with {pinned} unpaired edges \
+             against the default build's ~42. A different number means the gate \
+             or the fallback moved and the regression needs re-measuring, not \
+             re-pinning."
+        ),
+    }
 }

--- a/rust/geometry/tests/issue_098_v5c.rs
+++ b/rust/geometry/tests/issue_098_v5c.rs
@@ -100,42 +100,71 @@ fn voided_wall() -> Mesh {
 // exact (cleaner) batched cut instead of the sequential re-jitter. Together with
 // the off-plane fix this brings the wall from ~2072 open edges (badly torn) to
 // ~108 with the removed volume unchanged. Guard against regression past that.
+// #3440/#3871: under an accept gate (`csg_manifold_gate`, `csg_topology_gate`)
+// the boolean accept seam REJECTS a kernel result carrying a torn or
+// non-manifold edge, and the router falls back. On this fixture that fallback
+// is measurably WORSE than the tear it replaces, which is precisely why both
+// features are off by default. Where it regresses, the assertion below is not
+// relaxed - it is REPLACED by the measured value, so the gated build stays
+// green while still failing the moment the number moves in either direction.
+// The thing to fix is the FALLBACK path (the #635 AABB box-cut the void router
+// reaches when the exact cut is discarded), not the bar; when it is fixed,
+// these pins should go and the default bar apply to every build.
+//
+// The two gates read different defect classes and reject different hosts, so
+// each combination lands somewhere different and each is measured separately
+// rather than assumed. `None` means the real bar still holds in that
+// configuration and is left to do its job: `csg_topology_gate` alone measures
+// 124 unpaired edges, still inside the ~160 bar, so only its volume is pinned.
+#[cfg(not(any(feature = "csg_manifold_gate", feature = "csg_topology_gate")))]
+const PINNED_OPEN_EDGES: Option<i64> = None;
+#[cfg(not(any(feature = "csg_manifold_gate", feature = "csg_topology_gate")))]
+const PINNED_VOLUME_M3: Option<f64> = None;
+
+#[cfg(all(not(feature = "csg_manifold_gate"), feature = "csg_topology_gate"))]
+const PINNED_OPEN_EDGES: Option<i64> = None;
+#[cfg(all(not(feature = "csg_manifold_gate"), feature = "csg_topology_gate"))]
+const PINNED_VOLUME_M3: Option<f64> = Some(26.763);
+
+#[cfg(all(feature = "csg_manifold_gate", not(feature = "csg_topology_gate")))]
+const PINNED_OPEN_EDGES: Option<i64> = Some(416);
+#[cfg(all(feature = "csg_manifold_gate", not(feature = "csg_topology_gate")))]
+const PINNED_VOLUME_M3: Option<f64> = Some(24.956);
+
+#[cfg(all(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
+const PINNED_OPEN_EDGES: Option<i64> = Some(552);
+#[cfg(all(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
+const PINNED_VOLUME_M3: Option<f64> = Some(24.103);
+
 #[test]
 fn v5c_dense_reveal_wall_not_torn() {
     let voided = voided_wall();
     let open = open_edges(&voided);
     let vol = mesh_volume(&voided);
     println!("[V5C] tris={} vol={vol:.3} openEdges={open}", voided.triangle_count());
-    // #3440: under `csg_manifold_gate` the boolean accept seam REJECTS a kernel
-    // result carrying a non-manifold or reversed-winding edge, and the router
-    // falls back. On this fixture that fallback is measurably WORSE than the tear
-    // it replaces, which is precisely why the feature is off by default. The
-    // assertion is not relaxed - it is REPLACED by the measured regression, so the
-    // feature build stays green while still failing the moment the number moves in
-    // either direction. The thing to fix is the FALLBACK path (the #635 AABB
-    // box-cut the void router reaches when the exact cut is discarded), not this
-    // bar; when it is fixed, this branch should go and the default bar apply to
-    // both builds.
-    #[cfg(not(feature = "csg_manifold_gate"))]
-    assert!(open < 160, "V5C re-fragmented: {open} unpaired edges (was ~108)");
-    #[cfg(feature = "csg_manifold_gate")]
-    assert_eq!(
-        open, 416,
-        "known regression under csg_manifold_gate: the rejected cut falls back \
-         to a result with 416 unpaired edges against the default build's ~108. \
-         A different number means the gate or the fallback moved and the \
-         regression needs re-measuring, not re-pinning."
-    );
-    // Same #3440 note as above, on the other dimension this fixture guards.
+    match PINNED_OPEN_EDGES {
+        None => assert!(open < 160, "V5C re-fragmented: {open} unpaired edges (was ~108)"),
+        Some(pinned) => assert_eq!(
+            open, pinned,
+            "known regression under the accept gate(s) this build enables: the \
+             rejected cut falls back to a result with {pinned} unpaired edges \
+             against the default build's ~108. A different number means the gate \
+             or the fallback moved and the regression needs re-measuring, not \
+             re-pinning."
+        ),
+    }
     // The volume regression is the more serious half: the fallback does not
-    // merely re-fragment the surface, it removes ~25% more of the wall.
-    #[cfg(not(feature = "csg_manifold_gate"))]
-    assert!(vol > 30.0, "V5C under-cut: volume {vol:.3} m³ collapsed (was ~33.4)");
-    #[cfg(feature = "csg_manifold_gate")]
-    assert!(
-        (vol - 24.956).abs() < 0.01,
-        "known regression under csg_manifold_gate: the fallback leaves \
-         {vol:.3} m³ against the default build's ~33.4. A different number \
-         means the gate or the fallback moved and this needs re-measuring."
-    );
+    // merely re-fragment the surface, it removes a fifth to a quarter more of
+    // the wall. Every gated configuration regresses here, so every one is
+    // pinned.
+    match PINNED_VOLUME_M3 {
+        None => assert!(vol > 30.0, "V5C under-cut: volume {vol:.3} m³ collapsed (was ~33.4)"),
+        Some(pinned) => assert!(
+            (vol - pinned).abs() < 0.01,
+            "known regression under the accept gate(s) this build enables: the \
+             fallback leaves {vol:.3} m³ against the pinned {pinned:.3} m³ (the \
+             default build's ~33.4). A different number means the gate or the \
+             fallback moved and this needs re-measuring."
+        ),
+    }
 }

--- a/rust/geometry/tests/issue_960_segmented_roof_clip.rs
+++ b/rust/geometry/tests/issue_960_segmented_roof_clip.rs
@@ -114,16 +114,18 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
         );
 
         let (mn, mx) = mesh.bounds();
-        // #3440: under `csg_manifold_gate` the accept seam rejects the roof
-        // clip's kernel result on ONE of these five walls and the chain falls
-        // back, regrowing the very seam sliver this test exists to catch.
-        // Measured: #2152 goes to 9850 mm against its 7325 mm bar; the other
-        // four are unchanged to the millimetre. So the feature build keeps the
-        // real bar for the four and pins the fifth at its regressed value -
-        // green, but failing the moment either number moves. The thing to fix
-        // is the FALLBACK path (the #635 AABB box-cut the chain reaches when
-        // the exact clip is discarded); when it is, this branch goes.
-        #[cfg(feature = "csg_manifold_gate")]
+        // #3440/#3871: under either accept gate (`csg_manifold_gate`,
+        // `csg_topology_gate`) the accept seam rejects the roof clip's kernel
+        // result on ONE of these five walls and the chain falls back, regrowing
+        // the very seam sliver this test exists to catch. Measured: #2152 goes
+        // to 9850 mm against its 7325 mm bar under each gate alone and under
+        // both together; the other four are unchanged to the millimetre. So a
+        // gated build keeps the real bar for the four and pins the fifth at its
+        // regressed value - green, but failing the moment either number moves.
+        // The thing to fix is the FALLBACK path (the #635 AABB box-cut the
+        // chain reaches when the exact clip is discarded); when it is, this
+        // branch goes.
+        #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
         let want_zmax = if id == 2152 { 9850.0 } else { want_zmax };
         // The message is feature-split too. On the default build 9850 mm is the
         // FAILURE this test exists to catch; under `csg_manifold_gate` it is the


### PR DESCRIPTION
## Summary

Stacked on #3870; retarget to main once that lands.

Neither `csg_manifold_gate` nor `csg_topology_gate` was built by any workflow, so the feature-gated accept gates, their tests and the census could rot with no signal (#3871).

- The topology gate's three red targets (`geometry_correctness_harness`, `issue_098_v5c`, `issue_960_segmented_roof_clip`, inherited from #3717) are pinned under that feature the way #3870 pinned the manifold gate's. Measuring the combined build showed #3870's single manifold arm is wrong when both gates are on (the two gates reject different hosts: `reveal_wall` 352 vs 380, `v5c` 552 vs 416), so the pins are cfg-selected per feature combination, `None` where the real bar still holds (topology-only `reveal_wall` at 22 is better than the default's 42 and keeps its bar). The harness's snapshot early-return and `issue_960`'s override widened to either gate; the hard invariants still run in every build.
- New non-required `csg-accept-gates` job in test.yml, gated on the geometry path filter: clippy `-D warnings` and `cargo test -p ifc-lite-geometry --no-fail-fast` for the manifold gate, the topology gate, and both together (the third leg is the only thing that visits the combined pins). Absent from the aggregate's `needs` and results map; `pr-review-signal` derives its lane set from presence, not success.

Closes #3871

## Verification

- `cargo test -p ifc-lite-geometry` exit 0 for all four feature combinations; clippy `-D warnings` clean for all four; ratchet 6/6; `check-ci-path-coverage` (100 gates, 33 PR jobs) and `check-test-wiring` exit 0. Mutation-checked: flipping the combined `v5c` pin 552 to 553 fails.
- No changeset: tests and CI only (#3870 carries the feature's changeset).