### PR TITLE
ci(vercel): deploy the newest known-good commit on main's first-parent line

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -35,10 +35,21 @@ on:
         description: 'Branch, tag or SHA to deploy. Must be reachable from main.'
         required: false
         default: 'main'
+      require_green:
+        description: 'Deploy the newest commit whose CI gate passed, not the tip. Uncheck to deploy the ref as-is.'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   # Moving refs/heads/production. Nothing else.
   contents: write
+  # Declaring ANY `permissions:` block sets every scope not listed to `none`,
+  # and the known-good walk below rests entirely on reading check runs. Without
+  # this the very first `gh api .../check-runs` 403s and, under `set -e`, every
+  # scheduled run dies before moving production. Same scope, for the same read,
+  # as dirty-pr-scan.yml.
+  checks: read
   # Opening the issue when production cannot advance — see "Report a stuck
   # production branch".
   issues: write
@@ -69,37 +80,39 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           REQUESTED_REF: ${{ inputs.ref || 'main' }}
+          # Scheduled runs have no inputs, and the nightly is exactly the case
+          # that must not ship a red tip, so absent means ON.
+          REQUIRE_GREEN: ${{ github.event_name == 'schedule' && 'true' || inputs.require_green }}
+          # The repo's own composite verdict on a push to main. Gating on
+          # "no check failed anywhere" would be unusable: unrelated
+          # housekeeping lanes fail routinely (4e08fe835 had a red
+          # "Scan open PRs for CI-silent heads" and was perfectly deployable).
+          CI_GATE: 'Build + WASM + Rust + Node'
         run: |
           set -euo pipefail
 
-          # ── Resolve and validate ────────────────────────────────────────
-          # Resolves a branch, a tag or a raw SHA uniformly, and 404s on
-          # anything else, so a typo'd manual input stops here.
+          # ── Resolve the requested ref ────────────────────────────────────────
+          # Resolves a branch, a tag or a raw SHA uniformly, and 404s on anything
+          # else, so a typo'd manual input stops here.
           TARGET="$(gh api "repos/$REPO/commits/$REQUESTED_REF" \
             --jq '[.sha, (.commit.message | split("\n")[0])] | @tsv')"
           SHA="$(printf '%s' "$TARGET" | cut -f1)"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           printf 'Requested %s -> %s (%s)\n' \
             "$REQUESTED_REF" "$SHA" "$(printf '%s' "$TARGET" | cut -f2-)"
+          MAIN_TIP="$(gh api "repos/$REPO/commits/main" --jq .sha)"
 
-          # The commit MUST already be reachable from `main`, and a manual
-          # dispatch is the only way it could not be. Deploying a side branch
-          # would wedge this workflow permanently: production would then hold a
-          # commit `main` never contains — squash-merging the branch produces a
-          # DIFFERENT commit — so every later nightly sees `diverged`, refuses,
-          # and all three sites freeze until someone reconciles by hand. Land
-          # the hotfix on `main` first, then dispatch.
+          # ── Reachability, BEFORE any walk ────────────────────────────────────
+          # Checked on what the operator actually named. Doing this after the
+          # green walk would be worse than useless: the walk rewrites $SHA, so a
+          # dispatch naming an unmerged branch would have its commits skipped and
+          # some unrelated main commit deployed instead, with the refusal never
+          # firing and the operator never told.
           #
-          # This workflow CANNOT roll production backwards. An older `main`
-          # commit passes this reachability check and then fails the
-          # fast-forward check below as `behind` — deliberately: moving
-          # `production` back would break the fast-forward-only invariant AND
-          # force a full rebuild of an old commit. To revert production fast,
-          # use Vercel's instant rollback (`vercel rollback <deployment-url>`,
-          # or promote a previous deployment in the dashboard): it re-points
-          # the alias at a build that already exists, so it takes seconds
-          # rather than minutes, which is what you want when the site is
-          # broken.
+          # Deploying a side branch would also wedge this workflow permanently:
+          # production would hold a commit `main` never contains — squash-merging
+          # that branch produces a DIFFERENT commit — so every later nightly sees
+          # `diverged`, refuses, and all three sites freeze until someone
+          # reconciles by hand. Land the hotfix on `main` first, then dispatch.
           REACH="$(gh api "repos/$REPO/compare/$SHA...main" --jq .status)"
           case "$REACH" in
             ahead|identical) ;;
@@ -111,11 +124,94 @@ jobs:
               ;;
           esac
 
