### PR TITLE
perf(geometry): reuse mesh topology bookkeeping

### DIFF
--- a/.changeset/cold-load-mesh-bookkeeping.md
+++ b/.changeset/cold-load-mesh-bookkeeping.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Reuse per-mesh topology bookkeeping and compact filtered triangle indices in place while preserving geometry output, traversal order and retained buffer bounds.

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -491,17 +491,19 @@ impl Mesh {
             self.indices.clear();
             return;
         }
-        let mut valid = Vec::with_capacity(self.indices.len());
-        for chunk in self.indices.chunks(3) {
-            if chunk.len() == 3
-                && (chunk[0] as usize) < vertex_count
+        let original_len = self.indices.len();
+        let mut kept = 0;
+        for read in (0..original_len / 3 * 3).step_by(3) {
+            let chunk = [self.indices[read], self.indices[read + 1], self.indices[read + 2]];
+            if (chunk[0] as usize) < vertex_count
                 && (chunk[1] as usize) < vertex_count
-                && (chunk[2] as usize) < vertex_count
-            {
-                valid.extend_from_slice(chunk);
+                && (chunk[2] as usize) < vertex_count {
+                if kept != read { self.indices[kept..kept + 3].copy_from_slice(&chunk); }
+                kept += 3;
             }
         }
-        self.indices = valid;
+        self.indices.truncate(kept);
+        self.indices.shrink_to(original_len);
     }
 
     /// Drop triangles that collapsed into degenerate needles when the mesh was
@@ -554,14 +556,13 @@ impl Mesh {
         let dist = |a: [f64; 3], b: [f64; 3]| -> f64 {
             ((a[0] - b[0]).powi(2) + (a[1] - b[1]).powi(2) + (a[2] - b[2]).powi(2)).sqrt()
         };
-
-        let mut kept = Vec::with_capacity(self.indices.len());
-        for tri in self.indices.chunks_exact(3) {
+        // #3988: compact only after a drop; bound retained capacity as before.
+        let original_len = self.indices.len();
+        let mut kept = 0;
+        for read in (0..original_len / 3 * 3).step_by(3) {
+            let tri = [self.indices[read], self.indices[read + 1], self.indices[read + 2]];
             let (ia, ib, ic) = (tri[0], tri[1], tri[2]);
-            // Drop any out-of-range triangle BEFORE the unchecked `bits()` closure
-            // indexes positions[] (unlike `vert()` below, `bits()` has no bounds
-            // check). Matches the drop-not-panic contract of vert()/validate_indices;
-            // sibling drop_thin_triangles guards the same way.
+            // Guard before bits() indexes positions; invalid triangles are dropped.
             if ia as usize >= vertex_count
                 || ib as usize >= vertex_count
                 || ic as usize >= vertex_count
@@ -582,17 +583,16 @@ impl Mesh {
             let e2 = dist(vc, va);
             let min_edge = e0.min(e1).min(e2);
             let max_edge = e0.max(e1).max(e2);
-            // Catastrophic needle: a sliver whose longest edge dwarfs its
-            // shortest by >1e5. min_edge==0 is already handled by the bit check
-            // above, so a finite ratio here means near-but-not-identical f32.
+            // Drop catastrophic needles; bit-identical zero edges were handled above.
             if min_edge > 0.0 && max_edge / min_edge > MAX_ASPECT {
                 continue;
             }
-            kept.extend_from_slice(tri);
+            if kept != read { self.indices[kept..kept + 3].copy_from_slice(&tri); }
+            kept += 3;
         }
-        self.indices = kept;
+        self.indices.truncate(kept);
+        self.indices.shrink_to(original_len);
     }
-
     /// Check if mesh is empty
     #[inline]
     pub fn is_empty(&self) -> bool {

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -33,38 +33,11 @@ use crate::Mesh;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
 
-/// Incident-triangle record for one undirected welded edge. A boundary edge has
-/// one incident triangle and a manifold edge exactly two, so the two triangle
-/// slots are stored INLINE — replacing the old per-edge heap `Vec<usize>`, which
-/// allocated ~1.5 tiny Vecs per triangle and dominated the allocator churn of
-/// this pass on mesh-heavy models. `count` is the TRUE incidence; a value > 2
-/// marks a non-manifold edge, which the propagation skips before ever reading
-/// the slots. Only the first two triangles are consulted, stored in ascending
-/// scan order (identical to the old `Vec` push order), so the BFS traversal —
-/// and therefore every flip decision — is byte-identical.
-#[derive(Clone, Copy, Default)]
-struct EdgeInc {
-    tris: [usize; 2],
-    count: u32,
-}
-
-impl EdgeInc {
-    #[inline]
-    fn push(&mut self, t: usize) {
-        if (self.count as usize) < 2 {
-            self.tris[self.count as usize] = t;
-        }
-        self.count += 1;
-    }
-
-    /// The incident triangles the propagation may consult (the first two, in
-    /// push order). Only reached for `count` of 1 or 2 — the `count > 2` path
-    /// `continue`s first — so this yields exactly what the old `Vec` iterated.
-    #[inline]
-    fn incident(&self) -> &[usize] {
-        &self.tris[..(self.count as usize).min(2)]
-    }
-}
+#[path = "mesh_orient_adjacency.rs"]
+mod adjacency;
+use adjacency::EdgeAdjacency;
+#[cfg(test)]
+use adjacency::EdgeInc;
 
 /// Vertex weld grid scale (reciprocal of a 10 µm grid, i.e. positions are
 /// quantized to `round(v * WELD_SCALE)`): fine enough not to merge distinct
@@ -76,7 +49,7 @@ const WELD_SCALE: f64 = 1.0e5;
 
 /// Per-worker reusable scratch for [`orient_mesh_outward`], cleared (never freed)
 /// between meshes. The pass runs once per assembled submesh (~109k times on a
-/// mesh-heavy model), so each fresh call's two `FxHashMap`s + six `Vec`s were
+/// mesh-heavy model), so each fresh call's two `FxHashMap`s + the traversal `Vec`s were
 /// ~4-6% of busy CPU on pure-brep/steel models; pooling makes it allocate-once,
 /// clear-many. BYTE-IDENTICAL: neither map is ever iterated — both are only
 /// `.entry()`-inserted (order fixed by the deterministic scan) and keyed-looked-up,
@@ -88,7 +61,7 @@ struct OrientScratch {
     vid_of: FxHashMap<(i64, i64, i64), u32>,
     vpos: Vec<[f64; 3]>,
     corner: Vec<u32>,
-    edge_tris: FxHashMap<(u32, u32), EdgeInc>,
+    edge_tris: EdgeAdjacency,
     flip: Vec<bool>,
     visited: Vec<bool>,
     comp: Vec<usize>,
@@ -221,9 +194,14 @@ pub fn orient_mesh_outward_verdict(mesh: &mut Mesh) -> OrientVerdict {
     corner.clear();
     corner.reserve(mesh.indices.len());
 
-    // Weld positions -> welded vertex id; record the welded vid of every corner.
+    // #3988: indexed corners repeatedly use the SAME source vertex. Reuse its
+    // welded id, keeping the original first-corner insertion order. Sparse meshes
+    // use corner slots instead, so scratch never exceeds the old corner budget.
+    let indexed = vertex_count < mesh.indices.len();
+    if indexed { corner.resize(vertex_count, u32::MAX); }
     let q = |v: f32| (v as f64 * WELD_SCALE).round() as i64;
     for &idx in &mesh.indices {
+        if indexed && corner[idx as usize] != u32::MAX { continue; }
         let b = idx as usize * 3;
         let key = (
             q(mesh.positions[b]),
@@ -239,22 +217,23 @@ pub fn orient_mesh_outward_verdict(mesh: &mut Mesh) -> OrientVerdict {
             ]);
             id
         });
-        corner.push(vid);
+        if indexed { corner[idx as usize] = vid; } else { corner.push(vid); }
     }
-    let tv = |t: usize| [corner[3 * t], corner[3 * t + 1], corner[3 * t + 2]];
+    let tv = |t: usize| std::array::from_fn::<_, 3, _>(|k| {
+        corner[if indexed { mesh.indices[3 * t + k] as usize } else { 3 * t + k }]
+    });
 
     // Undirected welded edge -> incident triangles. >2 incident ⇒ non-manifold.
     // A closed manifold has ~1.5 edges per triangle; reserve to skip rehashing.
-    edge_tris.clear();
-    edge_tris.reserve(ntri * 2);
+    edge_tris.reset(ntri);
     for t in 0..ntri {
         let v = tv(t);
-        for &(a, b) in &[(v[0], v[1]), (v[1], v[2]), (v[2], v[0])] {
+        for (slot, &(a, b)) in [(v[0], v[1]), (v[1], v[2]), (v[2], v[0])].iter().enumerate() {
             if a == b {
                 continue; // welded-degenerate edge
             }
             let key = if a < b { (a, b) } else { (b, a) };
-            edge_tris.entry(key).or_default().push(t);
+            edge_tris.push(key, t * 3 + slot);
         }
     }
 
@@ -303,22 +282,16 @@ pub fn orient_mesh_outward_verdict(mesh: &mut Mesh) -> OrientVerdict {
             } else {
                 [(v[0], v[1]), (v[1], v[2]), (v[2], v[0])]
             };
-            for &(a, b) in &dirs {
+            for (slot, &(a, b)) in dirs.iter().enumerate() {
                 if a == b {
                     continue;
                 }
                 let key = if a < b { (a, b) } else { (b, a) };
-                let inc = &edge_tris[&key];
-                if inc.count != 2 {
-                    closed = false; // boundary (1) or non-manifold (>2) edge
-                }
-                if inc.count > 2 {
-                    continue; // ambiguous — don't propagate across a non-manifold edge
-                }
-                for &nb in inc.incident() {
-                    if nb == t {
-                        continue;
-                    }
+                let original_slot = if flip[t] { 2 - slot } else { slot };
+                let (closed_edge, neighbors) = edge_tris.neighbors(key, t * 3 + original_slot);
+                if !closed_edge { closed = false; }
+                for nb in neighbors {
+                    if nb == usize::MAX || nb == t { continue; }
                     // A consistent neighbour must traverse this edge as (b, a). Its
                     // UNFLIPPED winding has (a, b) iff it must flip to do so.
                     let nv = tv(nb);

--- a/rust/geometry/src/mesh_orient_adjacency.rs
+++ b/rust/geometry/src/mesh_orient_adjacency.rs
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Edge incidence construction and traversal for the canonical mesh orienter.
+
+use rustc_hash::FxHashMap;
+use std::collections::hash_map::Entry;
+
+const NONE: usize = usize::MAX;
+type Edge = (u32, u32);
+
+/// One byte buffer serves both widths, so switching mesh size cannot retain two
+/// independent neighbor allocations. Stored values are half-edge offsets; the
+/// maximum value in each width is reserved for no traversable neighbor.
+#[derive(Default)]
+struct Links { bytes: Vec<u8>, width: usize }
+
+impl Links {
+    fn reset(&mut self, slots: usize) {
+        self.width = if slots <= u16::MAX as usize { 2 } else { 4 };
+        self.bytes.clear();
+        self.bytes.reserve_exact(slots * self.width);
+        self.bytes.resize(slots * self.width, 0xff);
+    }
+
+    #[inline]
+    fn get(&self, slot: usize) -> usize {
+        let start = slot * self.width;
+        if self.width == 2 {
+            let value = u16::from_ne_bytes(self.bytes[start..start + 2].try_into().unwrap());
+            if value == u16::MAX { NONE } else { value as usize }
+        } else {
+            let value = u32::from_ne_bytes(self.bytes[start..start + 4].try_into().unwrap());
+            if value == u32::MAX { NONE } else { value as usize }
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, slot: usize, value: usize) {
+        let start = slot * self.width;
+        if self.width == 2 {
+            self.bytes[start..start + 2].copy_from_slice(&(value as u16).to_ne_bytes());
+        } else {
+            self.bytes[start..start + 4].copy_from_slice(&(value as u32).to_ne_bytes());
+        }
+    }
+}
+
+/// Dense meshes keep only their first half-edge in the construction map. After
+/// a third incidence, NONE means permanently non-manifold. The extraordinary
+/// `>u32::MAX` half-edge domain retains exact historical incidence wrap behavior
+/// using the same traversal and the original two-word map value (#3988).
+enum Storage {
+    Dense { first: FxHashMap<Edge, usize>, links: Links },
+    Wide(FxHashMap<Edge, EdgeInc>),
+}
+
+pub(super) struct EdgeAdjacency {
+    storage: Storage,
+    #[cfg(test)]
+    force_wide: bool,
+}
+
+impl Default for EdgeAdjacency {
+    fn default() -> Self {
+        Self {
+            storage: Storage::Dense { first: FxHashMap::default(), links: Links::default() },
+            #[cfg(test)]
+            force_wide: false,
+        }
+    }
+}
+
+impl EdgeAdjacency {
+    pub(super) fn reset(&mut self, triangles: usize) {
+        let slots = triangles * 3;
+        let wide = slots > u32::MAX as usize;
+        #[cfg(test)]
+        let wide = wide || self.force_wide;
+        if wide != matches!(self.storage, Storage::Wide(_)) {
+            // Replacing the variant drops the unused representation; no second
+            // large retained map survives an extraordinary-domain transition.
+            self.storage = if wide { Storage::Wide(FxHashMap::default()) }
+                else { Storage::Dense { first: FxHashMap::default(), links: Links::default() } };
+        }
+        match &mut self.storage {
+            Storage::Dense { first, links } => {
+                first.clear();
+                first.reserve(triangles * 2);
+                links.reset(slots);
+            }
+            Storage::Wide(edges) => {
+                edges.clear();
+                edges.reserve(triangles * 2);
+            }
+        }
+    }
+
+    pub(super) fn push(&mut self, edge: Edge, slot: usize) {
+        match &mut self.storage {
+            Storage::Dense { first, links } => match first.entry(edge) {
+                Entry::Vacant(entry) => { entry.insert(slot); }
+                Entry::Occupied(mut entry) => {
+                    let previous = *entry.get();
+                    if previous == NONE { return; }
+                    let paired = links.get(previous);
+                    if paired == NONE {
+                        links.set(previous, slot);
+                        links.set(slot, previous);
+                    } else {
+                        // Invalidate both earlier incidences on the third, even
+                        // when they are repeated edges of the same triangle.
+                        links.set(previous, NONE);
+                        links.set(paired, NONE);
+                        *entry.get_mut() = NONE;
+                    }
+                }
+            },
+            Storage::Wide(edges) => { edges.entry(edge).or_default().push(slot / 3); }
+        }
+    }
+
+    /// Return closed-edge status and the original neighbor order. A dense edge
+    /// has at most one other triangle; repeated incidences of the same triangle
+    /// yield that triangle and are skipped by the unchanged caller.
+    #[inline]
+    pub(super) fn neighbors(&self, edge: Edge, slot: usize) -> (bool, [usize; 2]) {
+        match &self.storage {
+            Storage::Dense { links, .. } => {
+                let neighbor = links.get(slot);
+                (neighbor != NONE, [if neighbor == NONE { NONE } else { neighbor / 3 }, NONE])
+            }
+            Storage::Wide(edges) => {
+                let inc = &edges[&edge];
+                let mut neighbors = [NONE; 2];
+                if inc.count() <= 2 {
+                    for (target, &source) in neighbors.iter_mut().zip(inc.incident()) { *target = source; }
+                }
+                (inc.count() == 2, neighbors)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn wide_for_test() -> Self {
+        Self { storage: Storage::Wide(FxHashMap::default()), force_wide: true }
+    }
+}
+
+/// #3988: two incident triangles fit in two words. Once there are more than
+/// two, traversal skips the edge, so the first word can hold the incidence
+/// count instead. Triangle indices are below `indices.len() / 3`, hence cannot
+/// equal either sentinel, including on wasm32. Preserve u32 overflow behavior.
+#[derive(Clone, Copy)]
+pub(super) struct EdgeInc { pub(super) tris: [usize; 2] }
+
+impl Default for EdgeInc {
+    fn default() -> Self { Self { tris: [usize::MAX; 2] } }
+}
+
+impl EdgeInc {
+    pub(super) const NONMANIFOLD: usize = usize::MAX - 1;
+
+    #[inline]
+    pub(super) fn push(&mut self, t: usize) {
+        if self.tris[1] == Self::NONMANIFOLD {
+            let count = self.tris[0] as u32 + 1;
+            if count == 0 { *self = Self::default(); }
+            else { self.tris[0] = count as usize; }
+        } else if self.tris[0] == usize::MAX {
+            self.tris[0] = t;
+        } else if self.tris[1] == usize::MAX {
+            self.tris[1] = t;
+        } else {
+            self.tris = [3, Self::NONMANIFOLD];
+        }
+    }
+
+    #[inline]
+    pub(super) fn count(&self) -> u32 {
+        if self.tris[1] == Self::NONMANIFOLD { self.tris[0] as u32 }
+        else if self.tris[0] == usize::MAX { 0 }
+        else if self.tris[1] == usize::MAX { 1 }
+        else { 2 }
+    }
+
+    /// Called only after the non-manifold path has been skipped.
+    #[inline]
+    pub(super) fn incident(&self) -> &[usize] { &self.tris[..self.count() as usize] }
+}

--- a/rust/geometry/src/mesh_orient_tests.rs
+++ b/rust/geometry/src/mesh_orient_tests.rs
@@ -436,3 +436,187 @@ fn a_closed_but_non_orientable_shell_is_refused_rather_than_wound_outward() {
         "a non-orientable component keeps the winding it was authored with"
     );
 }
+
+// #3988: index sharing is storage only. The orienter must produce the same
+// ordered, directed triangles and topology for shared, soup and sparse storage.
+#[test]
+fn issue_3988_orientation_is_independent_of_vertex_index_sharing() {
+    for flipped in [&[][..], &[0][..], &[2, 4, 7][..], &[0, 1, 2, 3, 4, 5][..]] {
+        let mut expanded = cube(flipped);
+        let mut indexed = Mesh::new();
+        let mut ids = FxHashMap::default();
+        for p in expanded.positions.chunks_exact(3) {
+            let key = (p[0].to_bits(), p[1].to_bits(), p[2].to_bits());
+            let id = *ids.entry(key).or_insert_with(|| {
+                let id = indexed.positions.len() as u32 / 3;
+                indexed.positions.extend_from_slice(p);
+                id
+            });
+            indexed.indices.push(id);
+        }
+        let mut sparse = indexed.clone();
+        // Unreferenced positions must not influence welding IDs or topology.
+        sparse.positions.extend(std::iter::repeat_n(37.0, 300));
+        let expected = orient_mesh_outward_verdict(&mut expanded);
+        let directed_positions = |m: &Mesh| -> Vec<u32> {
+            m.indices.iter().flat_map(|&i| {
+                m.positions[i as usize * 3..i as usize * 3 + 3].iter().map(|p| p.to_bits())
+            }).collect()
+        };
+        for m in [&mut indexed, &mut sparse] {
+            assert_eq!(orient_mesh_outward_verdict(m), expected);
+            assert_eq!(directed_positions(m), directed_positions(&expanded));
+        }
+        assert!(expected.is_single_closed_solid());
+    }
+}
+
+// #3988: compact edge bookkeeping must preserve the actual incidence stream,
+// including repeated triangle IDs. Only count<=2 exposes triangle slots.
+#[test]
+fn compact_incidence_preserves_incident_prefixes_3988() {
+    for sequence in [
+        (0..16).collect::<Vec<usize>>(),
+        vec![7; 16],
+        vec![usize::MAX / 3, usize::MAX / 3 - 1, 0, 1, 1, 0],
+    ] {
+        let mut edge = EdgeInc::default();
+        let mut oracle = Vec::new();
+        assert_eq!(edge.count(), 0);
+        assert!(edge.incident().is_empty());
+        for triangle in sequence {
+            oracle.push(triangle);
+            edge.push(triangle);
+            assert_eq!(edge.count() as usize, oracle.len());
+            if oracle.len() <= 2 {
+                assert_eq!(edge.incident(), oracle);
+            }
+        }
+    }
+}
+
+// #3988: the old record's u32 arithmetic is observable at overflow. Starting
+// near the boundary avoids allocating billions of triangles while checking the
+// same state transitions, including usize::MAX collision on wasm32.
+#[test]
+fn compact_incidence_preserves_counter_overflow_3988() {
+    #[derive(Clone)]
+    struct Original { tris: [usize; 2], count: u32 }
+    impl Original {
+        fn push(&mut self, triangle: usize) {
+            if self.count < 2 { self.tris[self.count as usize] = triangle; }
+            self.count += 1;
+        }
+    }
+    let mut original = Original { tris: [42, 73], count: u32::MAX - 1 };
+    let mut compact = EdgeInc {
+        tris: [(u32::MAX - 1) as usize, EdgeInc::NONMANIFOLD],
+    };
+    original.push(9);
+    compact.push(9);
+    assert_eq!(compact.count(), original.count);
+    let original_overflow = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        original.push(10);
+    }));
+    let compact_overflow = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        compact.push(10);
+    }));
+    assert_eq!(compact_overflow.is_err(), original_overflow.is_err());
+    assert_eq!(compact.count(), original.count);
+    if original_overflow.is_ok() {
+        assert!(compact.incident().is_empty());
+        for triangle in [19, 23] {
+            original.push(triangle);
+            compact.push(triangle);
+            assert_eq!(compact.count(), original.count);
+            assert_eq!(compact.incident(), &original.tris[..original.count as usize]);
+        }
+    }
+}
+
+/// #3988: compare dense links with the original map incidence representation
+/// through the SAME canonical orientation pass, including exact winding order.
+fn assert_dense_matches_map_3988(input: &Mesh) {
+    let mut dense = input.clone();
+    let mut wide = input.clone();
+    ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch::default()));
+    let dense_verdict = orient_mesh_outward_verdict(&mut dense);
+    ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch {
+        edge_tris: EdgeAdjacency::wide_for_test(), ..OrientScratch::default()
+    }));
+    let wide_verdict = orient_mesh_outward_verdict(&mut wide);
+    ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch::default()));
+    assert_eq!(dense_verdict, wide_verdict);
+    assert_eq!(dense.indices, wide.indices);
+    assert_eq!(dense.positions.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+        wide.positions.iter().map(|v| v.to_bits()).collect::<Vec<_>>());
+    assert_eq!(dense.normals.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+        wide.normals.iter().map(|v| v.to_bits()).collect::<Vec<_>>());
+}
+
+#[test]
+fn dense_adjacency_preserves_orientation_and_degenerate_incidence_3988() {
+    for mask in 0..256u32 {
+        let flips: Vec<usize> = (0..12).filter(|bit| mask & (1 << bit) != 0).collect();
+        assert_dense_matches_map_3988(&cube(&flips));
+    }
+    let vertices = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+    // Repeated non-zero edges within one degenerate triangle are two distinct
+    // incidences; a later third incidence must revoke BOTH earlier links.
+    for faces in [
+        vec![[0, 1, 0], [0, 2, 3]],
+        vec![[0, 1, 0], [0, 1, 2]],
+        vec![[0, 1, 2], [1, 0, 3], [0, 1, 3]],
+        vec![[0, 0, 0], [1, 1, 1]],
+        vec![[0, 1, 2], [0, 2, 1]],
+    ] { assert_dense_matches_map_3988(&soup(&vertices, &faces)); }
+    // File-like arbitrary topology, deterministic and including repeated refs.
+    let mut state = 0x3988u32;
+    for _ in 0..128 {
+        let faces: Vec<[usize; 3]> = (0..17).map(|_| std::array::from_fn(|_| {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            ((state >> 16) & 3) as usize
+        })).collect();
+        assert_dense_matches_map_3988(&soup(&vertices, &faces));
+    }
+    let mut malformed = cube(&[]);
+    malformed.indices.push(u32::MAX);
+    assert_dense_matches_map_3988(&malformed);
+    let mut partial = cube(&[3]);
+    partial.indices.push(0);
+    assert_dense_matches_map_3988(&partial);
+}
+
+#[test]
+fn dense_adjacency_reuses_links_across_width_transitions_3988() {
+    let mut retained_dense = OrientScratch::default();
+    for triangles in [2, 21845, 21846, 7, 24000, 2] {
+        // Disjoint closed tetrahedra exercise volume order and orientation;
+        // trailing open triangles cover counts not divisible by four.
+        let mut input = Mesh::new();
+        for t in 0..triangles {
+            let group = t / 4;
+            let x = group as f32 * 4.0;
+            let vertices = [[x, 0.0, 0.0], [x + 1.0, 0.0, 0.0],
+                [x, 1.0, 0.0], [x, 0.0, 1.0]];
+            let faces = [[0, 2, 1], [0, 1, 3], [1, 2, 3], [2, 0, 3]];
+            let part = soup(&vertices, &[faces[t % 4]]);
+            let offset = input.positions.len() as u32 / 3;
+            input.positions.extend(part.positions);
+            input.normals.extend(part.normals);
+            input.indices.extend(part.indices.into_iter().map(|i| i + offset));
+        }
+        let mut expected = input.clone();
+        ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch {
+            edge_tris: EdgeAdjacency::wide_for_test(), ..OrientScratch::default()
+        }));
+        let expected_verdict = orient_mesh_outward_verdict(&mut expected);
+        ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(retained_dense));
+        let actual_verdict = orient_mesh_outward_verdict(&mut input);
+        retained_dense = ORIENT_SCRATCH.with(|slot| slot.borrow_mut().take().unwrap());
+        assert_eq!(actual_verdict, expected_verdict, "{triangles} triangles");
+        assert_eq!(input.indices, expected.indices, "{triangles} triangles");
+    }
+    ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch::default()));
+}

