### PR TITLE
fix(ci): the label enforcer 403s on pull requests and folds a bot onto its maintainer

### DIFF
--- a/.github/workflows/label-authority.yml
+++ b/.github/workflows/label-authority.yml
@@ -16,7 +16,21 @@ on:
 
 permissions:
   contents: read
+  # BOTH SCOPES, and `pull-requests: write` is not redundant with `issues:
+  # write`. Measured on this repo 2026-08-31: `issues: write` alone returns 403
+  # when the target is a PULL REQUEST, on the REST
+  # `DELETE /repos/{o}/{r}/issues/{n}/labels/{name}` endpoint this script uses
+  # as well as through GraphQL. A label is an issue resource; a pull request is
+  # not enough of an issue for it. GitHub's
+  # `x-accepted-github-permissions: issues=write; pull_requests=write` reads
+  # like OR and does not behave like it.
+  #
+  # This matters most where the job matters most: `escapeLabel` (`unqueued`) is
+  # applied to PULL REQUESTS to waive the queue, so without this line the
+  # enforcer 403s on precisely the label with the highest blast radius, reports
+  # REMOVE_FAILED, and leaves the label attached.
   issues: write
+  pull-requests: write
 
 concurrency:
   group: label-authority-${{ github.event.issue.number || github.event.pull_request.number }}

--- a/scripts/enforce-pipeline-labels.mjs
+++ b/scripts/enforce-pipeline-labels.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from './lib/is-main-entry.mjs';
-import { normaliseLogin, readConfig } from './check-issue-queue.mjs';
+import { normaliseLogin, readConfig, IssueQueueError } from './check-issue-queue.mjs';
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CONFIG = join(ROOT, 'issue-queue.config.json');
@@ -24,6 +24,26 @@ export class LabelAuthorityError extends Error {
     this.name = 'LabelAuthorityError';
     this.reason = reason;
   }
+}
+
+/**
+ * Is this sender an app rather than the person of the same name?
+ *
+ * `normaliseLogin` folds `app/x`, `x[bot]` and `x` onto one key, which is what
+ * identifying dependabot across three APIs needs and the opposite of what an
+ * authority lookup needs: an app whose slug matches a login in
+ * `labelAuthorities` would fold onto that login and inherit the authority to
+ * steer the queue. So the fold stays for case, and a bot-shaped sender is
+ * refused before the lookup, whatever it folds to.
+ *
+ * Any of the three spellings is enough. Requiring all three would mean a
+ * spelling this repo has not seen yet reads as human.
+ */
+function isBotSender(sender) {
+  if (!sender || typeof sender !== 'object') return false;
+  if (sender.type === 'Bot') return true;
+  const login = typeof sender.login === 'string' ? sender.login.trim() : '';
+  return /\[bot\]$/i.test(login) || /^app\//i.test(login);
 }
 
 export function decideLabelEvent(payload, cfg) {
@@ -57,7 +77,7 @@ export function decideLabelEvent(payload, cfg) {
       `Protected label ${JSON.stringify(canonical)} was applied without a readable sender.`,
     );
   }