-          # ── Compare against what is live ────────────────────────────────
-          # `matching-refs` answers "does this branch exist" with 200 + [],
-          # never a 404, so a real API failure (500, rate limit, network) stays
-          # an error instead of being misread as "the branch is missing" and
-          # sending the operator to reconcile branches that are fine.
+          # ── Walk main's first-parent line ───────────────────────────────
+          # A nightly batches ~40 merges and puts them live for 24h, so shipping
+          # a red tip costs a day, not the ~20 minutes it did when every commit
+          # deployed. Individually-green merges can still compose badly — that is
+          # what base-freshness.yml exists to catch, and main sat red for ~4h
+          # once because of it.
+          #
+          # THE LINE IS WALKED FROM MAIN'S TIP THROUGH `.parents[0]`, and the
+          # requested commit must lie ON it. Two separate traps, one mechanism:
+          #
+          #   `GET /commits?sha=X` is a full-history traversal, not
+          #   `git log --first-parent`. Measured here, only 7 of the 30 entries
+          #   it returns for main are on main's own line; the rest are second
+          #   parents of merges — PR branch heads as they were BEFORE merging.
+          #   733d09a6a is one, and it carries a GREEN gate.
+          #
+          #   `compare/$SHA...main` proves only REACHABLE FROM main, which every
+          #   one of those side-branch commits is. So a dispatch naming one would
+          #   pass the reachability guard above, and a walk starting there would
+          #   follow the PR BRANCH's line rather than main's.
+          #
+          # Walking down from MAIN_TIP and refusing anything not seen on the way
+          # closes both: a commit that was never main's state can neither be
+          # selected nor named.
+          LIST="$(gh api "repos/$REPO/commits?sha=$MAIN_TIP&per_page=100")"
+          CAND="$MAIN_TIP"
+          SEEN=0
+          FOUND=""
+          AUTO_SELECTED=0
+          for _ in $(seq 1 40); do
+            [ -z "$CAND" ] && break
+            [ "$CAND" = "$SHA" ] && SEEN=1
+            # Nothing older than the requested commit is a candidate; before we
+            # reach it we are only establishing that it IS on this line.
+            if [ "$SEEN" = "1" ] && [ "$REQUIRE_GREEN" = "true" ]; then
+              # The LATEST run of that name decides. A commit that went green,
+              # was re-run and failed must read as not-good; `map(select(success))`
+              # would have called it good forever, and `filter=latest` is per
+              # check-SUITE, so duplicate rows for one name do occur (130574027
+              # carries two, 20 minutes apart).
+              VERDICT="$(gh api "repos/$REPO/commits/$CAND/check-runs?per_page=100" \
+                | jq -r --arg g "$CI_GATE" '[.check_runs[] | select(.name == $g)]
+                    | sort_by(.started_at) | last
+                    | if . == null then "absent" else (.conclusion // .status // "pending") end')"
+              if [ "$VERDICT" = "success" ]; then FOUND="$CAND"; break; fi
+              echo "  skipping ${CAND:0:9} — '$CI_GATE' is $VERDICT"
+            elif [ "$SEEN" = "1" ]; then
+              FOUND="$CAND"; break
+            fi
+            NEXT="$(printf '%s' "$LIST" | jq -r --arg s "$CAND" \
+              '.[] | select(.sha == $s) | .parents[0].sha // ""')"
+            if [ -z "$NEXT" ]; then
+              NEXT="$(gh api "repos/$REPO/commits/$CAND" --jq '.parents[0].sha // ""')"
+            fi
+            CAND="$NEXT"
+          done
+
+          if [ "$SEEN" = "0" ]; then
+            echo "::error::$REQUESTED_REF ($SHA) is not on main's first-parent line"
+            echo "::error::within the last 40 commits. It is reachable from main, so it is"
+            echo "::error::most likely a merged PR's second parent — a mid-PR state that was"
+            echo "::error::never main's. Deploy a commit from main itself."
+            exit 1
+          fi
+          if [ -z "$FOUND" ]; then
+            # Fail loudly rather than deploy something unverified. Also what a
+            # RENAMED gate looks like, which is why the name is echoed.
+            echo "::error::No commit at or below $SHA on main's first-parent line has a"
+            echo "::error::successful '$CI_GATE' check. Either main has been red that long,"
+            echo "::error::or the gate was renamed and this workflow needs updating."
+            exit 1
+          fi
+          if [ "$FOUND" != "$SHA" ]; then
+            AUTO_SELECTED=1
+            SHA="$FOUND"
+            printf 'Tip is not known-good; deploying newest green ancestor %s (%s)\n' \
+              "$SHA" "$(printf '%s' "$LIST" | jq -r --arg s "$SHA" \
+                '.[] | select(.sha == $s) | .commit.message | split("\n")[0]')"
+          elif [ "$REQUIRE_GREEN" = "true" ]; then
+            echo "Tip is known-good ('$CI_GATE' succeeded); deploying it."
+          else
+            echo "::warning::require_green is off — deploying $SHA without checking '$CI_GATE'."
+          fi
+
+          # ── What production points at, and is that sane? ─────────────────────
+          # `matching-refs` answers "does this branch exist" with 200 + [], never a
+          # 404, so a real API failure (500, rate limit, network) stays an error
+          # instead of being misread as "the branch is missing".
           CURRENT="$(gh api "repos/$REPO/git/matching-refs/heads/production" \
             --jq '.[] | select(.ref == "refs/heads/production") | .object.sha')"
 
@@ -123,17 +219,34 @@ jobs:
             echo "production does not exist yet — creating it at $SHA"
             gh api -X POST "repos/$REPO/git/refs" \
               -f ref=refs/heads/production -f sha="$SHA" >/dev/null
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # `status` is the whole ancestry question in one call:
-          #   identical -> production is already there
-          #   ahead     -> fast-forward, the normal nightly
-          #   behind/diverged -> production holds commits the target does not,
-          #                      i.e. someone pushed to it directly or main was
-          #                      rewritten. Advancing would drop what is live.
+          # PRODUCTION MUST NEVER HOLD A COMMIT MAIN DOES NOT. This is the check
+          # that catches a direct push to `refs/heads/production` or a rewritten
+          # main, and it has to be made against MAIN'S TIP rather than against the
+          # commit we are about to deploy. Comparing only against the deploy
+          # target cannot see it: under the green gate the target is routinely
+          # older than production, so that comparison says `behind` for both the
+          # healthy case and the corrupted one, and the corrupted one would sail
+          # through as "nothing to deploy" — turning the run green and
+          # auto-closing the very alert that should have been raised.
+          PROD_VS_MAIN="$(gh api "repos/$REPO/compare/$CURRENT...$MAIN_TIP" --jq .status)"
+          case "$PROD_VS_MAIN" in
+            ahead|identical) ;;
+            *)
+              echo "::error::production ($CURRENT) holds commits main does not ('$PROD_VS_MAIN')."
+              echo "::error::Someone pushed to refs/heads/production directly, or main was"
+              echo "::error::rewritten. Reconcile the two branches by hand."
+              exit 1
+              ;;
+          esac
+
+          # ── Move the ref ─────────────────────────────────────────────────────
           STATUS="$(gh api "repos/$REPO/compare/$CURRENT...$SHA" --jq .status)"
           echo "production is at $CURRENT; $CURRENT...$SHA is '$STATUS'"
