### PR TITLE
fix(server): extract IfcRelAssignsToGroup(ByFactor)/Nests/ConnectsPathElements

### DIFF
--- a/apps/server/src/services/data_model/relationships.rs
+++ b/apps/server/src/services/data_model/relationships.rs
@@ -26,6 +26,19 @@ pub(super) fn extract_relationships(
         "IFCRELASSOCIATESDOCUMENT",
         "IFCRELVOIDSELEMENT",
         "IFCRELFILLSELEMENT",
+        // Added for issue #3964. Each has a live consumer on the TS/WASM
+        // side (see the PR description for the full audit of what was and
+        // wasn't added):
+        //  - IFCRELASSIGNSTOGROUP / IFCRELASSIGNSTOGROUPBYFACTOR: the
+        //    viewer's Groups panel, "By Zone" lens, and IDS `partOf`.
+        //  - IFCRELNESTS: IDS `partOf` maps it onto the same edge bucket as
+        //    IfcRelAggregates (packages/ids/src/bridge/data-accessor.ts).
+        //  - IFCRELCONNECTSPATHELEMENTS: the Properties panel's "connected
+        //    walls" (extractRelationshipsOnDemand).
+        "IFCRELASSIGNSTOGROUP",
+        "IFCRELASSIGNSTOGROUPBYFACTOR",
+        "IFCRELNESTS",
+        "IFCRELCONNECTSPATHELEMENTS",
     ];
 
     let rel_jobs: Vec<_> = jobs
@@ -138,6 +151,24 @@ fn extract_relationship(
         }]);
     }
 
