### PR TITLE
docs(geometry): name #3353's classification tear and record the measured fix shapes

### DIFF
--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -547,7 +547,7 @@ pub(super) fn boolean_vids_components(
         // does not pin down. Measured on `sweep_261`, where it keeps a needle
         // that its neighbour in the same flat face correctly drops, tearing the
         // mesh. Before changing anything here read the per-triangle regime table
-        // and the four measured (and rejected) fix shapes in
+        // and the seven measured (and rejected) fix shapes in
         // `issue_3353_vid_census_tests.rs` — the promising one costs 20 golden
         // census hosts.
         if let Some(n_other) = bc.surface_normal(c) {

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -187,8 +187,20 @@ use super::super::near_band::{NearBand, near_band_from_extent};
 /// welding separate surfaces (`csg/world_frame_tests.rs`). Always THREE orders
 /// below the smallest real feature edge (~0.2 m), so a distinct parallel face
 /// can never be within it. All FMA-free f64 over input coords ⇒ byte-identical
-/// native==wasm. GATED on the near-coplanar-parent flag, so a transversal cut
-/// (every pinned box−box manifest face) never reaches it.
+/// native==wasm.
+///
+/// NOT GATED, despite what this paragraph used to claim ("GATED on the
+/// near-coplanar-parent flag, so a transversal cut never reaches it"). The
+/// A-side caller (`BComponents::surface_normal`) and the B-side one
+/// (`c_on_or_near_a`) both reach it unconditionally, and the triangle it wrongly
+/// accepts on `sweep_261` has `coplanar_a[i] == false` — so a transversal cut
+/// face DOES reach it. Gating the A-side call on the flag was measured as a fix
+/// for #3353: it closes `sweep_261` and takes the union sweep 98 -> 77, but it
+/// regresses 20 golden census hosts and breaks two pinned near-band invariants
+/// in `clash_intersection_oracle.rs`
+/// (`no_surviving_near_band_triangle_has_an_x_facing_normal` and
+/// `the_near_band_shortfall_is_a_missing_face_pair_not_a_shape_dependent_wedge`),
+/// both of which need this path ungated. See `issue_3353_vid_census_tests.rs`.
 fn near_on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
     let mut band = NearBand::default();
     band.observe_point(&c);
@@ -521,9 +533,23 @@ pub(super) fn boolean_vids_components(
         // EXACT first, then the snap-band-flush analogue (`near_on_surface_normal`)
         // which catches a face left a few µm off a TILTED shared plane by per-axis
         // import snapping (the #1007 flush roof-opening cap). The near test is
-        // ungated (like the exact one) because a coincident-shared-face DROP/keep is
-        // unconditionally correct, and its centroid-inside + µm-perp requirements
-        // never match a transversal cut face (every pinned box−box manifest face).
+        // ungated (like the exact one) because a coincident-shared-face DROP/keep
+        // is unconditionally correct.
+        //
+        // KNOWN FALSE POSITIVE (#3353, open). This comment used to end "and its
+        // centroid-inside + µm-perp requirements never match a transversal cut
+        // face". They do. Both tests establish coincidence from the CENTROID
+        // alone, and a sub-triangle need not have its parent's plane:
+        // retriangulation can leave one degenerate onto the LINE where the two
+        // parent planes meet, and every point of such a sliver lies in the other
+        // operand's plane however transversal the faces are. Normal agreement
+        // then decides it on the sign of a cross product a near-collinear triple
+        // does not pin down. Measured on `sweep_261`, where it keeps a needle
+        // that its neighbour in the same flat face correctly drops, tearing the
+        // mesh. Before changing anything here read the per-triangle regime table
+        // and the four measured (and rejected) fix shapes in
+        // `issue_3353_vid_census_tests.rs` — the promising one costs 20 golden
+        // census hosts.
         if let Some(n_other) = bc.surface_normal(c) {
             let co_oriented = dot3(tri_normal(arr, tri), n_other) > 0.0;
             keep = match op {

--- a/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
@@ -132,8 +132,8 @@
 //! near test gated on coplanar_a  passes      98 -> 77       20 hosts regressed
 //! parent NORMAL for the dot      FAILS       not run        not run
 //! flush test on the sub-tri      FAILS       not run        not run
-//! parent-flush, A side, 3 verts   passes      98 -> 77       26 regressed, 9 improved
-//! needle refused (area < 1e-6 parent) FAILS    98 -> 92       12 regressed, 3 improved
+//! parent-flush, A side, 3 verts  passes      98 -> 77       26 regressed, 9 improved
+//! needle refused (area < 1e-6 parent) FAILS   98 -> 92       12 regressed, 3 improved
 //! ```
 //!
 //! The last two rows were re-measured on 2026-09-04 with the parent index

--- a/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
@@ -132,7 +132,20 @@
 //! near test gated on coplanar_a  passes      98 -> 77       20 hosts regressed
 //! parent NORMAL for the dot      FAILS       not run        not run
 //! flush test on the sub-tri      FAILS       not run        not run
+//! parent-flush, A side, 3 verts   passes      98 -> 77       26 regressed, 9 improved
+//! needle refused (area < 1e-6 parent) FAILS    98 -> 92       12 regressed, 3 improved
 //! ```
+//!
+//! The last two rows were re-measured on 2026-09-04 with the parent index
+//! carried on the `Arrangement` (patches kept off-tree). The all-vertex flush
+//! gate fixes the target but also refuses the #1007 tilted-flush caps whose far
+//! vertices leave the band: one host doubles its open edges (622 -> 1333) and
+//! seven read "geometry lost". The needle gate is scale-free but a 1e-12 cut
+//! in |n|^2 misses the very needle in `sweep_261` (its ratio is 3.7e-10), and
+//! loosening it to catch that would be tuning a constant on one case. What a
+//! fix still needs: a coincidence criterion that is a property of the parent
+//! face yet tolerates a tilt of a few um across the face's extent, measured
+//! against the corpus golden, with the 26-host row as the first thing to beat.
 //!
 //! (The two that fail `sweep_261` were not carried further; "not run" is not a
 //! null result.)

--- a/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
@@ -53,6 +53,119 @@
 //!    classification (see `origin_of`'s doc comment for why this is valid
 //!    for `Union`).
 //!
+//! ## Which regime decides each implicated triangle (measured)
+//!
+//! The edge census below says WHICH triangles disagree. This section records
+//! WHY, from an instrumented run of `boolean_vids_components`'s own three-regime
+//! chain over this exact arrangement. Every triangle on an over-used edge:
+//!
+//! ```text
+//! edge (13,17)   A[17] [15,13,17] |n|=6.11e-1  R3 inside_b=true    keep=false
+//!                A[22] [17,13,14] |n|=6.56e-5  R1 dot=1.19e-4      keep=true
+//! edge (13,14)   A[15] [13,10,14] |n|=6.01e-6  R3 inside_b=false   keep=true
+//!                B[17] [13,39,14] |n|=1.62e-4  R3 inside_a=true    keep=false
+//!                B[18] [41,13,14] |n|=3.66e-5  R3 inside_a=false   keep=true
+//! edge (14,17)   A[21] [14,11,17] |n|=1.03e0   R3 inside_b=false   keep=true
+//!                B[66] [14,39,17] |n|=1.62e0   R3 inside_a=true    keep=false
+//!                B[67] [42,14,17] |n|=1.15e0   R3 inside_a=false   keep=true
+//! ```
+//!
+//! The last column is the DECIDING test, so the B rows name the ray cast that
+//! actually decided them. `c_on_or_near_a` — the B loop's dedup drop, which runs
+//! first — returned false for all four, so none of them reached it.
+//!
+//! `A[22]` is the whole defect, and it is the ONLY triangle here decided by
+//! regime 1. Edge `(13,17)` is bounded by exactly two A sub-triangles, `A[17]`
+//! and `A[22]`, and they lie in ONE A face plane — Vids 13, 14, 15 and 17 are
+//! exactly coplanar (`orient3d == 0`, not merely within a tolerance), on the
+//! plane the original `a[2]` and `a[3]` share as the diagonal split of one box
+//! face. Two sub-triangles of one flat face, and they disagree: the well-formed
+//! one is dropped as inside B by the ray cast, the needle is kept by the
+//! coincident-face regime. Dropping `A[22]` alone repairs all three edges:
+//! `(13,17)` goes to 0, since `A[22]` is its only user, and the other two to 2.
+//! So it is the single wrong verdict, not a symptom of several.
+//!
+//! And the ray cast agrees it should be dropped. Probed directly, `A[22]` has
+//! `R3 inside_b == true` and `R2 solid_side == (true, true)`: regime 1 is
+//! OVERRIDING a fallback that already had the right answer.
+//!
+//! ## Why regime 1 fires on it, and why that is the root cause
+//!
+//! `classify.rs`'s `on_surface_tri`/`near_on_surface_tri` establish "this is a
+//! coincident SHARED face of the other operand" from the sub-triangle's CENTROID
+//! alone: on the other face's plane (or within `NearBand`) and inside its
+//! outline. `boolean_vids_components` then resolves that by NORMAL AGREEMENT,
+//! `dot3(tri_normal, n_other) > 0.0`.
+//!
+//! A sub-triangle need not have its parent's plane. Retriangulation can leave
+//! one DEGENERATE onto the line where the two parent planes MEET, at which point
+//! its whole extent sits within the NEAR band of the other operand's plane
+//! however transversal the two faces are. (Measured: the exact
+//! `on_surface_normal` returns `None` here; only `near_on_surface_normal`
+//! accepts it, at 1.86e-5 off the B face.) `A[22]` is exactly that: a needle whose two ends are
+//! 8.4e-5 apart, sitting on the A-B plane intersection line, centroid 1.86e-5
+//! from a B face and inside its outline. So regime 1 fires on a face pair that
+//! is not coincident, and resolves it by the sign of a cross product a
+//! near-collinear triple does not pin down (`|own_n| = 6.56e-5` against
+//! `|n_other| = 3.4`). What it happens to yield is `cos = 5.32e-1`, 58 degrees:
+//! nowhere near parallel, so there is no shared face to be co-oriented with.
+//!
+//! ## What was tried against that, and why none of it landed
+//!
+//! Coincidence is a property of the two INPUT faces, so the natural fix is to
+//! ask it of the sub-triangle's PARENT face: carry the originating triangle on
+//! the `Arrangement` and require the whole parent to lie on, or be flush within
+//! the band of, the candidate face's plane. That is exact, threshold-free, and
+//! strictly stricter than the centroid test, so a genuine shared face keeps its
+//! verdict. Measured, against a corpus census whose baseline matches the golden
+//! exactly:
+//!
+//! A second shape drops out of the same reading. Only the NEAR test accepts
+//! `A[22]`, and `coplanar_a[22] == false`, so gating the A-side near call on the
+//! coplanar-parent flag also takes it out of regime 1 — and that is what
+//! `near_on_surface_normal`'s own doc claimed the code already did.
+//!
+//! ```text
+//!                                sweep_261   union sweep    census
+//! parent-flush, A and B sides    passes      98 -> 72       39 hosts regressed
+//! parent-flush, A side only      passes      98 -> 77       20 hosts regressed
+//! near test gated on coplanar_a  passes      98 -> 77       20 hosts regressed
+//! parent NORMAL for the dot      FAILS       not run        not run
+//! flush test on the sub-tri      FAILS       not run        not run
+//! ```
+//!
+//! (The two that fail `sweep_261` were not carried further; "not run" is not a
+//! null result.)
+//!
+//! Why the rows read as they do:
+//!
+//! 1. The B side must NOT require it. `c_on_or_near_a` is a DEDUP drop, not an
+//!    orientation verdict, so making coincidence harder there leaves B copies of
+//!    genuinely shared faces alive next to the A copy — the 39-host run's
+//!    reasons are dominated by hosts GAINING triangles and open edges.
+//! 2. The sliver has to LEAVE regime 1, not be re-oriented inside it: the
+//!    parent's normal gives the same sign, so substituting it changes nothing.
+//! 3. Gating the near test costs MORE than the census row shows: it also breaks
+//!    two pinned near-band invariants in `tests/clash_intersection_oracle.rs`,
+//!    `no_surviving_near_band_triangle_has_an_x_facing_normal` and
+//!    `the_near_band_shortfall_is_a_missing_face_pair_not_a_shape_dependent_wedge`,
+//!    which need that path ungated. So the doc claiming the gate exists is
+//!    describing an intent the corpus has since contradicted, not a lost
+//!    invariant to restore.
+//! 4. Both shapes that fix `sweep_261` improve every aggregate — the A-side
+//!    parent-flush one reads corpus unmatched edges 17863 -> 15992, strict-rule
+//!    edges 19344 -> 17612, torn hosts 165 -> 161 — while still regressing 20
+//!    pinned per-host rows, most of them reading "geometry lost". That is the
+//!    per-host golden doing its job: those hosts were watertight BECAUSE regime 1
+//!    kept a zero-area sliver on an arbitrary sign, and they have a pre-existing
+//!    tear the sliver was patching. Two independent shapes landing on the same
+//!    20 is itself evidence the cost is that population, not either criterion.
+//!
+//! So the remaining work is not another criterion for regime 1. It is the tear
+//! those hosts already carry, which today is masked. `various/rvt01.ifc` #7295,
+//! #7544, #16805 and `ISSUE_129_...` #34385, #295370, #296868 are the ones that
+//! lose the most geometry and are the place to start.
+//!
 //! ## Deliberately NOT changed
 //!
 //! No production function's signature, behaviour, or visibility changes.
@@ -67,13 +180,17 @@
 //! kept-triangle edge whose Vid-space multiplicity is not 2.
 //!
 //! It deliberately does NOT assert the exact Vid numbers
-//! `(13,17)`/`(14,17)`/`(13,14)` quoted above from the sibling file's doc
-//! comment — those are Vid-interner allocation labels, not geometry, and
-//! this file's reproduction was not executed against that prior run before
-//! this patch was written (no `cargo test` was run to produce this file —
-//! the workstation that wrote it was disk-constrained and cargo was
-//! off-limits). Pinning unverified literals would risk failing on the very
-//! first CI run for a labelling reason unrelated to the defect.
+//! `(13,17)`/`(14,17)`/`(13,14)` — those are Vid-interner allocation labels,
+//! not geometry, and pinning them would fail on any relabelling for a reason
+//! unrelated to the defect. The assertion stays on the SHAPE.
+//!
+//! The original reason given here was different, and is now spent: it said this
+//! file's reproduction had never been executed (no `cargo test` was run to
+//! produce it — the workstation that wrote it was disk-constrained), so the
+//! labels were unverified. They have since been verified. Every number in the
+//! regime table above comes from an instrumented run of this exact
+//! reproduction, and the labels match. Leaving the old wording in would tell
+//! the next reader the table directly above it is guesswork.
 //!
 //! The full kept set and edge census are printed, but CI will NOT show
 //! them: `.github/workflows/test.yml` runs `cargo test --workspace` with no
@@ -83,8 +200,8 @@
 //!
 //!   cargo test -p ifc-lite-geometry --lib issue_3353_vid_census -- --nocapture
 //!
-//! Once observed they can be pinned as assertions, which WOULD surface in
-//! CI on any change.
+//! They have now been observed (see the regime table above); they are still
+//! deliberately not pinned, for the relabelling reason given above.
 //!
 //! This is a characterisation pin of a KNOWN-DEFECTIVE state, not a health
 //! check: a green tick on this test means "the defect still reproduces
@@ -440,12 +557,18 @@ fn sweep_261_kept_triangles_are_nonmanifold_in_vid_space() {
     // because no threshold is known yet and pinning an unverified one is how a
     // diagnostic turns into a false signal.
     //
-    // `classify::centroid` rounds each Vid to f64 and then averages in IEEE.
-    // For this fixture no face pair is within 28 degrees of parallel, so the
-    // coincident-face regime never fires and every triangle is classified by
-    // the ray cast, which uses that centroid as its ray ORIGIN. Rounding can
-    // flip a parity verdict only if the true centroid sits within a few ULP of
-    // the other operand's surface. These numbers say whether it does.
+    // CORRECTION (measured, see this file's "Which regime decides" section):
+    // this block used to claim that "no face pair is within 28 degrees of
+    // parallel, so the coincident-face regime never fires and every triangle is
+    // classified by the ray cast". That is FALSE, and it is false about the one
+    // triangle that matters. `kept[16] = [17, 13, 14]` IS classified by regime 1
+    // — coincidence is established from the CENTROID, which needs no face pair
+    // to be parallel at all. Leaving the claim in place would send the next
+    // reader looking at the ray cast for a defect that is not there.
+    //
+    // What the distances below still say: whether a centroid sits close enough
+    // to the other operand's surface for the f64 rounding in `centroid` to
+    // matter. `kept[16]`'s 1.86e-5 is the one that does.
     //
     // NOTE: `cargo test --workspace` CAPTURES stdout for a passing test, and
     // this test passes while the defect exists, so CI will not show these

--- a/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
+++ b/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
@@ -80,9 +80,9 @@
 //!
 //! `kernel/arrangement/issue_3353_vid_census_tests.rs` is where this is written
 //! up: the per-triangle regime table for every triangle on an over-used edge,
-//! the measurements behind the paragraph above, and the five fix shapes tried
+//! the measurements behind the paragraph above, and the seven fix shapes tried
 //! against it — including why the two that fix this test each cost 20 golden
-//! census hosts. Read it before attempting a sixth.
+//! census hosts. Read it before attempting an eighth.
 //!
 //! One correction to record here, because it is this file's own earlier reading:
 //! the "84 um IN-PLANE vertex split" to be healed by a coplanar-overlay /

--- a/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
+++ b/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
@@ -59,18 +59,37 @@
 //! rotated corner-overlap family.
 //!
 //! `sweep_261` is only PARTLY that. With the weld in place its Union still
-//! reports 3 unmatched directed edges, unchanged. The residual is a different
-//! mechanism, and the trace names it: two vertices at the SAME height,
-//! `(-1.6740501, -0.2988684, 1.6377716)` and `(-1.6739786, -0.2989122,
-//! 1.6377716)`, 84 µm apart IN PLANE. That is an in-plane vertex split, not a
-//! near-coplanar face pair — nothing perpendicular for a plane weld to close,
-//! and it sits above the `NearBand` (~122 µm floor) only by being an in-plane
-//! separation the band does not measure at all.
+//! reports 3 unmatched directed edges, unchanged. Disabling the weld entirely
+//! leaves the committed 8000-pair union sweep at exactly 98 torn — measured on
+//! the issue, not here — so the residual is outside the weld's reach.
 //!
-//! So the remaining work here is the coplanar-overlay / retriangulation chord
-//! divergence that produced two nearly-coincident vertices where one belongs,
-//! NOT the snap reconciliation and NOT (per the earlier measurement recorded
-//! on the issue) the `unrecovered` conformity story.
+//! ## The mechanism, and where it is written up
+//!
+//! The residual is `rust/geometry/src/kernel/arrangement/classify.rs`'s regime 1
+//! — the coincident-shared-face test — firing on a face pair that is not
+//! coincident. It establishes coincidence from a sub-triangle's CENTROID alone,
+//! and a sub-triangle need not have its parent's plane: retriangulation can leave
+//! one degenerate onto the LINE where the two parent planes meet, at which point
+//! every one of its points lies in the other operand's plane however transversal
+//! the faces are. Here that is `arr.tris_a[22] = [17, 13, 14]`, kept by regime 1
+//! while its own neighbour in the same A face plane, `arr.tris_a[17]`, is
+//! correctly dropped as inside B. That leaves three Vid-space edges at the wrong
+//! multiplicity, and dropping `tris_a[22]` alone repairs all three: `(13,17)`
+//! goes to 0 (it was used once, by that triangle only) and the other two to 2.
+//! Measured in Vid space, one layer above the float `open_edges` below.
+//!
+//! `kernel/arrangement/issue_3353_vid_census_tests.rs` is where this is written
+//! up: the per-triangle regime table for every triangle on an over-used edge,
+//! the measurements behind the paragraph above, and the five fix shapes tried
+//! against it — including why the two that fix this test each cost 20 golden
+//! census hosts. Read it before attempting a sixth.
+//!
+//! One correction to record here, because it is this file's own earlier reading:
+//! the "84 um IN-PLANE vertex split" to be healed by a coplanar-overlay /
+//! retriangulation chord divergence is the same two vertices seen from the other
+//! end, but it points at the wrong repair. The vertices are exact and
+//! independently derived (measured on the issue), and nothing merges them. What
+//! goes wrong is the verdict taken on the sliver they span.
 //!
 //! ## Status
 //!


### PR DESCRIPTION
Refs #3353. Diagnosis only: no executable change in `classify.rs`, no pinned number moves (sweep_261 still 3 unmatched edges, the union sweep still 98 of 8000, the corpus census still matches its golden exactly).

The mechanism, measured by instrumenting `boolean_vids_components` over sweep_261's arrangement: edge (13,17) is bounded by two A sub-triangles in one flat A face. `tris_a[17]` is well-formed and the ray cast drops it as inside B; `tris_a[22]` is a needle 8.4e-5 long left by retriangulation on the line where the two transversal parent planes meet, so its centroid sits 1.86e-5 from a B face and inside its outline. Regime 1 accepts it on the centroid alone and decides it by the sign of a cross product a near-collinear triple does not pin down, overriding a ray cast that already had the right answer. Dropping that one triangle repairs all three over-used edges.

Three comments asserted the opposite and are corrected in place: regime 1's claim that its centroid-inside plus micrometre-perpendicular requirements never match a transversal cut face; `near_on_surface_normal`'s claim that it is gated on the coplanar-parent flag; and the census test's claim that no face pair here is within 28 degrees of parallel. The per-triangle regime table that refutes them is now in `issue_3353_vid_census_tests.rs`, with the seven fix shapes measured against the corpus golden: the parent-flush gates close sweep_261 and take the union sweep to 77 but regress 20 to 39 golden hosts (the tilted-flush caps whose far vertices leave the band, one host doubling its open edges); a scale-free needle gate at 1e-12 misses the sweep_261 needle (ratio 3.7e-10). What a fix still needs is written down there with the row to beat. The two patches carrying a parent index on the `Arrangement` are kept off-tree.

Gates on the head: geometry tests for the touched files 0, clippy -D warnings 0, module_size_ratchet 6/6, check-module-size 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for a known near-coplanar surface classification defect.
  * Added measured analysis of the affected classification regime, triangles, edges, and corpus behavior.
  * Documented the distinction between classification errors and weld or conformity failures.
  * Corrected commentary describing centroid-distance behavior and verified measurement details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->