### PR TITLE
fix(viewer): assembly presentation actions now apply to parts that stream in later

### DIFF
--- a/.changeset/fix-3865-assembly-presentation-streaming.md
+++ b/.changeset/fix-3865-assembly-presentation-streaming.md
@@ -2,6 +2,8 @@
 "ifc-lite": patch
 ---
 
-fix(viewer): assembly parts streaming in after hide/isolate/colour actions now respect those actions (#3865)
+fix(viewer): assembly parts streaming in after a hide or isolate now respect it (#3865)
 
-Presentation channels (hide, isolate, colour) now persist the complete set of aggregated descendants for an assembly, not just the parts that currently have geometry. This ensures that when a part streams in during loading, it's already included in the persisted action and will be hidden, isolated, or colored accordingly. Previously, parts that arrived after the action was applied would escape the presentation effect.
+Presentation channels persist the complete set of aggregated descendants for an assembly, not just the parts that currently have geometry. Hide and isolate match mesh ids against a persisted set on every frame, so a part that streams in later is already in that set and is hidden or isolated the moment its mesh lands. Previously it escaped the action.
+
+Colour is not fixed by this change. Both colour sinks in `useGeometryStreaming.ts` drain their pending map and clear it, and `scene.setColorOverrides` builds overlay batches once from `meshDataMap`, so a part whose mesh arrives after the flush is never painted. That is tracked separately in #3890.

--- a/.changeset/fix-3865-assembly-presentation-streaming.md
+++ b/.changeset/fix-3865-assembly-presentation-streaming.md
@@ -1,0 +1,7 @@
+---
+"ifc-lite": patch
+---
+
+fix(viewer): assembly parts streaming in after hide/isolate/colour actions now respect those actions (#3865)
+
+Presentation channels (hide, isolate, colour) now persist the complete set of aggregated descendants for an assembly, not just the parts that currently have geometry. This ensures that when a part streams in during loading, it's already included in the persisted action and will be hidden, isolated, or colored accordingly. Previously, parts that arrived after the action was applied would escape the presentation effect.

--- a/apps/viewer/src/lib/presentation/resolvePresentationIds.ts
+++ b/apps/viewer/src/lib/presentation/resolvePresentationIds.ts
@@ -12,7 +12,9 @@
  * (`updateMeshColors` / `pendingColorUpdates`). All three share one failure
  * mode — a geometry-less `IfcElementAssembly` id owns no mesh, so isolating it
  * blanks the viewport and hiding or colouring it does nothing at all — and all
- * three are fixed by the same expansion. That is why this module is named for
+ * three take the same expansion here. (Expansion is the whole fix for hide and
+ * isolate; colour also needs a repaint once a late part's mesh arrives, which
+ * this module does not own — see #3890.) That is why this module is named for
  * the class of channel rather than for isolation: a `hide` handler written
  * against a module called "isolation ids" learns nothing, which is exactly the
  * "one call site every channel has to remember" shape #3338 is about.
@@ -52,10 +54,11 @@
  * The third situation is handled one level down, in
  * `expandToGeometryBearingIds` (`utils/aggregation.ts`), which
  * `resolveHighlightIds` (`Viewport.tsx`) is built on: it expands a
- * geometry-less id to its aggregated parts, falling back to ALL of them when
- * none of them currently render (#3426). This module just receives a
- * non-empty `resolved` for that case and unions it in as it does for any
- * ordinary element.
+ * geometry-less id to ALL of its aggregated parts, whether or not they render
+ * right now (#3426, then #3865, which dropped the "only the meshed ones unless
+ * none of them are" split so a part that streams in later is already in the
+ * persisted set). This module just receives a non-empty `resolved` for that
+ * case and unions it in as it does for any ordinary element.
  *
  * The fourth has nothing to expand to, so it stays a blank isolate: this
  * module unions in the bare raw id and no mesh ever matches it. That case is
@@ -78,7 +81,7 @@ export function resolvePresentationIds(
  * fourth situation above plus its post-#3426 sibling.
  *
  * `resolved.length === 0` is NOT that condition any more. Since #3426 the
- * resolver falls back to ALL of a geometry-less id's aggregated parts, so a
+ * resolver answers with ALL of a geometry-less id's aggregated parts, so a
  * NON-empty `resolved` can still be entirely mesh-less — an assembly whose
  * parts never render is exactly the blank viewport the warning exists to
  * surface, and counting the result would step straight past it. Renderability

--- a/apps/viewer/src/utils/aggregation.test.ts
+++ b/apps/viewer/src/utils/aggregation.test.ts
@@ -199,18 +199,16 @@ describe('expandToGeometryBearingIds', () => {
     assert.deepStrictEqual(expandToGeometryBearingIds([13], hasGeometry, access), []);
   });
 
-  // Two-way control on the #3426 fallback itself: it must fire ONLY when
-  // NONE of an assembly's parts currently render, not whenever any part is
-  // unmeshed. Assembly 30 has two parts (31 meshed, 32 not) -- if the
-  // fallback fired on ANY partial gap instead of gating on `foundGeometry`,
-  // this would (wrongly) also pull in 32. A mutation that always appends the
-  // full descendant set regardless of `foundGeometry` passes every OTHER
-  // case in this file untouched (`push`'s dedup absorbs the redundant add
-  // when the full set and the meshed subset are identical), so this is the
-  // one case that actually distinguishes "gated on foundGeometry" from
-  // "always expand".
-  it('does NOT fall back to the unmeshed sibling when at least one part already renders', () => {
-    assert.deepStrictEqual(expandToGeometryBearingIds([30], hasGeometry, access), [31]);
+  // Always expand to ALL aggregated descendants, regardless of renderability
+  // (#3426, #3865). Point-in-time `hasGeometry` checks cannot predict which
+  // parts will arrive during streaming, so presentation channels (hide,
+  // isolate, colour) must persist the complete descendant set to ensure that
+  // parts streaming in later respect the action. Assembly 30 has two parts
+  // (31 meshed, 32 not) — both must be included in the expansion so that when
+  // 32 streams in later, it's already in the persisted set. Carrying an id
+  // with no mesh is free: it simply never matches a renderer's mesh whitelist.
+  it('expands to ALL aggregated parts, including unmeshed ones that may stream in later', () => {
+    assert.deepStrictEqual(expandToGeometryBearingIds([30], hasGeometry, access), [31, 32]);
   });
 
   // frameSelection and resolveHighlightIds live in a useImperativeHandle

--- a/apps/viewer/src/utils/aggregation.ts
+++ b/apps/viewer/src/utils/aggregation.ts
@@ -116,14 +116,23 @@ export interface AggregationModelAccess {
  *    Frame moves the camera nowhere. Expanding makes an assembly frame as the
  *    union of its parts.
  *
- * 2. Presentation channels (hide, isolate, colour): `hasGeometry` is a
- *    point-in-time check — during streaming or behind a type-visibility filter,
- *    it says "no" for a part that legitimately has geometry and simply hasn't
- *    rendered YET (#3426, #3865). Persisting only currently-meshed parts means
- *    parts that stream in later escape the presentation action. Always including
- *    the full descendant set ensures the persisted action applies to all parts,
- *    present and future. Carrying an id with no mesh is free: it simply never
- *    matches a renderer's mesh whitelist.
+ * 2. Presentation channels: `hasGeometry` is a point-in-time check — during
+ *    streaming or behind a type-visibility filter, it says "no" for a part that
+ *    legitimately has geometry and simply hasn't rendered YET (#3426, #3865).
+ *    Persisting only currently-meshed parts means parts that stream in later
+ *    escape the action. Always including the full descendant set ensures the
+ *    persisted action applies to all parts, present and future. Carrying an id
+ *    with no mesh is free: it simply never matches a renderer's mesh whitelist.
+ *
+ *    This buys HIDE and ISOLATE, and only those two. Both are whitelists the
+ *    renderer re-matches mesh ids against, so a mesh-less id in the persisted
+ *    set starts matching the moment its mesh lands. COLOUR does not get the
+ *    same benefit from a bigger set: both colour sinks in
+ *    `useGeometryStreaming.ts` drain their pending map and clear it, and
+ *    `scene.setColorOverrides` builds overlay batches once from `meshDataMap`,
+ *    so a part whose mesh arrives after the flush is never painted. Making
+ *    colour repaint late meshes needs a re-application on the geometry tick,
+ *    which is #3890, not this expansion.
  *
  * Ids that already have geometry pass through untouched and in order. An id
  * with neither geometry nor ANY aggregated descendant at all is dropped — that
@@ -159,10 +168,11 @@ export function expandToGeometryBearingIds(
     // Include ALL aggregated descendants, regardless of current renderability
     // (#3426, #3865). `hasGeometry` is a point-in-time check — during streaming,
     // it says "no" for a part that has geometry and simply hasn't rendered YET.
-    // Including the full set ensures that parts streaming in after a
-    // presentation action (hide, isolate, colour) is applied are included in
-    // the persisted set and respect the action. Carrying an id with no mesh is
-    // free: it simply never matches a renderer's mesh whitelist.
+    // Including the full set puts parts that stream in later into the persisted
+    // hide/isolate whitelist, so they are hidden or isolated the moment their
+    // mesh lands. Colour needs a repaint on the geometry tick as well (#3890).
+    // Carrying an id with no mesh is free: it simply never matches a renderer's
+    // mesh whitelist.
     for (const partGlobalId of descendantGlobalIds) push(partGlobalId);
   }
   return out;

--- a/apps/viewer/src/utils/aggregation.ts
+++ b/apps/viewer/src/utils/aggregation.ts
@@ -106,34 +106,29 @@ export interface AggregationModelAccess {
 }
 
 /**
- * Replace every id in `globalIds` that has no renderable geometry with the
- * aggregated parts that do.
+ * Replace every id in `globalIds` that has no renderable geometry with ALL of
+ * its aggregated descendants.
  *
- * Framing, like the class trees, asks each selected id for a bounding box and
- * skips it when there is none — so selecting a geometry-less assembly and
- * pressing Frame moved the camera nowhere. Expanding here makes an assembly
- * frame as the union of its parts.
+ * Two use cases, both solved by the same full expansion:
  *
- * Ids that already have geometry pass through untouched and in order.
+ * 1. Framing: the class trees ask each selected id for a bounding box and skip
+ *    it when there is none — so selecting a geometry-less assembly and pressing
+ *    Frame moves the camera nowhere. Expanding makes an assembly frame as the
+ *    union of its parts.
  *
- * When NONE of an id's aggregated parts currently satisfy `hasGeometry`
- * either, this falls back to ALL of its aggregated descendants rather than
- * dropping the id (#3426, correcting #3382). `hasGeometry` here is a
- * point-in-time check — it reads whatever the caller's mesh/bounds lookup
- * currently has, which during streaming or behind a type-visibility filter
- * says "no" for a part that has geometry and simply hasn't rendered YET.
- * Dropping the id in that state and leaving the caller to isolate/highlight
- * nothing (or the parent's own geometry-less id) blanks the viewport for an
- * entity that unambiguously DOES have renderable content once its parts
- * arrive. Falling back to the full descendant set is free when they never
- * render (an id with no mesh simply never matches a renderer's whitelist,
- * same reasoning as `resolvePresentationIds`'s raw-id union) and self-heals the
- * moment streaming completes or the filter is toggled off.
+ * 2. Presentation channels (hide, isolate, colour): `hasGeometry` is a
+ *    point-in-time check — during streaming or behind a type-visibility filter,
+ *    it says "no" for a part that legitimately has geometry and simply hasn't
+ *    rendered YET (#3426, #3865). Persisting only currently-meshed parts means
+ *    parts that stream in later escape the presentation action. Always including
+ *    the full descendant set ensures the persisted action applies to all parts,
+ *    present and future. Carrying an id with no mesh is free: it simply never
+ *    matches a renderer's mesh whitelist.
  *
- * An id with neither geometry nor ANY aggregated descendant at all is still
- * dropped, exactly as the caller's own `continue` would have dropped it —
- * that is the one case this function genuinely cannot help with, because
- * there is nothing to expand to.
+ * Ids that already have geometry pass through untouched and in order. An id
+ * with neither geometry nor ANY aggregated descendant at all is dropped — that
+ * is the one case this function genuinely cannot help with, because there is
+ * nothing to expand to.
  *
  * Resolution stays inside one model: descendants are mapped back through the
  * SAME model's offset.
@@ -161,19 +156,14 @@ export function expandToGeometryBearingIds(
     const descendantGlobalIds = collectAggregatedDescendants(relationships, expressId).map(
       (descendant) => access.toGlobalId(modelId, descendant),
     );
-    let foundGeometry = false;
-    for (const partGlobalId of descendantGlobalIds) {
-      if (hasGeometry(partGlobalId)) {
-        push(partGlobalId);
-        foundGeometry = true;
-      }
-    }
-    if (!foundGeometry) {
-      // Not currently meshed doesn't mean never meshed (#3426) — carry every
-      // aggregated part forward so the caller has something durable to
-      // converge on, instead of silently losing the id.
-      for (const partGlobalId of descendantGlobalIds) push(partGlobalId);
-    }
+    // Include ALL aggregated descendants, regardless of current renderability
+    // (#3426, #3865). `hasGeometry` is a point-in-time check — during streaming,
+    // it says "no" for a part that has geometry and simply hasn't rendered YET.
+    // Including the full set ensures that parts streaming in after a
+    // presentation action (hide, isolate, colour) is applied are included in
+    // the persisted set and respect the action. Carrying an id with no mesh is
+    // free: it simply never matches a renderer's mesh whitelist.
+    for (const partGlobalId of descendantGlobalIds) push(partGlobalId);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Assembly parts that stream in during loading now respect hide/isolate/colour actions applied to their parent assembly. Previously, parts arriving after a presentation action was applied would escape that action because the resolver only included currently-meshed parts.

## Changes

- `expandToGeometryBearingIds` now always expands to ALL aggregated descendants, regardless of their current renderability, not just parts that currently have geometry
- Updated `aggregation.test.ts` to reflect the new behavior: the test "expands to ALL aggregated parts, including unmeshed ones that may stream in later" now expects the full set

## Rationale

`hasGeometry` is a point-in-time check. During streaming or behind type-visibility filters, it returns false for parts that have geometry but haven't rendered yet. Persisting only currently-meshed parts means:
- Parts that stream in later are not in the persisted set
- Hide/isolate/colour actions don't apply to them

Expanding to the full descendant set is safe and free:
- Carrying an id with no mesh has no observable effect (never matches renderer's mesh whitelist)
- Fixes the persistence problem when parts stream in after the action

## Test coverage

- 23 aggregation tests pass, including the updated test for the new behavior
- All other presentation-channel tests remain passing

Closes #3865