### PR TITLE
test: green main after the release (changeset-bump self-test, gated issue_960 pin)

### DIFF
--- a/rust/geometry/tests/issue_960_segmented_roof_clip.rs
+++ b/rust/geometry/tests/issue_960_segmented_roof_clip.rs
@@ -99,6 +99,8 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
     // guards against are gross (a ~2.5 m sliver, or a fully empty mesh).
     let tol = 25.0_f32;
 
+    #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
+    let mut gated_regressions: Vec<u32> = Vec::new();
     for (id, gid, want_zmin, want_zmax) in cases {
         let mut decoder = EntityDecoder::with_index(&content, entity_index.clone());
         let entity = decoder.decode_by_id(id).expect("decode wall");
@@ -114,37 +116,33 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
         );
 
         let (mn, mx) = mesh.bounds();
-        // #3440/#3871: under either accept gate (`csg_manifold_gate`,
-        // `csg_topology_gate`) the accept seam rejects the roof clip's kernel
-        // result on ONE of these five walls and the chain falls back, regrowing
-        // the very seam sliver this test exists to catch. Measured: #2152 goes
-        // to 9850 mm against its 7325 mm bar under each gate alone and under
-        // both together; the other four are unchanged to the millimetre. So a
-        // gated build keeps the real bar for the four and pins the fifth at its
-        // regressed value - green, but failing the moment either number moves.
-        // The thing to fix is the FALLBACK path (the #635 AABB box-cut the
-        // chain reaches when the exact clip is discarded); when it is, this
-        // branch goes.
+        // #3440/#3871: an accept gate can reject the roof clip's kernel result
+        // on one of these five walls, and the chain then falls back and regrows
+        // the very seam sliver this test exists to catch. The gated builds keep
+        // the real bar for the walls that hold it and pin the regression as
+        // measured. The thing to fix is the FALLBACK path (the #635 AABB box-cut
+        // the chain reaches when the exact clip is discarded); when it is, the
+        // gated branch goes.
+        //
+        // Measured history (a value moving here means the gate or the fallback
+        // moved and needs re-measuring, not re-pinning):
+        //   - before #3912: #2152 read 9850 mm against its 7325 mm bar under
+        //     EACH gate alone and under both; the other four unchanged.
+        //   - after #3912 (the N-ary union weld, 2026-09-04, #3919): under
+        //     `csg_manifold_gate` alone #2152 is back on its bar and #5904 reads
+        //     9850 mm against its 8984 mm bar instead; under `csg_topology_gate`
+        //     (alone or with the manifold gate) BOTH #2152 and #5904 read 9850.
+        //     Stable across repeated runs. The gated pin is the exact set of
+        //     walls that regress, asserted after the loop.
         #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
-        let want_zmax = if id == 2152 { 9850.0 } else { want_zmax };
-        // The message is feature-split too. On the default build 9850 mm is the
-        // FAILURE this test exists to catch; under `csg_manifold_gate` it is the
-        // pinned regression and the expected value, so the default wording would
-        // send a reader debugging a failure in exactly the wrong direction.
-        #[cfg(not(feature = "csg_manifold_gate"))]
+        if (id == 2152 || id == 5904) && (mx.z - 9850.0).abs() < tol {
+            gated_regressions.push(id);
+            continue;
+        }
         assert!(
             (mx.z - want_zmax).abs() < tol,
             "#{id} ({gid}) max Z = {:.0} mm, expected ~{want_zmax} mm. A value near \
              9850 means a full-height seam sliver survived the roof clip.",
-            mx.z,
-        );
-        #[cfg(feature = "csg_manifold_gate")]
-        assert!(
-            (mx.z - want_zmax).abs() < tol,
-            "#{id} ({gid}) max Z = {:.0} mm, expected ~{want_zmax} mm. For #2152 that \
-             expectation IS the known csg_manifold_gate regression (the seam sliver \
-             the fallback regrows); any other value means the gate or the fallback \
-             moved and needs re-measuring, not re-pinning.",
             mx.z,
         );
         assert!(
@@ -153,4 +151,15 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
             mn.z,
         );
     }
+    #[cfg(all(feature = "csg_manifold_gate", not(feature = "csg_topology_gate")))]
+    let expected_regressions: &[u32] = &[5904];
+    #[cfg(feature = "csg_topology_gate")]
+    let expected_regressions: &[u32] = &[2152, 5904];
+    #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
+    assert_eq!(
+        gated_regressions, expected_regressions,
+        "the walls on which the accept gate lets the fallback regrow the seam \
+         sliver moved (#3919 pins {expected_regressions:?}); a different set means \
+         the gate or the fallback moved and needs re-measuring, not re-pinning."
+    );
 }

--- a/rust/geometry/tests/issue_960_segmented_roof_clip.rs
+++ b/rust/geometry/tests/issue_960_segmented_roof_clip.rs
@@ -100,7 +100,7 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
     let tol = 25.0_f32;
 
     #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
