### PR TITLE
fix(core,server): report when scanning stops on malformed input

### DIFF
--- a/apps/server/src/routes/parse/json.rs
+++ b/apps/server/src/routes/parse/json.rs
@@ -202,6 +202,14 @@ pub async fn parse_metadata(
             }
         }
 
+        // Report any scan diagnostics (oversized ids, malformed records) so
+        // truncated or corrupted files don't silently come back short
+        // (issue #3791).
+        ifc_lite_core::parser::report_scan_diagnostics(
+            scanner.skipped_oversized_ids(),
+            scanner.malformed_record_start().is_some(),
+        );
+
         let schema_version = detect_schema_version(&content);
 
         (

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -178,7 +178,10 @@ impl ColumnarEntityIndex {
             starts.push(start as u32);
             lengths.push((end - start) as u32);
         }
-        crate::parser::report_oversized_ids(scanner.skipped_oversized_ids());
+        crate::parser::report_scan_diagnostics(
+            scanner.skipped_oversized_ids(),
+            scanner.malformed_record_start().is_some(),
+        );
         Self::from_unsorted(ids, starts, lengths)
     }
 

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -8,7 +8,7 @@
 
 use crate::columnar_index::EntityIndexStore;
 use crate::error::{Error, Result};
-use crate::parser::{parse_entity, report_oversized_ids, EntityScanner};
+use crate::parser::{parse_entity, EntityScanner};
 use crate::schema_gen::{AttributeValue, DecodedEntity};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
@@ -36,7 +36,10 @@ where
     while let Some((id, _type_name, start, end)) = scanner.next_entity() {
         index.insert(id, (start, end));
     }
-    report_oversized_ids(scanner.skipped_oversized_ids());
+    crate::parser::report_scan_diagnostics(
+        scanner.skipped_oversized_ids(),
+        scanner.malformed_record_start().is_some(),
+    );
     index
 }
 

--- a/rust/core/src/parser/malformed_records.rs
+++ b/rust/core/src/parser/malformed_records.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The one place Rust reports that a scan encountered a malformed record
+//! (unterminated string or comment) and stopped (issue #3791).
+//!
+//! [`EntityScanner`](super::EntityScanner) stops scanning when it encounters
+//! an unterminated string literal or comment, recording the byte offset in
+//! [`malformed_record_start`](super::EntityScanner::malformed_record_start).
+//! Unlike oversized ids (which are skipped), a malformed record leaves no safe
+//! byte to resume from — every entity after that break is dropped silently
+//! without this diagnostic.
+//!
+//! This module provides the report infrastructure, mirroring the pattern from
+//! [`crate::parser::oversized_ids`].
+
+/// The one-line report for a malformed record, or `None` if the scan
+/// encountered no malformed input.
+///
+/// Exposed separately from [`report_malformed_records`] so a host that already
+/// has a place to put the text (the wasm bindings, for instance) emits the
+/// same sentence rather than writing a second one.
+pub fn malformed_record_report(malformed: bool) -> Option<String> {
+    if !malformed {
+        return None;
+    }
+    Some(
+        "scan: stopped early — a string literal or comment never closed; \
+         the entities returned may be an incomplete view of this file"
+            .to_string(),
+    )
+}
+
+/// Emit [`malformed_record_report`] to stderr if `malformed` is true.
+///
+/// A no-op when `malformed == false`, so a caller can hand it
+/// `scanner.malformed_record_start().is_some()` unconditionally.
+pub fn report_malformed_records(malformed: bool) {
+    let Some(message) = malformed_record_report(malformed) else {
+        return;
+    };
+    eprintln!("[ifc-lite] {message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_is_none_when_no_malformed_record() {
+        assert_eq!(malformed_record_report(false), None);
+    }
+
+    #[test]
+    fn report_names_the_stop_condition_when_malformed() {
+        let message = malformed_record_report(true).expect("malformed=true must produce a report");
+        assert!(
+            message.contains("stopped early"),
+            "report must indicate the scan stopped: {message}"
+        );
+        assert!(
+            message.contains("string literal") || message.contains("comment"),
+            "report must name the kind of malformation: {message}"
+        );
+    }
+}