-  if (cfg.labelAuthorities.has(sender)) {
+  if (!isBotSender(payload.sender) && cfg.labelAuthorities.has(sender)) {
     return { action: 'keep', label: canonical, sender };
   }
 
@@ -128,7 +148,12 @@ export function enforceLabelEvent(payload, { cfg, repo, spawn = spawnSync }) {
 function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) throw new LabelAuthorityError('BAD_EVENT', 'GITHUB_EVENT_PATH is unset.');
-  const payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch (error) {
+    throw new LabelAuthorityError('BAD_EVENT', `Could not read the webhook payload at ${eventPath}: ${error.message}`);
+  }
   const cfg = readConfig(DEFAULT_CONFIG);
   const decision = enforceLabelEvent(payload, {
     cfg,
@@ -152,7 +177,13 @@ if (isMainEntry(import.meta.url)) {
   try {
     main();
   } catch (error) {
-    if (error instanceof LabelAuthorityError) {
+    // BOTH ERROR CLASSES. The config is read through the queue gate's own
+    // `readConfig`, so it throws IssueQueueError, not this file's error.
+    // Guarding on one class left the single most likely failure -- a typo in
+    // the one config file both halves read -- escaping as an uncaught stack
+    // trace, which reads as a crashed removal rather than a config nobody can
+    // parse. Both carry `.reason`, so the same line formats both.
+    if (error instanceof LabelAuthorityError || error instanceof IssueQueueError) {
       console.error(`❌ ${error.reason}: ${error.message}`);
       process.exit(1);
     }

--- a/scripts/enforce-pipeline-labels.test.mjs
+++ b/scripts/enforce-pipeline-labels.test.mjs
@@ -3,7 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { decideLabelEvent, enforceLabelEvent, LabelAuthorityError } from './enforce-pipeline-labels.mjs';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'enforce-pipeline-labels.mjs');
 
 const cfg = {
   readyLabel: 'ready',
@@ -83,6 +90,25 @@ test('the guard cannot silently survive its authority policy being disabled', ()
   );
 });
 
+test('#3876: an app spelling of an authority login does not inherit its authority', () => {
+  // normaliseLogin folds `app/x`, `x[bot]` and `x` onto one key, so without a
+  // separate bot check every one of these reads as the maintainer and the
+  // label stays attached. Asserted per spelling: one shared assertion would
+  // pass while two of the three still folded through.
+  for (const login of ['louistrue[bot]', 'LOUISTRUE[BOT]', 'app/louistrue']) {
+    const decision = decideLabelEvent(event('ready', login, 73), cfg);
+    assert.equal(decision.action, 'remove', `${login} must not be treated as the maintainer`);
+  }
+  // `sender.type` alone is enough, even when the login carries no bot spelling.
+  assert.equal(
+    decideLabelEvent({ ...event('ready', 'louistrue', 73), sender: { login: 'louistrue', type: 'Bot' } }, cfg).action,
+    'remove',
+  );
+  // The human of that name is still an authority. Without this the test above
+  // would also pass with the authority lookup deleted outright.
+  assert.equal(decideLabelEvent(event('ready', 'louistrue', 73), cfg).action, 'keep');
+});
+
 test('a removal API failure is visible and never reported as enforcement', () => {
   let calls = 0;
   assert.throws(
@@ -98,4 +124,31 @@ test('a removal API failure is visible and never reported as enforcement', () =>
     }),
     (error) => error instanceof LabelAuthorityError && error.reason === 'REMOVE_FAILED' && /forbidden/.test(error.message),
   );
+});
+
+test('#3876: an unreadable payload exits with a reason, not a stack trace', () => {
+  // The `❌ REASON: message` handler is the only thing a maintainer reads in
+  // the run log. An unwrapped JSON.parse threw a raw SyntaxError past it, so
+  // the most likely operator error printed a Node stack trace and looked like
+  // a crashed removal rather than an input nobody can parse.
+  const dir = mkdtempSync(join(tmpdir(), 'label-authority-'));
+  try {
+    const eventPath = join(dir, 'event.json');
+    writeFileSync(eventPath, 'not json at all');
+
+    const r = spawnSync(process.execPath, [SCRIPT], {
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_EVENT_PATH: eventPath, GITHUB_REPOSITORY: 'LTplus-AG/ifc-lite' },
+    });
+
+    assert.equal(r.status, 1);
+    assert.match(r.stderr, /BAD_EVENT/);
+    assert.match(r.stderr, /Could not read the webhook payload/);
+    // The point of the wrap: no stack frame reaches the log.
+    assert.doesNotMatch(r.stderr, /at ModuleJob\.run/, 'the error must not escape as an uncaught throw');
+  } finally {
+    // In a `finally`, so a failed assertion still cleans up rather than
+    // leaving a temp dir behind on every red CI run.
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Follow-up to #3877 (the enforcer that landed for #3876). Three defects in main's `scripts/enforce-pipeline-labels.mjs` and its workflow, found by auditing it against the second implementation that was written for the same issue and then dropped.

- **The workflow declared only `issues: write`.** On this repo that permission returns 403 on `DELETE /repos/{o}/{r}/issues/{n}/labels/{name}` when the labelled object is a pull request, and `unqueued` is applied to pull requests to waive the queue. The enforcer was inert exactly there: 403, `REMOVE_FAILED`, red run, label still attached. Adds `pull-requests: write`.
- **A bot spelling of a maintainer read as that maintainer.** `normaliseLogin` strips `app/` and `[bot]`, which is right for identifying dependabot and wrong for an authority lookup: `louistrue[bot]`, `LOUISTRUE[BOT]` and `app/louistrue` all returned `keep`. A bot-shaped sender (login spelling or `sender.type === 'Bot'`) is now refused before the lookup.
- **A broken `issue-queue.config.json` printed a raw stack trace.** `readConfig` throws `IssueQueueError` and the handler caught only `LabelAuthorityError`, so the most likely operator error skipped the `REASON:` line. Both classes are caught, and the webhook `JSON.parse` is wrapped.

Both code fixes are mutation-tested: reverting each fails exactly one test. Reviewed and deliberately not changed: `requireLabelAuthority: false` throws `BAD_CONFIG` here while the queue gate treats it as a stand-down; that is the author's tested choice and it fails safe, so it is flagged rather than churned.

Exit codes on the head: `node --test scripts/enforce-pipeline-labels.test.mjs` 0 (9 pass), check-module-size 0, check-test-wiring 0, check-ci-path-coverage 0.