### PR TITLE
fix(renderer): fit every box corner when framing, and take the view direction from the camera basis

### DIFF
--- a/.changeset/renderer-frame-corner-fit.md
+++ b/.changeset/renderer-frame-corner-fit.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Frame Selection and Zoom Extents now frame far enough out to keep every corner of the box on screen, in both perspective and orthographic mode, and the ViewCube presets do the same in perspective. The fit came from the box's largest side measured at its centre, which ignores both the near half of the box and the direction it is seen from, so an oblique or portrait framing could crop the selection. Frame Selection also took its view direction from a mis-indexed read of the view matrix, which mirrored the camera on an ordinary orbited pose; it now uses the pose the camera is in.

--- a/packages/renderer/src/camera-fit-viewport-shape.test.ts
+++ b/packages/renderer/src/camera-fit-viewport-shape.test.ts
@@ -46,10 +46,11 @@ function makeMat4(): Mat4 {
 }
 
 /**
- * A state whose view matrix is the identity, which makes
- * `frameBoundsTarget`'s "forward is the negative Z column" read out as
- * `(0, 0, -1)` — a well-defined direction, so the fit takes its primary path
- * rather than either fallback.
+ * A state looking down -Z from 100 units away, on an identity view matrix.
+ *
+ * Since #3892 the fits derive their basis from the pose through `viewBasis`
+ * rather than reading the view matrix, so what makes the direction here
+ * well-defined is `position` / `target` / `up`, not the matrix.
  */
 function makeState(aspect: number, mode: 'perspective' | 'orthographic' = 'perspective'): CameraInternalState {
   const camera: CameraType = {
@@ -155,13 +156,19 @@ describe('fit distance honours the horizontal field of view (#2500)', () => {
     );
   });
 
-  it('anti-mutation: a landscape viewport is bit-for-bit unchanged', () => {
+  it('anti-mutation: a landscape viewport takes the vertical field alone', () => {
     // The vertical field is the binding one for every `aspect >= 1`, so the
     // aspect term must contribute exactly nothing there. If this drifts, the
     // fix has changed the framing of every desktop viewport rather than only
     // the portrait one it was for.
+    //
+    // The value moved with #3892, which is the only pin in this file that did:
+    // the fit is now the smallest standoff that puts every CORNER inside the
+    // half-angles, and the near face of the cube is `CUBE_SIZE / 2` closer
+    // than the centre the old side-based rule measured from. Head-on and
+    // axis-aligned as this state is, that near half is the whole difference.
     for (const aspect of [1, 4 / 3, 16 / 9, 21 / 9]) {
-      const vertical = (CUBE_SIZE / 2) / Math.tan(FOV / 2);
+      const vertical = (CUBE_SIZE / 2) / Math.tan(FOV / 2) + CUBE_SIZE / 2;
       for (const [label, pick, padding] of [
         ['frameBounds', frameBoundsTarget, 1.2],
         ['zoomExtent', zoomExtentTarget, 1.5],
@@ -206,7 +213,8 @@ describe('zoomExtent keeps a view direction for a degenerate box (#2500)', () =>
   it('anti-mutation: an ordinary box still fits to the FOV distance, not the current offset', () => {
     const fit = zoomExtentTarget(makeState(16 / 9), CUBE_MIN, CUBE_MAX);
     assert.ok(fit, 'fit expected');
-    const expected = (CUBE_SIZE / 2) / Math.tan(FOV / 2) * 1.5;
+    // Same corner-fit value as the landscape pin above (#3892), 1.5x padded.
+    const expected = ((CUBE_SIZE / 2) / Math.tan(FOV / 2) + CUBE_SIZE / 2) * 1.5;
     assert.ok(
       Math.abs(distanceBetween(fit.position, fit.target) - expected) < 1e-6,
       'a non-degenerate box must still take the FOV path, not the degenerate one',
@@ -233,10 +241,10 @@ describe('the fit direction floors reject Infinity, not only NaN (#2500)', () =>
     }
   });
 
-  it('frameBounds falls back to the isometric direction for an overflowed pose', () => {
-    // A zeroed view matrix is what pushes `frameBoundsTarget` past its primary
-    // (view-matrix) direction onto the pose-derived fallback that carries the
-    // floor. `MathUtils.lookAt` produces one for a pose it cannot orient from.
+  it('frameBounds keeps a finite pose for an overflowed one', () => {
+    // Since #3892 the direction comes from `viewBasis`, which scrubs the
+    // overflowed coordinate rather than dividing by it. The zeroed view matrix
+    // is left in place to show the fit no longer reads it at all.
     const state = makeState(16 / 9);
     state.viewMatrix = { m: new Float32Array(16) };
     state.camera.position = { ...OVERFLOWED };
@@ -248,10 +256,10 @@ describe('the fit direction floors reject Infinity, not only NaN (#2500)', () =>
   });
 
   it('anti-mutation: a finite pose still steers both fits', () => {
-    // The floors must reject only unusable lengths. If they rejected
-    // everything, both fits would silently snap to the isometric fallback and
-    // the tests above would pass against a camera that had stopped honouring
-    // the view direction at all.
+    // The scrubbing must apply only to unusable coordinates. If it applied to
+    // everything, both fits would silently snap to a substitute basis and the
+    // tests above would pass against a camera that had stopped honouring the
+    // view direction at all.
     const zoom = zoomExtentTarget(makeState(16 / 9), CUBE_MIN, CUBE_MAX);
     assert.ok(zoom, 'fit expected');
     // The state looks down -Z, so the fit sits on +Z of the centre.
@@ -263,7 +271,7 @@ describe('the fit direction floors reject Infinity, not only NaN (#2500)', () =>
     const framed = frameBoundsTarget(framedState, CUBE_MIN, CUBE_MAX);
     assert.ok(framed, 'fit expected');
     assert.ok(Math.abs(framed.position.x) < 1e-9 && Math.abs(framed.position.y) < 1e-9,
-      `frameBounds should fall back to the pose direction, got ${JSON.stringify(framed.position)}`);
+      `frameBounds should keep the pose direction, got ${JSON.stringify(framed.position)}`);
   });
 });
 

--- a/packages/renderer/src/camera-frame-corner-fit.test.ts
+++ b/packages/renderer/src/camera-frame-corner-fit.test.ts
@@ -1,0 +1,346 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Frame Selection has to leave every corner of the box it was handed on
+ * screen, for the direction the camera is actually pointing (#3892).
+ *
+ * `fitDistanceFor` used to fit the box's LARGEST SIDE into the half-angles,
+ * which answers a different question than the projection asks. Two ways that
+ * came apart, both of them live on the viewer's Frame Selection path:
+ *
+ *  1. **Depth.** The near half of the box is closer than its centre, so it
+ *     projects bigger than the side-based rule accounts for. Even head-on and
+ *     axis-aligned, a cube needs `half / tan + half`, not `half / tan`.
+ *  2. **Obliqueness.** The direction comes from the live pose and is
+ *     essentially never axis-aligned, and down a diagonal a box projects wider
+ *     than any single side of it.
+ *
+ * Orthographic mode gets its own suite at the bottom. There the standoff sets
+ * no scale at all — `orthoSize` does — so only the obliqueness half applies,
+ * and it applies to a different formula.
+ *
+ * The oracle is deliberately not the fit's own arithmetic: it builds a
+ * view-projection matrix from the pose the fit returned and pushes all eight
+ * corners through it. A corner is on screen when `|clip.x| <= clip.w` and
+ * `|clip.y| <= clip.w`. `MathUtils.perspective` rather than the renderer's
+ * `perspectiveReverseZ`: they differ only in the depth row, and the clip x, y
+ * and w these assertions read are identical between them.
+ *
+ * `worstClipRatio` also gives the anti-mutation half. The inside-check is
+ * monotone in distance, so it passes on a camera parked arbitrarily far away;
+ * the padding is a plain multiple of the fitted distance, so scaling the pose
+ * back by it must land the worst corner exactly ON the frustum edge.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import type { Vec3, Camera as CameraType, Mat4 } from './types.js';
+import type { CameraInternalState } from './camera-state.js';
+import {
+  frameBoundsTarget,
+  zoomExtentTarget,
+  type FramingBounds,
+  type FramingTarget,
+} from './camera-framing.js';
+import { CAMERA_CONSTANTS } from './constants.js';
+import { presetViewTarget } from './camera-preset-view.js';
+import { MathUtils } from './math.js';
+
+const FOV = Math.PI / 4;
+const UP: Vec3 = { x: 0, y: 1, z: 0 };
+
+/** `presetViewTarget` pads like Zoom Extents does. */
+const PRESET_PADDING = CAMERA_CONSTANTS.ZOOM_EXTENT_PADDING;
+
+/**
+ * A camera state at this pose.
+ *
+ * The view matrix is filled in with the one the renderer would build so the
+ * state is internally consistent, but since #3892 none of the fits read it:
+ * they take their basis from `position` / `target` / `up` through `viewBasis`.
+ */
+function makeState(
+  aspect: number,
+  position: Vec3,
+  target: Vec3,
+  mode: 'perspective' | 'orthographic' = 'perspective',
+): CameraInternalState {
+  const camera: CameraType = {
+    position,
+    target,
+    up: { ...UP },
+    fov: FOV,
+    aspect,
+    near: 0.1,
+    far: 100000,
+  };
+  const identity: Mat4 = { m: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]) };
+  return {
+    camera,
+    viewMatrix: MathUtils.lookAt(position, target, camera.up),
+    projMatrix: identity,
+    viewProjMatrix: identity,
+    projectionMode: mode,
+    orthoSize: 50,
+    sceneBounds: null,
+    orbitAnchorBounds: null,
+  };
+}
+
+/** `m * (v, 1)`, column-major, as `MathUtils.multiply` and `lookAt` store it. */
+function transform(m: Float32Array, v: Vec3): { x: number; y: number; w: number } {
+  return {
+    x: m[0] * v.x + m[4] * v.y + m[8] * v.z + m[12],
+    y: m[1] * v.x + m[5] * v.y + m[9] * v.z + m[13],
+    w: m[3] * v.x + m[7] * v.y + m[11] * v.z + m[15],
+  };
+}
+
+/** Enumerated here rather than shared with the fit, so the oracle cannot inherit its blind spot. */
+function cornersOf(bounds: FramingBounds): Vec3[] {
+  const out: Vec3[] = [];
+  for (const x of [bounds.min.x, bounds.max.x]) {
+    for (const y of [bounds.min.y, bounds.max.y]) {
+      for (const z of [bounds.min.z, bounds.max.z]) out.push({ x, y, z });
+    }
+  }
+  return out;
+}
+
+/**
+ * How far the worst corner of `bounds` reaches towards the edge of the frame,
+ * as a fraction of the half-frame it is measured against. `<= 1` is on screen.
+ */
+function worstClipRatio(
+  pose: FramingTarget,
+  bounds: FramingBounds,
+  projection: Mat4,
+  up: Vec3 = UP,
+): number {
+  const viewProj = MathUtils.multiply(projection, MathUtils.lookAt(pose.position, pose.target, up));
+  let worst = 0;
+  for (const corner of cornersOf(bounds)) {
+    const clip = transform(viewProj.m, corner);
+    assert.ok(clip.w > 0, `corner ${JSON.stringify(corner)} is behind the camera (w = ${clip.w})`);
+    worst = Math.max(worst, Math.abs(clip.x) / clip.w, Math.abs(clip.y) / clip.w);
+  }
+  return worst;
+}
+
+function perspectiveAt(aspect: number): Mat4 {
+  return MathUtils.perspective(FOV, aspect, 0.1, 100000);
+}
+
+/** The frame `orthoSize` describes: half-height `size`, half-width `size * aspect`. */
+function orthographicAt(size: number, aspect: number): Mat4 {
+  return MathUtils.orthographicReverseZ(-size * aspect, size * aspect, -size, size, 0.1, 100000);
+}
+
+/** The same pose with its standoff divided by `padding`. */
+function unpadded(pose: FramingTarget, padding: number): FramingTarget {
+  return {
+    ...pose,
+    position: {
+      x: pose.target.x + (pose.position.x - pose.target.x) / padding,
+      y: pose.target.y + (pose.position.y - pose.target.y) / padding,
+      z: pose.target.z + (pose.position.z - pose.target.z) / padding,
+    },
+  };
+}
+
+function boxAt(center: Vec3, size: Vec3): FramingBounds {
+  return {
+    min: { x: center.x - size.x / 2, y: center.y - size.y / 2, z: center.z - size.z / 2 },
+    max: { x: center.x + size.x / 2, y: center.y + size.y / 2, z: center.z + size.z / 2 },
+  };
+}
+
+const ORIGIN: Vec3 = { x: 0, y: 0, z: 0 };
+
+/** Centre of the one box that does not sit on the origin. */
+const OFF_CENTRE: Vec3 = { x: 120, y: -30, z: 55 };
+
+/** A unit cube, an elongated slab — the shape the issue names — and one away from the origin. */
+const BOXES: ReadonlyArray<readonly [string, Vec3, FramingBounds]> = [
+  ['unit cube', ORIGIN, boxAt(ORIGIN, { x: 1, y: 1, z: 1 })],
+  ['elongated slab', ORIGIN, boxAt(ORIGIN, { x: 40, y: 3, z: 8 })],
+  ['off-centre slab', OFF_CENTRE, boxAt(OFF_CENTRE, { x: 24, y: 2, z: 2 })],
+];
+
+/**
+ * Offsets whose view direction is oblique to every box axis, which is what the
+ * live pose almost always is: the camera has been orbited.
+ */
+const OBLIQUE_OFFSETS: ReadonlyArray<readonly [string, Vec3]> = [
+  ['south-east isometric', { x: 60, y: 50, z: 60 }],
+  ['shallow diagonal', { x: 130, y: 17, z: -71 }],
+  ['steep diagonal', { x: -23, y: 140, z: 41 }],
+];
+
+const ASPECTS: ReadonlyArray<readonly [string, number]> = [
+  ['16:9', 16 / 9],
+  ['1:1', 1],
+  ['9:16', 9 / 16],
+];
+
+/** The two fits that inherit the pose's direction, with the padding each uses. */
+const POSE_FITS = [
+  ['frameBounds', frameBoundsTarget, CAMERA_CONSTANTS.FRAME_PADDING_MULTIPLIER],
+  ['zoomExtent', zoomExtentTarget, CAMERA_CONSTANTS.ZOOM_EXTENT_PADDING],
+] as const;
+
+function posedAt(center: Vec3, offset: Vec3): Vec3 {
+  return { x: center.x + offset.x, y: center.y + offset.y, z: center.z + offset.z };
+}
+
+describe('Frame Selection keeps every box corner on screen (#3892)', () => {
+  for (const [boxLabel, center, bounds] of BOXES) {
+    for (const [dirLabel, offset] of OBLIQUE_OFFSETS) {
+      for (const [aspectLabel, aspect] of ASPECTS) {
+        for (const [fitLabel, pick] of POSE_FITS) {
+          it(`${fitLabel}: ${boxLabel}, ${dirLabel}, ${aspectLabel}`, () => {
+            const state = makeState(aspect, posedAt(center, offset), center);
+            const fit = pick(state, bounds.min, bounds.max);
+            assert.ok(fit, 'the box is usable and must produce a fit');
+            const ratio = worstClipRatio(fit, bounds, perspectiveAt(aspect));
+            assert.ok(ratio <= 1, `worst corner reaches ${ratio.toFixed(4)} of the half-frame; > 1 is cropped`);
+          });
+        }
+      }
+    }
+  }
+
+  it('a head-on preset view keeps the near face on screen too', () => {
+    // Not an oblique direction at all: the depth half of the defect on its
+    // own. The near face of a cube is `half` closer than the centre the
+    // side-based rule measured from.
+    for (const [, aspect] of ASPECTS) {
+      for (const view of ['front', 'back', 'left', 'right', 'top', 'bottom'] as const) {
+        const bounds = boxAt(ORIGIN, { x: 20, y: 20, z: 20 });
+        const state = makeState(aspect, { x: 0, y: 0, z: 100 }, ORIGIN);
+        const fit = presetViewTarget(state, view, bounds, 0);
+        const ratio = worstClipRatio(fit, bounds, perspectiveAt(aspect), fit.up);
+        assert.ok(ratio <= 1, `${view} @ ${aspect}: worst corner reaches ${ratio.toFixed(4)}`);
+      }
+    }
+  });
+});
+
+describe('the corner fit is tight under its padding (#3892)', () => {
+  // Without this the suite above would pass on a camera parked arbitrarily far
+  // away, since the inside-check only ever relaxes with distance.
+  for (const [boxLabel, center, bounds] of BOXES) {
+    for (const [fitLabel, pick, padding] of POSE_FITS) {
+      it(`${fitLabel} puts the worst corner on the edge once padding is removed: ${boxLabel}`, () => {
+        const position = posedAt(center, { x: 130, y: 17, z: -71 });
+        for (const [, aspect] of ASPECTS) {
+          const fit = pick(makeState(aspect, position, center), bounds.min, bounds.max);
+          assert.ok(fit, 'fit expected');
+          const ratio = worstClipRatio(unpadded(fit, padding), bounds, perspectiveAt(aspect));
+          assert.ok(
+            Math.abs(ratio - 1) < 1e-4,
+            `@ aspect ${aspect}: unpadded worst corner reaches ${ratio.toFixed(6)}, expected 1`,
+          );
+        }
+      });
+    }
+  }
+
+  it('presetViewTarget is tight too', () => {
+    const bounds = boxAt(ORIGIN, { x: 40, y: 6, z: 12 });
+    for (const [, aspect] of ASPECTS) {
+      const state = makeState(aspect, { x: 0, y: 0, z: 100 }, ORIGIN);
+      const fit = presetViewTarget(state, 'front', bounds, 0);
+      const ratio = worstClipRatio(unpadded(fit, PRESET_PADDING), bounds, perspectiveAt(aspect), fit.up);
+      assert.ok(
+        Math.abs(ratio - 1) < 1e-4,
+        `@ aspect ${aspect}: unpadded worst corner reaches ${ratio.toFixed(6)}, expected 1`,
+      );
+    }
+  });
+});
+
+describe('orthographic framing keeps every box corner on screen (#3892)', () => {
+  // `orthoSize` is the whole framing in orthographic mode — the standoff sets
+  // no scale — so the corner fit has to reach it as well. There is no depth
+  // term to answer here, an orthographic projection does not foreshorten, but
+  // the obliqueness one lands in full: down a south-east isometric direction a
+  // 20-unit cube reaches 15.9 units above the centre line, against the 10 the
+  // largest-side rule allowed.
+  for (const [boxLabel, center, bounds] of BOXES) {
+    for (const [dirLabel, offset] of OBLIQUE_OFFSETS) {
+      for (const [aspectLabel, aspect] of ASPECTS) {
+        for (const [fitLabel, pick] of POSE_FITS) {
+          it(`${fitLabel}: ${boxLabel}, ${dirLabel}, ${aspectLabel}`, () => {
+            const state = makeState(aspect, posedAt(center, offset), center, 'orthographic');
+            const fit = pick(state, bounds.min, bounds.max);
+            assert.ok(fit, 'the box is usable and must produce a fit');
+            assert.ok(fit.orthoSize !== undefined, 'orthographic mode must report an orthoSize');
+            const ratio = worstClipRatio(fit, bounds, orthographicAt(fit.orthoSize, aspect));
+            assert.ok(ratio <= 1, `worst corner reaches ${ratio.toFixed(4)} of the half-frame; > 1 is cropped`);
+          });
+        }
+      }
+    }
+  }
+
+  it('the orthographic fit is tight under its padding', () => {
+    // Same guard as the perspective one: `orthoSize` grows the frame, so the
+    // check above passes on any value large enough. Divide the padding back
+    // out and the worst corner must sit exactly on the edge.
+    const center = OFF_CENTRE;
+    const bounds = boxAt(center, { x: 24, y: 2, z: 2 });
+    for (const [, aspect] of ASPECTS) {
+      for (const [fitLabel, pick, padding] of POSE_FITS) {
+        const state = makeState(aspect, posedAt(center, { x: 130, y: 17, z: -71 }), center, 'orthographic');
+        const fit = pick(state, bounds.min, bounds.max);
+        assert.ok(fit?.orthoSize !== undefined, 'orthoSize expected');
+        const ratio = worstClipRatio(fit, bounds, orthographicAt(fit.orthoSize / padding, aspect));
+        assert.ok(
+          Math.abs(ratio - 1) < 1e-4,
+          `${fitLabel} @ aspect ${aspect}: unpadded worst corner reaches ${ratio.toFixed(6)}, expected 1`,
+        );
+      }
+    }
+  });
+
+  it('a degenerate box still gets a usable orthoSize floor', () => {
+    // The floor the largest-side rule carried and the corner walk must keep: a
+    // box with no size fits at every scale including zero, which would leave
+    // the viewer at infinite zoom. Reached with a degenerate POSE as well,
+    // which is what sends a point-sized box past `zoomExtent`'s
+    // keep-the-current-offset branch and into the fit.
+    const point: Vec3 = { x: 5, y: 5, z: 5 };
+    const state = makeState(16 / 9, point, point, 'orthographic');
+    const fit = zoomExtentTarget(state, point, point);
+    assert.ok(fit, 'a degenerate box is valid and must still produce a fit');
+    assert.ok((fit.orthoSize ?? 0) > 0, `orthoSize must stay positive, was ${fit.orthoSize}`);
+  });
+});
+
+describe('Frame Selection points the camera where the pose points (#3892)', () => {
+  // The fit read the view matrix as `-(m[8], m[9], m[10])`, which is the world
+  // Z axis expressed in CAMERA coordinates, not the camera's world-space
+  // backward axis (that is `(m[2], m[6], m[10])`). It is unit length, so no
+  // finiteness or magnitude guard could notice, and it agreed with the pose
+  // only for a symmetric rotation. Frame Selection therefore jumped to a
+  // mirrored direction on the very poses the corner fit is about.
+  it('keeps the current view direction for an oblique pose', () => {
+    const bounds = boxAt(ORIGIN, { x: 10, y: 10, z: 10 });
+    const offset: Vec3 = { x: 60, y: 50, z: 60 };
+    const state = makeState(16 / 9, offset, ORIGIN);
+    const fit = frameBoundsTarget(state, bounds.min, bounds.max);
+    assert.ok(fit, 'fit expected');
+    const len = Math.sqrt(offset.x ** 2 + offset.y ** 2 + offset.z ** 2);
+    const fitLen = Math.sqrt(fit.position.x ** 2 + fit.position.y ** 2 + fit.position.z ** 2);
+    for (const axis of ['x', 'y', 'z'] as const) {
+      assert.ok(
+        Math.abs(fit.position[axis] / fitLen - offset[axis] / len) < 1e-6,
+        `position.${axis} is ${fit.position[axis]}, off the pose's own direction`,
+      );
+    }
+  });
+});

--- a/packages/renderer/src/camera-framing.ts
+++ b/packages/renderer/src/camera-framing.ts
@@ -10,8 +10,8 @@
  * The ViewCube's *preset* directions are the neighbouring subject and live in
  * `camera-preset-view.ts`: there the direction is dictated by a named face and
  * a rotation cycle rather than inherited from the pose, and the box has to pass
- * its own admission check first. They share only the box arithmetic below,
- * which is why `centerOf` / `maxExtentOf` are exported.
+ * its own admission check first. They share the box arithmetic below and the
+ * corner fit, which is why `centerOf` and `fitDistanceFor` are exported.
  *
  * Pure by construction — every function here reads `CameraInternalState` and
  * returns a target, and none of them writes to it or touches the tween. That
@@ -36,6 +36,8 @@
 import type { Vec3 } from './types.js';
 import type { CameraInternalState } from './camera-state.js';
 import { areFiniteNumbers, isUsableBounds, isUsableDistance } from './camera-guards.js';
+import { MathUtils, viewBasis } from './math.js';
+import { CAMERA_CONSTANTS } from './constants.js';
 
 /** A pose to animate to. `orthoSize` is undefined when the fit should not touch zoom. */
 export interface FramingTarget {
@@ -64,47 +66,205 @@ export function centerOf(min: Vec3, max: Vec3): Vec3 {
   };
 }
 
-/** Largest edge length of a box. */
-export function maxExtentOf(min: Vec3, max: Vec3): number {
+/** Largest edge length of a box. Local: only the two fits below measure it. */
+function maxExtentOf(min: Vec3, max: Vec3): number {
   return Math.max(max.x - min.x, max.y - min.y, max.z - min.z);
 }
 
 /**
- * Orthographic half-height that shows a box of `maxSize` with `padding` slack,
- * or `undefined` in perspective mode where `orthoSize` is not in play.
+ * The viewport's width-to-height ratio, or 1 when it carries no usable one.
+ *
+ * `setAspect` is the only writer and already rejects a non-positive or
+ * non-finite ratio, so the substitute is only for a hand-built state — but
+ * both fits below key on it, and an `Infinity` would silently drop the
+ * horizontal constraint from one while the other substituted.
  */
-function orthoSizeFor(state: CameraInternalState, maxSize: number, padding: number): number | undefined {
-  if (state.projectionMode !== 'orthographic') return undefined;
-  const aspect = state.camera.aspect || 1;
-  return Math.max(0.01, maxSize / 2, maxSize / 2 / aspect) * padding;
+function usableAspect(state: CameraInternalState): number {
+  const aspect = state.camera.aspect;
+  return Number.isFinite(aspect) && aspect > 0 ? aspect : 1;
+}
+
+/** Smallest half-height in model units that shows every corner of the box. */
+function orthoHalfHeightFor(bounds: FramingBounds, axes: ViewAxes, aspect: number): number {
+  let half = 0;
+  for (const corner of cornerOffsets(bounds)) {
+    const h = Math.abs(MathUtils.dot(corner, axes.right));
+    const v = Math.abs(MathUtils.dot(corner, axes.up));
+    half = Math.max(half, v, h / aspect);
+  }
+  return half;
 }
 
 /**
- * Distance at which a box of `maxSize` fits the perspective frustum, with
- * `padding` slack. Shared with `camera-preset-view.ts`, which fits the same
- * way from a dictated direction.
+ * Orthographic half-height that shows the box with `padding` slack, or
+ * `undefined` in perspective mode where `orthoSize` is not in play.
  *
- * Fits **both** screen axes. The vertical half-angle is `fov / 2`; the
- * horizontal one is `atan(tan(fov / 2) * aspect)`, so on a portrait viewport
- * (`aspect < 1`) the horizontal field is the *narrower* of the two and a
- * distance derived from the vertical field alone leaves the box overflowing
- * left and right — the fit silently clips the very thing it was asked to
- * frame. Landscape is unaffected: for `aspect >= 1` the vertical field is
- * already the binding one and this returns the vertical distance exactly,
- * bit for bit.
- *
- * `orthoSizeFor` above has divided by `aspect` for the same reason since it
- * was written; this is the perspective half of the same rule, which had been
- * missing (the three fit-distance formulas in this package all predate it).
+ * Corner-based for the same reason {@link fitDistanceFor} is (#3892), and it
+ * is the half that decides what an orthographic viewer actually sees: there
+ * the standoff sets no scale at all, so a largest-side `orthoSize` cropped the
+ * selection on its own. The depth term does not appear — an orthographic
+ * projection does not foreshorten — but the obliqueness one does, and in full:
+ * down a south-east isometric direction a 20-unit cube reaches 15.9 units
+ * above the centre line, against the 10 the largest-side rule allowed.
  */
-export function fitDistanceFor(state: CameraInternalState, maxSize: number, padding: number): number {
-  const fovFactor = Math.tan(state.camera.fov / 2);
-  const vertical = (maxSize / 2) / fovFactor * padding;
-  const aspect = state.camera.aspect;
-  // `setAspect` is the only writer and already rejects a non-positive or
-  // non-finite ratio, so this only ever narrows the *portrait* case.
-  if (!Number.isFinite(aspect) || aspect <= 0 || aspect >= 1) return vertical;
-  return vertical / aspect;
+function orthoSizeFor(
+  state: CameraInternalState,
+  bounds: FramingBounds,
+  axes: ViewAxes,
+  padding: number,
+): number | undefined {
+  if (state.projectionMode !== 'orthographic') return undefined;
+  return Math.max(0.01, orthoHalfHeightFor(bounds, axes, usableAspect(state))) * padding;
+}
+
+/**
+ * The screen axes a fit projects into: unit length and mutually perpendicular.
+ *
+ * A structural subset of what {@link viewBasis} returns, and the direction
+ * convention is its one: `forward` points from the eye TOWARDS the target,
+ * which is the negation of `lookAt`'s third row. Handing in the backward axis
+ * type-checks and would frame the box from the wrong side.
+ */
+export interface ViewAxes {
+  right: Vec3;
+  up: Vec3;
+  forward: Vec3;
+}
+
+/**
+ * The eight corners of a box, as offsets from its own centre.
+ *
+ * Both fits below need exactly this, and the offset form is what makes the
+ * corner arithmetic independent of where the box sits in the world. (The
+ * package has other corner walks — `shadow-light-matrix.ts`,
+ * `render-section-plane.ts` — but they take tuples and return world points.)
+ */
+function cornerOffsets(bounds: FramingBounds): Vec3[] {
+  const center = centerOf(bounds.min, bounds.max);
+  const offsets: Vec3[] = [];
+  for (const x of [bounds.min.x, bounds.max.x]) {
+    for (const y of [bounds.min.y, bounds.max.y]) {
+      for (const z of [bounds.min.z, bounds.max.z]) {
+        offsets.push({ x: x - center.x, y: y - center.y, z: z - center.z });
+      }
+    }
+  }
+  return offsets;
+}
+
+/**
+ * Smallest standoff along `-axes.forward` that puts every corner of the box
+ * inside both half-angles, times `padding`. Shared with
+ * `camera-preset-view.ts`, which fits the same way from a dictated direction.
+ *
+ * The distance used to come from the box's largest SIDE, which answers a
+ * different question than the projection asks (#3892). Two ways that came
+ * apart:
+ *
+ *  - **Depth.** The near half of the box is closer than its centre, so it
+ *    projects bigger than a rule measured at the centre allows for. Head-on
+ *    and axis-aligned, a cube of side `s` needs `s/2 / tan + s/2`, not
+ *    `s/2 / tan`; at a 60 degree field the old rule cropped it even under the
+ *    1.5 padding.
+ *  - **Obliqueness.** `frameBoundsTarget` fits along the live view direction,
+ *    which is essentially never axis-aligned, and down a diagonal a box
+ *    projects wider than any single side of it.
+ *
+ * Only the corners answer the question, so all eight are walked. A corner's
+ * sideways offsets do not depend on the standoff and its depth is
+ * `dot(corner, forward) + distance`, so it is inside when
+ * `|h| <= tanH * depth` and `|v| <= tanV * depth`; solving each for `distance`
+ * and taking the largest satisfies all sixteen constraints at once, because
+ * growing the distance only ever relaxes them.
+ *
+ * Both half-angles bind. The vertical one is `fov / 2` and the horizontal one
+ * is `atan(tan(fov / 2) * aspect)`, so on a portrait viewport (`aspect < 1`)
+ * the horizontal field is the *narrower* of the two and fitting the vertical
+ * field alone would leave the box overflowing left and right. `orthoSizeFor`
+ * above has divided by `aspect` for the same reason since it was written, and
+ * now walks the same corners.
+ *
+ * Two fit-distance formulas in this package are deliberately NOT this one:
+ * `CameraProjection.fitToBounds` and the compact branch of
+ * `camera-fit-policy.ts`, which reproduce the legacy opening pose of every
+ * model 1:1 and have tests pinning exactly that. They are a different subject
+ * — the initial auto-fit, not "frame what I selected" — and moving them would
+ * change the first thing every user sees.
+ *
+ * The twin of `fitCornersInFrustum` in `packages/bcf/src/ids-camera.ts`
+ * (#3882), which fits the same closed form to the BCF camera's one dictated
+ * isometric direction. A copy rather than a shared helper because sharing runs
+ * the dependency the wrong way — `bcf` does not depend on `renderer`, and this
+ * signature is stated in terms of `CameraInternalState`. Keep the arithmetic
+ * legible enough that the two read alike.
+ */
+export function fitDistanceFor(
+  state: CameraInternalState,
+  bounds: FramingBounds,
+  axes: ViewAxes,
+  padding: number,
+): number {
+  const tanV = Math.tan(state.camera.fov / 2);
+  const tanH = usableAspect(state) * tanV;
+
+  let distance = 0;
+  for (const corner of cornerOffsets(bounds)) {
+    const depth = MathUtils.dot(corner, axes.forward);
+    const h = Math.abs(MathUtils.dot(corner, axes.right)) / tanH;
+    const v = Math.abs(MathUtils.dot(corner, axes.up)) / tanV;
+    distance = Math.max(distance, h - depth, v - depth);
+  }
+  return distance * padding;
+}
+
+/**
+ * The pose both fits return: the box centred, seen from the direction the
+ * camera is already looking in, at the standoff that keeps every corner of it
+ * on screen.
+ *
+ * `frameBounds` and `zoomExtent` differ only in their padding and in what they
+ * do with a degenerate box, so the pose itself is built once here. Callers
+ * have already run `isUsableBounds` and their own degenerate branch.
+ *
+ * The direction comes from the pose rather than from `state.viewMatrix`.
+ * `frameBoundsTarget` used to read its forward axis as `-(m[8], m[9], m[10])`,
+ * which is the world Z axis expressed in CAMERA coordinates, not the camera's
+ * world-space backward axis (that is `(m[2], m[6], m[10])`). It is unit
+ * length, so neither a finiteness nor a magnitude floor could notice, and it
+ * agreed with the pose only for a symmetric rotation — Frame Selection jumped
+ * to a mirrored direction on an ordinary orbited pose (#3892).
+ *
+ * `viewBasis` is the one function that builds this frame, shared with
+ * `MathUtils.lookAt` and `unprojectToRay` (#2467). It scrubs non-finite
+ * coordinates and substitutes a deterministic basis for a degenerate pose or
+ * `up`, so it always returns finite unit axes: the two direction ladders that
+ * used to stand in these functions (view matrix, then pose, then a hard-coded
+ * isometric) were reimplementing that fallback with less care, and one of them
+ * against the wrong vector. The fit needs the `up` axis as well, and only the
+ * basis has it.
+ */
+function fitPoseFor(
+  state: CameraInternalState,
+  bounds: FramingBounds,
+  center: Vec3,
+  padding: number,
+): ZoomExtentTarget {
+  const basis = viewBasis(state.camera.position, state.camera.target, state.camera.up);
+  const distance = fitDistanceFor(state, bounds, basis, padding);
+
+  return {
+    // The camera sits opposite the direction it looks in.
+    position: {
+      x: center.x - basis.forward.x * distance,
+      y: center.y - basis.forward.y * distance,
+      z: center.z - basis.forward.z * distance,
+    },
+    target: center,
+    // orthoSize so the zoom level resets properly in orthographic mode.
+    orthoSize: orthoSizeFor(state, bounds, basis, padding),
+    // `zoomExtent`'s caller hands this to `CameraProjection.updateNearFarPlanes`.
+    fitDistance: distance,
+  };
 }
 
 /**
@@ -159,68 +319,12 @@ export function frameBoundsTarget(state: CameraInternalState, min: Vec3, max: Ve
     return framePointTarget(state, center);
   }
 
-  // Calculate required distance based on FOV to fit bounds
-  const distance = fitDistanceFor(state, maxSize, 1.2); // 1.2x padding for nice framing
-
-  // Get current viewing direction from view matrix (more reliable than position-target)
-  // View matrix forward is -Z axis in view space
-  const viewMatrix = state.viewMatrix.m;
-  // Extract forward direction from view matrix (negative Z column, normalized)
-  let dir = {
-    x: -viewMatrix[8],   // -m[2][0] (forward X)
-    y: -viewMatrix[9],   // -m[2][1] (forward Y)
-    z: -viewMatrix[10],  // -m[2][2] (forward Z)
-  };
-  const dirLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-
-  // Normalize direction
-  if (dirLen > 1e-6) {
-    dir.x /= dirLen;
-    dir.y /= dirLen;
-    dir.z /= dirLen;
-  } else {
-    // Fallback: use position-target if view matrix is invalid
-    dir = {
-      x: state.camera.position.x - state.camera.target.x,
-      y: state.camera.position.y - state.camera.target.y,
-      z: state.camera.position.z - state.camera.target.z,
-    };
-    const fallbackLen = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-    // Finiteness, not just magnitude — see `zoomExtentTarget`. `dirLen` above
-    // is safe (`MathUtils.lookAt` guarantees a finite view matrix), but this
-    // fallback reads the raw pose, where an overflowed coordinate is reachable.
-    if (isUsableDistance(fallbackLen, 1e-6)) {
-      dir.x /= fallbackLen;
-      dir.y /= fallbackLen;
-      dir.z /= fallbackLen;
-    } else {
-      // Last resort: southeast isometric
-      dir.x = 0.6;
-      dir.y = 0.5;
-      dir.z = 0.6;
-      const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-      dir.x /= len;
-      dir.y /= len;
-      dir.z /= len;
-    }
-  }
-
-  return {
-    // New position: center + direction * distance
-    position: {
-      x: center.x + dir.x * distance,
-      y: center.y + dir.y * distance,
-      z: center.z + dir.z * distance,
-    },
-    target: center,
-    // Calculate orthoSize for orthographic mode so zoom level resets properly
-    orthoSize: orthoSizeFor(state, maxSize, 1.2),
-  };
+  return fitPoseFor(state, { min, max }, center, CAMERA_CONSTANTS.FRAME_PADDING_MULTIPLIER);
 }
 
 /**
- * Zoom to extents: same fit, wider padding, and the current view direction is
- * taken from the pose rather than the view matrix.
+ * Zoom to extents: same fit and the same view direction as `frameBounds`, with
+ * wider padding and the fit distance reported back to the caller.
  */
 export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec3): ZoomExtentTarget | null {
   // Same input class and same reasoning as `frameBoundsTarget` (#2461).
@@ -229,13 +333,13 @@ export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec
   const center = centerOf(min, max);
   const maxSize = maxExtentOf(min, max);
 
-  // Keep current viewing direction
-  const dir = {
-    x: state.camera.position.x - state.camera.target.x,
-    y: state.camera.position.y - state.camera.target.y,
-    z: state.camera.position.z - state.camera.target.z,
-  };
-  const currentDistance = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+  // The standoff the camera already has, which the degenerate-box branch
+  // below keeps rather than fitting.
+  const currentDistance = Math.sqrt(
+    (state.camera.position.x - state.camera.target.x) ** 2 +
+    (state.camera.position.y - state.camera.target.y) ** 2 +
+    (state.camera.position.z - state.camera.target.z) ** 2,
+  );
 
   // The degenerate box `frameBoundsTarget` has always special-cased and this
   // one did not. `isUsableBounds` deliberately admits `max === min` (a flat
@@ -248,46 +352,16 @@ export function zoomExtentTarget(state: CameraInternalState, min: Vec3, max: Vec
   //
   // Only when the current offset is usable. When it is not, the pose already
   // has position === target (or is non-finite), so there is no offset to keep
-  // and nothing is gained by keeping it; fall through to the isometric
-  // fallback below, which is what this path did before.
+  // and nothing is gained by keeping it. Such a call falls through to the fit,
+  // which for a point-sized box returns a zero standoff and so writes
+  // `position === target` again — unchanged from before #3892, and the one
+  // input for which this function still hands back a pose with no direction in
+  // it. `MathUtils.lookAt` substitutes a basis for it downstream.
   if (maxSize < 1e-6 && isUsableDistance(currentDistance, 1e-10)) {
     const framed = framePointTarget(state, center);
     if (framed) return { ...framed, fitDistance: currentDistance };
   }
 
-  // Calculate required distance based on FOV
-  const distance = fitDistanceFor(state, maxSize, 1.5); // 1.5x for padding
-
-  // Normalize direction. Finiteness, not just magnitude: `len > 1e-10` is
-  // *true* for Infinity, and `Infinity / Infinity` is NaN, so a pose whose
-  // position has overflowed walks past a bare floor and writes a NaN position
-  // from a perfectly usable box (#2441).
-  if (isUsableDistance(currentDistance, 1e-10)) {
-    dir.x /= currentDistance;
-    dir.y /= currentDistance;
-    dir.z /= currentDistance;
-  } else {
-    // Fallback direction
-    dir.x = 0.6;
-    dir.y = 0.5;
-    dir.z = 0.6;
-    const len = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
-    dir.x /= len;
-    dir.y /= len;
-    dir.z /= len;
-  }
-
-  return {
-    // New position: center + direction * distance
-    position: {
-      x: center.x + dir.x * distance,
-      y: center.y + dir.y * distance,
-      z: center.z + dir.z * distance,
-    },
-    target: center,
-    // Calculate orthoSize for orthographic mode so zoom level resets properly
-    orthoSize: orthoSizeFor(state, maxSize, 1.5),
-    // The caller hands this to `CameraProjection.updateNearFarPlanes`.
-    fitDistance: distance,
-  };
+  return fitPoseFor(state, { min, max }, center, CAMERA_CONSTANTS.ZOOM_EXTENT_PADDING);
 }
+

--- a/packages/renderer/src/camera-preset-view.ts
+++ b/packages/renderer/src/camera-preset-view.ts
@@ -11,8 +11,8 @@
  * current direction"). Presets are the opposite subject: the direction is
  * dictated by the named face and the caller's rotation cycle, and the box is
  * whatever the caller supplied or whatever the current pose implies. The two
- * share only box arithmetic, which is why this module imports `centerOf` /
- * `maxExtentOf` rather than owning a second copy.
+ * share the box arithmetic and the corner fit, which is why this module
+ * imports `centerOf` / `fitDistanceFor` rather than owning a second copy.
  *
  * Pure by construction, exactly as `camera-framing.ts` is: everything here
  * reads `CameraInternalState` and returns a target, nothing writes to it or
@@ -29,7 +29,16 @@
 import type { Vec3 } from './types.js';
 import type { CameraInternalState } from './camera-state.js';
 import { isUsableBounds } from './camera-guards.js';
-import { centerOf, fitDistanceFor, maxExtentOf, type FramingBounds } from './camera-framing.js';
+import { centerOf, fitDistanceFor, type FramingBounds } from './camera-framing.js';
+import { viewBasis } from './math.js';
+import { CAMERA_CONSTANTS } from './constants.js';
+
+/**
+ * The ~0.6 degree tilt that keeps the top and bottom presets off the pole, so
+ * the orbit math that follows has a well-defined polar tangent.
+ */
+const POLE_TILT_SIN = Math.sin(0.01);
+const POLE_TILT_COS = Math.cos(0.01);
 
 /**
  * Get current bounds estimate (simplified - in production would use scene bounds).
@@ -102,15 +111,12 @@ export function presetViewTarget(
   buildingRotation?: number,
 ): { position: Vec3; target: Vec3; up: Vec3 } {
   const center = centerOf(bounds.min, bounds.max);
-  const maxSize = maxExtentOf(bounds.min, bounds.max);
 
-  // Calculate distance based on FOV for proper fit. Aspect-aware: on a
-  // portrait viewport the horizontal field is the narrower one, and a preset
-  // fitted to the vertical field alone overflows it. See `fitDistanceFor`.
-  const distance = fitDistanceFor(state, maxSize, 1.5); // 1.5x for padding
-
-  let endPos: Vec3;
-  const endTarget = center;
+  // Unit offset from the centre to the camera, per named face. The fit
+  // distance depends on it — the box's projected extent is a property of the
+  // direction it is seen from — so the switch below picks the direction and
+  // the standoff is applied once, afterwards.
+  let offsetDir: Vec3;
 
   // WebGL uses Y-up coordinate system internally
   // We set both position AND up vector for proper orthogonal views
@@ -121,7 +127,7 @@ export function presetViewTarget(
   // Normalized rather than trusted: this is the IfcSite placement angle,
   // derived from the file and threaded through `Camera.setPresetView` — the
   // published entry point — without ever meeting a guard. `Math.cos(NaN)` is
-  // NaN, and the four horizontal presets multiply it straight into `endPos`,
+  // NaN, and the four horizontal presets multiply it straight into the offset,
   // so a malformed placement would send the ViewCube to a non-finite pose. A
   // zero rotation is the same answer as "no rotation supplied", which is what
   // the undefined case already resolves to.
@@ -146,32 +152,32 @@ export function presetViewTarget(
       //   rotation 3 → camera slightly to -X → screen-up = -X
       // Building rotation is applied as the same Y-axis rotation that
       // setPresetView would have used to remap the legacy up vector.
-      const poleOffset = Math.sin(0.01) * distance; // ~0.6° tilt
-      const verticalOffset = Math.cos(0.01) * distance;
+      const poleOffset = POLE_TILT_SIN;
+      const verticalOffset = POLE_TILT_COS;
       // `?? 0`: `rotation` is the animator's 0-3 cycle counter today, but it
       // is a plain `number` on the signature, and an out-of-range, fractional
       // or non-finite one indexes past the table and makes `thetaWorld` — and
       // with it the whole preset pose — NaN.
       const thetaPerRotation = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
       const thetaWorld = (thetaPerRotation[rotation] ?? 0) + rotationRadians;
-      endPos = {
-        x: center.x + poleOffset * Math.sin(thetaWorld),
-        y: center.y + verticalOffset,
-        z: center.z + poleOffset * Math.cos(thetaWorld),
+      offsetDir = {
+        x: poleOffset * Math.sin(thetaWorld),
+        y: verticalOffset,
+        z: poleOffset * Math.cos(thetaWorld),
       };
       upVector = { x: 0, y: 1, z: 0 };
       break;
     }
     case 'bottom': {
       // Bottom view: mirror of top — phi = π − MIN_PHI.
-      const poleOffset = Math.sin(0.01) * distance;
-      const verticalOffset = Math.cos(0.01) * distance;
+      const poleOffset = POLE_TILT_SIN;
+      const verticalOffset = POLE_TILT_COS;
       const thetaPerRotation = [Math.PI, Math.PI / 2, 0, -Math.PI / 2];
       const thetaWorld = (thetaPerRotation[rotation] ?? 0) + rotationRadians;
-      endPos = {
-        x: center.x + poleOffset * Math.sin(thetaWorld),
-        y: center.y - verticalOffset,
-        z: center.z + poleOffset * Math.cos(thetaWorld),
+      offsetDir = {
+        x: poleOffset * Math.sin(thetaWorld),
+        y: -verticalOffset,
+        z: poleOffset * Math.cos(thetaWorld),
       };
       upVector = { x: 0, y: 1, z: 0 };
       break;
@@ -182,44 +188,49 @@ export function presetViewTarget(
       // Standard rotation: x' = x*cos - z*sin, z' = x*sin + z*cos
       // For +Z direction (0,0,1): x' = -sin, z' = cos
       // But we need to look at building's front, so use negative rotation
-      endPos = {
-        x: center.x + sinR * distance,
-        y: center.y,
-        z: center.z + cosR * distance,
-      };
+      offsetDir = { x: sinR, y: 0, z: cosR };
       upVector = { x: 0, y: 1, z: 0 }; // Y-up
       break;
     case 'back':
       // Back view: from -Z looking at model
       // For -Z direction (0,0,-1) rotated: x' = sin, z' = -cos
-      endPos = {
-        x: center.x - sinR * distance,
-        y: center.y,
-        z: center.z - cosR * distance,
-      };
+      offsetDir = { x: -sinR, y: 0, z: -cosR };
       upVector = { x: 0, y: 1, z: 0 }; // Y-up
       break;
     case 'left':
       // Left view: from -X looking at model
       // For -X direction (-1,0,0) rotated: x' = -cos, z' = sin
-      endPos = {
-        x: center.x - cosR * distance,
-        y: center.y,
-        z: center.z + sinR * distance,
-      };
+      offsetDir = { x: -cosR, y: 0, z: sinR };
       upVector = { x: 0, y: 1, z: 0 }; // Y-up
       break;
     case 'right':
       // Right view: from +X looking at model
       // For +X direction (1,0,0) rotated: x' = cos, z' = -sin
-      endPos = {
-        x: center.x + cosR * distance,
-        y: center.y,
-        z: center.z - sinR * distance,
-      };
+      offsetDir = { x: cosR, y: 0, z: -sinR };
       upVector = { x: 0, y: 1, z: 0 }; // Y-up
       break;
   }
 
-  return { position: endPos, target: endTarget, up: upVector };
+  // The standoff that keeps every corner of the box on screen from this
+  // direction, with 1.5x padding. `viewBasis` is the same function
+  // `MathUtils.lookAt` will build the real view matrix with, so the axes here
+  // are the ones the frame is drawn in — including the substitute up axis a
+  // near-vertical top/bottom preset gets. It is given `offsetDir` about the
+  // origin rather than the real pose because it only ever uses `eye - target`,
+  // and the difference at the real centre is the same direction with the low
+  // bits of a georeferenced coordinate rounded off it.
+  const basis = viewBasis(offsetDir, { x: 0, y: 0, z: 0 }, upVector);
+  const distance = fitDistanceFor(state, bounds, basis, CAMERA_CONSTANTS.ZOOM_EXTENT_PADDING);
+
+  return {
+    // Off the basis rather than off `offsetDir`, so the standoff is the
+    // distance whatever length the switch above happened to build.
+    position: {
+      x: center.x - basis.forward.x * distance,
+      y: center.y - basis.forward.y * distance,
+      z: center.z - basis.forward.z * distance,
+    },
+    target: center,
+    up: upVector,
+  };
 }


### PR DESCRIPTION
Closes #3892.

`fitDistanceFor` fitted the largest box side into both half-angles, so a corner could sit outside the frustum after Frame Selection, most visibly on elongated selections at 16:9 or portrait viewports. It now returns the smallest standoff that puts all eight corners inside both half-angles (tanH = aspect * tanV) for the axes the caller passes; paddings and the degenerate-box branches are unchanged. `orthoSizeFor` walks the same corners, since in orthographic the standoff sets no scale and leaving it would have been a half fix. `frameBounds` and `zoomExtent` share one `fitPoseFor`, and the preset view path uses the same fit. This is the renderer twin of #3882 in `@ifc-lite/bcf`; the code is a deliberate copy, not shared across packages.

A second defect surfaced on the same call: `frameBoundsTarget` read the forward direction as `-(m[8], m[9], m[10])` of the view matrix. In `Mat4.lookAt` those indices hold world Z expressed in camera coordinates; the camera's backward axis sits at `m[2], m[6], m[10]`. Both are unit length so no guard caught it, and the two coincide only on near-symmetric poses, so Frame Selection could mirror the camera on an orbited pose. Both fits now take the basis from `viewBasis`.

Test written first: against main, 25 of 63 perspective cases failed with the worst corner at 1.79x the half-frame; 119 cases pass now including orthographic. Mutation probes on the finished code: restoring the side rule fails 24 (perspective) and 13 (ortho) cases, restoring the old view-matrix read fails 22; tightness cases divide the padding back out and require the worst corner on the frustum edge, so a far-parked camera passes nothing. Two pins in `camera-fit-viewport-shape.test.ts` encoded the old side rule and moved to the corner form. No viewer test pins camera positions.

Not verified in the running viewer; the claim rests on the unit and mutation tests. Gates on the head: typecheck 0, build 0, `@ifc-lite/renderer` 1323 pass, viewer framing tests 9/9, viewer-embed bridge 112/112, check-module-size 0, check-changesets 0. Changeset: `@ifc-lite/renderer` patch.