### PR TITLE
feat(server): cache the optimized parquet route like the flat one

### DIFF
--- a/.changeset/cache-optimized-parquet-route.md
+++ b/.changeset/cache-optimized-parquet-route.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/server-bin': minor
+---
+
+`POST /api/v1/parse/parquet/optimized` is now cached, so a repeat request is a disk read instead of a full re-parse (#3889). The route was added without a cache key of its own, which left the two Parquet endpoints with opposite properties: the flat route stored its large payload and replayed it, while the optimized route rebuilt its small payload on every request, and got no benefit from a flat response cached seconds earlier either. On a 57.9 MB file the flat route roughly halved on its second call and the optimized route did not improve at all.
+
+The optimized response now has its own key pair, `{sha256}-{filter}-parquet-optimized-v1` for the body and `{sha256}-{filter}-parquet-optimized-metadata-v1` for the `X-IFC-Metadata` header, `optimization_stats` included, so a replay reports what the live parse reported. They are a separate namespace from the flat route's `-parquet-v5` / `-parquet-metadata-v4` on purpose: the optimized payload is quantized and deduplicated, so a cached flat response must never satisfy the optimized route or the other way round. Bump the suffix on any change to the optimized payload's columns.
+
+Two details of the write. It happens before the response goes out rather than in a background task, because this payload is the small one and a background write races the very next request, which is the request the cache exists to serve. And a hit requires the symbolic sidecar to still be present alongside the body and metadata: the optimized parse is what writes that sidecar, so replaying past a missing one would leave `GET /api/v1/parse/symbolic/{cache_key}` polling a key nobody writes.

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -159,10 +159,19 @@ pub(crate) fn data_model_cache_key(cache_key: &str) -> String {
 ///
 /// A cache read error answers `false`: re-parsing is the safe direction.
 pub(crate) async fn has_current_data_model(cache: &DiskCache, cache_key: &str) -> bool {
-    matches!(
-        cache.get_bytes(&data_model_cache_key(cache_key)).await,
-        Ok(Some(_))
-    )
+    has_entry(cache, &data_model_cache_key(cache_key)).await
+}
+
+/// Whether `key` has a readable entry.
+///
+/// Reads the value rather than asking `DiskCache::has`, which is an index
+/// lookup only: an index row whose content is gone would answer `true` here
+/// while every real reader still gets nothing, and a gate that reports present
+/// for an entry nobody can read is worse than no gate.
+///
+/// A read error answers `false`: re-parsing is the safe direction.
+async fn has_entry(cache: &DiskCache, key: &str) -> bool {
+    matches!(cache.get_bytes(key).await, Ok(Some(_)))
 }
 
 /// Build the symbolic-data cache key for a given file cache key.
@@ -208,13 +217,8 @@ pub(crate) async fn cache_symbolic_data(cache: &DiskCache, cache_key: &str, symb
 /// [`load_cached_symbolic`] cannot stand in: it answers `SymbolicData::default()`
 /// for an absent entry and for a model with no 2D symbols alike, so absence
 /// there is indistinguishable from success.
-///
-/// A cache read error answers `false`: re-parsing is the safe direction.
 pub(crate) async fn has_cached_symbolic(cache: &DiskCache, cache_key: &str) -> bool {
-    matches!(
-        cache.get_bytes(&symbolic_cache_key(cache_key)).await,
-        Ok(Some(_))
-    )
+    has_entry(cache, &symbolic_cache_key(cache_key)).await
 }
 
 /// Load cached symbolic data for `cache_key`, defaulting to empty when the

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -100,6 +100,36 @@ pub(crate) fn parquet_metadata_cache_key(
     )
 }
 
+/// Build the optimized-Parquet body cache key for a given file cache key.
+///
+/// `POST /api/v1/parse/parquet/optimized` was added without a key of its own,
+/// so its response had nowhere to be stored and every request re-parsed the
+/// file while the flat route beside it replayed from disk (issue #3889). This
+/// is that key.
+///
+/// Deliberately a DIFFERENT namespace from `-parquet-v5`: the two routes emit
+/// different payloads (quantized vertices, deduplicated shapes, byte colours),
+/// so a hit on one must never satisfy the other.
+///
+/// `v1` is the ara3d BOS payload as it stands after #3595 (rotation-aware
+/// instancing). Bump on EVERY change to the optimized payload's columns or to
+/// what one of them means, for the same reason the other suffixes bump: a warm
+/// cache otherwise replays a pre-change blob that the decoder reads cleanly,
+/// and the change is silently absent.
+pub(crate) fn parquet_optimized_cache_key(cache_key: &str) -> String {
+    format!("{cache_key}-parquet-optimized-v1")
+}
+
+/// Build the optimized-Parquet metadata cache key for a given file cache key.
+///
+/// Holds the serialized `X-IFC-Metadata` header, `optimization_stats` included,
+/// so a replay carries the same stats the live parse reported. Versioned in
+/// lockstep with [`parquet_optimized_cache_key`], and distinct from the flat
+/// route's `-parquet-metadata-v4` for the same reason the bodies are.
+pub(crate) fn parquet_optimized_metadata_cache_key(cache_key: &str) -> String {
+    format!("{cache_key}-parquet-optimized-metadata-v1")
+}
+
 /// Build the data-model cache key for a given file cache key.
 ///
 /// One definition for the writers (`parse_parquet`, `parse_parquet_stream`) and
@@ -165,6 +195,26 @@ pub(crate) async fn cache_symbolic_data(cache: &DiskCache, cache_key: &str, symb
             tracing::error!(error = %e, "Failed to serialize symbolic data for caching");
         }
     }
+}
+
+/// Whether symbolic data is cached for `cache_key`.
+///
+/// The optimized-Parquet route's parse is what writes the symbolic sidecar, so
+/// a replay that skips the parse must first check the sidecar is there. Without
+/// this, a body entry that outlived its symbolic entry replays forever and
+/// `GET /api/v1/parse/symbolic/{cache_key}` answers `202` to a key nobody
+/// writes -- the same shape as the geometry/data-model trap in #3869.
+///
+/// [`load_cached_symbolic`] cannot stand in: it answers `SymbolicData::default()`
+/// for an absent entry and for a model with no 2D symbols alike, so absence
+/// there is indistinguishable from success.
+///
+/// A cache read error answers `false`: re-parsing is the safe direction.
+pub(crate) async fn has_cached_symbolic(cache: &DiskCache, cache_key: &str) -> bool {
+    matches!(
+        cache.get_bytes(&symbolic_cache_key(cache_key)).await,
+        Ok(Some(_))
+    )
 }
 
 /// Load cached symbolic data for `cache_key`, defaulting to empty when the

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -112,10 +112,14 @@ pub(crate) fn parquet_metadata_cache_key(
 /// so a hit on one must never satisfy the other.
 ///
 /// `v1` is the ara3d BOS payload as it stands after #3595 (rotation-aware
-/// instancing). Bump on EVERY change to the optimized payload's columns or to
-/// what one of them means, for the same reason the other suffixes bump: a warm
-/// cache otherwise replays a pre-change blob that the decoder reads cleanly,
-/// and the change is silently absent.
+/// instancing). Bump on EVERY change to the optimized payload's columns, to
+/// what one of them means, OR to the geometry pipeline behind them -- this key
+/// covers `process_geometry_filtered_with_quality` output just as
+/// [`parquet_cache_key`] does, and that key's own `v3` -> `v4` bump was a
+/// pipeline change with no column change at all. In practice: a bump of
+/// `-parquet-v5` almost always needs a bump here too. Otherwise a warm cache
+/// replays a pre-change blob that the decoder reads cleanly, and the change is
+/// silently absent.
 pub(crate) fn parquet_optimized_cache_key(cache_key: &str) -> String {
     format!("{cache_key}-parquet-optimized-v1")
 }

--- a/apps/server/src/routes/parse/cache_keys_tests.rs
+++ b/apps/server/src/routes/parse/cache_keys_tests.rs
@@ -318,26 +318,4 @@ fn optimized_parquet_keys_are_a_distinct_namespace_from_the_flat_route() {
         assert_ne!(optimized, data_model_cache_key(&seed));
         assert_ne!(optimized, json_response_cache_key(&seed));
     }
-
-    // Every (filter, quality) pair keeps its own optimized entry, because the
-    // seed carries both -- measured pairwise, so this cannot pass on one case.
-    let mut seen = std::collections::HashSet::new();
-    for mode in [
-        OpeningFilterMode::Default,
-        OpeningFilterMode::IgnoreAll,
-        OpeningFilterMode::IgnoreOpaque,
-    ] {
-        for quality in [
-            TessellationQuality::Lowest,
-            TessellationQuality::Low,
-            TessellationQuality::Medium,
-            TessellationQuality::High,
-            TessellationQuality::Highest,
-        ] {
-            let seed = cache_key_from_parts(hash, mode, quality);
-            assert!(seen.insert(parquet_optimized_cache_key(&seed)));
-            assert!(seen.insert(parquet_optimized_metadata_cache_key(&seed)));
-        }
-    }
-    assert_eq!(seen.len(), 30);
 }