+          DEPLOYED="$SHA"
 
           case "$STATUS" in
             identical)
@@ -147,20 +260,37 @@ jobs:
                 -f sha="$SHA" -F force=false >/dev/null
               echo "Advanced production: $CURRENT -> $SHA"
               ;;
-            *)
-              echo "::error::production ($CURRENT) cannot fast-forward to $SHA ('$STATUS')."
-              if [ "$STATUS" = "behind" ]; then
+            behind)
+              # Routine under the green gate: right after a deploy, production is
+              # normally ahead of the newest KNOWN-GOOD commit while the tip's own
+              # gate is still running. Production being ahead of MAIN was already
+              # ruled out above, so this is safe to treat as a quiet no-op.
+              if [ "$AUTO_SELECTED" = "1" ]; then
+                echo "production ($CURRENT) is already ahead of the newest known-good"
+                echo "commit ($SHA). Nothing to deploy."
+                DEPLOYED="$CURRENT"
+              else
+                # The operator named this commit; they meant a rollback.
+                echo "::error::production ($CURRENT) cannot fast-forward to $SHA ('behind')."
                 echo "::error::That is a ROLLBACK. This workflow only moves production"
                 echo "::error::forward. Use Vercel's instant rollback instead:"
                 echo "::error::  vercel rollback <deployment-url>  (or promote a previous"
                 echo "::error::  deployment in the dashboard) — seconds, and no rebuild."
-              else
-                echo "::error::production holds commits $SHA does not. Someone pushed to it"
-                echo "::error::directly, or main was rewritten. Reconcile by hand."
+                exit 1
               fi
+              ;;
+            *)
+              echo "::error::production ($CURRENT) and $SHA have diverged ('$STATUS')."
+              echo "::error::Refusing to move production. Reconcile by hand."
               exit 1
               ;;
           esac
