### PR TITLE
chore(rust): re-measure router/diagnostics.rs, grown to 595 lines by #3863 without a row update

### DIFF
--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -174,7 +174,7 @@
      706 rust/geometry/src/profiles/simplify.rs
 # +26: cap the fast-path opening count (O(N^3) DoS guard) + regression test.
      807 rust/geometry/src/rect_fast.rs
-     586 rust/geometry/src/router/diagnostics.rs
+     595 rust/geometry/src/router/diagnostics.rs
 # +26: #2866 — item_has_identity_position chases IfcBooleanResult.FirstOperand,
 # a file-supplied reference, so one self-referential entity aborted the process
 # (stack overflow = abort in Rust, not a catchable panic). The walk is now

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 7194159970789730787),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 5850574697340138616),
+    ("rust/geometry", 2973351381616537576),
     ("rust/processing", 7633784028779437211),
     ("rust/wasm-bindings", 11372642225568989008),
 ];


### PR DESCRIPTION
## Summary

The Rust module-size ratchet (`cargo test -p ifc-lite-processing --test module_size_ratchet`) is red on main: #3863 (cb8719878) added `skip_serializing_if` attributes and a test to `rust/geometry/src/router/diagnostics.rs`, taking it from 586 to 595 lines, and the merge driver checked only the TS gate. This sets the row to the measured count and re-pins the `rust/geometry` digest as the test's own message directs.

## Verification

- `cargo test -p ifc-lite-processing --test module_size_ratchet`: 6/6 pass on this branch; `allowlist_digest_is_pinned` and `no_module_grows_past_its_ratchet_budget` both fail on main.
- Diff: one row and one digest pin.