### PR TITLE
feat(server,server-client): a streaming cache hit by hash, without re-uploading the file

### DIFF
--- a/.changeset/stream-hit-by-hash.md
+++ b/.changeset/stream-hit-by-hash.md
@@ -1,0 +1,19 @@
+---
+'@ifc-lite/server-bin': minor
+'@ifc-lite/server-client': minor
+---
+
+Streaming cache hits no longer pay for the upload.
+
+`POST /api/v1/parse/parquet-stream` keys on the SHA-256 of the bytes it
+receives, so the whole file had to arrive before the cache could be consulted.
+On a 40 MB model that upload was the entire cost of a hit. The route now also
+accepts `?sha256={hex}` with no request body: if everything the replay needs is
+already cached it streams it back, and otherwise answers 404 meaning "send the
+file". A hash that arrives alongside a body is ignored, so the received bytes
+still decide which entry is read and written.
+
+`parseParquetStream` in `@ifc-lite/server-client` hashes the file locally and
+probes before uploading. This also makes a hit progressive: it used to fetch the
+whole model through `/cache/geometry` and hand it over as one batch. Pass
+`{ skipCacheProbe: true }` to upload straight away.

--- a/.changeset/stream-hit-by-hash.md
+++ b/.changeset/stream-hit-by-hash.md
@@ -14,6 +14,8 @@ file". A hash that arrives alongside a body is ignored, so the received bytes
 still decide which entry is read and written.
 
 `parseParquetStream` in `@ifc-lite/server-client` hashes the file locally and
-probes before uploading. This also makes a hit progressive: it used to fetch the
+probes before uploading. The probe degrades to the upload whenever it is not
+answered, so pointing an upgraded client at a server that predates this change
+still works. This also makes a hit progressive: it used to fetch the
 whole model through `/cache/geometry` and hand it over as one batch. Pass
 `{ skipCacheProbe: true }` to upload straight away.

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -37,6 +37,24 @@ pub(crate) fn cache_key_from_parts(
     )
 }
 