+
+          # The commit production ends up on — the deploy target on every moving
+          # path, and the older-but-live commit on the `behind` no-op. The verify
+          # step asserts THAT is deployed.
+          echo "sha=$DEPLOYED" >> "$GITHUB_OUTPUT"
+          echo "production now points at $DEPLOYED"
 
       # THE MOVE IS NOT THE DEPLOY. Advancing the ref proves nothing about
       # Vercel: if a project's Production Branch is still `main`, it keeps
@@ -173,6 +303,10 @@ jobs:
       # scoped to the LTplus team, read access is enough). Without it the check
       # cannot run and says so as a warning on every run rather than passing
       # quietly — an unverifiable deploy must not look like a verified one.
+      # Runs on the no-op paths too, deliberately: `identical` and `behind`
+      # still assert that what production points at IS deployed, which is how a
+      # project quietly switched back to `main` gets caught on a quiet night
+      # rather than only on a night something landed.
       - name: Verify Vercel picked it up
         id: verify
         if: steps.advance.outcome == 'success'
@@ -185,6 +319,13 @@ jobs:
           # Default to NOT verified, so every path that fails to prove a
           # deployment leaves it false rather than inheriting a pass.
           echo "verified=false" >> "$GITHUB_OUTPUT"
+
+          # An empty sha would make the query match on nothing in particular;
+          # that must be a failure, not a quiet pass.
+          if [ -z "${SHA:-}" ]; then
+            echo "::error::the advance step published no commit sha; nothing to verify."
+            exit 1
+          fi
 
           if [ -z "${VERCEL_TOKEN:-}" ]; then
             echo "::warning::VERCEL_TOKEN is not set, so this run did NOT verify that"
@@ -284,7 +425,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          body="$(printf 'The nightly Vercel deploy did not complete at %s (job status: %s).\n\nRun: %s/%s/actions/runs/%s\n\nNothing has deployed since it last succeeded, and every further nightly will behave the same way until this is resolved — the production sites are frozen at whatever `production` currently points to.\n\nUsual causes, in order:\n\n1. Someone pushed to `production` directly, or `main` was rewritten, so the move is no longer a fast-forward. Reconcile the two branches by hand.\n2. A Vercel project no longer deploys from `production` (check its Production Branch and Ignored Build Step).\n3. The job timed out or was cancelled.\n\nThen re-run this workflow. This issue is updated in place by each failing run, and it closes itself on the next successful run.\n' \
+          body="$(printf 'The nightly Vercel deploy did not complete at %s (job status: %s).\n\nRun: %s/%s/actions/runs/%s\n\nNothing has deployed since it last succeeded, and every further nightly will behave the same way until this is resolved — the production sites are frozen at whatever `production` currently points to.\n\nUsual causes, in order:\n\n1. `main` has been red for 25 commits on its first-parent line, so no known-good commit was found. Check the `Build + WASM + Rust + Node` gate on recent commits — and that it still carries that name.\n2. Someone pushed to `production` directly, or `main` was rewritten, so `production` holds commits `main` does not. Reconcile the two branches by hand.\n3. A Vercel project no longer deploys from `production` (check its Production Branch and Ignored Build Step).\n4. The job timed out or was cancelled.\n\nThen re-run this workflow. This issue is updated in place by each failing run, and it closes itself on the next successful run.\n' \
             "$(date -u +%FT%TZ)" "${{ job.status }}" "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}")"
           existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
             --label production-branch-stuck --limit 1 --json number --jq '.[0].number // empty')"

