### PR TITLE
perf(renderer): preserve exact LOD cells with numeric keys

### DIFF
--- a/.changeset/eighty-poems-enjoy.md
+++ b/.changeset/eighty-poems-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Avoid allocating string cell keys for bounded LOD neighborhoods while preserving full entity IDs, representative selection and triangle order.

--- a/packages/renderer/src/lod-cell-key-equivalence.test.ts
+++ b/packages/renderer/src/lod-cell-key-equivalence.test.ts
@@ -72,6 +72,35 @@ describe('issue #3991 exact LOD cell keys', () => {
     });
   }
 
+  it('avoids per-cell string keys while simplifying an eligible finite mesh (#3991)', () => {
+    const { data, indices } = fixture([[0, 0, 0], [4, 0, 0], [0, 4, 4]]);
+    // Build the independent tuple oracle before observing the real simplifier:
+    // the oracle intentionally allocates string keys, unlike the eligible path.
+    const expected = stringCellOracle(data, 7, indices, 1);
+    assert.ok(expected);
+    const originalSet = Map.prototype.set;
+    let stringInsertions = 0;
+    let numericInsertions = 0;
+    let result: Uint32Array | null;
+    // Transparent, synchronous observation: preserve every key, value, receiver
+    // and return value. No await or assertion runs with the global hook installed.
+    Map.prototype.set = function <K, V>(this: Map<K, V>, key: K, value: V) {
+      if (typeof key === 'string') stringInsertions++;
+      if (typeof key === 'number') numericInsertions++;
+      return originalSet.call(this, key, value);
+    };
+    try {
+      result = simplifyIndicesByClustering(data, 7, indices, 1);
+    } finally {
+      Map.prototype.set = originalSet;
+    }
+    assert.ok(result, 'the observed call must produce an accepted LOD');
+    assert.equal(result.length, 120 * 3, 'the mesh must actually lose collapsed triangles');
+    assert.deepEqual(result, expected, 'numeric cells preserve first representatives and entity lanes');
+    assert.equal(numericInsertions, 6, 'three occupied cells for each of two full-u32 entity lanes');
+    assert.equal(stringInsertions, 0, 'eligible cells must use no string map keys');
+  });
+
   it('keeps coincident cells from different full-u32 entity lanes isolated', () => {
     const { data, indices } = fixture([[0, 0, 0], [4, 0, 0], [0, 4, 4]]);
     const result = simplifyIndicesByClustering(data, 7, indices, 1);

--- a/packages/renderer/src/lod-cell-key-equivalence.test.ts
+++ b/packages/renderer/src/lod-cell-key-equivalence.test.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { simplifyIndicesByClustering, LOD_MIN_TRIANGLES } from './lod-simplify.js';
+
+/** Independent cell-equivalence oracle: first referenced vertex wins each
+ * full string tuple, then discard triangles with repeated representatives.
+ * Deliberately has no numeric packing or per-vertex memoization (#3991).
+ */
+function stringCellOracle(data: Float32Array, stride: number, indices: Uint32Array, cellSize: number) {
+  if (indices.length < LOD_MIN_TRIANGLES * 3 || !(cellSize > 0) || !Number.isFinite(cellSize)) return null;
+  const lanes = new Uint32Array(data.buffer, data.byteOffset, data.length);
+  const cells = new Map<string, number>();
+  const representatives: number[] = [];
+  for (const vertex of indices) {
+    const offset = vertex * stride;
+    const entity = stride > 6 ? lanes[offset + 6] : 0;
+    const key = `${Math.floor(data[offset] / cellSize)},${Math.floor(data[offset + 1] / cellSize)},${Math.floor(data[offset + 2] / cellSize)},${entity}`;
+    if (!cells.has(key)) cells.set(key, vertex);
+    representatives.push(cells.get(key)!);
+  }
+  const result: number[] = [];
+  for (let i = 0; i < representatives.length; i += 3) {
+    const [a, b, c] = representatives.slice(i, i + 3);
+    if (a !== b && b !== c && a !== c) result.push(a, b, c);
+  }
+  return result.length === 0 || result.length >= indices.length * 0.75 ? null : Uint32Array.from(result);
+}
+
+type Point = readonly [number, number, number];
+
+function fixture(triangle: readonly [Point, Point, Point], stride = 7) {
+  const count = 600;
+  // Nonzero byteOffset witnesses correct entity-lane reads from a subview.
+  const storage = new Float32Array(count * 3 * stride + 8);
+  const data = storage.subarray(4, storage.length - 4);
+  const lanes = new Uint32Array(data.buffer, data.byteOffset, data.length);
+  const indices = new Uint32Array(count * 3);
+  for (let t = 0; t < count; t++) {
+    for (let corner = 0; corner < 3; corner++) {
+      const vertex = t * 3 + corner;
+      // Four out of five triangles collapse, so nontrivial output qualifies.
+      const point = triangle[t % 5 === 0 ? corner : 0];
+      data.set(point, vertex * stride);
+      if (stride > 6) lanes[vertex * stride + 6] = t % 2 === 0 ? 0xffffffff : 1;
+      indices[vertex] = vertex;
+    }
+  }
+  return { data, indices };
+}
+
+const cases: Array<{ name: string; triangle: readonly [Point, Point, Point]; cellSize: number }> = [
+  { name: 'negative cells', triangle: [[-12.25, -3.5, -7.1], [-8.2, -3.5, -7.1], [-12.25, 0.5, -3.1]], cellSize: 1 },
+  { name: 'far-field safe cells', triangle: [[2 ** 30, 2 ** 29, 0], [2 ** 30 + 1024, 2 ** 29, 0], [2 ** 30, 2 ** 29 + 1024, 1024]], cellSize: 256 },
+  { name: 'positive packed-range boundary', triangle: [[0, 0, 0], [63, 1, 0], [64, 0, 1]], cellSize: 1 },
+  { name: 'negative packed-range boundary', triangle: [[0, 0, 0], [-64, 1, 0], [-65, 0, 1]], cellSize: 1 },
+  { name: 'tiny cells across safe-integer boundary', triangle: [[1, 0, 0], [2, 1, 0], [0, 0, 1]], cellSize: 2 ** -52 },
+  { name: 'unsafe cell anchor', triangle: [[2 ** 80, 0, 0], [2 ** 80 + 2 ** 65, 1, 0], [2 ** 80, 0, 2]], cellSize: 1 },
+  { name: 'nonfinite coordinates', triangle: [[NaN, 0, 0], [Infinity, 1, 0], [-Infinity, 0, 1]], cellSize: 1 },
+];
+
+describe('issue #3991 exact LOD cell keys', () => {
+  for (const { name, triangle, cellSize } of cases) {
+    it(`preserves representatives and triangle order for ${name}`, () => {
+      const { data, indices } = fixture(triangle);
+      const expected = stringCellOracle(data, 7, indices, cellSize);
+      assert.ok(expected, 'fixture must produce a nonempty accepted LOD');
+      assert.deepEqual(simplifyIndicesByClustering(data, 7, indices, cellSize), expected);
+    });
+  }
+
+  it('keeps coincident cells from different full-u32 entity lanes isolated', () => {
+    const { data, indices } = fixture([[0, 0, 0], [4, 0, 0], [0, 4, 4]]);
+    const result = simplifyIndicesByClustering(data, 7, indices, 1);
+    assert.ok(result);
+    // First survivor belongs to entity 0xffffffff; the next belongs to 1.
+    // Even though their positions coincide, each entity elects its own first
+    // referenced vertices. These exact representatives are picking identity.
+    assert.deepEqual([...result.subarray(0, 6)], [0, 1, 2, 3, 16, 17]);
+    assert.deepEqual(result, stringCellOracle(data, 7, indices, 1));
+  });
+
+  it('preserves first-reference order when vertices are encountered out of index order', () => {
+    const { data, indices } = fixture([[0, 0, 0], [4, 0, 0], [0, 4, 4]]);
+    const reversed = new Uint32Array(indices.length);
+    for (let t = 0; t < indices.length; t += 3) {
+      reversed.set(indices.subarray(indices.length - t - 3, indices.length - t), t);
+    }
+    const expected = stringCellOracle(data, 7, reversed, 1);
+    assert.ok(expected);
+    assert.deepEqual(simplifyIndicesByClustering(data, 7, reversed, 1), expected);
+  });
+
+  it('preserves supported data without an entity lane', () => {
+    const { data, indices } = fixture([[0, 0, 0], [4, 0, 0], [0, 4, 4]], 3);
+    const expected = stringCellOracle(data, 3, indices, 1);
+    assert.ok(expected);
+    assert.deepEqual(simplifyIndicesByClustering(data, 3, indices, 1), expected);
+  });
+});

--- a/packages/renderer/src/lod-simplify.ts
+++ b/packages/renderer/src/lod-simplify.ts
@@ -72,7 +72,8 @@ export function simplifyIndicesByClustering(
   // same population.
   const vertexCount = strideFloats > 0 ? (vertexData.length / strideFloats) | 0 : 0;
   const cellOf = new Int32Array(vertexCount).fill(-1); // vertexIndex -> representative, -1 = unset
-  const repOfCell = new Map<string, number>(); // cell key -> representative vertexIndex
+  const repOfCell = new Map<number | string, number>(); // exact cell key -> representative vertexIndex
+  let cellOrigin: readonly [number, number, number] | undefined;
 
   // Clustering is ENTITY-SCOPED: the per-vertex entityId lane (u32 bit-cast
   // at float offset 6 in the batch layout) joins the cell key, so co-located
@@ -93,7 +94,26 @@ export function simplifyIndicesByClustering(
     const cy = Math.floor(vertexData[base + 1] / cellSize);
     const cz = Math.floor(vertexData[base + 2] / cellSize);
     const entity = idLane ? idLane[base + 6] : 0;
-    const key = `${cx},${cy},${cz},${entity}`;
+    // #3991: normal LOD cells fit in a small neighborhood. Pack that exact
+    // neighborhood with the FULL u32 entity lane instead of allocating a key
+    // string per vertex. Keep generic tiny-cell/huge/nonfinite inputs exact.
+    let key: number | string;
+    if (Number.isSafeInteger(cx) && Number.isSafeInteger(cy) && Number.isSafeInteger(cz)) {
+      cellOrigin ??= [cx, cy, cz];
+      const dx = cx - cellOrigin[0];
+      const dy = cy - cellOrigin[1];
+      const dz = cz - cellOrigin[2];
+      if (dx >= -64 && dx < 64 && dy >= -64 && dy < 64 && dz >= -64 && dz < 64) {
+        // Safe integer coordinates and anchor make these bounded differences
+        // exact. 3 * 7 cell bits + 32 entity bits fit in 53 bits: the largest
+        // possible key is 2^53 - 1, with no rounding or dropped entity bits.
+        key = entity * 0x200000 + (dx + 64) * 0x4000 + (dy + 64) * 0x80 + dz + 64;
+      } else {
+        key = `${cx},${cy},${cz},${entity}`;
+      }
+    } else {
+      key = `${cx},${cy},${cz},${entity}`;
+    }
     const existing = repOfCell.get(key);
     let rep: number;
     if (existing === undefined) {

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -627,3 +627,14 @@ prepared reload, a diagnostic profile nor an unrun experiment supplies a
 throughput gain. No universal absence of performance regressions or target
 corpus gain is claimed. Original failures and private exploratory work remain
 archived; the published projections identify their source records by hash.
+
+### Retained cold-load work: exact LOD keys (#3991)
+
+Bounded LOD cell neighborhoods use exact integer keys containing all three cell
+coordinates and the full entity ID. Inputs outside the proved range keep the
+existing string representation. The independent tuple oracle checks identical
+representatives and triangle order, including range boundaries, subviews,
+nonfinite coordinates and full-width entity IDs. This removes per-vertex key
+allocation; no isolated end-to-end speedup is attributed to this layer. The
+retained cold-load stack must carry its cumulative browser qualification,
+including picking and peak-memory observations, before landing.


### PR DESCRIPTION
LOD simplification allocated a coordinate/entity string for every referenced vertex. Pack bounded cell neighborhoods into exact safe-integer keys while preserving all 32 entity bits. Inputs outside the proved range keep their supported string representation; representative selection and triangle order remain unchanged.

Closes #3991. An independent tuple oracle covers negative/far-field coordinates, packing boundaries, unsafe/nonfinite coordinates, subviews, full-width entity IDs and encounter order. A synchronous resource-observation test exercises the real simplifier and verifies numeric cell insertions without string insertions, alongside actual nonempty LOD output and oracle equivalence. The local production-revert gate is OBSERVED; this does not replace final-head CI.

The [shared evidence](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) covers the combined retained stack: native full-call improvement 15.53%; supplemental Chrome full-readiness improvement 28.70%, with Haus +26ms and slower geometry completion on some models. These are combined results, not this layer's isolated gain. Chrome's original strict console audit remains failed; exact-artifact static diagnostics identify the reproduced local analytics 404, while original per-event URLs were not retained. Firefox's strict cohort is invalid; later passing controls do not establish a corpus gain. The 30% target and universal absence of regressions are not established. All pairs and failures are retained.

Final landing-head CI and review remain pending. Prior cumulative checks and functional witnesses do not substitute for those gates; this PR will land only after its prerequisites and applicable exact-head gates are green.
