### PR TITLE
perf(geometry): share immutable built-in processor registrations

### DIFF
--- a/.changeset/cold-load-processor-registry.md
+++ b/.changeset/cold-load-processor-registry.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Share immutable built-in geometry processor setup while preserving custom processor replacement and independently owned diagnostics.

--- a/rust/geometry/src/router/diagnostics/processor_failures.rs
+++ b/rust/geometry/src/router/diagnostics/processor_failures.rs
@@ -42,9 +42,9 @@ impl GeometryRouter {
     /// down to every `processor.process` call site; that is a follow-up, not a
     /// reason to keep dropping the records.
     ///
-    /// `register` stores ONE `Arc` per processor under each supported IFC type
+    /// `register` stores ONE `Rc` per custom processor under each supported IFC type
     /// (`IfcBooleanResult` and `IfcBooleanClippingResult` share an instance),
-    /// so iterating the map visits the same processor twice; the second visit
+    /// so iterating custom registrations can visit the same processor twice; the second visit
     /// drains an already-emptied log and contributes nothing. No double count.
     pub fn drain_processor_failures(&self) {
         let mut swept: Vec<BoolFailure> = Vec::new();

--- a/rust/geometry/src/router/instancing.rs
+++ b/rust/geometry/src/router/instancing.rs
@@ -101,11 +101,11 @@ impl GeometryRouter {
                     // the drop is recorded rather than the source withheld — but it
                     // MUST be recorded, or the one place the loss is visible at all
                     // is the one place instancing removed.
-                    match self.processors.get(&sub_item.ifc_type) {
+                    match self.processors.get(&sub_item.ifc_type, self.schema) {
                         Some(processor) => match processor.process(
                             &sub_item,
                             decoder,
-                            &self.schema,
+                            self.schema,
                             self.tessellation_quality,
                         ) {
                             Ok(mut sub_mesh) => {

--- a/rust/geometry/src/router/mapped_item.rs
+++ b/rust/geometry/src/router/mapped_item.rs
@@ -204,11 +204,11 @@ impl GeometryRouter {
                 }
                 continue;
             }
-            match self.processors.get(&sub_item.ifc_type) {
+            match self.processors.get(&sub_item.ifc_type, self.schema) {
                 Some(processor) => match processor.process(
                     &sub_item,
                     decoder,
-                    &self.schema,
+                    self.schema,
                     self.tessellation_quality,
                 ) {
                     Ok(mut sub_mesh) => {

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -40,22 +40,17 @@ pub use content_hash::FACETED_BREP_DEDUP_FACE_LIMIT;
 mod tests;
 
 use crate::material_layer_index::MaterialLayerIndex;
-use crate::processors::{
-    AdvancedBrepProcessor, BSplineSurfaceProcessor, BlockProcessor, BooleanClippingProcessor,
-    CsgSolidProcessor, ExtrudedAreaSolidProcessor, ExtrudedAreaSolidTaperedProcessor,
-    FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, IfcAlignmentProcessor,
-    PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor,
-    SectionedSolidHorizontalProcessor, ShellBasedSurfaceModelProcessor, SphereProcessor,
-    SurfaceCurveSweptAreaSolidProcessor, SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
-};
+use crate::processors::{BooleanClippingProcessor, CsgSolidProcessor};
+mod processor_registry;
+use processor_registry::ProcessorRegistry;
 use crate::tessellation::TessellationQuality;
 use crate::{BoolFailure, Mesh, Result};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 use nalgebra::Matrix4;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 /// Shared content-dedup cache: maps a 128-bit structural item hash to the
 /// LOCAL (pre-placement, void-free, colour-free) item mesh PLUS its precomputed
@@ -110,8 +105,8 @@ pub type MappedInstancePlan = Arc<FxHashMap<u32, (u32, u32)>>;
 
 /// Geometry router - routes entities to processors
 pub struct GeometryRouter {
-    schema: IfcSchema,
-    processors: HashMap<IfcType, Arc<dyn GeometryProcessor>>,
+    schema: &'static IfcSchema,
+    processors: ProcessorRegistry,
     /// Cache for IfcRepresentationMap source geometry (MappedItem instancing)
     /// Key: RepresentationMap entity ID, Value: Processed mesh.
     ///
@@ -243,11 +238,13 @@ pub struct GeometryRouter {
 impl GeometryRouter {
     /// Create new router with default processors
     pub fn new() -> Self {
-        let schema = IfcSchema::new();
-        let schema_clone = schema.clone();
-        let mut router = Self {
+        // Routing metadata is immutable through this API. Keep one default
+        // per process/wasm instance; processor diagnostics remain router-local.
+        static SCHEMA: OnceLock<IfcSchema> = OnceLock::new();
+        let schema = SCHEMA.get_or_init(IfcSchema::new);
+        Self {
             schema,
-            processors: HashMap::new(),
+            processors: ProcessorRegistry::new(),
             mapped_item_cache: RefCell::new(FxHashMap::default()),
             shared_mapped_item_cache: None, // armed by `enable_shared_mapped_item_cache`
             geometry_hash_cache: RefCell::new(FxHashMap::default()),
@@ -271,39 +268,7 @@ impl GeometryRouter {
             instancing_batch_local: false, // native global-template mode by default
             instanced_sources_materialized: RefCell::new(FxHashSet::default()),
             unsupported: RefCell::new(Default::default()),
-        };
-
-        // Register default P0 processors
-        router.register(Box::new(ExtrudedAreaSolidProcessor::new(
-            schema_clone.clone(),
-        )));
-        router.register(Box::new(ExtrudedAreaSolidTaperedProcessor::new(
-            schema_clone.clone(),
-        )));
-        router.register(Box::new(TriangulatedFaceSetProcessor::new()));
-        router.register(Box::new(PolygonalFaceSetProcessor::new()));
-        router.register(Box::new(FacetedBrepProcessor::new()));
-        router.register(Box::new(BooleanClippingProcessor::new()));
-        router.register(Box::new(SweptDiskSolidProcessor::new(schema_clone.clone())));
-        router.register(Box::new(RevolvedAreaSolidProcessor::new(
-            schema_clone.clone(),
-        )));
-        router.register(Box::new(SurfaceCurveSweptAreaSolidProcessor::new(
-            schema_clone.clone(),
-        )));
-        router.register(Box::new(SectionedSolidHorizontalProcessor::new(
-            schema_clone.clone(),
-        )));
-        router.register(Box::new(AdvancedBrepProcessor::new()));
-        router.register(Box::new(BSplineSurfaceProcessor::new()));
-        router.register(Box::new(ShellBasedSurfaceModelProcessor::new()));
-        router.register(Box::new(FaceBasedSurfaceModelProcessor::new()));
-        router.register(Box::new(BlockProcessor::new()));
-        router.register(Box::new(SphereProcessor::new()));
-        router.register(Box::new(CsgSolidProcessor::new()));
-        router.register(Box::new(IfcAlignmentProcessor::new()));
-
-        router
+        }
     }
 
     /// Create router and extract unit scale from IFC file
@@ -702,9 +667,9 @@ impl GeometryRouter {
 
     /// Register a geometry processor
     pub fn register(&mut self, processor: Box<dyn GeometryProcessor>) {
-        let processor_arc: Arc<dyn GeometryProcessor> = Arc::from(processor);
-        for ifc_type in processor_arc.supported_types() {
-            self.processors.insert(ifc_type, Arc::clone(&processor_arc));
+        let processor_rc: Rc<dyn GeometryProcessor> = Rc::from(processor);
+        for ifc_type in processor_rc.supported_types() {
+            self.processors.insert(ifc_type, Rc::clone(&processor_rc));
         }
     }
 
@@ -727,7 +692,7 @@ impl GeometryRouter {
 
     /// Get schema reference
     pub fn schema(&self) -> &IfcSchema {
-        &self.schema
+        self.schema
     }
 }
 

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -25,6 +25,7 @@ pub(crate) const IDENTITY_ROW_MAJOR: [f64; 16] = [
 ];
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use rustc_hash::FxHashSet;
+use std::rc::Rc;
 use std::sync::Arc;
 
 // Maximum nested IfcMappedItem depth for a single geometry item. Shared with
@@ -736,7 +737,7 @@ impl GeometryRouter {
                 self.rtc_offset.2 / self.unit_scale,
             );
             let mut mesh =
-                processor.process_with_rtc(item, decoder, &self.schema, rtc_file_units)?;
+                processor.process_with_rtc(item, decoder, self.schema, rtc_file_units)?;
             mesh.validate_indices();
             self.scale_mesh(&mut mesh);
             // Mark positions as already RTC-shifted by setting a flag
@@ -749,9 +750,9 @@ impl GeometryRouter {
         }
 
         // Check if we have a processor for this type
-        if let Some(processor) = self.processors.get(&item.ifc_type) {
+        if let Some(processor) = self.processors.get(&item.ifc_type, self.schema) {
             let mut mesh =
-                processor.process(item, decoder, &self.schema, self.tessellation_quality)?;
+                processor.process(item, decoder, self.schema, self.tessellation_quality)?;
             // Safety net: strip any out-of-bounds indices before downstream use
             mesh.validate_indices();
 
@@ -810,12 +811,12 @@ impl GeometryRouter {
         element: &DecodedEntity,
         decoder: &mut EntityDecoder,
     ) -> Result<Option<Mesh>> {
-        let processor = match self.processors.get(&IfcType::IfcAlignment) {
-            Some(p) => Arc::clone(p),
+        let processor = match self.processors.get(&IfcType::IfcAlignment, self.schema) {
+            Some(p) => Rc::clone(p),
             None => return Ok(None),
         };
         let mut mesh =
-            match processor.process(element, decoder, &self.schema, self.tessellation_quality) {
+            match processor.process(element, decoder, self.schema, self.tessellation_quality) {
             Ok(m) => m,
             // Missing Axis or unparseable curve isn't fatal — fall back so
             // the caller can still walk a normal representation if present.

--- a/rust/geometry/src/router/processor_registry.rs
+++ b/rust/geometry/src/router/processor_registry.rs
@@ -127,7 +127,3 @@ impl ProcessorRegistry {
         self.overrides.values().chain(self.defaults.iter().filter_map(OnceCell::get))
     }
 }
-
-#[cfg(test)]
-#[path = "processor_registry_tests.rs"]
-mod tests;

--- a/rust/geometry/src/router/processor_registry.rs
+++ b/rust/geometry/src/router/processor_registry.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Router-local processors, initialized only for representation families used.
+//! Custom registrations retain the public per-type replacement contract.
+
+use super::GeometryProcessor;
+use crate::processors::{
+    AdvancedBrepProcessor, BSplineSurfaceProcessor, BlockProcessor, BooleanClippingProcessor,
+    CsgSolidProcessor, ExtrudedAreaSolidProcessor, ExtrudedAreaSolidTaperedProcessor,
+    FaceBasedSurfaceModelProcessor, FacetedBrepProcessor, IfcAlignmentProcessor,
+    PolygonalFaceSetProcessor, RevolvedAreaSolidProcessor, SectionedSolidHorizontalProcessor,
+    ShellBasedSurfaceModelProcessor, SphereProcessor, SurfaceCurveSweptAreaSolidProcessor,
+    SweptDiskSolidProcessor, TriangulatedFaceSetProcessor,
+};
+use ifc_lite_core::{IfcSchema, IfcType};
+use std::cell::OnceCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+const TYPES: [&[IfcType]; 18] = [
+    &[IfcType::IfcExtrudedAreaSolid],
+    &[IfcType::IfcExtrudedAreaSolidTapered],
+    &[IfcType::IfcTriangulatedFaceSet, IfcType::IfcTriangulatedIrregularNetwork],
+    &[IfcType::IfcPolygonalFaceSet],
+    &[IfcType::IfcFacetedBrep],
+    &[IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult],
+    &[IfcType::IfcSweptDiskSolid],
+    &[IfcType::IfcRevolvedAreaSolid],
+    &[IfcType::IfcSurfaceCurveSweptAreaSolid, IfcType::IfcFixedReferenceSweptAreaSolid],
+    &[IfcType::IfcSectionedSolidHorizontal],
+    &[IfcType::IfcAdvancedBrep, IfcType::IfcAdvancedBrepWithVoids],
+    &[IfcType::IfcBSplineSurfaceWithKnots, IfcType::IfcRationalBSplineSurfaceWithKnots],
+    &[IfcType::IfcShellBasedSurfaceModel],
+    &[IfcType::IfcFaceBasedSurfaceModel],
+    &[IfcType::IfcBlock],
+    &[IfcType::IfcSphere],
+    &[IfcType::IfcCsgSolid],
+    &[IfcType::IfcAlignment],
+];
+
+fn slot(ifc_type: IfcType) -> Option<usize> {
+    Some(match ifc_type {
+        IfcType::IfcExtrudedAreaSolid => 0,
+        IfcType::IfcExtrudedAreaSolidTapered => 1,
+        IfcType::IfcTriangulatedFaceSet | IfcType::IfcTriangulatedIrregularNetwork => 2,
+        IfcType::IfcPolygonalFaceSet => 3,
+        IfcType::IfcFacetedBrep => 4,
+        IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => 5,
+        IfcType::IfcSweptDiskSolid => 6,
+        IfcType::IfcRevolvedAreaSolid => 7,
+        IfcType::IfcSurfaceCurveSweptAreaSolid | IfcType::IfcFixedReferenceSweptAreaSolid => 8,
+        IfcType::IfcSectionedSolidHorizontal => 9,
+        IfcType::IfcAdvancedBrep | IfcType::IfcAdvancedBrepWithVoids => 10,
+        IfcType::IfcBSplineSurfaceWithKnots | IfcType::IfcRationalBSplineSurfaceWithKnots => 11,
+        IfcType::IfcShellBasedSurfaceModel => 12,
+        IfcType::IfcFaceBasedSurfaceModel => 13,
+        IfcType::IfcBlock => 14,
+        IfcType::IfcSphere => 15,
+        IfcType::IfcCsgSolid => 16,
+        IfcType::IfcAlignment => 17,
+        _ => return None,
+    })
+}
+
+fn create(index: usize, schema: &IfcSchema) -> Rc<dyn GeometryProcessor> {
+    match index {
+        0 => Rc::new(ExtrudedAreaSolidProcessor::new(schema.clone())),
+        1 => Rc::new(ExtrudedAreaSolidTaperedProcessor::new(schema.clone())),
+        2 => Rc::new(TriangulatedFaceSetProcessor::new()),
+        3 => Rc::new(PolygonalFaceSetProcessor::new()),
+        4 => Rc::new(FacetedBrepProcessor::new()),
+        5 => Rc::new(BooleanClippingProcessor::new()),
+        6 => Rc::new(SweptDiskSolidProcessor::new(schema.clone())),
+        7 => Rc::new(RevolvedAreaSolidProcessor::new(schema.clone())),
+        8 => Rc::new(SurfaceCurveSweptAreaSolidProcessor::new(schema.clone())),
+        9 => Rc::new(SectionedSolidHorizontalProcessor::new(schema.clone())),
+        10 => Rc::new(AdvancedBrepProcessor::new()),
+        11 => Rc::new(BSplineSurfaceProcessor::new()),
+        12 => Rc::new(ShellBasedSurfaceModelProcessor::new()),
+        13 => Rc::new(FaceBasedSurfaceModelProcessor::new()),
+        14 => Rc::new(BlockProcessor::new()),
+        15 => Rc::new(SphereProcessor::new()),
+        16 => Rc::new(CsgSolidProcessor::new()),
+        17 => Rc::new(IfcAlignmentProcessor::new()),
+        _ => unreachable!("built-in processor slot"),
+    }
+}
+
+pub(super) struct ProcessorRegistry {
+    defaults: [OnceCell<Rc<dyn GeometryProcessor>>; TYPES.len()],
+    overrides: HashMap<IfcType, Rc<dyn GeometryProcessor>>,
+}
+
+impl ProcessorRegistry {
+    pub(super) fn new() -> Self {
+        Self {
+            defaults: std::array::from_fn(|_| OnceCell::new()),
+            overrides: HashMap::new(),
+        }
+    }
+
+    pub(super) fn get(&self, ifc_type: &IfcType, schema: &IfcSchema) -> Option<&Rc<dyn GeometryProcessor>> {
+        if let Some(processor) = self.overrides.get(ifc_type) {
+            return Some(processor);
+        }
+        let index = slot(*ifc_type)?;
+        Some(self.defaults[index].get_or_init(|| create(index, schema)))
+    }
+
+    pub(super) fn insert(&mut self, ifc_type: IfcType, processor: Rc<dyn GeometryProcessor>) {
+        self.overrides.insert(ifc_type, processor);
+        if let Some(index) = slot(ifc_type) {
+            // Match eager map replacement: an instance loses its failure log
+            // and allocation when its last supported type is overridden.
+            if TYPES[index].iter().all(|t| self.overrides.contains_key(t)) {
+                self.defaults[index].take();
+            }
+        }
+    }
+
+    pub(super) fn values(&self) -> impl Iterator<Item = &Rc<dyn GeometryProcessor>> {
+        // Draining must not initialize unused processors. Multi-type built-ins
+        // share one cell and are drained once; custom aliases share an Rc as
+        // before (subsequent visits drain an empty log).
+        self.overrides.values().chain(self.defaults.iter().filter_map(OnceCell::get))
+    }
+}
+
+#[cfg(test)]
+#[path = "processor_registry_tests.rs"]
+mod tests;

--- a/rust/geometry/src/router/processor_registry_tests.rs
+++ b/rust/geometry/src/router/processor_registry_tests.rs
@@ -2,95 +2,132 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::*;
-use ifc_lite_core::{DecodedEntity, EntityDecoder};
-use crate::{BoolFailure, Mesh, Result, TessellationQuality};
+// Included by the existing test module, never the new production registry:
+// a production-only revert must still collect and run every assertion.
+use crate::processors::*;
+use crate::{BoolFailure, GeometryProcessor, GeometryRouter, Mesh, Result, TessellationQuality};
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+use std::cell::Cell;
+use std::rc::Rc;
 
 const UNSUPPORTED_BOOLEAN: &str = "#1=IFCBOOLEANRESULT(.DIFFERENCE.,#2,#3);\n\
     #2=IFCSECTIONEDSPINE($,(),());\n#3=IFCEXTRUDEDAREASOLID($,$,$,1.);";
 
-fn mesh_unsupported_boolean(registry: &ProcessorRegistry) {
+fn mesh_unsupported_boolean(router: &GeometryRouter) {
     let mut decoder = EntityDecoder::new(UNSUPPORTED_BOOLEAN);
     let entity = decoder.decode_by_id(1).unwrap();
-    let mesh = registry.get(&entity.ifc_type, &IfcSchema::new()).unwrap()
-        .process(&entity, &mut decoder, &IfcSchema::new(), TessellationQuality::Medium)
-        .unwrap();
+    let mesh = router.process_representation_item(&entity, &mut decoder).unwrap();
     assert!(mesh.is_empty(), "unsupported base operands must not invent geometry");
 }
 
-fn failure_count(registry: &ProcessorRegistry) -> usize {
-    registry.values().map(|p| p.take_bool_failures().len()).sum()
+fn failure_count(router: &GeometryRouter) -> usize {
+    router.take_csg_failures().values().map(Vec::len).sum()
 }
 
-// A consumer can replace only one of a processor's supported IFC types. Use
-// the real boolean mesher to exercise its diagnostic state across that boundary.
-struct SingleTypeBoolean(BooleanClippingProcessor);
+// Delegate real meshing and diagnostics; observe ownership through Drop only.
+struct RegisteredBoolean {
+    processor: BooleanClippingProcessor,
+    types: Vec<IfcType>,
+    drops: Rc<Cell<usize>>,
+}
 
-impl GeometryProcessor for SingleTypeBoolean {
+impl Drop for RegisteredBoolean {
+    fn drop(&mut self) { self.drops.set(self.drops.get() + 1); }
+}
+
+impl GeometryProcessor for RegisteredBoolean {
     fn process(&self, entity: &DecodedEntity, decoder: &mut EntityDecoder,
         schema: &IfcSchema, quality: TessellationQuality) -> Result<Mesh> {
-        self.0.process(entity, decoder, schema, quality)
+        self.processor.process(entity, decoder, schema, quality)
     }
+    fn supported_types(&self) -> Vec<IfcType> { self.types.clone() }
+    fn take_bool_failures(&self) -> Vec<BoolFailure> { self.processor.take_bool_failures() }
+}
 
-    fn supported_types(&self) -> Vec<IfcType> {
-        vec![IfcType::IfcBooleanResult]
-    }
-
-    fn take_bool_failures(&self) -> Vec<BoolFailure> {
-        self.0.take_bool_failures()
-    }
+fn register_boolean(router: &mut GeometryRouter, types: Vec<IfcType>, drops: &Rc<Cell<usize>>) {
+    router.register(Box::new(RegisteredBoolean {
+        processor: BooleanClippingProcessor::new(), types, drops: drops.clone(),
+    }));
 }
 
 #[test]
 fn issue_3987_default_dispatch_preserves_every_advertised_subtype() {
-    // Dispatch must cover each processor's own compatibility contract, including
-    // less-common subtypes such as IfcTriangulatedIrregularNetwork. Aliases must
-    // share an instance so processing and destructive diagnostics share state.
-    let registry = ProcessorRegistry::new();
-    for index in 0..TYPES.len() {
-        let reference = create(index, &IfcSchema::new());
-        let supported = reference.supported_types();
-        assert_eq!(TYPES[index], supported.as_slice());
-        let first = registry.get(&supported[0], &IfcSchema::new()).unwrap();
-        for ifc_type in supported {
-            let processor = registry.get(&ifc_type, &IfcSchema::new()).expect("advertised IFC subtype must route");
-            assert!(processor.supported_types().contains(&ifc_type));
-            assert!(Rc::ptr_eq(first, processor), "aliases must retain one failure log");
+    let schema = IfcSchema::new();
+    let references: Vec<Box<dyn GeometryProcessor>> = vec![
+        Box::new(ExtrudedAreaSolidProcessor::new(schema.clone())),
+        Box::new(ExtrudedAreaSolidTaperedProcessor::new(schema.clone())),
+        Box::new(TriangulatedFaceSetProcessor::new()), Box::new(PolygonalFaceSetProcessor::new()),
+        Box::new(FacetedBrepProcessor::new()), Box::new(BooleanClippingProcessor::new()),
+        Box::new(SweptDiskSolidProcessor::new(schema.clone())),
+        Box::new(RevolvedAreaSolidProcessor::new(schema.clone())),
+        Box::new(SurfaceCurveSweptAreaSolidProcessor::new(schema.clone())),
+        Box::new(SectionedSolidHorizontalProcessor::new(schema.clone())),
+        Box::new(AdvancedBrepProcessor::new()), Box::new(BSplineSurfaceProcessor::new()),
+        Box::new(ShellBasedSurfaceModelProcessor::new()), Box::new(FaceBasedSurfaceModelProcessor::new()),
+        Box::new(BlockProcessor::new()), Box::new(SphereProcessor::new()),
+        Box::new(CsgSolidProcessor::new()), Box::new(IfcAlignmentProcessor::new()),
+    ];
+    let router = GeometryRouter::new();
+    for processor in references {
+        for ifc_type in processor.supported_types() {
+            // Missing attributes are a bounded decoder fixture. The actual
+            // processor's error/empty mesh must survive dispatch, rather than
+            // becoming the router's unsupported-type error for a missed alias.
+            let source = format!("#1={}();", ifc_type.to_string().to_uppercase());
+            let mut direct_decoder = EntityDecoder::new(&source);
+            let mut routed_decoder = EntityDecoder::new(&source);
+            let direct_entity = direct_decoder.decode_by_id(1).unwrap();
+            let routed_entity = routed_decoder.decode_by_id(1).unwrap();
+            let expected = processor.process(&direct_entity, &mut direct_decoder, &schema, TessellationQuality::Medium);
+            let actual = router.process_representation_item(&routed_entity, &mut routed_decoder);
+            match (expected, actual) {
+                (Err(expected), Err(actual)) => assert_eq!(actual.to_string(), expected.to_string(), "{ifc_type:?}"),
+                (Ok(expected), Ok(actual)) => {
+                    assert_eq!(actual.positions, expected.positions, "{ifc_type:?}");
+                    assert_eq!(actual.indices, expected.indices, "{ifc_type:?}");
+                    assert_eq!(actual.normals, expected.normals, "{ifc_type:?}");
+                }
+                (expected, actual) => panic!("{ifc_type:?}: direct={expected:?}, routed={actual:?}"),
+            }
         }
     }
 }
 
 #[test]
 fn issue_3987_partial_override_preserves_the_remaining_alias_diagnostics() {
-    let mut registry = ProcessorRegistry::new();
-    mesh_unsupported_boolean(&registry);
-    registry.insert(IfcType::IfcBooleanResult,
-        Rc::new(SingleTypeBoolean(BooleanClippingProcessor::new())));
-    assert_eq!(failure_count(&registry), 1, "the clipping alias still owns the original log");
-    mesh_unsupported_boolean(&registry);
-    assert_eq!(failure_count(&registry), 1, "the replacement must report its own meshing failure");
-    assert_eq!(failure_count(&registry), 0, "diagnostics are drained once");
+    let mut router = GeometryRouter::new();
+    mesh_unsupported_boolean(&router);
+    let drops = Rc::new(Cell::new(0));
+    register_boolean(&mut router, vec![IfcType::IfcBooleanResult], &drops);
+    assert_eq!(failure_count(&router), 1, "the clipping alias still owns the original log");
+    mesh_unsupported_boolean(&router);
+    assert_eq!(failure_count(&router), 1, "the replacement reports its own meshing failure");
+    assert_eq!(failure_count(&router), 0, "aliases drain a shared log only once");
 }
 
 #[test]
 fn issue_3987_full_override_releases_the_replaced_processor_and_its_log() {
-    let mut registry = ProcessorRegistry::new();
-    mesh_unsupported_boolean(&registry);
-    let original = Rc::downgrade(registry.get(&IfcType::IfcBooleanResult, &IfcSchema::new()).unwrap());
-    let replacement: Rc<dyn GeometryProcessor> = Rc::new(BooleanClippingProcessor::new());
-    for ifc_type in replacement.supported_types() {
-        registry.insert(ifc_type, replacement.clone());
-    }
-    assert!(original.upgrade().is_none(), "last-alias replacement must release retained state");
-    assert_eq!(failure_count(&registry), 0, "an orphaned old processor cannot report failures");
-    mesh_unsupported_boolean(&registry);
-    assert_eq!(failure_count(&registry), 1);
+    let mut router = GeometryRouter::new();
+    mesh_unsupported_boolean(&router);
+    router.register(Box::new(BooleanClippingProcessor::new()));
+    assert_eq!(failure_count(&router), 0, "last-alias override must discard the old built-in log");
+    let drops = Rc::new(Cell::new(0));
+    register_boolean(&mut router, vec![IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult], &drops);
+    mesh_unsupported_boolean(&router);
+    let replacements = Rc::new(Cell::new(0));
+    register_boolean(&mut router, vec![IfcType::IfcBooleanResult], &replacements);
+    assert_eq!(drops.get(), 0, "one remaining alias still owns the processor");
+    register_boolean(&mut router, vec![IfcType::IfcBooleanClippingResult], &replacements);
+    assert_eq!(drops.get(), 1, "the final alias releases the processor immediately");
+    assert_eq!(failure_count(&router), 0, "orphaned processors cannot report stale failures");
+    mesh_unsupported_boolean(&router);
+    assert_eq!(failure_count(&router), 1);
 }
 
 #[test]
 fn issue_3987_two_routers_cannot_share_failure_state() {
-    let first = ProcessorRegistry::new();
-    let second = ProcessorRegistry::new();
+    let first = GeometryRouter::new();
+    let second = GeometryRouter::new();
     mesh_unsupported_boolean(&first);
     assert_eq!(failure_count(&second), 0);
     mesh_unsupported_boolean(&second);

--- a/rust/geometry/src/router/processor_registry_tests.rs
+++ b/rust/geometry/src/router/processor_registry_tests.rs
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+use ifc_lite_core::{DecodedEntity, EntityDecoder};
+use crate::{BoolFailure, Mesh, Result, TessellationQuality};
+
+const UNSUPPORTED_BOOLEAN: &str = "#1=IFCBOOLEANRESULT(.DIFFERENCE.,#2,#3);\n\
+    #2=IFCSECTIONEDSPINE($,(),());\n#3=IFCEXTRUDEDAREASOLID($,$,$,1.);";
+
+fn mesh_unsupported_boolean(registry: &ProcessorRegistry) {
+    let mut decoder = EntityDecoder::new(UNSUPPORTED_BOOLEAN);
+    let entity = decoder.decode_by_id(1).unwrap();
+    let mesh = registry.get(&entity.ifc_type, &IfcSchema::new()).unwrap()
+        .process(&entity, &mut decoder, &IfcSchema::new(), TessellationQuality::Medium)
+        .unwrap();
+    assert!(mesh.is_empty(), "unsupported base operands must not invent geometry");
+}
+
+fn failure_count(registry: &ProcessorRegistry) -> usize {
+    registry.values().map(|p| p.take_bool_failures().len()).sum()
+}
+
+// A consumer can replace only one of a processor's supported IFC types. Use
+// the real boolean mesher to exercise its diagnostic state across that boundary.
+struct SingleTypeBoolean(BooleanClippingProcessor);
+
+impl GeometryProcessor for SingleTypeBoolean {
+    fn process(&self, entity: &DecodedEntity, decoder: &mut EntityDecoder,
+        schema: &IfcSchema, quality: TessellationQuality) -> Result<Mesh> {
+        self.0.process(entity, decoder, schema, quality)
+    }
+
+    fn supported_types(&self) -> Vec<IfcType> {
+        vec![IfcType::IfcBooleanResult]
+    }
+
+    fn take_bool_failures(&self) -> Vec<BoolFailure> {
+        self.0.take_bool_failures()
+    }
+}
+
+#[test]
+fn issue_3987_default_dispatch_preserves_every_advertised_subtype() {
+    // Dispatch must cover each processor's own compatibility contract, including
+    // less-common subtypes such as IfcTriangulatedIrregularNetwork. Aliases must
+    // share an instance so processing and destructive diagnostics share state.
+    let registry = ProcessorRegistry::new();
+    for index in 0..TYPES.len() {
+        let reference = create(index, &IfcSchema::new());
+        let supported = reference.supported_types();
+        assert_eq!(TYPES[index], supported.as_slice());
+        let first = registry.get(&supported[0], &IfcSchema::new()).unwrap();
+        for ifc_type in supported {
+            let processor = registry.get(&ifc_type, &IfcSchema::new()).expect("advertised IFC subtype must route");
+            assert!(processor.supported_types().contains(&ifc_type));
+            assert!(Rc::ptr_eq(first, processor), "aliases must retain one failure log");
+        }
+    }
+}
+
+#[test]
+fn issue_3987_partial_override_preserves_the_remaining_alias_diagnostics() {
+    let mut registry = ProcessorRegistry::new();
+    mesh_unsupported_boolean(&registry);
+    registry.insert(IfcType::IfcBooleanResult,
+        Rc::new(SingleTypeBoolean(BooleanClippingProcessor::new())));
+    assert_eq!(failure_count(&registry), 1, "the clipping alias still owns the original log");
+    mesh_unsupported_boolean(&registry);
+    assert_eq!(failure_count(&registry), 1, "the replacement must report its own meshing failure");
+    assert_eq!(failure_count(&registry), 0, "diagnostics are drained once");
+}
+
+#[test]
+fn issue_3987_full_override_releases_the_replaced_processor_and_its_log() {
+    let mut registry = ProcessorRegistry::new();
+    mesh_unsupported_boolean(&registry);
+    let original = Rc::downgrade(registry.get(&IfcType::IfcBooleanResult, &IfcSchema::new()).unwrap());
+    let replacement: Rc<dyn GeometryProcessor> = Rc::new(BooleanClippingProcessor::new());
+    for ifc_type in replacement.supported_types() {
+        registry.insert(ifc_type, replacement.clone());
+    }
+    assert!(original.upgrade().is_none(), "last-alias replacement must release retained state");
+    assert_eq!(failure_count(&registry), 0, "an orphaned old processor cannot report failures");
+    mesh_unsupported_boolean(&registry);
+    assert_eq!(failure_count(&registry), 1);
+}
+
+#[test]
+fn issue_3987_two_routers_cannot_share_failure_state() {
+    let first = ProcessorRegistry::new();
+    let second = ProcessorRegistry::new();
+    mesh_unsupported_boolean(&first);
+    assert_eq!(failure_count(&second), 0);
+    mesh_unsupported_boolean(&second);
+    assert_eq!(failure_count(&first), 1);
+    assert_eq!(failure_count(&second), 1);
+}

--- a/rust/geometry/src/router/tests.rs
+++ b/rust/geometry/src/router/tests.rs
@@ -9,8 +9,8 @@ use ifc_lite_core::EntityDecoder;
 #[test]
 fn test_router_creation() {
     let router = GeometryRouter::new();
-    // Router registers default processors on creation
-    assert!(!router.processors.is_empty());
+    // Default dispatch is available before any custom registration.
+    assert!(router.processors.get(&ifc_lite_core::IfcType::IfcExtrudedAreaSolid, router.schema).is_some());
 }
 
 #[test]

--- a/rust/geometry/src/router/tests.rs
+++ b/rust/geometry/src/router/tests.rs
@@ -9,8 +9,11 @@ use ifc_lite_core::EntityDecoder;
 #[test]
 fn test_router_creation() {
     let router = GeometryRouter::new();
-    // Default dispatch is available before any custom registration.
-    assert!(router.processors.get(&ifc_lite_core::IfcType::IfcExtrudedAreaSolid, router.schema).is_some());
+    let mut decoder = EntityDecoder::new("#1=IFCSPHERE($,2.);");
+    let sphere = decoder.decode_by_id(1).unwrap();
+    let mesh = router.process_representation_item(&sphere, &mut decoder).unwrap();
+    assert!(mesh.triangle_count() > 0);
+    assert!(mesh.positions.iter().all(|value| value.is_finite()));
 }
 
 #[test]
@@ -1062,3 +1065,6 @@ fn the_same_item_under_a_body_source_is_still_counted_on_the_occurrence_path() {
         "the gate keys on the representation, not on the item type: {unsupported:?}"
     );
 }
+
+#[path = "processor_registry_tests.rs"]
+mod processor_registry_tests;

--- a/rust/geometry/src/router/textured.rs
+++ b/rust/geometry/src/router/textured.rs
@@ -161,11 +161,11 @@ impl GeometryRouter {
                 }
             }
 
-            match self.processors.get(&item.ifc_type) {
+            match self.processors.get(&item.ifc_type, self.schema) {
                 Some(processor) => match processor.process(
                     &item,
                     decoder,
-                    &self.schema,
+                    self.schema,
                     self.tessellation_quality,
                 ) {
                     Ok(mut sub_mesh) => {

--- a/rust/geometry/tests/router_construction_allocations.rs
+++ b/rust/geometry/tests/router_construction_allocations.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3987: repeated per-job construction must not allocate unused routing state.
+//! This standalone integration target survives a production-only revert and
+//! measures a resource contract, not elapsed time or an assumed byte threshold.
+use ifc_lite_geometry::GeometryRouter;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+struct CountingSystem;
+thread_local! {
+    static ENABLED: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+
+fn record_allocation() {
+    if ENABLED.try_with(Cell::get).unwrap_or(false) {
+        let _ = ALLOCATIONS.try_with(|count| count.set(count.get() + 1));
+    }
+}
+
+unsafe impl GlobalAlloc for CountingSystem {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        // SAFETY: forward the allocator's original layout unchanged.
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        // SAFETY: forward the allocator's original layout unchanged.
+        unsafe { System.alloc_zeroed(layout) }
+    }
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        record_allocation();
+        // SAFETY: preserve pointer ownership, old layout and requested size.
+        unsafe { System.realloc(pointer, layout, size) }
+    }
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: forward the allocation and its original layout unchanged.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingSystem = CountingSystem;
+
+struct Recording;
+impl Drop for Recording {
+    fn drop(&mut self) { ENABLED.with(|enabled| enabled.set(false)); }
+}
+
+#[test]
+fn issue_3987_warmed_router_construction_allocates_no_unused_registry_or_schema() {
+    // Initialize immutable shared schema and TLS before the measured scope.
+    drop(std::hint::black_box(GeometryRouter::new()));
+    ALLOCATIONS.with(|count| count.set(0));
+    ENABLED.with(|enabled| enabled.set(true));
+    let recording = Recording;
+    let router = std::hint::black_box(GeometryRouter::new());
+    drop(recording); // disable before assertions, formatting and router cleanup
+    let allocations = ALLOCATIONS.with(Cell::get);
+    assert_eq!(allocations, 0, "an unused per-job router must reuse immutable routing metadata");
+    drop(router);
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -129,7 +129,7 @@ Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
 
 ### Retained processor registry ownership (#3987)
 
-Built-in processor registrations now share immutable setup while each router keeps its own failure state and custom replacement behavior. Retained in the cumulative cold-load candidate; no isolated throughput gain is attributed to this layer. Native constructor profiles identify the mechanism, but native and actual browser-worker verdicts remain separate. Do not replace custom processors or share mutable diagnostics to reduce setup further.
+Built-in processor registrations share immutable setup while each router keeps its own failure state and custom replacement behavior. Own-layer native subset comparisons did not establish a meaningful full-load improvement; the cumulative result must not be attributed to this layer. Constructor profiles identify avoided setup work, not a throughput verdict. Keep custom processors and mutable diagnostics independent. Browser performance is a separate verdict; invalid Firefox cohorts and unrun follow-ups provide no supporting result.
 
 ### N-ary repair validation (#3925)
 

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -127,6 +127,10 @@ WASM-specific structural cost (not in the native probe, by design):
 
 Encoded so a spike does not re-walk a dead end. History lives in the PRs cited.
 
+### Retained processor registry ownership (#3987)
+
+Built-in processor registrations now share immutable setup while each router keeps its own failure state and custom replacement behavior. Retained in the cumulative cold-load candidate; no isolated throughput gain is attributed to this layer. Native constructor profiles identify the mechanism, but native and actual browser-worker verdicts remain separate. Do not replace custom processors or share mutable diagnostics to reduce setup further.
+
 ### N-ary repair validation (#3925)
 
 Rebase before measuring geometry. The old direct-router census converted survey


### PR DESCRIPTION
Constructing a `GeometryRouter` repeatedly allocated the same built-in processor registrations. Share immutable defaults while preserving router-local custom `register()` replacements and diagnostic state.

Closes #3987.

At `abe32005b9892d3a16db406843a20e2b2a7eecb9`, focused registry tests passed; `cargo test --workspace` passed 2,809 tests with 36 ignored, and `cargo clippy --workspace --all-targets -- -D warnings` passed. The actual revert oracle using the corrected executor collected the same 1,265 tests on both sides: all passed at the head, while restoring old production caused one resource-invariant assertion failure. Earlier discovery/fail-fast failures are retained rather than presented as successful coverage. The tests also exercise custom override precedence, release of replaced processors and independent failure state.

Own-layer native Haus/CSG-129 comparisons used five interleaved fresh-process pairs per fixture against `06ef1dcd80fae841f33c6ec7d96166b1d01e23af`; the full-call subset was effectively flat/slightly slower (+0.30%), with matching ordered geometry fingerprints/counts. No meaningful isolated speedup or isolated browser gain is claimed.

The [committed evidence bundle](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) keeps these layer results separate from the cumulative stack: native full-call loading improved 15.53% across the fixed corpus; supplemental Chrome full readiness improved 28.70%, but Haus was slower in every pair (median paired increase 26 ms) and several geometry-completion results regressed. The original Chrome strict audit remains failed; the reviewed local analytics-404 disposition and missing historical event URLs are explicit. Firefox's original cohort is invalid under its memory rule; functional controls do not qualify Firefox throughput, and recovery remains unrun. Neither the 30% target nor universal absence of performance regressions is established.

These are prior, artifact-pinned validation results, not certification of the eventual landing head. Applicable exact-head CI, parity/API/WASM gates and review must complete before merge; this body makes no all-green or deployment claim.