--- a/apps/server/src/routes/parse/cache_keys_tests.rs
+++ b/apps/server/src/routes/parse/cache_keys_tests.rs
@@ -242,6 +242,8 @@ fn derived_keys_never_collide_with_each_other() {
         data_model_cache_key(seed),
         parquet_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
         parquet_metadata_cache_key("0ab20f4e4014", OpeningFilterMode::Default, TessellationQuality::Medium),
+        parquet_optimized_cache_key(seed),
+        parquet_optimized_metadata_cache_key(seed),
     ];
     let unique: std::collections::HashSet<&String> = derived.iter().collect();
     assert_eq!(unique.len(), derived.len(), "derived keys collide: {derived:?}");
@@ -280,4 +282,62 @@ DATA;
 ENDSEC;";
 
     assert_eq!(detect_schema_version(content), "IFC2X3");
+}
+
+/// The optimized-Parquet route got a key of its own with #3889. Its whole
+/// point is that it is a DIFFERENT namespace from the flat route's: the two
+/// emit different payloads, so a hit on one must never satisfy the other.
+/// Deriving the optimized key from the flat one (or reusing `-parquet-v5`)
+/// would put a quantized, deduplicated payload where a client expecting flat
+/// meshes reads it.
+#[test]
+fn optimized_parquet_keys_are_a_distinct_namespace_from_the_flat_route() {
+    let hash = "0ab20f4e4014";
+    let seed = format!("{hash}-default");
+
+    assert_eq!(
+        parquet_optimized_cache_key(&seed),
+        format!("{seed}-parquet-optimized-v1")
+    );
+    assert_eq!(
+        parquet_optimized_metadata_cache_key(&seed),
+        format!("{seed}-parquet-optimized-metadata-v1")
+    );
+
+    // Neither optimized key may equal, or be a prefix-shadow of, the flat pair.
+    let flat = parquet_cache_key(hash, OpeningFilterMode::Default, TessellationQuality::Medium);
+    let flat_metadata =
+        parquet_metadata_cache_key(hash, OpeningFilterMode::Default, TessellationQuality::Medium);
+    for optimized in [
+        parquet_optimized_cache_key(&seed),
+        parquet_optimized_metadata_cache_key(&seed),
+    ] {
+        assert_ne!(optimized, flat);
+        assert_ne!(optimized, flat_metadata);
+        assert_ne!(optimized, symbolic_cache_key(&seed));
+        assert_ne!(optimized, data_model_cache_key(&seed));
+        assert_ne!(optimized, json_response_cache_key(&seed));
+    }
+
+    // Every (filter, quality) pair keeps its own optimized entry, because the
+    // seed carries both -- measured pairwise, so this cannot pass on one case.
+    let mut seen = std::collections::HashSet::new();
+    for mode in [
+        OpeningFilterMode::Default,
+        OpeningFilterMode::IgnoreAll,
+        OpeningFilterMode::IgnoreOpaque,
+    ] {
+        for quality in [
+            TessellationQuality::Lowest,
+            TessellationQuality::Low,
+            TessellationQuality::Medium,
+            TessellationQuality::High,
+            TessellationQuality::Highest,
+        ] {
+            let seed = cache_key_from_parts(hash, mode, quality);
+            assert!(seen.insert(parquet_optimized_cache_key(&seed)));
+            assert!(seen.insert(parquet_optimized_metadata_cache_key(&seed)));
+        }
+    }
+    assert_eq!(seen.len(), 30);
 }

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -6,18 +6,13 @@
 //! request's geometry + metadata are already cached, replay them as a
 //! three-event stream (Start / one Batch / Complete) without re-parsing.
 
-use super::cache_keys::{
-    has_cached_symbolic, has_current_data_model, load_cached_symbolic,
-    parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
-};
+use super::cache_keys::{has_current_data_model, load_cached_symbolic};
 use super::parquet::ParquetMetadataHeader;
 use super::parquet_stream::ParquetStreamEvent;
 use crate::error::ApiError;
 use crate::AppState;
-use axum::body::Body;
-use axum::http::{header, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::convert::Infallible;
 
@@ -148,70 +143,4 @@ pub(super) async fn try_cached_replay(
             .keep_alive(KeepAlive::default())
             .into_response(),
     ))