-    let mut gated_regressions: Vec<u32> = Vec::new();
+    let mut gated_regressions: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
     for (id, gid, want_zmin, want_zmax) in cases {
         let mut decoder = EntityDecoder::with_index(&content, entity_index.clone());
         let entity = decoder.decode_by_id(id).expect("decode wall");
@@ -136,7 +136,7 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
         //     walls that regress, asserted after the loop.
         #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
         if (id == 2152 || id == 5904) && (mx.z - 9850.0).abs() < tol {
-            gated_regressions.push(id);
+            gated_regressions.insert(id);
             continue;
         }
         assert!(
@@ -152,9 +152,9 @@ fn segmented_roof_walls_render_without_slivers_or_drops() {
         );
     }
     #[cfg(all(feature = "csg_manifold_gate", not(feature = "csg_topology_gate")))]
-    let expected_regressions: &[u32] = &[5904];
+    let expected_regressions: std::collections::BTreeSet<u32> = [5904].into();
     #[cfg(feature = "csg_topology_gate")]
-    let expected_regressions: &[u32] = &[2152, 5904];
+    let expected_regressions: std::collections::BTreeSet<u32> = [2152, 5904].into();
     #[cfg(any(feature = "csg_manifold_gate", feature = "csg_topology_gate"))]
     assert_eq!(
         gated_regressions, expected_regressions,

--- a/scripts/check-changeset-bump.test.mjs
+++ b/scripts/check-changeset-bump.test.mjs
@@ -555,18 +555,19 @@ test('REFUSE: a changeset whose frontmatter cannot be parsed', () => {
 
 // --- the shipped configuration ----------------------------------------------
 
-test('the real repository passes, and the run is not vacuous', () => {
+test('the real repository passes, and the run reports its baseline', () => {
   const res = spawnSync(process.execPath, [CHECKER], { cwd: ROOT, encoding: 'utf8' });
   const out = `${res.stdout}${res.stderr}`;
   assert.equal(res.status, 0, out);
-  // Anti-vacuity: the tree really does carry an unreleased shrink
-  // (bcd716a0b unexported Scene, PickingManager and Section2DOverlayRenderer),
-  // so a run reporting zero shrinks here would mean the baseline derivation had
-  // silently stopped finding anything to compare against.
-  assert.match(out, /pending changeset\(s\)/);
-  // And the SHRINK RESULT itself, not merely that a changeset was found. Without
-  // this the test still passes if baseline derivation silently stops comparing
-  // API surfaces and reports zero shrunk packages: a green run over a check that
-  // did nothing, which is the shape this gate exists to prevent.
-  assert.match(out, /1 package\(s\) shrank/);
+  // Anti-vacuity, without pinning live repository state: the summary must
+  // say how many changesets it read and which baseline it compared against.
+  // An earlier version required "1 package(s) shrank" from a specific
+  // unreleased shrink, which turned red the moment a release consumed the
+  // changesets (main after #3357, 2026-09-04): a released tree legitimately
+  // has 0 pending and nothing shrank. Whether the checker DETECTS a shrink is
+  // pinned by the synthetic RED/GREEN cases above, which do not depend on
+  // what happens to be unreleased today.
+  assert.match(out, /\d+ pending changeset\(s\)/);
+  assert.match(out, /since [0-9a-f]{7,}:scripts\/api-surface\.json/);
 });
+


### PR DESCRIPTION
Main's Test run is red on the current head for two test-side reasons, neither a product defect.

**Node tests.** `scripts/check-changeset-bump.test.mjs` required "1 package(s) shrank" among the pending changesets as its anti-vacuity, tied to a specific unreleased shrink. The release (#3357) consumed every changeset, so the assertion fails on any released tree. It now asserts the summary shape (a changeset count and the baseline it compared against); whether the checker detects a shrink is pinned by the synthetic RED and GREEN cases in the same file, which do not depend on what is unreleased today. 26 of 26 pass.

**Rust tests (accept-gate features).** `issue_960_segmented_roof_clip.rs` pinned #2152 at the 9850 mm regressed value under either accept gate. After #3912 the gates reject different clips: under `csg_manifold_gate` alone #2152 is back on its 7325 mm bar and #5904 regrows the sliver instead; under `csg_topology_gate` (alone or with manifold) both #2152 and #5904 do. Measured with fixtures, stable across repeated runs, and tracked as #3919. The gated pin is now the exact set of regressed walls, compared as a set so it does not depend on the case order, asserted after the loop; the default build's per-wall assertions are unchanged.

Verified: the Rust test passes twice under each of the four feature combinations, clippy -D warnings is clean under each, the Node test file passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for segmented-roof clipping regressions, including gated fallback scenarios and seam-related geometry cases.
  - Updated validation to check pending changeset counts and API-surface baseline references more reliably.
  - Removed brittle expectations tied to a specific unreleased change count, allowing checks to remain valid after releases consume pending changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->