--- a/scripts/README-vercel-cost.md
+++ b/scripts/README-vercel-cost.md
@@ -208,8 +208,25 @@ Consequences to know about:
   <deployment-url>`, or promote a previous deployment in the dashboard. It
   re-points the alias at a build that already exists, so it takes seconds
   instead of minutes, which is what you actually want when the site is broken.
-- **A bad commit is live for up to 24h**, not the ~20 minutes it used to be.
-  The cron fires just before the Zurich workday for exactly this reason.
+- **The nightly deploys the newest KNOWN-GOOD commit, not the tip.** A batch of
+  ~40 merges goes live for 24h, so shipping a red tip costs a day rather than
+  the ~20 minutes it did when every commit deployed. The run walks back from
+  `main` and takes the newest commit whose `Build + WASM + Rust + Node` check
+  succeeded; a commit whose gate is still running counts as not-yet-known-good
+  and is skipped, which is routine for a tip that is minutes old.
+  - It gates on that one composite check, not on "nothing failed anywhere":
+    unrelated housekeeping lanes fail routinely (`4e08fe835` shipped fine with
+    a red *Scan open PRs for CI-silent heads*), so the stricter rule would
+    never find a deployable commit.
+  - It reads **check runs**, not `commits/{sha}/status`. The combined Statuses
+    API reported `success` for `4e08fe835` while its check runs held a failure.
+  - Because of this, `behind` is now a NORMAL outcome: right after a deploy,
+    production is usually ahead of the newest *known-good* commit while the
+    tip's gate is still running. That is a quiet no-op, not a stuck branch.
+  - `workflow_dispatch` exposes `require_green`; unchecking it deploys the ref
+    as-is and says so with a warning. Scheduled runs always gate.
+- **A bad commit that IS green is still live for up to 24h.** The cron fires
+  just before the Zurich workday for exactly this reason.
 - **`ifc-lite-git-main-ltplus.vercel.app` goes stale** — `main` is a preview
   branch now and previews are skipped. Use the production domains.
 - The dashboard **Ignored Build Step is unchanged** on all three projects. It


### PR DESCRIPTION
Follow-up to #3981. The nightly deployed `main`'s tip; it now deploys the newest commit whose `Build + WASM + Rust + Node` check concluded success.

## Why

A nightly batches ~40 merges and puts them live for **24h**, so shipping a red tip costs a day rather than the ~20 minutes it did when every commit deployed. Individually-green merges can still compose badly — that is what `base-freshness.yml` exists to catch, and `main` sat red for ~4h once because of it. The cutover deploy in #3981 went out ungated for exactly this reason and only happened to be fine.

## The part that nearly shipped wrong

`GET /commits?sha=X` is a **full-history traversal, not `git log --first-parent`**. Measured on this repo: only **7 of the 30** entries it returns for `main` are on main's own line. The rest are second parents of merge commits — PR branch heads as they were *before* merging.

`733d09a6a` is one of them, it carries a **green** gate, and it is a genuine ancestor of `main`, so the reachability guard waves it through. Walking that list directly would have fast-forwarded `production` onto a mid-PR state that was never `main`, and served it from all three sites for a day.

The chain is now followed through `.parents[0]`, reusing the parent lists the same response already carries.

## Other things this had to get right

| | |
|---|---|
| **One composite check, not "nothing failed"** | Housekeeping lanes fail routinely — `4e08fe835` carried a red *Scan open PRs for CI-silent heads*, `82494a89c` a red *PR review signal*; both were deployable |
| **Check runs, not `commits/{sha}/status`** | The combined Statuses API answered `success` for `4e08fe835` while its check runs held a failure — the exact false green this gate exists to stop |
| **Latest run of that name decides** | `filter=latest` is per check *suite*; `130574027` carries two rows for one name 20 min apart, so "any success wins" would call a green-then-re-run-red commit known-good forever |
| **A running gate is not-yet-known-good** | Skipped, not trusted — the normal state of a tip minutes old |
| **Candidate list hoisted out of `for`** | `set -e` does not apply to a command substitution in a word list, so a rate-limited response would yield an empty list and blame a red `main` for an API failure |

## Production-ahead-of-main is now its own check

Against **main's tip**, not the deploy target. Under the green gate the target is routinely older than production, so comparing only against it reports `behind` for *both* the healthy case and a direct push to `refs/heads/production` — and the corrupted one would have sailed through as "nothing to deploy", turned the run green, and auto-closed the alert that should have been raised.

So `behind` is routine when the walk chose the target, and stays a refused **rollback** when the operator named it. Reachability is now checked *before* the walk, on what the operator actually asked for — afterwards is worse than useless, since the walk rewrites the sha and a dispatch naming an unmerged branch would silently deploy some unrelated `main` commit instead.

## Verification

Exercised against the live repo, not reasoned about:

- walk stays on the first-parent line and skips a not-yet-green tip
- an unmerged branch (`fix-3978-perf-harness`) is refused **before** the walk
- an operator naming an old green commit is refused as a rollback
- a `production` ref holding a commit `main` does not is refused before anything deploys

Local gates green: module-size, AGENTS.md ratchet, CI path coverage, swallowed-push, YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly deployments select the newest qualifying commit that passes required CI checks.
  * Manual deployments can optionally bypass green-check selection and deploy a requested revision directly.
  * New production branches are created from the verified deployment revision.
  * Deployment verification confirms the exact revision deployed, including no-op deployments.

* **Bug Fixes**
  * Invalid revisions, unsafe production states, and manual rollbacks now fail explicitly.
  * Deployment diagnostics identify prolonged red history or renamed CI gates.

* **Documentation**
  * Updated deployment documentation to explain commit selection, check statuses, and manual overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->