### PR TITLE
fix(viewer): split CommandPalette's search/ranking helpers into their own module

### DIFF
--- a/.changeset/command-palette-module-size.md
+++ b/.changeset/command-palette-module-size.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Split `CommandPalette.tsx`'s fuzzy search/ranking and recent-usage helpers into a new `commandPaletteSearch.ts` module. This is a pure internal refactor to bring the file back under the repo's module-size budget (it had grown to 852 lines against an 849-line budget after two same-day PRs each added a command entry) — no command was renamed, removed, or behaviorally changed.

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -107,115 +107,15 @@ import { getRecentFiles, formatFileSize, getCachedFile, getCachedFileNames } fro
 import type { RecentFileEntry } from '@/lib/recent-files';
 import { closeActiveAnalysisExtension } from '@/services/analysis-extensions';
 import { describeRunCommandError } from '@/services/extensions/runtime-errors';
-
-// ── Types ──────────────────────────────────────────────────────────────
-
-type Category =
-  | 'Recent'
-  | 'File'
-  | 'View'
-  | 'Tools'
-  | 'Visibility'
-  | 'Panels'
-  | 'Export'
-  | 'Automation'
-  | 'Preferences'
-  | 'Extensions'
-  | 'Learn';
-
-interface Command {
-  id: string;
-  label: string;
-  keywords: string;           // extra search tokens (no UI display)
-  category: Exclude<Category, 'Recent'>;
-  icon: React.ElementType;
-  shortcut?: string;
-  detail?: string;            // subtle secondary text (e.g. file size)
-  action: () => void;
-  /**
-   * Run the action synchronously in the click handler instead of deferring to the
-   * next animation frame — needed for a file dialog: Chrome only honours
-   * `input.click()` / `showOpenFilePicker()` while transient user activation is
-   * live, which a `requestAnimationFrame` hop would discard.
-   */
-  immediate?: boolean;
-}
-
-interface FlatItem {
-  cmd: Command;
-  flatIdx: number;
-}
-
-// ── Constants ──────────────────────────────────────────────────────────
-
-const RECENT_KEY = 'ifc-lite:cmd-palette:recent';
-const MAX_RECENT = 5;
-const CATEGORY_ORDER: Category[] = [
-  'Recent', 'File', 'View', 'Tools', 'Visibility', 'Panels', 'Export', 'Automation', 'Preferences',
-];
-
-// ── Search scoring ─────────────────────────────────────────────────────
-
-/**
- * Score how well `query` matches `text`.
- *   0   = no match
- *   100 = exact substring
- *   50  = word-start initials
- *   1-25 = tight fuzzy (avg gap ≤ 5)
- */
-function score(query: string, text: string): number {
-  const q = query.toLowerCase();
-  const t = text.toLowerCase();
-
-  // Exact substring
-  if (t.includes(q)) return 100;
-
-  // Word-start initials (e.g. "cs" → "Color Spaces")
-  const words = t.split(/[\s\-_:\/,]+/);
-  let wi = 0, qi = 0;
-  while (wi < words.length && qi < q.length) {
-    if (words[wi].length > 0 && words[wi][0] === q[qi]) qi++;
-    wi++;
-  }
-  if (qi === q.length) return 50;
-
-  // Tight fuzzy — reject if chars are scattered
-  let lastIdx = -1, totalGap = 0;
-  qi = 0;
-  for (let i = 0; i < t.length && qi < q.length; i++) {
-    if (t[i] === q[qi]) {
-      if (lastIdx >= 0) totalGap += i - lastIdx - 1;
-      lastIdx = i;
-      qi++;
-    }
-  }
-  if (qi < q.length) return 0;
-  const avgGap = q.length > 1 ? totalGap / (q.length - 1) : 0;
-  if (avgGap > 5) return 0;
-  return Math.max(1, 25 - Math.round(avgGap * 3));
-}
-
-/** Rank a command against the search query. Label dominates. */
-function rankCommand(cmd: Command, query: string): number {
-  const l = score(query, cmd.label);
-  const k = score(query, cmd.keywords) * 0.9;
-  const c = score(query, cmd.category) * 0.5;
-  return Math.max(l, k, c);
-}
-
-// ── Recent usage ───────────────────────────────────────────────────────
-
-function getRecentIds(): string[] {
-  try { return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]'); }
-  catch { return []; }
-}
-function recordUsage(id: string) {
-  try {
-    const r = getRecentIds().filter(x => x !== id);
-    r.unshift(id);
-    localStorage.setItem(RECENT_KEY, JSON.stringify(r.slice(0, 30)));
-  } catch { /* noop */ }
-}
+import {
+  type Command,
+  type FlatItem,
+  MAX_RECENT,
+  CATEGORY_ORDER,
+  rankCommand,
+  getRecentIds,
+  recordUsage,
+} from './commandPaletteSearch';
 
 /** Toggle a sidebar workspace panel (#1208). The store's `toggleWorkspacePanel`
  *  owns the single-tenant + re-dock + detach semantics; a second activation closes

--- a/apps/viewer/src/components/viewer/commandPaletteSearch.test.ts
+++ b/apps/viewer/src/components/viewer/commandPaletteSearch.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { rankCommand, score, type Command } from './commandPaletteSearch.js';
+
+function command(overrides: Partial<Command> = {}): Command {
+  return {
+    id: 'export:json',
+    label: 'Export JSON',
+    keywords: 'download data',
+    category: 'Export',
+    icon: () => null,
+    action: () => {},
+    ...overrides,
+  };
+}
+
+describe('command palette search extraction (#3957)', () => {
+  it('preserves exact, initials, fuzzy, and rejected-match score tiers', () => {
+    assert.equal(score('json', 'Export JSON'), 100);
+    assert.equal(score('ej', 'Export JSON'), 50);
+    assert.ok(score('ept', 'Export') > 0 && score('ept', 'Export') < 50);
+    assert.equal(score('xyz', 'Export JSON'), 0);
+  });
+
+  it('keeps label matches ahead of keyword and category matches', () => {
+    const cmd = command();
+    assert.equal(rankCommand(cmd, 'json'), 100);
+    assert.equal(rankCommand(cmd, 'download'), 90);
+    assert.equal(rankCommand(cmd, 'export'), 100);
+  });
+});

--- a/apps/viewer/src/components/viewer/commandPaletteSearch.ts
+++ b/apps/viewer/src/components/viewer/commandPaletteSearch.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * CommandPalette search — fuzzy scoring, ranking, and "recent commands"
+ * persistence. Split out of `CommandPalette.tsx`: these are pure functions
+ * (no React, no store) that the palette component composes.
+ */
+
+export type Category =
+  | 'Recent'
+  | 'File'
+  | 'View'
+  | 'Tools'
+  | 'Visibility'
+  | 'Panels'
+  | 'Export'
+  | 'Automation'
+  | 'Preferences'
+  | 'Extensions'
+  | 'Learn';
+
+export interface Command {
+  id: string;
+  label: string;
+  keywords: string;           // extra search tokens (no UI display)
+  category: Exclude<Category, 'Recent'>;
+  icon: React.ElementType;
+  shortcut?: string;
+  detail?: string;            // subtle secondary text (e.g. file size)
+  action: () => void;
+  /**
+   * Run the action synchronously in the click handler instead of deferring to the
+   * next animation frame — needed for a file dialog: Chrome only honours
+   * `input.click()` / `showOpenFilePicker()` while transient user activation is
+   * live, which a `requestAnimationFrame` hop would discard.
+   */
+  immediate?: boolean;
+}
+
+export interface FlatItem {
+  cmd: Command;
+  flatIdx: number;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+export const RECENT_KEY = 'ifc-lite:cmd-palette:recent';
+export const MAX_RECENT = 5;
+export const CATEGORY_ORDER: Category[] = [
+  'Recent', 'File', 'View', 'Tools', 'Visibility', 'Panels', 'Export', 'Automation', 'Preferences',
+];
+
+// ── Search scoring ─────────────────────────────────────────────────────
+
+/**
+ * Score how well `query` matches `text`.
+ *   0   = no match
+ *   100 = exact substring
+ *   50  = word-start initials
+ *   1-25 = tight fuzzy (avg gap ≤ 5)
+ */
+export function score(query: string, text: string): number {
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+
+  // Exact substring
+  if (t.includes(q)) return 100;
+
+  // Word-start initials (e.g. "cs" → "Color Spaces")
+  const words = t.split(/[\s\-_:\/,]+/);
+  let wi = 0, qi = 0;
+  while (wi < words.length && qi < q.length) {
+    if (words[wi].length > 0 && words[wi][0] === q[qi]) qi++;
+    wi++;
+  }
+  if (qi === q.length) return 50;
+
+  // Tight fuzzy — reject if chars are scattered
+  let lastIdx = -1, totalGap = 0;
+  qi = 0;
+  for (let i = 0; i < t.length && qi < q.length; i++) {
+    if (t[i] === q[qi]) {
+      if (lastIdx >= 0) totalGap += i - lastIdx - 1;
+      lastIdx = i;
+      qi++;
+    }
+  }
+  if (qi < q.length) return 0;
+  const avgGap = q.length > 1 ? totalGap / (q.length - 1) : 0;
+  if (avgGap > 5) return 0;
+  return Math.max(1, 25 - Math.round(avgGap * 3));
+}
+
+/** Rank a command against the search query. Label dominates. */
+export function rankCommand(cmd: Command, query: string): number {
+  const l = score(query, cmd.label);
+  const k = score(query, cmd.keywords) * 0.9;
+  const c = score(query, cmd.category) * 0.5;
+  return Math.max(l, k, c);
+}
+
+// ── Recent usage ───────────────────────────────────────────────────────
+
+export function getRecentIds(): string[] {
+  try { return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]'); }
+  catch { return []; }
+}
+export function recordUsage(id: string) {
+  try {
+    const r = getRecentIds().filter(x => x !== id);
+    r.unshift(id);
+    localStorage.setItem(RECENT_KEY, JSON.stringify(r.slice(0, 30)));
+  } catch { /* noop */ }
+}

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -54,7 +54,7 @@
    418 apps/viewer/src/components/viewer/chat/ExecutableCodeBlock.tsx
   1802 apps/viewer/src/components/viewer/ChatPanel.tsx
   1314 apps/viewer/src/components/viewer/ClashPanel.tsx
-   849 apps/viewer/src/components/viewer/CommandPalette.tsx
+   752 apps/viewer/src/components/viewer/CommandPalette.tsx
    410 apps/viewer/src/components/viewer/ComparePanel.tsx
   1059 apps/viewer/src/components/viewer/DataConnector.tsx
   1842 apps/viewer/src/components/viewer/Drawing2DCanvas.tsx


### PR DESCRIPTION
## Summary

`CommandPalette.tsx` grew to 852 lines on `main` against its 849-line `scripts/module-size-allowlist.txt` budget after #3942 and #3945 each landed a command entry the same day. Neither PR individually crossed the budget; together they did, so `node scripts/check-module-size.mjs` exits 1 on a clean checkout of `main` and every open PR inherits the red.

Closes #3957

## Fix

Extracted a coherent, dependency-free seam: the fuzzy-search/ranking and recent-usage-tracking helpers (`Category`/`Command`/`FlatItem` types, `score`/`rankCommand`, `getRecentIds`/`recordUsage`) into a new `commandPaletteSearch.ts`. None of it touches React or the Zustand store, so it lifts out cleanly.

- `CommandPalette.tsx`: 852 -> 752 lines (97 lines of headroom against the new 752-line budget)
- `commandPaletteSearch.ts`: 116 lines (new, well under the 400-line rule)
- The moved code is byte-identical apart from the mechanical `export` keywords the extraction requires (diffed against the pre-extraction file).
- Every command `id` is unchanged (diffed the full `id: '...'` list before/after); the new module is imported and its exports (`Command`, `FlatItem`, `MAX_RECENT`, `CATEGORY_ORDER`, `rankCommand`, `getRecentIds`, `recordUsage`) are used in place, not orphaned.

This is a pure internal refactor — no command was renamed, removed, or behaviorally changed. Never raised the budget or touched CI workflow files.

## Verification

```
$ node scripts/check-module-size.mjs
check-module-size: OK (2339 files measured, 340 allowlisted, 0 new over 400)
```
(exit 0)

- `pnpm --filter @ifc-lite/viewer typecheck` — clean.
- Both existing CommandPalette test files pass:
  - `CommandPalette.anonymized-export.test.tsx`
  - `CommandPalette.exact-type.test.ts`
  - `tests 2, pass 2, fail 0`
- `node scripts/check-test-wiring.mjs` — OK.
- `node scripts/check-source-text-assertions.mjs` — OK (0 new).
- Changeset added (`@ifc-lite/viewer` patch) describing this as a pure internal refactor.

## Test plan

- [x] `node scripts/check-module-size.mjs` exits 0
- [x] `pnpm --filter @ifc-lite/viewer typecheck`
- [x] Targeted CommandPalette tests pass
- [x] `check-test-wiring` / `check-source-text-assertions` pass
- [ ] CI (full viewer suite left to CI per repo convention)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * No user-facing behavior changes. Command palette search, ranking, and recent-command functionality continue to work as before.

* **Refactor**
  * Improved the internal organization and maintainability of command palette functionality while preserving available commands and user interactions.

* **Tests**
  * Added coverage for search matching, ranking, and result prioritization to help ensure consistent command palette behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->