--- a/rust/core/src/parser/mod.rs
+++ b/rust/core/src/parser/mod.rs
@@ -17,11 +17,22 @@
 //! unterminated comment mean" differently gives the same answer (#3303).
 
 mod lexical;
+mod malformed_records;
 mod oversized_ids;
 mod scanner;
 mod tokenizer;
 
 pub use lexical::skip_step_comment;
+pub use malformed_records::{malformed_record_report, report_malformed_records};
 pub use oversized_ids::{oversized_id_report, report_oversized_ids, set_report_sink};
 pub use scanner::{entity_count, EntityScanner};
 pub use tokenizer::{parse_entity, Token};
+
+/// Report both oversized-id refusals and malformed-record stops from a scan.
+/// A convenience combining [`report_oversized_ids`] and
+/// [`report_malformed_records`] for the many call sites that scan and then
+/// report both diagnostics unconditionally.
+pub fn report_scan_diagnostics(oversized_count: usize, has_malformed: bool) {
+    report_oversized_ids(oversized_count);
+    report_malformed_records(has_malformed);
+}

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -20,6 +20,12 @@ pub struct EntityScanner<'a> {
     /// [`Self::skipped_oversized_id_starts`]. It never allocates on a file
     /// with nothing to refuse, which is every real file.
     skipped_oversized_id_starts: Vec<usize>,
+    /// Byte offset where a malformed record (unterminated string or comment)
+    /// was encountered, if any. Once set, the scan is terminal — `next_entity`
+    /// will return `None` on every subsequent call. This is the companion to
+    /// `skipped_oversized_id_starts`: oversized ids are skipped and the scan
+    /// resumes, but malformed input leaves no safe resume point.
+    malformed_record_start: Option<usize>,
 }
 
 impl<'a> EntityScanner<'a> {
@@ -38,6 +44,7 @@ impl<'a> EntityScanner<'a> {
             bytes,
             position: data_section_start(bytes),
             skipped_oversized_id_starts: Vec::new(),
+            malformed_record_start: None,
         }
     }
 
@@ -61,6 +68,7 @@ impl<'a> EntityScanner<'a> {
             bytes,
             position: clamped,
             skipped_oversized_id_starts: Vec::new(),
+            malformed_record_start: None,
         }
     }
 
