### PR TITLE
perf(core): bound transient decoder allocation lifetimes

### DIFF
--- a/.changeset/cold-load-decoder-lifetimes.md
+++ b/.changeset/cold-load-decoder-lifetimes.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Add reusable-output Rust decoder helpers while preserving allocating wrappers, reduce discarded transient metadata values, and join expired-cache disposal before native processing returns.

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -394,6 +394,19 @@ await client.parseParquetStream(file, (batch) => {
 
 See the [Server Guide](server.md) for complete server documentation.
 
+### Native Rust decoder scratch buffers
+
+For repeated native decoding, caller-owned scratch vectors can be reused with
+`EntityDecoder::get_entity_ref_list_fast_into(entity_id, &mut ids)` and
+`get_polyloop_coords_cached_into(entity_id, &mut coords)`. Each replaces the
+buffer contents and returns `Some(())` on success or `None` with an empty buffer
+on failure. The reference-list helper preserves authored order and duplicates,
+dropping oversized references. The PolyLoop helper preserves coordinate order
+and rejects the whole loop for missing or oversized point references; points
+already resolved remain in the decoder's existing point cache even on failure.
+Both retain the behavior of their allocating convenience accessors. The caller
+controls scratch-vector lifetime; reuse does not promise physical memory release.
+
 ## Parse Options
 
 ```typescript
@@ -678,17 +691,3 @@ When working with multiple IFC files (e.g., architectural, structural, and MEP m
 - [Query Guide](querying.md) - Query parsed data
 - [Federation Guide](federation.md) - Load and coordinate multiple models
 - [API Reference](../api/typescript.md) - Complete API docs
-
-
-### Native Rust decoder scratch buffers
-
-For repeated native decoding, caller-owned scratch vectors can be reused with
-`EntityDecoder::get_entity_ref_list_fast_into(entity_id, &mut ids)` and
-`get_polyloop_coords_cached_into(entity_id, &mut coords)`. Each replaces the
-buffer contents and returns `Some(())` on success or `None` with an empty buffer
-on failure. The reference-list helper preserves authored order and duplicates,
-dropping oversized references. The PolyLoop helper preserves coordinate order
-and rejects the whole loop for missing or oversized point references; points
-already resolved remain in the decoder's existing point cache even on failure.
-Both retain the behavior of their allocating convenience accessors. The caller
-controls scratch-vector lifetime; reuse does not promise physical memory release.

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -678,3 +678,17 @@ When working with multiple IFC files (e.g., architectural, structural, and MEP m
 - [Query Guide](querying.md) - Query parsed data
 - [Federation Guide](federation.md) - Load and coordinate multiple models
 - [API Reference](../api/typescript.md) - Complete API docs
+
+
+### Native Rust decoder scratch buffers
+
+For repeated native decoding, caller-owned scratch vectors can be reused with
+`EntityDecoder::get_entity_ref_list_fast_into(entity_id, &mut ids)` and
+`get_polyloop_coords_cached_into(entity_id, &mut coords)`. Each replaces the
+buffer contents and returns `Some(())` on success or `None` with an empty buffer
+on failure. The reference-list helper preserves authored order and duplicates,
+dropping oversized references. The PolyLoop helper preserves coordinate order
+and rejects the whole loop for missing or oversized point references; points
+already resolved remain in the decoder's existing point cache even on failure.
+Both retain the behavior of their allocating convenience accessors. The caller
+controls scratch-vector lifetime; reuse does not promise physical memory release.

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 
 #[path = "decoder/caches.rs"]
 mod caches;
+#[path = "decoder/fast_buffers.rs"]
+mod fast_buffers;
 
 /// Pre-built entity index type
 pub type EntityIndex = FxHashMap<u32, (usize, usize)>;
@@ -174,29 +176,7 @@ impl<'a> EntityDecoder<'a> {
     /// take down the whole worker.
     #[inline]
     pub fn decode_at(&mut self, start: usize, end: usize) -> Result<DecodedEntity> {
-        let content_len = self.content.len();
-        if start > end || end > content_len {
-            return Err(Error::parse(
-                0,
-                format!(
-                    "decode_at: invalid byte span ({}, {}) for content length {}",
-                    start, end, content_len,
-                ),
-            ));
-        }
-        let line = &self.content[start..end];
-        let (id, ifc_type, tokens) = parse_entity(line).map_err(|e| {
-            // Add bounded, lossy debug info without requiring the source to be UTF-8.
-            let cut = line.len().min(100);
-            Error::parse(
-                0,
-                format!(
-                    "Failed to parse entity: {:?}, input: {:?}",
-                    e,
-                    String::from_utf8_lossy(&line[..cut])
-                ),
-            )
-        })?;
+        let (id, ifc_type, tokens) = self.parse_at(start, end, "decode_at")?;
 
         // Check cache first - return clone of inner DecodedEntity
         if let Some(entity_arc) = self.cache.get(&id) {
@@ -225,18 +205,33 @@ impl<'a> EntityDecoder<'a> {
     /// the result; for identical bytes it yields an identical [`DecodedEntity`] to
     /// `decode_at`, only without the cache side effect.
     pub fn decode_at_uncached(&self, start: usize, end: usize) -> Result<DecodedEntity> {
+        let (id, ifc_type, tokens) = self.parse_at(start, end, "decode_at_uncached")?;
+        let attributes = tokens
+            .iter()
+            .map(|token| AttributeValue::from_token(token))
+            .collect();
+        Ok(DecodedEntity::new(id, ifc_type, attributes))
+    }
+
+    /// Shared full-record validation and existing error context. The returned
+    /// tokens borrow immutable source bytes, not the decoder's entity cache.
+    #[inline]
+    fn parse_at(
+        &self, start: usize, end: usize, method: &str,
+    ) -> Result<(u32, crate::IfcType, Vec<crate::parser::Token<'a>>)> {
         let content_len = self.content.len();
         if start > end || end > content_len {
             return Err(Error::parse(
                 0,
                 format!(
-                    "decode_at_uncached: invalid byte span ({}, {}) for content length {}",
+                    "{method}: invalid byte span ({}, {}) for content length {}",
                     start, end, content_len,
                 ),
             ));
         }
         let line = &self.content[start..end];
-        let (id, ifc_type, tokens) = parse_entity(line).map_err(|e| {
+        parse_entity(line).map_err(|e| {
+            // Add bounded, lossy debug info without requiring the source to be UTF-8.
             let cut = line.len().min(100);
             Error::parse(
                 0,
@@ -246,12 +241,7 @@ impl<'a> EntityDecoder<'a> {
                     String::from_utf8_lossy(&line[..cut])
                 ),
             )
-        })?;
-        let attributes = tokens
-            .iter()
-            .map(|token| AttributeValue::from_token(token))
-            .collect();
-        Ok(DecodedEntity::new(id, ifc_type, attributes))
+        })
     }
 
     /// Decode entity at byte offset with known ID (faster - checks cache before parsing)
@@ -501,75 +491,6 @@ impl<'a> EntityDecoder<'a> {
         }
 
         None
-    }
-
-    /// Fast extraction of entity reference IDs from a list attribute in raw bytes
-    /// Useful for getting face list from ClosedShell, bounds from Face, etc.
-    /// Returns list of entity IDs
-    #[inline]
-    pub fn get_entity_ref_list_fast(&mut self, entity_id: u32) -> Option<Vec<u32>> {
-        let bytes = self.get_raw_bytes(entity_id)?;
-
-        // Pattern: IFCTYPE((#id1,#id2,...)); or IFCTYPE((#id1,#id2,...),other);
-        let mut i = 0;
-        let len = bytes.len();
-
-        // Skip to first '(' after '='
-        while i < len && bytes[i] != b'(' {
-            i += 1;
-        }
-        if i >= len {
-            return None;
-        }
-        i += 1; // Skip first '('
-
-        // Skip to second '(' for the list
-        while i < len && bytes[i] != b'(' {
-            i += 1;
-        }
-        if i >= len {
-            return None;
-        }
-        i += 1; // Skip second '('
-
-        // Parse entity IDs
-        let mut ids = Vec::with_capacity(32);
-
-        while i < len {
-            // Skip whitespace and commas
-            while i < len
-                && (bytes[i] == b' ' || bytes[i] == b',' || bytes[i] == b'\n' || bytes[i] == b'\r')
-            {
-                i += 1;
-            }
-
-            if i >= len || bytes[i] == b')' {
-                break;
-            }
-
-            // Expect '#' followed by number
-            if bytes[i] == b'#' {
-                i += 1;
-                let start = i;
-                while i < len && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                if i > start {
-                    // Shared checked accumulator (#3421): an oversized id is dropped, not wrapped.
-                    if let Some(id) = crate::express_id::parse_express_id(&bytes[start..i]) {
-                        ids.push(id);
-                    }
-                }
-            } else {
-                i += 1; // Skip unknown character
-            }
-        }
-
-        if ids.is_empty() {
-            None
-        } else {
-            Some(ids)
-        }
     }
 
     /// Fast extraction of PolyLoop point IDs directly from raw bytes
@@ -860,107 +781,7 @@ impl<'a> EntityDecoder<'a> {
         }
     }
 
-    /// Fast extraction of PolyLoop COORDINATES with point caching
-    /// Uses a cache to avoid re-parsing the same cartesian points
-    /// For files with many faces sharing points, this can be 2-3x faster
-    #[inline]
-    pub fn get_polyloop_coords_cached(&mut self, entity_id: u32) -> Option<Vec<(f64, f64, f64)>> {
-        // Ensure index is built once
-        self.build_index();
-        let index = self.entity_index.as_ref()?;
-        let bytes_full = self.content;
 
-        // Get polyloop raw bytes
-        let (start, end) = index.lookup(entity_id)?;
-        let bytes = &bytes_full[start..end];
-
-        // IFCPOLYLOOP((#id1,#id2,#id3,...));
-        let mut i = 0;
-        let len = bytes.len();
-
-        // Skip to first '(' after '='
-        while i < len && bytes[i] != b'(' {
-            i += 1;
-        }
-        if i >= len {
-            return None;
-        }
-        i += 1; // Skip first '('
-
-        // Skip to second '(' for the point list
-        while i < len && bytes[i] != b'(' {
-            i += 1;
-        }
-        if i >= len {
-            return None;
-        }
-        i += 1; // Skip second '('
-
-        // Parse point IDs and fetch coordinates (with caching)
-        // CRITICAL: Track expected count to ensure all points are resolved
-        let mut coords = Vec::with_capacity(8);
-        let mut expected_count = 0u32;
-
-        while i < len {
-            // Skip whitespace and commas
-            while i < len
-                && (bytes[i] == b' ' || bytes[i] == b',' || bytes[i] == b'\n' || bytes[i] == b'\r')
-            {
-                i += 1;
-            }
-
-            if i >= len || bytes[i] == b')' {
-                break;
-            }
-
-            // Expect '#' followed by number
-            if bytes[i] == b'#' {
-                i += 1;
-                let id_start = i;
-                while i < len && bytes[i].is_ascii_digit() {
-                    i += 1;
-                }
-                if i > id_start {
-                    expected_count += 1; // Count every point ID we encounter
-
-                    // Shared checked accumulator (#3421): `expected_count`
-                    // was already bumped, so a refused id here trips the
-                    // `coords.len() == expected_count` check below, same as
-                    // any other missing point.
-                    if let Some(point_id) =
-                        crate::express_id::parse_express_id(&bytes[id_start..i])
-                    {
-                        // Check cache first
-                        if let Some(&coord) = self.point_cache.get(&point_id) {
-                            self.point_cache_hits += 1;
-                            coords.push(coord);
-                        } else {
-                            // Not in cache - parse and cache
-                            if let Some((pt_start, pt_end)) = index.lookup(point_id) {
-                                if let Some(coord) =
-                                    parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
-                                {
-                                    self.point_cache_misses += 1;
-                                    self.point_cache.insert(point_id, coord);
-                                    coords.push(coord);
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                i += 1; // Skip unknown character
-            }
-        }
-
-        // CRITICAL: Return None if ANY point failed to resolve
-        // This matches the old behavior where missing points invalidated the whole polygon
-        if coords.len() >= 3 && coords.len() == expected_count as usize {
-            Some(coords)
-        } else {
-            None
-        }
-    }
 }
 
 /// Parse cartesian point coordinates inline from raw bytes

--- a/rust/core/src/decoder/caches.rs
+++ b/rust/core/src/decoder/caches.rs
@@ -16,22 +16,32 @@ use super::EntityDecoder;
 use crate::DecodedEntity;
 
 impl EntityDecoder<'_> {
-    /// Read an indexed entity, honoring existing memoized values but retaining
-    /// no new value. Linear discovery passes must not fill the geometry cache
-    /// with every unrelated property set they inspect once.
-    pub(crate) fn decode_by_id_transient(&mut self, id: u32) -> crate::Result<DecodedEntity> {
+    /// #3987: validate an indexed record fully, but materialize only a string
+    /// attribute. Discovery must not allocate discarded property/reference trees.
+    /// Honor both requested-id and parsed-id memoized values without adding any.
+    pub(crate) fn decode_string_by_id_transient(
+        &mut self, id: u32, attribute: usize,
+    ) -> crate::Result<Option<String>> {
         if let Some(entity) = self.cache.get(&id) {
-            return Ok(entity.as_ref().clone());
+            return Ok(entity.get_string(attribute).map(str::to_owned));
         }
         self.build_index();
         let (start, end) = self.entity_index.as_ref().and_then(|index| index.lookup(id))
             .ok_or_else(|| crate::Error::parse(0, format!("Entity #{} not found", id)))?;
-        let entity = self.decode_at_uncached(start, end)?;
-        // Match decode_at's parsed-id cache lookup, including caller-supplied
-        // indexes whose key differs from the id declared at that span.
-        Ok(match self.cache.get(&entity.id) {
-            Some(cached) => cached.as_ref().clone(),
-            None => entity,
+        // The SAME parser checks unused fields too. A malformed tail must fail
+        // even when Name was already readable or the parsed id is memoized.
+        let (parsed_id, _, tokens) = self.parse_at(start, end, "decode_at_uncached")?;
+        if let Some(entity) = self.cache.get(&parsed_id) {
+            return Ok(entity.get_string(attribute).map(str::to_owned));
+        }
+        Ok(match tokens.get(attribute) {
+            Some(token @ crate::parser::Token::String(_)) => {
+                match crate::AttributeValue::from_token(token) {
+                    crate::AttributeValue::String(value) => Some(value),
+                    _ => None,
+                }
+            }
+            _ => None,
         })
     }
 
@@ -146,3 +156,7 @@ impl EntityDecoder<'_> {
         self.cache.len()
     }
 }
+
+#[cfg(test)]
+#[path = "transient_projection_tests.rs"]
+mod transient_projection_tests;

--- a/rust/core/src/decoder/fast_buffers.rs
+++ b/rust/core/src/decoder/fast_buffers.rs
@@ -1,0 +1,207 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Fast STEP list decoding into caller-owned scratch (#3988). The owned-return
+//! accessors use the same fill routines; only scratch ownership differs.
+
+use super::{parse_cartesian_point_inline, EntityDecoder};
+
+impl EntityDecoder<'_> {
+    /// Extract entity reference IDs from a raw list attribute, in authored order.
+    #[inline]
+    pub fn get_entity_ref_list_fast(&mut self, entity_id: u32) -> Option<Vec<u32>> {
+        let mut ids = Vec::new();
+        self.get_entity_ref_list_fast_into(entity_id, &mut ids)?;
+        Some(ids)
+    }
+
+    /// Replace `ids` with the same list as [`Self::get_entity_ref_list_fast`],
+    /// reusing its allocation. Duplicates retain authored order; oversized refs
+    /// are dropped. On `None`, `ids` is empty. The caller owns the scratch lifetime.
+    #[inline]
+    pub fn get_entity_ref_list_fast_into(&mut self, entity_id: u32, ids: &mut Vec<u32>) -> Option<()> {
+        ids.clear();
+        let bytes = self.get_raw_bytes(entity_id)?;
+
+        // Pattern: IFCTYPE((#id1,#id2,...)); or IFCTYPE((#id1,#id2,...),other);
+        let mut i = 0;
+        let len = bytes.len();
+
+        // Skip to first '(' after '='
+        while i < len && bytes[i] != b'(' {
+            i += 1;
+        }
+        if i >= len {
+            return None;
+        }
+        i += 1; // Skip first '('
+
+        // Skip to second '(' for the list
+        while i < len && bytes[i] != b'(' {
+            i += 1;
+        }
+        if i >= len {
+            return None;
+        }
+        i += 1; // Skip second '('
+
+        // Parse entity IDs
+        ids.reserve(32);
+
+        while i < len {
+            // Skip whitespace and commas
+            while i < len
+                && (bytes[i] == b' ' || bytes[i] == b',' || bytes[i] == b'\n' || bytes[i] == b'\r')
+            {
+                i += 1;
+            }
+
+            if i >= len || bytes[i] == b')' {
+                break;
+            }
+
+            // Expect '#' followed by number
+            if bytes[i] == b'#' {
+                i += 1;
+                let start = i;
+                while i < len && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i > start {
+                    // Shared checked accumulator (#3421): an oversized id is dropped, not wrapped.
+                    if let Some(id) = crate::express_id::parse_express_id(&bytes[start..i]) {
+                        ids.push(id);
+                    }
+                }
+            } else {
+                i += 1; // Skip unknown character
+            }
+        }
+
+        if ids.is_empty() {
+            None
+        } else {
+            Some(())
+        }
+    }
+
+    /// Extract PolyLoop coordinates with the decoder's existing point cache.
+    #[inline]
+    pub fn get_polyloop_coords_cached(&mut self, entity_id: u32) -> Option<Vec<(f64, f64, f64)>> {
+        let mut coords = Vec::new();
+        self.get_polyloop_coords_cached_into(entity_id, &mut coords)?;
+        Some(coords)
+    }
+
+    /// Replace `coords` with [`Self::get_polyloop_coords_cached`]'s ordered result,
+    /// reusing its allocation and the same point-cache policy and counters.
+    /// Missing/oversized point refs invalidate the whole loop. On `None`, the
+    /// buffer is empty; resolved points remain cached, as with the owned accessor.
+    #[inline]
+    pub fn get_polyloop_coords_cached_into(
+        &mut self, entity_id: u32, coords: &mut Vec<(f64, f64, f64)>,
+    ) -> Option<()> {
+        coords.clear();
+        // Ensure index is built once
+        self.build_index();
+        let index = self.entity_index.as_ref()?;
+        let bytes_full = self.content;
+
+        // Get polyloop raw bytes
+        let (start, end) = index.lookup(entity_id)?;
+        let bytes = &bytes_full[start..end];
+
+        // IFCPOLYLOOP((#id1,#id2,#id3,...));
+        let mut i = 0;
+        let len = bytes.len();
+
+        // Skip to first '(' after '='
+        while i < len && bytes[i] != b'(' {
+            i += 1;
+        }
+        if i >= len {
+            return None;
+        }
+        i += 1; // Skip first '('
+
+        // Skip to second '(' for the point list
+        while i < len && bytes[i] != b'(' {
+            i += 1;
+        }
+        if i >= len {
+            return None;
+        }
+        i += 1; // Skip second '('
+
+        // Parse point IDs and fetch coordinates (with caching)
+        // CRITICAL: Track expected count to ensure all points are resolved
+        coords.reserve(8);
+        let mut expected_count = 0u32;
+
+        while i < len {
+            // Skip whitespace and commas
+            while i < len
+                && (bytes[i] == b' ' || bytes[i] == b',' || bytes[i] == b'\n' || bytes[i] == b'\r')
+            {
+                i += 1;
+            }
+
+            if i >= len || bytes[i] == b')' {
+                break;
+            }
+
+            // Expect '#' followed by number
+            if bytes[i] == b'#' {
+                i += 1;
+                let id_start = i;
+                while i < len && bytes[i].is_ascii_digit() {
+                    i += 1;
+                }
+                if i > id_start {
+                    expected_count += 1; // Count every point ID we encounter
+
+                    // Shared checked accumulator (#3421): `expected_count`
+                    // was already bumped, so a refused id here trips the
+                    // `coords.len() == expected_count` check below, same as
+                    // any other missing point.
+                    if let Some(point_id) =
+                        crate::express_id::parse_express_id(&bytes[id_start..i])
+                    {
+                        // Check cache first
+                        if let Some(&coord) = self.point_cache.get(&point_id) {
+                            self.point_cache_hits += 1;
+                            coords.push(coord);
+                        } else {
+                            // Not in cache - parse and cache
+                            if let Some((pt_start, pt_end)) = index.lookup(point_id) {
+                                if let Some(coord) =
+                                    parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
+                                {
+                                    self.point_cache_misses += 1;
+                                    self.point_cache.insert(point_id, coord);
+                                    coords.push(coord);
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                i += 1; // Skip unknown character
+            }
+        }
+
+        // CRITICAL: Return None if ANY point failed to resolve
+        // This matches the old behavior where missing points invalidated the whole polygon
+        if coords.len() >= 3 && coords.len() == expected_count as usize {
+            Some(())
+        } else {
+            coords.clear();
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "fast_buffers_tests.rs"]
+mod tests;

--- a/rust/core/src/decoder/fast_buffers_tests.rs
+++ b/rust/core/src/decoder/fast_buffers_tests.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+
+const SOURCE: &str = "\
+#1=IFCCARTESIANPOINT((-0.,2.,3.));
+#2=IFCCARTESIANPOINT((1.,0.,0.));
+#3=IFCCARTESIANPOINT((0.,1.,0.));
+#10=IFCPOLYLOOP((#1,#2,#1,#3));
+#11=IFCPOLYLOOP((#3,#99,#2,#1));
+#12=IFCPOLYLOOP((#1,#4294967296,#2,#3));
+#13=IFCPOLYLOOP((#1,#2));
+#14=IFCPOLYLOOP(());
+#15=IFCPOLYLOOP($);
+#20=IFCFACE((#10,#11,#10,#4294967296,#12));
+#21=IFCFACE(());
+#22=IFCFACE($);
+";
+
+#[test]
+fn issue_3988_polyloop_scratch_preserves_order_failures_and_point_cache() {
+    let mut fill = EntityDecoder::new(SOURCE);
+    let mut owned = EntityDecoder::new(SOURCE);
+    let mut coords = Vec::with_capacity(32);
+    let ptr = coords.as_ptr();
+    for id in [10, 11, 10, 12, 13, 14, 15, 99, 10] {
+        let expected = owned.get_polyloop_coords_cached(id);
+        let result = fill.get_polyloop_coords_cached_into(id, &mut coords);
+        assert_eq!(result.is_some(), id == 10);
+        assert_eq!(result.is_some(), expected.is_some());
+        assert_eq!(fill.point_cache_stats(), owned.point_cache_stats());
+        assert_eq!(coords.as_ptr(), ptr, "scratch must be reused across loop decodes");
+        if id == 10 {
+            let bits = |points: &[(f64, f64, f64)]| -> Vec<[u64; 3]> {
+                points.iter().map(|&(x, y, z)| [x.to_bits(), y.to_bits(), z.to_bits()]).collect()
+            };
+            assert_eq!(bits(&coords), bits(&[
+                (-0.0, 2.0, 3.0), (1.0, 0.0, 0.0),
+                (-0.0, 2.0, 3.0), (0.0, 1.0, 0.0),
+            ]));
+            assert_eq!(bits(&coords), bits(&expected.unwrap()));
+        } else {
+            assert!(coords.is_empty(), "failed loops must expose no stale/partial polygon");
+        }
+    }
+}
+
+#[test]
+fn issue_3988_ref_scratch_retains_duplicates_and_drops_oversized_refs() {
+    let mut decoder = EntityDecoder::new(SOURCE);
+    let mut ids = Vec::with_capacity(32);
+    let ptr = ids.as_ptr();
+    for id in [20, 21, 20, 22, 99, 20] {
+        let result = decoder.get_entity_ref_list_fast_into(id, &mut ids);
+        assert_eq!(result.is_some(), id == 20);
+        assert_eq!(ids.as_ptr(), ptr);
+        if id == 20 {
+            assert_eq!(ids, [10, 11, 10, 12]);
+            assert_eq!(decoder.get_entity_ref_list_fast(id), Some(ids.clone()));
+        } else {
+            assert!(ids.is_empty());
+            assert_eq!(decoder.get_entity_ref_list_fast(id), None);
+        }
+    }
+}

--- a/rust/core/src/decoder/transient_projection_tests.rs
+++ b/rust/core/src/decoder/transient_projection_tests.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::{EntityDecoder, EntityIndex};
+use std::sync::Arc;
+
+fn indexed(source: &[u8]) -> EntityDecoder<'_> {
+    let mut index = EntityIndex::default();
+    index.insert(1, (0, source.len()));
+    EntityDecoder::with_index(source, index)
+}
+
+// #3987: projection retains Name's exact string contract, including IFC
+// escaping and non-string/absent fields. Other fields are still fully parsed.
+#[test]
+fn transient_string_projection_preserves_name_semantics_3987() {
+    for (name, expected) in [
+        ("'ePSet_MapConversion'", Some("ePSet_MapConversion")),
+        ("''", Some("")),
+        ("'O''Brien'", Some("O'Brien")),
+        (r"'ePSet_\X2\004D00610070\X0\Conversion'", Some("ePSet_MapConversion")),
+        ("$", None),
+        ("*", None),
+        ("42", None),
+        (".TRUE.", None),
+        ("IFCLABEL('ePSet_MapConversion')", None),
+        ("('ePSet_MapConversion')", None),
+    ] {
+        let source = format!("#1=IFCPROPERTYSET('g',$,{name},'unused',(#2,#3,#2));");
+        let mut decoder = indexed(source.as_bytes());
+        let actual = decoder.decode_string_by_id_transient(1, 2).unwrap();
+        assert_eq!(actual.as_deref(), expected, "{name}");
+        let original = decoder.decode_at_uncached(0, source.len()).unwrap();
+        assert_eq!(actual.as_deref(), original.get_string(2));
+        assert_eq!(decoder.cache_size(), 0, "transient reads retain no entity");
+    }
+    let mut empty = indexed(b"#1=IFCPROPERTYSET();");
+    assert_eq!(empty.decode_string_by_id_transient(1, 2).unwrap(), None);
+    let source = b"#1=IFCPROPERTYSET('g',$,'invalid \xff',$,());";
+    let mut decoder = indexed(source);
+    assert_eq!(decoder.decode_string_by_id_transient(1, 2).unwrap().as_deref(), Some("invalid \u{fffd}"));
+}
+
+// #3987: a readable Name does not excuse invalid unused fields, even if those
+// fields would never be converted into AttributeValue by the projection.
+#[test]
+fn transient_string_projection_validates_unused_tail_3987() {
+    for source in [
+        "#1=IFCPROPERTYSET('g',$,'readable',$,(#4294967296));",
+        "#1=IFCPROPERTYSET('g',$,'readable',$,(@));",
+        "#1=IFCPROPERTYSET('g',$,'readable',$,('unterminated));",
+        "#1=IFCPROPERTYSET('g',$,'readable',$,(1e999999));",
+        "#1=IFCPROPERTYSET('g',$,'readable',$,(#2));/*",
+    ] {
+        let mut decoder = indexed(source.as_bytes());
+        let original = decoder.decode_at_uncached(0, source.len());
+        let projected = decoder.decode_string_by_id_transient(1, 2);
+        // parse_entity historically accepts bytes after the terminating ';'.
+        // Preserve that too: do not add a stricter full-slice grammar here.
+        match original {
+            Ok(entity) => assert_eq!(projected.unwrap().as_deref(), entity.get_string(2)),
+            Err(error) => assert_eq!(projected.unwrap_err().to_string(), error.to_string()),
+        }
+        assert_eq!(decoder.cache_size(), 0);
+    }
+    let source = b"#1=IFCPROPERTYSET('g',$,'readable',$,(@));";
+    assert!(indexed(source).decode_string_by_id_transient(1, 2).is_err());
+}
+
+// #3987: a supplied index can map a requested id onto another declared id.
+// Requested cache hits bypass parsing; parsed-id hits happen AFTER validation.
+#[test]
+fn transient_string_projection_preserves_alias_cache_precedence_3987() {
+    let records = [
+        "#1=IFCPROPERTYSET('g',$,'requested cache',$,());",
+        "#2=IFCPROPERTYSET('g',$,'parsed cache',$,());",
+        "#2=IFCPROPERTYSET('g',$,'uncached alias',$,());",
+        "#2=IFCPROPERTYSET('g',$,'malformed alias',$,(@));",
+    ];
+    let mut source = String::new();
+    let mut spans = Vec::new();
+    for record in records {
+        let start = source.len();
+        source.push_str(record);
+        spans.push((start, source.len()));
+    }
+    let mut decoder = EntityDecoder::new(&source);
+    decoder.decode_at(spans[0].0, spans[0].1).unwrap();
+    decoder.decode_at(spans[1].0, spans[1].1).unwrap();
+    let mut index = EntityIndex::default();
+    index.insert(1, (source.len() + 10, 0));
+    index.insert(9, spans[2]);
+    index.insert(10, spans[3]);
+    index.insert(11, (source.len() + 10, 0));
+    decoder.set_entity_index(Arc::new(index));
+    assert_eq!(decoder.decode_string_by_id_transient(1, 2).unwrap().as_deref(), Some("requested cache"));
+    assert_eq!(decoder.decode_string_by_id_transient(9, 2).unwrap().as_deref(), Some("parsed cache"));
+    assert!(decoder.decode_string_by_id_transient(10, 2).is_err());
+    let original = decoder.decode_at_uncached(source.len() + 10, 0).unwrap_err();
+    assert_eq!(decoder.decode_string_by_id_transient(11, 2).unwrap_err().to_string(), original.to_string());
+    assert_eq!(decoder.decode_string_by_id_transient(99, 2).unwrap_err().to_string(), "Parse error at position 0: Entity #99 not found");
+    assert_eq!(decoder.cache_size(), 2);
+}

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -490,8 +490,7 @@ impl GeoRefExtractor {
             if *ifc_type != IfcType::IfcPropertySet {
                 continue;
             }
-            let entity = decoder.decode_by_id_transient(*id)?;
-            if let Some(name) = entity.get_string(2) {
+            if let Some(name) = decoder.decode_string_by_id_transient(*id, 2)? {
                 if name.eq_ignore_ascii_case("ePSet_MapConversion") && map_conversion_pset.is_none() {
                     map_conversion_pset = Some(*id);
                 } else if name.eq_ignore_ascii_case("ePSet_ProjectedCRS") && projected_crs_pset.is_none() {

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -1301,9 +1301,9 @@ pub fn process_geometry_streaming_filtered_with_options(
                 {
                     return;
                 }
-                let mut local_decoder =
-                    entity_index_for_meta.decoder(content);
-                let Ok(entity) = local_decoder.decode_at(job.start, job.end) else {
+                let local_decoder = entity_index_for_meta.decoder(content);
+                // #3987: this decoder is read once; an entity-cache clone is never reused.
+                let Ok(entity) = local_decoder.decode_at_uncached(job.start, job.end) else {
                     return;
                 };
                 job.global_id = normalize_optional_string(entity.get_string(0));
@@ -1570,6 +1570,21 @@ pub fn process_geometry_streaming_filtered_with_options(
         "Geometry processing complete"
     );
 
+    let extract_georeferencing = || crate::georeferencing::extract_georeferencing_from_candidates(
+        &mut entity_index_arc.decoder(content), &georeferencing_candidates,
+    );
+    // #3987: jobs and instance finalization have finished using these caches.
+    // Keep metadata on the caller thread; join ALL disposal before returning,
+    // including on unwind. No cleanup survives the full-load readiness boundary.
+    #[cfg(not(target_arch = "wasm32"))]
+    let georeferencing = rayon::in_place_scope(|scope| {
+        scope.spawn(move |_| drop(decoder));
+        scope.spawn(move |_| drop(item_dedup_cache));
+        extract_georeferencing()
+    });
+    #[cfg(target_arch = "wasm32")]
+    let georeferencing = extract_georeferencing();
+
     ProcessingResult {
         meshes,
         instances,
@@ -1585,9 +1600,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                 is_geo_referenced: has_rtc_offset,
             },
             length_unit_scale: Some(unit_scale),
-            georeferencing: crate::georeferencing::extract_georeferencing_from_candidates(
-                &mut entity_index_arc.decoder(content), &georeferencing_candidates,
-            ),
+            georeferencing,
         },
         stats: ProcessingStats {
             total_meshes,

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -158,7 +158,7 @@ full-detail identity alone does not establish browser identity.
 
 ### Retained transient decoder ownership (#4000)
 
-Use reusable output buffers and a validated string projection where consumers discard full decoded attribute trees; one-read metadata avoids filling a cache. Expired native decoder/item caches are disposed in a joined scope while trailing georeferencing runs. Retained with the cumulative cold-load candidate, without an isolated percentage claim. Full-call timing must include the disposal join and trailing metadata; summed worker high-water allocations do not establish retained or simultaneous memory.
+Reusable output buffers and a validated string projection avoid building discarded attribute trees; one-read metadata avoids filling a cache. Expired native decoder/item caches are disposed in a joined scope while trailing georeferencing runs. Own-layer native and actual Chrome worker-pool subset comparisons did not establish a meaningful full-load improvement. Keep the cumulative result separate, include the disposal join and trailing metadata in timing, and do not treat summed worker allocations as simultaneous memory. No isolated browser gain is established here; invalid Firefox cohorts and unrun follow-ups remain excluded.
 
 ### Cold-load validation notes
 

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -156,6 +156,10 @@ note. The performance-only stack is evaluated separately against this corrected
 baseline. **Lesson:** qualify the browser's actual detail settings too; native
 full-detail identity alone does not establish browser identity.
 
+### Retained transient decoder ownership (#4000)
+
+Use reusable output buffers and a validated string projection where consumers discard full decoded attribute trees; one-read metadata avoids filling a cache. Expired native decoder/item caches are disposed in a joined scope while trailing georeferencing runs. Retained with the cumulative cold-load candidate, without an isolated percentage claim. Full-call timing must include the disposal join and trailing metadata; summed worker high-water allocations do not establish retained or simultaneous memory.
+
 ### Cold-load validation notes
 
 A geometry-complete event does not imply an interactive viewer: metadata,


### PR DESCRIPTION
Reference/coordinate extraction and one-read metadata created buffers and attribute trees that their callers discarded. Reuse caller scratch vectors and validated string projections, avoid caching one-read roots, and join disposal of expired caches while trailing georeferencing runs. Public allocating wrappers and parsed/requested-ID cache precedence remain intact.

Closes #4000.

The [review timing request is answered with exact-layer evidence](https://github.com/LTplus-AG/ifc-lite/pull/4004#discussion_r3943471858): parent `1a8405e7a4f622bb1e06a3cc6bb53920f88b50fb` versus `2c8f4743227500c780230034f27501abc719af22`, five fresh interleaved pairs per Haus/CSG-129 fixture. Native full-call loading, including trailing metadata and the disposal join, was slightly slower (+0.66%). The actual Chrome worker-pool subset had flat median-paired full-readiness and geometry ratios. Counts, geometry, search/store witnesses and expected cache completion matched. Its strict console audit remains failed with a separately reviewed missing-local-analytics disposition; original event URLs were not retained. No isolated throughput win is claimed.

The prior cumulative candidate frozen over `06ef1dcd80fae841f33c6ec7d96166b1d01e23af` passed root build/typecheck/test/lint, `cargo test --workspace` (2,834 passed, 36 ignored), strict workspace Clippy and matched real-WASM contracts (86 passed). Its exact public native observable oracle and browser functional witnesses are bounded to the recorded fixtures/modes; partial browser fingerprints do not prove closure or every vertex-buffer byte.

The [committed evidence bundle](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) keeps these layer results separate from the cumulative stack: native full-call loading improved 15.53% across the fixed corpus; supplemental Chrome full readiness improved 28.70%, but Haus was slower in every pair (median paired increase 26 ms) and several geometry-completion results regressed. The original Chrome strict audit remains failed; the reviewed local analytics-404 disposition and missing historical event URLs are explicit. Firefox's original cohort is invalid under its memory rule; functional controls do not qualify Firefox throughput, and recovery remains unrun. Neither the 30% target nor universal absence of performance regressions is established.

These are prior, artifact-pinned validation results, not certification of the eventual landing head. Applicable exact-head CI, parity/API/WASM gates and review must complete before merge; this body makes no all-green or deployment claim.

This main-based landing is independent of the original stack order. Measurements retain their original frozen source/parent identities; the source-preserving integration does not create a new isolated performance result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reusable output buffers for entity-reference lists and polyloop coordinates, reducing temporary allocations during decoding.
  - Improved handling of malformed, missing, duplicate, and oversized references with clearer output behavior.

- **Performance**
  - Reduced transient metadata processing and unnecessary entity materialization.
  - Improved native cleanup timing and georeferencing extraction efficiency.

- **Bug Fixes**
  - Preserved coordinate ordering, duplicate references, cache consistency, and exact numeric values.
  - Improved validation of malformed data and invalid UTF-8 text.

- **Documentation**
  - Documented decoder buffer reuse, validation behavior, string projections, caching, and point handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->