### PR TITLE
fix(bcf): fit every box corner in the frustum instead of the largest side

### DIFF
--- a/.changeset/bcf-camera-corner-fit.md
+++ b/.changeset/bcf-camera-corner-fit.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Frame IDS report cameras from the box corners, not the largest side
+
+`computeCameraFromBounds` derived its standoff from the longest side of the
+entity bounds times a fixed factor. A side length is not what the projection
+sees: down the southeast-isometric axis the camera uses, a box projects wider
+than any of its sides, so the worst corner of a unit cube sat outside the
+frustum at 16/9 (vertical slope 0.837 against the tan(30 deg) = 0.577 limit)
+and outside it horizontally at 9/16 (0.344 against 0.325).
+
+The distance is now the smallest standoff that puts all eight corners inside
+both half-angles for the given field of view and aspect ratio, with the same
+1.5x padding on top. The view direction and up vector are unchanged. Cameras
+for boxes that were already cropped move further out; a landscape export of a
+cube frames exactly as a square one does.

--- a/packages/bcf/src/ids-camera.ts
+++ b/packages/bcf/src/ids-camera.ts
@@ -76,6 +76,100 @@ export function requireAspectRatioOption(aspectRatio: number): number {
   return aspectRatio;
 }
 
+type Vec3 = readonly [number, number, number];
+
+function dot(a: Vec3, b: Vec3): number {
+  return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+
+function cross(a: Vec3, b: Vec3): Vec3 {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+function normalize(v: Vec3): Vec3 {
+  const len = Math.sqrt(dot(v, v));
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+/**
+ * Slack left around the framed box, as a multiple of the fitted distance.
+ *
+ * The fit below puts the worst corner exactly on the frustum edge, which
+ * reads as a crop in any viewer that letterboxes or draws a border.
+ *
+ * Exported so the tests can take the padding back out and assert the fit
+ * underneath it is TIGHT. `cornersOutsideFrustum` is monotone in distance, so
+ * without that the whole corner-fit suite would pass on a camera parked
+ * arbitrarily far away.
+ */
+export const FRAMING_PADDING = 1.5;
+
+/**
+ * Floor on the FITTED distance for a box with no size, in model units.
+ *
+ * A point fits at every distance including zero, which would put the camera
+ * inside the entity it is meant to be looking at. Floored before
+ * {@link FRAMING_PADDING} applies, so the standoff such a box actually gets is
+ * this times the padding.
+ */
+const MIN_FRAMED_DISTANCE = 0.1;
+
+/**
+ * The southeast-isometric camera basis, in viewer coordinates (Y-up).
+ *
+ * Fixed for every computed camera, so it is derived once here rather than per
+ * call. The camera sits at `center + CAMERA_OFFSET * distance` and looks back
+ * along `CAMERA_FORWARD`; `CAMERA_RIGHT` and `CAMERA_UP` are perpendicular to
+ * that, which is why the standoff cancels out of a corner's sideways offsets
+ * in the fit below and appears only in its depth.
+ */
+const CAMERA_OFFSET = normalize([0.6, 0.5, 0.6]);
+const CAMERA_FORWARD: Vec3 = [-CAMERA_OFFSET[0], -CAMERA_OFFSET[1], -CAMERA_OFFSET[2]];
+const CAMERA_RIGHT = normalize(cross(CAMERA_FORWARD, [0, 1, 0]));
+const CAMERA_UP = cross(CAMERA_RIGHT, CAMERA_FORWARD);
+
+/**
+ * The smallest standoff along {@link CAMERA_OFFSET} that puts every corner of
+ * `bounds` inside both half-angles, before padding.
+ *
+ * The distance used to come from the largest SIDE of the box, which is not
+ * what the projection sees: down this isometric axis a box projects wider than
+ * any of its sides, so a unit cube's worst corner sat at a vertical slope of
+ * 0.837 against the tan(30 deg) = 0.577 limit at 16/9, and overran
+ * horizontally at 9/16 (#3882). Only the corners answer the question, so all
+ * eight are walked.
+ *
+ * A corner's sideways offsets `h` and `v` do not depend on the standoff, and
+ * its depth is `dot(corner, CAMERA_FORWARD) + distance`. It is inside when
+ * `h <= tanH * depth` and `v <= tanV * depth`; solving each for `distance` and
+ * taking the largest satisfies all sixteen constraints at once, because
+ * growing the distance only ever relaxes them.
+ */
+function fitCornersInFrustum(
+  bounds: EntityBoundsInput,
+  center: Vec3,
+  tanH: number,
+  tanV: number,
+): number {
+  let distance = 0;
+  for (const x of [bounds.min.x, bounds.max.x]) {
+    for (const y of [bounds.min.y, bounds.max.y]) {
+      for (const z of [bounds.min.z, bounds.max.z]) {
+        const corner: Vec3 = [x - center[0], y - center[1], z - center[2]];
+        const depthAtCenter = dot(corner, CAMERA_FORWARD);
+        const h = Math.abs(dot(corner, CAMERA_RIGHT)) / tanH;
+        const v = Math.abs(dot(corner, CAMERA_UP)) / tanV;
+        distance = Math.max(distance, h - depthAtCenter, v - depthAtCenter);
+      }
+    }
+  }
+  return distance;
+}
+
 /**
  * Compute a BCF perspective camera from entity bounds.
  *
@@ -97,56 +191,37 @@ export function computeCameraFromBounds(
   aspectRatio: number = DEFAULT_ASPECT_RATIO,
 ): BCFPerspectiveCamera {
   // Center in viewer coords (Y-up)
-  const cx = (bounds.min.x + bounds.max.x) / 2;
-  const cy = (bounds.min.y + bounds.max.y) / 2;
-  const cz = (bounds.min.z + bounds.max.z) / 2;
+  const center: Vec3 = [
+    (bounds.min.x + bounds.max.x) / 2,
+    (bounds.min.y + bounds.max.y) / 2,
+    (bounds.min.z + bounds.max.z) / 2,
+  ];
 
-  // Max extent for framing distance
-  const sx = bounds.max.x - bounds.min.x;
-  const sy = bounds.max.y - bounds.min.y;
-  const sz = bounds.max.z - bounds.min.z;
-  const maxSize = Math.max(sx, sy, sz, 0.1); // Floor to avoid zero
-
-  // Camera distance: fit maxSize into the 60deg FOV with 1.5x padding.
-  //
   // `FieldOfView` is the VERTICAL angle in BCF, and the horizontal one follows
-  // from the aspect ratio: tan(hHalf) = aspectRatio * tan(vHalf). Framing off
-  // the vertical angle alone therefore held only while the viewport was at
-  // least as wide as it is tall; at a portrait ratio the horizontal angle is
-  // the NARROWER of the two, and a wide entity was cropped by exactly the
-  // factor the ratio understated (at 9/16, by 16/9). Dividing by the narrower
-  // half-angle frames the box in whichever direction is tighter, and is inert
-  // at every ratio >= 1 -- including the 16/9 default -- because the vertical
-  // angle is the narrower one there.
-  const vHalf = (FIELD_OF_VIEW_DEGREES * Math.PI) / 360;
-  const hHalf = Math.atan(aspectRatio * Math.tan(vHalf));
-  const distance = (maxSize / 2) / Math.tan(Math.min(vHalf, hHalf)) * 1.5;
+  // from the aspect ratio: tan(hHalf) = aspectRatio * tan(vHalf). Both bound
+  // every corner below, so neither a portrait nor a landscape viewport crops
+  // the box.
+  const tanV = Math.tan((FIELD_OF_VIEW_DEGREES * Math.PI) / 360);
+  const tanH = aspectRatio * tanV;
 
-  // Southeast-isometric offset in viewer coords (Y-up):
-  // camera position = center + normalized(0.6, 0.5, 0.6) * distance
-  const offsetLen = Math.sqrt(0.6 * 0.6 + 0.5 * 0.5 + 0.6 * 0.6);
-  const ox = (0.6 / offsetLen) * distance;
-  const oy = (0.5 / offsetLen) * distance;
-  const oz = (0.6 / offsetLen) * distance;
+  const distance =
+    Math.max(fitCornersInFrustum(bounds, center, tanH, tanV), MIN_FRAMED_DISTANCE) *
+    FRAMING_PADDING;
 
-  const camX = cx + ox;
-  const camY = cy + oy;
-  const camZ = cz + oz;
-
-  // Direction: from camera to center (viewer coords)
-  const dx = cx - camX;
-  const dy = cy - camY;
-  const dz = cz - camZ;
-  const dLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  // Southeast-isometric position in viewer coords (Y-up).
+  const camX = center[0] + CAMERA_OFFSET[0] * distance;
+  const camY = center[1] + CAMERA_OFFSET[1] * distance;
+  const camZ = center[2] + CAMERA_OFFSET[2] * distance;
 
   // Convert to BCF coords (Z-up)
-  // Viewer (x, y, z) → BCF (x, -z, y)
+  // Viewer (x, y, z) → BCF (x, -z, y). The camera sits on the +CAMERA_OFFSET
+  // ray from the center, so it looks back along CAMERA_FORWARD exactly.
   return {
     cameraViewPoint: { x: camX, y: -camZ, z: camY },
     cameraDirection: {
-      x: dx / dLen,
-      y: -dz / dLen,
-      z: dy / dLen,
+      x: CAMERA_FORWARD[0],
+      y: -CAMERA_FORWARD[2],
+      z: CAMERA_FORWARD[1],
     },
     cameraUpVector: { x: 0, y: 0, z: 1 }, // BCF Z-up
     fieldOfView: FIELD_OF_VIEW_DEGREES,

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import { createBCFFromIDSReport } from './ids-reporter.js';
 import type { IDSReportInput, EntityBoundsInput } from './ids-reporter.js';
+import { FRAMING_PADDING } from './ids-camera.js';
 
 type Vec3 = { x: number; y: number; z: number };
 const dot = (a: Vec3, b: Vec3) => a.x * b.x + a.y * b.y + a.z * b.z;
@@ -950,11 +951,11 @@ describe('IDS BCF Reporter', () => {
      * `fieldOfView` rather than from the numbers that produced them, so a
      * framing that agrees with itself but not with the geometry still fails.
      */
-    function cornersOutsideFrustum(
+    function cornerFills(
       cam: NonNullable<ReturnType<typeof perspectiveCameraOf>>,
       box: EntityBoundsInput,
       aspectRatio: number,
-    ): string[] {
+    ): { label: string; fill: number }[] {
       // BCF FieldOfView is the VERTICAL angle; the horizontal one follows
       // from the aspect ratio.
       const halfV = (cam.fieldOfView * Math.PI) / 360;
@@ -964,7 +965,7 @@ describe('IDS BCF Reporter', () => {
       const right = normalize(cross(d, cam.cameraUpVector));
       const up = cross(right, d);
 
-      const outside: string[] = [];
+      const fills: { label: string; fill: number }[] = [];
       for (const x of [box.min.x, box.max.x]) {
         for (const y of [box.min.y, box.max.y]) {
           for (const z of [box.min.z, box.max.z]) {
@@ -975,15 +976,71 @@ describe('IDS BCF Reporter', () => {
               z: y - cam.cameraViewPoint.z,
             };
             const depth = dot(v, d);
-            const h = Math.abs(dot(v, right)) / depth;
-            const vt = Math.abs(dot(v, up)) / depth;
-            if (depth <= 0 || h > Math.tan(halfH) || vt > Math.tan(halfV)) {
-              outside.push(`(${x}, ${y}, ${z}) h=${h.toFixed(3)} v=${vt.toFixed(3)}`);
+            if (depth <= 0) {
+              fills.push({ label: `(${x}, ${y}, ${z}) behind the camera`, fill: Infinity });
+              continue;
             }
+            const h = Math.abs(dot(v, right)) / depth / Math.tan(halfH);
+            const vt = Math.abs(dot(v, up)) / depth / Math.tan(halfV);
+            fills.push({
+              label: `(${x}, ${y}, ${z}) h=${h.toFixed(3)} v=${vt.toFixed(3)}`,
+              fill: Math.max(h, vt),
+            });
           }
         }
       }
-      return outside;
+      return fills;
+    }
+
+    /** The corners that miss the frustum, labelled with how far they miss by. */
+    function cornersOutsideFrustum(
+      cam: NonNullable<ReturnType<typeof perspectiveCameraOf>>,
+      box: EntityBoundsInput,
+      aspectRatio: number,
+    ): string[] {
+      return cornerFills(cam, box, aspectRatio)
+        .filter(corner => corner.fill > 1)
+        .map(corner => corner.label);
+    }
+
+    /** How much of the frustum the worst corner fills; 1 is exactly the edge. */
+    function worstCornerFill(
+      cam: NonNullable<ReturnType<typeof perspectiveCameraOf>>,
+      box: EntityBoundsInput,
+      aspectRatio: number,
+    ): number {
+      return Math.max(...cornerFills(cam, box, aspectRatio).map(corner => corner.fill));
+    }
+
+    /**
+     * The same camera with the framing padding taken back out.
+     *
+     * `cornersOutsideFrustum` is monotone in distance -- a camera parked twice
+     * as far away passes it too -- so on its own it cannot tell a fit from an
+     * over-frame. Pulling the standoff back to the unpadded fit and finding
+     * the worst corner exactly ON the edge is what pins the fit as tight.
+     *
+     * `FRAMING_PADDING` is imported rather than copied, so changing the
+     * padding does not fail twelve tests that assert nothing about it.
+     */
+    function withoutPadding(
+      cam: NonNullable<ReturnType<typeof perspectiveCameraOf>>,
+      box: EntityBoundsInput,
+    ): NonNullable<ReturnType<typeof perspectiveCameraOf>> {
+      // Box centre in BCF coords, the point the camera stands off from.
+      const centre = {
+        x: (box.min.x + box.max.x) / 2,
+        y: -(box.min.z + box.max.z) / 2,
+        z: (box.min.y + box.max.y) / 2,
+      };
+      return {
+        ...cam,
+        cameraViewPoint: {
+          x: centre.x + (cam.cameraViewPoint.x - centre.x) / FRAMING_PADDING,
+          y: centre.y + (cam.cameraViewPoint.y - centre.y) / FRAMING_PADDING,
+          z: centre.z + (cam.cameraViewPoint.z - centre.z) / FRAMING_PADDING,
+        },
+      };
     }
 
     function perspectiveCameraOf(project: ReturnType<typeof createBCFFromIDSReport>) {
@@ -1001,36 +1058,63 @@ describe('IDS BCF Reporter', () => {
       });
     }
 
-    it('keeps a wide entity inside the frustum at a portrait aspect ratio', () => {
-      // fieldOfView is VERTICAL, so at 9/16 the HORIZONTAL half-angle is the
-      // narrower one. A distance derived from the vertical angle alone crops
-      // a box that is much wider than it is tall.
-      const aspectRatio = 9 / 16;
-      const box: EntityBoundsInput = {
-        min: { x: -5, y: -0.5, z: -0.5 },
-        max: { x: 5, y: 0.5, z: 0.5 },
+    // Every corner of each box, at the three aspect ratios a report is
+    // realistically written at. Framing off the vertical half-angle alone
+    // cropped a wide box at a portrait ratio (#3864); framing off the largest
+    // SIDE cropped a cube at any ratio, because down the isometric axis a box
+    // projects wider than any of its sides (#3882).
+    const CORNER_FIT_BOXES: ReadonlyArray<readonly [string, EntityBoundsInput]> = [
+      ['a unit cube', { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 1 } }],
+      ['a wide box', { min: { x: -6, y: -0.25, z: -0.25 }, max: { x: 6, y: 0.25, z: 0.25 } }],
+      ['a tall box', { min: { x: -0.25, y: -6, z: -0.25 }, max: { x: 0.25, y: 6, z: 0.25 } }],
+      ['a flat wide slab', { min: { x: -3, y: -0.5, z: -3 }, max: { x: 3, y: 0.5, z: 3 } }],
+    ];
+
+    for (const [aspectName, aspectRatio] of [
+      ['16/9', 16 / 9],
+      ['1/1', 1],
+      ['9/16', 9 / 16],
+    ] as const) {
+      for (const [boxName, box] of CORNER_FIT_BOXES) {
+        it(`fits every corner of ${boxName} inside the frustum at ${aspectName}`, () => {
+          const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
+          expect(cornersOutsideFrustum(cam, box, aspectRatio)).toEqual([]);
+        });
+
+        it(`frames ${boxName} tightly at ${aspectName}, not merely from far away`, () => {
+          // Take the padding back out: the fit is the SMALLEST standoff that
+          // works, so the worst corner then sits exactly on the frustum edge.
+          const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
+          expect(worstCornerFill(withoutPadding(cam, box), box, aspectRatio))
+            .toBeCloseTo(1, 9);
+        });
+      }
+    }
+
+    it('stands a degenerate box off rather than sitting inside it', () => {
+      // A point fits the frustum at every distance including zero, so the
+      // corner walk returns 0 and only the floor keeps the camera out of the
+      // entity. Nothing else in this suite exercises that branch.
+      const point: EntityBoundsInput = {
+        min: { x: 3, y: 4, z: 5 },
+        max: { x: 3, y: 4, z: 5 },
       };
+      const cam = perspectiveCameraOf(frameOneBox(point, 16 / 9))!;
 
-      const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
-      expect(cornersOutsideFrustum(cam, box, aspectRatio)).toEqual([]);
-    });
-
-    it('keeps a tall entity inside the frustum at a landscape aspect ratio', () => {
-      // The other direction, so a fix that merely swapped which angle is used
-      // fails here instead of passing both.
-      const aspectRatio = 16 / 9;
-      const box: EntityBoundsInput = {
-        min: { x: -0.5, y: -5, z: -0.5 },
-        max: { x: 0.5, y: 5, z: 0.5 },
-      };
-
-      const cam = perspectiveCameraOf(frameOneBox(box, aspectRatio))!;
-      expect(cornersOutsideFrustum(cam, box, aspectRatio)).toEqual([]);
+      // BCF centre of the point is (3, -5, 4).
+      const standoff = Math.sqrt(
+        (cam.cameraViewPoint.x - 3) ** 2 +
+        (cam.cameraViewPoint.y - -5) ** 2 +
+        (cam.cameraViewPoint.z - 4) ** 2,
+      );
+      expect(standoff).toBeCloseTo(0.1 * FRAMING_PADDING, 9);
     });
 
     it('does not move the camera at all for a 16/9 cube', () => {
-      // The narrower half-angle at 16/9 IS the vertical one, so the widening
-      // must be inert here -- a landscape export frames exactly as before.
+      // A cube's projection down the isometric axis is taller than it is
+      // wide, so the VERTICAL half-angle binds at 16/9 and at 1/1 alike, and
+      // the wider horizontal angle at 16/9 changes nothing. Pins that a
+      // landscape export of a cube frames exactly as a square one does.
       const box: EntityBoundsInput = { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 2, z: 2 } };
       const wide = perspectiveCameraOf(frameOneBox(box, 16 / 9))!;
       const square = perspectiveCameraOf(frameOneBox(box, 1))!;


### PR DESCRIPTION
Closes #3882.

`computeCameraFromBounds` derived the standoff from the largest box side times a fixed factor, so a corner could sit outside the frustum: on a unit cube the worst corner reached a vertical slope of 0.837 against tan(30 degrees) = 0.577 at 16:9, and overran horizontally at 9:16. The standoff is now the smallest distance that puts all eight corners inside both half-angles for the given field of view and aspect ratio, with the same 1.5 padding, a floor for a zero-size box, and the view direction and up vector unchanged.

Test written first, against main: five of eleven corner-fit cases failed with the issue's numbers; after the fix, 442 pass in the package. Two mutation probes guard against a camera parked far away: raising the padding fails twelve tightness tests that assert the worst corner sits on the frustum edge once padding is removed, and neutralising the floor fails the zero-size-box test. No pinned expectation moved; two single-ratio tests from #3864 became rows of the parameterised table.

Not a parallel copy: clash's `cameraForBounds` in `packages/clash/src/bcf-bridge.ts` uses a bounding-sphere radius, which is corner-safe by construction. The renderer's `fitDistanceFor` has the same defect on a live UI path and is filed as #3892.

Gates on the head: `pnpm typecheck` 0, `@ifc-lite/bcf` 444/444 after rebase, `@ifc-lite/bcf-api` 53/53, `@ifc-lite/clash` 460/460, check-module-size 0, check-changesets 0.