-}
-
-/// Try to serve a `parse_parquet_optimized` request from the cache (issue
-/// #3889). Returns `Ok(Some(response))` on a usable hit (the caller returns it
-/// as-is and never parses), `Ok(None)` on anything else, which falls through to
-/// the live parse and rewrites the entries.
-///
-/// The stored metadata is the response header VERBATIM, so nothing here has to
-/// deserialize `OptimizedParquetMetadataHeader` -- a replay reports the same
-/// `optimization_stats` and `cache_key` the live parse did. A header that is
-/// not valid UTF-8 (a corrupt entry) is a miss, not a 500.
-///
-/// The symbolic gate is not optional: the optimized parse also writes the
-/// symbolic sidecar, and replaying past a missing one leaves the client's
-/// `GET /api/v1/parse/symbolic/{cache_key}` polling a key nobody writes.
-pub(super) async fn try_cached_optimized_parquet(
-    state: &AppState,
-    cache_key: &str,
-) -> Result<Option<axum::response::Response>, ApiError> {
-    let (Some(cached_body), Some(cached_metadata_json)) = (
-        state
-            .cache
-            .get_bytes(&parquet_optimized_cache_key(cache_key))
-            .await?,
-        state
-            .cache
-            .get_bytes(&parquet_optimized_metadata_cache_key(cache_key))
-            .await?,
-    ) else {
-        return Ok(None);
-    };
-
-    if !has_cached_symbolic(&state.cache, cache_key).await {
-        tracing::info!(
-            cache_key = %cache_key,
-            "Optimized Parquet cached but the symbolic sidecar is missing; re-parsing"
-        );
-        return Ok(None);
-    }
-
-    let Ok(metadata_json) = String::from_utf8(cached_metadata_json) else {
-        tracing::warn!(
-            cache_key = %cache_key,
-            "Cached optimized metadata is not valid UTF-8; ignoring cache and re-parsing"
-        );
-        return Ok(None);
-    };
-
-    tracing::info!(
-        cache_key = %cache_key,
-        payload_size = cached_body.len(),
-        "Optimized Parquet cache HIT - returning cached response"
-    );
-
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            header::CONTENT_TYPE,
-            "application/x-parquet-geometry-optimized",
-        )
-        .header("X-IFC-Metadata", metadata_json)
-        .header(header::CONTENT_LENGTH, cached_body.len())
-        .body(Body::from(cached_body))
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-
-    Ok(Some(response))
 }

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -6,13 +6,18 @@
 //! request's geometry + metadata are already cached, replay them as a
 //! three-event stream (Start / one Batch / Complete) without re-parsing.
 
-use super::cache_keys::{has_current_data_model, load_cached_symbolic};
+use super::cache_keys::{
+    has_cached_symbolic, has_current_data_model, load_cached_symbolic,
+    parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
+};
 use super::parquet::ParquetMetadataHeader;
 use super::parquet_stream::ParquetStreamEvent;
 use crate::error::ApiError;
 use crate::AppState;
+use axum::body::Body;
+use axum::http::{header, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::convert::Infallible;
 
@@ -143,4 +148,70 @@ pub(super) async fn try_cached_replay(
             .keep_alive(KeepAlive::default())
             .into_response(),
     ))
+}
+
+/// Try to serve a `parse_parquet_optimized` request from the cache (issue
+/// #3889). Returns `Ok(Some(response))` on a usable hit (the caller returns it
+/// as-is and never parses), `Ok(None)` on anything else, which falls through to
+/// the live parse and rewrites the entries.
+///
+/// The stored metadata is the response header VERBATIM, so nothing here has to
+/// deserialize `OptimizedParquetMetadataHeader` -- a replay reports the same
+/// `optimization_stats` and `cache_key` the live parse did. A header that is
+/// not valid UTF-8 (a corrupt entry) is a miss, not a 500.
+///
+/// The symbolic gate is not optional: the optimized parse also writes the
+/// symbolic sidecar, and replaying past a missing one leaves the client's
+/// `GET /api/v1/parse/symbolic/{cache_key}` polling a key nobody writes.
+pub(super) async fn try_cached_optimized_parquet(
+    state: &AppState,
+    cache_key: &str,
+) -> Result<Option<axum::response::Response>, ApiError> {
+    let (Some(cached_body), Some(cached_metadata_json)) = (
+        state
+            .cache
+            .get_bytes(&parquet_optimized_cache_key(cache_key))
+            .await?,
+        state
+            .cache
+            .get_bytes(&parquet_optimized_metadata_cache_key(cache_key))
+            .await?,
+    ) else {
+        return Ok(None);
+    };
+
+    if !has_cached_symbolic(&state.cache, cache_key).await {
+        tracing::info!(
+            cache_key = %cache_key,
+            "Optimized Parquet cached but the symbolic sidecar is missing; re-parsing"
+        );
+        return Ok(None);
+    }
+
+    let Ok(metadata_json) = String::from_utf8(cached_metadata_json) else {
+        tracing::warn!(
+            cache_key = %cache_key,
+            "Cached optimized metadata is not valid UTF-8; ignoring cache and re-parsing"
+        );
+        return Ok(None);
+    };
+
+    tracing::info!(
+        cache_key = %cache_key,
+        payload_size = cached_body.len(),
+        "Optimized Parquet cache HIT - returning cached response"
+    );
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-parquet-geometry-optimized",
+        )
+        .header("X-IFC-Metadata", metadata_json)
+        .header(header::CONTENT_LENGTH, cached_body.len())
+        .body(Body::from(cached_body))
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    Ok(Some(response))
 }

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -9,11 +9,13 @@ mod cached_replay;
 mod fetch;
 mod json;
 mod parquet;
+mod parquet_optimized;
 mod parquet_stream;
 
 pub use fetch::{check_cache, get_cached_geometry, get_data_model, get_symbolic};
 pub use json::{parse_full, parse_metadata, parse_stream};
-pub use parquet::{parse_parquet, parse_parquet_optimized};
+pub use parquet::parse_parquet;
+pub use parquet_optimized::parse_parquet_optimized;
 pub use parquet_stream::parse_parquet_stream;
 
 use crate::error::ApiError;
@@ -257,6 +259,9 @@ mod ifczip_tests;
 
 #[cfg(test)]
 mod parquet_tests;
