### PR TITLE
chore(changeset): name @ifc-lite/viewer in the #3899 changeset instead of the repo root

### DIFF
--- a/.changeset/fix-3890-late-mesh-colour.md
+++ b/.changeset/fix-3890-late-mesh-colour.md
@@ -1,5 +1,5 @@
 ---
-"ifc-lite": patch
+"@ifc-lite/viewer": patch
 "@ifc-lite/renderer": minor
 ---
 


### PR DESCRIPTION
Same defect as #3905: the viewer changeset from #3899 named "ifc-lite", which is no workspace package, so check-changesets is red on main again. Renamed to "@ifc-lite/viewer"; the renderer line is untouched. `node scripts/check-changesets.mjs` exits 0 (280 pending).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where mesh colour overrides could be lost when geometry arrived after the initial scene load.
  - Colour overrides now remain effective for streamed and instanced mesh content.
  - Prevented unnecessary visual updates and ensured colour resets or newer corrections are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->