+    // IfcRelConnectsElements (and its subtype IfcRelConnectsPathElements)
+    // carries an OPTIONAL ConnectionGeometry at attr 4, then RelatingElement
+    // at attr 5 and RelatedElement at attr 6 — both SINGLE refs, not lists
+    // (mirrors the TS `extractRelFast` ConnectsElements/ConnectsPathElements
+    // branch in columnar-parser-relationships.ts). The list-based path below
+    // would call `get_list(6)` on a single entity ref, get `None`, and
+    // silently drop the relationship, same failure mode as #1751.
+    if type_upper == "IFCRELCONNECTSPATHELEMENTS" {
+        let relating_id = entity.get_ref(5)?;
+        let related_id = entity.get_ref(6)?;
+        return Some(vec![Relationship {
+            rel_type: type_name.to_string(),
+            rel_id,
+            relating_id,
+            related_id,
+        }]);
+    }
+
     let (relating_idx, related_idx) = match type_upper.as_str() {
         "IFCRELDEFINESBYPROPERTIES" => (5, 4), // RelatingPropertyDefinition at 5, RelatedObjects at 4
         // RelatingType (single ref) at 5, RelatedObjects (list) at 4 — same
@@ -151,6 +182,15 @@ fn extract_relationship(
         "IFCRELASSOCIATESMATERIAL"
         | "IFCRELASSOCIATESCLASSIFICATION"
         | "IFCRELASSOCIATESDOCUMENT" => (5, 4),
+        // IfcRelAssigns base attrs: RelatedObjects(4), RelatedObjectsType(5,
+        // an enum, not a ref), then IfcRelAssignsToGroup adds RelatingGroup(6).
+        // IfcRelAssignsToGroupByFactor is a subtype (adds a trailing Factor
+        // we don't read) with the identical RelatedObjects/RelatingGroup
+        // layout, so it shares this arm.
+        "IFCRELASSIGNSTOGROUP" | "IFCRELASSIGNSTOGROUPBYFACTOR" => (6, 4),
+        // IFCRELNESTS (IfcRelDecomposes): RelatingObject(4), RelatedObjects(5)
+        // — identical layout to IFCRELAGGREGATES, so it falls through to the
+        // default arm below; listed here only for discoverability.
         _ => (4, 5), // Standard: RelatingObject at 4, RelatedObjects at 5
     };
 

--- a/apps/server/src/services/data_model/tests.rs
+++ b/apps/server/src/services/data_model/tests.rs
@@ -733,3 +733,115 @@ fn voids_and_fills_carry_the_ifcrel_express_id() {
     assert_eq!(rel_id_of("IFCRELVOIDSELEMENT"), 40);
     assert_eq!(rel_id_of("IFCRELFILLSELEMENT"), 50);
 }
+
+/// Fixture for issue #3964: a `IfcSystem` grouping a wall via
+/// `IfcRelAssignsToGroup`, an `IfcZone` grouping the same wall via
+/// `IfcRelAssignsToGroupByFactor` (adds a proportional Factor, e.g. zone
+/// occupancy share, but shares the same RelatedObjects/RelatingGroup
+/// membership semantics as its supertype), a door decomposed into a panel via
+/// `IfcRelNests` (a decomposition edge some IFC4 exporters use instead of
+/// `IfcRelAggregates`, e.g. feature/fastener nesting), and two walls joined
+/// end-to-end via `IfcRelConnectsPathElements` (the "connected walls" edge the
+/// Properties panel reads via `extractRelationshipsOnDemand`). None of these
+/// four types were extracted before this fix.
+const NEW_REL_TYPES_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
+#11=IFCWALL('Wall00000000000000002',$,'W2',$,$,$,$,$,$);
+#20=IFCSYSTEM('Sys0000000000000000001',$,'HVAC-1',$,$);
+#21=IFCRELASSIGNSTOGROUP('Grp0000000000000000001',$,$,$,(#10),$,#20);
+#25=IFCZONE('Zon0000000000000000001',$,'Zone-A',$,$);
+#26=IFCRELASSIGNSTOGROUPBYFACTOR('Grf0000000000000000001',$,$,$,(#10),$,#25,0.5);
+#30=IFCDOOR('Doo0000000000000000001',$,'D1',$,$,$,$,$,$);
+#31=IFCDOOR('Doo0000000000000000002',$,'D2',$,$,$,$,$,$);
+#32=IFCRELNESTS('Nst0000000000000000001',$,$,$,#30,(#31));
+#40=IFCRELCONNECTSPATHELEMENTS('Con0000000000000000001',$,$,$,$,#10,#11,$,$,.ATEND.,.ATSTART.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn extracts_assigns_to_group_relationship_orientation() {
+    let dm = extract_data_model(NEW_REL_TYPES_IFC);
+    // RelatingGroup=#20 (IfcSystem), RelatedObjects=(#10) (the wall).
+    assert!(
+        dm.relationships.iter().any(|r| {
+            r.rel_type.eq_ignore_ascii_case("IFCRELASSIGNSTOGROUP")
+                && r.relating_id == 20
+                && r.related_id == 10
+        }),
+        "IFCRELASSIGNSTOGROUP (system -> wall) missing or misoriented: {:?}",
+        dm.relationships
+    );
+}
+
+#[test]
+fn extracts_assigns_to_group_by_factor_relationship_orientation() {
+    let dm = extract_data_model(NEW_REL_TYPES_IFC);
+    // RelatingGroup=#25 (IfcZone), RelatedObjects=(#10) (the wall).
+    assert!(
+        dm.relationships.iter().any(|r| {
+            r.rel_type.eq_ignore_ascii_case("IFCRELASSIGNSTOGROUPBYFACTOR")
+                && r.relating_id == 25
+                && r.related_id == 10
+        }),
+        "IFCRELASSIGNSTOGROUPBYFACTOR (zone -> wall) missing or misoriented: {:?}",
+        dm.relationships
+    );
+}
+
+#[test]
+fn extracts_nests_relationship_orientation() {
+    let dm = extract_data_model(NEW_REL_TYPES_IFC);
+    // RelatingObject=#30 (door), RelatedObjects=(#31) (the nested panel).
+    assert!(
+        dm.relationships.iter().any(|r| {
+            r.rel_type.eq_ignore_ascii_case("IFCRELNESTS")
+                && r.relating_id == 30
+                && r.related_id == 31
+        }),
+        "IFCRELNESTS (door -> panel) missing or misoriented: {:?}",
+        dm.relationships
+    );
+}
+
+#[test]
+fn extracts_connects_path_elements_relationship_orientation() {
+    let dm = extract_data_model(NEW_REL_TYPES_IFC);
+    // RelatingElement=#10 (wall 1), RelatedElement=#11 (wall 2).
+    assert!(
+        dm.relationships.iter().any(|r| {
+            r.rel_type.eq_ignore_ascii_case("IFCRELCONNECTSPATHELEMENTS")
+                && r.relating_id == 10
+                && r.related_id == 11
+        }),
+        "IFCRELCONNECTSPATHELEMENTS (wall -> wall) missing or misoriented: {:?}",
+        dm.relationships
+    );
+}
+
+/// Control: a fixture with none of the four new types must extract exactly as
+/// before — none of them should ever appear for a model that never wrote
+/// them, so a future change to the new-type match arms can't silently start
+/// matching an unrelated type.
+#[test]
+fn fixture_without_new_types_is_unaffected() {
+    let dm = extract_data_model(ASSOCIATIONS_IFC);
+    assert!(
+        !dm.relationships.iter().any(|r| {
+            matches!(
+                r.rel_type.to_uppercase().as_str(),
+                "IFCRELASSIGNSTOGROUP"
+                    | "IFCRELASSIGNSTOGROUPBYFACTOR"
+                    | "IFCRELNESTS"
+                    | "IFCRELCONNECTSPATHELEMENTS"
+            )
+        }),
+        "fixture has none of the new types, but one was extracted: {:?}",
+        dm.relationships
+    );
+}


