### PR TITLE
test(scripts): the review-signal lane tripwire counts the CSG accept-gates lane

### DIFF
--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -102,10 +102,12 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
     'Docs checks (docs-only PRs)',
     'AGENTS.md ratchet',
     'Build + WASM + Rust + Node',
+    // #3878: the two CSG accept gates are feature builds nothing else compiles.
+    'CSG accept gates (feature builds)',
   ]) {
     assert.ok(names.includes(observed), `derived set is missing the observed lane "${observed}"`);
   }
-  assert.equal(names.length, 18);
+  assert.equal(names.length, 19);
 });
 
 test('FAIL CLOSED: an empty workflow file is NO_WORKFLOW_TEXT, not an empty lane set', () => {


### PR DESCRIPTION
The PR review signal self-test pins the lane count derived from test.yml as a tripwire (18, with a names list). #3878 added the `CSG accept gates (feature builds)` lane, so the self-test has failed on every PR since, including the release branch. The lane joins the names list and the count moves to 19; the 19 derived names were listed and checked, no other lane was absorbed. `node --test scripts/lib/pr-review-signal.test.mjs` 81/81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated workflow validation to include the “CSG accept gates (feature builds)” lane.
  * Expanded the expected workflow lane coverage from 18 to 19 entries, helping ensure lane derivation remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->