### PR TITLE
fix(geometry): weld the N-ary union without destroying pre-existing exact seams (#3353)

### DIFF
--- a/rust/geometry/src/kernel/mesh_bridge.rs
+++ b/rust/geometry/src/kernel/mesh_bridge.rs
@@ -244,14 +244,18 @@ pub fn union_many(meshes: &[&Mesh]) -> Mesh {
     // Participate in the #1109 budget like `subtract` / `union` — fresh per-boolean
     // count, per-element accumulator preserved (see `union`).
     super::budget::begin();
-    // NO near-coplanar weld here, unlike the binary `union` (#3353). The root
-    // cause DOES reach this path, and the weld does help it — but its gate is
-    // PLANE-level rather than footprint-level, which scales badly with operand
-    // count and regressed `issue_960_segmented_roof_clip`. The measurements and
-    // the pin are in `mesh_bridge_tests::issue_3353_nary_near_coplanar`, kept
-    // there rather than restated here so the numbers have one home.
-    let tri_lists: Vec<Vec<Tri>> =
-        meshes.iter().map(|m| orient_outward(mesh_to_tris(m))).collect();
+    // Mutual near-coplanar weld, same as the binary `union` (#3353 N-ary
+    // half). An earlier attempt at this welded already bit-identical shared
+    // vertices onto a spurious nearby plane from an unrelated operand and
+    // regressed `issue_960_segmented_roof_clip`; the guard that fixes that
+    // (skip a cutter vertex already exactly matching a host vertex) lives in
+    // `promote_cutter_verts_onto_host_faces` (`plane_weld.rs`). The
+    // measurements are in `mesh_bridge_tests::issue_3353_nary_near_coplanar`,
+    // kept there rather than restated here so the numbers have one home.
+    let mut tri_lists: Vec<Vec<Tri>> =
+        meshes.iter().map(|m| mesh_to_tris(m)).collect();
+    promote_operands_mutually(&mut tri_lists);
+    let tri_lists: Vec<Vec<Tri>> = tri_lists.into_iter().map(orient_outward).collect();
     let refs: Vec<&[Tri]> = tri_lists.iter().map(|t| t.as_slice()).collect();
     let (out, conforming) = union_all(&refs);
     // #1109 budget trip ⇒ `arrange_many` bailed and `out` is PARTIAL; return empty so

--- a/rust/geometry/src/kernel/mesh_bridge_tests.rs
+++ b/rust/geometry/src/kernel/mesh_bridge_tests.rs
@@ -440,7 +440,7 @@ fn subtract_many_disjoint_openings_matches_sequential() {
     );
 }
 
-/// Issue #3353, the N-ary half — a KNOWN-OPEN defect, pinned and `#[ignore]`d.
+/// Issue #3353, the N-ary half.
 ///
 /// `union_many` reaches the same broadphase, `near_coplanar` guard and
 /// classifier as the binary union, so the per-axis snap that leaves two flush
@@ -448,25 +448,37 @@ fn subtract_many_disjoint_openings_matches_sequential() {
 /// PRIMARY union in the pipeline (`processors/boolean` builds the cutter union
 /// with it, `coaxial_union` behind that), not a side path.
 ///
-/// # Why the binary fix does not simply extend here
+/// # Why the binary fix did not simply extend here, and what was actually wrong
 ///
 /// Applying `promote_operands_mutually` in `union_many` DOES help this family:
 /// a three-box near-coplanar sweep (49 corner placements x 3 snap offsets)
 /// tears 105 of 147 without it and 36 of 147 with it, and this fixture goes
 /// from 20 unmatched directed edges to 0.
 ///
-/// It also breaks `tests/issue_960_segmented_roof_clip.rs`. The weld's gate is
-/// PLANE-level, not footprint-level, which is sound for two operands and scales
-/// badly with more: on #960's segmented-roof cutter union it moved 624 vertices
-/// across 11 operands, perturbing seams the analytic prisms had already built
-/// consistently, and wall #4148 came back 9850 mm tall against an expected
-/// ~8984 mm — the sequential fallback's full-height seam sliver, the exact
-/// defect #960 removed.
-///
-/// So the N-ary half is not a matter of calling the same function in one more
-/// place. It needs the many-operand plane-gate interaction understood first,
-/// which is its own change with its own evidence. Do not un-ignore this without
-/// `issue_960_segmented_roof_clip` staying green and a clean census.
+/// Naively applying it also broke `tests/issue_960_segmented_roof_clip.rs`:
+/// wall #4148 came back 9850 mm tall against an expected ~8984 mm — the
+/// sequential fallback's full-height seam sliver, the exact defect #960
+/// removed. The mechanism (confirmed by instrumenting a debug build against
+/// the #960 fixture, not inferred): the roof-segment cutter prisms are
+/// authored analytically and already share BIT-IDENTICAL vertices at their
+/// true adjacency seams — no reconciliation needed there. But
+/// `promote_cutter_verts_onto_host_faces`'s per-vertex plane search
+/// deliberately EXCLUDES a vertex's own exact-match plane from candidacy
+/// (`d == 0.0 { continue }`, load-bearing for the tunnel-wall jamb-corner
+/// case elsewhere in this module) and then searches every OTHER host face
+/// within band for a nearer one. With `host` pooling many roof segments that
+/// share the same pitch (hence near-parallel planes), that search finds a
+/// spurious near-match on an unrelated, non-adjacent operand's plane and
+/// nudges the vertex a few µm off its true neighbour — measured on the #960
+/// fixture's four `union_many` calls: the count of bit-identical vertex pairs
+/// shared between operand pairs drops from (148, 4, 12, 248) pre-weld to
+/// (88, 4, 5, 159) post-weld. The weld was actively DESTROYING pre-existing
+/// exact seams, not merely reconciling noisy ones. The fix
+/// (`promote_cutter_verts_onto_host_faces` in `plane_weld.rs`) skips any
+/// cutter vertex that is already bit-identical to some host vertex — safe
+/// everywhere, since a genuinely-imprecise cutter vertex (the tunnel-wall
+/// case this guard was designed around) is by construction never in that
+/// set.
 ///
 /// These live in-crate rather than beside
 /// `tests/issue_3353_near_coplanar_rotated_overlap.rs` because the production
@@ -569,9 +581,6 @@ mod issue_3353_nary_near_coplanar {
     /// reached `union_many`, closed after. `dz = 0` is the control — exactly
     /// flush was always clean, which is what names the near-coplanar regime.
     #[test]
-    #[ignore = "known-open #3353 N-ary half: union_many has no near-coplanar weld, \
-                because the two-operand weld regresses issue_960_segmented_roof_clip \
-                (see the module doc). Verified to fail at 20 unmatched edges."]
     fn a_three_operand_near_coplanar_union_stays_closed() {
         for dz in [SG, 0.0] {
             let [a, b, c] = three_boxes(dz);

--- a/rust/geometry/src/kernel/near_band.rs
+++ b/rust/geometry/src/kernel/near_band.rs
@@ -176,3 +176,23 @@ impl NearBand {
 pub(crate) fn near_band_from_extent(extent: f64) -> f64 {
     NEAR_BAND_FLOOR.max(extent * F32_ULP_SCALE)
 }
+
+/// Bit-pattern key for exact (not near-) vertex equality: `HashSet`-able,
+/// unlike `[f64; 3]`.
+pub(crate) fn vertex_bits(v: &[f64; 3]) -> [u64; 3] {
+    [v[0].to_bits(), v[1].to_bits(), v[2].to_bits()]
+}
+
+/// The set of every vertex position in `tris`, as [`vertex_bits`] keys.
+///
+/// Used by `plane_weld::promote_cutter_verts_onto_host_faces` (#3353 N-ary
+/// half) to skip a cutter vertex already bit-identical to a host vertex: with
+/// `host` pooling several operands (`promote_operands_mutually`), the
+/// per-plane search there can otherwise pull an already-exact shared vertex a
+/// few µm onto an unrelated operand's near-parallel plane. Measured on the
+/// #960 segmented-roof cutter union: bit-identical vertex pairs shared
+/// between operands fell from (148, 4, 12, 248) to (88, 4, 5, 159) without
+/// this guard. See `mesh_bridge_tests::issue_3353_nary_near_coplanar`.
+pub(crate) fn exact_vertex_set(tris: &[Tri]) -> std::collections::HashSet<[u64; 3]> {
+    tris.iter().flat_map(|t| t.iter()).map(vertex_bits).collect()
+}

--- a/rust/geometry/src/kernel/plane_weld.rs
+++ b/rust/geometry/src/kernel/plane_weld.rs
@@ -249,10 +249,9 @@ pub(crate) fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[T
     if cutter.is_empty() || host.is_empty() {
         return 0;
     }
-    let mut welded = 0usize;
-    let mut band = NearBand::default();
-    band.observe_tris(cutter);
-    band.observe_tris(host);
+    let (mut welded, mut band) = (0usize, NearBand::default());
+    [cutter as &[Tri], host].into_iter().for_each(|t| band.observe_tris(t));
+    let host_verts = super::near_band::exact_vertex_set(host); // #3353 N-ary half
 
     struct Face {
         /// `t[0]` anchors the plane; all three are [`exact_on_plane_weld`]'s
@@ -288,6 +287,7 @@ pub(crate) fn promote_cutter_verts_onto_host_faces(cutter: &mut [Tri], host: &[T
 
     for t in cutter.iter_mut() {
         for v in t.iter_mut() {
+            if host_verts.contains(&super::near_band::vertex_bits(v)) { continue; } // #3353
             // Nearest host plane the vertex is within the band of but NOT
             // exactly on (d == 0 planes are already reconciled — and must not
             // shadow a second, still-noisy plane: in the repro the jamb verts


### PR DESCRIPTION
## Summary

Closes #3353 (booleans tear on overlapping and rotated operands) — this lands the **N-ary union half**, the last part of that report not already fixed. The pair-union half was fixed and merged in #3874.

**Everything still outstanding now has its own issue**, so nothing is lost by closing #3353:
- #3913 — the measured residual: 88 of 441 swept configurations still tear after this fix (down from 294 on `main`).
- #3914 — the consolidation-level tear (`c_on_or_near_a` vs `BComponents::surface_normal` disagreeing on a near-degenerate rotated overlap).
- #3915 — `sweep_261`'s 84 µm **in-plane** vertex split, which the near band's ~122 µm floor cannot see because it measures perpendicular distance.

Switched from `Refs` to `Closes` because our PRs must link a `ready` issue to pass the `Issue queue` gate, and that link is only honest once the remaining scope is tracked separately — which it now is. If you would rather keep #3353 open as the umbrella, say so and I will revert this to `Refs`; the three issues above stand either way.

### Background from #3874

#3874's `promote_operands_mutually` weld fixed the binary `union`. It reported (in its own `#[ignore]`d test and PR body) that naively extending the same weld to `union_many` fixed a 3-box near-coplanar family but broke `issue_960_segmented_roof_clip`, and left the "why" unproven.

### The mechanism (measured against the real #960 fixture, not inferred)

`promote_cutter_verts_onto_host_faces`'s per-vertex candidate search deliberately excludes a vertex's own exact-plane match from candidacy:

```rust
if d == 0.0 {
    continue; // already exactly on this plane
}
```

This is load-bearing for a genuine tunnel-wall jamb-corner repro (documented elsewhere in `plane_weld.rs`): a vertex can be exactly on one host plane while needing correction onto a second, still-noisy plane it should also satisfy. With a single host operand (`subtract`, binary `union`) that's safe — there's nothing else nearby to steal the vertex.

`union_many`'s `promote_operands_mutually` pools *every other operand* into one flat `host` list per operand. The #960 roof-segment cutter prisms are authored analytically and already share **bit-identical vertices at their true adjacency seams** — no reconciliation needed. But because the exact-match plane is excluded from candidacy, and many roof segments share the same pitch (hence near-parallel planes), the search finds a spurious near-match on an **unrelated, non-adjacent operand's plane** and nudges an already-correct shared vertex a few µm off it.

Measured by instrumenting a debug build against the real `#960` fixture: the count of bit-identical vertex pairs shared between operand pairs, across the fixture's four `union_many` calls, **before** vs **after** the weld:

```
(148, 4, 12, 248)  ->  (88, 4, 5, 159)
```

The weld was actively *destroying* pre-existing exact seams in three of four unions, not merely reconciling noisy ones. That is why wall #4148 came back at 9850 mm (the sequential-fallback seam sliver #960 removed) instead of ~8984 mm.

### The fix

`promote_cutter_verts_onto_host_faces` (`rust/geometry/src/kernel/plane_weld.rs`) now skips any cutter vertex that is already bit-identical to *some* host vertex, before the plane search runs. Safe everywhere — a genuinely-imprecise (f32-rounded) vertex is by construction never bit-identical to anything in host, so the tunnel-wall subtract case this exclusion rule was built for is untouched. New `near_band::exact_vertex_set` / `vertex_bits` hold the dedup (`near_band.rs` had headroom; `plane_weld.rs` was already at the 400-line module-size-ratchet limit, so the helper lives there instead of raising a budget).

`union_many` now calls `promote_operands_mutually` before the arrangement, same as the binary `union`. `issue_3353_nary_near_coplanar::a_three_operand_near_coplanar_union_stays_closed` is un-`#[ignore]`d — it and `issue_960_segmented_roof_clip` now pass together.

### Honest limits — this does NOT fully close N-ary near-coplanar tearing

I ran a broader synthetic sweep (3 operands, 7×7 corner-offset grid, 3 snap-grid `dz` steps, 3 orderings — 441 configurations; not committed, a local measurement) to check how far the fix goes beyond the single pinned fixture:

| | torn / 441 |
|---|---|
| baseline (`main`, no weld in `union_many`) | 294 |
| weld, no exact-match guard (the naive extension #3874 tried) | 88 |
| weld + exact-match guard (this PR) | 88 |

The fix substantially reduces tearing (294 → 88) but, unlike #3874's pairwise sweep (which the weld drove to exactly 0 on a 4732-pair sweep), a real residual remains on this broader N-ary sweep. The guard added here does **not** change that residual at all on this sweep (88 → 88 both with and without it) — its value is specific to the #960-shaped case (operands that already share exact seams), evidenced separately above. The residual 88/441 is a distinct, still-open N-ary defect this PR does not attempt to fix.

### Mutation check

Removing the guard (`if host_verts.contains(...) { continue; }` -> no-op) reproduces the exact original #960 failure:
```
#4148 (0wFZS1FlX4uQG90eXr1foJ) max Z = 9850 mm, expected ~8984 mm.
```
Restoring the guard returns both `issue_960_segmented_roof_clip` and the pairwise suite to green.

### Pairwise path unaffected

`issue_3353_near_coplanar_rotated_overlap.rs` (#3874's pinned pairwise suite, including the pass-cap oscillation test) passes unchanged — 4/4, run on the final code:
```
test a_rotated_corner_overlap_one_snap_off_stays_closed ... ok
test the_weld_pass_cap_is_load_bearing_because_the_weld_can_oscillate ... ok
test the_exactly_flush_and_plainly_transversal_neighbours_stay_closed ... ok
test no_offset_within_the_snap_band_tears_the_corner_overlap ... ok
```

## Verification

- `cargo clippy -p ifc-lite-geometry --lib -- -D warnings`: clean, 0 warnings.
- `cargo test -p ifc-lite-processing --test module_size_ratchet`: 6/6 passed (`plane_weld.rs` sits exactly at the 400-line budget, no allowlist entry added).
- `cargo test -p ifc-lite-geometry --no-fail-fast`: 103 `test result: ok` blocks, 0 `FAILED`, including `issue_960_segmented_roof_clip` and the full pairwise suite.
- `node scripts/check-module-size.mjs`, `check-test-wiring.mjs`, `check-source-text-assertions.mjs`: all OK, 0 new offenders.
- No `packages/*` files changed — no changeset needed.

I do **not** have the pairwise 4732-pair-style sweep numbers for the N-ary case as a committed, reproducible harness (#3874's "105 of 147" / "36 of 147" three-box figures were prose-only, never landed as a test). The 294/88/88 numbers above are a real, freshly-run measurement from this session, not a restatement of #3874's pairwise figures — but they are from an uncommitted local sweep, not a permanent CI-checked harness, so treat them as directional evidence rather than a pinned invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unions involving three or more nearly coplanar meshes.
  * Prevented gaps and open surfaces when combining near-coplanar geometry.
  * Improved handling of vertices that already align exactly, producing more reliable closed results.
  * Preserved correct behavior for segmented roof clipping and related geometry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
