### PR TITLE
perf(core): reuse canonical lexical and schema results

### DIFF
--- a/.changeset/cold-load-native-classification.md
+++ b/.changeset/cold-load-native-classification.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Expose combined Rust geometry classification flags and avoid repeated lexical/schema work while preserving canonical names, legacy mappings and malformed-record diagnostics.

--- a/.changeset/quiet-types-borrow.md
+++ b/.changeset/quiet-types-borrow.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/codegen": patch
+---
+
+Generate a canonical-first Rust type lookup without duplicating the finite match, preserving Unicode case normalization and unknown-type identifiers.

--- a/docs/architecture/geometry-pipeline.md
+++ b/docs/architecture/geometry-pipeline.md
@@ -27,6 +27,12 @@ prepass resolution exist exactly once, in `ifc-lite-processing`:
   incremental job emission), but they only span-stash — all semantics resolve
   in the shared module.
 
+The native scanner uses `ifc_lite_core::geometry_flags_by_name` to obtain
+`(has_geometry, representationless_spatial)` with one lookup of the existing
+immutable schema table. These are the same predicates exposed separately by
+`has_geometry_by_name` and `is_representationless_spatial_container_by_name`;
+the second still requires the instance's `Representation` to be present.
+
 Geometry/styling fixes belong in those two modules; re-inlining logic in
 `processor.rs` or `gpu_meshes.rs` re-creates the historic both-sides drift
 (#858, #913, #957, #961 each had to be fixed twice before the unification).

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -515,6 +515,14 @@ Entity counts are taken from the EXPRESS schemas the code generators consume
 (`IFC4_ADD2_TC1`, `IFC4X3`). IFC2X3 files are parsed with the same pipeline;
 the runtime schema registry itself is generated from IFC4.
 
+### Native Rust geometry classification
+
+`ifc_lite_core::geometry_flags_by_name(type_name)` returns
+`(has_geometry, is_representationless_spatial_container)`, using the same
+case normalization and legacy-type rules as the two individual predicates.
+These flags classify a type; they do not establish whether a particular record
+contains a usable representation.
+
 ### Schema Registry
 
 Access runtime schema metadata (generated from `IFC4_ADD2_TC1`):

--- a/packages/codegen/src/rust-generator.ts
+++ b/packages/codegen/src/rust-generator.ts
@@ -16,6 +16,7 @@ import type { ExpressSchema, EntityDefinition } from './express-parser.js';
 import { crc32, formatCRC32TableLiteral } from './crc32.js';
 import { getInheritanceChain } from './express-parser.js';
 import { generateSchemaQueries } from './rust-schema-queries.js';
+import { generateTypeNameParser } from './rust-type-name-parser.js';
 
 export interface RustGeneratedCode {
   typeIds: string;
@@ -109,22 +110,7 @@ pub enum IfcType {
 }
 
 impl IfcType {
-    /// Parse IFC type from string (case-insensitive)
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
-        let upper = s.to_uppercase();
-        match upper.as_str() {
-`;
-
-  // Generate match arms for all entities
-  for (const entity of schema.entities) {
-    code += `            "${entity.name.toUpperCase()}" => Self::${entity.name},\n`;
-  }
-
-  code += `            _ => Self::Unknown(crc32_hash(&upper)),
-        }
-    }
-
+${generateTypeNameParser(schema)}
     /// Parse from CRC32 type ID
     pub fn from_id(id: u32) -> Self {
         match id {

--- a/packages/codegen/src/rust-type-name-parser.ts
+++ b/packages/codegen/src/rust-type-name-parser.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { ExpressSchema } from './express-parser.js';
+
+/** One exact-name match shared by canonical and normalized input. */
+export function generateTypeNameParser(schema: ExpressSchema): string {
+  return `    /// Parse IFC type from string (case-insensitive)
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Self {
+        // #3987: recognized STEP names need no normalization scan.
+        if let Some(known) = Self::from_canonical_name(s) {
+            return known;
+        }
+        if s.bytes().all(|b| b.is_ascii() && !b.is_ascii_lowercase()) {
+            return Self::Unknown(crc32_hash(s));
+        }
+        // Keep Unicode uppercase expansion and the exact unknown-type CRC.
+        let upper = s.to_uppercase();
+        Self::from_canonical_name(&upper)
+            .unwrap_or_else(|| Self::Unknown(crc32_hash(&upper)))
+    }
+
+    fn from_canonical_name(s: &str) -> Option<Self> {
+        Some(match s {
+${schema.entities.map(entity =>
+    `            "${entity.name.toUpperCase()}" => Self::${entity.name},`).join('\n')}
+            _ => return None,
+        })
+    }
+`;
+}

--- a/packages/codegen/test/rust-generator.test.ts
+++ b/packages/codegen/test/rust-generator.test.ts
@@ -85,8 +85,7 @@ describe('generateRust — schema.rs IfcType enum', () => {
     expect(rust.schema).not.toContain('    IFCWALL,\n');
   });
 
-  it('matches from_str on the UPPERCASE spelling (it is fed s.to_uppercase())', () => {
-    expect(rust.schema).toContain('let upper = s.to_uppercase();');
+  it('emits uppercase schema match arms', () => {
     expect(rust.schema).toContain('"IFCWALL" => Self::IfcWall,');
     // Both directions: a PascalCase match arm would be dead code.
     expect(rust.schema).not.toContain('"IfcWall" => Self::IfcWall,');

--- a/rust/core/src/express_id.rs
+++ b/rust/core/src/express_id.rs
@@ -13,14 +13,14 @@
 //! collision, not a missing value (issue #3395, split for the reference
 //! readers in #3421).
 //!
-//! [`parse_express_id`] is called from both sides of that contract: the
+//! [`parse_express_id`] and the internal prefix reader serve both sides: the
 //! definition scanner ([`crate::parser::scanner::EntityScanner`]) and every
 //! `#<digits>` reference reader in [`crate::fast_parse`] and
 //! [`crate::decoder`], and — now that it is `pub` — the REFERENCE readers in
 //! `ifc-lite-geometry`, `ifc-lite-export` and `ifc-lite-processing` that read
 //! raw STEP bytes outside this crate. A second, independently-written copy of
-//! this accumulation is exactly the drift #3395 was careful to avoid, so a
-//! new caller must reuse this function rather than writing its own loop.
+//! this accumulation is exactly the drift #3395 was careful to avoid. New
+//! callers reuse these canonical readers, which share the digit arithmetic.
 //!
 //! The bound is inclusive: `u32::MAX` is a legitimate express id and parses
 //! successfully. Refusal (`None`) is the only outcome for anything past it —
@@ -32,6 +32,41 @@
 //! *saturates* an out-of-range vertex index to `u32::MAX`: that value is a
 //! sentinel a downstream bounds check drops, not a key another value could
 //! collide with, so saturation is safe there and is not safe here.
+
+const UNCHECKED_DIGITS: usize = 9;
+
+#[inline]
+fn append_digit(value: u32, byte: u8) -> u32 {
+    value * 10 + (byte - b'0') as u32
+}
+
+#[inline]
+fn append_digit_checked(value: u32, byte: u8) -> Option<u32> {
+    value.checked_mul(10)?.checked_add((byte - b'0') as u32)
+}
+
+/// Read the leading ASCII digit run, returning its byte length and express id.
+/// An empty or overflowing run yields None, but overflow never stops scanning:
+/// callers still need the exact prefix end to validate the declaration (#3987).
+/// First-nine-digit arithmetic is unchecked because it cannot exceed 999999999.
+#[inline]
+pub(crate) fn parse_express_id_prefix(input: &[u8]) -> (usize, Option<u32>) {
+    let mut end = 0;
+    let mut result = 0u32;
+    for &byte in input.iter().take(UNCHECKED_DIGITS) {
+        if !byte.is_ascii_digit() { return (end, (end != 0).then_some(result)); }
+        result = append_digit(result, byte);
+        end += 1;
+    }
+    if end == 0 { return (0, None); }
+    let mut value = Some(result);
+    for &byte in &input[end..] {
+        if !byte.is_ascii_digit() { break; }
+        value = value.and_then(|value| append_digit_checked(value, byte));
+        end += 1;
+    }
+    (end, value)
+}
 
 /// Parse `digits` — an already-validated, non-empty run of ASCII digit bytes
 /// — into a `u32` express id, or `None` if the value does not fit.
@@ -54,14 +89,14 @@ pub fn parse_express_id(digits: &[u8]) -> Option<u32> {
         "parse_express_id expects a validated, non-empty digit run"
     );
     let mut result: u32 = 0;
-    if digits.len() <= 9 {
+    if digits.len() <= UNCHECKED_DIGITS {
         for &b in digits {
-            result = result * 10 + (b - b'0') as u32;
+            result = append_digit(result, b);
         }
         return Some(result);
     }
     for &b in digits {
-        result = result.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+        result = append_digit_checked(result, b)?;
     }
     Some(result)
 }
@@ -94,5 +129,32 @@ mod tests {
         // real #1, which is the actual defect (#3421), not merely an
         // overflow that errors.
         assert_eq!(parse_express_id(b"4294967297"), None);
+    }
+
+    /// #3987: independent decimal-parser oracle covers leading zeroes and long
+    /// overflow prefixes, including bytes that must remain for the scanner.
+    #[test]
+    fn express_prefix_matches_checked_decimal_oracle_3987() {
+        let runs = ["0", "1", "999999999", "1000000000", "4294967295",
+            "4294967296", "4294967297", "999999999999999999999999999999999"];
+        for zeros in [0, 1, 9, 10, 64, 1024] {
+            for run in runs {
+                let digits = format!("{}{run}", "0".repeat(zeros));
+                let expected = digits.parse::<u32>().ok();
+                assert_eq!(parse_express_id(digits.as_bytes()), expected);
+                for suffix in [b"".as_slice(), b"=IFCWALL($);", b"/* ; */ =", b"x", b"\xff"] {
+                    let source = [digits.as_bytes(), suffix].concat();
+                    assert_eq!(parse_express_id_prefix(&source), (digits.len(), expected));
+                }
+            }
+        }
+        for source in [b"".as_slice(), b"=", b"-1", b"+1", b" ", b"\xff"] {
+            assert_eq!(parse_express_id_prefix(source), (0, None));
+        }
+        for value in [2u32, 19, 100, 123456789, u32::MAX - 1] {
+            let source = format!("{value};trailing");
+            assert_eq!(parse_express_id_prefix(source.as_bytes()),
+                (value.to_string().len(), Some(value)));
+        }
     }
 }

--- a/rust/core/src/generated/schema.rs
+++ b/rust/core/src/generated/schema.rs
@@ -1062,8 +1062,20 @@ impl IfcType {
     /// Parse IFC type from string (case-insensitive)
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
+        // #3987: recognized STEP names need no normalization scan.
+        if let Some(known) = Self::from_canonical_name(s) {
+            return known;
+        }
+        if s.bytes().all(|b| b.is_ascii() && !b.is_ascii_lowercase()) {
+            return Self::Unknown(crc32_hash(s));
+        }
+        // Keep Unicode uppercase expansion and the exact unknown-type CRC.
         let upper = s.to_uppercase();
-        match upper.as_str() {
+        Self::from_canonical_name(&upper).unwrap_or_else(|| Self::Unknown(crc32_hash(&upper)))
+    }
+
+    fn from_canonical_name(s: &str) -> Option<Self> {
+        Some(match s {
             "IFCACTIONREQUEST" => Self::IfcActionRequest,
             "IFCACTOR" => Self::IfcActor,
             "IFCACTORROLE" => Self::IfcActorRole,
@@ -1952,8 +1964,8 @@ impl IfcType {
             "IFCWORKTIME" => Self::IfcWorkTime,
             "IFCZSHAPEPROFILEDEF" => Self::IfcZShapeProfileDef,
             "IFCZONE" => Self::IfcZone,
-            _ => Self::Unknown(crc32_hash(&upper)),
-        }
+            _ => return None,
+        })
     }
 
     /// Parse from CRC32 type ID

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -110,7 +110,8 @@ pub use project_units::{
 };
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
 pub use schema_helpers::{
-    has_geometry_by_name, is_representationless_spatial_container_by_name, is_simple_geometry_type,
+    geometry_flags_by_name, has_geometry_by_name, is_representationless_spatial_container_by_name,
+    is_simple_geometry_type,
     legacy_aware_ifc_type, legacy_aware_ifc_type_from_record, nth_attribute_is_present,
     type_product_ifc_type,
 };

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -162,7 +162,7 @@ impl<'a> EntityScanner<'a> {
         // Outer loop so a record this scanner refuses (an oversized
         // instance name, below) is SKIPPED rather than ending the scan.
         loop {
-            let (line_start, id_end_validated, eq_pos) = loop {
+            let (line_start, parsed_id, eq_pos) = loop {
                 // Step (1): jump past any `/* … */` comment that starts at or
                 // before the next candidate '#'. Use memchr2 so we look for
                 // '#' and '/' in one SIMD pass — whichever comes first
@@ -197,15 +197,13 @@ impl<'a> EntityScanner<'a> {
 
                 // candidate_byte == b'#'. Step (2): validate `#<digits>[ws]*=`.
                 let after = candidate + 1;
-                if after >= len || !bytes[after].is_ascii_digit() {
+                let (digit_count, parsed_id) =
+                    crate::express_id::parse_express_id_prefix(&bytes[after..]);
+                if digit_count == 0 {
                     self.position = after;
                     continue;
                 }
-                // Walk the digit run.
-                let mut digit_end = after;
-                while digit_end < len && bytes[digit_end].is_ascii_digit() {
-                    digit_end += 1;
-                }
+                let digit_end = after + digit_count;
                 // Skip optional trivia and verify the next byte is '='.
                 // `None` means a comment opened here and never closes, which
                 // is not a declaration either — fall through to the rescan
@@ -213,7 +211,7 @@ impl<'a> EntityScanner<'a> {
                 // `skip_step_comment` ends the scan on it.
                 let probe = super::lexical::skip_step_trivia(bytes, digit_end).unwrap_or(len);
                 if probe < len && bytes[probe] == b'=' {
-                    break (candidate, digit_end, probe);
+                    break (candidate, parsed_id, probe);
                 }
                 // '#<digits>' not followed by '=' — this is a comment or string
                 // reference, not an entity definition. Skip past the digits and
@@ -223,7 +221,9 @@ impl<'a> EntityScanner<'a> {
 
             // Find the end of the entity (semicolon) while respecting quoted strings
             // IFC strings use single quotes and can contain semicolons
-            let line_content = &bytes[line_start..];
+            // The prefix contains only digits and already-closed trivia (#3987).
+            let body_start = eq_pos + 1;
+            let line_content = &bytes[body_start..];
             let end_offset = match self.find_entity_end(line_content) {
                 Some(o) => o,
                 None => {
@@ -233,12 +233,10 @@ impl<'a> EntityScanner<'a> {
                     return None;
                 }
             };
-            let line_end = line_start + end_offset + 1;
+            let line_end = body_start + end_offset + 1;
 
-            // Parse entity ID — digit range already validated in the candidate loop.
-            let id_start = line_start + 1;
-            let id_end = id_end_validated;
-            let Some(id) = self.parse_u32_fast(id_start, id_end) else {
+            // Refusal is still reported AFTER malformed-body detection (#3987).
+            let Some(id) = parsed_id else {
                 // The instance name does not fit `u32` (issue #3395). SKIP
                 // the record and keep scanning: returning `None` here would
                 // end the whole scan at the first oversized id, silently
@@ -288,24 +286,6 @@ impl<'a> EntityScanner<'a> {
 
             return Some((id, type_name, line_start, line_end));
         }
-    }
-
-    /// Fast u32 parsing without string allocation.
-    ///
-    /// `start..end` is a validated ASCII digit run (the candidate loop in
-    /// [`next_entity`](Self::next_entity) walks it with `is_ascii_digit`), so
-    /// `None` means exactly one thing: the value does not fit `u32`. It used to
-    /// be `wrapping_mul`/`wrapping_add`, which turned `#4294967297` into `1` —
-    /// a real entity's id, indistinguishable from it downstream (issue #3395).
-    ///
-    /// Delegates to [`crate::express_id::parse_express_id`], the single
-    /// checked accumulator shared with every `#<digits>` reference reader in
-    /// [`crate::fast_parse`] and [`crate::decoder`] (issue #3421) — the
-    /// definition and reference sides of an express id agree on the bound
-    /// because they call the same function, not two copies of the same rule.
-    #[inline]
-    fn parse_u32_fast(&self, start: usize, end: usize) -> Option<u32> {
-        crate::express_id::parse_express_id(&self.bytes[start..end])
     }
 
     /// Find the terminating semicolon of an entity, skipping over quoted strings.

--- a/rust/core/src/parser/scanner_tests.rs
+++ b/rust/core/src/parser/scanner_tests.rs
@@ -603,3 +603,46 @@ ENDSEC;\nDATA;\n\
         "an unterminated HEADER comment must be reported, not silently skipped"
     );
 }
+
+/// #3987: a numerically oversized prefix is not reported until its entire body
+/// has a terminator. Closed prefix trivia must not affect span/quote handling.
+#[test]
+fn fused_id_prefix_retains_refusal_and_malformed_order_3987() {
+    for id in ["1", "0000000000000000001", "4294967295", "4294967296",
+        "999999999999999999999999999999999999"] {
+        for trivia in ["", " ", "/* quote' ; #7=IFCX(); */", "\r\n/* a=b */\x0b"] {
+            let prefix = format!("#{id}{trivia}=");
+            let parsed = id.parse::<u32>().ok();
+            for body in ["IFCWALL('a;''b',/* x; */$);", "/* x'; */IFCWALL($);", "IFCWALL($);"] {
+                let record = format!("{prefix}{body}");
+                let source = format!("{record}#7=IFCDOOR($);");
+                let mut scanner = EntityScanner::new(&source);
+                if let Some(expected) = parsed {
+                    let found = scanner.next_entity().unwrap();
+                    assert_eq!((found.0, found.1, found.2, found.3),
+                        (expected, "IFCWALL", 0, record.len()));
+                }
+                assert_eq!(scanner.next_entity(), Some((7, "IFCDOOR", record.len(), source.len())));
+                assert_eq!(scanner.skipped_oversized_id_starts(),
+                    if parsed.is_none() { &[0][..] } else { &[][..] });
+                assert_eq!(scanner.malformed_record_start(), None);
+            }
+            for body in ["IFCWALL('unterminated);", "IFCWALL(/* unterminated", "IFCWALL($)"] {
+                let source = format!("{prefix}{body}");
+                let mut scanner = EntityScanner::new(&source);
+                assert!(scanner.next_entity().is_none());
+                assert_eq!(scanner.malformed_record_start(), Some(0));
+                assert!(scanner.skipped_oversized_id_starts().is_empty());
+            }
+        }
+    }
+    let source = "#4294967296/* never closed";
+    let mut scanner = EntityScanner::new(source);
+    assert!(scanner.next_entity().is_none());
+    assert_eq!(scanner.malformed_record_start(), source.find("/*"));
+    assert!(scanner.skipped_oversized_id_starts().is_empty());
+    let source = "#4294967296 not-a-declaration #8=IFCWALL($);";
+    let mut scanner = EntityScanner::new(source);
+    assert_eq!(scanner.next_entity().map(|x| x.0), Some(8));
+    assert!(scanner.skipped_oversized_id_starts().is_empty());
+}

--- a/rust/core/src/schema_gen_tests.rs
+++ b/rust/core/src/schema_gen_tests.rs
@@ -333,3 +333,52 @@ mod attribute_names {
         assert_eq!(u.attribute_index("GlobalId"), None);
     }
 }
+
+// #3987: borrowing canonical names must retain case-insensitive schema identity
+// and the public Unicode-normalized CRC for unknown names.
+#[test]
+fn type_name_normalization_preserves_catalog_and_unknown_unicode_3987() {
+    for &ty in crate::IFC_TYPES {
+        for spelling in [ty.name().to_string(), ty.name().to_uppercase(), ty.name().to_lowercase()] {
+            assert_eq!(IfcType::from_str(&spelling), ty, "{spelling}");
+        }
+    }
+    // Independent bitwise IEEE CRC32 oracle, avoiding the generated table.
+    fn crc32(bytes: &[u8]) -> u32 {
+        let mut crc = !0u32;
+        for &byte in bytes {
+            crc ^= u32::from(byte);
+            for _ in 0..8 {
+                crc = (crc >> 1) ^ (0xedb8_8320 & 0u32.wrapping_sub(crc & 1));
+            }
+        }
+        !crc
+    }
+    // Unicode normalization may produce a KNOWN canonical keyword.
+    assert_eq!(IfcType::from_str("IFCſPACE"), IfcType::IfcSpace);
+    // Legacy spelling stays a raw schema lookup here; legacy-aware remapping
+    // belongs to its existing wrapper, not this normalization optimization.
+    for &name in crate::legacy_entities::LEGACY_ENTITY_NAMES {
+        let upper = name.to_uppercase();
+        let expected = crate::IFC_TYPES.iter().copied()
+            .find(|ty| ty.as_str() == upper)
+            .unwrap_or_else(|| IfcType::Unknown(crc32(upper.as_bytes())));
+        for spelling in [name.to_owned(), name.to_lowercase()] {
+            assert_eq!(IfcType::from_str(&spelling), expected, "{spelling}");
+        }
+    }
+    for (input, uppercase) in [
+        ("", ""),
+        ("IFCÉ", "IFCÉ"),
+        ("IFCWALL ", "IFCWALL "),
+        ("IFC\0WALL", "IFC\0WALL"),
+        ("IFC_VENDOR_123", "IFC_VENDOR_123"),
+        ("Ifc_Vendor_123", "IFC_VENDOR_123"),
+        ("ifcstraße", "IFCSTRASSE"),
+        ("ifcﬃ", "IFCFFI"),
+        ("ifcé", "IFCÉ"),
+        ("ifcı", "IFCI"),
+    ] {
+        assert_eq!(IfcType::from_str(input), IfcType::Unknown(crc32(uppercase.as_bytes())), "{input}");
+    }
+}

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -91,6 +91,22 @@ pub fn has_geometry_by_name(type_name: &str) -> bool {
     )
 }
 
+/// Return the geometry-bearing and representationless-spatial predicates together.
+/// The tuple matches [`has_geometry_by_name`] and
+/// [`is_representationless_spatial_container_by_name`], respectively, while
+/// sharing one lookup of the immutable schema classification (#3987).
+pub fn geometry_flags_by_name(type_name: &str) -> (bool, bool) {
+    let upper = normalise_uppercase(type_name);
+    classifications().get(upper.as_ref()).map_or_else(
+        || {
+            let geometry = compute_has_geometry(upper.as_ref());
+            // These predicates are disjoint, including legacy and unknown names.
+            (geometry, !geometry && compute_is_representationless_spatial_container(upper.as_ref()))
+        },
+        |class| (class.has_geometry, class.representationless_spatial),
+    )
+}
+
 fn compute_has_geometry(upper: &str) -> bool {
     if let Some(info) = get_legacy_entity_info(upper) {
         return info.has_geometry;

--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -676,3 +676,37 @@ fn every_legacy_key_is_unknown_to_the_generated_enum() {
         );
     }
 }
+
+/// #3987: combining existing lookups must preserve inheritance, legacy overrides,
+/// normalization, and unknown-name fallbacks across the complete catalog.
+#[test]
+fn combined_geometry_flags_match_canonical_predicates_3987() {
+    let table_len = classifications().len();
+    for name in crate::generated::IFC_TYPES.iter().map(IfcType::as_str)
+        .chain(crate::legacy_entities::LEGACY_ENTITY_NAMES.iter().copied())
+        .chain([
+            "", "IfcVendorGeometry", "IfcReinforcingVendorExtension",
+            "IfcReinforcedVendorExtension", "IfcVendorReinforcingExtension",
+            "IfcVéndor", "IFCſPACE", "IfcßBuilding", "ifcwall ",
+        ])
+    {
+        let mixed: String = name.chars().enumerate().map(|(i, ch)| {
+            if i % 2 == 0 { ch.to_ascii_lowercase() } else { ch }
+        }).collect();
+        for spelling in [name.to_owned(), name.to_ascii_lowercase(), mixed] {
+            let upper = normalise_uppercase(&spelling);
+            let expected = (
+                compute_has_geometry(upper.as_ref()),
+                compute_is_representationless_spatial_container(upper.as_ref()),
+            );
+            assert_eq!(geometry_flags_by_name(&spelling), expected, "{spelling}");
+            assert_eq!(
+                geometry_flags_by_name(&spelling),
+                (has_geometry_by_name(&spelling),
+                 is_representationless_spatial_container_by_name(&spelling)),
+                "separate public predicates differ for {spelling}",
+            );
+        }
+    }
+    assert_eq!(classifications().len(), table_len);
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -31,6 +31,7 @@ mod jobs;
 mod opening_filter;
 mod properties;
 mod quick_metadata;
+mod schema_detection;
 mod site_local;
 
 pub use quick_metadata::is_quick_spatial_type_ci;
@@ -579,7 +580,6 @@ pub fn process_geometry_streaming_filtered_with_options(
     } else {
         HashMap::new()
     };
-    let mut schema_version = "IFC2X3".to_string();
     let mut total_entities = 0usize;
     let mut site_entity_pos: Option<(usize, usize)> = None;
     let mut building_entity_pos: Option<(usize, usize)> = None;
@@ -707,7 +707,9 @@ pub fn process_geometry_streaming_filtered_with_options(
             building_entity_pos = Some((start, end));
         }
 
-        if ifc_lite_core::has_geometry_by_name(type_name) {
+        let (has_geometry, representationless_spatial) =
+            ifc_lite_core::geometry_flags_by_name(type_name);
+        if has_geometry {
             // Legacy-aware so a remapped entity (IfcProxy, IfcSolidStratum, …)
             // labels its node with the real base type, not "Unknown", and matches
             // the attribute pass's row type (#1496).
@@ -740,7 +742,7 @@ pub fn process_geometry_streaming_filtered_with_options(
                 space_zone_properties: None,
                 representation_map_id: None,
             });
-        } else if ifc_lite_core::is_representationless_spatial_container_by_name(type_name)
+        } else if representationless_spatial
             && ifc_lite_core::nth_attribute_is_present(&content[start..end], 6)
         {
             // #1910: `has_geometry_by_name` excludes spatial containers like
@@ -915,14 +917,7 @@ pub fn process_geometry_streaming_filtered_with_options(
         opening_filter,
     );
 
-    // Detect schema version. SIMD substring search (memmem) instead of the naive
-    // per-position `windows().any()`, which walked the WHOLE file — twice for an
-    // IFC2X3 file where both matches fail. Same predicate, byte-identical result.
-    if memchr::memmem::find(content, b"IFC4X3").is_some() {
-        schema_version = "IFC4X3".into();
-    } else if memchr::memmem::find(content, b"IFC4").is_some() {
-        schema_version = "IFC4".into();
-    }
+    let schema_version = schema_detection::detect_schema_version(content).to_string();
 
     let geometry_entity_count = entity_jobs.len();
     tracing::info!(

--- a/rust/processing/src/processor/schema_detection.rs
+++ b/rust/processing/src/processor/schema_detection.rs
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Preserve the historical raw-byte predicate, including matches outside HEADER:
+/// IFC4X3 anywhere wins over IFC4. Search disjoint source regions rather than
+/// scanning the whole file twice when IFC4X3 is absent (#3987).
+pub(super) fn detect_schema_version(content: &[u8]) -> &'static str {
+    let Some(offset) = memchr::memmem::find(content, b"IFC4") else {
+        return "IFC2X3";
+    };
+    let remaining = &content[offset + 4..];
+    // IFC4 has no self-overlap: a later IFC4X3 cannot start inside this match.
+    if remaining.starts_with(b"X3")
+        || memchr::memmem::find(remaining, b"IFC4X3").is_some()
+    {
+        "IFC4X3"
+    } else {
+        "IFC4"
+    }
+}
+
+#[cfg(test)]
+#[path = "schema_detection_tests.rs"]
+mod tests;

--- a/rust/processing/src/processor/schema_detection_tests.rs
+++ b/rust/processing/src/processor/schema_detection_tests.rs
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::detect_schema_version;
+
+fn original_predicate(content: &[u8]) -> &'static str {
+    if content.windows(6).any(|window| window == b"IFC4X3") {
+        "IFC4X3"
+    } else if content.windows(4).any(|window| window == b"IFC4") {
+        "IFC4"
+    } else {
+        "IFC2X3"
+    }
+}
+
+/// #3987: this optimization retains substring compatibility, not header parsing.
+#[test]
+fn schema_search_preserves_anywhere_precedence_3987() {
+    let cases: &[(&[u8], &str)] = &[
+        (b"", "IFC2X3"),
+        (b"FILE_SCHEMA(('IFC2X3'));", "IFC2X3"),
+        (b"FILE_SCHEMA(('IFC4'));", "IFC4"),
+        (b"IFC4...IFC4X3", "IFC4X3"),
+        (b"IFC4X3...IFC4", "IFC4X3"),
+        (b"FILE_SCHEMA(('IFC2X3'));DATA;#1=IFCLABEL('IFC4X3');", "IFC4X3"),
+        (b"/* IFC4X3 */ FILE_SCHEMA(('IFC4'));", "IFC4X3"),
+        (b"IFCIFC4X3", "IFC4X3"),
+        (b"IFC4IFC4X3", "IFC4X3"),
+        (b"IFC4XIFC4X3", "IFC4X3"),
+        (b"IFC4IFC4", "IFC4"),
+        (b"IFC4X", "IFC4"),
+        (b"IFC4X2", "IFC4"),
+        (b"ifc4x3", "IFC2X3"),
+        (b"\xffIFC4X3\0", "IFC4X3"),
+    ];
+    for &(content, expected) in cases {
+        assert_eq!(original_predicate(content), expected);
+        assert_eq!(detect_schema_version(content), expected, "{content:?}");
+    }
+}
+
+/// IFC4 has no self-overlapping prefix/suffix, so skipping the first match
+/// cannot hide a second IFC4X3 match. Exercise matches across chunk boundaries,
+/// all prefix/suffix truncations, adjacent occurrences, and non-UTF8 bytes.
+#[test]
+fn schema_search_matches_raw_window_oracle_3987() {
+    let chunks: &[&[u8]] = &[
+        b"", b"I", b"IF", b"IFC", b"IFC4", b"IFC4X", b"IFC4X3",
+        b"FC4X3", b"C4X3", b"4X3", b"X3", b"3", b"\0\xff", b"IFC2X3",
+    ];
+    for &left in chunks {
+        for &middle in chunks {
+            for &right in chunks {
+                let content = [left, middle, right].concat();
+                assert_eq!(detect_schema_version(&content), original_predicate(&content),
+                    "{content:?}");
+            }
+        }
+    }
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -433,6 +433,10 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
   is a judgement call (an order of magnitude clear of realistic repeated parts, which run to
   low hundreds of faces), not a measured optimum.
 
+### Retained canonical lexical and schema work (#4001)
+
+Reuse checked ID-prefix accumulation and the scanner's existing ASCII proof; obtain native geometry flags from one immutable classification lookup. Generated type parsing checks canonical names before normalization, and schema detection retains the original match priority. Retained as part of cumulative cold-load qualification; no isolated native or browser gain is claimed. Scalar tokenizer dispatch, scanner dictionaries and ordinal transport are separate experiments, not part of this change.
+
 ### Measured feature costs (not levers — recorded so nobody re-measures)
 - **Local-frame void-cut origin preservation** (#3446, measured 2026-08-31,
   base = `2edd144329`, arm64 native). This correctness fix keeps a rotated

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -435,7 +435,7 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
 
 ### Retained canonical lexical and schema work (#4001)
 
-Reuse checked ID-prefix accumulation and the scanner's existing ASCII proof; obtain native geometry flags from one immutable classification lookup. Generated type parsing checks canonical names before normalization, and schema detection retains the original match priority. Retained as part of cumulative cold-load qualification; no isolated native or browser gain is claimed. Scalar tokenizer dispatch, scanner dictionaries and ordinal transport are separate experiments, not part of this change.
+Reuse checked ID-prefix accumulation and the scanner's existing ASCII proof; obtain native geometry flags from one immutable classification lookup. Generated type parsing checks canonical names before normalization, and schema detection retains the original match priority. Own-layer native subset comparisons showed a modest full-load improvement, not a corpus-wide or browser result. Keep the cumulative verdict separate and exclude invalid Firefox cohorts and unrun follow-ups. Scalar tokenizer dispatch, scanner dictionaries and ordinal transport are separate experiments, not part of this change.
 
 ### Measured feature costs (not levers — recorded so nobody re-measures)
 - **Local-frame void-cut origin preservation** (#3446, measured 2026-08-31,


### PR DESCRIPTION
Cold-load classification reread validated ID/type bytes and normalized canonical type names before lookup. Reuse checked prefix/ASCII results and the immutable classification table, generate a canonical-first type match, and preserve schema detection priority plus malformed/unknown input behavior.

Closes #4001.

Own-layer native Haus/CSG-129 comparisons used five fresh interleaved pairs per fixture: parent `2c8f4743227500c780230034f27501abc719af22` versus `76080b221878ff379a90431b69ee802bde576c6f`. Full-call loading improved modestly (1.78%) on that subset, with matching ordered geometry fingerprints/counts. This is not a whole-corpus or isolated browser improvement. Scalar tokenizer dispatch, scanner dictionaries and ordinal transport experiments are excluded.

The prior cumulative candidate frozen over `06ef1dcd80fae841f33c6ec7d96166b1d01e23af` passed root build/typecheck/test/lint, `cargo test --workspace` (2,834 passed, 36 ignored), strict workspace Clippy and matched real-WASM contracts (86 passed). Its exact public native observable oracle and browser functional witnesses are bounded to the recorded fixtures/modes; partial browser fingerprints do not prove closure or every vertex-buffer byte.

The [committed evidence bundle](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) keeps these layer results separate from the cumulative stack: native full-call loading improved 15.53% across the fixed corpus; supplemental Chrome full readiness improved 28.70%, but Haus was slower in every pair (median paired increase 26 ms) and several geometry-completion results regressed. The original Chrome strict audit remains failed; the reviewed local analytics-404 disposition and missing historical event URLs are explicit. Firefox's original cohort is invalid under its memory rule; functional controls do not qualify Firefox throughput, and recovery remains unrun. Neither the 30% target nor universal absence of performance regressions is established.

These are prior, artifact-pinned validation results, not certification of the eventual landing head. Applicable exact-head CI, parity/API/WASM gates and review must complete before merge; this body makes no all-green or deployment claim.

This main-based landing is independent of the original stack order. Measurements retain their original frozen source/parent identities; the source-preserving integration does not create a new isolated performance result.