--- a/rust/geometry/src/mesh_tests.rs
+++ b/rust/geometry/src/mesh_tests.rs
@@ -533,3 +533,46 @@ fn clean_degenerate_uses_the_reconcile_grid() {
     mesh.clean_degenerate();
     assert_eq!(mesh.indices, vec![3, 4, 5]);
 }
+
+// #3988: stable in-place compaction must preserve every survivor's index order,
+// handle adjacent drops and discard the same incomplete trailing triangle.
+#[test]
+fn issue_3988_degenerate_compaction_preserves_survivors_and_storage() {
+    let mut mesh = Mesh::new();
+    mesh.positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    mesh.indices = vec![0, 1, 2, 0, 0, 2, 99, 1, 2, 2, 1, 0, 1, 2];
+    let ptr = mesh.indices.as_ptr();
+    let capacity = mesh.indices.capacity();
+    mesh.drop_degenerate_triangles();
+    assert_eq!(mesh.indices, [0, 1, 2, 2, 1, 0]);
+    assert_eq!(mesh.indices.as_ptr(), ptr, "compaction must reuse owned storage");
+    assert_eq!(mesh.indices.capacity(), capacity);
+    mesh.drop_degenerate_triangles();
+    assert_eq!(mesh.indices, [0, 1, 2, 2, 1, 0]);
+    let settled_ptr = mesh.indices.as_ptr();
+    mesh.drop_degenerate_triangles();
+    assert_eq!(mesh.indices.as_ptr(), settled_ptr, "a settled no-op pass must reuse storage");
+}
+
+// #3988: valid-index and geometric-degeneracy filters share the old retained
+// capacity bound even when an upstream builder deliberately over-reserved.
+#[test]
+fn issue_3988_filters_release_excess_reservation_without_reordering() {
+    for filter in [Mesh::validate_indices, Mesh::drop_degenerate_triangles] {
+        let mut mesh = Mesh::new();
+        mesh.positions = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        mesh.indices = Vec::with_capacity(4096);
+        mesh.indices.extend_from_slice(&[0, 1, 2, 99, 1, 2, 2, 1, 0, 1]);
+        let original_len = mesh.indices.len();
+        filter(&mut mesh);
+        assert_eq!(mesh.indices, [0, 1, 2, 2, 1, 0]);
+        assert_eq!(mesh.indices.capacity(), original_len);
+        // The first pass may retain the old pre-drop length, exactly as before;
+        // the second pass establishes the same bound for its shorter input.
+        filter(&mut mesh);
+        assert_eq!(mesh.indices.capacity(), mesh.indices.len());
+        let settled_ptr = mesh.indices.as_ptr();
+        filter(&mut mesh);
+        assert_eq!(mesh.indices.as_ptr(), settled_ptr);
+    }
+}