+
+#[cfg(test)]
+mod parquet_optimized_tests;
 
 #[cfg(test)]
 mod json_tests;

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -234,7 +234,11 @@ pub async fn parse_parquet(
     let metadata_json_clone = metadata_json.clone();
     let cache = state.cache.clone();
 
-    // Cache in background (don't block response)
+    // Cache in background (don't block response). Deliberately NOT the
+    // optimized route's synchronous write (#3889): this payload is the large
+    // one, so blocking the response on it costs the client real time. The
+    // trade is a window where an immediate repeat request re-parses because
+    // the write has not landed yet.
     tokio::spawn(async move {
         if let Err(e) = cache
             .set_bytes(&parquet_cache_key, &combined_parquet_clone)

--- a/apps/server/src/routes/parse/parquet.rs
+++ b/apps/server/src/routes/parse/parquet.rs
@@ -9,10 +9,7 @@ use super::cache_keys::{
 };
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
-use crate::services::{
-    extract_data_model, serialize_data_model_to_parquet, serialize_to_parquet,
-    serialize_to_parquet_optimized_with_stats, OptimizedStats, VERTEX_MULTIPLIER,
-};
+use crate::services::{extract_data_model, serialize_data_model_to_parquet, serialize_to_parquet};
 use crate::types::{ModelMetadata, ProcessingStats};
 use crate::AppState;
 use axum::{
@@ -265,127 +262,6 @@ pub async fn parse_parquet(
         .header("X-IFC-Metadata", metadata_json)
         .header(header::CONTENT_LENGTH, combined_parquet.len())
         .body(Body::from(combined_parquet))
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-
-    Ok(response)
-}
-
-/// Response header containing metadata for optimized Parquet response.
-#[derive(Debug, Clone, Serialize)]
-pub struct OptimizedParquetMetadataHeader {
-    pub cache_key: String,
-    pub metadata: ModelMetadata,
-    pub stats: ProcessingStats,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mesh_coordinate_space: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub site_transform: Option<Vec<f64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub building_transform: Option<Vec<f64>>,
-    pub optimization_stats: OptimizedStats,
-    /// Vertex multiplier for dequantization (10,000 = 0.1mm precision)
-    pub vertex_multiplier: f32,
-}
-
-/// POST /api/v1/parse/parquet/optimized - Full parse with ara3d BOS-optimized Parquet format.
-///
-/// Returns highly optimized binary Parquet data with:
-/// - Integer quantized vertices (0.1mm precision)
-/// - Mesh deduplication (instancing)
-/// - Byte colors instead of floats
-/// - Optional normals
-///
-/// Query params:
-/// - `normals=true` - Include normals (default: false, compute on client)
-///
-/// Typical compression: 3-5x smaller than basic Parquet, 50-75x smaller than JSON.
-pub async fn parse_parquet_optimized(
-    State(state): State<AppState>,
-    Query(query): Query<ParseQuery>,
-    mut multipart: Multipart,
-) -> Result<Response, ApiError> {
-    // Extract file from multipart
-    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
-    // upload is buffered, reserving the max upload size since multipart rarely
-    // declares a length up front. Held for the request's whole lifetime so a
-    // disconnected-but-still-running job keeps its memory slot.
-    let admission_guard = state
-        .admission
-        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
-        .await?;
-    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
-
-    // Generate cache key (include opening filter so different modes get different cache entries)
-    let tessellation_quality = query.resolved_tessellation_quality()?;
-    let cache_key = request_cache_key(&data, &query, tessellation_quality);
-
-    tracing::info!(
-        cache_key = %cache_key,
-        size = data.len(),
-        "Processing with optimized Parquet output (ara3d BOS format)"
-    );
-
-    // Parse content
-    let content = data;
-    let opening_filter = query.opening_filter;
-
-    // Process on blocking thread pool (CPU-intensive). Extract the 2D symbol
-    // stream (IfcAnnotation + IfcGrid) alongside geometry for endpoint parity
-    // (issue #900) — it's cached and served via the symbolic fetch endpoint.
-    // Guard rides the blocking task (see parse_full).
-    let ((result, symbolic_data), _admission) = tokio::task::spawn_blocking(move || {
-        (
-            rayon::join(
-                || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
-                || extract_symbolic_data(&content),
-            ),
-            admission_guard,
-        )
-    })
-    .await?;
-
-    // Cache the symbolic stream so the client can fetch it via
-    // `GET /api/v1/parse/symbolic/{cache_key}`.
-    cache_symbolic_data(&state.cache, &cache_key, &symbolic_data).await;
-
-    // Serialize to optimized Parquet (with deduplication, quantization, etc.)
-    // Don't include normals by default - client can compute them
-    let (parquet_data, opt_stats) =
-        serialize_to_parquet_optimized_with_stats(&result.meshes, false)?;
-
-    tracing::info!(
-        input_meshes = opt_stats.input_meshes,
-        unique_meshes = opt_stats.unique_meshes,
-        unique_materials = opt_stats.unique_materials,
-        mesh_reuse_ratio = opt_stats.mesh_reuse_ratio,
-        payload_size = parquet_data.len(),
-        "Optimized Parquet serialization complete"
-    );
-
-    // Create metadata header
-    let metadata_header = OptimizedParquetMetadataHeader {
-        cache_key,
-        metadata: result.metadata,
-        stats: result.stats,
-        mesh_coordinate_space: result.mesh_coordinate_space,
-        site_transform: result.site_transform,
-        building_transform: result.building_transform,
-        optimization_stats: opt_stats,
-        vertex_multiplier: VERTEX_MULTIPLIER,
-    };
-
-    let metadata_json = serde_json::to_string(&metadata_header)?;
-
-    // Build response with binary body and metadata header
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            header::CONTENT_TYPE,
-            "application/x-parquet-geometry-optimized",
-        )
-        .header("X-IFC-Metadata", metadata_json)
-        .header(header::CONTENT_LENGTH, parquet_data.len())
-        .body(Body::from(parquet_data))
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
     Ok(response)

--- a/apps/server/src/routes/parse/parquet_optimized.rs
+++ b/apps/server/src/routes/parse/parquet_optimized.rs
@@ -7,10 +7,9 @@
 //! (issue #3889) so neither module crosses the 400-line ratchet.
 
 use super::cache_keys::{
-    cache_symbolic_data, parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
-    request_cache_key,
+    cache_symbolic_data, has_cached_symbolic, parquet_optimized_cache_key,
+    parquet_optimized_metadata_cache_key, request_cache_key,
 };
-use super::cached_replay::try_cached_optimized_parquet;
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
 use crate::services::{
@@ -42,6 +41,83 @@ pub struct OptimizedParquetMetadataHeader {
     pub optimization_stats: OptimizedStats,
     /// Vertex multiplier for dequantization (10,000 = 0.1mm precision)
     pub vertex_multiplier: f32,
+}
+
+/// The optimized route's wire response, built in ONE place.
+///
+/// The live parse and the cache replay must be indistinguishable to a client,
+/// and two hand-copied builders are indistinguishable only for as long as
+/// nobody edits one of them.
+fn optimized_parquet_response(
+    metadata_json: String,
+    body: bytes::Bytes,
+) -> Result<Response, ApiError> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-parquet-geometry-optimized",
+        )
+        .header("X-IFC-Metadata", metadata_json)
+        .header(header::CONTENT_LENGTH, body.len())
+        .body(Body::from(body))
+        .map_err(|e| ApiError::Internal(e.to_string()))
+}
+
+/// Try to serve this request from the cache (issue #3889). `Ok(Some(_))` is a
+/// usable hit the caller returns as-is without parsing; anything else falls
+/// through to the live parse, which rewrites the entries.
+///
+/// Ordered cheapest-gate-first: the body is the only large read, so it comes
+/// last, once the hit is otherwise known good.
+///
+/// The stored metadata is the response header VERBATIM, so nothing here
+/// deserializes `OptimizedParquetMetadataHeader` and a replay reports the same
+/// `optimization_stats` the live parse did. A header that is not valid UTF-8
+/// (a corrupt entry) is a miss, not a 500.
+///
+/// The symbolic gate is not optional: this route's parse also writes the
+/// symbolic sidecar, so replaying past a missing one leaves the client's
+/// `GET /api/v1/parse/symbolic/{cache_key}` polling a key nobody writes.
+async fn try_cached_optimized_parquet(
+    state: &AppState,
+    cache_key: &str,
+) -> Result<Option<Response>, ApiError> {
+    if !has_cached_symbolic(&state.cache, cache_key).await {
+        return Ok(None);
+    }
+
+    let Some(cached_metadata_json) = state
+        .cache
+        .get_bytes(&parquet_optimized_metadata_cache_key(cache_key))
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    let Ok(metadata_json) = String::from_utf8(cached_metadata_json) else {
+        tracing::warn!(
+            cache_key = %cache_key,
+            "Cached optimized metadata is not valid UTF-8; ignoring cache and re-parsing"
+        );
+        return Ok(None);
+    };
+
+    let Some(cached_body) = state
+        .cache
+        .get_bytes(&parquet_optimized_cache_key(cache_key))
+        .await?
+    else {
+        return Ok(None);
+    };
+
+    tracing::info!(
+        cache_key = %cache_key,
+        payload_size = cached_body.len(),
+        "Optimized Parquet cache HIT - returning cached response"
+    );
+
+    optimized_parquet_response(metadata_json, cached_body.into()).map(Some)
 }
 
 /// POST /api/v1/parse/parquet/optimized - Full parse with ara3d BOS-optimized Parquet format.
@@ -141,28 +217,15 @@ pub async fn parse_parquet_optimized(
     let metadata_json = serde_json::to_string(&metadata_header)?;
 
     // Store body and metadata BEFORE responding, not in a background task like
-    // the flat route (issue #3889). This payload is the small one -- that is the
-    // whole point of the route -- so the write is cheap, and a background write
-    // races the client's very next request, which is exactly the request the
-    // cache exists to serve. A write failure is logged and the response still
-    // goes out: the parse succeeded, only the replay is lost.
-    if let Err(e) = state
-        .cache
-        .set_bytes(&parquet_optimized_cache_key(&cache_key), &parquet_data)
-        .await
+    // the flat route (issue #3889): a background write races the client's very
+    // next request, which is the request the cache exists to serve, and this
+    // payload is the small one so the write is cheap. Metadata is written only
+    // after the body lands, so it can never sit under a key with no body behind
+    // it. A write failure is logged and the response still goes out: the parse
+    // succeeded, only the replay is lost.
+    if let Err(e) = cache_optimized_response(&state, &cache_key, &parquet_data, &metadata_json).await
     {
-        tracing::error!(error = %e, "Failed to cache optimized Parquet bytes");
-    } else if let Err(e) = state
-        .cache
-        .set_bytes(
-            &parquet_optimized_metadata_cache_key(&cache_key),
-            metadata_json.as_bytes(),
-        )
-        .await
-    {
-        // Reached only when the body landed, so a failure here cannot leave
-        // metadata sitting alone under a key with no body behind it.
-        tracing::error!(error = %e, "Failed to cache optimized Parquet metadata");
+        tracing::error!(error = %e, cache_key = %cache_key, "Failed to cache optimized Parquet response");
     } else {
         tracing::info!(
             cache_key = %cache_key,
@@ -171,17 +234,26 @@ pub async fn parse_parquet_optimized(
         );
     }
 
-    // Build response with binary body and metadata header
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            header::CONTENT_TYPE,
-            "application/x-parquet-geometry-optimized",
-        )
-        .header("X-IFC-Metadata", metadata_json)
-        .header(header::CONTENT_LENGTH, parquet_data.len())
-        .body(Body::from(parquet_data))
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    optimized_parquet_response(metadata_json, parquet_data)
+}
 
-    Ok(response)
+/// Write the optimized body and then its metadata, stopping at the first
+/// failure so metadata never outlives a body that was never stored.
+async fn cache_optimized_response(
+    state: &AppState,
+    cache_key: &str,
+    body: &[u8],
+    metadata_json: &str,
+) -> Result<(), ApiError> {
+    state
+        .cache
+        .set_bytes(&parquet_optimized_cache_key(cache_key), body)
+        .await?;
+    state
+        .cache
+        .set_bytes(
+            &parquet_optimized_metadata_cache_key(cache_key),
+            metadata_json.as_bytes(),
+        )
+        .await
 }

--- a/apps/server/src/routes/parse/parquet_optimized.rs
+++ b/apps/server/src/routes/parse/parquet_optimized.rs
@@ -1,0 +1,187 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `POST /api/v1/parse/parquet/optimized`: the ara3d BOS-optimized Parquet
+//! parse endpoint, split out of `parquet.rs` when it gained a cache of its own
+//! (issue #3889) so neither module crosses the 400-line ratchet.
+
+use super::cache_keys::{
+    cache_symbolic_data, parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
+    request_cache_key,
+};
+use super::cached_replay::try_cached_optimized_parquet;
+use super::{extract_file, ParseQuery};
+use crate::error::ApiError;
+use crate::services::{
+    serialize_to_parquet_optimized_with_stats, OptimizedStats, VERTEX_MULTIPLIER,
+};
+use crate::types::{ModelMetadata, ProcessingStats};
+use crate::AppState;
+use axum::{
+    body::Body,
+    extract::{Multipart, Query, State},
+    http::{header, StatusCode},
+    response::Response,
+};
+use ifc_lite_processing::{extract_symbolic_data, process_geometry_filtered_with_quality};
+use serde::Serialize;
+
+/// Response header containing metadata for optimized Parquet response.
+#[derive(Debug, Clone, Serialize)]
+pub struct OptimizedParquetMetadataHeader {
+    pub cache_key: String,
+    pub metadata: ModelMetadata,
+    pub stats: ProcessingStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mesh_coordinate_space: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_transform: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub building_transform: Option<Vec<f64>>,
+    pub optimization_stats: OptimizedStats,
+    /// Vertex multiplier for dequantization (10,000 = 0.1mm precision)
+    pub vertex_multiplier: f32,
+}
+
+/// POST /api/v1/parse/parquet/optimized - Full parse with ara3d BOS-optimized Parquet format.
+///
+/// Returns highly optimized binary Parquet data with:
+/// - Integer quantized vertices (0.1mm precision)
+/// - Mesh deduplication (instancing)
+/// - Byte colors instead of floats
+/// - Optional normals
+///
+/// Query params:
+/// - `normals=true` - Include normals (default: false, compute on client)
+///
+/// Typical compression: 3-5x smaller than basic Parquet, 50-75x smaller than JSON.
+pub async fn parse_parquet_optimized(
+    State(state): State<AppState>,
+    Query(query): Query<ParseQuery>,
+    mut multipart: Multipart,
+) -> Result<Response, ApiError> {
+    // Extract file from multipart
+    // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
+    // upload is buffered, reserving the max upload size since multipart rarely
+    // declares a length up front. Held for the request's whole lifetime so a
+    // disconnected-but-still-running job keeps its memory slot.
+    let admission_guard = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
+    let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
+
+    // Generate cache key (include opening filter so different modes get different cache entries)
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+    let cache_key = request_cache_key(&data, &query, tessellation_quality);
+
+    // Cache first, before any processing (issue #3889). The optimized route is
+    // the SMALL payload and the one a viewer opens repeatedly, so re-parsing it
+    // on every request was the worst of both shapes.
+    if let Some(response) = try_cached_optimized_parquet(&state, &cache_key).await? {
+        return Ok(response);
+    }
+
+    tracing::info!(
+        cache_key = %cache_key,
+        size = data.len(),
+        "Optimized Parquet cache MISS - processing file (ara3d BOS format)"
+    );
+
+    // Parse content
+    let content = data;
+    let opening_filter = query.opening_filter;
+
+    // Process on blocking thread pool (CPU-intensive). Extract the 2D symbol
+    // stream (IfcAnnotation + IfcGrid) alongside geometry for endpoint parity
+    // (issue #900) — it's cached and served via the symbolic fetch endpoint.
+    // Guard rides the blocking task (see parse_full).
+    let ((result, symbolic_data), _admission) = tokio::task::spawn_blocking(move || {
+        (
+            rayon::join(
+                || process_geometry_filtered_with_quality(&content, opening_filter, tessellation_quality),
+                || extract_symbolic_data(&content),
+            ),
+            admission_guard,
+        )
+    })
+    .await?;
+
+    // Cache the symbolic stream so the client can fetch it via
+    // `GET /api/v1/parse/symbolic/{cache_key}`.
+    cache_symbolic_data(&state.cache, &cache_key, &symbolic_data).await;
+
+    // Serialize to optimized Parquet (with deduplication, quantization, etc.)
+    // Don't include normals by default - client can compute them
+    let (parquet_data, opt_stats) =
+        serialize_to_parquet_optimized_with_stats(&result.meshes, false)?;
+
+    tracing::info!(
+        input_meshes = opt_stats.input_meshes,
+        unique_meshes = opt_stats.unique_meshes,
+        unique_materials = opt_stats.unique_materials,
+        mesh_reuse_ratio = opt_stats.mesh_reuse_ratio,
+        payload_size = parquet_data.len(),
+        "Optimized Parquet serialization complete"
+    );
+
+    // Create metadata header
+    let metadata_header = OptimizedParquetMetadataHeader {
+        cache_key: cache_key.clone(),
+        metadata: result.metadata,
+        stats: result.stats,
+        mesh_coordinate_space: result.mesh_coordinate_space,
+        site_transform: result.site_transform,
+        building_transform: result.building_transform,
+        optimization_stats: opt_stats,
+        vertex_multiplier: VERTEX_MULTIPLIER,
+    };
+
+    let metadata_json = serde_json::to_string(&metadata_header)?;
+
+    // Store body and metadata BEFORE responding, not in a background task like
+    // the flat route (issue #3889). This payload is the small one -- that is the
+    // whole point of the route -- so the write is cheap, and a background write
+    // races the client's very next request, which is exactly the request the
+    // cache exists to serve. A write failure is logged and the response still
+    // goes out: the parse succeeded, only the replay is lost.
+    if let Err(e) = state
+        .cache
+        .set_bytes(&parquet_optimized_cache_key(&cache_key), &parquet_data)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to cache optimized Parquet bytes");
+    } else if let Err(e) = state
+        .cache
+        .set_bytes(
+            &parquet_optimized_metadata_cache_key(&cache_key),
+            metadata_json.as_bytes(),
+        )
+        .await
+    {
+        // Reached only when the body landed, so a failure here cannot leave
+        // metadata sitting alone under a key with no body behind it.
+        tracing::error!(error = %e, "Failed to cache optimized Parquet metadata");
+    } else {
+        tracing::info!(
+            cache_key = %cache_key,
+            payload_size = parquet_data.len(),
+            "Cached optimized Parquet response"
+        );
+    }
+
+    // Build response with binary body and metadata header
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-parquet-geometry-optimized",
+        )
+        .header("X-IFC-Metadata", metadata_json)
+        .header(header::CONTENT_LENGTH, parquet_data.len())
+        .body(Body::from(parquet_data))
+        .map_err(|e| ApiError::Internal(e.to_string()))?;
+
+    Ok(response)
+}

--- a/apps/server/src/routes/parse/parquet_optimized.rs
+++ b/apps/server/src/routes/parse/parquet_optimized.rs
@@ -43,6 +43,20 @@ pub struct OptimizedParquetMetadataHeader {
     pub vertex_multiplier: f32,
 }
 
+/// Read a cache entry, treating an unreadable one as absent.
+///
+/// A corrupt entry must look like a miss to every caller on the replay path,
+/// or the route answers 500 forever for that file.
+async fn readable_entry(state: &AppState, key: &str) -> Option<Vec<u8>> {
+    match state.cache.get_bytes(key).await {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            tracing::warn!(error = %e, cache_key = %key, "Unreadable cache entry; re-parsing");
+            None
+        }
+    }
+}
+
 /// The optimized route's wire response, built in ONE place.
 ///
 /// The live parse and the cache replay must be indistinguishable to a client,
