### PR TITLE
chore(sandbox): regenerate bim-globals.d.ts after the clash type changes

### DIFF
--- a/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
+++ b/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
@@ -187,6 +187,16 @@ declare namespace BimClash {
     a: string;
     /** Selector for set B. Omitted ⇒ self-clash within A. */
     b?: string;
+    /**
+     * Explicit membership for set A — `clashMemberKey(model, ref)` strings. When
+     * present it REPLACES the `a` selector, so a caller that can resolve a richer
+     * filter than a type name (properties, attributes, storeys) against the model
+     * can express it. An empty array means "matched nothing", never "everything".
+     * See `members.ts`.
+     */
+    membersA?: readonly string[];
+    /** Explicit membership for set B, replacing the `b` selector. See `membersA`. */
+    membersB?: readonly string[];
     mode: ClashMode;
     /** Touching band (m). Defaults to the run-level tolerance. */
     tolerance?: number;
@@ -248,6 +258,15 @@ declare namespace BimClash {
     rule: string;
     matchedA: number;
     matchedB: number | null;
+    /**
+     * Whether each side was resolved from explicit membership (`membersA` /
+     * `membersB`) rather than from its type selector. A caller explaining an
+     * empty side needs it and cannot recover it from `rulesRun`, which
+     * deliberately drops the resolved member lists. Absent on a result recorded
+     * before this existed — which is the same thing as "by selector".
+     */
+    fromMembersA?: boolean;
+    fromMembersB?: boolean;
   }
 
   /**


### PR DESCRIPTION
Main's Node tests job fails on `node scripts/generate-bim-globals.mjs --check`: #3908 added `membersA`/`membersB` (and the `fromMembers*` refs) to the clash types and the generated sandbox surface was not regenerated. This is the generator's output, nothing hand-edited (19 insertions in one file). On the head: the freshness check exits 0, `check:templates` typechecks the built-in scripts against it, package READMEs and generated doc sections pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clash rules can now define explicit member sets for each side, providing an alternative to selector-based resolution.
  * Clash coverage data can indicate when either side was resolved from an explicit member set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->