+/// Whether `hash` has the shape [`DiskCache::generate_key`] produces: 64
+/// lowercase hex characters.
+///
+/// Lives beside [`cache_key_from_parts`] because that is what it protects. The
+/// hash a client supplies is concatenated into `{hash}-{filter}{quality}` and
+/// the namespace suffix (`-parquet-v5`, `-datamodel-v6`, ...) is appended after
+/// it, so a caller-shaped string is a caller-shaped cache key. Checking the
+/// shape keeps the value to the one job it has, naming a file.
+///
+/// Applied by the hash-only stream probe (#3901). The two older hash-taking
+/// endpoints, `check_cache` and `get_cached_geometry`, do NOT call it yet: a
+/// malformed hash there names a key nobody wrote and gets a 404, which is a
+/// correct answer by a different route. Tightening them is a behaviour change
+/// to a published surface and is deliberately not part of #3901.
+pub(crate) fn is_file_digest(hash: &str) -> bool {
+    hash.len() == 64 && hash.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 /// Request-level cache key: file hash + opening-filter suffix + quality suffix.
 pub(crate) fn request_cache_key(data: &[u8], query: &ParseQuery, quality: TessellationQuality) -> String {
     cache_key_from_parts(

--- a/apps/server/src/routes/parse/cache_keys.rs
+++ b/apps/server/src/routes/parse/cache_keys.rs
@@ -205,6 +205,22 @@ pub(crate) async fn has_current_data_model(cache: &DiskCache, cache_key: &str) -
     has_entry(cache, &data_model_cache_key(cache_key)).await
 }
 
+/// Whether the Parquet metadata header is cached for `cache_key`.
+///
+/// The cheap half of "is this replayable": the header is a few hundred bytes,
+/// where the geometry blob is the whole model. The hash-only stream probe
+/// (#3901) asks this, plus [`has_current_data_model`], BEFORE it takes an
+/// admission slot, so the common miss (a file the server has never seen) is
+/// answered by two small reads rather than by charging a parse slot for a disk
+/// lookup. It is a pre-filter, never the decision: [`try_cached_replay`] still
+/// makes that, and a metadata entry present here with no geometry beside it
+/// falls through to the same 404.
+///
+/// [`try_cached_replay`]: super::cached_replay::try_cached_replay
+pub(crate) async fn has_parquet_metadata(cache: &DiskCache, cache_key: &str) -> bool {
+    has_entry(cache, &parquet_metadata_key(cache_key)).await
+}
+
 /// Whether `key` has a readable entry.
 ///
 /// Reads the value rather than asking `DiskCache::has`, which is an index

--- a/apps/server/src/routes/parse/cache_keys_tests.rs
+++ b/apps/server/src/routes/parse/cache_keys_tests.rs
@@ -267,9 +267,18 @@ fn request_cache_key_separates_content_filter_and_quality() {
                 opening_filter: mode,
                 tessellation_quality: None,
                 parquet_layout: ParquetLayout::Flat,
+                // A client-supplied hash is a SELECTOR for the hash-only
+                // stream probe (#3901); it is not part of the cache identity
+                // a body-carrying request builds. Set to a value that would
+                // be visible if it leaked in.
+                sha256: Some("f".repeat(64)),
             };
             let key = request_cache_key(data, &query, quality);
             assert!(key.starts_with(&hash), "the file hash must lead the key: {key}");
+            assert!(
+                !key.contains(&"f".repeat(64)),
+                "request_cache_key must key off the bytes, never the query hash: {key}"
+            );
             assert!(
                 seen.insert(key.clone()),
                 "collision: {mode:?}/{quality:?} reuses an existing key {key}"

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -18,8 +18,8 @@
 //! still monotonic and still ends at its own stated total.
 
 use super::cache_keys::{
-    cache_key_from_parts, has_current_data_model, is_file_digest, load_cached_symbolic,
-    parquet_geometry_key, parquet_metadata_key,
+    cache_key_from_parts, has_current_data_model, has_parquet_metadata, is_file_digest,
+    load_cached_symbolic, parquet_geometry_key, parquet_metadata_key,
 };
 use super::ParseQuery;
 use ifc_lite_processing::TessellationQuality;
@@ -54,14 +54,21 @@ use std::convert::Infallible;
 /// `GET /api/v1/cache/check/{hash}` already uses for "upload it", and the
 /// client uploads.
 ///
-/// Admission is acquired around the replay BUILD, then dropped before the
-/// response is returned. That is what the body-carrying hit path does, and for
-/// the same reason: `try_cached_replay` is not free. It reads the whole
-/// geometry blob into memory, base64-encodes every batch, and materializes the
-/// full event vector before a byte is sent, which is several times the model's
-/// geometry resident at once. A probe is the cheapest request a client can
-/// send, so leaving that window unbounded would make it the cheapest way to
-/// exhaust the server. Draining the finished stream needs no slot.
+/// A MISS costs no admission slot. The probe answers it from two small reads
+/// (the metadata header and the data-model marker) before touching the gate,
+/// because the common miss is a file the server has never seen and charging a
+/// parse slot for a disk lookup would mean every cold-cache client wins
+/// admission twice, probe then upload, and could be shed on the probe rather
+/// than queueing for the upload that would have succeeded.
+///
+/// A HIT does take one, around the replay BUILD, dropped before the response is
+/// returned. That is what the body-carrying hit path does, and for the same
+/// reason: `try_cached_replay` reads the whole geometry blob into memory,
+/// base64-encodes every batch, and materializes the full event vector before a
+/// byte is sent, which is several times the model's geometry resident at once.
+/// Leaving that window unbounded would make the cheapest request a client can
+/// send the cheapest way to exhaust the server. Draining the finished stream
+/// needs no slot.
 pub(super) async fn replay_by_client_hash(
     state: &AppState,
     query: &ParseQuery,
@@ -74,13 +81,22 @@ pub(super) async fn replay_by_client_hash(
         ));
     }
     let cache_key = cache_key_from_parts(sha256, query.opening_filter, quality);
-    let admission_guard = state
-        .admission
-        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
-        .await?;
-    let replay = try_cached_replay(state, &cache_key, query.parquet_layout).await;
-    drop(admission_guard);
-    if let Some(response) = replay? {
+
+    let replay = if has_parquet_metadata(&state.cache, &cache_key).await
+        && has_current_data_model(&state.cache, &cache_key).await
+    {
+        let admission_guard = state
+            .admission
+            .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+            .await?;
+        let replay = try_cached_replay(state, &cache_key, query.parquet_layout).await;
+        drop(admission_guard);
+        replay?
+    } else {
+        None
+    };
+
+    if let Some(response) = replay {
         tracing::info!(
             cache_key = %cache_key,
             "Streaming cache HIT by client-supplied hash - no upload"

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -18,8 +18,8 @@
 //! still monotonic and still ends at its own stated total.
 
 use super::cache_keys::{
-    cache_key_from_parts, has_current_data_model, load_cached_symbolic, parquet_geometry_key,
-    parquet_metadata_key,
+    cache_key_from_parts, has_current_data_model, is_file_digest, load_cached_symbolic,
+    parquet_geometry_key, parquet_metadata_key,
 };
 use super::ParseQuery;
 use ifc_lite_processing::TessellationQuality;
@@ -34,19 +34,6 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::convert::Infallible;
-
-/// Whether `hash` has the shape `DiskCache::generate_key` produces: 64
-/// lowercase hex characters.
-///
-/// This is a GUARD, not a validation nicety. The hash goes straight into
-/// `cache_key_from_parts`, which builds `{hash}-{filter}{quality}`, and the
-/// namespace suffix (`-parquet-v5`, `-datamodel-v6`, ...) is appended after
-/// that. A caller-shaped string is therefore a caller-shaped cache key.
-/// Rejecting anything that is not a bare digest keeps the parameter to the one
-/// job it has, naming a file, and no other.
-fn is_file_digest(hash: &str) -> bool {
-    hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
-}
 
 /// Serve `POST /api/v1/parse/parquet-stream` from a client-supplied file hash,
 /// with no request body at all (issue #3901).
@@ -67,9 +54,14 @@ fn is_file_digest(hash: &str) -> bool {
 /// `GET /api/v1/cache/check/{hash}` already uses for "upload it", and the
 /// client uploads.
 ///
-/// No admission guard: there is no upload to buffer and no parse to run, and
-/// the body-carrying hit path drops its own guard before returning a replay for
-/// that same reason.
+/// Admission is acquired around the replay BUILD, then dropped before the
+/// response is returned. That is what the body-carrying hit path does, and for
+/// the same reason: `try_cached_replay` is not free. It reads the whole
+/// geometry blob into memory, base64-encodes every batch, and materializes the
+/// full event vector before a byte is sent, which is several times the model's
+/// geometry resident at once. A probe is the cheapest request a client can
+/// send, so leaving that window unbounded would make it the cheapest way to
+/// exhaust the server. Draining the finished stream needs no slot.
 pub(super) async fn replay_by_client_hash(
     state: &AppState,
     query: &ParseQuery,
@@ -82,7 +74,13 @@ pub(super) async fn replay_by_client_hash(
         ));
     }
     let cache_key = cache_key_from_parts(sha256, query.opening_filter, quality);
-    if let Some(response) = try_cached_replay(state, &cache_key, query.parquet_layout).await? {
+    let admission_guard = state
+        .admission
+        .acquire(state.config.max_file_size_mb as u64 * 1024 * 1024)
+        .await?;
+    let replay = try_cached_replay(state, &cache_key, query.parquet_layout).await;
+    drop(admission_guard);
+    if let Some(response) = replay? {
         tracing::info!(
             cache_key = %cache_key,
             "Streaming cache HIT by client-supplied hash - no upload"

--- a/apps/server/src/routes/parse/cached_replay.rs
+++ b/apps/server/src/routes/parse/cached_replay.rs
@@ -18,11 +18,14 @@
 //! still monotonic and still ends at its own stated total.
 
 use super::cache_keys::{
-    has_current_data_model, load_cached_symbolic, parquet_geometry_key, parquet_metadata_key,
+    cache_key_from_parts, has_current_data_model, load_cached_symbolic, parquet_geometry_key,
+    parquet_metadata_key,
 };
+use super::ParseQuery;
+use ifc_lite_processing::TessellationQuality;
 use crate::services::ParquetLayout;
 use super::parquet::ParquetMetadataHeader;
-use super::parquet_stream::ParquetStreamEvent;
+use super::stream_event::ParquetStreamEvent;
 use super::stream_progress::load_stream_progress;
 use crate::error::ApiError;
 use crate::services::parquet_replay_batches::split_into_batches;
@@ -31,6 +34,69 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::convert::Infallible;
+
+/// Whether `hash` has the shape `DiskCache::generate_key` produces: 64
+/// lowercase hex characters.
+///
+/// This is a GUARD, not a validation nicety. The hash goes straight into
+/// `cache_key_from_parts`, which builds `{hash}-{filter}{quality}`, and the
+/// namespace suffix (`-parquet-v5`, `-datamodel-v6`, ...) is appended after
+/// that. A caller-shaped string is therefore a caller-shaped cache key.
+/// Rejecting anything that is not a bare digest keeps the parameter to the one
+/// job it has, naming a file, and no other.
+fn is_file_digest(hash: &str) -> bool {
+    hash.len() == 64 && hash.bytes().all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Serve `POST /api/v1/parse/parquet-stream` from a client-supplied file hash,
+/// with no request body at all (issue #3901).
+///
+/// The upload used to be unavoidable on a hit: the cache key is the SHA-256 of
+/// the RECEIVED bytes, so `extract_file` had to finish before the cache could
+/// be consulted, and on a 40 MB model over a real connection that upload was
+/// the whole cost of the hit. A client that hashes locally can name the entry
+/// instead.
+///
+/// The hash SELECTS; it never asserts. Everything the replay needs has to be on
+/// disk under that key already, which is exactly what [`try_cached_replay`]
+/// checks (geometry body, metadata header, a data model at the current payload
+/// version, plus whatever it later adds). Delegating to it rather than
+/// re-listing those entries here is what makes "a hash-only hit replays the
+/// same events as an upload hit" true by construction instead of by two lists
+/// agreeing. A miss answers `404`, the status
+/// `GET /api/v1/cache/check/{hash}` already uses for "upload it", and the
+/// client uploads.
+///
+/// No admission guard: there is no upload to buffer and no parse to run, and
+/// the body-carrying hit path drops its own guard before returning a replay for
+/// that same reason.
+pub(super) async fn replay_by_client_hash(
+    state: &AppState,
+    query: &ParseQuery,
+    quality: TessellationQuality,
+    sha256: &str,
+) -> Result<axum::response::Response, ApiError> {
+    if !is_file_digest(sha256) {
+        return Err(ApiError::BadRequest(
+            "sha256 must be a 64-character lowercase hex SHA-256 digest".to_string(),
+        ));
+    }
+    let cache_key = cache_key_from_parts(sha256, query.opening_filter, quality);
+    if let Some(response) = try_cached_replay(state, &cache_key, query.parquet_layout).await? {
+        tracing::info!(
+            cache_key = %cache_key,
+            "Streaming cache HIT by client-supplied hash - no upload"
+        );
+        return Ok(response);
+    }
+    tracing::debug!(
+        cache_key = %cache_key,
+        "Hash-only stream request has nothing cached; asking the client to upload"
+    );
+    Err(ApiError::NotFound(format!(
+        "Nothing cached for sha256 {sha256} under this opening_filter / tessellation_quality / parquet_layout. Resend the request with the multipart file body."
+    )))
+}
 
 /// Return the geometry slice from a cached combined-Parquet blob, framed as
 /// `[geometry_len: u32-LE][geometry_data][data_model_len: u32]...`. Returns

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -48,19 +48,15 @@ pub struct ParseQuery {
     pub parquet_layout: ParquetLayout,
     /// SHA-256 of the file the client is asking about, hex, lowercase (#3901).
     ///
-    /// Only `POST /api/v1/parse/parquet-stream` reads it, and only when the
-    /// request carries NO multipart body: it turns that route into a
-    /// replay-or-404 probe so a cache hit costs no upload. It lives here
-    /// rather than in a header so it travels with the rest of the cache
-    /// identity (`opening_filter`, `tessellation_quality`, `parquet_layout`)
-    /// through the one struct every parse route already parses -- a hash
-    /// paired with the wrong layout names a different entry, and splitting
-    /// the identity across two transports is how those pairings drift apart.
-    ///
-    /// NEVER trusted for anything but SELECTING entries that already exist:
-    /// it names a cache key, and a key that misses answers 404. It can not
-    /// cause anything to be written, and when a body IS present it is ignored
-    /// outright in favour of hashing the received bytes.
+    /// Read only by `POST /api/v1/parse/parquet-stream`, and only when the
+    /// request carries no multipart body: see
+    /// [`cached_replay::replay_by_client_hash`] for what it does and what it
+    /// is not allowed to do. It lives on this struct rather than in a header
+    /// so it travels with the rest of the cache identity (`opening_filter`,
+    /// `tessellation_quality`, `parquet_layout`) through the one place every
+    /// parse route already parses. A hash paired with the wrong layout names a
+    /// different entry, and splitting one identity across two transports is how
+    /// such pairings drift apart.
     #[serde(default)]
     pub sha256: Option<String>,
 }

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -6,6 +6,7 @@
 
 mod cache_keys;
 mod cached_replay;
+mod stream_event;
 mod stream_progress;
 mod fetch;
 mod json;
@@ -45,6 +46,23 @@ pub struct ParseQuery {
     /// takes this struct, so the signal travels with the cache identity.
     #[serde(default)]
     pub parquet_layout: ParquetLayout,
+    /// SHA-256 of the file the client is asking about, hex, lowercase (#3901).
+    ///
+    /// Only `POST /api/v1/parse/parquet-stream` reads it, and only when the
+    /// request carries NO multipart body: it turns that route into a
+    /// replay-or-404 probe so a cache hit costs no upload. It lives here
+    /// rather than in a header so it travels with the rest of the cache
+    /// identity (`opening_filter`, `tessellation_quality`, `parquet_layout`)
+    /// through the one struct every parse route already parses -- a hash
+    /// paired with the wrong layout names a different entry, and splitting
+    /// the identity across two transports is how those pairings drift apart.
+    ///
+    /// NEVER trusted for anything but SELECTING entries that already exist:
+    /// it names a cache key, and a key that misses answers 404. It can not
+    /// cause anything to be written, and when a body IS present it is ignored
+    /// outright in favour of hashing the received bytes.
+    #[serde(default)]
+    pub sha256: Option<String>,
 }
 
 impl ParseQuery {

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -9,55 +9,18 @@ use super::cache_keys::{
     request_cache_key,
 };
 use super::parquet::ParquetMetadataHeader;
+use super::stream_event::ParquetStreamEvent;
 use super::stream_progress::{cache_stream_progress, StreamProgressRecorder};
 use super::{extract_file, ParseQuery};
 use crate::error::ApiError;
 use crate::services::{extract_data_model, process_streaming, serialize_data_model_to_parquet};
-use crate::types::{ModelMetadata, ProcessingStats, StreamEvent};
+use crate::types::StreamEvent;
 use crate::AppState;
 use axum::{
     extract::{Multipart, Query, State},
     response::sse::{Event, KeepAlive, Sse},
 };
-use ifc_lite_processing::SymbolicData;
-use serde::Serialize;
 use std::convert::Infallible;
-
-/// SSE event types for Parquet streaming.
-// Variant sizes differ because the payload events carry buffers; boxing them
-// would complicate the SSE serialization path for no runtime benefit here.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum ParquetStreamEvent {
-    /// Initial event with estimated totals.
-    Start {
-        total_estimate: usize,
-        cache_key: String,
-    },
-    /// Progress update.
-    Progress { processed: usize, total: usize },
-    /// Batch of geometry data as base64-encoded Parquet.
-    Batch {
-        /// Base64-encoded Parquet data containing this batch's meshes.
-        data: String,
-        /// Number of meshes in this batch.
-        mesh_count: usize,
-        /// Batch sequence number (1-indexed).
-        batch_number: usize,
-    },
-    /// Processing complete.
-    Complete {
-        stats: ProcessingStats,
-        metadata: ModelMetadata,
-        /// 2D symbol data extracted from `IfcAnnotation` and `IfcGrid`
-        /// entities — parity with `POST /api/v1/parse` (issue #900).
-        #[serde(default, skip_serializing_if = "SymbolicData::is_empty")]
-        symbolic_data: SymbolicData,
-    },
-    /// Error occurred.
-    Error { message: String },
-}
 
 /// POST /api/v1/parse/parquet-stream - Streaming parse with Parquet batches.
 ///
@@ -72,16 +35,50 @@ pub enum ParquetStreamEvent {
 /// - `error`: Error event with `message`
 ///
 /// After `complete`, client should fetch data model via `/api/v1/data-model/{cache_key}`.
+///
+/// ## Two ways to ask
+///
+/// With a multipart `file` body: the normal path. The cache key is the SHA-256
+/// of the RECEIVED bytes, so the upload always completes first, and a `sha256`
+/// query parameter sent alongside a body is IGNORED - the bytes on the wire
+/// decide which entry is read and written, never the client's claim about them.
+///
+/// With `?sha256={hex}` and no body: a probe (issue #3901). It replays the
+/// cached stream if, and only if, every entry the replay needs already exists
+/// under that key, and otherwise answers `404` meaning "upload it". See
+/// [`cached_replay::replay_by_client_hash`]. This is what lets a 40 MB cache
+/// hit cost no upload.
 pub async fn parse_parquet_stream(
     State(state): State<AppState>,
     Query(query): Query<ParseQuery>,
-    mut multipart: Multipart,
+    multipart: Option<Multipart>,
 ) -> Result<axum::response::Response, ApiError> {
     use crate::services::{serialize_batch_with_layout, StreamingParquetCacheWriter};
     use axum::response::IntoResponse;
     use base64::{engine::general_purpose::STANDARD, Engine};
     use futures::StreamExt;
     use std::sync::{Arc, Mutex};
+
+    let tessellation_quality = query.resolved_tessellation_quality()?;
+
+    // Hash-only probe: no body was sent, so there is nothing to extract and
+    // nothing to parse. Checked BEFORE the admission gate because this path
+    // buffers no upload and runs no geometry work.
+    let Some(mut multipart) = multipart else {
+        let Some(sha256) = query.sha256.as_deref() else {
+            // No body and no hash: there is nothing to identify a file with.
+            // `MissingFile` (400) is what a body with no `file` field already
+            // answers, and it says the same thing here.
+            return Err(ApiError::MissingFile);
+        };
+        return super::cached_replay::replay_by_client_hash(
+            &state,
+            &query,
+            tessellation_quality,
+            sha256,
+        )
+        .await;
+    };
 
     // Extract file
     // Admission gate (bounded concurrency + byte budget): acquired BEFORE the
@@ -94,8 +91,10 @@ pub async fn parse_parquet_stream(
         .await?;
     let data = extract_file(&mut multipart, state.config.max_file_size_mb).await?;
 
-    // Generate cache key before processing (include opening filter + quality)
-    let tessellation_quality = query.resolved_tessellation_quality()?;
+    // Generate cache key before processing (include opening filter + quality).
+    // From the RECEIVED BYTES, always: a `sha256` parameter that arrived
+    // alongside a body has no say here, so a client whose claimed hash does not
+    // describe what it uploaded still reads and writes the entry its bytes name.
     let cache_key = request_cache_key(&data, &query, tessellation_quality);
     let cache_key_clone = cache_key.clone();
     // This route SHARES nothing -- a per-batch writer cannot see across a batch

--- a/apps/server/src/routes/parse/parquet_stream.rs
+++ b/apps/server/src/routes/parse/parquet_stream.rs
@@ -62,8 +62,10 @@ pub async fn parse_parquet_stream(
     let tessellation_quality = query.resolved_tessellation_quality()?;
 
     // Hash-only probe: no body was sent, so there is nothing to extract and
-    // nothing to parse. Checked BEFORE the admission gate because this path
-    // buffers no upload and runs no geometry work.
+    // nothing to parse. It is checked before the gate below only because that
+    // gate reserves an upload that does not exist. The probe takes admission
+    // itself, on the hit path where it has real work to bound -- see
+    // `replay_by_client_hash`.
     let Some(mut multipart) = multipart else {
         let Some(sha256) = query.sha256.as_deref() else {
             // No body and no hash: there is nothing to identify a file with.

--- a/apps/server/src/routes/parse/parquet_stream_hash_only_tests.rs
+++ b/apps/server/src/routes/parse/parquet_stream_hash_only_tests.rs
@@ -1,0 +1,258 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `POST /api/v1/parse/parquet-stream?sha256=...` with NO request body
+//! (issue #3901).
+//!
+//! Before this, a cache hit on the streaming route still paid the full upload:
+//! the key is the SHA-256 of the received bytes, so `extract_file` had to run
+//! before the cache could be consulted. These tests pin the three properties
+//! that make presenting a hash instead safe:
+//!
+//! 1. A hash-only HIT replays byte-for-byte the same SSE events an upload hit
+//!    replays. If it did not, the parameter would be a second, divergent
+//!    transport for the same data.
+//! 2. A hash-only MISS answers `404` and runs no parse. A probe must not be a
+//!    way to make the server do work, and the client has to be told to upload.
+//! 3. A hash sent ALONGSIDE a body is ignored. The client's claim about its
+//!    bytes never decides which entry is read or written.
+
+use super::*;
+use crate::services::cache::DiskCache;
+
+/// SHA-256 of `content`, in the hex shape the cache key is built from.
+fn digest(content: &str) -> String {
+    DiskCache::generate_key(content.as_bytes())
+}
+
+/// Drive the route with a `sha256` query parameter and NO multipart body at
+/// all: no `Content-Type`, no bytes. That absence is the point of the feature,
+/// so the test has to send a genuinely empty request rather than an empty
+/// multipart envelope.
+async fn hash_only_request(state: &AppState, sha256: &str) -> axum::response::Response {
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!(
+            "/api/v1/parse/parquet-stream?sha256={sha256}"
+        ))
+        .body(Body::empty())
+        .unwrap();
+    build_router(state.clone()).oneshot(request).await.unwrap()
+}
+
+/// Read an SSE response body into its JSON events.
+async fn sse_events(response: axum::response::Response) -> Vec<Value> {
+    let bytes = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        to_bytes(response.into_body(), usize::MAX),
+    )
+    .await
+    .expect("SSE stream should finish")
+    .unwrap();
+    parse_sse_events(std::str::from_utf8(&bytes).unwrap())
+}
+
+/// Warm the cache by parsing `content` through the real route, then wait until
+/// every entry `try_cached_replay` needs has actually landed. The geometry,
+/// metadata, data model and progress sidecar are all written by tasks spawned
+/// off the `Complete` event, so without this wait a follow-up request re-parses
+/// and any comparison is between two live runs, which matches for every
+/// implementation of the replay including none.
+async fn warm_cache(state: &AppState, content: &str) -> String {
+    let live = stream_once(state, content).await;
+    let key = live
+        .iter()
+        .find(|e| e["type"] == "start")
+        .expect("live run must emit start")["cache_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let required = [
+        format!("{key}-parquet-v5"),
+        format!("{key}-parquet-metadata-v4"),
+        crate::routes::parse::cache_keys::data_model_cache_key(&key),
+        crate::routes::parse::stream_progress::stream_progress_cache_key(&key),
+    ];
+    for _ in 0..200 {
+        let mut all = true;
+        for k in &required {
+            if !matches!(state.cache.get_bytes(k).await, Ok(Some(_))) {
+                all = false;
+            }
+        }
+        if all {
+            return key;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("cache fill never completed for {key}");
+}
+
+/// Property 1: the hash-only hit is the SAME stream as the upload hit.
+///
+/// Both requests replay from the same cache entries, so every event — start,
+/// each batch's base64 payload and counters, each progress checkpoint, the
+/// complete stats and metadata — has to be identical. The only difference is
+/// that one of them sent 0 bytes of file.
+#[tokio::test]
+async fn a_hash_only_hit_replays_the_same_events_as_an_upload_hit() {
+    let state = test_state("hash-only-hit").await;
+    let key = warm_cache(&state, JOBS_NE_MESHES_FIXTURE).await;
+
+    let upload_hit = stream_once(&state, JOBS_NE_MESHES_FIXTURE).await;
+
+    let response = hash_only_request(&state, &digest(JOBS_NE_MESHES_FIXTURE)).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a warm entry must be replayable from the hash alone"
+    );
+    let hash_only = sse_events(response).await;
+
+    // Anti-vacuity: two empty vectors are also equal. A replay of this fixture
+    // carries a batch with real Parquet bytes and a terminal complete.
+    assert!(
+        hash_only.iter().any(|e| e["type"] == "batch"
+            && !e["data"].as_str().unwrap_or("").is_empty()),
+        "replay must carry at least one non-empty batch, got {hash_only:?}"
+    );
+    assert!(hash_only.iter().any(|e| e["type"] == "complete"));
+
+    assert_eq!(
+        hash_only, upload_hit,
+        "a hash-only hit must be indistinguishable from an upload hit"
+    );
+    assert_eq!(
+        hash_only[0]["cache_key"].as_str().unwrap(),
+        key,
+        "the replay must be keyed by the same request cache key the upload produced"
+    );
+}
+
+/// Property 2: nothing cached means `404` and no parse.
+///
+/// `404` is the status `GET /api/v1/cache/check/{hash}` already uses for
+/// "upload it", so a client that understands one understands the other.
+///
+/// The second half is what stops the parameter from becoming a way to make the
+/// server work for a body it never received: after the miss, the cache must
+/// still be empty for that key. A route that fell through to parsing something
+/// would leave entries behind.
+#[tokio::test]
+async fn a_hash_only_miss_answers_404_and_runs_no_parse() {
+    let state = test_state("hash-only-miss").await;
+    let hash = digest(JOBS_NE_MESHES_FIXTURE);
+
+    let response = hash_only_request(&state, &hash).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], serde_json::json!("NOT_FOUND"));
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("multipart"),
+        "the miss has to tell the client to send the body, got {json}"
+    );
+
+    // No parse ran, so nothing was written under the key the hash names.
+    let key = format!("{hash}-default");
+    for suffix in ["-parquet-v5", "-parquet-v6", "-parquet-metadata-v4"] {
+        assert!(
+            matches!(
+                state.cache.get_bytes(&format!("{key}{suffix}")).await,
+                Ok(None)
+            ),
+            "a hash-only miss must not have parsed or cached anything ({suffix})"
+        );
+    }
+}
+
+/// Property 3: with a body present, the body wins.
+///
+/// The hash is a SELECTOR for entries that already exist, never an assertion
+/// about the bytes. A request that uploads one file while claiming the hash of
+/// another must read and write the entry its BYTES name — otherwise a client
+/// could poison one file's cache slot with another file's geometry.
+#[tokio::test]
+async fn a_hash_that_contradicts_the_uploaded_body_still_keys_off_the_body() {
+    let state = test_state("hash-vs-body").await;
+
+    // A real digest, of a DIFFERENT file. Well-formed, so it passes the shape
+    // guard and only the precedence rule can reject it.
+    let lie = digest(TWO_WALL_FIXTURE);
+    let truth = digest(JOBS_NE_MESHES_FIXTURE);
+    assert_ne!(lie, truth, "the two fixtures must hash differently");
+
+    let (content_type, body) = multipart_body(JOBS_NE_MESHES_FIXTURE.as_bytes());
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/parse/parquet-stream?sha256={lie}"))
+        .header(header::CONTENT_TYPE, content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let response = build_router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let events = sse_events(response).await;
+    let cache_key = events
+        .iter()
+        .find(|e| e["type"] == "start")
+        .expect("upload must emit start")["cache_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    assert!(
+        cache_key.starts_with(&truth),
+        "the cache key must come from the uploaded bytes, got {cache_key}"
+    );
+    assert!(
+        !cache_key.starts_with(&lie),
+        "the client-supplied hash must not select the entry when a body is present"
+    );
+}
+
+/// The shape guard. The hash is concatenated into a cache key, so a value that
+/// is not a bare digest is a caller-shaped key: `sha256=<key>-datamodel-v6`
+/// would address another request's data-model slot through the geometry
+/// reader. Anything but 64 lowercase hex characters is a `400`, not a lookup.
+#[tokio::test]
+async fn a_sha256_that_is_not_a_bare_digest_is_rejected() {
+    let state = test_state("hash-only-shape").await;
+    for bogus in [
+        "not-a-hash",
+        // Right alphabet, wrong length.
+        "abc123",
+        // A well-formed digest with a namespace suffix glued on.
+        &format!("{}-default-datamodel-v6", digest(TWO_WALL_FIXTURE)),
+        // Uppercase: `DiskCache::generate_key` only ever emits lowercase, so
+        // accepting this would make two spellings of one file.
+        &digest(TWO_WALL_FIXTURE).to_uppercase(),
+    ] {
+        let response = hash_only_request(&state, bogus).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "{bogus} must be rejected on shape, not looked up"
+        );
+    }
+}
+
+/// Neither a body nor a hash: there is nothing to identify a file with. This is
+/// the same `400 MISSING_FILE` a multipart body with no `file` field answers,
+/// and making the body optional must not turn it into a `500` or a hang.
+#[tokio::test]
+async fn a_request_with_neither_body_nor_hash_is_a_missing_file() {
+    let state = test_state("hash-only-neither").await;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/parse/parquet-stream")
+        .body(Body::empty())
+        .unwrap();
+    let response = build_router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["code"], serde_json::json!("MISSING_FILE"));
+}

--- a/apps/server/src/routes/parse/parquet_stream_hash_only_tests.rs
+++ b/apps/server/src/routes/parse/parquet_stream_hash_only_tests.rs
@@ -53,42 +53,6 @@ async fn sse_events(response: axum::response::Response) -> Vec<Value> {
     parse_sse_events(std::str::from_utf8(&bytes).unwrap())
 }
 
-/// Warm the cache by parsing `content` through the real route, then wait until
-/// every entry `try_cached_replay` needs has actually landed. The geometry,
-/// metadata, data model and progress sidecar are all written by tasks spawned
-/// off the `Complete` event, so without this wait a follow-up request re-parses
-/// and any comparison is between two live runs, which matches for every
-/// implementation of the replay including none.
-async fn warm_cache(state: &AppState, content: &str) -> String {
-    let live = stream_once(state, content).await;
-    let key = live
-        .iter()
-        .find(|e| e["type"] == "start")
-        .expect("live run must emit start")["cache_key"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    let required = [
-        format!("{key}-parquet-v5"),
-        format!("{key}-parquet-metadata-v4"),
-        crate::routes::parse::cache_keys::data_model_cache_key(&key),
-        crate::routes::parse::stream_progress::stream_progress_cache_key(&key),
-    ];
-    for _ in 0..200 {
-        let mut all = true;
-        for k in &required {
-            if !matches!(state.cache.get_bytes(k).await, Ok(Some(_))) {
-                all = false;
-            }
-        }
-        if all {
-            return key;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    }
-    panic!("cache fill never completed for {key}");
-}
-
 /// Property 1: the hash-only hit is the SAME stream as the upload hit.
 ///
 /// Both requests replay from the same cache entries, so every event — start,
@@ -98,7 +62,8 @@ async fn warm_cache(state: &AppState, content: &str) -> String {
 #[tokio::test]
 async fn a_hash_only_hit_replays_the_same_events_as_an_upload_hit() {
     let state = test_state("hash-only-hit").await;
-    let key = warm_cache(&state, JOBS_NE_MESHES_FIXTURE).await;
+    let live = stream_once(&state, JOBS_NE_MESHES_FIXTURE).await;
+    let key = await_cache_fill(&state, &live).await;
 
     let upload_hit = stream_once(&state, JOBS_NE_MESHES_FIXTURE).await;
 

--- a/apps/server/src/routes/parse/parquet_stream_tests.rs
+++ b/apps/server/src/routes/parse/parquet_stream_tests.rs
@@ -338,3 +338,6 @@ async fn a_cache_hit_reports_the_same_progress_numbers_as_the_miss() {
     assert_eq!(total_estimate(&replay), total_estimate(&live));
     assert_eq!(total_estimate(&replay), live_total);
 }
+
+#[path = "parquet_stream_hash_only_tests.rs"]
+mod hash_only;

--- a/apps/server/src/routes/parse/parquet_stream_tests.rs
+++ b/apps/server/src/routes/parse/parquet_stream_tests.rs
@@ -248,6 +248,48 @@ async fn stream_once(state: &AppState, content: &str) -> Vec<Value> {
     parse_sse_events(&text)
 }
 
+/// Wait until every entry `try_cached_replay` needs for `live`'s cache key has
+/// actually landed, and return that key.
+///
+/// The geometry, metadata, data model and progress sidecar are all written by
+/// tasks spawned off the `Complete` event. Without this wait a follow-up
+/// request re-parses, and a comparison between a "hit" and a miss is really
+/// between two live runs, which matches for every implementation of the replay
+/// including none.
+///
+/// ONE copy of this suffix list. `docs/guide/server.md` says each suffix bumps
+/// whenever its payload changes shape, so two lists here would be two things to
+/// bump and one of them would be forgotten.
+async fn await_cache_fill(state: &AppState, live: &[Value]) -> String {
+    let key = live
+        .iter()
+        .find(|e| e["type"] == "start")
+        .expect("live run must emit start")["cache_key"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let required = [
+        format!("{key}-parquet-v5"),
+        format!("{key}-parquet-metadata-v4"),
+        crate::routes::parse::cache_keys::data_model_cache_key(&key),
+        crate::routes::parse::stream_progress::stream_progress_cache_key(&key),
+    ];
+    for _ in 0..200 {
+        let mut all = true;
+        for k in &required {
+            if !matches!(state.cache.get_bytes(k).await, Ok(Some(_))) {
+                all = false;
+                break;
+            }
+        }
+        if all {
+            return key;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("cache fill never completed for {key}; a follow-up run would not be a hit");
+}
+
 /// `progress` is a public event with one meaning, so a cache HIT must report
 /// the same numbers a MISS did for the same file (issue #3897).
 ///
@@ -261,39 +303,7 @@ async fn a_cache_hit_reports_the_same_progress_numbers_as_the_miss() {
 
     let live = stream_once(&state, JOBS_NE_MESHES_FIXTURE).await;
 
-    // The geometry, metadata, data model and progress sidecar are all filled
-    // by tasks spawned off the Complete event, and `try_cached_replay` needs
-    // every one of them. Without this wait the second request re-parses and
-    // the comparison below is between two LIVE runs, which matches for any
-    // implementation of the replay at all.
-    let key = live
-        .iter()
-        .find(|e| e["type"] == "start")
-        .unwrap()["cache_key"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    let required = [
-        format!("{key}-parquet-v5"),
-        format!("{key}-parquet-metadata-v4"),
-        crate::routes::parse::cache_keys::data_model_cache_key(&key),
-        crate::routes::parse::stream_progress::stream_progress_cache_key(&key),
-    ];
-    let mut filled = false;
-    for _ in 0..200 {
-        let mut all = true;
-        for k in &required {
-            if !matches!(state.cache.get_bytes(k).await, Ok(Some(_))) {
-                all = false;
-            }
-        }
-        if all {
-            filled = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-    }
-    assert!(filled, "cache fill never completed; the second run would not be a hit");
+    await_cache_fill(&state, &live).await;
 
     let replay = stream_once(&state, JOBS_NE_MESHES_FIXTURE).await;
 

--- a/apps/server/src/routes/parse/stream_event.rs
+++ b/apps/server/src/routes/parse/stream_event.rs
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The SSE wire type of `POST /api/v1/parse/parquet-stream`.
+//!
+//! Its own module because it has two producers that must not drift: the live
+//! parse in `parquet_stream.rs` and the cache replay in `cached_replay.rs`,
+//! whose whole contract is that a hit is indistinguishable from a miss.
+
+use crate::types::{ModelMetadata, ProcessingStats};
+use ifc_lite_processing::SymbolicData;
+use serde::Serialize;
+
+/// SSE event types for Parquet streaming.
+// Variant sizes differ because the payload events carry buffers; boxing them
+// would complicate the SSE serialization path for no runtime benefit here.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ParquetStreamEvent {
+    /// Initial event with estimated totals.
+    Start {
+        total_estimate: usize,
+        cache_key: String,
+    },
+    /// Progress update.
+    Progress { processed: usize, total: usize },
+    /// Batch of geometry data as base64-encoded Parquet.
+    Batch {
+        /// Base64-encoded Parquet data containing this batch's meshes.
+        data: String,
+        /// Number of meshes in this batch.
+        mesh_count: usize,
+        /// Batch sequence number (1-indexed).
+        batch_number: usize,
+    },
+    /// Processing complete.
+    Complete {
+        stats: ProcessingStats,
+        metadata: ModelMetadata,
+        /// 2D symbol data extracted from `IfcAnnotation` and `IfcGrid`
+        /// entities — parity with `POST /api/v1/parse` (issue #900).
+        #[serde(default, skip_serializing_if = "SymbolicData::is_empty")]
+        symbolic_data: SymbolicData,
+    },
+    /// Error occurred.
+    Error { message: String },
+}

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -592,10 +592,13 @@ a client that does not know to apply its rotation columns.
 The `{SHA256}` half is what a client can supply itself, and two endpoints let
 it: `GET /api/v1/cache/check/{hash}` and `POST /api/v1/parse/parquet-stream?sha256=`
 (above). A client-supplied hash is a SELECTOR for entries that already exist and
-nothing more. It is required to be 64 lowercase hex characters, because it is
-concatenated into the keys above and a caller-shaped hash would otherwise be a
-caller-shaped key; it never causes a write; and on a request that also carries a
-file body it is discarded in favour of hashing that body.
+nothing more: it never causes a parse or a write, and on a request that also
+carries a file body it is discarded in favour of hashing that body. The stream
+probe additionally requires it to be 64 lowercase hex characters and answers
+`400` otherwise, because the value is concatenated into the keys above and a
+caller-shaped hash would otherwise be a caller-shaped key. `/cache/check` and
+`/cache/geometry` do not check the shape; a malformed hash there simply names a
+key nobody wrote, and they answer `404`.
 
 Each suffix is bumped whenever the payload it names changes shape: a column
 added to or removed from its tables, or a change in what an existing column

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -789,8 +789,14 @@ would send with the file. They are part of the cache identity, so a hash paired
 with a different layout asks about a different entry.
 
 `@ifc-lite/server-client` does this for you: `parseParquetStream` hashes the
-file locally, probes, and uploads on the 404. Pass `{ skipCacheProbe: true }`
-to go straight to the upload.
+file locally, probes, and uploads on the 404. It also uploads when the probe is
+not answered at all, which is what a server built before this change does (its
+route still requires a multipart body, so a bodyless POST is rejected as a bad
+boundary), when a proxy refuses the shape, when admission sheds the probe, or
+when it times out. A probe gets a 5 second budget for its headers, not the
+client's full request timeout, because a probe that is not fast is not worth
+the upload it is delaying. Pass `{ skipCacheProbe: true }` to go straight to
+the upload.
 
 !!! note "Compressed uploads never hit the probe"
 

--- a/docs/guide/server.md
+++ b/docs/guide/server.md
@@ -129,7 +129,7 @@ console.log(`From cache: ${result.stats.from_cache}`);
 | `/api/v1/parse/parquet` | POST | Full parse, Parquet response (~15x smaller) |
 | `/api/v1/parse/parquet/optimized` | POST | Optimized Parquet (~50x smaller) |
 | `/api/v1/parse/stream` | POST | Streaming JSON (SSE) |
-| `/api/v1/parse/parquet-stream` | POST | Streaming Parquet (SSE) |
+| `/api/v1/parse/parquet-stream` | POST | Streaming Parquet (SSE); `?sha256=` replays a cache hit with no upload |
 | `/api/v1/parse/metadata` | POST | Quick metadata only (no geometry) |
 
 All parse endpoints that return geometry also surface the 2D symbol stream
@@ -589,6 +589,14 @@ reaches one or the other according to its `parquet_layout` parameter (below).
 They never cross-serve, because the shared-shape layout renders incorrectly on
 a client that does not know to apply its rotation columns.
 
+The `{SHA256}` half is what a client can supply itself, and two endpoints let
+it: `GET /api/v1/cache/check/{hash}` and `POST /api/v1/parse/parquet-stream?sha256=`
+(above). A client-supplied hash is a SELECTOR for entries that already exist and
+nothing more. It is required to be 64 lowercase hex characters, because it is
+concatenated into the keys above and a caller-shaped hash would otherwise be a
+caller-shaped key; it never causes a write; and on a request that also carries a
+file body it is discarded in favour of hashing that body.
+
 Each suffix is bumped whenever the payload it names changes shape: a column
 added to or removed from its tables, or a change in what an existing column
 means. Without the bump a warm cache replays the old blob, the client decodes
@@ -745,6 +753,49 @@ sequenceDiagram
     Server->>Cache: Store data model
     Server->>Client: SSE: complete {stats, metadata}
 ```
+
+### Skipping the upload on a cache hit
+
+The cache key is the SHA-256 of the bytes the server receives, so the upload
+used to finish before the cache could be consulted: a hit on a 40 MB model
+still paid for 40 MB on the wire. `POST /api/v1/parse/parquet-stream` therefore
+accepts the hash on its own (issue #3901):
+
+```bash
+# No body. The hash names the entry; the query names which entry.
+curl -X POST "$SERVER/api/v1/parse/parquet-stream?sha256=$SHA&parquet_layout=shared-shapes"
+```
+
+- **200** with the SSE stream: everything the replay needs was cached, and it
+  replays exactly the events a live parse emits, batch by batch.
+- **404**: nothing cached under that key. Resend the request with the multipart
+  `file` body, which is the normal path. This is the same status
+  `GET /api/v1/cache/check/{hash}` uses for "upload it".
+- **400**: the `sha256` value is not 64 lowercase hex characters.
+
+Two rules keep the parameter honest:
+
+- **A hash sent alongside a body is ignored.** The received bytes decide which
+  entry is read and written, always. A client cannot store one file's geometry
+  under another file's key.
+- **The hash only selects.** It can not cause anything to be parsed or written;
+  a key with nothing behind it is a 404, never a parse.
+
+Send the same `opening_filter`, `tessellation_quality` and `parquet_layout` you
+would send with the file. They are part of the cache identity, so a hash paired
+with a different layout asks about a different entry.
+
+`@ifc-lite/server-client` does this for you: `parseParquetStream` hashes the
+file locally, probes, and uploads on the 404. Pass `{ skipCacheProbe: true }`
+to go straight to the upload.
+
+!!! note "Compressed uploads never hit the probe"
+
+    The server keys on the bytes it parses, which is what it receives after
+    unwrapping `.ifcZIP` or gzip. A probe carrying the hash of a still-packed
+    file names a key nothing was written under, so it answers 404 and the
+    client uploads. That is correct, just not a saving. `GET /cache/check`
+    behaves the same way, for the same reason.
 
 ### Client-Side Streaming
 

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -6,36 +6,24 @@ import type {
   ErrorResponse,
   HealthResponse,
   MetadataResponse,
-  ModelMetadata,
   OptimizedParquetMetadataHeader,
   OptimizedParquetParseResponse,
   ParquetBatch,
   ParquetMetadataHeader,
   ParquetParseResponse,
-  ParquetStreamEvent,
   ParquetStreamResult,
   ParseResponse,
-  ProcessingStats,
   ServerConfig,
   StreamEvent,
   SymbolicData,
 } from './types.js';
 import { decodeParquetGeometry, decodeOptimizedParquetGeometry, isParquetAvailable } from './parquet-decoder.js';
 import { parseQuery } from './parse-query.js';
+import {
+  consumeParquetStream,
+  STREAM_ENDED_WITHOUT_TERMINAL_EVENT,
+} from './parquet-stream-events.js';
 
-/**
- * Raised when an SSE parse stream ends with no terminal event.
- *
- * Shared by `parseStream` and `parseStreamToParquet` so the two cannot drift
- * apart by an article. The wording has to hold on BOTH paths, which it does:
- * `parseStreamToParquet` throws on an `error` event at its own `case 'error'`,
- * so it can only reach its `!stats || !metadata` check in the same state
- * `parseStream`'s `!terminated` describes — the stream stopped without ever
- * saying why. Not exported: it is an internal guarantee about two call sites,
- * not part of the published surface.
- */
-const STREAM_ENDED_WITHOUT_TERMINAL_EVENT =
-  'Stream ended without a complete event (connection dropped or the server failed mid-parse)';
 
 /**
  * Compress a file or ArrayBuffer using gzip compression.
@@ -96,6 +84,21 @@ export interface ParseRequestOptions {
    * server cache entries.
    */
   tessellationQuality?: 'lowest' | 'low' | 'medium' | 'high' | 'highest';
+}
+
+/**
+ * Options for {@link IfcServerClient.parseParquetStream}.
+ */
+export interface ParseStreamOptions extends ParseRequestOptions {
+  /**
+   * Skip the hash-only cache probe and upload straight away (#3901).
+   *
+   * The probe costs one round trip plus a local SHA-256 of the file, and saves
+   * the entire upload when the server already has the model. Turn it off when
+   * you know the server is cold, or when hashing locally is the expensive part
+   * (a very large file behind a fast link).
+   */
+  skipCacheProbe?: boolean;
 }
 
 /** Build the query string shared by the parse endpoints. */
@@ -245,11 +248,22 @@ export class IfcServerClient {
 
   /**
    * Parse IFC file with streaming Parquet response for progressive rendering.
-   * 
+   *
    * Returns an async generator that yields geometry batches as they're processed.
    * Use this for large files (>50MB) to show geometry progressively.
-   * 
+   *
    * After streaming completes, fetch the data model via `fetchDataModel(cacheKey)`.
+   *
+   * **Cache-aware, without paying the upload.** The file is hashed locally and
+   * the hash is presented to `/parse/parquet-stream` on its own, with no body
+   * (issue #3901). A warm server replays the cached stream immediately; a cold
+   * one answers `404` and this method uploads. Either way the SSE events are
+   * read by the same code, so a hit and a miss render identically.
+   *
+   * The probe replaced a two-request `cache/check` + `cache/geometry` dance
+   * that fetched the whole model as ONE batch on a hit, i.e. no progressive
+   * rendering exactly when the data was already there. Set
+   * `skipCacheProbe: true` to go straight to the upload.
    *
    * @param file - IFC file to parse (File or ArrayBuffer)
    * @param onBatch - Callback for each geometry batch (for immediate rendering)
@@ -263,7 +277,7 @@ export class IfcServerClient {
    *     scene.add(createMesh(mesh));
    *   }
    * });
-   * 
+   *
    * // After geometry is complete, fetch data model for properties panel
    * const dataModel = await client.fetchDataModel(result.cache_key);
    * ```
@@ -271,7 +285,7 @@ export class IfcServerClient {
   async parseParquetStream(
     file: File | ArrayBuffer,
     onBatch: (batch: ParquetBatch) => void,
-    options?: ParseRequestOptions
+    options?: ParseStreamOptions
   ): Promise<ParquetStreamResult> {
     const parquetReady = await isParquetAvailable();
     if (!parquetReady) {
@@ -284,60 +298,39 @@ export class IfcServerClient {
     const fileSize = file instanceof File ? file.size : file.byteLength;
     const fileName = file instanceof File ? file.name : 'model.ifc';
 
-    // Step 1: Compute hash and check cache first (even for streaming)
-    const hashStart = performance.now();
-    const hash = await computeFileHash(file);
-    const hashTime = performance.now() - hashStart;
-    console.log(`[client] Stream: computed hash in ${hashTime.toFixed(0)}ms: ${hash.substring(0, 16)}...`);
+    if (!options?.skipCacheProbe) {
+      // Hash locally and ask by hash. On a hit this is the WHOLE request: the
+      // 40 MB the upload would have cost never leaves the machine.
+      const hashStart = performance.now();
+      const hash = await computeFileHash(file);
+      console.log(`[client] Stream: computed hash in ${(performance.now() - hashStart).toFixed(0)}ms: ${hash.substring(0, 16)}...`);
 
-    // Step 2: Check if already cached
-    const cacheCheckStart = performance.now();
-    const cacheCheck = await fetch(`${this.baseUrl}/api/v1/cache/check/${hash}${parseQuery(options, true)}`, {
-      method: 'GET',
-      headers: this.authHeaders(),
-      signal: AbortSignal.timeout(5000),
-    });
-    const cacheCheckTime = performance.now() - cacheCheckStart;
+      const probeStart = performance.now();
+      const probe = await fetch(
+        `${this.baseUrl}/api/v1/parse/parquet-stream${parseQuery(options, true, hash)}`,
+        {
+          method: 'POST',
+          headers: this.authHeaders(),
+          signal: AbortSignal.timeout(this.timeout),
+        }
+      );
 
-    if (cacheCheck.ok) {
-      // CACHE HIT - fetch all geometry at once (much faster than re-parsing)
-      console.log(`[client] Stream: Cache HIT (check: ${cacheCheckTime.toFixed(0)}ms) - fetching cached geometry`);
-
-      // Pass options: `/cache/geometry/:hash` keys on the same parse query, so
-      // omitting them would fetch default `medium` geometry (or 404) even
-      // though the option-scoped cache-check above hit the requested variant.
-      const cachedResult = await this.fetchCachedGeometry(hash, options);
-
-      // Send all meshes as a single batch to the callback
-      const decodeStart = performance.now();
-      onBatch({
-        meshes: cachedResult.meshes,
-        batch_number: 1,
-        decode_time_ms: performance.now() - decodeStart,
-      });
-
-      // Symbolic data isn't in the cached geometry payload — fetch it by key
-      // so the cache-HIT path reaches the same parity as the live stream.
-      // Symbols are supplementary, so a fetch failure must not fail the geometry
-      // load: log and continue without them (fetchSymbolic surfaces real errors).
-      let cachedSymbolic: SymbolicData | null = null;
-      try {
-        cachedSymbolic = await this.fetchSymbolic(cachedResult.cache_key);
-      } catch (error) {
-        console.warn('[client] Symbolic fetch failed on cache hit; continuing without symbols:', error);
+      if (probe.ok) {
+        console.log(`[client] Stream: cache HIT by hash (${(performance.now() - probeStart).toFixed(0)}ms) - replaying without upload`);
+        return consumeParquetStream(probe, onBatch, probeStart);
       }
 
-      return {
-        cache_key: cachedResult.cache_key,
-        total_meshes: cachedResult.meshes.length,
-        stats: cachedResult.stats,
-        metadata: cachedResult.metadata,
-        symbolic_data: cachedSymbolic ?? undefined,
-      };
+      // 404 is the server's "nothing cached under that hash, send the body".
+      // Anything else is a real failure and must surface rather than being
+      // retried as a full upload.
+      if (probe.status !== 404) {
+        throw await this.handleError(probe);
+      }
+      await probe.body?.cancel();
+      console.log(`[client] Stream: cache MISS by hash (${(performance.now() - probeStart).toFixed(0)}ms) - uploading`);
     }
 
-    // CACHE MISS - use streaming for progressive rendering
-    console.log(`[client] Stream: Cache MISS (check: ${cacheCheckTime.toFixed(0)}ms) - starting stream for ${fileName} (${(fileSize / 1024 / 1024).toFixed(1)}MB)`);
+    console.log(`[client] Stream: starting upload for ${fileName} (${(fileSize / 1024 / 1024).toFixed(1)}MB)`);
 
     const formData = new FormData();
     formData.append('file', file instanceof File ? file : new Blob([file]), fileName);
@@ -354,113 +347,7 @@ export class IfcServerClient {
       throw await this.handleError(response);
     }
 
-    if (!response.body) {
-      throw new Error('No response body for streaming');
-    }
-
-    // Parse SSE stream
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-    let cache_key = '';
-    let total_meshes = 0;
-    let stats: ProcessingStats | null = null;
-    let metadata: ModelMetadata | null = null;
-    let symbolic_data: SymbolicData | undefined;
-
-    // A thrown 'error' event (or any other exception mid-loop) must not
-    // leave the reader locked on `response.body` — mirrors the try/finally
-    // `parseStream` already uses for the same SSE-reading shape.
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-
-        // Process complete SSE events
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || ''; // Keep incomplete line in buffer
-
-        for (const line of lines) {
-          if (!line.startsWith('data:')) continue;
-
-          const jsonStr = line.slice(5).trim();
-          if (!jsonStr) continue;
-
-          try {
-            const event: ParquetStreamEvent = JSON.parse(jsonStr);
-
-            switch (event.type) {
-              case 'start':
-                cache_key = event.cache_key;
-                console.log(`[client] Stream started: ${event.total_estimate} entities, cache_key: ${cache_key.substring(0, 16)}...`);
-                break;
-
-              case 'progress':
-                // Progress events can be used for UI feedback
-                break;
-
-              case 'batch': {
-                const decodeStart = performance.now();
-                // Decode base64 Parquet data
-                const binaryStr = atob(event.data);
-                const bytes = new Uint8Array(binaryStr.length);
-                for (let i = 0; i < binaryStr.length; i++) {
-                  bytes[i] = binaryStr.charCodeAt(i);
-                }
-
-                // Decode Parquet to meshes
-                const meshes = await decodeParquetGeometry(bytes.buffer);
-                const decodeTime = performance.now() - decodeStart;
-
-                total_meshes += meshes.length;
-                console.log(`[client] Batch #${event.batch_number}: ${meshes.length} meshes, decode: ${decodeTime.toFixed(0)}ms`);
-
-                // Call the batch callback for immediate rendering
-                onBatch({
-                  meshes,
-                  batch_number: event.batch_number,
-                  decode_time_ms: decodeTime,
-                });
-                break;
-              }
-
-              case 'complete':
-                stats = event.stats;
-                metadata = event.metadata;
-                symbolic_data = event.symbolic_data;
-                const totalTime = performance.now() - uploadStart;
-                console.log(`[client] Stream complete: ${total_meshes} meshes in ${totalTime.toFixed(0)}ms`);
-                break;
-
-              case 'error':
-                throw new Error(`Stream error: ${event.message}`);
-            }
-          } catch (e) {
-            if (e instanceof SyntaxError) {
-              console.warn('[client] Failed to parse SSE event:', jsonStr);
-            } else {
-              throw e;
-            }
-          }
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-
-    if (!stats || !metadata) {
-      throw new Error(STREAM_ENDED_WITHOUT_TERMINAL_EVENT);
-    }
-
-    return {
-      cache_key,
-      total_meshes,
-      stats,
-      metadata,
-      symbolic_data,
-    };
+    return consumeParquetStream(response, onBatch, uploadStart);
   }
 
   /**

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -25,6 +25,34 @@ import {
 } from './parquet-stream-events.js';
 
 /**
+ * How long the hash-only cache probe may take to answer with its HEADERS
+ * before the client gives up and uploads (issue #3901).
+ *
+ * Short on purpose, and short of `timeout`, which covers the replay body once
+ * the headers have arrived. The probe's whole value is being cheaper than the
+ * upload; a probe that is not cheap has to get out of the way of it. Matches
+ * the 5s the `/cache/check` request it replaced used, for the same reason.
+ */
+const PROBE_HEADER_TIMEOUT_MS = 5000;
+
+/**
+ * Probe statuses that mean "no cached replay, send the file", as opposed to a
+ * failure worth surfacing.
+ *
+ * `404` is the server saying it looked and found nothing. The rest are a
+ * server that does not understand the probe at all: `@ifc-lite/server-client`
+ * is published to npm and pointed at a user-supplied `baseUrl`, so a client
+ * upgraded ahead of a self-hosted server is ordinary. On a server built before
+ * #3901 the route's `Multipart` extractor rejects a bodyless POST with `400`
+ * (axum's InvalidBoundary); `405`/`415`/`501` cover a proxy or a future server
+ * refusing the shape. Treating those as a failure would take the streaming
+ * path from working to broken on every such deployment, when uploading is
+ * right there and always correct. `503` is admission shedding: queueing for
+ * the upload is the older, better behaviour.
+ */
+const PROBE_NOT_ANSWERED = new Set([400, 404, 405, 415, 501, 503]);
+
+/**
  * Compress a file or ArrayBuffer using gzip compression.
  * Uses the browser's CompressionStream API for efficient compression.
  *
@@ -304,29 +332,52 @@ export class IfcServerClient {
       const hash = await computeFileHash(file);
       console.log(`[client] Stream: computed hash in ${(performance.now() - hashStart).toFixed(0)}ms: ${hash.substring(0, 16)}...`);
 
+      // Two budgets on one signal. The probe's HEADERS must arrive fast or the
+      // probe is not worth waiting for — the upload it is trying to avoid
+      // would already be in flight. Once they do, the same request is the
+      // replay, and draining it gets the full request timeout. Without the
+      // split, a server that is slow to answer burns `this.timeout` (5 min by
+      // default) and then rejects with an AbortError that never reaches the
+      // fallback below, so the load dies instead of uploading.
+      const controller = new AbortController();
+      let timer = setTimeout(() => controller.abort(), PROBE_HEADER_TIMEOUT_MS);
       const probeStart = performance.now();
-      const probe = await fetch(
-        `${this.baseUrl}/api/v1/parse/parquet-stream${parseQuery(options, true, hash)}`,
-        {
-          method: 'POST',
-          headers: this.authHeaders(),
-          signal: AbortSignal.timeout(this.timeout),
-        }
-      );
 
-      if (probe.ok) {
-        console.log(`[client] Stream: cache HIT by hash (${(performance.now() - probeStart).toFixed(0)}ms) - replaying without upload`);
-        return consumeParquetStream(probe, onBatch, probeStart);
+      let probe: Response | null = null;
+      try {
+        probe = await fetch(
+          `${this.baseUrl}/api/v1/parse/parquet-stream${parseQuery(options, true, hash)}`,
+          {
+            method: 'POST',
+            headers: this.authHeaders(),
+            signal: controller.signal,
+          }
+        );
+      } catch (error) {
+        // A probe that times out or fails to connect is not an answer about
+        // the cache. Upload, which is what would have happened without it.
+        console.warn('[client] Stream: hash probe failed; uploading instead:', error);
+      } finally {
+        clearTimeout(timer);
       }
 
-      // 404 is the server's "nothing cached under that hash, send the body".
-      // Anything else is a real failure and must surface rather than being
-      // retried as a full upload.
-      if (probe.status !== 404) {
+      if (probe?.ok) {
+        console.log(`[client] Stream: cache HIT by hash (${(performance.now() - probeStart).toFixed(0)}ms) - replaying without upload`);
+        timer = setTimeout(() => controller.abort(), this.timeout);
+        try {
+          return await consumeParquetStream(probe, onBatch, probeStart);
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      if (probe && !PROBE_NOT_ANSWERED.has(probe.status)) {
+        // A real server-side failure. Surfacing it beats silently spending the
+        // upload the probe exists to avoid.
         throw await this.handleError(probe);
       }
-      await probe.body?.cancel();
-      console.log(`[client] Stream: cache MISS by hash (${(performance.now() - probeStart).toFixed(0)}ms) - uploading`);
+      await probe?.body?.cancel();
+      console.log(`[client] Stream: no cached replay (${(performance.now() - probeStart).toFixed(0)}ms) - uploading`);
     }
 
     console.log(`[client] Stream: starting upload for ${fileName} (${(fileSize / 1024 / 1024).toFixed(1)}MB)`);

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -24,7 +24,6 @@ import {
   STREAM_ENDED_WITHOUT_TERMINAL_EVENT,
 } from './parquet-stream-events.js';
 
-
 /**
  * Compress a file or ArrayBuffer using gzip compression.
  * Uses the browser's CompressionStream API for efficient compression.
@@ -249,8 +248,8 @@ export class IfcServerClient {
   /**
    * Parse IFC file with streaming Parquet response for progressive rendering.
    *
-   * Returns an async generator that yields geometry batches as they're processed.
-   * Use this for large files (>50MB) to show geometry progressively.
+   * Calls `onBatch` with each geometry batch as it is decoded. Use this for
+   * large files (>50MB) to show geometry progressively.
    *
    * After streaming completes, fetch the data model via `fetchDataModel(cacheKey)`.
    *

--- a/packages/server-client/src/parquet-stream-events.ts
+++ b/packages/server-client/src/parquet-stream-events.ts
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reading the SSE body of `POST /api/v1/parse/parquet-stream`.
+ *
+ * Its own module because there are now TWO requests that answer with that
+ * stream and they must be consumed identically (issue #3901): the hash-only
+ * probe, which sends no file at all and replays from cache, and the multipart
+ * upload it falls back to. The server guarantees a hit replays the same events
+ * a live parse emits; duplicating this loop per call site is how that
+ * guarantee stops being observable on the client.
+ */
+
+import { decodeParquetGeometry } from './parquet-decoder.js';
+import type {
+  ModelMetadata,
+  ParquetBatch,
+  ParquetStreamEvent,
+  ParquetStreamResult,
+  ProcessingStats,
+  SymbolicData,
+} from './types.js';
+
+/**
+ * Raised when an SSE parse stream ends with no terminal event.
+ *
+ * Shared by `parseStream` and the Parquet stream reader below so the two
+ * cannot drift apart by an article. The wording has to hold on BOTH paths,
+ * which it does: this reader throws on an `error` event at its own
+ * `case 'error'`, so it can only reach its `!stats || !metadata` check in the
+ * same state `parseStream`'s `!terminated` describes, the stream stopped
+ * without ever saying why. Not re-exported from the package index: it is an
+ * internal guarantee about two call sites, not part of the published surface.
+ */
+export const STREAM_ENDED_WITHOUT_TERMINAL_EVENT =
+  'Stream ended without a complete event (connection dropped or the server failed mid-parse)';
+
+/**
+ * Drain a `parquet-stream` SSE response, decoding each batch and handing it to
+ * `onBatch` as it arrives.
+ *
+ * @param response - An OK response whose body is the SSE stream.
+ * @param onBatch - Called once per decoded batch, for immediate rendering.
+ * @param startedAt - `performance.now()` at request time, for the timing log.
+ */
+export async function consumeParquetStream(
+  response: Response,
+  onBatch: (batch: ParquetBatch) => void,
+  startedAt: number,
+): Promise<ParquetStreamResult> {
+  if (!response.body) {
+    throw new Error('No response body for streaming');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let cache_key = '';
+  let total_meshes = 0;
+  let stats: ProcessingStats | null = null;
+  let metadata: ModelMetadata | null = null;
+  let symbolic_data: SymbolicData | undefined;
+
+  // A thrown 'error' event (or any other exception mid-loop) must not
+  // leave the reader locked on `response.body` — mirrors the try/finally
+  // `parseStream` already uses for the same SSE-reading shape.
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      // Process complete SSE events
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || ''; // Keep incomplete line in buffer
+
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue;
+
+        const jsonStr = line.slice(5).trim();
+        if (!jsonStr) continue;
+
+        try {
+          const event: ParquetStreamEvent = JSON.parse(jsonStr);
+
+          switch (event.type) {
+            case 'start':
+              cache_key = event.cache_key;
+              console.log(`[client] Stream started: ${event.total_estimate} entities, cache_key: ${cache_key.substring(0, 16)}...`);
+              break;
+
+            case 'progress':
+              // Progress events can be used for UI feedback
+              break;
+
+            case 'batch': {
+              const decodeStart = performance.now();
+              // Decode base64 Parquet data
+              const binaryStr = atob(event.data);
+              const bytes = new Uint8Array(binaryStr.length);
+              for (let i = 0; i < binaryStr.length; i++) {
+                bytes[i] = binaryStr.charCodeAt(i);
+              }
+
+              // Decode Parquet to meshes
+              const meshes = await decodeParquetGeometry(bytes.buffer);
+              const decodeTime = performance.now() - decodeStart;
+
+              total_meshes += meshes.length;
+              console.log(`[client] Batch #${event.batch_number}: ${meshes.length} meshes, decode: ${decodeTime.toFixed(0)}ms`);
+
+              // Call the batch callback for immediate rendering
+              onBatch({
+                meshes,
+                batch_number: event.batch_number,
+                decode_time_ms: decodeTime,
+              });
+              break;
+            }
+
+            case 'complete': {
+              stats = event.stats;
+              metadata = event.metadata;
+              symbolic_data = event.symbolic_data;
+              const totalTime = performance.now() - startedAt;
+              console.log(`[client] Stream complete: ${total_meshes} meshes in ${totalTime.toFixed(0)}ms`);
+              break;
+            }
+
+            case 'error':
+              throw new Error(`Stream error: ${event.message}`);
+          }
+        } catch (e) {
+          if (e instanceof SyntaxError) {
+            console.warn('[client] Failed to parse SSE event:', jsonStr);
+          } else {
+            throw e;
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (!stats || !metadata) {
+    throw new Error(STREAM_ENDED_WITHOUT_TERMINAL_EVENT);
+  }
+
+  return {
+    cache_key,
+    total_meshes,
+    stats,
+    metadata,
+    symbolic_data,
+  };
+}

--- a/packages/server-client/src/parse-parquet-stream-probe.test.ts
+++ b/packages/server-client/src/parse-parquet-stream-probe.test.ts
@@ -12,7 +12,7 @@
  * requests were made and whether any of them carried a body.
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The batch decoder is irrelevant to request shape; stub it so no WASM is
 // needed and 'batch' events resolve to empty mesh lists.
@@ -65,7 +65,15 @@ function calls(mock: ReturnType<typeof vi.fn>): Call[] {
 const client = () => new IfcServerClient({ baseUrl: 'https://example.invalid' });
 const file = () => new File([new Uint8Array([1, 2, 3, 4])], 'x.ifc');
 
+beforeEach(() => {
+  // Fake timers so the probe's header budget can be measured without waiting
+  // it out. Every other test here resolves fetch immediately and never arms a
+  // timer, so this is inert for them.
+  vi.useFakeTimers();
+});
+
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -115,7 +123,7 @@ describe('parseParquetStream hash probe', () => {
     expect(made[1][0]).not.toContain('sha256=');
   });
 
-  it('surfaces a non-404 probe failure instead of quietly uploading', async () => {
+  it('surfaces a genuine probe failure instead of quietly uploading', async () => {
     // A 500 is not "not cached". Retrying it as a full upload would turn a
     // server fault into a silent 40 MB transfer.
     const fetchMock = vi
@@ -135,16 +143,82 @@ describe('parseParquetStream hash probe', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('uploads directly when the probe is skipped', async () => {
-    const fetchMock = vi.fn().mockResolvedValueOnce(streamResponse());
+  // A server built before #3901 still declares the route's body as multipart,
+  // so a bodyless POST is rejected by the extractor (400 InvalidBoundary in
+  // axum) rather than reaching the handler. This client is published to npm
+  // and pointed at a self-hosted baseUrl, so a client ahead of its server is
+  // ordinary — and it must degrade to the upload, not break the load.
+  it.each([
+    ['an older server that rejects the bodyless POST', 400],
+    ['a proxy that refuses the method', 405],
+    ['a server that refuses the media type', 415],
+    ['a server that has not implemented the probe', 501],
+    ['admission shedding', 503],
+  ])('uploads when the probe is not answered: %s', async (_label, status) => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status }))
+      .mockResolvedValueOnce(streamResponse());
     vi.stubGlobal('fetch', fetchMock);
 
-    await client().parseParquetStream(file(), () => {}, { skipCacheProbe: true });
+    const result = await client().parseParquetStream(file(), () => {});
+    expect(result.cache_key).toBe('key-default');
+    expect(calls(fetchMock)).toHaveLength(2);
+    expect(calls(fetchMock)[1][1].body).toBeInstanceOf(FormData);
+  });
 
-    const made = calls(fetchMock);
-    expect(made).toHaveLength(1);
-    expect(made[0][0]).not.toContain('sha256=');
-    expect(made[0][1].body).toBeInstanceOf(FormData);
+  it('uploads when the probe never answers at all', async () => {
+    // A probe that throws (timed out, connection refused) says nothing about
+    // the cache. Uploading is what would have happened without it.
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new DOMException('aborted', 'AbortError'))
+      .mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await client().parseParquetStream(file(), () => {});
+    expect(result.cache_key).toBe('key-default');
+    expect(calls(fetchMock)).toHaveLength(2);
+    expect(calls(fetchMock)[1][1].body).toBeInstanceOf(FormData);
+  });
+
+  it('gives the probe a short header budget, not the full request timeout', async () => {
+    // The probe exists to be cheaper than the upload. Letting it inherit the
+    // request timeout means a slow server delays the upload by the whole
+    // budget and then fails it, so the load dies where it used to succeed.
+    // The replay body still gets the full budget, which is why the two share
+    // one AbortController instead of a per-request AbortSignal.timeout.
+    let probeSignal: AbortSignal | undefined;
+    let probeSent!: () => void;
+    const sent = new Promise<void>((resolve) => {
+      probeSent = resolve;
+    });
+    // Never resolves: the point is what happens while the server says nothing.
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      probeSignal ??= init.signal ?? undefined;
+      probeSent();
+      return new Promise<Response>(() => {});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const timeout = 300_000;
+    void new IfcServerClient({ baseUrl: 'https://example.invalid', timeout })
+      .parseParquetStream(file(), () => {})
+      .catch(() => {});
+
+    // The local hash is not timer-driven, so this settles on its own.
+    await sent;
+    expect(probeSignal).toBeDefined();
+    expect(probeSignal?.aborted).toBe(false);
+
+    // Just under the probe budget: still waiting.
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(probeSignal?.aborted).toBe(false);
+
+    // At the probe budget: given up on, far short of the request timeout.
+    await vi.advanceTimersByTimeAsync(1);
+    expect(probeSignal?.aborted).toBe(true);
+    expect(timeout).toBeGreaterThan(5_000);
   });
 
   it('sends the layout signal on the probe, since it selects the cache entry', async () => {

--- a/packages/server-client/src/parse-parquet-stream-probe.test.ts
+++ b/packages/server-client/src/parse-parquet-stream-probe.test.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `parseParquetStream` presents the file's SHA-256 before it presents the file
+ * (issue #3901).
+ *
+ * The point of the feature is a NEGATIVE: on a cache hit the upload never
+ * happens. A test that only checks the happy result would pass with the probe
+ * deleted and the upload always running, so each test here pins how many
+ * requests were made and whether any of them carried a body.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The batch decoder is irrelevant to request shape; stub it so no WASM is
+// needed and 'batch' events resolve to empty mesh lists.
+vi.mock('./parquet-decoder.js', () => ({
+  isParquetAvailable: vi.fn(async () => true),
+  decodeParquetGeometry: vi.fn(async () => []),
+  decodeOptimizedParquetGeometry: vi.fn(async () => []),
+}));
+
+import { IfcServerClient } from './client.js';
+
+function frame(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+/** A complete, minimal parquet-stream SSE response. */
+function streamResponse(): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of [
+        frame({ type: 'start', cache_key: 'key-default', total_estimate: 3 }),
+        frame({ type: 'progress', processed: 0, total: 3 }),
+        frame({ type: 'batch', data: '', mesh_count: 2, batch_number: 1 }),
+        frame({ type: 'progress', processed: 3, total: 3 }),
+        frame({
+          type: 'complete',
+          stats: { total_meshes: 2 },
+          metadata: { schema: 'IFC4' },
+        }),
+      ]) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+/** Every fetch call as [url, init]. */
+type Call = [string, RequestInit];
+
+function calls(mock: ReturnType<typeof vi.fn>): Call[] {
+  return mock.mock.calls.map((c) => [String(c[0]), (c[1] ?? {}) as RequestInit]);
+}
+
+const client = () => new IfcServerClient({ baseUrl: 'https://example.invalid' });
+const file = () => new File([new Uint8Array([1, 2, 3, 4])], 'x.ifc');
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseParquetStream hash probe', () => {
+  it('replays from the probe on a hit, and never uploads the file', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const batches: number[] = [];
+    const result = await client().parseParquetStream(file(), (b) =>
+      batches.push(b.batch_number),
+    );
+
+    expect(result.cache_key).toBe('key-default');
+    expect(batches).toEqual([1]);
+
+    // ONE request, and it carried no body. This is the mutation check: an
+    // implementation that probed and then uploaded anyway, or that skipped the
+    // probe entirely, changes this count.
+    const made = calls(fetchMock);
+    expect(made).toHaveLength(1);
+    const [url, init] = made[0];
+    expect(url).toContain('/api/v1/parse/parquet-stream');
+    expect(url).toContain('sha256=');
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('falls back to the multipart upload when the probe answers 404', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await client().parseParquetStream(file(), () => {});
+    expect(result.total_meshes).toBe(0);
+
+    const made = calls(fetchMock);
+    expect(made).toHaveLength(2);
+    // The probe: hash, no body.
+    expect(made[0][0]).toContain('sha256=');
+    expect(made[0][1].body).toBeUndefined();
+    // The upload: body, and NO hash — the server keys off the bytes when a
+    // body is present, so sending one would only invite the two to disagree.
+    expect(made[1][1].body).toBeInstanceOf(FormData);
+    expect(made[1][0]).not.toContain('sha256=');
+  });
+
+  it('surfaces a non-404 probe failure instead of quietly uploading', async () => {
+    // A 500 is not "not cached". Retrying it as a full upload would turn a
+    // server fault into a silent 40 MB transfer.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'boom', code: 'INTERNAL_ERROR' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      client().parseParquetStream(file(), () => {}),
+    ).rejects.toThrow(/boom/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('uploads directly when the probe is skipped', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(streamResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    await client().parseParquetStream(file(), () => {}, { skipCacheProbe: true });
+
+    const made = calls(fetchMock);
+    expect(made).toHaveLength(1);
+    expect(made[0][0]).not.toContain('sha256=');
+    expect(made[0][1].body).toBeInstanceOf(FormData);
+  });
+
+  it('sends the layout signal on the probe, since it selects the cache entry', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await client()
+      .parseParquetStream(file(), () => {}, { tessellationQuality: 'high' })
+      .catch(() => {});
+
+    const [probeUrl] = calls(fetchMock)[0];
+    // A hash paired with the wrong layout or quality names a different blob,
+    // so all three have to travel together.
+    expect(probeUrl).toContain('parquet_layout=shared-shapes');
+    expect(probeUrl).toContain('tessellation_quality=high');
+    expect(probeUrl).toContain('sha256=');
+  });
+});

--- a/packages/server-client/src/parse-parquet-stream.test.ts
+++ b/packages/server-client/src/parse-parquet-stream.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 
 describe('parseParquetStream', () => {
   it('releases the response body reader when the stream reports a terminal error', async () => {
-    // First call: cache-check (miss, so the streaming upload path runs).
+    // First call: the hash-only probe (404, so the streaming upload path runs).
     // Second call: the parquet-stream upload itself, whose SSE body carries
     // a terminal `error` event — the same shape `parseStream` already
     // handles by releasing its reader in a `finally`.
@@ -55,7 +55,7 @@ describe('parseParquetStream', () => {
 
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(new Response(null, { status: 404 })) // cache/check miss
+      .mockResolvedValueOnce(new Response(null, { status: 404 })) // hash probe: not cached
       .mockResolvedValueOnce(streamResponse); // parquet-stream upload
     vi.stubGlobal('fetch', fetchMock);
 

--- a/packages/server-client/src/parse-query.ts
+++ b/packages/server-client/src/parse-query.ts
@@ -20,13 +20,23 @@
 
 import type { ParseRequestOptions } from './client.js';
 
-export function parseQuery(options?: ParseRequestOptions, flatLayout = false): string {
+export function parseQuery(
+  options?: ParseRequestOptions,
+  flatLayout = false,
+  sha256?: string
+): string {
   const params = new URLSearchParams();
   if (options?.tessellationQuality && options.tessellationQuality !== 'medium') {
     params.set('tessellation_quality', options.tessellationQuality);
   }
   if (flatLayout) {
     params.set('parquet_layout', 'shared-shapes');
+  }
+  // The hash-only stream probe (#3901). It belongs here, beside the rest of the
+  // cache identity, because the entry it names is the one THIS query selects:
+  // a hash paired with the wrong layout or quality asks about a different blob.
+  if (sha256) {
+    params.set('sha256', sha256);
   }
   const qs = params.toString();
   return qs ? `?${qs}` : '';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4358,6 +4358,7 @@
     "ParquetStreamStartEvent: interface",
     "ParseRequestOptions: interface",
     "ParseResponse: interface",
+    "ParseStreamOptions: interface",
     "ProcessingStats: interface",
     "Quantity: interface",
     "QuantitySet: interface",


### PR DESCRIPTION
Closes #3901.

`POST /parse/parquet-stream` accepts an optional `sha256` query parameter (the same `ParseQuery` mechanism as `parquet_layout`, so it composes with layout and quality in the cache identity). With no body and a hash, the route validates the shape (400 otherwise), builds the key and delegates to the same `try_cached_replay` the upload path uses, so "the entries a hit needs" is one list; a hash-only miss answers 404 like `GET /cache/check`; a body present ignores the hash entirely, so a client hash can only select entries that already exist. `parseParquetStream` in `@ifc-lite/server-client` hashes locally, probes, and uploads on any answer that is not a replay (a pre-change server's 400 included); `skipCacheProbe` opts out. The SSE reader moved to its own module so probe and upload share one loop, and `ParquetStreamEvent` moved to `stream_event.rs` to keep the route under the ratchet without an allowlist row.

Mutation checks: disabling the probe hit path fails the no-upload test; narrowing the fallback set to 404 fails all five degradation cases; removing the non-404 passthrough fails the 500 test. Not measured against a real server or a 40 MB file; the saving is argued from the code path.

Gates on the head: `cargo test -p ifc-lite-server` 269 pass, clippy -D warnings 0, module_size_ratchet 0, typecheck 0, server-client 91 pass, check-module-size 0, check-changesets 0, docs:check-samples 0, api-surface regenerated. Changesets: `@ifc-lite/server-bin` minor, `@ifc-lite/server-client` minor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Parquet streaming now supports SHA-256 cache probes, allowing cached results to replay without re-uploading files.
  - Cache misses automatically fall back to the standard upload flow.
  - Added `skipCacheProbe` configuration for clients that do not want to probe.
  - Streaming responses now provide consistent progress, batch, completion, error, statistics, metadata, and optional symbolic IFC data.

- **Bug Fixes**
  - Invalid hashes are rejected, and missing files return clear errors.
  - Upload-provided content takes precedence over conflicting query hashes.

- **Documentation**
  - Updated server guidance with cache-probe behavior and fallback rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->