### PR TITLE
fix(scripts): the vitest-timeout audit reads a regex literal after an arrow

### DIFF
--- a/scripts/lib/vitest-timeout-audit.mjs
+++ b/scripts/lib/vitest-timeout-audit.mjs
@@ -71,13 +71,13 @@
  *     heuristic: a `/` starts a regex when the last significant token
  *     before it is an operator, punctuator, or one of the keywords in
  *     `REGEX_PRECEDING_RE` (`(`, `,`, `=`, `:`, `[`, `!`, `&`, `|`, `?`,
- *     `{`, `;`, `return`, `typeof`, … or start-of-file), and is division
- *     otherwise — including right after a string or template literal,
+ *     `{`, `;`, `>`, `return`, `typeof`, … or start-of-file), and is
+ *     division otherwise — including right after a string or template literal,
  *     which `stripNoise` tracks separately because a blanked literal is
  *     indistinguishable from whitespace. This covers every shape actually
  *     seen in this codebase. NOT handled, and each of these is a REAL
  *     defect verified by running this module, not a theoretical one:
- *       * a regex after an operator absent from that list;
+ *       * a regex after an operator absent from that list (`<` is out DELIBERATELY -- see the JSX test);
  *       * a regex spanning a line break (bailed on, and the `/` is then read
  *         as ordinary);
  *       * a regex immediately after `}` (a block close) or after `)` — both
@@ -199,7 +199,7 @@ const CALL_KEYWORD_RE = /(?<![.\w$])(describe|it|test)(?![\w$])/g;
  * modifier argument list, and must NOT be skipped as one.
  */
 const PARAMETERIZED_MODIFIERS = new Set(['each', 'skipIf', 'runIf', 'extend']);
-const REGEX_PRECEDING_RE = /[([{,;:=!&|?~^%*+-]$|^$|(?:^|[^\w$])(return|typeof|instanceof|in|of|new|delete|void|throw|case|do|else|yield|await)$/;
+const REGEX_PRECEDING_RE = /[([{,;:=!&|?~^%*+>-]$|^$|(?:^|[^\w$])(return|typeof|instanceof|in|of|new|delete|void|throw|case|do|else|yield|await)$/;
 
 /**
  * Replace every comment, string, and template literal in `source` with

--- a/scripts/lib/vitest-timeout-audit.test.mjs
+++ b/scripts/lib/vitest-timeout-audit.test.mjs
@@ -663,6 +663,38 @@ test('a regex containing an unbalanced paren still does not corrupt the call it 
   assert.deepEqual(unprotectedNames(src), ['next']);
 });
 
+test('a regex opening right after an arrow (=>) is not read as division', () => {
+  // #3856's `document-reference-guid.test.ts` shape: a one-line arrow whose
+  // body IS a regex literal. `>` was absent from the regex-start heuristic, so
+  // the `/` was read as division, the `"` in the pattern opened a phantom
+  // string that ran to the next `"` fifteen lines later, and the call sites in
+  // between vanished while the enclosing `describe` and `it` became unparsable.
+  const src = [
+    "describe('suite', () => {",
+    "  it('arrow regex', () => {",
+    '    const line = (xml) => /<Ref Guid="[^"]+"/.exec(xml)[0];',
+    '    expect(line(a)).toBe(line(b));',
+    '  });',
+    "  it('after', () => { doWork(); });",
+    '});',
+  ].join('\n');
+  assert.deepEqual(findUnparsedCallSites(src), []);
+  assert.deepEqual(auditSource(src).map((r) => r.name), ['arrow regex', 'after']);
+});
+
+// `<` is NOT a regex-starter here even though `a < /re/` is legal JS: in a
+// `.test.tsx` a JSX closing tag puts `/` straight after `<`, and treating that
+// as a regex opening runs it to the next `/` on the line, swallowing whatever
+// quote sits between. That costs a real, common shape to buy a contrived one.
+test('a JSX closing tag is not read as a regex opening', () => {
+  const src = [
+    "it('a', () => { render(<div>x</div>); expect(u).toBe('/p'); });",
+    "it('b', () => { doWork(); });",
+  ].join('\n');
+  assert.deepEqual(findUnparsedCallSites(src), []);
+  assert.deepEqual(auditSource(src).map((r) => r.name), ['a', 'b']);
+});
+
 test('a slash that is division after a string literal is not read as a regex opening', () => {
   // A blanked string is indistinguishable from whitespace, so without
   // tracking where the literal ended the `=` before it would make this `/`


### PR DESCRIPTION
Main's Node tests job fails on `check:vitest-timeout-audit` since #3856: two call sites in `packages/bcf/src/document-reference-guid.test.ts` could not be parsed. The gate asks for the parser to be fixed rather than the file, and that is what this does.

Mechanism: `REGEX_PRECEDING_RE` in `scripts/lib/vitest-timeout-audit.mjs` lacked `>`, and `isRegexStart` inspects only the last significant character, so a `/` right after `=>` was read as division. Line 162 of that test, `const line = (xml: string) => /<DocumentReference Guid="[^"]+"/.exec(xml)![0];`, then opened a phantom string at its first `"` that closed on the next `"` fourteen lines later, blanking an `it` outright and unbalancing the parens of the `describe` and `it` the gate reported.

`>` is added. `<` is deliberately not: in a `.test.tsx` a JSX closing tag puts `/` straight after `<`, and treating that as a regex start parsed a legitimate JSX test to zero call sites. Two regression tests, mutation-checked in both directions: dropping `>` fails only the arrow test, adding `<` fails only the JSX test. Repo-wide listing diff before and after: zero call sites lost, five recovered, only the errors disappear.

Exit codes on the head: `node --test scripts/lib/vitest-timeout-audit.test.mjs` 0 (79 pass), `pnpm run check:vitest-timeout-audit` 0, check-module-size 0 (the module stays at exactly its allowlisted 1165 lines).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test analysis when regular expressions follow arrow functions or JSX closing tags.
  - Prevented these syntax patterns from disrupting call-site parsing, causing false parsing errors, or hiding subsequent tests.

- **Tests**
  - Added regression coverage to verify reliable handling of regular expressions in arrow-function and JSX contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->