### PR TITLE
chore(changeset): name @ifc-lite/viewer in the #3880 changeset instead of the repo root

### DIFF
--- a/.changeset/fix-3865-assembly-presentation-streaming.md
+++ b/.changeset/fix-3865-assembly-presentation-streaming.md
@@ -1,5 +1,5 @@
 ---
-"ifc-lite": patch
+"@ifc-lite/viewer": patch
 ---
 
 fix(viewer): assembly parts streaming in after a hide or isolate now respect it (#3865)


### PR DESCRIPTION
check-changesets has been red on main since #3880 merged: its changeset named "ifc-lite", which is no workspace package. Renamed to "@ifc-lite/viewer", matching the other viewer changesets. `node scripts/check-changesets.mjs` exits 0 (275 pending, all naming workspace packages).