### PR TITLE
fix(viewer): colour overrides reach assembly parts whose meshes stream in later

### DIFF
--- a/.changeset/fix-3890-late-mesh-colour.md
+++ b/.changeset/fix-3890-late-mesh-colour.md
@@ -1,0 +1,9 @@
+---
+"ifc-lite": patch
+---
+
+fix(viewer): colouring an assembly now reaches parts whose meshes stream in later (#3890)
+
+Hide and isolate are whitelists the renderer re-matches mesh ids against, so a part that streams in after the action is caught the moment its mesh lands. Colour was not: `pendingColorUpdates` is a one-shot signal that is flushed and nulled, and `scene.setColorOverrides` builds overlay batches once from `meshDataMap`, so a part with no mesh at flush time was never painted at all.
+
+The colour channel now hands the scene back its own retained override map once the geometry counter settles and the mesh queue has drained, which rebuilds the overlay batches with the late meshes included. It does that only when an override id it was waiting on has actually arrived, so an active overlay does not pay a rebuild after every later streaming burst, and it costs nothing when nothing is coloured. Because the map is read from the scene at that moment rather than remembered, a targeted `resetColors` is not repainted and a correction made in the meantime is the colour that lands.

--- a/.changeset/fix-3890-late-mesh-colour.md
+++ b/.changeset/fix-3890-late-mesh-colour.md
@@ -1,5 +1,6 @@
 ---
 "ifc-lite": patch
+"@ifc-lite/renderer": minor
 ---
 
 fix(viewer): colouring an assembly now reaches parts whose meshes stream in later (#3890)
@@ -7,3 +8,7 @@ fix(viewer): colouring an assembly now reaches parts whose meshes stream in late
 Hide and isolate are whitelists the renderer re-matches mesh ids against, so a part that streams in after the action is caught the moment its mesh lands. Colour was not: `pendingColorUpdates` is a one-shot signal that is flushed and nulled, and `scene.setColorOverrides` builds overlay batches once from `meshDataMap`, so a part with no mesh at flush time was never painted at all.
 
 The colour channel now hands the scene back its own retained override map once the geometry counter settles and the mesh queue has drained, which rebuilds the overlay batches with the late meshes included. It does that only when an override id it was waiting on has actually arrived, so an active overlay does not pay a rebuild after every later streaming burst, and it costs nothing when nothing is coloured. Because the map is read from the scene at that moment rather than remembered, a targeted `resetColors` is not repainted and a correction made in the meantime is the colour that lands.
+
+GPU-instanced occurrences need their own half of this and cannot use the counter: a streaming event carrying only instanced shards appends through `appendInstancedShards`, which never changes `geometryResult`, so the counter does not move. `Scene.addInstancedShard` now applies a recorded colour override to occurrences arriving in the shard, mirroring the late-selection seeding that already sat beside it.
+
+`SceneContents` gains `getColorOverrides`, `hasMeshData` and `isInstancedEntity`. The first exposes the retained map the catch-up re-applies; the other two are the O(1) presence probes it needs, since `getMeshDataPieces` and `getInstancedMeshDataPieces` answer the same question but materialize geometry to do it.

--- a/apps/viewer/src/components/viewer/useColorOverlaySync.late-mesh.test.tsx
+++ b/apps/viewer/src/components/viewer/useColorOverlaySync.late-mesh.test.tsx
@@ -307,14 +307,26 @@ describe('useColorOverlaySync — colour reaches late-streamed meshes (#3890)', 
     try {
       h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
       await h.render();
+
+      // What makes this test bite, pinned rather than assumed: the map keeps
+      // the geometry-less ASSEMBLY id next to its parts. The fixture's resolver
+      // answers with the parts only, but `resolvePresentationColorMap` unions
+      // the raw ids back in (#2680's never-substitute policy), so the id that
+      // can never gain a mesh IS in the override map, exactly as in the app.
+      assert.ok(
+        scene.getColorOverrides()?.has(ASSEMBLY),
+        'the geometry-less assembly id must be in the override map',
+      );
+      assert.equal(scene.hasMeshData(ASSEMBLY), false, 'and it never gains a mesh');
+
       scene.meshedIds.add(PART_LATE);
       await h.bumpGeometry();
       const afterCatchUp = scene.setColorOverridesCalls;
 
       // Two more streaming bursts that bring nothing the overlay is waiting
-      // for. ASSEMBLY itself is in the override map (#3880 keeps the raw id)
-      // and never gains a mesh, so "is anything still waiting" would rebuild
-      // here forever.
+      // for. Because ASSEMBLY stays unmeshed forever, "is anything still
+      // waiting" would rebuild here on every burst, for the life of the
+      // overlay. "Did an awaited id arrive" is the question that terminates.
       await h.bumpGeometry();
       await h.bumpGeometry();
 

--- a/apps/viewer/src/components/viewer/useColorOverlaySync.late-mesh.test.tsx
+++ b/apps/viewer/src/components/viewer/useColorOverlaySync.late-mesh.test.tsx
@@ -1,0 +1,363 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Colour reaches parts whose meshes stream in AFTER the colour was applied
+ * (#3890).
+ *
+ * #3880 made hide and isolate complete at action time by expanding an assembly
+ * to every aggregated descendant: those two are whitelists the renderer
+ * re-matches mesh ids against, so a mesh-less id starts matching the moment
+ * its mesh lands. Colour gets no such benefit. `pendingColorUpdates` is a
+ * one-shot signal — `useColorOverlaySync` hands it to `scene.setColorOverrides`
+ * and nulls it out — and `setColorOverrides` builds overlay batches ONCE by
+ * looking each id up in `meshDataMap`. An id with no mesh at flush time
+ * contributes nothing to a batch and nothing ever revisits it.
+ *
+ * The stub scene below models exactly that: `setColorOverrides` retains the
+ * map and derives `paintedIds` from the ids that currently have a mesh. The
+ * real `Scene` does the same thing (packages/renderer/src/scene.ts: it copies
+ * `overrides` into `this.colorOverrides`, then walks the map and only pushes
+ * `meshDataMap.get(expressId)` pieces into a colour group).
+ *
+ * The two hazards recorded on the issue get a test each:
+ *   - a targeted `resetColors([part])` must not be repainted by the next tick;
+ *   - the repaint must not undo a user's LATER correction.
+ * Both are covered by re-reading `scene.getColorOverrides()` at the moment the
+ * debounce fires rather than capturing a map when it is scheduled, and both
+ * are asserted below so that a future "optimisation" that captures early
+ * fails here.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Renderer } from '@ifc-lite/renderer';
+import { createViewerAdapter } from '../../sdk/adapters/viewer-adapter.js';
+import type { StoreApi } from '../../sdk/adapters/types.js';
+import { useColorOverlaySync } from './useColorOverlaySync.js';
+
+type Color = [number, number, number, number];
+type ColorMap = Map<number, Color>;
+
+/**
+ * Stands in for `Scene`'s colour-overlay half. `paintedIds` is the overlay
+ * batch: built once per `setColorOverrides` call from the ids that have a mesh
+ * RIGHT NOW, which is the defect's whole mechanism.
+ */
+class StubScene {
+  meshedIds = new Set<number>();
+  private overrides: ColorMap | null = null;
+  paintedIds: number[] = [];
+  setColorOverridesCalls = 0;
+
+  setColorOverrides(overrides: ColorMap): void {
+    this.setColorOverridesCalls++;
+    if (overrides.size === 0) {
+      this.overrides = null;
+      this.paintedIds = [];
+      return;
+    }
+    this.overrides = new Map(overrides);
+    this.paintedIds = [...overrides.keys()].filter((id) => this.meshedIds.has(id));
+  }
+
+  getColorOverrides(): ColorMap | null {
+    return this.overrides;
+  }
+
+  /** `meshDataMap` presence: what the hook asks to decide whether an id that
+   *  had no mesh at the last build has since gained one. */
+  hasMeshData(expressId: number): boolean {
+    return this.meshedIds.has(expressId);
+  }
+
+  isInstancedEntity(): boolean {
+    return false;
+  }
+
+  /** Meshes are RECEIVED into a queue and only enter `meshDataMap` when the
+   *  animation loop drains it, so "a batch arrived" and "the mesh is paintable"
+   *  are different moments. Scenarios that care set this. */
+  queuedMeshes = false;
+
+  hasQueuedMeshes(): boolean {
+    return this.queuedMeshes;
+  }
+
+  clearColorOverrides(): void {
+    this.overrides = null;
+    this.paintedIds = [];
+  }
+}
+
+function fakeRenderer(scene: StubScene): Renderer {
+  return {
+    getGPUDevice: () => ({}) as unknown,
+    getPipeline: () => ({}) as unknown,
+    getScene: () => scene,
+    requestRender: () => {},
+  } as unknown as Renderer;
+}
+
+/** The store shape `createViewerAdapter` actually reads, with idOffset 0 so a
+ *  ref's expressId IS its global id. */
+function makeStore(): { store: StoreApi; getPending: () => ColorMap | null; clear: () => void } {
+  let pendingColorUpdates: ColorMap | null = null;
+  const state = {
+    models: new Map([['default', { idOffset: 0 }]]),
+    // #3880's expansion: the assembly resolves to both of its parts, meshed or
+    // not. This is `cameraCallbacks.resolveHighlightIds`' post-#3865 answer.
+    cameraCallbacks: {
+      resolveHighlightIds: (ids: number[]) =>
+        ids.flatMap((id) => (id === ASSEMBLY ? [PART_MESHED, PART_LATE] : [id])),
+    },
+    get pendingColorUpdates() {
+      return pendingColorUpdates;
+    },
+    setPendingColorUpdates: (updates: ColorMap) => {
+      pendingColorUpdates = new Map(updates);
+    },
+  };
+  return {
+    store: { getState: () => state, subscribe: () => () => {} } as unknown as StoreApi,
+    getPending: () => pendingColorUpdates,
+    clear: () => {
+      pendingColorUpdates = null;
+    },
+  };
+}
+
+const ASSEMBLY = 100;
+const PART_MESHED = 101;
+const PART_LATE = 102;
+const RED: Color = [1, 0, 0, 1];
+const BLUE: Color = [0, 0, 1, 1];
+
+/** Debounce window in `useColorOverlaySync`, plus slack. */
+const PAST_DEBOUNCE_MS = 400;
+
+function Harness({
+  rendererRef,
+  pendingColorUpdates,
+  clearPendingColorUpdates,
+  geometryVersion,
+}: {
+  rendererRef: { current: Renderer | null };
+  pendingColorUpdates: ColorMap | null;
+  clearPendingColorUpdates: () => void;
+  geometryVersion: number;
+}) {
+  useColorOverlaySync({
+    rendererRef,
+    isInitialized: true,
+    pendingColorUpdates,
+    clearPendingColorUpdates,
+    geometryVersion,
+  });
+  return null;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Drives one scenario: the real adapter writes into the real-shaped store, the
+ * real hook flushes into the stub scene, then a mesh lands and the geometry
+ * counter bumps.
+ */
+async function mount(scene: StubScene) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  const rendererRef = { current: fakeRenderer(scene) };
+  const { store, getPending, clear } = makeStore();
+  const adapter = createViewerAdapter(store);
+  let version = 0;
+
+  const render = async () => {
+    await act(async () => {
+      root.render(
+        <Harness
+          rendererRef={rendererRef}
+          pendingColorUpdates={getPending()}
+          clearPendingColorUpdates={clear}
+          geometryVersion={version}
+        />,
+      );
+    });
+  };
+
+  return {
+    adapter,
+    render,
+    async bumpGeometry() {
+      version++;
+      await render();
+      await act(async () => {
+        await sleep(PAST_DEBOUNCE_MS);
+      });
+    },
+    /** Let pending timers run without bumping the geometry counter. */
+    async settle() {
+      await act(async () => {
+        await sleep(PAST_DEBOUNCE_MS);
+      });
+    },
+    cleanup() {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe('useColorOverlaySync — colour reaches late-streamed meshes (#3890)', () => {
+  it('repaints a part whose mesh arrives after the colour was flushed', async () => {
+    const scene = new StubScene();
+    scene.meshedIds.add(PART_MESHED);
+    const h = await mount(scene);
+    try {
+      h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
+      await h.render();
+
+      assert.deepEqual(
+        scene.paintedIds.sort(),
+        [PART_MESHED],
+        'only the already-meshed part can be in the first overlay batch',
+      );
+
+      // PART_LATE's mesh streams in.
+      scene.meshedIds.add(PART_LATE);
+      await h.bumpGeometry();
+
+      assert.ok(
+        scene.paintedIds.includes(PART_LATE),
+        'the late part must be in the rebuilt overlay batch',
+      );
+      assert.ok(
+        scene.paintedIds.includes(PART_MESHED),
+        'the already-painted part must survive the rebuild',
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  it('leaves a part the user reset alone when its mesh arrives later', async () => {
+    const scene = new StubScene();
+    scene.meshedIds.add(PART_MESHED);
+    const h = await mount(scene);
+    try {
+      h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
+      await h.render();
+      // The user un-colours the part that has not rendered yet.
+      h.adapter.resetColors([{ modelId: 'default', expressId: PART_LATE }]);
+      await h.render();
+
+      scene.meshedIds.add(PART_LATE);
+      await h.bumpGeometry();
+
+      assert.equal(
+        scene.paintedIds.includes(PART_LATE),
+        false,
+        'a reset part must stay reset when its mesh lands',
+      );
+      assert.ok(scene.paintedIds.includes(PART_MESHED), 'the rest of the assembly stays painted');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  it('applies a correction made before the late mesh landed, not the older colour', async () => {
+    const scene = new StubScene();
+    scene.meshedIds.add(PART_MESHED);
+    const h = await mount(scene);
+    try {
+      h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
+      await h.render();
+      // The user corrects the still-unmeshed part to BLUE. The catch-up has
+      // not run yet, so this is the map it will find when it does.
+      h.adapter.colorize([{ modelId: 'default', expressId: PART_LATE }], BLUE);
+      await h.render();
+
+      scene.meshedIds.add(PART_LATE);
+      await h.bumpGeometry();
+
+      assert.ok(
+        scene.paintedIds.includes(PART_LATE),
+        'the catch-up must actually run for this test to mean anything',
+      );
+      assert.deepEqual(
+        scene.getColorOverrides()?.get(PART_LATE),
+        BLUE,
+        'the correction must survive: the catch-up re-reads the scene map rather than replaying an older one',
+      );
+      assert.deepEqual(scene.getColorOverrides()?.get(PART_MESHED), RED);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  it('stops rebuilding once every override that can be painted has been', async () => {
+    const scene = new StubScene();
+    scene.meshedIds.add(PART_MESHED);
+    const h = await mount(scene);
+    try {
+      h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
+      await h.render();
+      scene.meshedIds.add(PART_LATE);
+      await h.bumpGeometry();
+      const afterCatchUp = scene.setColorOverridesCalls;
+
+      // Two more streaming bursts that bring nothing the overlay is waiting
+      // for. ASSEMBLY itself is in the override map (#3880 keeps the raw id)
+      // and never gains a mesh, so "is anything still waiting" would rebuild
+      // here forever.
+      await h.bumpGeometry();
+      await h.bumpGeometry();
+
+      assert.equal(
+        scene.setColorOverridesCalls,
+        afterCatchUp,
+        'a burst that lands no awaited mesh must not rebuild the overlay batches',
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  it('waits for the mesh queue to drain instead of spending its one shot mid-drain', async () => {
+    const scene = new StubScene();
+    scene.meshedIds.add(PART_MESHED);
+    const h = await mount(scene);
+    try {
+      h.adapter.colorize([{ modelId: 'default', expressId: ASSEMBLY }], RED);
+      await h.render();
+
+      // The last batch has been RECEIVED — the counter bumps and will never
+      // bump again — but the animation loop has not drained it, so PART_LATE
+      // is not in meshDataMap yet.
+      scene.queuedMeshes = true;
+      await h.bumpGeometry();
+      assert.equal(
+        scene.paintedIds.includes(PART_LATE),
+        false,
+        'nothing to paint yet: the mesh is still queued',
+      );
+
+      // The drain completes. No further geometry counter bump follows.
+      scene.queuedMeshes = false;
+      scene.meshedIds.add(PART_LATE);
+      await h.settle();
+
+      assert.ok(
+        scene.paintedIds.includes(PART_LATE),
+        'the catch-up must retry across the drain, not give up after one attempt',
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/useColorOverlaySync.ts
+++ b/apps/viewer/src/components/viewer/useColorOverlaySync.ts
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The colour-overlay channel's whole path into the renderer: the one-shot
+ * flush of `pendingColorUpdates`, split out of `useGeometryStreaming.ts`, plus
+ * the catch-up that paints meshes which arrive after that flush (#3890).
+ *
+ * `pendingColorUpdates` is a SIGNAL, not state — the flush hands it to
+ * `scene.setColorOverrides` and then nulls it out. The scene keeps the map
+ * (`getColorOverrides()`), and that retained map is the only durable record of
+ * what is currently painted. `setColorOverrides` builds overlay batches ONCE,
+ * looking each id up in `meshDataMap`, so an id with no mesh at flush time
+ * contributes nothing and, without the catch-up below, nothing revisits it.
+ *
+ * ## Why the catch-up waits for the DRAIN, not for the batch counter
+ *
+ * `geometryVersion` bumps when a batch is RECEIVED. Received is not painted:
+ * `useGeometryStreaming` hands new meshes to `scene.queueMeshes`, and they
+ * only enter `meshDataMap` when the animation loop drains that queue under a
+ * per-frame time budget. On a large model the last batch is received long
+ * before the queue empties, and the counter never bumps again — so a catch-up
+ * keyed on the settled counter alone would fire exactly once, mid-drain, find
+ * the meshes it is looking for still queued, and never get a second chance.
+ * It therefore retries while `scene.hasQueuedMeshes()` is true.
+ *
+ * That same drain is why the "still waiting for a mesh" set is only narrowed
+ * when the queue is EMPTY. `queueMeshes` takes `splitMeshForStreaming`
+ * fragments, so one entity can be several `MeshData` sharing an expressId and
+ * the drain can stop between them. An id that looks meshed mid-drain may have
+ * most of itself still queued; dropping it from the waiting set there would
+ * leave a large element painted in part with nothing to repaint the rest.
+ *
+ * ## The other two decisions
+ *
+ * The catch-up rebuilds only when an id it was waiting for has since arrived.
+ * Without that, an active overlay would pay a full destroy-rebuild-upload
+ * cycle after every later streaming burst, forever. Note the test is "did an
+ * awaited id ARRIVE", not "is anything still awaited": #3880 puts the
+ * geometry-less assembly id itself in the colour map next to its parts, and
+ * that id never gains a mesh, so the latter would never short-circuit in
+ * exactly the case this module exists for.
+ *
+ * And it re-hands the scene its OWN retained map, read at the moment it fires,
+ * never a remembered one. That is what keeps a targeted `resetColors([part])`
+ * from being repainted (the reset flushed a smaller map, so the reset id is
+ * not in what the scene hands back) and keeps a correction made in the
+ * meantime from being overwritten. Both hazards come from a re-expansion
+ * prototype dropped in favour of #3880, both have a test in
+ * `useColorOverlaySync.late-mesh.test.tsx`, and both fall out of that one
+ * decision rather than needing a branch each.
+ *
+ * NOT COVERED, deliberately: the other colour sink, `updateMeshColors`, which
+ * mutates mesh colours in `meshDataMap` in place and retains no map. There is
+ * nothing to re-apply for it; giving it one is a new retained-state decision,
+ * not a repaint. Deeper still, the renderer could fold a late mesh into the
+ * live overlay batches inside `appendToBatches`, which would be incremental
+ * and channel-agnostic instead of a whole-set rebuild. That is a renderer
+ * change well outside this fix.
+ */
+
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
+import type { Renderer, SceneContents } from '@ifc-lite/renderer';
+import { useDebouncedValue } from '../../hooks/useDebouncedValue.js';
+
+/** How long the geometry counter must hold still before the catch-up starts. */
+const REPAINT_DEBOUNCE_MS = 250;
+/** Re-check interval while the mesh queue is still draining. */
+const DRAIN_POLL_MS = 250;
+
+type ColorMap = Map<number, [number, number, number, number]>;
+
+/**
+ * Whether the scene can paint this id. Both halves are O(1) map lookups —
+ * `getMeshDataPieces` and `getInstancedMeshDataPieces` answer the same
+ * question but MATERIALIZE geometry to do it (per-entity extraction out of a
+ * colour-merged batch; a fresh transformed Float32Array per occurrence), which
+ * a presence probe run over every override id must never pay.
+ */
+function isMeshed(scene: SceneContents, expressId: number): boolean {
+  return scene.hasMeshData(expressId) || scene.isInstancedEntity(expressId);
+}
+
+export interface UseColorOverlaySyncParams {
+  rendererRef: MutableRefObject<Renderer | null>;
+  isInitialized: boolean;
+  pendingColorUpdates: ColorMap | null;
+  clearPendingColorUpdates: () => void;
+  /**
+   * Monotonic per-batch geometry counter (`ViewportContainer.tsx`). Every bump
+   * means meshes may have arrived that a live colour overlay has never seen.
+   */
+  geometryVersion?: number;
+}
+
+export function useColorOverlaySync({
+  rendererRef,
+  isInitialized,
+  pendingColorUpdates,
+  clearPendingColorUpdates,
+  geometryVersion,
+}: UseColorOverlaySyncParams): void {
+  /** Override ids not yet known to be paintable. See the drain note above. */
+  const awaitingMeshRef = useRef<number[]>([]);
+
+  const recordAwaitingMesh = useCallback(
+    (scene: SceneContents, overrides: ReadonlyMap<number, unknown>) => {
+      const ids = [...overrides.keys()];
+      // Mid-drain an id can look meshed while most of it is still queued, so
+      // narrow the set only once the queue is empty.
+      awaitingMeshRef.current = scene.hasQueuedMeshes()
+        ? ids
+        : ids.filter((id) => !isMeshed(scene, id));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (pendingColorUpdates === null || !isInitialized) return;
+    const renderer = rendererRef.current;
+    if (!renderer) return;
+
+    const device = renderer.getGPUDevice();
+    const pipeline = renderer.getPipeline();
+    const scene = renderer.getScene();
+    if (device && pipeline) {
+      if (pendingColorUpdates.size === 0) {
+        scene.clearColorOverrides();
+        awaitingMeshRef.current = [];
+      } else {
+        scene.setColorOverrides(pendingColorUpdates, device, pipeline);
+        recordAwaitingMesh(scene, pendingColorUpdates);
+      }
+      renderer.requestRender();
+      clearPendingColorUpdates();
+    }
+    // rendererRef is a ref; re-running on its identity would be meaningless.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingColorUpdates, isInitialized, clearPendingColorUpdates, recordAwaitingMesh]);
+
+  // ─── Catch up meshes that streamed in after the flush ────────────────
+  const settledGeometryVersion = useDebouncedValue(geometryVersion, REPAINT_DEBOUNCE_MS);
+  useEffect(() => {
+    if (!isInitialized) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const attempt = () => {
+      // Cheapest guard first: with no overrides installed, or none of them
+      // waiting on a mesh, there is nothing to catch up and the scene is not
+      // worth asking. This is the common case — most sessions never colour
+      // anything — so it must not poll a drain or touch the renderer.
+      if (awaitingMeshRef.current.length === 0) return;
+      const renderer = rendererRef.current;
+      if (!renderer) return;
+      const scene = renderer.getScene();
+      if (scene.hasQueuedMeshes()) {
+        timer = setTimeout(attempt, DRAIN_POLL_MS);
+        return;
+      }
+      if (!awaitingMeshRef.current.some((id) => isMeshed(scene, id))) return;
+
+      const overrides = scene.getColorOverrides();
+      if (!overrides || overrides.size === 0) return;
+      const device = renderer.getGPUDevice();
+      const pipeline = renderer.getPipeline();
+      if (!device || !pipeline) return;
+
+      // The scene copies what it is handed, so handing back its own map is
+      // safe and the cast only satisfies the mutable-Map parameter type.
+      scene.setColorOverrides(overrides as ColorMap, device, pipeline);
+      recordAwaitingMesh(scene, overrides);
+      renderer.requestRender();
+    };
+
+    attempt();
+    return () => clearTimeout(timer);
+    // rendererRef is a ref; re-running on its identity would be meaningless.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settledGeometryVersion, isInitialized, recordAwaitingMesh]);
+}

--- a/apps/viewer/src/components/viewer/useGeometryStreaming.ts
+++ b/apps/viewer/src/components/viewer/useGeometryStreaming.ts
@@ -25,6 +25,7 @@ import { decodeInstancedShard, NORMAL_COORD_THRESHOLD_M } from '@ifc-lite/geomet
 import { toast } from '../ui/toast.js';
 import { runGpuUpload } from './gpu-upload-guard';
 import { createRobustFitBoundsAccumulator } from './robustFitBoundsAccumulator.js';
+import { useColorOverlaySync } from './useColorOverlaySync.js';
 
 // Session-scoped flag so the linear-infrastructure hint fires at most once
 // per page load (model swaps included). Stored at module scope rather than
@@ -927,24 +928,13 @@ export function useGeometryStreaming(params: UseGeometryStreamingParams): void {
   }, [pendingMeshRotations, isInitialized, clearPendingMeshRotations]);
 
   // ─── Lens color overlays ─────────────────────────────────────────────
-  useEffect(() => {
-    if (pendingColorUpdates === null || !isInitialized) return;
-    const renderer = rendererRef.current;
-    if (!renderer) return;
-
-    const device = renderer.getGPUDevice();
-    const pipeline = renderer.getPipeline();
-    const scene = renderer.getScene();
-    if (device && pipeline) {
-      if (pendingColorUpdates.size === 0) {
-        scene.clearColorOverrides();
-      } else {
-        scene.setColorOverrides(pendingColorUpdates, device, pipeline);
-      }
-      renderer.requestRender();
-      clearPendingColorUpdates();
-    }
-  }, [pendingColorUpdates, isInitialized, clearPendingColorUpdates]);
+  useColorOverlaySync({
+    rendererRef,
+    isInitialized,
+    pendingColorUpdates,
+    clearPendingColorUpdates,
+    geometryVersion,
+  });
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────

--- a/packages/renderer/src/instanced-override-color.ts
+++ b/packages/renderer/src/instanced-override-color.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * How a colour override and X-Ray compose on one instanced occurrence.
+ *
+ * The two channels share the instance colour bytes, so whichever wrote last
+ * would otherwise win. The rule is that the override owns RGB and the ghost
+ * owns alpha: X-Ray is a stronger statement about visibility than a lens tint,
+ * and the flat path resolves it the same way.
+ *
+ * It lives here because there are now two writers. `setInstancedColorOverrides`
+ * applies it when the override changes, and `addInstancedShard` applies it to
+ * occurrences that arrive AFTER an override was recorded (#3890) — a shard can
+ * stream in long after the colour was chosen, and nothing re-derives the
+ * overlay for it. Two copies of a composition rule held together by nothing but
+ * proximity is how they drift.
+ */
+
+export function composeInstancedOverrideColor(
+  rgba: readonly [number, number, number, number],
+  ghosted: boolean,
+  ghostAlpha: number,
+): [number, number, number, number] {
+  return ghosted ? [rgba[0], rgba[1], rgba[2], ghostAlpha] : [rgba[0], rgba[1], rgba[2], rgba[3]];
+}

--- a/packages/renderer/src/scene-contents.ts
+++ b/packages/renderer/src/scene-contents.ts
@@ -81,6 +81,13 @@ export interface SceneContents {
   getMeshes(): Mesh[];
   getBatchedMeshes(): BatchedMesh[];
   getMeshDataPieces(expressId: number, modelIndex?: number): MeshData[] | undefined;
+  /**
+   * O(1) "is this id in the flat mesh map" — the presence question, without
+   * `getMeshDataPieces`' per-entity extraction out of a colour-merged batch.
+   * Pair it with `isInstancedEntity` to ask the same thing of both geometry
+   * paths (`useColorOverlaySync` does, per settled geometry batch).
+   */
+  hasMeshData(expressId: number, modelIndex?: number): boolean;
   getAllMeshDataExpressIds(): number[];
   getBounds(): {
     min: { x: number; y: number; z: number };
@@ -96,6 +103,12 @@ export interface SceneContents {
   ): void;
   getAllInstancedMeshData(): MeshData[];
   getInstancedMeshDataPieces(expressId: number): MeshData[] | undefined;
+  /**
+   * O(1) instanced-membership test. `getInstancedMeshDataPieces` MATERIALIZES
+   * world-space triangles per occurrence, so it is never the right way to ask
+   * whether an id exists.
+   */
+  isInstancedEntity(expressId: number): boolean;
   getInstancedEntityBounds(expressId: number): BoundingBox | null;
   getInstancedEntityCount(): number;
   getInstancedEntityIds(): IterableIterator<number>;
@@ -116,6 +129,14 @@ export interface SceneContents {
     device: GPUDevice,
     pipeline: RenderPipeline,
   ): void;
+  /**
+   * The overrides currently installed, or null when nothing is painted. The
+   * store's `pendingColorUpdates` is a one-shot signal that is nulled after it
+   * flushes, so this retained map is the only readable record of what is
+   * painted — `useColorOverlaySync` re-hands it back to `setColorOverrides` so
+   * meshes that streamed in after the flush get their colour (#3890).
+   */
+  getColorOverrides(): ReadonlyMap<number, readonly [number, number, number, number]> | null;
   clearColorOverrides(): void;
   updateMeshColors(
     updates: Map<number, [number, number, number, number]>,

--- a/packages/renderer/src/scene-instanced-late-shard-color.test.ts
+++ b/packages/renderer/src/scene-instanced-late-shard-color.test.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A colour override applied BEFORE an instanced shard arrives must reach the
+ * occurrences in that shard (#3890).
+ *
+ * `addInstancedShard` already re-seeds a late shard's SELECTION: it checks each
+ * arriving occurrence against `instancedSelected` and writes the flag, because
+ * `setInstancedSelection` diffs by id and would early-return on an unchanged
+ * set. Colour has exactly the same hole and had no such seeding.
+ * `setInstancedColorOverrides` records the id in `instancedOverridden` even
+ * when no occurrence exists yet to paint, so the intent survives; nothing
+ * consulted it when the occurrence finally showed up.
+ *
+ * The viewer's catch-up (`useColorOverlaySync`) cannot cover this one. It is
+ * driven by the geometry counter, and a streaming event carrying only
+ * instanced shards appends through `appendInstancedShards`, which touches
+ * `pendingInstancedShards` alone: `geometryResult` does not change, so the
+ * counter never bumps and the catch-up is never scheduled.
+ *
+ * These assert on the bytes written to the instance colour lane, the same way
+ * `scene-instanced-ghosting.test.ts` does. No GPU needed.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Scene } from './scene.js';
+import { DEFAULT_GHOST_ALPHA } from './overlay-routing.js';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+function fakeDevice() {
+  const writes: Array<{ offset: number; data: number[] }> = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: (desc: { size: number }) => {
+      const backing = new ArrayBuffer(desc.size);
+      return { size: desc.size, getMappedRange: () => backing, unmap() {}, destroy() {} };
+    },
+    queue: {
+      writeBuffer: (_buf: unknown, offset: number, data: ArrayBufferView) => {
+        writes.push({ offset, data: Array.from(new Float32Array((data as Float32Array).buffer)) });
+      },
+    },
+  };
+  return { device: device as unknown as GPUDevice, writes };
+}
+
+function rowMajorTranslation(x: number): Float32Array {
+  return new Float32Array([1, 0, 0, x, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+}
+
+const ORIGINAL: [number, number, number, number] = [0.4, 0.5, 0.6, 1];
+
+function shard(entityIds: number[]): DecodedInstancedShard {
+  const templates = [];
+  const instances = [];
+  for (let t = 0; t < entityIds.length; t++) {
+    templates.push({
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      origin: [0, 0, 0] as [number, number, number],
+    });
+    instances.push({
+      templateIndex: t,
+      entityId: entityIds[t],
+      color: ORIGINAL,
+      transform: rowMajorTranslation(t),
+    });
+  }
+  return { templates, instances, carriesItemIds: false };
+}
+
+const F32 = (n: number) => Math.fround(n);
+const RED: [number, number, number, number] = [1, 0, 0, 1];
+const BLUE: [number, number, number, number] = [0, 0, 1, 1];
+
+/** The 4-float colour writes since the marker, in write order. */
+function colorsSince(writes: Array<{ data: number[] }>, from: number): number[][] {
+  return writes.slice(from).filter((w) => w.data.length === 4).map((w) => w.data);
+}
+
+describe('addInstancedShard applies a colour override recorded before the shard arrived (#3890)', () => {
+  it('paints an occurrence whose shard streams in after the override', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    // Entity 1's shard is here; entity 2's is still streaming.
+    scene.addInstancedShard(device, shard([1]), 0);
+    scene.setInstancedColorOverrides(new Map([[1, RED], [2, RED]]));
+    const mark = writes.length;
+
+    scene.addInstancedShard(device, shard([2]), 0);
+
+    assert.deepEqual(
+      colorsSince(writes, mark),
+      [[F32(1), 0, 0, F32(1)]],
+      'the late occurrence must be painted with the override that was already recorded',
+    );
+  });
+
+  it('leaves an occurrence with no override at its uploaded colour', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard([1]), 0);
+    scene.setInstancedColorOverrides(new Map([[1, RED]]));
+    const mark = writes.length;
+
+    // Entity 2 was never coloured.
+    scene.addInstancedShard(device, shard([2]), 0);
+
+    assert.deepEqual(colorsSince(writes, mark), [], 'nothing to paint, nothing written');
+  });
+
+  it('applies the newest override, not the one in force when the id was first named', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard([1]), 0);
+    scene.setInstancedColorOverrides(new Map([[2, RED]]));
+    scene.setInstancedColorOverrides(new Map([[2, BLUE]]));
+    const mark = writes.length;
+
+    scene.addInstancedShard(device, shard([2]), 0);
+
+    assert.deepEqual(colorsSince(writes, mark), [[0, 0, F32(1), F32(1)]]);
+  });
+
+  it('does not repaint an id the user reset while its shard was still streaming', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard([1]), 0);
+    scene.setInstancedColorOverrides(new Map([[1, RED], [2, RED]]));
+    // The user un-colours the occurrence that has not arrived yet.
+    scene.setInstancedColorOverrides(new Map([[1, RED]]));
+    const mark = writes.length;
+
+    scene.addInstancedShard(device, shard([2]), 0);
+
+    assert.deepEqual(colorsSince(writes, mark), [], 'a reset id must arrive at its own colour');
+  });
+
+  it('keeps the ghost alpha for a further occurrence of an already-ghosted id', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard([1, 2]), 0);
+    scene.setInstancedColorOverrides(new Map([[2, RED]]));
+    // Ghost everything except entity 1, so entity 2 is faded and IS in the
+    // ghost set by the time its next shard arrives.
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    const mark = writes.length;
+
+    scene.addInstancedShard(device, shard([2]), 0);
+
+    // `writeInstanceColor` addresses every occurrence of the id, so entity 2's
+    // pre-existing one is rewritten too. That is idempotent, and the same thing
+    // the late-SELECTION seeding one line above it does.
+    const painted = colorsSince(writes, mark);
+    assert.equal(painted.length, 2, 'both of entity 2 occurrences are written');
+    for (const write of painted) {
+      assert.deepEqual(
+        write,
+        [F32(1), 0, 0, F32(DEFAULT_GHOST_ALPHA)],
+        'the override RGB wins and X-Ray keeps the alpha, as on the flat path',
+      );
+    }
+  });
+
+  /**
+   * An id the ghost set has never seen is a different case: `setInstancedGhosting`
+   * enumerates `instancedEntityMap`, so an id with no occurrence yet is not in
+   * `instancedGhosted`. `addInstancedShard` writes the plain override, then sets
+   * `instancedGhostDirty` so the next ghosting pass folds in the fade. This pins
+   * that hand-off, since the shard-time write alone looks like a missing fade.
+   */
+  it('hands a brand-new id to the next ghosting pass, which composes the fade', () => {
+    const { device, writes } = fakeDevice();
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard([1]), 0);
+    scene.setInstancedColorOverrides(new Map([[2, RED]]));
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+
+    let mark = writes.length;
+    scene.addInstancedShard(device, shard([2]), 0);
+    assert.deepEqual(
+      colorsSince(writes, mark),
+      [[F32(1), 0, 0, F32(1)]],
+      'at shard time the override lands solid: entity 2 is not in the ghost set yet',
+    );
+
+    mark = writes.length;
+    scene.setInstancedGhosting(new Set([1]), null, DEFAULT_GHOST_ALPHA);
+    assert.deepEqual(
+      colorsSince(writes, mark),
+      [[F32(1), 0, 0, F32(DEFAULT_GHOST_ALPHA)]],
+      'the dirty flag makes the next pass fade it, keeping the override RGB',
+    );
+  });
+});

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -21,6 +21,7 @@ import {
 import { selectBoundingBoxesInRect } from './scene-rect-select.js';
 import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane, worldAabbFromPieces } from './scene-geometry.js';
 import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
+import { composeInstancedOverrideColor } from './instanced-override-color.js';
 import { simplifyIndicesByClustering, lodCellSizeForBounds, LOD_MIN_TRIANGLES } from './lod-simplify.js';
 import { quantizeInterleaved } from './quantize.js';
 import { bucketBaseKeyFor, type SpatialChunkingConfig } from './chunk-grid.js';
@@ -3263,6 +3264,11 @@ export class Scene {
     // Selected ids whose occurrences arrived in THIS shard (selection recorded
     // before the shard streamed in) — their flags are written after upload.
     const lateSelectedEids = new Set<number>();
+    // Same for COLOUR (#3890): an override is recorded against ids with no
+    // occurrence yet, and nothing consulted it when they arrived. The viewer's
+    // catch-up cannot cover this — a shard-only streaming event never moves the
+    // geometry counter it keys on.
+    const lateOverriddenEids = new Set<number>();
     for (const t of prepared) {
       const vcount = Math.floor(t.positions.length / 3);
       if (vcount === 0 || t.indices.length === 0 || t.instanceCount === 0) continue;
@@ -3385,6 +3391,7 @@ export class Scene {
           template.selectedCount++;
           lateSelectedEids.add(eid);
         }
+        if (this.instancedOverrideColors?.has(eid)) lateOverriddenEids.add(eid);
 
         if (haveBox) {
           const w = this.unionInstancedWorldAabb(eid, cdv, byteOffset, lmnx, lmny, lmnz, lmxx, lmxy, lmxz);
@@ -3402,6 +3409,11 @@ export class Scene {
     // so the highlight shows on late-streamed geometry too.
     for (const eid of lateSelectedEids) {
       this.writeInstanceFlags(device, eid);
+    }
+    // Paint ids whose override predates their occurrences.
+    for (const eid of lateOverriddenEids) {
+      const rgba = this.instancedOverrideColors?.get(eid);
+      if (rgba) this.writeInstanceColor(device, eid, composeInstancedOverrideColor(rgba, this.instancedGhosted.has(eid), this.lastGhostAlpha));
     }
     // New occurrences default to flags=0 (visible). Force the next setInstancedVisibility
     // to recompute so an already-active isolate/hide also applies to geometry that
@@ -3668,11 +3680,7 @@ export class Scene {
     }
     let hasTransparent = false;
     for (const [eid, rgba] of next) {
-      // An occurrence that is currently ghosted keeps the ghost alpha: X-Ray is
-      // a stronger statement about visibility than a lens tint, and the flat
-      // path resolves the same way.
-      const ghosted = this.instancedGhosted.has(eid);
-      this.writeInstanceColor(device, eid, ghosted ? [rgba[0], rgba[1], rgba[2], this.lastGhostAlpha] : rgba);
+      this.writeInstanceColor(device, eid, composeInstancedOverrideColor(rgba, this.instancedGhosted.has(eid), this.lastGhostAlpha));
       // Instanced occurrences are opaque by partition; only an override can drop alpha
       // below the cutoff (lens-ghost / x-ray / compare). Track it so the renderer runs
       // the transparent instanced sub-pass only when something is actually translucent.

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -317,7 +317,7 @@
    474 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
    462 packages/renderer/src/scene-raycaster.ts
-  4436 packages/renderer/src/scene.ts
+  4444 packages/renderer/src/scene.ts
    639 packages/renderer/src/section-2d-overlay.ts
    514 packages/renderer/src/section-plane.ts
    639 packages/renderer/src/shaders/main.wgsl.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -108,7 +108,7 @@
    436 apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
   1510 apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
    406 apps/viewer/src/components/viewer/useAnimationLoop.ts
-   991 apps/viewer/src/components/viewer/useGeometryStreaming.ts
+   981 apps/viewer/src/components/viewer/useGeometryStreaming.ts
    946 apps/viewer/src/components/viewer/useMouseControls.ts
    782 apps/viewer/src/components/viewer/ViewerLayout.tsx
   1843 apps/viewer/src/components/viewer/Viewport.tsx


### PR DESCRIPTION
Closes #3890. Stacked on #3880 and retargeted to main once it lands.

#3880 makes hide and isolate complete at action time, but colour was left out: both colour sinks drain and clear, and `scene.setColorOverrides` builds overlay batches once from the meshes present, so an assembly part that streams in later stays unpainted. A small hook now watches geometry arrival while a colour override map is installed and re-issues `setColorOverrides(scene.getColorOverrides())` so the overlay batches are rebuilt with the late meshes. Guards: it reads the scene's retained map rather than a captured one, so a user's targeted reset stays reset and a later correction is not undone; it retries while `hasQueuedMeshes()` because meshes only enter the scene on queue drain, not batch receipt; and the waiting set is only narrowed once the queue is empty so an entity whose remaining stream fragments are still queued is not stranded. The presence probe uses the two O(1) scene accessors added here rather than materialising instanced geometry.

Test written first: with the flush effect alone the late part was absent from the rebuilt overlay batch (2 pass, 1 fail); after the fix 5 of 5, and each guard is mutation-tested (deleting the arrival check, replaying a captured map, or deleting the drain retry each fails its test). Deferred with a note in the module doc: the deeper fix would live in `scene.appendToBatches`.

Gates on the head: viewer typecheck 0, full viewer suite 6880 pass / 0 fail, renderer suite 1204 pass, check-module-size 0 (`useGeometryStreaming.ts` shrank and its row was ratcheted down), check-isolate-expansion-routing 0, check-unused-locals 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Color overrides now correctly reapply to meshes that arrive through late streaming.
  * User resets and subsequent color corrections are preserved.
  * Instanced streamed meshes retain the correct override colors and ghosting transparency.
  * Unnecessary renderer rebuilds are avoided while streamed geometry is still loading.
* **Improvements**
  * Color updates are retried automatically as queued meshes become available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->