### PR DESCRIPTION
## Summary
`apps/server/src/services/data_model/relationships.rs`'s `extract_relationships` only extracted 9 `IfcRel*` types; the TS/WASM path (`packages/parser/src/columnar-parser-indexes.ts`) resolves ~19. This adds the 4 of the 10 missing types with confirmed live consumer chains:

- `IFCRELASSIGNSTOGROUP` / `IFCRELASSIGNSTOGROUPBYFACTOR`: viewer Groups panel, "By Zone" lens, IDS `partOf`.
- `IFCRELNESTS`: `packages/ids/src/bridge/data-accessor.ts` maps it onto the same edge bucket as `IfcRelAggregates` for IDS `partOf`.
- `IFCRELCONNECTSPATHELEMENTS`: Properties panel's "connected walls" (`extractRelationshipsOnDemand`).

Left out (no consumer found beyond generic cache/export/query/DuckDB plumbing and parser-level tests): `IFCRELASSIGNSTOPRODUCT`, `IFCRELCONNECTSELEMENTS`, `IFCRELCONNECTSPORTTOELEMENT`, `IFCRELCONNECTSPORTS`, `IFCRELSPACEBOUNDARY`, `IFCRELREFERENCEDINSPATIALSTRUCTURE`.

Edge orientation was verified per added type against the TS `extractRelFast` byte-level scanner, not assumed — `AssignsToGroup(ByFactor)` reads `RelatingGroup` at attr 6, `ConnectsPathElements` reads both ends as single refs at attrs 5/6, `Nests` shares the existing default `(4,5)` arm used for `Aggregates`.

Closes #3964

## Test plan
- [x] RED: new tests failed (`[]`) before the fix
- [x] GREEN: `cargo test -p ifc-lite-server` — 274 passed, 0 failed
- [x] Mutation: removing `IFCRELNESTS` from the type list fails `extracts_nests_relationship_orientation`
- [x] Mutation: flipping `ConnectsPathElements` orientation fails `extracts_connects_path_elements_relationship_orientation`
- [x] Control: all 9 pre-existing relationship types unaffected (same ids/orientation)
- [x] Control: a fixture with none of the new types produces the same output as before
- [x] `cargo clippy -p ifc-lite-server -- -D warnings` clean
- [x] `node scripts/check-test-wiring.mjs` / `check-source-text-assertions.mjs` clean
- [x] `node scripts/check-module-size.mjs` — only the pre-existing `CommandPalette.tsx` offender (fixed in #3958), no new offender
- [x] Browser/WASM path untouched (no `packages/*` changes, no changeset needed)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved relationship data extraction for additional grouping, nesting, and connected path elements.
  - Relationship links now preserve the correct relating and related element orientation.

- **Bug Fixes**
  - Previously unrecognized relationship types are now included in extracted model data.
  - Added validation to ensure models without these relationships continue to produce no incorrect results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->