### PR TITLE
fix(ci): route Rust test manifests to Cargo in revert oracle

### DIFF
--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -89,6 +89,7 @@ import {
   UNOBSERVED,
   SURGICAL_ADVICE,
 } from './lib/revert-oracle.mjs';
+import { cargoTestOwner } from './lib/revert-oracle-cargo.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 
 const SELF_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -177,14 +178,6 @@ function findUp(startDir, filename) {
   }
 }
 
-function crateNameFor(absFile) {
-  const dir = findUp(dirname(absFile), 'Cargo.toml');
-  if (!dir) return null;
-  const toml = readFileSync(join(dir, 'Cargo.toml'), 'utf8');
-  const m = /^\s*\[package\][\s\S]*?^\s*name\s*=\s*"([^"]+)"/m.exec(toml);
-  return m ? { dir, crate: m[1] } : null;
-}
-
 /** Group test files by the package that owns them and pick each one's runner. */
 function planRuns(testPaths) {
   /** @type {Map<string, {dir: string, files: string[], script: string|undefined, crate: string|null}>} */
@@ -193,14 +186,14 @@ function planRuns(testPaths) {
 
   for (const rel of testPaths) {
     const abs = join(ROOT, rel);
-    if (rel.endsWith('.rs')) {
-      const c = crateNameFor(abs);
-      if (!c) { unassigned.push(rel); continue; }
+    const c = cargoTestOwner(abs, ROOT);
+    if (c) {
       const key = `cargo:${c.crate}`;
       if (!groups.has(key)) groups.set(key, { dir: c.dir, files: [], script: undefined, crate: c.crate });
       groups.get(key).files.push(rel);
       continue;
     }
+    if (rel.endsWith('.rs')) { unassigned.push(rel); continue; }
     const pkgDir = findUp(dirname(abs), 'package.json');
     if (!pkgDir) { unassigned.push(rel); continue; }
     if (!groups.has(pkgDir)) {

--- a/scripts/lib/revert-oracle-cargo.mjs
+++ b/scripts/lib/revert-oracle-cargo.mjs
@@ -1,0 +1,18 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+
+/** Test sources and data share the nearest Cargo package's runner (#3974). */
+export function cargoTestOwner(file, root) {
+  let dir = dirname(file);
+  while (!isAbsolute(relative(root, dir)) && relative(root, dir).split(sep)[0] !== '..') {
+    const manifest = join(dir, 'Cargo.toml');
+    if (existsSync(manifest)) {
+      const toml = readFileSync(manifest, 'utf8');
+      const name = /^\s*\[package\][\s\S]*?^\s*name\s*=\s*"([^"]+)"/m.exec(toml);
+      return name ? { dir, crate: name[1] } : null;
+    }
+    if (dir === root || dirname(dir) === dir) break;
+    dir = dirname(dir);
+  }
+  return null;
+}

--- a/scripts/lib/revert-oracle-cargo.test.mjs
+++ b/scripts/lib/revert-oracle-cargo.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { cargoTestOwner } from './revert-oracle-cargo.mjs';
+
+test('#3974: Rust test data and source resolve to Cargo; workspace-only manifests do not', () => {
+  const root = mkdtempSync(join(tmpdir(), 'oracle-cargo-'));
+  try {
+    const dir = join(root, 'rust', 'geometry');
+    mkdirSync(join(dir, 'tests', 'manifests'), { recursive: true });
+    writeFileSync(join(root, 'Cargo.toml'), '[workspace]\nmembers = ["rust/geometry"]\n');
+    writeFileSync(join(dir, 'Cargo.toml'), '[package]\nname = "ifc-lite-geometry"\n');
+    const owner = { dir, crate: 'ifc-lite-geometry' };
+    assert.deepEqual(cargoTestOwner(join(dir, 'tests', 'manifests', 'census.tsv'), root), owner);
+    assert.deepEqual(cargoTestOwner(join(dir, 'tests', 'census.rs'), root), owner);
+    assert.equal(cargoTestOwner(join(root, 'scripts', 'gate.test.mjs'), root), null);
+    assert.equal(cargoTestOwner(join(root, '..', 'outside.rs'), root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #3974.

Rust test reference manifests were classified as tests but sent to the root JavaScript package, causing the production-observation gate to abort before executing assertions. Resolve the nearest Cargo package for test sources and data alike, preserving the existing Cargo verdict handling and refusing workspace-only ownership.

Validation: 50 oracle tests passed, including real temporary-directory fixtures for Rust source, manifest data, workspace-only and out-of-root paths. No tests or gate verdicts are skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust test ownership detection by associating test files with their nearest Cargo package.
  * Rust test files without a matching package are now marked as unassigned.

* **Tests**
  * Added coverage for package ownership resolution, workspace-only manifests, and files outside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->