### PR TITLE
docs(server): declare metadata in the malformed-record snippet so the sample typechecks

### DIFF
--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -288,6 +288,7 @@ than these fields sends neither, which means "not scanned for" — never
 "clean". Branch on presence before reading the value:
 
 ```typescript
+const metadata = await client.getMetadata(file);
 if (metadata.malformed_record_found) {
   console.warn('This file is truncated — the counts above are partial.');
 } else if (metadata.malformed_record_found === undefined) {


### PR DESCRIPTION
`pnpm docs:check-samples` has been red on main since #3858: the second fenced sample under `getMetadata` in docs/guide/server.md reads `metadata` without declaring it, and each fenced block is typechecked on its own. One line added. Exit code on the head: docs:check-samples 0 (382 snippets across 84 docs).