@@ -73,8 +87,14 @@ fn optimized_parquet_response(
 ///
 /// The stored metadata is the response header VERBATIM, so nothing here
 /// deserializes `OptimizedParquetMetadataHeader` and a replay reports the same
-/// `optimization_stats` the live parse did. A header that is not valid UTF-8
-/// (a corrupt entry) is a miss, not a 500.
+/// `optimization_stats` the live parse did.
+///
+/// EVERY way an entry can be unusable is a miss, never an error: a read that
+/// fails, and a header that is not valid UTF-8. cacache verifies content on
+/// read, so a truncated or orphaned blob (interrupted write, partial GC) comes
+/// back as an error -- and propagating it would 500 this file's every future
+/// request, because the parse that would overwrite the bad entry is the thing
+/// the error skips. A miss re-parses and rewrites it.
 ///
 /// The symbolic gate is not optional: this route's parse also writes the
 /// symbolic sidecar, so replaying past a missing one leaves the client's
@@ -87,10 +107,8 @@ async fn try_cached_optimized_parquet(
         return Ok(None);
     }
 
-    let Some(cached_metadata_json) = state
-        .cache
-        .get_bytes(&parquet_optimized_metadata_cache_key(cache_key))
-        .await?
+    let Some(cached_metadata_json) =
+        readable_entry(state, &parquet_optimized_metadata_cache_key(cache_key)).await
     else {
         return Ok(None);
     };
@@ -103,10 +121,7 @@ async fn try_cached_optimized_parquet(
         return Ok(None);
     };
 
-    let Some(cached_body) = state
-        .cache
-        .get_bytes(&parquet_optimized_cache_key(cache_key))
-        .await?
+    let Some(cached_body) = readable_entry(state, &parquet_optimized_cache_key(cache_key)).await
     else {
         return Ok(None);
     };

--- a/apps/server/src/routes/parse/parquet_optimized_tests.rs
+++ b/apps/server/src/routes/parse/parquet_optimized_tests.rs
@@ -1,0 +1,335 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Route-level tests for the optimized-Parquet endpoint's cache
+//! (`parse_parquet_optimized`, `POST /api/v1/parse/parquet/optimized`),
+//! added with issue #3889: the route had no cache key of its own, so every
+//! request re-parsed the file while the flat route beside it replayed.
+//!
+//! The proof that a repeat request does NOT parse is a sentinel: after a real
+//! request warms the cache, the stored body is overwritten with bytes no parse
+//! could ever produce. A second identical request that answers with those bytes
+//! read them off disk; one that parses answers with real Parquet instead.
+
+use super::cache_keys::{
+    data_model_cache_key, parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
+    request_cache_key, symbolic_cache_key,
+};
+use super::ParseQuery;
+use crate::config::Config;
+use crate::services::cache::DiskCache;
+use crate::{build_router, AppState};
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Request, StatusCode};
+use ifc_lite_processing::TessellationQuality;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const BOUNDARY: &str = "ifclite-3889-optimized-boundary";
+
+/// Bytes no optimized-Parquet serialization could ever emit (a real payload
+/// starts with the Parquet magic `PAR1`), so seeing them in a response is
+/// unambiguous evidence the response came from the cache.
+const SENTINEL_BODY: &[u8] = b"SENTINEL-OPTIMIZED-BODY-NOT-PARQUET";
+
+/// A minimal but real IFC file: the fall-through parse must actually succeed,
+/// so a failed assertion below is about the cache gate, not a parse error.
+const MINIMAL_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3889 optimized cache fixture'),'2;1');
+FILE_NAME('opt.ifc','2026-09-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn multipart_body(content: &[u8]) -> (String, Vec<u8>) {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"t.ifc\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(content);
+    body.extend_from_slice(format!("\r\n--{BOUNDARY}--\r\n").as_bytes());
+    (format!("multipart/form-data; boundary={BOUNDARY}"), body)
+}
+
+async fn test_state(label: &str) -> AppState {
+    let dir = std::env::temp_dir().join(format!(
+        "ifc-lite-server-3889-optimized-{}-{}",
+        std::process::id(),
+        label
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    let cache = Arc::new(DiskCache::new(dir.to_str().unwrap()).await);
+    AppState {
+        cache,
+        config: Arc::new(Config::from_env()),
+        admission: Arc::new(crate::admission::Admission::new(
+            crate::admission::AdmissionCfg {
+                max_concurrent_parses: 4,
+                mem_budget_bytes: 0,
+                queue_depth: 8,
+                queue_timeout: std::time::Duration::from_millis(100),
+                shed_pct: 85,
+            },
+        )),
+    }
+}
+
+/// Issue an optimized-Parquet request against `state` and return
+/// `(status, X-IFC-Metadata, body)`.
+async fn post_optimized(state: &AppState, content: &[u8]) -> (StatusCode, String, Vec<u8>) {
+    post_to(state, "/api/v1/parse/parquet/optimized", content).await
+}
+
+async fn post_to(state: &AppState, uri: &str, content: &[u8]) -> (StatusCode, String, Vec<u8>) {
+    let (content_type, body) = multipart_body(content);
+    let request = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(header::CONTENT_TYPE, content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let response = build_router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let metadata = response
+        .headers()
+        .get("X-IFC-Metadata")
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, metadata, body.to_vec())
+}
+
+/// The headline behaviour from #3889: a second identical request must be a
+/// disk read, not a parse.
+///
+/// The first request warms the cache; its body is then replaced with bytes no
+/// parse can produce. If the second request re-parsed (the pre-fix behaviour,
+/// where the route had no key at all) it would answer with real Parquet and
+/// this fails.
+#[tokio::test]
+async fn a_second_identical_optimized_request_replays_without_parsing() {
+    let state = test_state("replays").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
+
+    let (status, first_metadata, first_body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!first_body.is_empty(), "the live parse must return a payload");
+
+    // The write is synchronous, so the entries are there the moment the first
+    // response is in hand -- no sleep, no polling.
+    let body_key = parquet_optimized_cache_key(&cache_key);
+    let stored = state
+        .cache
+        .get_bytes(&body_key)
+        .await
+        .unwrap()
+        .expect("the optimized body must be cached after the first request");
+    assert_eq!(stored, first_body, "the cached body must be what was served");
+
+    state
+        .cache
+        .set_bytes(&body_key, SENTINEL_BODY)
+        .await
+        .expect("overwrite the cached body with a sentinel");
+
+    let (status, second_metadata, second_body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        second_body, SENTINEL_BODY,
+        "the second request re-parsed instead of replaying the cached body"
+    );
+    assert_eq!(
+        second_metadata, first_metadata,
+        "a replay must report the same metadata header (optimization_stats included)"
+    );
+}
+
+/// A hit on the flat route must NOT make the optimized route think it is
+/// cached. The two emit different payloads (quantized vertices, deduplicated
+/// shapes), so serving one where the other is expected is a decode error at
+/// best and a wrong model at worst.
+#[tokio::test]
+async fn a_cached_flat_response_does_not_satisfy_the_optimized_route() {
+    let state = test_state("flat-does-not-satisfy-optimized").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
+
+    // Everything the FLAT route's cache hit needs, and nothing else.
+    for (key, value) in [
+        (format!("{cache_key}-parquet-v5"), b"FLAT-GEOMETRY".as_slice()),
+        (format!("{cache_key}-parquet-metadata-v4"), b"{}".as_slice()),
+        (data_model_cache_key(&cache_key), b"FLAT-DATA-MODEL".as_slice()),
+        (symbolic_cache_key(&cache_key), b"{}".as_slice()),
+    ] {
+        state.cache.set_bytes(&key, value).await.expect("seed flat entry");
+    }
+
+    // Anti-vacuity: the flat entries really are a hit for the flat route.
+    let (status, _, flat_body) = post_to(&state, "/api/v1/parse/parquet", content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        flat_body, b"FLAT-GEOMETRY",
+        "fixture is wrong: the flat route did not treat its seeded entries as a hit"
+    );
+
+    let (status, metadata, body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        body, b"FLAT-GEOMETRY",
+        "the optimized route served the flat route's cached body"
+    );
+    assert!(
+        metadata.contains("optimization_stats"),
+        "the optimized route must have parsed and emitted its own header, got: {metadata}"
+    );
+}
+
+/// And the reverse: a cached optimized response must not be served by the flat
+/// route, whose clients decode a different format.
+#[tokio::test]
+async fn a_cached_optimized_response_does_not_satisfy_the_flat_route() {
+    let state = test_state("optimized-does-not-satisfy-flat").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
+
+    for (key, value) in [
+        (parquet_optimized_cache_key(&cache_key), SENTINEL_BODY),
+        (
+            parquet_optimized_metadata_cache_key(&cache_key),
+            b"{}".as_slice(),
+        ),
+        (symbolic_cache_key(&cache_key), b"{}".as_slice()),
+    ] {
+        state
+            .cache
+            .set_bytes(&key, value)
+            .await
+            .expect("seed optimized entry");
+    }
+
+    // Anti-vacuity: those entries really are a hit for the optimized route.
+    let (status, _, optimized_body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        optimized_body, SENTINEL_BODY,
+        "fixture is wrong: the optimized route did not treat its seeded entries as a hit"
+    );
+
+    let (status, _, body) = post_to(&state, "/api/v1/parse/parquet", content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        body, SENTINEL_BODY,
+        "the flat route served the optimized route's cached body"
+    );
+}
+
+/// The optimized parse is what writes the symbolic sidecar, so a body entry
+/// that outlived its sidecar must re-parse rather than replay. Otherwise the
+/// client's `GET /api/v1/parse/symbolic/{cache_key}` polls a key nobody ever
+/// writes -- the shape of #3869, one route over.
+#[tokio::test]
+async fn an_optimized_hit_with_no_symbolic_sidecar_re_parses_and_writes_one() {
+    let state = test_state("missing-symbolic").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
+    let symbolic_key = symbolic_cache_key(&cache_key);
+
+    state
+        .cache
+        .set_bytes(&parquet_optimized_cache_key(&cache_key), SENTINEL_BODY)
+        .await
+        .expect("seed optimized body");
+    state
+        .cache
+        .set_bytes(
+            &parquet_optimized_metadata_cache_key(&cache_key),
+            b"{\"stale\":true}",
+        )
+        .await
+        .expect("seed optimized metadata");
+
+    // Anti-vacuity: the sidecar really is absent before the request.
+    assert!(
+        state.cache.get_bytes(&symbolic_key).await.unwrap().is_none(),
+        "fixture must start with no symbolic sidecar"
+    );
+
+    let (status, _, body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        body, SENTINEL_BODY,
+        "a body with no symbolic sidecar must re-parse, not replay"
+    );
+    assert!(
+        state.cache.get_bytes(&symbolic_key).await.unwrap().is_some(),
+        "the re-parse must write the symbolic sidecar"
+    );
+}
+
+/// A body cached with no metadata beside it is a miss, not a 500 and not a
+/// response with an empty header: the client reads `cache_key`,
+/// `vertex_multiplier` and `optimization_stats` out of that header and cannot
+/// decode the payload without them.
+#[tokio::test]
+async fn an_optimized_body_with_no_metadata_re_parses() {
+    let state = test_state("body-without-metadata").await;
+    let content = MINIMAL_IFC.as_bytes();
+    let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
+
+    state
+        .cache
+        .set_bytes(&parquet_optimized_cache_key(&cache_key), SENTINEL_BODY)
+        .await
+        .expect("seed optimized body");
+    state
+        .cache
+        .set_bytes(&symbolic_cache_key(&cache_key), b"{}")
+        .await
+        .expect("seed symbolic sidecar");
+
+    let (status, metadata, body) = post_optimized(&state, content).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(body, SENTINEL_BODY, "a body with no metadata must re-parse");
+    assert!(
+        metadata.contains("vertex_multiplier"),
+        "the re-parse must emit a full metadata header, got: {metadata}"
+    );
+}
+
+/// Different files must not share an optimized entry: the second request's
+/// content differs, so it parses rather than replaying the first one's body.
+#[tokio::test]
+async fn a_different_file_does_not_hit_the_first_files_optimized_entry() {
+    let state = test_state("different-file").await;
+    let first = MINIMAL_IFC.as_bytes();
+    let second = MINIMAL_IFC.replace("'W1'", "'W2'");
+
+    let (status, _, _) = post_optimized(&state, first).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let first_key =
+        request_cache_key(first, &ParseQuery::default(), TessellationQuality::default());
+    state
+        .cache
+        .set_bytes(&parquet_optimized_cache_key(&first_key), SENTINEL_BODY)
+        .await
+        .expect("mark the first file's entry");
+
+    let (status, _, body) = post_optimized(&state, second.as_bytes()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_ne!(
+        body, SENTINEL_BODY,
+        "a different file read the first file's cached body"
+    );
+}

--- a/apps/server/src/routes/parse/parquet_optimized_tests.rs
+++ b/apps/server/src/routes/parse/parquet_optimized_tests.rs
@@ -13,12 +13,14 @@
 //! read them off disk; one that parses answers with real Parquet instead.
 
 use super::cache_keys::{
-    data_model_cache_key, parquet_optimized_cache_key, parquet_optimized_metadata_cache_key,
-    request_cache_key, symbolic_cache_key,
+    data_model_cache_key, parquet_cache_key, parquet_metadata_cache_key,
+    parquet_optimized_cache_key, parquet_optimized_metadata_cache_key, request_cache_key,
+    symbolic_cache_key,
 };
 use super::ParseQuery;
 use crate::config::Config;
 use crate::services::cache::DiskCache;
+use crate::services::OpeningFilterMode;
 use crate::{build_router, AppState};
 use axum::body::{to_bytes, Body};
 use axum::http::{header, Request, StatusCode};
@@ -165,10 +167,23 @@ async fn a_cached_flat_response_does_not_satisfy_the_optimized_route() {
     let content = MINIMAL_IFC.as_bytes();
     let cache_key = request_cache_key(content, &ParseQuery::default(), TessellationQuality::default());
 
-    // Everything the FLAT route's cache hit needs, and nothing else.
+    // Everything the FLAT route's cache hit needs, and nothing else. Built
+    // from the shared key helpers, so a flat-suffix bump moves this fixture
+    // with the route instead of leaving it seeding a dead key.
+    let hash = DiskCache::generate_key(content);
+    let flat_key = parquet_cache_key(
+        &hash,
+        OpeningFilterMode::Default,
+        TessellationQuality::default(),
+    );
+    let flat_metadata_key = parquet_metadata_cache_key(
+        &hash,
+        OpeningFilterMode::Default,
+        TessellationQuality::default(),
+    );
     for (key, value) in [
-        (format!("{cache_key}-parquet-v5"), b"FLAT-GEOMETRY".as_slice()),
-        (format!("{cache_key}-parquet-metadata-v4"), b"{}".as_slice()),
+        (flat_key, b"FLAT-GEOMETRY".as_slice()),
+        (flat_metadata_key, b"{}".as_slice()),
         (data_model_cache_key(&cache_key), b"FLAT-DATA-MODEL".as_slice()),
         (symbolic_cache_key(&cache_key), b"{}".as_slice()),
     ] {

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -543,7 +543,8 @@ Cache keys are derived from file content:
 
 # POST /parse/parquet/optimized has its own pair (issue #3889): the optimized
 # payload is quantized and deduplicated, so a hit on one route must never
-# satisfy the other.
+# satisfy the other. Both pairs are built from the same geometry pipeline, so
+# a bump of -parquet-v5 almost always needs a bump of -parquet-optimized-v1.
 {SHA256}-{filter}-parquet-optimized-v1          # Optimized geometry
 {SHA256}-{filter}-parquet-optimized-metadata-v1 # Optimized metadata header
 ```

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -540,6 +540,12 @@ Cache keys are derived from file content:
 {SHA256}-{filter}-parquet-metadata-v4 # Metadata header
 {SHA256}-{filter}-datamodel-v6        # Properties & hierarchy
 {SHA256}-{filter}-symbolic-v1         # 2D symbol stream
+
+# POST /parse/parquet/optimized has its own pair (issue #3889): the optimized
+# payload is quantized and deduplicated, so a hit on one route must never
+# satisfy the other.
+{SHA256}-{filter}-parquet-optimized-v1          # Optimized geometry
+{SHA256}-{filter}-parquet-optimized-metadata-v1 # Optimized metadata header
 ```
 
 Each suffix is bumped whenever the payload it names changes shape: a column


### PR DESCRIPTION
Closes #3889.

`POST /api/v1/parse/parquet/optimized` re-parsed on every request because the response shape had no cache key. It now has two, `{seed}-parquet-optimized-v1` for the body and `{seed}-parquet-optimized-metadata-v1` for the `X-IFC-Metadata` header stored verbatim, so a replay reports the same `optimization_stats` the live parse did. The namespace is separate from `-parquet-v5`, so a cached flat response never satisfies the optimized route and vice versa. The handler moves to its own module so `parquet.rs` stays under the ratchet.

Three design points on the record: the write is synchronous rather than backgrounded, because a background write races the very next request and this is the small payload; a hit also requires the symbolic sidecar, since the optimized parse writes it and replaying past a missing one would leave `GET /parse/symbolic/{key}` polling a key nobody writes; and a truncated or orphaned cached blob degrades to a miss with a warning instead of a 500 on every later request.

Tests: a second identical request replays without parsing (a sentinel written over the cached body comes back), flat-cached does not satisfy optimized and vice versa with anti-vacuity checks, a missing sidecar re-parses and writes one, a body without metadata re-parses, a different file does not read the first file's entry, and key uniqueness across all suffixes. Both keys documented in docs/guide/server.md and cache_keys.rs.

Not verified against a live server or the 57.9 MB file from the issue; what is proven is that the second request does not parse. Gates on the head: `cargo test -p ifc-lite-server` 0 (246 passed), clippy -D warnings 0, module_size_ratchet 6/6, check-module-size 0, check-changesets 0. Changeset: `@ifc-lite/server-bin` minor.