### PR TITLE
feat(viewer): save and reopen a portable federation setup

### DIFF
--- a/.changeset/federation-setup-portable-save-reopen.md
+++ b/.changeset/federation-setup-portable-save-reopen.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": minor
+---
+
+Add a portable federation setup file: save which models make up a federation (load order, visibility, and the alignment anchor) and reopen it later by matching saved slots back to local files by content fingerprint. The file references source files by name, size, and a content fingerprint — it never embeds file bytes, paths, or handles. Reopening replays the existing alignment pipeline against the restored anchor rather than storing baked transforms, and always reports how many models were restored versus missing or mismatched instead of silently accepting a partial restore. Reachable via the command palette ("Save Federation Setup" / "Open Federation Setup").

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -287,6 +287,9 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => {
           window.dispatchEvent(new CustomEvent('ifc-lite:open-files'));
         } },
+      // #3930 portable federation setup — handlers live in `FederationSetupControls` (mounted from `useFileCommands`, ShareDialog's pattern).
+      { id: 'file:save-federation-setup', label: 'Save Federation Setup', keywords: 'federation setup save export portable models order alignment anchor', category: 'File', icon: Save, action: () => { window.dispatchEvent(new CustomEvent('ifc-lite:save-federation-setup')); } },
+      { id: 'file:open-federation-setup', label: 'Open Federation Setup', keywords: 'federation setup restore reopen import portable models order alignment anchor', category: 'File', icon: FolderOpen, immediate: true, action: () => { window.dispatchEvent(new CustomEvent('ifc-lite:open-federation-setup')); } },
     );
     for (const rf of recentFiles) {
       const fileName = rf.name;

--- a/apps/viewer/src/components/viewer/FederationSetupControls.tsx
+++ b/apps/viewer/src/components/viewer/FederationSetupControls.tsx
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Save/reopen a portable federation setup (#3930).
+ *
+ * Mounted once from `useFileCommands` (same pattern as `ShareDialog`), so it
+ * is reachable from the command palette regardless of which toolbar style is
+ * active. Two hidden `<input type="file">`s drive the two-step "open" flow
+ * (pick the saved `.federation.json`, then pick the local model files to
+ * match against it); the review step never applies anything silently — every
+ * slot is shown as matched, mismatched (same name, different content/size),
+ * or missing before the user confirms.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AlertTriangle, Anchor, Check, FileWarning } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { useFederationSetup } from '@/hooks/useFederationSetup';
+import {
+  parseFederationSetupFile,
+  type FederationSetupFile,
+  type FederationSetupSlotMatch,
+} from '@/lib/federation/federationSetupFile';
+
+const EVENT_SAVE = 'ifc-lite:save-federation-setup';
+const EVENT_OPEN = 'ifc-lite:open-federation-setup';
+
+function confidenceBadge(match: FederationSetupSlotMatch): { label: string; icon: typeof Check; tone: string } {
+  switch (match.confidence) {
+    case 'content':
+      return { label: 'Matched', icon: Check, tone: 'text-emerald-600 dark:text-emerald-400' };
+    case 'name-size':
+      return { label: 'Matched (by name)', icon: Check, tone: 'text-emerald-600 dark:text-emerald-400' };
+    case 'name-only':
+      return { label: 'Same name, different file', icon: FileWarning, tone: 'text-amber-600 dark:text-amber-400' };
+    case 'none':
+      return { label: 'Missing', icon: AlertTriangle, tone: 'text-red-600 dark:text-red-400' };
+  }
+}
+
+export function FederationSetupControls() {
+  const { exportFederationSetup, matchFederationSetup, applyFederationSetup } = useFederationSetup();
+
+  const setupFileInputRef = useRef<HTMLInputElement>(null);
+  const modelFilesInputRef = useRef<HTMLInputElement>(null);
+  const [pendingSetup, setPendingSetup] = useState<FederationSetupFile | null>(null);
+  const [matches, setMatches] = useState<FederationSetupSlotMatch[] | null>(null);
+  const [applying, setApplying] = useState(false);
+
+  const handleSave = useCallback(() => {
+    void exportFederationSetup().then((result) => {
+      if (!result.ok) toast.error(result.error);
+      else toast.success('Federation setup saved.');
+    });
+  }, [exportFederationSetup]);
+
+  useEffect(() => {
+    const onSave = () => handleSave();
+    const onOpen = () => setupFileInputRef.current?.click();
+    window.addEventListener(EVENT_SAVE, onSave);
+    window.addEventListener(EVENT_OPEN, onOpen);
+    return () => {
+      window.removeEventListener(EVENT_SAVE, onSave);
+      window.removeEventListener(EVENT_OPEN, onOpen);
+    };
+  }, [handleSave]);
+
+  const handleSetupFileSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    void file.text().then((text) => {
+      const result = parseFederationSetupFile(text);
+      if (!result.ok) {
+        toast.error(`Not a valid federation setup file: ${result.error}`);
+        return;
+      }
+      setPendingSetup(result.setup);
+      toast.info(
+        `Loaded a setup with ${result.setup.slots.length} model slot${result.setup.slots.length === 1 ? '' : 's'} — now pick the model file(s) to match against it.`,
+      );
+      modelFilesInputRef.current?.click();
+    });
+  }, []);
+
+  const handleModelFilesSelected = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    e.target.value = '';
+    if (!pendingSetup || files.length === 0) return;
+    void matchFederationSetup(pendingSetup, files).then(setMatches);
+  }, [pendingSetup, matchFederationSetup]);
+
+  const closeReview = useCallback(() => {
+    setMatches(null);
+    setPendingSetup(null);
+  }, []);
+
+  const handleApply = useCallback(() => {
+    if (!matches) return;
+    setApplying(true);
+    void applyFederationSetup(matches).then((result) => {
+      setApplying(false);
+      closeReview();
+      if (result.outcome === 'failed') {
+        toast.error('Could not restore the federation setup — none of the saved models were found.');
+        return;
+      }
+      const parts: string[] = [`Restored ${result.restoredCount}/${result.totalSlots} model(s)`];
+      if (result.missingSlots.length > 0) parts.push(`missing: ${result.missingSlots.join(', ')}`);
+      if (result.mismatchedSlots.length > 0) parts.push(`same name, different content: ${result.mismatchedSlots.join(', ')}`);
+      if (result.anchorMissing) parts.push('alignment anchor could not be restored');
+      const message = parts.join(' — ');
+      if (result.outcome === 'restored' && !result.anchorMissing) toast.success(message);
+      else toast.error(message);
+    });
+  }, [matches, applyFederationSetup, closeReview]);
+
+  return (
+    <>
+      <input
+        ref={setupFileInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="hidden"
+        onChange={handleSetupFileSelected}
+      />
+      <input
+        ref={modelFilesInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={handleModelFilesSelected}
+      />
+      <Dialog open={matches !== null} onOpenChange={(open) => { if (!open) closeReview(); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reopen federation setup</DialogTitle>
+            <DialogDescription>
+              Review how each saved model slot matched your local files before restoring.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-80 overflow-y-auto space-y-1">
+            {matches?.map((match) => {
+              const badge = confidenceBadge(match);
+              const Icon = badge.icon;
+              return (
+                <div
+                  key={match.slotIndex}
+                  className="flex items-center gap-2 px-2 py-1.5 border border-zinc-200 dark:border-zinc-800 rounded text-sm"
+                >
+                  {match.slot.anchor && <Anchor className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />}
+                  <span className="truncate flex-1">{match.slot.name}</span>
+                  <span className={`inline-flex items-center gap-1 text-xs ${badge.tone}`}>
+                    <Icon className="h-3.5 w-3.5" />
+                    {badge.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeReview} disabled={applying}>Cancel</Button>
+            <Button
+              onClick={handleApply}
+              disabled={applying || !matches?.some((m) => m.file !== null)}
+            >
+              {applying ? 'Restoring…' : 'Restore federation'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+export default FederationSetupControls;

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -24,6 +24,7 @@ import { toast } from '@/components/ui/toast';
 import { isCollabEnabled } from '@/lib/collab/config';
 import { ingestDxfFiles, splitDxfFiles } from '@/hooks/ingest/dxfIngest';
 import { ShareDialog } from '../ShareDialog';
+import { FederationSetupControls } from '../FederationSetupControls';
 
 import { FILE_ACCEPT, isSupportedModelFile } from '@/services/supported-model-files';
 
@@ -374,6 +375,7 @@ export function useFileCommands(): FileCommands {
         className="hidden"
       />
       {collabEnabled && <ShareDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} />}
+      <FederationSetupControls />
     </>
   );
 

--- a/apps/viewer/src/hooks/useFederationSetup.ts
+++ b/apps/viewer/src/hooks/useFederationSetup.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Save and reopen a portable federation setup (issue #3930).
+ *
+ * Thin glue between the pure logic in `lib/federation/federationSetupFile.ts`
+ * and the live viewer store / canonical load path (`useIfcFederation.addModel`,
+ * `realignFederation`). See that module's header for what the saved file
+ * references versus embeds, and how alignment is replayed rather than baked in.
+ */
+
+import { useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useViewerStore, type FederatedModel } from '../store/index.js';
+import { useIfc } from './useIfc.js';
+import { findReferenceGeorefModel } from './ingest/federationAlign.js';
+import {
+  buildFederationSetupFile,
+  serializeFederationSetupFile,
+  matchFederationSetupSlots,
+  summarizeFederationSetupMatches,
+  type FederationSetupFile,
+  type FederationSetupSlotMatch,
+} from '../lib/federation/federationSetupFile.js';
+import { downloadFile, sanitizeFilename } from '../lib/export/download.js';
+
+/** Result of applying a federation setup — always distinguishes full vs. partial vs. failed restore. */
+export interface FederationSetupApplyResult {
+  outcome: 'restored' | 'partial' | 'failed';
+  /** Models actually (re-)loaded, in the order they were loaded. */
+  restoredCount: number;
+  totalSlots: number;
+  /** Slots for which no local file could be found. */
+  missingSlots: string[];
+  /** Slots matched only by filename, with different size/content than saved. */
+  mismatchedSlots: string[];
+  /** True when the saved anchor's model was restored and re-alignment ran. */
+  anchorRestored: boolean;
+  /** True when the setup had a saved anchor but that model could not be restored. */
+  anchorMissing: boolean;
+}
+
+export function useFederationSetup() {
+  const { addModel, realignFederation } = useIfc();
+  const { anchorModelIdOverride, setAnchorModelIdOverride } = useViewerStore(
+    useShallow((s) => ({
+      anchorModelIdOverride: s.anchorModelIdOverride,
+      setAnchorModelIdOverride: s.setAnchorModelIdOverride,
+    })),
+  );
+
+  /** Build and download the current federation as a portable setup file. Read-only — never mutates the store. */
+  const exportFederationSetup = useCallback(async (): Promise<{ ok: true } | { ok: false; error: string }> => {
+    const state = useViewerStore.getState();
+    const models = Array.from(state.models.values()) as FederatedModel[]; // Map insertion order = load order.
+    if (models.length === 0) {
+      return { ok: false, error: 'No models loaded — nothing to save.' };
+    }
+    const reference = findReferenceGeorefModel();
+    const anchorModelId = reference?.modelId ?? anchorModelIdOverride ?? null;
+
+    const setup = await buildFederationSetupFile(models, anchorModelId);
+    const json = serializeFederationSetupFile(setup);
+    const stem = models.length === 1
+      ? sanitizeFilename(models[0].name, { fallback: 'federation' })
+      : `federation-setup-${models.length}-models`;
+    downloadFile(json, `${sanitizeFilename(stem, { fallback: 'federation' })}.federation.json`, 'application/json;charset=utf-8;');
+    return { ok: true };
+  }, [anchorModelIdOverride]);
+
+  /** Match saved slots to freshly-picked local files, without applying anything yet (for the review step). */
+  const matchFederationSetup = useCallback(
+    (setup: FederationSetupFile, files: readonly File[]): Promise<FederationSetupSlotMatch[]> =>
+      matchFederationSetupSlots(setup, files),
+    [],
+  );
+
+  /**
+   * Load every resolvable (matched or name-only) slot through the ONE canonical
+   * load path (`addModel` -> `loadFile`), in saved order, then restore the
+   * anchor and re-run alignment. Never silently drops a slot: the return value
+   * always states exactly how many restored, which were missing, and whether
+   * the anchor could be restored.
+   */
+  const applyFederationSetup = useCallback(
+    async (matches: readonly FederationSetupSlotMatch[]): Promise<FederationSetupApplyResult> => {
+      const summary = summarizeFederationSetupMatches(matches);
+      const loadable = matches.filter((m) => m.file !== null);
+
+      let restoredCount = 0;
+      let restoredAnchorModelId: string | null = null;
+      const hadAnchorSlot = matches.some((m) => m.slot.anchor);
+
+      // Sequential, in saved order — mirrors loadFilesSequentially (the WASM
+      // parser isn't thread-safe) and preserves the saved federation's
+      // relative model order even when some slots are missing.
+      for (const match of loadable) {
+        if (!match.file) continue;
+        const modelId = await addModel(match.file, {
+          name: match.slot.name,
+          visible: match.slot.visible,
+          collapsed: match.slot.collapsed,
+        });
+        if (modelId) {
+          restoredCount += 1;
+          if (match.slot.anchor) restoredAnchorModelId = modelId;
+        }
+      }
+
+      let anchorRestored = false;
+      if (restoredAnchorModelId) {
+        setAnchorModelIdOverride(restoredAnchorModelId);
+        await realignFederation();
+        anchorRestored = true;
+      }
+
+      const outcome: FederationSetupApplyResult['outcome'] =
+        restoredCount === 0 ? 'failed' : restoredCount === matches.length ? 'restored' : 'partial';
+
+      return {
+        outcome,
+        restoredCount,
+        totalSlots: matches.length,
+        missingSlots: summary.missing.map((m) => m.slot.name),
+        mismatchedSlots: summary.mismatched.map((m) => m.slot.name),
+        anchorRestored,
+        anchorMissing: hadAnchorSlot && !anchorRestored,
+      };
+    },
+    [addModel, realignFederation, setAnchorModelIdOverride],
+  );
+
+  return { exportFederationSetup, matchFederationSetup, applyFederationSetup };
+}
+
+export default useFederationSetup;

--- a/apps/viewer/src/lib/federation/federationSetupFile.test.ts
+++ b/apps/viewer/src/lib/federation/federationSetupFile.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { FederatedModel } from '../../store/types.js';
+import {
+  buildFederationSetupFile,
+  serializeFederationSetupFile,
+  parseFederationSetupFile,
+  matchFederationSetupSlots,
+  summarizeFederationSetupMatches,
+  FEDERATION_SETUP_FORMAT_VERSION,
+} from './federationSetupFile.js';
+
+/** Build a real `FederatedModel` (not a hand-shaped fixture) with a real `File` source. */
+function makeModel(overrides: Partial<FederatedModel> & { name: string; bytes: string }): FederatedModel {
+  const { bytes, ...rest } = overrides;
+  const file = new File([bytes], overrides.name, { type: 'application/octet-stream' });
+  const model: FederatedModel = {
+    id: overrides.id ?? crypto.randomUUID(),
+    name: overrides.name,
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: overrides.visible ?? true,
+    collapsed: overrides.collapsed ?? false,
+    schemaVersion: overrides.schemaVersion ?? 'IFC4',
+    loadedAt: overrides.loadedAt ?? Date.now(),
+    fileSize: file.size,
+    sourceFile: file,
+    idOffset: 0,
+    maxExpressId: 0,
+    federationAlignmentStatus: overrides.federationAlignmentStatus,
+  };
+  return { ...model, ...rest };
+}
+
+describe('buildFederationSetupFile / parseFederationSetupFile round trip', () => {
+  it('round-trips slot data exactly, marking the anchor', async () => {
+    const arch = makeModel({ name: 'ARCH.ifc', bytes: 'architecture-bytes' });
+    const struct = makeModel({ name: 'STRUCT.ifc', bytes: 'structure-bytes', visible: false, collapsed: true });
+
+    const setup = await buildFederationSetupFile([arch, struct], arch.id);
+    const json = serializeFederationSetupFile(setup);
+    const parsed = parseFederationSetupFile(json);
+
+    assert.strictEqual(parsed.ok, true);
+    if (!parsed.ok) return;
+    assert.strictEqual(parsed.setup.formatVersion, FEDERATION_SETUP_FORMAT_VERSION);
+    assert.strictEqual(parsed.setup.slots.length, 2);
+    assert.strictEqual(parsed.setup.slots[0].name, 'ARCH.ifc');
+    assert.strictEqual(parsed.setup.slots[0].anchor, true);
+    assert.strictEqual(parsed.setup.slots[0].visible, true);
+    assert.strictEqual(parsed.setup.slots[1].name, 'STRUCT.ifc');
+    assert.strictEqual(parsed.setup.slots[1].anchor, false);
+    assert.strictEqual(parsed.setup.slots[1].visible, false);
+    assert.strictEqual(parsed.setup.slots[1].collapsed, true);
+    assert.strictEqual(typeof parsed.setup.slots[0].fingerprintHex, 'string');
+  });
+
+  it('is deterministic: saving the same state twice produces byte-identical JSON', async () => {
+    const model = makeModel({ name: 'MEP.ifc', bytes: 'mep-bytes' });
+    const a = serializeFederationSetupFile(await buildFederationSetupFile([model], model.id));
+    const b = serializeFederationSetupFile(await buildFederationSetupFile([model], model.id));
+    assert.strictEqual(a, b);
+  });
+
+  it('records null fingerprint when a model has no retained source file', async () => {
+    const model = makeModel({ name: 'CACHED.ifc', bytes: 'x' });
+    delete (model as { sourceFile?: File }).sourceFile;
+    const setup = await buildFederationSetupFile([model], null);
+    assert.strictEqual(setup.slots[0].fingerprintHex, null);
+    assert.strictEqual(setup.slots[0].anchor, false);
+  });
+});
+
+describe('parseFederationSetupFile validation (fails loudly on malformed input)', () => {
+  it('rejects non-JSON', () => {
+    const result = parseFederationSetupFile('not json{');
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('rejects a wrong format version instead of silently coercing', () => {
+    const result = parseFederationSetupFile(JSON.stringify({ formatVersion: 99, slots: [] }));
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) assert.match(result.error, /Unsupported federation setup version/);
+  });
+
+  it('rejects zero slots', () => {
+    const result = parseFederationSetupFile(JSON.stringify({ formatVersion: 1, slots: [] }));
+    assert.strictEqual(result.ok, false);
+  });
+
+  it('rejects more than one anchor slot', () => {
+    const badSlot = {
+      name: 'A.ifc', fileSize: 1, fingerprintHex: null, visible: true, collapsed: false, anchor: true,
+    };
+    const result = parseFederationSetupFile(JSON.stringify({ formatVersion: 1, slots: [badSlot, badSlot] }));
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) assert.match(result.error, /Exactly one slot may be the anchor/);
+  });
+
+  it('rejects a slot missing a required field rather than defaulting it', () => {
+    const badSlot = { name: 'A.ifc', fileSize: 1, fingerprintHex: null, visible: true, collapsed: false };
+    const result = parseFederationSetupFile(JSON.stringify({ formatVersion: 1, slots: [badSlot] }));
+    assert.strictEqual(result.ok, false);
+    if (!result.ok) assert.match(result.error, /anchor must be a boolean/);
+  });
+});
+
+describe('matchFederationSetupSlots', () => {
+  it('matches a present model fully by content fingerprint even if renamed', async () => {
+    const original = makeModel({ name: 'ARCH.ifc', bytes: 'same-content' });
+    const setup = await buildFederationSetupFile([original], original.id);
+    const renamedFile = new File(['same-content'], 'ARCH-renamed.ifc', { type: 'application/octet-stream' });
+
+    const matches = await matchFederationSetupSlots(setup, [renamedFile]);
+    assert.strictEqual(matches.length, 1);
+    assert.strictEqual(matches[0].confidence, 'content');
+    assert.strictEqual(matches[0].file, renamedFile);
+  });
+
+  it('reports missing when no candidate file is provided', async () => {
+    const original = makeModel({ name: 'ARCH.ifc', bytes: 'content' });
+    const setup = await buildFederationSetupFile([original], null);
+
+    const matches = await matchFederationSetupSlots(setup, []);
+    assert.strictEqual(matches[0].confidence, 'none');
+    assert.strictEqual(matches[0].file, null);
+  });
+
+  it('does not let two same-named slots collide on one local file (content disambiguates)', async () => {
+    // The keyed-write trap: two distinct models were federated under the
+    // SAME filename (e.g. two revisions both called "MODEL.ifc"). Reopening
+    // with both distinct local files present must match each slot to its
+    // own content, never both to the first file found by name.
+    const modelA = makeModel({ name: 'MODEL.ifc', bytes: 'revision-A-content' });
+    const modelB = makeModel({ name: 'MODEL.ifc', bytes: 'revision-B-content' });
+    const setup = await buildFederationSetupFile([modelA, modelB], null);
+
+    const fileA = new File(['revision-A-content'], 'MODEL.ifc', { type: 'application/octet-stream' });
+    const fileB = new File(['revision-B-content'], 'MODEL.ifc', { type: 'application/octet-stream' });
+
+    // Provide files in the OPPOSITE order from the slots to prove matching
+    // isn't just consuming candidates positionally.
+    const matches = await matchFederationSetupSlots(setup, [fileB, fileA]);
+    assert.strictEqual(matches[0].confidence, 'content');
+    assert.strictEqual(matches[0].file, fileA); // slot 0 (revision A) -> fileA
+    assert.strictEqual(matches[1].confidence, 'content');
+    assert.strictEqual(matches[1].file, fileB); // slot 1 (revision B) -> fileB
+  });
+
+  it('does not double-assign one local file to two slots when only one copy is present', async () => {
+    const modelA = makeModel({ name: 'MODEL.ifc', bytes: 'revision-A-content' });
+    const modelB = makeModel({ name: 'MODEL.ifc', bytes: 'revision-B-content' });
+    const setup = await buildFederationSetupFile([modelA, modelB], null);
+
+    const fileA = new File(['revision-A-content'], 'MODEL.ifc', { type: 'application/octet-stream' });
+
+    const matches = await matchFederationSetupSlots(setup, [fileA]);
+    const matchedFiles = matches.map((m) => m.file);
+    assert.strictEqual(matchedFiles.filter((f) => f === fileA).length, 1);
+    assert.strictEqual(matches.filter((m) => m.confidence === 'none').length, 1);
+  });
+
+  it('falls back to name-only and flags it when size/content differ (same name, different file)', async () => {
+    const original = makeModel({ name: 'ARCH.ifc', bytes: 'old-content-longer-than-new' });
+    const setup = await buildFederationSetupFile([original], null);
+    const different = new File(['new'], 'ARCH.ifc', { type: 'application/octet-stream' });
+
+    const matches = await matchFederationSetupSlots(setup, [different]);
+    assert.strictEqual(matches[0].confidence, 'name-only');
+    assert.strictEqual(matches[0].file, different);
+  });
+});
+
+describe('summarizeFederationSetupMatches', () => {
+  it('classifies a full restore as fully resolved with nothing missing or mismatched', async () => {
+    const modelA = makeModel({ name: 'A.ifc', bytes: 'a' });
+    const modelB = makeModel({ name: 'B.ifc', bytes: 'b' });
+    const setup = await buildFederationSetupFile([modelA, modelB], modelA.id);
+    const fileA = new File(['a'], 'A.ifc');
+    const fileB = new File(['b'], 'B.ifc');
+    const matches = await matchFederationSetupSlots(setup, [fileA, fileB]);
+
+    const summary = summarizeFederationSetupMatches(matches);
+    assert.strictEqual(summary.total, 2);
+    assert.strictEqual(summary.resolved.length, 2);
+    assert.strictEqual(summary.missing.length, 0);
+    assert.strictEqual(summary.mismatched.length, 0);
+  });
+
+  it('never counts a missing slot as resolved (partial restore must be visible)', async () => {
+    const modelA = makeModel({ name: 'A.ifc', bytes: 'a' });
+    const modelB = makeModel({ name: 'B.ifc', bytes: 'b' });
+    const setup = await buildFederationSetupFile([modelA, modelB], null);
+    const fileA = new File(['a'], 'A.ifc');
+    const matches = await matchFederationSetupSlots(setup, [fileA]); // B.ifc not provided
+
+    const summary = summarizeFederationSetupMatches(matches);
+    assert.strictEqual(summary.resolved.length, 1);
+    assert.strictEqual(summary.missing.length, 1);
+    assert.strictEqual(summary.missing[0].slot.name, 'B.ifc');
+  });
+
+  it('surfaces a name-only match as mismatched, not resolved (must not silently accept a different file)', async () => {
+    const modelA = makeModel({ name: 'A.ifc', bytes: 'original-content' });
+    const setup = await buildFederationSetupFile([modelA], null);
+    const different = new File(['different'], 'A.ifc');
+    const matches = await matchFederationSetupSlots(setup, [different]);
+
+    const summary = summarizeFederationSetupMatches(matches);
+    assert.strictEqual(summary.resolved.length, 0);
+    assert.strictEqual(summary.mismatched.length, 1);
+  });
+});

--- a/apps/viewer/src/lib/federation/federationSetupFile.ts
+++ b/apps/viewer/src/lib/federation/federationSetupFile.ts
@@ -1,0 +1,304 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Portable federation setup file (issue #3930): lets a user save which
+ * models make up a federation — load order, visibility, and which model is
+ * the alignment anchor — and reopen that setup later, possibly on a
+ * different machine, matching the saved slots back to local files.
+ *
+ * ## What the file references, versus embeds
+ * The file stores each model's original filename, byte size, and a content
+ * fingerprint (`computeSourceFingerprint`, the same sampled 64-bit hash used
+ * to key the geometry cache). It never embeds file bytes, an absolute path,
+ * a `FileSystemFileHandle`, or any credential — reopening it always requires
+ * the user to (re-)select the actual model files, which is what keeps the
+ * file small and portable across machines. See `matchFederationSetupSlots`.
+ *
+ * ## Alignment is replayed, not baked in
+ * Rather than serialize per-model transform matrices (which would silently
+ * go stale the moment a matched file's own IFC georeferencing differs from
+ * the original), the file records only WHICH slot was the federation anchor.
+ * On reopen, the caller re-adds every matched model through the normal
+ * `addModel` load path and then calls `realignFederation()` against the
+ * restored anchor — the exact same alignment logic a fresh multi-file load
+ * would run. This keeps the saved file simple and guarantees alignment
+ * always reflects the actual (possibly updated) georeferencing of the files
+ * being opened, matching the codebase's existing single alignment pipeline
+ * (`useIfcFederation.realignFederation`) instead of forking a second one.
+ *
+ * ## Determinism
+ * `buildFederationSetupFile` takes models as an ARRAY in federation load
+ * order (the caller passes `Array.from(models.values())`, which is a Map's
+ * insertion order — the order models were actually added, never re-sorted
+ * here). The serialized JSON's key order is fixed by explicit object
+ * construction (never a spread of an arbitrary object), so saving the same
+ * federation state twice produces byte-identical output — no hash-map
+ * iteration ordering and no embedded timestamp to make two saves differ.
+ */
+
+import { computeSourceFingerprint } from '../../hooks/sourceFingerprint.js';
+import type { FederatedModel } from '../../store/types.js';
+
+/** Current on-disk format version. Bump on any breaking shape change. */
+export const FEDERATION_SETUP_FORMAT_VERSION = 1;
+
+/** One saved model slot: what is needed to find the file again and restore its state. */
+export interface FederationSetupSlot {
+  /** Original filename at save time (display + fallback matching key). */
+  name: string;
+  /** Original file size in bytes. */
+  fileSize: number;
+  /**
+   * Content fingerprint (`computeSourceFingerprint(...).hex`) of the source
+   * file, or `null` when the model's source bytes were not available at
+   * save time (e.g. a model restored from cache without its original File).
+   * A `null` fingerprint degrades matching to name/size only.
+   */
+  fingerprintHex: string | null;
+  /** Model-level visibility at save time. */
+  visible: boolean;
+  /** Hierarchy-panel collapse state at save time. */
+  collapsed: boolean;
+  /** True for exactly one slot: the federation's alignment anchor. */
+  anchor: boolean;
+}
+
+/** A complete, versioned, portable federation setup. */
+export interface FederationSetupFile {
+  formatVersion: 1;
+  /** Slots in federation load order. */
+  slots: FederationSetupSlot[];
+}
+
+/** Compute the content fingerprint of a `File`'s current bytes. */
+export async function computeFileFingerprint(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  return computeSourceFingerprint(buffer).hex;
+}
+
+/**
+ * Build a {@link FederationSetupFile} from the live federation state.
+ *
+ * @param models - Models in federation load order (`Array.from(models.values())`).
+ * @param anchorModelId - The id of the model currently acting as the
+ *   alignment anchor (the "effective anchor", not necessarily the pinned
+ *   override — see `findReferenceGeorefModel`), or `null` if none.
+ */
+export async function buildFederationSetupFile(
+  models: readonly FederatedModel[],
+  anchorModelId: string | null,
+): Promise<FederationSetupFile> {
+  const slots: FederationSetupSlot[] = await Promise.all(
+    models.map(async (model) => {
+      const fingerprintHex = model.sourceFile
+        ? await computeFileFingerprint(model.sourceFile)
+        : null;
+      return {
+        name: model.name,
+        fileSize: model.fileSize,
+        fingerprintHex,
+        visible: model.visible,
+        collapsed: model.collapsed,
+        anchor: model.id === anchorModelId,
+      };
+    }),
+  );
+  return { formatVersion: FEDERATION_SETUP_FORMAT_VERSION, slots };
+}
+
+/** Serialize a setup to its canonical on-disk JSON text (stable key order, 2-space indent). */
+export function serializeFederationSetupFile(setup: FederationSetupFile): string {
+  const canonical: FederationSetupFile = {
+    formatVersion: setup.formatVersion,
+    slots: setup.slots.map((slot) => ({
+      name: slot.name,
+      fileSize: slot.fileSize,
+      fingerprintHex: slot.fingerprintHex,
+      visible: slot.visible,
+      collapsed: slot.collapsed,
+      anchor: slot.anchor,
+    })),
+  };
+  return JSON.stringify(canonical, null, 2);
+}
+
+export type FederationSetupParseResult =
+  | { ok: true; setup: FederationSetupFile }
+  | { ok: false; error: string };
+
+/**
+ * Parse and strictly validate a federation setup file. Fails loudly (returns
+ * `ok: false` with a specific reason) on anything malformed rather than
+ * silently coercing or dropping fields — an unreadable field here must not
+ * be mistaken for "restored fully".
+ */
+export function parseFederationSetupFile(raw: string): FederationSetupParseResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: 'Not valid JSON.' };
+  }
+  if (typeof json !== 'object' || json === null || Array.isArray(json)) {
+    return { ok: false, error: 'Expected a JSON object at the top level.' };
+  }
+  const obj = json as Record<string, unknown>;
+
+  if (obj.formatVersion !== FEDERATION_SETUP_FORMAT_VERSION) {
+    return {
+      ok: false,
+      error: `Unsupported federation setup version: ${JSON.stringify(obj.formatVersion)} (expected ${FEDERATION_SETUP_FORMAT_VERSION}).`,
+    };
+  }
+  if (!Array.isArray(obj.slots)) {
+    return { ok: false, error: '"slots" must be an array.' };
+  }
+  if (obj.slots.length === 0) {
+    return { ok: false, error: 'A federation setup with zero model slots is not valid.' };
+  }
+
+  const slots: FederationSetupSlot[] = [];
+  let anchorCount = 0;
+  for (let i = 0; i < obj.slots.length; i++) {
+    const raw = obj.slots[i];
+    if (typeof raw !== 'object' || raw === null) {
+      return { ok: false, error: `slots[${i}] is not an object.` };
+    }
+    const s = raw as Record<string, unknown>;
+    if (typeof s.name !== 'string' || s.name.length === 0) {
+      return { ok: false, error: `slots[${i}].name must be a non-empty string.` };
+    }
+    if (typeof s.fileSize !== 'number' || !Number.isFinite(s.fileSize) || s.fileSize < 0) {
+      return { ok: false, error: `slots[${i}].fileSize must be a non-negative number.` };
+    }
+    if (s.fingerprintHex !== null && typeof s.fingerprintHex !== 'string') {
+      return { ok: false, error: `slots[${i}].fingerprintHex must be a string or null.` };
+    }
+    if (typeof s.visible !== 'boolean') {
+      return { ok: false, error: `slots[${i}].visible must be a boolean.` };
+    }
+    if (typeof s.collapsed !== 'boolean') {
+      return { ok: false, error: `slots[${i}].collapsed must be a boolean.` };
+    }
+    if (typeof s.anchor !== 'boolean') {
+      return { ok: false, error: `slots[${i}].anchor must be a boolean.` };
+    }
+    if (s.anchor) anchorCount += 1;
+    slots.push({
+      name: s.name,
+      fileSize: s.fileSize,
+      fingerprintHex: s.fingerprintHex as string | null,
+      visible: s.visible,
+      collapsed: s.collapsed,
+      anchor: s.anchor,
+    });
+  }
+  if (anchorCount > 1) {
+    return { ok: false, error: `Exactly one slot may be the anchor; found ${anchorCount}.` };
+  }
+
+  return { ok: true, setup: { formatVersion: FEDERATION_SETUP_FORMAT_VERSION, slots } };
+}
+
+/** How confidently a local file was matched back to a saved slot. */
+export type FederationSetupMatchConfidence = 'content' | 'name-size' | 'name-only' | 'none';
+
+export interface FederationSetupSlotMatch {
+  slot: FederationSetupSlot;
+  slotIndex: number;
+  /** The local file matched to this slot, or `null` when nothing matched (missing). */
+  file: File | null;
+  confidence: FederationSetupMatchConfidence;
+}
+
+/**
+ * Match saved slots to a set of freshly-picked local files. One-to-one:
+ * a given local file is consumed by at most one slot, so two saved slots
+ * that happen to share a filename never both grab the same file — each
+ * pass below only assigns from files not already consumed by an earlier,
+ * higher-confidence pass or an earlier slot in the same pass.
+ *
+ * Pass order (highest confidence first):
+ *   1. content: fingerprint match (exact bytes, robust to a rename)
+ *   2. name-size: same filename AND same byte size (fingerprint unknown/absent)
+ *   3. name-only: same filename only (size differs) — flagged, likely a
+ *      same-name-different-content collision; still offered so the user can
+ *      decide, never auto-applied silently
+ *   4. none: no candidate left — reported as missing
+ */
+export async function matchFederationSetupSlots(
+  setup: FederationSetupFile,
+  files: readonly File[],
+): Promise<FederationSetupSlotMatch[]> {
+  const candidates = await Promise.all(
+    files.map(async (file, index) => ({
+      index,
+      file,
+      fingerprintHex: await computeFileFingerprint(file),
+    })),
+  );
+  const used = new Set<number>();
+
+  const results: (FederationSetupSlotMatch | undefined)[] = new Array(setup.slots.length);
+
+  // Pass 1: content fingerprint.
+  setup.slots.forEach((slot, slotIndex) => {
+    if (!slot.fingerprintHex) return;
+    const match = candidates.find((c) => !used.has(c.index) && c.fingerprintHex === slot.fingerprintHex);
+    if (match) {
+      used.add(match.index);
+      results[slotIndex] = { slot, slotIndex, file: match.file, confidence: 'content' };
+    }
+  });
+
+  // Pass 2: name + size.
+  setup.slots.forEach((slot, slotIndex) => {
+    if (results[slotIndex]) return;
+    const match = candidates.find(
+      (c) => !used.has(c.index) && c.file.name === slot.name && c.file.size === slot.fileSize,
+    );
+    if (match) {
+      used.add(match.index);
+      results[slotIndex] = { slot, slotIndex, file: match.file, confidence: 'name-size' };
+    }
+  });
+
+  // Pass 3: name only (content/size differs — a real collision or a stale file).
+  setup.slots.forEach((slot, slotIndex) => {
+    if (results[slotIndex]) return;
+    const match = candidates.find((c) => !used.has(c.index) && c.file.name === slot.name);
+    if (match) {
+      used.add(match.index);
+      results[slotIndex] = { slot, slotIndex, file: match.file, confidence: 'name-only' };
+    }
+  });
+
+  // Pass 4: missing.
+  setup.slots.forEach((slot, slotIndex) => {
+    if (results[slotIndex]) return;
+    results[slotIndex] = { slot, slotIndex, file: null, confidence: 'none' };
+  });
+
+  return results as FederationSetupSlotMatch[];
+}
+
+/** Outcome classification for a batch of {@link FederationSetupSlotMatch}es, before anything is applied. */
+export interface FederationSetupMatchSummary {
+  total: number;
+  /** Matched with high confidence (content, or name+size) — safe to restore without asking. */
+  resolved: FederationSetupSlotMatch[];
+  /** Same filename but different size/content — offered, but the user should confirm. */
+  mismatched: FederationSetupSlotMatch[];
+  /** No candidate file found at all. */
+  missing: FederationSetupSlotMatch[];
+}
+
+/** Pure classification of match results — used both by the review UI and by tests. */
+export function summarizeFederationSetupMatches(matches: readonly FederationSetupSlotMatch[]): FederationSetupMatchSummary {
+  const resolved = matches.filter((m) => m.confidence === 'content' || m.confidence === 'name-size');
+  const mismatched = matches.filter((m) => m.confidence === 'name-only');
+  const missing = matches.filter((m) => m.confidence === 'none');
+  return { total: matches.length, resolved, mismatched, missing };
+}


### PR DESCRIPTION
## Summary

Closes #3930.

Lets a user save which models make up a federation — load order, visibility, and the alignment anchor — to a small portable JSON file, and reopen it later (possibly on a different machine), matching saved slots back to local files.

### What the file references vs. embeds
Each slot stores the model's original filename, byte size, and a content fingerprint (`computeSourceFingerprint`, the same sampled 64-bit hash the geometry cache already uses). It never embeds file bytes, an absolute path, a `FileSystemFileHandle`, or credentials — reopening always requires re-selecting the actual files. This keeps the format both small and genuinely portable.

### Alignment is replayed, not baked in
Rather than serialize per-model transform matrices, the file records only which slot was the federation anchor. On reopen, every matched model is re-added through the canonical `addModel` load path and `realignFederation()` is re-run against the restored anchor — the same alignment logic a fresh multi-file load performs. This avoids a second alignment pipeline and keeps the file simple.

### Missing/mismatched models are always visible
Matching is one-to-one and content-first: content fingerprint, then name+size, then name-only (flagged as a possible collision), then missing. `applyFederationSetup` always reports `restored / partial / failed` plus explicit missing and mismatched slot names — never a bare "success" when some models weren't found. A review dialog shows every slot's status before anything is applied.

### Determinism
Slots are built from `Array.from(models.values())` (a Map's insertion order = actual load order, never re-sorted) and serialized with an explicit, fixed key order — no hash-map iteration ordering and no embedded timestamp, so saving the same federation state twice produces byte-identical JSON (tested).

### Where it's reachable
Command palette: "Save Federation Setup" / "Open Federation Setup" (dispatches `window` events handled by `FederationSetupControls`, mounted once from `useFileCommands` — the same pattern `ShareDialog` uses — so it works regardless of which toolbar style is active).

## Analogue matched
The viewer's own `handleRefresh` (`toolbar/useFileCommands.tsx`) — "rebuild the federation from fresh bytes, preserving id + order + state" via sequential `addModel(...)` calls — is the closest existing pattern, since the CLI's `delivery-recipe.ts` saved-definition file referenced in earlier guidance does not exist on `upstream/main` yet (still open as #3934). Content fingerprinting reuses the existing `sourceFingerprint.ts` / cache-key pattern rather than inventing a new hash.

## Test plan
- [x] `apps/viewer/src/lib/federation/federationSetupFile.test.ts` — 16 tests: round-trip, determinism (two saves of the same state are byte-identical), strict/loud validation of malformed files (bad version, zero slots, two anchors, missing field), and the keyed-write trap (two federated models sharing a filename resolve correctly by content, one-to-one, regardless of file pick order).
- [x] Mutation testing: removed the anchor-uniqueness check, the one-to-one match guarantee, the format-version check, and the "resolved" classification — each caught by a test.
- [x] `pnpm typecheck` (viewer + all deps) — clean.
- [x] `node scripts/check-module-size.mjs`, `check-test-wiring.mjs`, `check-source-text-assertions.mjs` — all pass (CommandPalette.tsx addition trimmed to stay at its existing 849-line budget).
- Not unit-tested (UI wiring, thin glue over already-tested primitives): `useFederationSetup.ts`'s calls into `addModel`/`realignFederation`, and `FederationSetupControls.tsx`'s dialog/file-input wiring. Left to CI/manual QA per the viewer's runner constraints.
- Full 666-file viewer suite left to CI (not run locally per repo guidance); ran the targeted 102 tests covering touched files, toolbar/export parity, command palette, and federation load-gate/model-slice — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save the current federation setup—including model order, visibility, collapsed state, and alignment anchor—for later reuse.
  * Reopen saved setups by selecting the setup file and matching local model files.
  * Review matched, mismatched, and missing models before restoring.
  * Receive clear results for complete, partial, or failed restorations, including alignment-anchor status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->