--- a/rust/geometry/src/mesh_weld.rs
+++ b/rust/geometry/src/mesh_weld.rs
@@ -150,15 +150,11 @@ pub fn weld_indexed(
             Some(u) => [u[v * 2], u[v * 2 + 1]],
             None => [0.0, 0.0],
         };
-        let id = match map.get(&vkey(p, n, uv)) {
-            Some(&id) => id,
-            None => {
-                let id = first_vert.len() as u32;
-                first_vert.push(v as u32);
-                map.insert(vkey(p, n, uv), id);
-                id
-            }
-        };
+        let id = *map.entry(vkey(p, n, uv)).or_insert_with(|| {
+            let id = first_vert.len() as u32;
+            first_vert.push(v as u32);
+            id
+        });
         remap[v] = id;
     }
 

--- a/rust/geometry/src/router/content_hash.rs
+++ b/rust/geometry/src/router/content_hash.rs
@@ -163,19 +163,19 @@ pub(super) fn try_faceted_brep_signature(decoder: &mut EntityDecoder, brep_id: u
         parse_first_ref(bytes)?
     };
     let face_ids = decoder.get_entity_ref_list_fast(shell_id)?;
-
+    let (mut bound_ids, mut coords) = (Vec::new(), Vec::new());
     let mut acc = fold(0, FACETED_BREP_TAG);
     acc = fold(acc, face_ids.len() as u64);
     for face_id in face_ids {
-        let bound_ids = decoder.get_entity_ref_list_fast(face_id)?;
+        decoder.get_entity_ref_list_fast_into(face_id, &mut bound_ids)?;
         acc = fold(acc, bound_ids.len() as u64);
-        for bound_id in bound_ids {
+        for &bound_id in &bound_ids {
             let (loop_id, orientation, is_outer) = decoder.get_face_bound_fast(bound_id)?;
             acc = fold(acc, orientation as u64);
             acc = fold(acc, is_outer as u64);
-            let coords = decoder.get_polyloop_coords_cached(loop_id)?;
+            decoder.get_polyloop_coords_cached_into(loop_id, &mut coords)?;
             acc = fold(acc, coords.len() as u64);
-            for (x, y, z) in coords {
+            for &(x, y, z) in &coords {
                 acc = fold(acc, x.to_bits());
                 acc = fold(acc, y.to_bits());
                 acc = fold(acc, z.to_bits());
@@ -305,8 +305,8 @@ fn sig_entity(
     // net loss on procedural geometry (#1177) and kept the gate brep-only. Walk
     // the record bytes folding literals, and on each `#ref` recurse so the hash
     // stays structural + renumbering-invariant (the entity's own id is skipped).
-    let raw: Vec<u8> = match decoder.get_raw_bytes(id) {
-        Some(b) => b.to_vec(),
+    let raw = match decoder.get_raw_bytes(id) { // #3988: borrows source, not decoder state.
+        Some(b) => b,
         None => {
             // Unresolvable reference: a fixed sentinel (NOT the id, so structurally
             // identical-but-renumbered files still collide).
@@ -315,7 +315,7 @@ fn sig_entity(
             return s;
         }
     };
-    let acc = sig_walk_bytes(decoder, &raw, memo, depth, refused);
+    let acc = sig_walk_bytes(decoder, raw, memo, depth, refused);
     memo.insert(id, acc);
     acc
 }

--- a/rust/geometry/src/router/content_hash_tests.rs
+++ b/rust/geometry/src/router/content_hash_tests.rs
@@ -158,3 +158,43 @@ fn geometry_routing_key_feeds_take_content_hash_oversized_ref_drops() {
         "a second drain must return zero — the counter resets, it isn't recomputed"
     );
 }
+
+// #3988: a face with two bounds followed by one with a single shorter loop
+// must consume exactly those authored corners. Buffer reuse must not retain the
+// previous face's hole or the previous loop's fourth point.
+#[test]
+fn issue_3988_brep_signature_reuses_scratch_without_stale_faces_or_points() {
+    let source = "\
+#1=IFCFACETEDBREP(#2);
+#2=IFCCLOSEDSHELL((#3,#4));
+#3=IFCFACE((#5,#6));
+#4=IFCFACE((#7));
+#5=IFCFACEOUTERBOUND(#10,.T.);
+#6=IFCFACEBOUND(#11,.F.);
+#7=IFCFACEOUTERBOUND(#12,.T.);
+#10=IFCPOLYLOOP((#20,#21,#22,#23));
+#11=IFCPOLYLOOP((#20,#21,#22));
+#12=IFCPOLYLOOP((#21,#22,#23));
+#20=IFCCARTESIANPOINT((0.,0.,0.));
+#21=IFCCARTESIANPOINT((1.,0.,0.));
+#22=IFCCARTESIANPOINT((0.,1.,0.));
+#23=IFCCARTESIANPOINT((0.,0.,1.));
+";
+    let mut decoder = EntityDecoder::new(source);
+    let signature = try_faceted_brep_signature(&mut decoder, 1).expect("complete BREP");
+    assert_eq!(decoder.point_cache_stats(), (6, 4), "ten authored corners, four unique points");
+    // STEP ids are identities, not geometry: an otherwise identical source
+    // with all references renumbered must retain the content signature.
+    let mut renumbered = source.to_string();
+    for id in (1..=23).rev() {
+        // Punctuation delimits STEP refs so #2 cannot accidentally replace #20.
+        for suffix in [",", ")", "="] {
+            renumbered = renumbered.replace(&format!("#{id}{suffix}"), &format!("#{}{suffix}", id + 100));
+        }
+    }
+    let mut other = EntityDecoder::new(&renumbered);
+    assert_eq!(try_faceted_brep_signature(&mut other, 101), Some(signature));
+    let missing = source.replace("#12=IFCPOLYLOOP((#21,#22,#23))", "#12=IFCPOLYLOOP((#21,#22,#99))");
+    let mut missing_decoder = EntityDecoder::new(&missing);
+    assert_eq!(try_faceted_brep_signature(&mut missing_decoder, 1), None);
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -283,7 +283,7 @@ as well as JavaScript errors, and stop memory sampling on every exit path.
 
 ### Retained mesh bookkeeping and no-op copies (#3988)
 
-Orientation reuses deterministic edge adjacency, while triangle filters compact their existing index buffer and welding/content hashing avoid duplicate map probes. Geometry policy, tolerances and traversal/output order remain unchanged. Retained in cumulative cold-load qualification; do not extrapolate sampled leaf CPU to a per-layer throughput claim. Keep exact output and diagnostic oracles, including invalid/degenerate triangles and reused buffer capacity. Owned-weld, sliver-incidence and alternate meshing experiments are not included.
+Orientation reuses deterministic edge adjacency, triangle filters compact their existing index buffer, and welding/content hashing avoid duplicate map probes. Geometry policy, tolerances and traversal/output order remain unchanged. Own-layer native subset comparisons did not establish a meaningful full-load improvement; sampled leaf CPU and the cumulative result cannot establish a layer-specific gain. Preserve exact output and diagnostic oracles, including invalid/degenerate triangles and reused-buffer capacity. No isolated browser gain is established here; invalid Firefox cohorts and unrun follow-ups remain excluded. Owned-weld, sliver-incidence and alternate meshing experiments are not included.
 
 ### Dead ends (do NOT re-spike without a new mechanism)
 - **More geometry workers** -> zero CSG speedup: memory-bandwidth bound, not CPU.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -281,6 +281,10 @@ as well as JavaScript errors, and stop memory sampling on every exit path.
   shipped and is a real win; it is NOT the viewer huge-file case below (see dead ends).
 - **Vertex weld at faceted-brep source** (#1562): closes the volume-metric gap.
 
+### Retained mesh bookkeeping and no-op copies (#3988)
+
+Orientation reuses deterministic edge adjacency, while triangle filters compact their existing index buffer and welding/content hashing avoid duplicate map probes. Geometry policy, tolerances and traversal/output order remain unchanged. Retained in cumulative cold-load qualification; do not extrapolate sampled leaf CPU to a per-layer throughput claim. Keep exact output and diagnostic oracles, including invalid/degenerate triangles and reused buffer capacity. Owned-weld, sliver-incidence and alternate meshing experiments are not included.
+
 ### Dead ends (do NOT re-spike without a new mechanism)
 - **More geometry workers** -> zero CSG speedup: memory-bandwidth bound, not CPU.
 - **Shared entity-index for the VIEWER huge-file path** (#1445): CLOSED, branch


### PR DESCRIPTION
Mesh postprocessing repeated edge-map work and allocated fresh index vectors even when no triangle was removed. Reuse deterministic adjacency and compact existing buffers while preserving first-seen weld IDs, triangle/traversal order, diagnostics and geometry policy.

Closes #3988.

Behavioral regressions cover orientation, invalid/degenerate triangles, retained buffer capacity, weld ordering and content-hash compatibility. Own-layer native subset measurements did not establish a meaningful full-load improvement; no isolated browser speedup is claimed. Owned-weld, sliver-incidence and alternate meshing experiments are excluded.

The [shared evidence](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) records combined native full-call improvement 15.53% and supplemental Chrome full-readiness improvement 28.70%, with Haus +26ms and slower geometry completion on some models. These are combined results, not this layer's gain. Chrome's original strict audit remains failed with an explicit local analytics 404 disposition and missing historical event URLs. Firefox's strict cohort is invalid; later passing controls do not establish a corpus gain. Neither the 30% target nor universal absence of regressions is established.

This main-based head preserves all nine D source/test/changeset blobs exactly against the combined local-validation tree and the original D head. The combined tree passed full root build 49/49, typecheck covering 1739 test files, all 98 test tasks, lint and 86 real WASM contracts with a matched historical pair. Rust and geometry correctness evidence remains scoped to its recorded source and fixtures. Local source-equivalent validation supports the maintainer's landing review; it is not a claim that pending remote checks have passed or that this exact rebased runtime was benchmarked. Exact-head remote CI/review status remains visible, and post-merge main CI is monitored separately.