@@ -97,6 +105,13 @@ impl<'a> EntityScanner<'a> {
     /// retained from that shard (issue #3395/#3430).
     pub fn skipped_oversized_id_starts(&self) -> &[usize] {
         &self.skipped_oversized_id_starts
+    }
+
+    /// Byte offset where the scan encountered a malformed record
+    /// (unterminated string or comment), if any. The scan is terminal once
+    /// this is set — no more entities are returned after this point.
+    pub fn malformed_record_start(&self) -> Option<usize> {
+        self.malformed_record_start
     }
 
     /// Scan for the next entity
@@ -157,8 +172,18 @@ impl<'a> EntityScanner<'a> {
                         // than silently consuming the rest of the file — see
                         // its doc comment for why that's the right call for a
                         // scanner (issue #3303).
-                        self.position = super::lexical::skip_step_comment(bytes, candidate)?;
-                        continue;
+                        match super::lexical::skip_step_comment(bytes, candidate) {
+                            Some(pos) => {
+                                self.position = pos;
+                                continue;
+                            }
+                            None => {
+                                // Unterminated comment before any entity. Mark
+                                // malformed and end scan (issue #3791, #3781).
+                                self.malformed_record_start = Some(candidate);
+                                return None;
+                            }
+                        }
                     }
                     // Lone '/' — not a comment. Skip past.
                     self.position = candidate + 1;
@@ -194,7 +219,19 @@ impl<'a> EntityScanner<'a> {
             // Find the end of the entity (semicolon) while respecting quoted strings
             // IFC strings use single quotes and can contain semicolons
             let line_content = &bytes[line_start..];
-            let end_offset = self.find_entity_end(line_content)?;
+            let end_offset = match self.find_entity_end(line_content) {
+                Some(offset) => offset,
+                None => {
+                    // An unterminated string or comment left the record with no
+                    // terminator. Mark this as malformed and end the scan — there
+                    // is no safe byte to resume from after an unterminated quote
+                    // or comment (issue #3791, #3781). The malformed_record_start
+                    // is already `None` here (the first malformation ends the scan),
+                    // so this assignment is only ever made once per scan.
+                    self.malformed_record_start = Some(line_start);
+                    return None;
+                }
+            };
             let line_end = line_start + end_offset + 1;
 
             // Parse entity ID — digit range already validated in the candidate loop.

--- a/rust/core/src/parser/scanner_tests.rs
+++ b/rust/core/src/parser/scanner_tests.rs
@@ -429,3 +429,35 @@ fn entity_scanner_does_not_treat_a_form_feed_inside_a_string_as_trivia() {
     assert_eq!(type_name, "IFCWALL");
     assert_eq!(&content[start..end], content);
 }
+
+/// An unterminated string literal causes the scan to stop at that entity and
+/// mark it as malformed (issue #3791). The scan returns None and
+/// `malformed_record_start()` reports the byte offset.
+#[test]
+fn entity_scanner_stops_on_unterminated_string() {
+    let content = "DATA;\n#1=IFCWALL('valid',$);\n#2=IFCDOOR('unterminated,;";
+    let mut scanner = EntityScanner::new(content);
+    // First entity parses fine
+    let (id1, type1, _, _) = scanner.next_entity().unwrap();
+    assert_eq!(id1, 1);
+    assert_eq!(type1, "IFCWALL");
+    // Second entity has unterminated string, scan stops
+    assert!(scanner.next_entity().is_none());
+    // malformed_record_start points to the start of #2
+    assert!(scanner.malformed_record_start().is_some());
+}
+
+/// An unterminated comment causes the scan to stop and mark it as malformed
+/// (issue #3791).
+#[test]
+fn entity_scanner_stops_on_unterminated_comment() {
+    let content = "DATA;\n#1=IFCWALL('a',$);\n#2=IFCDOOR('b',/* never closes;";
+    let mut scanner = EntityScanner::new(content);
+    // First entity parses fine
+    let (id1, _, _, _) = scanner.next_entity().unwrap();
+    assert_eq!(id1, 1);
+    // Second entity has unterminated comment, scan stops
+    assert!(scanner.next_entity().is_none());
+    // malformed_record_start is set
+    assert!(scanner.malformed_record_start().is_some());
+}

--- a/rust/core/src/streaming.rs
+++ b/rust/core/src/streaming.rs
@@ -166,6 +166,13 @@ impl<'a> ParserState<'a> {
             let Some((id, type_name, start, _end)) = self.scanner.next_entity() else {
                 // No more entities - emit Completed event and end stream
                 self.completed = true;
+                // Report any scan diagnostics (oversized ids, malformed records)
+                // before the Completed event so they appear in the logs in order
+                // (issue #3791).
+                crate::parser::report_scan_diagnostics(
+                    self.scanner.skipped_oversized_ids(),
+                    self.scanner.malformed_record_start().is_some(),
+                );
                 let duration_ms = get_timestamp() - self.start_time;
                 return Some(ParseEvent::Completed {
                     duration_ms,


### PR DESCRIPTION
## Summary

Scanning entities without reporting when a truncated download, failed export, or lossy round-trip leaves an unterminated string or comment mid-file makes the model come back quietly short and indistinguishable from a legitimately short file. This PR adds malformed-record tracking and reporting to all entity-scan entry points.

## Changes

- Add `malformed_record_start: Option<usize>` field to EntityScanner to track where unterminated input occurred
- New `parser::malformed_records` module for diagnostic reporting
- New `parser::report_scan_diagnostics()` combining oversized-id and malformed-record reporting
- Wire diagnostics into streaming.rs, server parse/json, columnar_index, and decoder

## Verification

RED: fixture with unterminated string mid-file returns shorter entity refs with zero diagnostic
GREEN: same fixture now reports malformed diagnostic
CONTROL: valid file still produces no extra diagnostic

Closes #3791