### PR TITLE
perf(wasm): reuse installed source and owned index buffers

### DIFF
--- a/.changeset/green-games-return.md
+++ b/.changeset/green-games-return.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/wasm": minor
+"@ifc-lite/geometry": patch
+---
+
+Add installed-source shard scanning and style resolution methods. Reuse matching load-session source bytes and binding-owned index columns, preserve the borrowed Rust index API, and transfer already-owned mesh getter buffers without redundant copies.

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -122,6 +122,30 @@ processGeometryBatchFromSource(jobsFlat, unitScale, /* same trailing args */): M
 processGeometryBatchPartitionedFromSource(jobsFlat, unitScale, /* ... */): PartitionedBatch;
 ```
 
+The sharded pre-pass can reuse the same installed source before geometry batches:
+
+```typescript
+scanEntityIndexShardFromSource(start: number, end: number): any;
+resolveStyledItemsShardFromSource(spans: Uint32Array): any;
+finalizePrepassStylesFromSource(
+  orphanIds: Uint32Array, orphanColors: Float32Array,
+  geomIds: Uint32Array, geomColors: Float32Array,
+  colourMapSpans: Uint32Array, materialDefSpans: Uint32Array,
+  relMaterialSpans: Uint32Array, voidSpans: Uint32Array,
+  fillsSpans: Uint32Array, aggregateSpans: Uint32Array,
+  planeAngleToRadians: number,
+): any;
+```
+
+Call `setSourceBytes` before these methods and `setEntityIndex` before resolving
+or finalizing styles. They use the same scanner and style processing as the
+byte-taking methods, with identical arguments after omitting the source bytes.
+`clearPrePassCache()` releases the installed source and index; use it on completion,
+cancellation, or failure. Install the new source and index before reusing an API
+instance for another model. JavaScript input arrays remain usable after
+`setEntityIndex`; its binding adopts its own WASM allocations, while the Rust
+`set_entity_index` method continues to accept borrowed slices.
+
 #### Export
 
 Each exporter takes the raw IFC bytes (or already-produced meshes) and returns a `Uint8Array`.

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -678,3 +678,12 @@ When working with multiple IFC files (e.g., architectural, structural, and MEP m
 - [Query Guide](querying.md) - Query parsed data
 - [Federation Guide](federation.md) - Load and coordinate multiple models
 - [API Reference](../api/typescript.md) - Complete API docs
+
+### Native Rust owned index columns
+
+`ColumnarEntityIndex::from_owned_columns(ids, starts, lengths)` consumes three
+`Vec<u32>` columns. Like the borrowed `from_columns` constructor, it sorts when
+needed, keeps the last input occurrence of duplicate IDs, and returns an empty
+index for empty or mismatched columns. Already sorted, unique columns retain
+their existing allocations. Use `from_columns` when the caller must keep owning
+its input vectors.

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -470,6 +470,15 @@ interface IfcDataStore {
 
 Source-empty server stores can provide `resolvedClassifications`, an optional map from entity express IDs to `ClassificationInfo[]`. `extractClassificationsOnDemand` combines the entity's rows with those inherited through `IfcRelDefinesByType`, using the relationship graph to confirm classification associations. The server derives classifications and relationships from the same immutable IFC input. Repeated relationships may produce multiple resolved rows for one deduplicated graph edge. When resolved rows are absent, the parser returns unresolved markers instead of certifying classification attributes. Source-bearing stores continue to decode classifications from their IFC bytes.
 
+### Native Rust owned index columns
+
+`ColumnarEntityIndex::from_owned_columns(ids, starts, lengths)` consumes three
+`Vec<u32>` columns. Like the borrowed `from_columns` constructor, it sorts when
+needed, keeps the last input occurrence of duplicate IDs, and returns an empty
+index for empty or mismatched columns. Already sorted, unique columns retain
+their existing allocations. Use `from_columns` when the caller must keep owning
+its input vectors.
+
 ## Spatial Hierarchy
 
 ```typescript
@@ -678,12 +687,3 @@ When working with multiple IFC files (e.g., architectural, structural, and MEP m
 - [Query Guide](querying.md) - Query parsed data
 - [Federation Guide](federation.md) - Load and coordinate multiple models
 - [API Reference](../api/typescript.md) - Complete API docs
-
-### Native Rust owned index columns
-
-`ColumnarEntityIndex::from_owned_columns(ids, starts, lengths)` consumes three
-`Vec<u32>` columns. Like the borrowed `from_columns` constructor, it sorts when
-needed, keeps the last input occurrence of duplicate IDs, and returns an empty
-index for empty or mismatched columns. Already sorted, unique columns retain
-their existing allocations. Use `from_columns` when the caller must keep owning
-its input vectors.

--- a/packages/geometry/src/geometry-parallel-options.ts
+++ b/packages/geometry/src/geometry-parallel-options.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { TessellationQuality } from './types.js';
+import type { BatchSizingConfig } from './batch-sizing.js';
+
+export interface ProcessParallelOptions {
+  /**
+   * Fires when the streaming pre-pass finishes building the entity index
+   * (after styles), with SAB-backed Uint32Array views over the shared
+   * column buffers. The parser worker uses this to skip its own
+   * `scanEntitiesFastBytes` call (~10 s on 1 GB files under WASM
+   * contention with the geometry workers).
+   */
+  onEntityIndex?: (
+    ids: Uint32Array,
+    starts: Uint32Array,
+    lengths: Uint32Array, oversizedIdCount?: number, // #3395 refused records
+    malformedRecordCount?: number, // #3790 scan stopped: 0 or 1
+  ) => void;
+  /**
+   * Issue #540 — "Merge Multilayer Walls" load-time toggle. When
+   * `true`, the geometry workers' IfcAPI receive
+   * `setMergeLayers(true)` before the first stream-chunk lands, so
+   * Revit-style multilayer-wall part meshes are suppressed at the
+   * Rust layer. Default `false` keeps existing behaviour.
+   */
+  mergeLayers?: boolean;
+  /**
+   * GPU-instancing partition toggle (default true). Set false for FEDERATED loads:
+   * the instanced render path is primary-model only, so a federated model must keep
+   * all geometry on the flat path or its opaque repeated occurrences are dropped.
+   */
+  enableInstancing?: boolean;
+  /**
+   * Issue #924 — per-entity geometry-hash tolerance in metres. When a
+   * positive value is given, each geometry worker's IfcAPI receives
+   * `setComputeGeometryHashes(tol)` before the first stream-chunk, so the
+   * RTC-invariant `geometryHash` lands on every emitted mesh for the
+   * model-diff / compare feature. `undefined`/`null` ⇒ off (zero overhead).
+   */
+  geometryHashTolerance?: number | null;
+  /**
+   * Issue #976 — tessellation detail level for curved geometry. When set,
+   * each geometry worker's IfcAPI receives `setTessellationQuality(level)`
+   * before the first stream-chunk. `undefined`/`null` ⇒ engine default
+   * (`'medium'`, output identical to the pre-quality pipeline).
+   */
+  tessellationQuality?: TessellationQuality | null;
+  /**
+   * Issue #1286 — tier-independent small-cut skip. When true, each geometry
+   * worker's IfcAPI receives `setSkipSmallCuts(true)` before the first
+   * stream-chunk, dropping tiny `IfcBooleanResult` detail cuts while keeping the
+   * tessellation tier. `undefined`/`false` ⇒ every cut runs (default).
+   */
+  skipSmallCuts?: boolean;
+  /**
+   * Explicit URL for the wasm-bindgen `.wasm` binary. When provided,
+   * forwarded to the geometry workers' init messages so they call
+   * `init(wasmUrl)` instead of relying on wasm-bindgen's default
+   * `import.meta.url`-based resolution.
+   *
+   * Vite + webpack 5 consumers don't need to set this — the bundler
+   * rewrites the `new URL('ifc-lite_bg.wasm', import.meta.url)` literal
+   * inside the wasm-bindgen glue at build time. This option exists for
+   * consumers whose bundler doesn't transform that pattern, or who
+   * serve the wasm from a CDN at a different origin (e.g., self-hosted
+   * deployments, Tauri custom protocols, embedded usage).
+   */
+  wasmUrls?: {
+    wasm?: string;
+  };
+  /**
+   * Issue #1097 — optional override for the worker's adaptive batch sizing
+   * (the watchdog↔throughput knob). Takes precedence over the `globalThis`
+   * tuning hook; omitted ⇒ `DEFAULT_BATCH_SIZING`. Forwarded to every worker
+   * in its `stream-start` message and validated there.
+   */
+  batchSizing?: Partial<BatchSizingConfig>;
+  /**
+   * #1097 load-time visibility filter. `disabledTypes` (uppercase STEP keywords)
+   * and `skipTypeGeometry` are forwarded to the prepass so the matching geometry
+   * jobs are never produced — cutting decode + CSG + tessellation + upload for
+   * hidden types (spaces/annotations/grids/type-library). Takes precedence over
+   * the `globalThis.__IFC_LITE_VISIBILITY_FILTER` hook. Toggling a type back on
+   * requires a reload.
+   */
+  visibilityFilter?: { disabledTypes?: string[]; skipTypeGeometry?: boolean };
+  /**
+   * Explicit geometry-worker count for A/B tuning (the viewer's
+   * `?geomWorkers=N` knob). Overrides the cores-tier heuristic but stays
+   * clamped to the memory budget — see the worker-count policy. `undefined`
+   * ⇒ use the heuristic. Lets a user measure their host's true thermal optimum
+   * (which is machine-specific). Geometry output is unaffected by the count
+   * (workers process disjoint, deterministic element slices).
+   */
+  workerCountOverride?: number;
+}

--- a/packages/geometry/src/geometry-parallel.ts
+++ b/packages/geometry/src/geometry-parallel.ts
@@ -24,12 +24,13 @@
  * scans first 100 K bytes → meta → first chunk → first batch).
  */
 
+import type { ProcessParallelOptions } from './geometry-parallel-options.js';
+import type { BatchSizingConfig } from './batch-sizing.js';
 import type { CoordinateHandler } from './coordinate-handler.js';
-import type { MeshData, TessellationQuality } from './types.js';
+import type { MeshData } from './types.js';
 import type { StreamingGeometryEvent } from './index.js';
 import { mergeGeometryDiagnostics, type GeometryDiagnostics } from './diagnostics.js';
 import { computeWorkerCount } from './worker-count.js';
-import type { BatchSizingConfig } from './batch-sizing.js';
 import { notifyIfWasmAssetUnavailable, notifyIfWorkerScriptUnavailable } from './wasm-asset-error.js';
 import { restashWasmPanicLocation } from './wasm-panic-forward.js';
 // The compiled-module memo lives in its own module so the main-thread
@@ -211,98 +212,9 @@ interface PrepassMeta {
   buildingRotation?: number | null;
 }
 
-export interface ProcessParallelOptions {
-  /**
-   * Fires when the streaming pre-pass finishes building the entity index
-   * (after styles), with SAB-backed Uint32Array views over the shared
-   * column buffers. The parser worker uses this to skip its own
-   * `scanEntitiesFastBytes` call (~10 s on 1 GB files under WASM
-   * contention with the geometry workers).
-   */
-  onEntityIndex?: (
-    ids: Uint32Array,
-    starts: Uint32Array,
-    lengths: Uint32Array, oversizedIdCount?: number, // #3395 refused records
-    malformedRecordCount?: number, // #3790 scan stopped: 0 or 1
-  ) => void;
-  /**
-   * Issue #540 — "Merge Multilayer Walls" load-time toggle. When
-   * `true`, the geometry workers' IfcAPI receive
-   * `setMergeLayers(true)` before the first stream-chunk lands, so
-   * Revit-style multilayer-wall part meshes are suppressed at the
-   * Rust layer. Default `false` keeps existing behaviour.
-   */
-  mergeLayers?: boolean;
-  /**
-   * GPU-instancing partition toggle (default true). Set false for FEDERATED loads:
-   * the instanced render path is primary-model only, so a federated model must keep
-   * all geometry on the flat path or its opaque repeated occurrences are dropped.
-   */
-  enableInstancing?: boolean;
-  /**
-   * Issue #924 — per-entity geometry-hash tolerance in metres. When a
-   * positive value is given, each geometry worker's IfcAPI receives
-   * `setComputeGeometryHashes(tol)` before the first stream-chunk, so the
-   * RTC-invariant `geometryHash` lands on every emitted mesh for the
-   * model-diff / compare feature. `undefined`/`null` ⇒ off (zero overhead).
-   */
-  geometryHashTolerance?: number | null;
-  /**
-   * Issue #976 — tessellation detail level for curved geometry. When set,
-   * each geometry worker's IfcAPI receives `setTessellationQuality(level)`
-   * before the first stream-chunk. `undefined`/`null` ⇒ engine default
-   * (`'medium'`, output identical to the pre-quality pipeline).
-   */
-  tessellationQuality?: TessellationQuality | null;
-  /**
-   * Issue #1286 — tier-independent small-cut skip. When true, each geometry
-   * worker's IfcAPI receives `setSkipSmallCuts(true)` before the first
-   * stream-chunk, dropping tiny `IfcBooleanResult` detail cuts while keeping the
-   * tessellation tier. `undefined`/`false` ⇒ every cut runs (default).
-   */
-  skipSmallCuts?: boolean;
-  /**
-   * Explicit URL for the wasm-bindgen `.wasm` binary. When provided,
-   * forwarded to the geometry workers' init messages so they call
-   * `init(wasmUrl)` instead of relying on wasm-bindgen's default
-   * `import.meta.url`-based resolution.
-   *
-   * Vite + webpack 5 consumers don't need to set this — the bundler
-   * rewrites the `new URL('ifc-lite_bg.wasm', import.meta.url)` literal
-   * inside the wasm-bindgen glue at build time. This option exists for
-   * consumers whose bundler doesn't transform that pattern, or who
-   * serve the wasm from a CDN at a different origin (e.g., self-hosted
-   * deployments, Tauri custom protocols, embedded usage).
-   */
-  wasmUrls?: {
-    wasm?: string;
-  };
-  /**
-   * Issue #1097 — optional override for the worker's adaptive batch sizing
-   * (the watchdog↔throughput knob). Takes precedence over the `globalThis`
-   * tuning hook; omitted ⇒ `DEFAULT_BATCH_SIZING`. Forwarded to every worker
-   * in its `stream-start` message and validated there.
-   */
-  batchSizing?: Partial<BatchSizingConfig>;
-  /**
-   * #1097 load-time visibility filter. `disabledTypes` (uppercase STEP keywords)
-   * and `skipTypeGeometry` are forwarded to the prepass so the matching geometry
-   * jobs are never produced — cutting decode + CSG + tessellation + upload for
-   * hidden types (spaces/annotations/grids/type-library). Takes precedence over
-   * the `globalThis.__IFC_LITE_VISIBILITY_FILTER` hook. Toggling a type back on
-   * requires a reload.
-   */
-  visibilityFilter?: { disabledTypes?: string[]; skipTypeGeometry?: boolean };
-  /**
-   * Explicit geometry-worker count for A/B tuning (the viewer's
-   * `?geomWorkers=N` knob). Overrides the cores-tier heuristic but stays
-   * clamped to the memory budget — see {@link computeWorkerCount}. `undefined`
-   * ⇒ use the heuristic. Lets a user measure their host's true thermal optimum
-   * (which is machine-specific). Geometry output is unaffected by the count
-   * (workers process disjoint, deterministic element slices).
-   */
-  workerCountOverride?: number;
-}
+export type { ProcessParallelOptions } from './geometry-parallel-options.js';
+
+let nextSourceSessionId = 0;
 
 export async function* processParallel(
   buffer: Uint8Array,
@@ -312,11 +224,10 @@ export async function* processParallel(
   existingSab?: SharedArrayBuffer,
   options?: ProcessParallelOptions,
 ): AsyncGenerator<StreamingGeometryEvent> {
+  const sourceSessionId = `geometry-source-${++nextSourceSessionId}`;
   coordinator.reset();
-
   yield { type: 'start', totalEstimate: buffer.length / 1000 };
   yield { type: 'model-open', modelID: 0 };
-
   // Kick off the ONE shared wasm compile immediately so it overlaps the SAB
   // setup + worker-count planning below; awaited just before the workers init
   // (see `compileSharedWasmModule`). Null ⇒ each worker self-inits (unchanged).
@@ -809,7 +720,7 @@ export async function* processParallel(
     const batchSizing = options?.batchSizing ?? readBatchSizingOverride();
     for (const worker of workers) {
       worker.postMessage({
-        type: 'stream-start' as const,
+        type: 'stream-start' as const, sourceSessionId,
         sharedBuffer,
         unitScale: prepassMeta.unitScale,
         planeAngleToRadians: prepassMeta.planeAngleToRadians,
@@ -1103,7 +1014,7 @@ export async function* processParallel(
       const to = i + 1 === sliceCount ? styledCount * 3 : Math.floor(((i + 1) * styledCount) / sliceCount) * 3;
       const slice = styledSpans.slice(from, to);
       workers[i % workers.length].postMessage(
-        { type: 'resolve-styles-shard' as const, sharedBuffer, sliceIndex: i, spans: slice },
+        { type: 'resolve-styles-shard' as const, sourceSessionId, sharedBuffer, sliceIndex: i, spans: slice },
         [slice.buffer],
       );
     }
@@ -1171,7 +1082,7 @@ export async function* processParallel(
     const m = mergedStylesForFinalize;
     workers[0].postMessage(
       {
-        type: 'finalize-styles' as const,
+        type: 'finalize-styles' as const, sourceSessionId,
         sharedBuffer,
         orphanIds: m.orphanIds,
         orphanColors: m.orphanColors,
@@ -1204,7 +1115,7 @@ export async function* processParallel(
       const rangeStart = Math.floor((i * len) / n);
       const rangeEnd = i + 1 === n ? len : Math.floor(((i + 1) * len) / n);
       workers[i].postMessage({
-        type: 'scan-shard' as const,
+        type: 'scan-shard' as const, sourceSessionId,
         sharedBuffer,
         shardIndex: i,
         rangeStart,
@@ -1220,7 +1131,6 @@ export async function* processParallel(
   // is suspended at a `yield` or the `resolveWaiting` await. The viewer's
   // `watchedGeometryStream` relies on this `finally` to tear down workers
   // on break / abort / watchdog (see boundedIteratorReturn). The existing
-  // branch-local `terminate()` calls remain — `terminate()` is idempotent.
   try {
   // Forward the consumer-supplied wasm URL to the pre-pass worker so it
   // doesn't fall back to wasm-bindgen's `import.meta.url` default. The

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { ownedWasmBuffer } from './wasm-owned-buffer.js';
+import { canReuseWorkerSource, type SourcePrepassApi, type FinalizeStyleArgs } from './worker-prepass-source.js';
 import init, { initSync, IfcAPI } from '@ifc-lite/wasm';
 import { initWasmWithRetry } from './wasm-init-retry.js';
 import { largeFilePrepassError } from './huge-file-error.js';
@@ -58,6 +60,7 @@ export interface GeometryWorkerInitMessage {
 export interface GeometryWorkerStreamStartMessage {
   type: 'stream-start';
   sharedBuffer: SharedArrayBuffer;
+  sourceSessionId?: string;
   unitScale: number;
   rtcX: number; rtcY: number; rtcZ: number;
   needsShift: boolean;
@@ -163,6 +166,7 @@ export interface GeometryWorkerSetPrepassColumnsMessage {
 export interface GeometryWorkerScanShardMessage {
   type: 'scan-shard';
   sharedBuffer: SharedArrayBuffer;
+  sourceSessionId?: string;
   shardIndex: number;
   rangeStart: number;
   rangeEnd: number;
@@ -291,6 +295,7 @@ export interface GeometryWorkerShardResultMessage {
 export interface GeometryWorkerResolveStylesShardMessage {
   type: 'resolve-styles-shard';
   sharedBuffer: SharedArrayBuffer;
+  sourceSessionId?: string;
   sliceIndex: number;
   spans: Uint32Array;
 }
@@ -334,6 +339,7 @@ export interface GeometryWorkerPrePassShardedMessage {
 export interface GeometryWorkerFinalizeStylesMessage {
   type: 'finalize-styles';
   sharedBuffer: SharedArrayBuffer;
+  sourceSessionId?: string;
   orphanIds: Uint32Array;
   orphanColors: Float32Array;
   geomIds: Uint32Array;
@@ -608,16 +614,8 @@ function applySkipSmallCutsToApi(): void {
   skipSmallCutsApplied = true;
 }
 
-/**
- * Cached pre-built entity index (issue #1097). Same replay contract as the
- * flags above, but here it guards a perf cliff rather than a feature toggle:
- * the binary-split recovery in `processBatch` sets `api = null` to force a
- * WASM re-init after a failing entity. Without replay, the freshly-built
- * IfcAPI has no entity index, so its next `processGeometryBatch` falls back to
- * the lazy O(file) re-scan (~5 s on a 1 GB IFC) — a giant silent window that
- * compounds across a cluster of failures. Re-applying the cached index keeps
- * recovery cheap and quiet.
- */
+/** Retain immutable index columns for recovery re-init so a failed geometry
+ * batch does not rescan the source. Cleared at stream-end and replaced per load. */
 let cachedEntityIndex: { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array } | null = null;
 let entityIndexApplied: boolean = false;
 
@@ -674,35 +672,16 @@ function applyPrepassColumnsToApi(): void {
   prepassColumnsApplied = true;
 }
 
-/**
- * Cached session source bytes (cold-load lever 1c). Same replay contract as the
- * entity index above, but it removes a per-call copy rather than a per-load
- * scan: the wasm-bindgen glue `passArray8ToWasm0` mallocs + memcpys the WHOLE
- * source file into the worker's wasm heap on EVERY `processGeometryBatch*` call
- * (~4 ms/call on 169 MB). A huge CSG-dense model adapts down to 64-job batches
- * and makes 600+ calls/worker, so the per-call copy alone is 15-25 s/worker of
- * pure memcpy. `setSourceBytes` copies the file ONCE per load; the `*FromSource`
- * batch variants then read it from the heap. The bytes are identical across a
- * worker's calls (one model per worker), so one copy suffices.
- *
- * Points at the active session's `localBytes`; the SAB fallback in `processBatch`
- * swaps it for the materialised copy and re-applies. `null` between loads
- * (released at `stream-end`). Reset (applied=false) on every fresh IfcAPI so the
- * binary-split recovery re-init (`api = null`) re-installs it, exactly like the
- * entity index. When the loaded wasm predates `setSourceBytes`, the apply is a
- * no-op and `processBatch` stays on the legacy `data`-per-call path.
- */
+/** One owned WASM source per load, reused from shard scanning through meshing
+ * (#3989). The JS view is retained for instance recovery; all source-taking
+ * callers still support older WASM. A shard scan starts the load; stream-start
+ * consumes that preparation instead of discarding it. */
 let cachedSourceBytes: Uint8Array | null = null;
 let sourceBytesApplied: boolean = false;
+let sourcePreparedForStream = false;
+let installedSourceSessionId: string | undefined;
 
-/**
- * Install `cachedSourceBytes` onto the IfcAPI ONCE per instance so the
- * `*FromSource` batch variants read the file from the wasm heap instead of the
- * glue re-copying it every call. MAY THROW if the runtime rejects the
- * (SAB-backed) view during the copy — the `processBatch` caller's SAB fallback
- * materialises and re-applies. No-op on wasm builds without `setSourceBytes`
- * (leaving `sourceBytesApplied` false, so `processBatch` uses the legacy path).
- */
+/** Install once per API; a SAB rejection is retried by the caller with owned JS bytes. */
 function applySourceBytesToApi(): void {
   const ifcApi = api as IfcAPIWithMerge | null;
   if (!ifcApi || sourceBytesApplied || !cachedSourceBytes) return;
@@ -964,9 +943,10 @@ function collectMeshes(
       const mesh = collection.takeMesh(i);
       if (!mesh) continue;
       try {
-        const positions = new Float32Array(mesh.positions);
-        const normals = new Float32Array(mesh.normals);
-        const indices = new Uint32Array(mesh.indices);
+        // #3989: Getters already own JS arrays; retain through free() and transfer.
+        const positions = mesh.positions;
+        const normals = mesh.normals;
+        const indices = mesh.indices;
         // Read the WASM copy-to-JS color getter once; indexing it directly
         // would copy a fresh Float32Array out of WASM per access.
         const color = mesh.color;
@@ -1014,13 +994,13 @@ function collectMeshes(
           ...(mesh.geometryItemId !== undefined ? { geometryItemId: mesh.geometryItemId } : {}), // #3199: two DISJOINT ids, TWO
           ...(mesh.materialId !== undefined ? { materialId: mesh.materialId } : {}), // spreads as in convertMeshCollectionToBatch
         };
-        session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
+        session.pendingTransfers.push(ownedWasmBuffer(positions), ownedWasmBuffer(normals), ownedWasmBuffer(indices));
         session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;
         // #961: surface texture + per-vertex UVs (decoded to RGBA8 in Rust). Carried
         // as transferables so there is no SAB→scratch copy (see SAB-streaming memo).
         if (mesh.hasTexture) {
-          const uvs = new Float32Array(mesh.uvs);
-          const rgba = new Uint8Array(mesh.textureRgba);
+          const uvs = mesh.uvs;
+          const rgba = mesh.textureRgba;
           meshData.uvs = uvs;
           meshData.texture = {
             rgba,
@@ -1029,14 +1009,14 @@ function collectMeshes(
             repeatS: mesh.textureRepeatS,
             repeatT: mesh.textureRepeatT,
           };
-          session.pendingTransfers.push(uvs.buffer, rgba.buffer);
+          session.pendingTransfers.push(ownedWasmBuffer(uvs), ownedWasmBuffer(rgba));
           session.cumulativeMeshBytes += uvs.byteLength + rgba.byteLength;
         } else if (mesh.textureUrl) {
           // #1781: external image reference (`IfcImageTexture`) — UVs travel as
           // a transferable like #961, but the texture itself is only a URL +
           // repeat flags; the main thread resolves it against the `.ifcZIP`
           // sibling images and decodes ONCE per `textureId`.
-          const uvs = new Float32Array(mesh.uvs);
+          const uvs = mesh.uvs;
           meshData.uvs = uvs;
           meshData.textureRef = {
             textureId: mesh.textureId,
@@ -1044,7 +1024,7 @@ function collectMeshes(
             repeatS: mesh.textureRepeatS,
             repeatT: mesh.textureRepeatT,
           };
-          session.pendingTransfers.push(uvs.buffer);
+          session.pendingTransfers.push(ownedWasmBuffer(uvs));
           session.cumulativeMeshBytes += uvs.byteLength;
         }
         // #924 / #1891: attach the per-entity geometry fingerprint — hash and,
@@ -1365,7 +1345,10 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
         });
         let res;
         try {
-          res = styleApi.resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
+          const sourceApi = ifcApi as unknown as SourcePrepassApi;
+          res = sourceBytesApplied && canReuseWorkerSource(installedSourceSessionId, e.data.sourceSessionId) && sourceApi.resolveStyledItemsShardFromSource
+            ? sourceApi.resolveStyledItemsShardFromSource(spans)
+            : styleApi.resolveStyledItemsShard(viewSharedBytes(sharedBuffer), spans);
         } catch (err) {
           // SAB-view rejection fallback (see scan-shard above).
           warnSabViewFallbackOnce('resolve-styles-shard', err);
@@ -1459,18 +1442,22 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           planeAngleToRadians: number,
         ) => Record<string, unknown>;
       });
-      const callFinalize = (bytes: Uint8Array) => finalizeApi.finalizePrepassStyles(
-        bytes, m.orphanIds, m.orphanColors, m.geomIds, m.geomColors,
+      const args: FinalizeStyleArgs = [
+        m.orphanIds, m.orphanColors, m.geomIds, m.geomColors,
         m.colourMapSpans, m.materialDefSpans, m.relMaterialSpans,
         m.voidSpans, m.fillsSpans, m.aggregateSpans, m.planeAngleToRadians,
-      );
+      ];
+      const sourceApi = ifcApi as unknown as SourcePrepassApi;
+      const callFinalize = (bytes: Uint8Array) => sourceBytesApplied && canReuseWorkerSource(installedSourceSessionId, m.sourceSessionId) && sourceApi.finalizePrepassStylesFromSource
+        ? sourceApi.finalizePrepassStylesFromSource(...args)
+        : finalizeApi.finalizePrepassStyles(bytes, ...args);
       let payload;
       try {
         payload = callFinalize(viewSharedBytes(m.sharedBuffer));
       } catch (err) {
         // SAB-view rejection fallback (see scan-shard above).
         warnSabViewFallbackOnce('finalize-prepass-styles', err);
-        payload = callFinalize(materialiseSharedBytes(m.sharedBuffer));
+        payload = finalizeApi.finalizePrepassStyles(materialiseSharedBytes(m.sharedBuffer), ...args);
       }
       (self as unknown as Worker).postMessage({ type: 'styles-final', payload });
       return;
@@ -1528,14 +1515,27 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
           // `malformedStart` is TODO(#3699) -- not returned by Rust yet.
         ) => { ids: Uint32Array; starts: Uint32Array; lengths: Uint32Array; classes: Uint8Array; handoff: number; oversizedIdStarts?: Uint32Array; malformedStart?: number };
       });
+      const sourceApi = ifcApi as unknown as SourcePrepassApi;
+      sourceBytesApplied = false;
+      cachedSourceBytes = view;
+      sourcePreparedForStream = e.data.sourceSessionId !== undefined;
+      installedSourceSessionId = e.data.sourceSessionId;
+      const scan = (bytes: Uint8Array) => {
+        cachedSourceBytes = bytes;
+        if (sourcePreparedForStream && sourceApi.scanEntityIndexShardFromSource) applySourceBytesToApi();
+        return sourceBytesApplied && sourceApi.scanEntityIndexShardFromSource
+          ? sourceApi.scanEntityIndexShardFromSource(rangeStart, rangeEnd)
+          : scanApi.scanEntityIndexShard(bytes, rangeStart, rangeEnd);
+      };
       let shard;
       try {
-        shard = scanApi.scanEntityIndexShard(view, rangeStart, rangeEnd);
+        shard = scan(view);
       } catch (err) {
         // Some runtimes reject SAB-backed views at the wasm boundary (same
         // fallback the streaming pre-pass ships) — retry with a copy.
         warnSabViewFallbackOnce('scan-entity-index-shard', err);
-        shard = scanApi.scanEntityIndexShard(materialiseSharedBytes(sharedBuffer), rangeStart, rangeEnd);
+        sourceBytesApplied = false;
+        shard = scan(materialiseSharedBytes(sharedBuffer));
       }
       (self as unknown as Worker).postMessage(
         {
@@ -1593,15 +1593,13 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // size from a previous dense model).
       batchSizing = resolveBatchSizing(e.data.batchSizing);
       adaptiveBatchJobs = batchSizing.maxJobs;
-      // Fresh load: drop any source held for a PREVIOUS load so this load's bytes
-      // are re-installed on its first batch. The in-repo host spawns a fresh
-      // worker per load so this is belt-and-braces there, but a host that reuses a
-      // worker across loads without a `stream-end` between them would otherwise
-      // mesh the new load against the previous file's held bytes (a similar-size
-      // stale source decodes wrong entities). Resetting here makes that misuse
-      // fail to the byte-identical legacy path instead of silently meshing wrong.
-      sourceBytesApplied = false;
-      cachedSourceBytes = null;
+      // Reuse this load's shard source; reset non-sharded/reused loads before geometry (#3989).
+      if (!sourcePreparedForStream || !canReuseWorkerSource(installedSourceSessionId, e.data.sourceSessionId)) {
+        sourceBytesApplied = false;
+        cachedSourceBytes = null;
+      }
+      sourcePreparedForStream = false;
+      installedSourceSessionId = e.data.sourceSessionId;
       activeSession = startSession({
         sharedBuffer: e.data.sharedBuffer,
         unitScale: e.data.unitScale,
@@ -1747,6 +1745,8 @@ async function handleMessage(e: MessageEvent<GeometryWorkerRequest>): Promise<vo
       // reused instance; mirrors the entity index.
       cachedSourceBytes = null;
       sourceBytesApplied = false;
+      sourcePreparedForStream = false;
+      installedSourceSessionId = undefined;
       return;
     }
   } catch (err) {

--- a/packages/geometry/src/wasm-owned-buffer.ts
+++ b/packages/geometry/src/wasm-owned-buffer.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** WASM getter declarations use ArrayBufferLike; transfers require owned backing.
+ * The real WASM ownership contract covers free(), memory growth and transfer. */
+export function ownedWasmBuffer(array: ArrayBufferView): ArrayBuffer {
+  const buffer = array.buffer;
+  if (!(buffer instanceof ArrayBuffer)) {
+    throw new Error('WASM mesh getter returned non-transferable backing');
+  }
+  return buffer;
+}

--- a/packages/geometry/src/worker-prepass-source.test.ts
+++ b/packages/geometry/src/worker-prepass-source.test.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, expect, it } from 'vitest';
+import { canReuseWorkerSource } from './worker-prepass-source.js';
+
+describe('source isolation across worker requests (#3989)', () => {
+  it.each([
+    { scenario: 'aborted scan A then stream B', installed: 'load-a', requested: 'load-b', allowed: false },
+    { scenario: 'aborted scan A then older unversioned stream', installed: 'load-a', requested: undefined, allowed: false },
+    { scenario: 'two unversioned requests', installed: undefined, requested: undefined, allowed: false },
+    { scenario: 'styles before any source installation', installed: undefined, requested: 'load-a', allowed: false },
+    { scenario: 'same load across cloned scan/style/finalize messages', installed: 'load-a', requested: 'load-a', allowed: true },
+  ])('$scenario', ({ installed, requested, allowed }) => {
+    // Protocol invariant: only an explicit same-load lease permits reuse.
+    // Missing tokens must not compare equal and accidentally authorize stale
+    // bytes from a previous request that never reached stream-start.
+    const delivered = structuredClone({ sourceSessionId: requested });
+    expect(canReuseWorkerSource(installed, delivered.sourceSessionId)).toBe(allowed);
+  });
+});

--- a/packages/geometry/src/worker-prepass-source.ts
+++ b/packages/geometry/src/worker-prepass-source.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// TODO(remove-by: all supported deployed WASM assets include source-backed prepass APIs, louistrue)
+// Track compatibility retirement in #3989; cached viewers can pair with older engine assets.
+/** Optional ABI additions preserve the real staged older-WASM byte-taking contract. */
+export interface SourcePrepassApi {
+  scanEntityIndexShardFromSource?: (start: number, end: number) => ShardColumns;
+  resolveStyledItemsShardFromSource?: (spans: Uint32Array) => ShardStyles;
+  finalizePrepassStylesFromSource?: (...args: FinalizeStyleArgs) => Record<string, unknown>;
+}
+
+export interface ShardColumns {
+  ids: Uint32Array;
+  starts: Uint32Array;
+  lengths: Uint32Array;
+  classes: Uint8Array;
+  handoff: number;
+  oversizedIdStarts?: Uint32Array;
+  malformedStart?: number;
+}
+
+export interface ShardStyles {
+  orphanIds: Uint32Array;
+  orphanColors: Float32Array;
+  geomIds: Uint32Array;
+  geomColors: Float32Array;
+}
+
+export type FinalizeStyleArgs = [
+  orphanIds: Uint32Array, orphanColors: Float32Array,
+  geomIds: Uint32Array, geomColors: Float32Array,
+  colourMapSpans: Uint32Array, materialDefSpans: Uint32Array,
+  relMaterialSpans: Uint32Array, voidSpans: Uint32Array,
+  fillsSpans: Uint32Array, aggregateSpans: Uint32Array,
+  planeAngleToRadians: number,
+];
+
+/** A missing/foreign token never authorizes reuse, even for equal-size sources.
+ * SAB wrappers differ after postMessage, so object identity cannot prove this. */
+export function canReuseWorkerSource(installed: string | undefined, requested: string | undefined): boolean {
+  return requested !== undefined && installed === requested;
+}

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -533,6 +533,10 @@ export class IfcAPI {
      */
     finalizePrepassStyles(data: Uint8Array, orphan_ids: Uint32Array, orphan_colors: Float32Array, geom_ids: Uint32Array, geom_colors: Float32Array, colour_map_spans: Uint32Array, material_def_spans: Uint32Array, rel_material_spans: Uint32Array, void_spans: Uint32Array, fills_spans: Uint32Array, aggregate_spans: Uint32Array, plane_angle_to_radians: number): any;
     /**
+     * Finalize prepass styles against the installed source and entity index.
+     */
+    finalizePrepassStylesFromSource(orphan_ids: Uint32Array, orphan_colors: Float32Array, geom_ids: Uint32Array, geom_colors: Float32Array, colour_map_spans: Uint32Array, material_def_spans: Uint32Array, rel_material_spans: Uint32Array, void_spans: Uint32Array, fills_spans: Uint32Array, aggregate_spans: Uint32Array, plane_angle_to_radians: number): any;
+    /**
      * Get WASM memory for zero-copy access
      */
     getMemory(): any;
@@ -655,6 +659,10 @@ export class IfcAPI {
      */
     resolveStyledItemsShard(data: Uint8Array, spans: Uint32Array): any;
     /**
+     * Resolve styled-item spans against the installed source and entity index.
+     */
+    resolveStyledItemsShardFromSource(spans: Uint32Array): any;
+    /**
      * Fast entity scanning using SIMD-accelerated Rust scanner
      * Returns array of entity references for data model parsing
      * Much faster than TypeScript byte-by-byte scanning (5-10x speedup)
@@ -706,6 +714,10 @@ export class IfcAPI {
      */
     scanEntityIndexShard(data: Uint8Array, range_start: number, range_end: number): any;
     /**
+     * Scan a shard of the source installed by `setSourceBytes`.
+     */
+    scanEntityIndexShardFromSource(start: number, end: number): any;
+    /**
      * Fast geometry-only entity scanning
      * Scans only entities that have geometry, skipping 99% of non-geometry entities
      * Returns array of geometry entity references for parallel processing
@@ -735,10 +747,10 @@ export class IfcAPI {
      * even though the pre-pass worker built the same index minutes
      * earlier.
      *
-     * Builds a compact [`ColumnarEntityIndex`] from the three input slices
+     * Adopts the three binding-owned columns into a compact [`ColumnarEntityIndex`]
      * (sorted `u32` columns + binary search) instead of a per-worker
      * `FxHashMap` — ~229 MB vs ~436 MB on a 19.1 M-entity model (#1682).
-     * [`ColumnarEntityIndex::from_columns`] verifies the id ordering once
+     * [`ColumnarEntityIndex::from_owned_columns`] verifies the id ordering once
      * (O(n)) and only argsorts if the producer did not emit sorted columns.
      *
      * `lengths[i]` is the byte length of entity `ids[i]`, so lookup returns
@@ -1995,6 +2007,7 @@ export interface InitOutput {
     readonly ifcapi_exportUsd: (a: number, b: number, c: number, d: number) => void;
     readonly ifcapi_extractProfiles: (a: number, b: number, c: number, d: number) => number;
     readonly ifcapi_finalizePrepassStyles: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number) => void;
+    readonly ifcapi_finalizePrepassStylesFromSource: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number) => void;
     readonly ifcapi_getMemory: (a: number) => number;
     readonly ifcapi_getPipelineDiagnostics: (a: number) => number;
     readonly ifcapi_is_ready: (a: number) => number;
@@ -2009,9 +2022,11 @@ export interface InitOutput {
     readonly ifcapi_processGeometryBatchPartitioned: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number) => number;
     readonly ifcapi_processGeometryBatchPartitionedFromSource: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number) => number;
     readonly ifcapi_resolveStyledItemsShard: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
+    readonly ifcapi_resolveStyledItemsShardFromSource: (a: number, b: number, c: number, d: number) => void;
     readonly ifcapi_scanEntitiesFast: (a: number, b: number, c: number) => number;
     readonly ifcapi_scanEntitiesFastBytes: (a: number, b: number, c: number) => number;
     readonly ifcapi_scanEntityIndexShard: (a: number, b: number, c: number, d: number, e: number) => number;
+    readonly ifcapi_scanEntityIndexShardFromSource: (a: number, b: number, c: number) => number;
     readonly ifcapi_scanGeometryEntitiesFast: (a: number, b: number, c: number) => number;
     readonly ifcapi_setComputeGeometryHashes: (a: number, b: number, c: number) => void;
     readonly ifcapi_setEntityIndex: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => void;

--- a/rust/core/src/columnar_index.rs
+++ b/rust/core/src/columnar_index.rs
@@ -80,16 +80,19 @@ impl ColumnarEntityIndex {
                 lengths: Vec::new(),
             };
         }
-        if is_strictly_ascending(ids) {
-            // Already sorted AND unique — the common case once the producer
-            // emits sorted columns. No permutation, no dedup: just adopt them.
-            return Self {
-                ids: ids.to_vec(),
-                starts: starts.to_vec(),
-                lengths: lengths.to_vec(),
-            };
+        Self::from_owned_columns(ids.to_vec(), starts.to_vec(), lengths.to_vec())
+    }
+
+    /// Consume binding-owned columns without another full allocation (#3989).
+    /// Validation and last-in-input-order duplicate precedence match `from_columns`.
+    pub fn from_owned_columns(ids: Vec<u32>, starts: Vec<u32>, lengths: Vec<u32>) -> Self {
+        if ids.is_empty() || starts.len() != ids.len() || lengths.len() != ids.len() {
+            return Self { ids: Vec::new(), starts: Vec::new(), lengths: Vec::new() };
         }
-        Self::from_unsorted(ids.to_vec(), starts.to_vec(), lengths.to_vec())
+        if is_strictly_ascending(&ids) {
+            return Self { ids, starts, lengths };
+        }
+        Self::from_unsorted(ids, starts, lengths)
     }
 
     /// Build from an already-scanned [`EntityIndex`](crate::EntityIndex)

--- a/rust/core/src/columnar_index_tests.rs
+++ b/rust/core/src/columnar_index_tests.rs
@@ -127,3 +127,29 @@ fn consuming_and_borrowing_hashmap_builds_agree() {
     }
     assert_eq!(consumed.len(), 4);
 }
+
+#[test]
+fn issue_3989_owned_sorted_columns_keep_allocations_and_lookup_spans() {
+    // Ownership invariant: adopting a sorted index must not transiently double
+    // its three buffers while the worker already retains the source file.
+    let ids = vec![1, 7, 90];
+    let starts = vec![10, 25, 70];
+    let lengths = vec![5, 8, 11];
+    let pointers = (ids.as_ptr(), starts.as_ptr(), lengths.as_ptr());
+    let index = ColumnarEntityIndex::from_owned_columns(ids, starts, lengths);
+    assert_eq!((index.ids.as_ptr(), index.starts.as_ptr(), index.lengths.as_ptr()), pointers);
+    assert_eq!(index.lookup(7), Some((25, 33)));
+    assert_eq!(index.lookup(90), Some((70, 81)));
+    assert_eq!(index.lookup(8), None);
+}
+
+#[test]
+fn issue_3989_owned_columns_preserve_unsorted_and_adjacent_duplicate_precedence() {
+    for ids in [vec![7, 3, 7], vec![3, 7, 7]] {
+        let index = ColumnarEntityIndex::from_owned_columns(ids, vec![10, 20, 30], vec![1, 2, 3]);
+        assert_eq!(index.ids(), &[3, 7]);
+        assert_eq!(index.lookup(7), Some((30, 33)), "last input occurrence wins");
+    }
+    assert!(ColumnarEntityIndex::from_owned_columns(vec![1, 2], vec![10], vec![1, 2]).is_empty());
+    assert!(ColumnarEntityIndex::from_owned_columns(vec![], vec![], vec![]).is_empty());
+}

--- a/rust/wasm-bindings/src/api/entity_index.rs
+++ b/rust/wasm-bindings/src/api/entity_index.rs
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::IfcAPI;
+use ifc_lite_core::ColumnarEntityIndex;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Populate `cached_entity_index` from pre-extracted column arrays.
+    ///
+    /// Used by the streaming pre-pass to share its already-built entity
+    /// index across worker realms via SAB-backed Uint32Arrays — every
+    /// process worker would otherwise re-scan the entire file in
+    /// `processGeometryBatch`'s lazy build path (~5 s on a 1 GB IFC),
+    /// even though the pre-pass worker built the same index minutes
+    /// earlier.
+    ///
+    /// Adopts the three binding-owned columns into a compact [`ColumnarEntityIndex`]
+    /// (sorted `u32` columns + binary search) instead of a per-worker
+    /// `FxHashMap` — ~229 MB vs ~436 MB on a 19.1 M-entity model (#1682).
+    /// [`ColumnarEntityIndex::from_owned_columns`] verifies the id ordering once
+    /// (O(n)) and only argsorts if the producer did not emit sorted columns.
+    ///
+    /// `lengths[i]` is the byte length of entity `ids[i]`, so lookup returns
+    /// `(start, start + length)` to match the existing `(start, end)` layout.
+    ///
+    /// Idempotent in the sense that repeated calls REPLACE the cache —
+    /// supports the parser-worker pattern of reusing one IfcAPI across
+    /// multiple loads with different files.
+    #[wasm_bindgen(js_name = setEntityIndex)]
+    pub fn set_entity_index_owned_binding(&self, ids: Vec<u32>, starts: Vec<u32>, lengths: Vec<u32>) {
+        self.install_entity_index(ColumnarEntityIndex::from_owned_columns(ids, starts, lengths));
+    }
+}
+
+impl IfcAPI {
+    /// Install an entity index from borrowed columns, preserving the public Rust
+    /// API. The JavaScript binding consumes its owned ABI buffers separately
+    /// so it does not copy them again (#3989).
+    pub fn set_entity_index(&self, ids: &[u32], starts: &[u32], lengths: &[u32]) {
+        self.install_entity_index(ColumnarEntityIndex::from_columns(ids, starts, lengths));
+    }
+
+    fn install_entity_index(&self, index: ColumnarEntityIndex) {
+        // Invalid or empty input preserves the previous index and caches.
+        if index.is_empty() {
+            return;
+        }
+        let mut slot = self
+            .cached_entity_index
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *slot = Some(std::sync::Arc::new(index));
+        drop(slot);
+
+        // Swapping the entity index means a different file. The other caches are
+        // content-scoped (keyed off the previous load) — carrying them into the
+        // next file would wrongly suppress/keep orphan type geometry, reuse a
+        // stale texture index, or skip the wrong parts. Drop them so they
+        // rebuild against the new content (#962 review). Mirrors clearPrePassCache.
+        self.cached_parts_to_skip
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_material_layer_index
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_referenced_repmaps
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_instantiated_type_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_mapped_instance_plan
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_texture_index
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_indexed_colour_maps
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        self.cached_plane_angle_to_radians
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        // The geometry-style maps belong to the previous load's wire styles —
+        // drop them on content swap so a reused IfcAPI can't reuse a stale map
+        // (the (len,first,last) signature would otherwise collide rarely).
+        self.cached_geometry_styles
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        // The content-dedup cache holds the previous model's item meshes — drop it
+        // on content swap so a reused IfcAPI starts the new file with an empty
+        // cache (bounds memory across loads).
+        self.cached_item_dedup
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        // The mapped-item source cache holds the previous model's source meshes —
+        // drop it on content swap so a reused IfcAPI starts the new file empty
+        // (bounds memory across loads; #1623).
+        self.cached_mapped_item
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        // A new entity index means a new file — the pipeline diagnostics
+        // describe the previous load, so start fresh.
+        self.reset_pipeline_diagnostics();
+    }
+}
+
+#[cfg(test)]
+#[path = "entity_index_tests.rs"]
+mod tests;

--- a/rust/wasm-bindings/src/api/entity_index_tests.rs
+++ b/rust/wasm-bindings/src/api/entity_index_tests.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::IfcAPI;
+
+#[test]
+fn issue_3989_borrowed_rust_api_preserves_caller_ownership_and_duplicate_semantics() {
+    // A Rust consumer of the published pre-change signature must still compile.
+    let install: fn(&IfcAPI, &[u32], &[u32], &[u32]) = IfcAPI::set_entity_index;
+    let api = IfcAPI::new();
+    let mut ids = [7, 3, 7];
+    let mut starts = [10, 20, 30];
+    let mut lengths = [1, 2, 3];
+    install(&api, &ids, &starts, &lengths);
+    // Borrowed inputs remain caller-owned. Reusing them cannot corrupt the
+    // installed index, and stable last-occurrence-wins behavior is unchanged.
+    ids.fill(99);
+    starts.fill(99);
+    lengths.fill(99);
+    let slot = api.cached_entity_index.lock().unwrap();
+    let index = slot.as_ref().unwrap();
+    assert_eq!(index.lookup(7), Some((30, 33)));
+    assert_eq!(index.lookup(3), Some((20, 22)));
+    assert_eq!(index.lookup(99), None);
+}
+
+#[test]
+fn issue_3989_owned_binding_adopts_sorted_columns_without_reallocation() {
+    let api = IfcAPI::new();
+    let ids = vec![3, 7];
+    let starts = vec![20, 30];
+    let lengths = vec![2, 3];
+    let pointers = (ids.as_ptr(), starts.as_ptr(), lengths.as_ptr());
+    api.set_entity_index_owned_binding(ids, starts, lengths);
+    let slot = api.cached_entity_index.lock().unwrap();
+    let index = slot.as_ref().unwrap();
+    assert_eq!((index.ids().as_ptr(), index.starts().as_ptr(), index.lengths().as_ptr()), pointers);
+    assert_eq!(index.lookup(7), Some((30, 33)));
+}
+
+#[test]
+fn issue_3989_both_adapters_ignore_invalid_input_and_reset_content_caches_on_replacement() {
+    let api = IfcAPI::new();
+    api.set_entity_index(&[1], &[10], &[2]);
+    api.set_referenced_repmaps(&[1]);
+    // Neither empty nor mismatched columns constitute a model replacement.
+    api.set_entity_index(&[2], &[], &[3]);
+    api.set_entity_index_owned_binding(Vec::new(), Vec::new(), Vec::new());
+    assert_eq!(api.cached_entity_index.lock().unwrap().as_ref().unwrap().lookup(1), Some((10, 12)));
+    assert!(api.cached_referenced_repmaps.lock().unwrap().as_ref().unwrap().contains(&1));
+    // A new source must not inherit old representation-map suppression.
+    api.set_entity_index_owned_binding(vec![2], vec![30], vec![4]);
+    assert!(api.cached_referenced_repmaps.lock().unwrap().is_none());
+    api.set_referenced_repmaps(&[2]);
+    api.set_entity_index(&[3], &[40], &[5]);
+    assert!(api.cached_referenced_repmaps.lock().unwrap().is_none());
+    assert_eq!(api.cached_entity_index.lock().unwrap().as_ref().unwrap().lookup(3), Some((40, 45)));
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch_from_source.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch_from_source.rs
@@ -33,7 +33,7 @@ impl IfcAPI {
     /// the JS worker (it gates `*FromSource` on a successful `setSourceBytes`),
     /// but is handled defensively: the decoder validates every byte span, so an
     /// empty source simply yields zero meshes instead of panicking.
-    fn source_bytes_arc(&self) -> std::sync::Arc<Vec<u8>> {
+    pub(super) fn source_bytes_arc(&self) -> std::sync::Arc<Vec<u8>> {
         self.cached_source_bytes
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)

--- a/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/mod.rs
@@ -15,3 +15,6 @@ pub(crate) mod prepass;
 mod prepass_discovery;
 mod prepass_sharded;
 mod void_index;
+
+mod prepass_affinity;
+mod prepass_from_source;

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass.rs
@@ -6,17 +6,7 @@ use crate::api::IfcAPI;
 use js_sys::Function;
 use wasm_bindgen::prelude::*;
 
-/// Reduce a 128-bit geometry hash to the 32-bit worker-affinity key the job
-/// stream carries. Jobs with the SAME key are routed to the same geometry worker,
-/// so their (byte-identical) geometry is meshed once per model instead of once per
-/// worker — the win the per-worker content-dedup cache can't get across separate
-/// WASM realms. A 32-bit collision only co-locates two unrelated geometries on one
-/// worker (harmless: the cache still keys them apart), so xor-folding the lanes is
-/// plenty.
-#[inline]
-fn fold_u128_to_u32(h: u128) -> u32 {
-    (h as u32) ^ ((h >> 32) as u32) ^ ((h >> 64) as u32) ^ ((h >> 96) as u32)
-}
+use super::prepass_affinity::fold_u128_to_u32;
 
 // The per-submesh #858 palette split lives inside the canonical per-element
 // producer (`ifc_lite_processing::element`) — shared with the native pipeline.
@@ -774,24 +764,5 @@ impl IfcAPI {
         on_event.call1(&JsValue::NULL, &done.into())?;
 
         Ok(JsValue::UNDEFINED)
-    }
-}
-
-#[cfg(test)]
-mod affinity_tests {
-    use super::fold_u128_to_u32;
-
-    #[test]
-    fn fold_is_stable_and_mixes_all_lanes() {
-        // Identical hashes fold to identical keys (routing stickiness).
-        assert_eq!(fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444),
-                   fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444));
-        // A change confined to ANY single 32-bit lane changes the key — so two
-        // geometries differing only in their high bits still route apart.
-        let base = 0u128;
-        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 0)));
-        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 40)));
-        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 72)));
-        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 120)));
     }
 }

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_affinity.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_affinity.rs
@@ -1,4 +1,6 @@
-// SPDX-License-Identifier: MPL-2.0
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 /// Reduce a 128-bit geometry hash to the 32-bit worker-affinity key the job
 /// stream carries. Jobs with the SAME key are routed to the same geometry worker,

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_affinity.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_affinity.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MPL-2.0
+
+/// Reduce a 128-bit geometry hash to the 32-bit worker-affinity key the job
+/// stream carries. Jobs with the SAME key are routed to the same geometry worker,
+/// so their (byte-identical) geometry is meshed once per model instead of once per
+/// worker — the win the per-worker content-dedup cache can't get across separate
+/// WASM realms. A 32-bit collision only co-locates two unrelated geometries on one
+/// worker (harmless: the cache still keys them apart), so xor-folding the lanes is
+/// plenty.
+#[inline]
+pub(super) fn fold_u128_to_u32(h: u128) -> u32 {
+    (h as u32) ^ ((h >> 32) as u32) ^ ((h >> 64) as u32) ^ ((h >> 96) as u32)
+}
+
+#[cfg(test)]
+mod affinity_tests {
+    use super::fold_u128_to_u32;
+
+    #[test]
+    fn fold_is_stable_and_mixes_all_lanes() {
+        // Identical hashes fold to identical keys (routing stickiness).
+        assert_eq!(fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444),
+                   fold_u128_to_u32(0x1234_5678_9abc_def0_1111_2222_3333_4444));
+        // A change confined to ANY single 32-bit lane changes the key — so two
+        // geometries differing only in their high bits still route apart.
+        let base = 0u128;
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 0)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 40)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 72)));
+        assert_ne!(fold_u128_to_u32(base), fold_u128_to_u32(base | (1u128 << 120)));
+    }
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_from_source.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_from_source.rs
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Reuse the geometry worker's owned source during prepass assistance (#3989).
+//! The byte-taking entry points remain the canonical implementations and are
+//! also used by clients that do not install a session source.
+
+use crate::api::IfcAPI;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Scan a shard of the source installed by `setSourceBytes`.
+    #[wasm_bindgen(js_name = scanEntityIndexShardFromSource)]
+    pub fn scan_entity_index_shard_from_source(&self, start: u32, end: u32) -> JsValue {
+        let source = self.source_bytes_arc();
+        self.scan_entity_index_shard(&source, start, end)
+    }
+
+    /// Resolve styled-item spans against the installed source and entity index.
+    #[wasm_bindgen(js_name = resolveStyledItemsShardFromSource)]
+    pub fn resolve_styled_items_shard_from_source(&self, spans: &[u32]) -> Result<JsValue, JsValue> {
+        let source = self.source_bytes_arc();
+        self.resolve_styled_items_shard(&source, spans)
+    }
+
+    /// Finalize prepass styles against the installed source and entity index.
+    #[wasm_bindgen(js_name = finalizePrepassStylesFromSource)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn finalize_prepass_styles_from_source(
+        &self,
+        orphan_ids: &[u32],
+        orphan_colors: &[f32],
+        geom_ids: &[u32],
+        geom_colors: &[f32],
+        colour_map_spans: &[u32],
+        material_def_spans: &[u32],
+        rel_material_spans: &[u32],
+        void_spans: &[u32],
+        fills_spans: &[u32],
+        aggregate_spans: &[u32],
+        plane_angle_to_radians: f64,
+    ) -> Result<JsValue, JsValue> {
+        let source = self.source_bytes_arc();
+        self.finalize_prepass_styles(
+            &source, orphan_ids, orphan_colors, geom_ids, geom_colors,
+            colour_map_spans, material_def_spans, rel_material_spans,
+            void_spans, fills_spans, aggregate_spans, plane_angle_to_radians,
+        )
+    }
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -11,6 +11,7 @@ mod clash;
 mod clash_solid;
 mod csg_diagnostics;
 mod diagnose;
+mod entity_index;
 mod export_data;
 mod export_dfjson;
 mod export_glb;
@@ -394,104 +395,6 @@ impl IfcAPI {
         // can read getPipelineDiagnostics(). Diagnostics are an accumulator, not
         // a cache, so they reset only at load START (set_entity_index), unlike
         // cached_item_dedup which is safe to drop on every clear.
-    }
-
-    /// Populate `cached_entity_index` from pre-extracted column arrays.
-    ///
-    /// Used by the streaming pre-pass to share its already-built entity
-    /// index across worker realms via SAB-backed Uint32Arrays — every
-    /// process worker would otherwise re-scan the entire file in
-    /// `processGeometryBatch`'s lazy build path (~5 s on a 1 GB IFC),
-    /// even though the pre-pass worker built the same index minutes
-    /// earlier.
-    ///
-    /// Builds a compact [`ColumnarEntityIndex`] from the three input slices
-    /// (sorted `u32` columns + binary search) instead of a per-worker
-    /// `FxHashMap` — ~229 MB vs ~436 MB on a 19.1 M-entity model (#1682).
-    /// [`ColumnarEntityIndex::from_columns`] verifies the id ordering once
-    /// (O(n)) and only argsorts if the producer did not emit sorted columns.
-    ///
-    /// `lengths[i]` is the byte length of entity `ids[i]`, so lookup returns
-    /// `(start, start + length)` to match the existing `(start, end)` layout.
-    ///
-    /// Idempotent in the sense that repeated calls REPLACE the cache —
-    /// supports the parser-worker pattern of reusing one IfcAPI across
-    /// multiple loads with different files.
-    #[wasm_bindgen(js_name = setEntityIndex)]
-    pub fn set_entity_index(&self, ids: &[u32], starts: &[u32], lengths: &[u32]) {
-        let n = ids.len();
-        if n == 0 || starts.len() != n || lengths.len() != n {
-            return;
-        }
-        let index = ColumnarEntityIndex::from_columns(ids, starts, lengths);
-        let mut slot = self
-            .cached_entity_index
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *slot = Some(std::sync::Arc::new(index));
-        drop(slot);
-
-        // Swapping the entity index means a different file. The other caches are
-        // content-scoped (keyed off the previous load) — carrying them into the
-        // next file would wrongly suppress/keep orphan type geometry, reuse a
-        // stale texture index, or skip the wrong parts. Drop them so they
-        // rebuild against the new content (#962 review). Mirrors clearPrePassCache.
-        self.cached_parts_to_skip
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_material_layer_index
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_referenced_repmaps
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_instantiated_type_ids
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_mapped_instance_plan
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_texture_index
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_indexed_colour_maps
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        self.cached_plane_angle_to_radians
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        // The geometry-style maps belong to the previous load's wire styles —
-        // drop them on content swap so a reused IfcAPI can't reuse a stale map
-        // (the (len,first,last) signature would otherwise collide rarely).
-        self.cached_geometry_styles
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        // The content-dedup cache holds the previous model's item meshes — drop it
-        // on content swap so a reused IfcAPI starts the new file with an empty
-        // cache (bounds memory across loads).
-        self.cached_item_dedup
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        // The mapped-item source cache holds the previous model's source meshes —
-        // drop it on content swap so a reused IfcAPI starts the new file empty
-        // (bounds memory across loads; #1623).
-        self.cached_mapped_item
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .take();
-        // A new entity index means a new file — the pipeline diagnostics
-        // describe the previous load, so start fresh.
-        self.reset_pipeline_diagnostics();
     }
 
     /// Install the pre-computed set of `IfcRepresentationMap` ids referenced by

--- a/scripts/lib/wasm-cold-load-contracts.mjs
+++ b/scripts/lib/wasm-cold-load-contracts.mjs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/** Source and owned-buffer contracts registered by the real WASM harness. */
+import { checkMeshGetterOwnershipContract } from './wasm-mesh-getter-ownership-contract.mjs';
+import { checkPrepassSourceContract } from './wasm-prepass-source-contract.mjs';
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { pathToFileURL } from 'url';
+import assert from 'node:assert/strict';
+
+/** Preserve the caller's test/skip accounting and optional retained-runtime checks. */
+export async function runColdLoadContracts({
+  IfcAPI, ownershipWasmExports, columnContent, FIXTURES_DIR, FIXTURES_HINT, SPACES_AVAILABLE, SPACES_IFC, test, skip
+}) {
+  test('processGeometryBatchFromSource returns empty when no source is installed (defensive)', () => {
+    const freshApi = new IfcAPI();
+    const bytes = new TextEncoder().encode(columnContent);
+    try {
+      const pre = freshApi.buildPrePassOnce(bytes);
+      // No setSourceBytes: the held bytes are empty → zero meshes, and crucially
+      // NO panic (the decoder validates every byte span). The JS worker gates the
+      // *FromSource path on a successful setSourceBytes, so this is unreachable in
+      // production, but it must degrade gracefully rather than corrupt/crash.
+      const col = freshApi.processGeometryBatchFromSource(
+        pre.jobs, pre.unitScale,
+        pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
+        pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+      );
+      try {
+        assert.equal(col.length, 0, 'FromSource without setSourceBytes must produce no meshes');
+      } finally {
+        col.free();
+      }
+    } finally {
+      freshApi.clearPrePassCache();
+      freshApi.free();
+    }
+  });
+
+  // Optional retained baseline artifacts exercise a genuinely matched historical pair.
+  if (process.env.IFC_WASM_BASE_JS || process.env.IFC_WASM_BASE_BINARY) {
+    assert.ok(process.env.IFC_WASM_BASE_JS && process.env.IFC_WASM_BASE_BINARY,
+      'Both IFC_WASM_BASE_JS and IFC_WASM_BASE_BINARY must identify the same retained build');
+    const baselineWasm = await import(pathToFileURL(process.env.IFC_WASM_BASE_JS).href);
+    const baselineOwnershipExports = baselineWasm.initSync(readFileSync(process.env.IFC_WASM_BASE_BINARY));
+    test('matched historical mesh getters preserve owned-buffer contract (#3989)', () => {
+      checkMeshGetterOwnershipContract(baselineWasm.IfcAPI, baselineOwnershipExports.memory, new TextEncoder().encode(columnContent));
+    });
+  } else {
+    skip('matched historical mesh getter ownership', 'set IFC_WASM_BASE_JS and IFC_WASM_BASE_BINARY to one retained baseline build');
+  }
+
+  test('mesh getters own transferable backing after free and memory growth (#3989)', () => {
+    checkMeshGetterOwnershipContract(IfcAPI, ownershipWasmExports.memory, new TextEncoder().encode(columnContent));
+  });
+  for (const [kind, name] of [['embedded', 'tessellation-with-pixel-texture.ifc'], ['external', 'tessellation-with-image-texture.ifc']]) {
+    const file = join(FIXTURES_DIR, 'buildingsmart/annex_e/tessellated-shape-with-style', name);
+    if (existsSync(file)) test(`${kind} texture getters own transferable backing (#3989)`, () => {
+      checkMeshGetterOwnershipContract(IfcAPI, ownershipWasmExports.memory, new Uint8Array(readFileSync(file)), kind);
+    });
+    else skip(`${kind} texture getter ownership (#3989)`, `${name} absent; ${FIXTURES_HINT}`);
+  }
+
+  test('owned source spans scan, style assistance, replacement and cleanup (#3989)', () => {
+    const sources = [new TextEncoder().encode(columnContent)];
+    if (SPACES_AVAILABLE) sources.push(new Uint8Array(readFileSync(SPACES_IFC)));
+    checkPrepassSourceContract(IfcAPI, sources);
+  });
+}

--- a/scripts/lib/wasm-mesh-getter-ownership-contract.mjs
+++ b/scripts/lib/wasm-mesh-getter-ownership-contract.mjs
@@ -1,0 +1,63 @@
+// Real WASM ownership invariant for redundant worker getter copies (#3989).
+import assert from 'node:assert/strict';
+const bytesOf = array => new Uint8Array(array.buffer, array.byteOffset, array.byteLength);
+function collection(api, source) {
+  const pre = api.buildPrePassOnce(source);
+  assert.ok(pre.totalJobs > 0, 'Ownership fixture needs real geometry jobs');
+  return api.processGeometryBatch(source, pre.jobs, pre.unitScale,
+    ...pre.rtcOffset, pre.needsShift, pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors);
+}
+export function checkMeshGetterOwnershipContract(IfcAPI, memory, source, kind = 'geometry') {
+  const api = new IfcAPI();
+  const retained = {}, snapshots = {};
+  try {
+    const meshes = collection(api, source);
+    let found = false;
+    try {
+      for (let i = 0; i < meshes.length; i++) {
+        const mesh = meshes.takeMesh(i);
+        if (!mesh) continue;
+        try {
+          const eligible = kind === 'embedded' ? mesh.hasTexture : kind === 'external' ? !!mesh.textureUrl : mesh.vertexCount > 0;
+          if (!eligible) continue;
+          const fields = ['positions', 'normals', 'indices', ...(kind !== 'geometry' ? ['uvs'] : []), ...(kind === 'embedded' ? ['textureRgba'] : [])];
+          for (const field of fields) {
+            const first = mesh[field], second = mesh[field];
+            assert.ok(ArrayBuffer.isView(first), `${field} must be a typed-array getter`);
+            assert.ok(first.length > 0, `${kind} fixture needs nonempty ${field}`);
+            assert.notEqual(first.buffer, memory.buffer, `${field} must not alias the WASM heap`);
+            assert.notEqual(first.buffer, second.buffer, `${field} calls must own independent backing`);
+            const expected = bytesOf(second).slice();
+            assert.deepEqual(bytesOf(first), expected);
+            const owned = bytesOf(first); owned[0] ^= 0x80;
+            assert.deepEqual(bytesOf(second), expected, `${field} getter copies alias each other`);
+            assert.deepEqual(bytesOf(mesh[field]), expected, `${field} JS mutation reached Rust mesh`);
+            owned[0] ^= 0x80;
+            retained[field] = first; snapshots[field] = expected;
+          }
+          found = true;
+        } finally { mesh.free(); }
+        if (found) break;
+      }
+      assert.ok(found, `Missing actual ${kind} ownership witness`);
+    } finally { meshes.free(); api.clearPrePassCache(); }
+    // Real subsequent processing reuses freed Rust allocations.
+    const next = collection(api, source);
+    try { assert.ok(next.totalVertices > 0, 'Next allocation must produce geometry'); }
+    finally { next.free(); api.clearPrePassCache(); }
+    const priorWasmBytes = memory.buffer.byteLength;
+    memory.grow(1);
+    assert.equal(memory.buffer.byteLength, priorWasmBytes + 65536, 'Exercise actual WASM memory growth');
+    for (const [field, value] of Object.entries(retained)) {
+      assert.deepEqual(bytesOf(value), snapshots[field], `${field} changed after free/reallocation/growth`);
+    }
+    // Mirrors existing worker transfers, without wrapping getter arrays.
+    const buffers = Object.values(retained).map(value => value.buffer);
+    assert.equal(new Set(buffers).size, buffers.length, 'Different getters need separately transferable backing');
+    const received = structuredClone(retained, { transfer: buffers });
+    for (const [field, value] of Object.entries(retained)) {
+      assert.equal(value.byteLength, 0, `${field} worker ownership was not transferred`);
+      assert.deepEqual(bytesOf(received[field]), snapshots[field], `${field} receiver data changed`);
+    }
+  } finally { api.clearPrePassCache(); api.free(); }
+}

--- a/scripts/lib/wasm-mesh-getter-ownership-contract.mjs
+++ b/scripts/lib/wasm-mesh-getter-ownership-contract.mjs
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 // Real WASM ownership invariant for redundant worker getter copies (#3989).
 import assert from 'node:assert/strict';
 const bytesOf = array => new Uint8Array(array.buffer, array.byteOffset, array.byteLength);

--- a/scripts/lib/wasm-prepass-source-contract.mjs
+++ b/scripts/lib/wasm-prepass-source-contract.mjs
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import assert from 'node:assert/strict';
+
+/** Real WASM boundary equivalence and source lifetime regression for #3989. */
+export function checkPrepassSourceContract(IfcAPI, sources) {
+  const api = new IfcAPI();
+  try {
+    for (const bytes of sources) {
+      const expected = api.scanEntityIndexShard(bytes, 0, bytes.length);
+      assert.ok(expected.ids.length > 0, 'fixture must contain actual IFC entities');
+      api.setSourceBytes(bytes);
+      const actual = api.scanEntityIndexShardFromSource(0, bytes.length);
+      assert.deepEqual(actual, expected, 'owned-source shard must preserve all columns and refusals');
+      api.setEntityIndex(actual.ids, actual.starts, actual.lengths);
+      assert.deepEqual(actual, expected, 'owned Rust adapter must not detach or mutate JS input columns');
+      assert.deepEqual(api.scanEntityIndexShardFromSource(0, bytes.length), expected,
+        'installing the same load index must preserve its preinstalled source');
+      const decoder = new TextDecoder();
+      const spans = [];
+      for (let i = 0; i < actual.ids.length; i++) {
+        const start = actual.starts[i], length = actual.lengths[i];
+        const record = decoder.decode(bytes.subarray(start, start + Math.min(length, 100)));
+        if (/=\s*IFCSTYLEDITEM\s*\(/i.test(record)) spans.push(actual.ids[i], start, length);
+      }
+      const styleSpans = new Uint32Array(spans);
+      const styles = api.resolveStyledItemsShard(bytes, styleSpans);
+      if (styleSpans.length > 0) assert.ok(styles.geomIds.length + styles.orphanIds.length > 0,
+        'styled fixture must exercise nonempty canonical style resolution');
+      assert.deepEqual(api.resolveStyledItemsShardFromSource(styleSpans), styles,
+        'style recursion must see the same full source and referenced entities');
+      const empty = new Uint32Array();
+      const args = [styles.orphanIds, styles.orphanColors, styles.geomIds, styles.geomColors,
+        empty, empty, empty, empty, empty, empty, 1];
+      assert.deepEqual(api.finalizePrepassStylesFromSource(...args),
+        api.finalizePrepassStyles(bytes, ...args), 'same canonical style finalization');
+      // Exercise replacement WITHOUT intervening cleanup on the next fixture.
+    }
+    api.clearPrePassCache();
+    assert.equal(api.scanEntityIndexShardFromSource(0, 100000).ids.length, 0,
+      'clearPrePassCache must release the installed source');
+  } finally {
+    api.clearPrePassCache();
+    api.free();
+  }
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -589,15 +589,7 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
 
 ### Source and buffer ownership during WASM prepass (#3989)
 
-Retained source-session reuse, binding-owned index adoption and direct transfer of
-already-owned mesh getter arrays as part of the qualified cold-load changes.
-The combined native/browser corpus evidence does not isolate a throughput gain
-for this layer; do not attribute the cumulative result to these copies alone.
-Installed-source methods retain byte-taking compatibility and reset on source
-replacement. Real WASM contracts verify returned buffers survive handle free,
-memory growth and transfer, including textures. Ownership must be established
-at the actual binding: a JavaScript view alone does not remove the copy into WASM,
-and borrowed views into WASM memory must not be transferred as owned output.
+Source-session reuse, binding-owned index adoption and direct transfer of already-owned mesh getter arrays preserve byte-taking compatibility and source-replacement resets. The standalone own-layer native subset was slower in full-load timing, while Holter's measured peak memory fell; the cause remains unestablished and favorable memory does not waive the timing concern. The intended integrated merge parent differs from that standalone comparison, and its proposed comparison remains unrun; results with different parents must not be pooled. Combined native/browser results do not isolate a gain for this layer, and invalid Firefox cohorts provide no throughput evidence. Real WASM contracts verify returned buffers survive handle free, memory growth and transfer, including textures. Establish ownership at the binding: a JavaScript view does not remove the WASM input copy, and borrowed WASM-memory views must not be transferred as owned output.
 
 ### Standing constraints
 - Geometry is **client-side only** (no server meshing).

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -587,6 +587,18 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
   plus slicing phase 2; BVH query results are exact AABB tests at the leaves, so
   a different tree shape is output-equivalent and can be asserted as such.
 
+### Source and buffer ownership during WASM prepass (#3989)
+
+Retained source-session reuse, binding-owned index adoption and direct transfer of
+already-owned mesh getter arrays as part of the qualified cold-load changes.
+The combined native/browser corpus evidence does not isolate a throughput gain
+for this layer; do not attribute the cumulative result to these copies alone.
+Installed-source methods retain byte-taking compatibility and reset on source
+replacement. Real WASM contracts verify returned buffers survive handle free,
+memory growth and transfer, including textures. Ownership must be established
+at the actual binding: a JavaScript view alone does not remove the copy into WASM,
+and borrowed views into WASM memory must not be transferred as owned output.
+
 ### Standing constraints
 - Geometry is **client-side only** (no server meshing).
 - One mesh home: `produce_element_meshes` - a fix in one pipeline diverges the other.

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -9,6 +9,7 @@
  * Focus on structural invariants, not exact values.
  */
 
+import { runColdLoadContracts } from './lib/wasm-cold-load-contracts.mjs';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -76,7 +77,7 @@ if (!SPACES_AVAILABLE) {
 // Initialize WASM
 console.log('📦 Loading WASM...');
 const wasmBuffer = readFileSync(WASM_BIN);
-initSync(wasmBuffer);
+const ownershipWasmExports = initSync(wasmBuffer);
 console.log('✅ WASM initialized\n');
 
 // Load fixture files
@@ -468,29 +469,8 @@ if (LAYERED_AVAILABLE) {
     `${LAYERED_IFC} missing \u2014 ${FIXTURES_HINT}`);
 }
 
-test('processGeometryBatchFromSource returns empty when no source is installed (defensive)', () => {
-  const freshApi = new IfcAPI();
-  const bytes = new TextEncoder().encode(columnContent);
-  try {
-    const pre = freshApi.buildPrePassOnce(bytes);
-    // No setSourceBytes: the held bytes are empty → zero meshes, and crucially
-    // NO panic (the decoder validates every byte span). The JS worker gates the
-    // *FromSource path on a successful setSourceBytes, so this is unreachable in
-    // production, but it must degrade gracefully rather than corrupt/crash.
-    const col = freshApi.processGeometryBatchFromSource(
-      pre.jobs, pre.unitScale,
-      pre.rtcOffset[0], pre.rtcOffset[1], pre.rtcOffset[2], pre.needsShift,
-      pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
-    );
-    try {
-      assert.equal(col.length, 0, 'FromSource without setSourceBytes must produce no meshes');
-    } finally {
-      col.free();
-    }
-  } finally {
-    freshApi.clearPrePassCache();
-    freshApi.free();
-  }
+await runColdLoadContracts({
+  IfcAPI, ownershipWasmExports, columnContent, FIXTURES_DIR, FIXTURES_HINT, SPACES_AVAILABLE, SPACES_IFC, test, skip
 });
 
 // ===== Pre-pass contract (viewer boundary) =====


### PR DESCRIPTION
Sharded geometry workers copied an already-installed source again for style assistance and geometry batches, copied binding-owned index columns during installation, and copied owned mesh getter arrays before transfer. Reuse the installed source for its matching load session, adopt the binding's index allocations, and transfer owned getter buffers directly. Source replacement, cleanup and older runtime methods preserve their behavior.

Installed-source scan/style methods are additive. The existing borrowed Rust `set_entity_index` API remains available. Documentation, changesets and supported regenerated WASM declarations are included; real contracts cover malformed columns, source replacement, missing-source errors, retained-runtime compatibility, handle free, memory growth, transfer and textures.

Closes #3989.

Prior local validation at `e65148c476bc37b770c69b85e987a3a4f5d96d8c` over `06ef1dcd80fae841f33c6ec7d96166b1d01e23af`: supported WASM build with pinned nightly/wasm-pack 0.15.0/Node 22.14.0; root build (49 tasks), root typecheck (89 tasks, 1,728 test sources), root Turbo geometry tests (402 passed), and real WASM contracts (83 passed, none failed/skipped). Module-size and the official API-surface updater passed. The later `318595820` correction changes license headers only. Earlier setup failures were retained and corrected without weakening a check.

Standalone native five-pair Haus/Holter comparisons of `06ef1dcd80fae841f33c6ec7d96166b1d01e23af` versus `318595820a2b3340eca4c8867b0647932dac826e` were slower in full-load timing (+3.56% aggregate; Haus +2.75%, Holter +4.38%), while Holter peak physical footprint fell 10.23%. The cause remains unestablished; favorable memory and cumulative results do not waive this concern. The earlier proposed D-to-integrated-E comparison was stopped before execution; shipping order may now place E before A. That unrun plan supplies no merge-parent evidence, and differing parents are not pooled. No isolated browser gain is claimed.

The [committed evidence bundle](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) keeps these layer results separate from the cumulative stack: native full-call loading improved 15.53% across the fixed corpus; supplemental Chrome full readiness improved 28.70%, but Haus was slower in every pair (median paired increase 26 ms) and several geometry-completion results regressed. The original Chrome strict audit remains failed; the reviewed local analytics-404 disposition and missing historical event URLs are explicit. Firefox's original cohort is invalid under its memory rule; functional controls do not qualify Firefox throughput, and recovery remains unrun. Neither the 30% target nor universal absence of performance regressions is established.

These are prior, artifact-pinned validation results, not certification of the eventual landing head. Applicable exact-head CI, parity/API/WASM gates and review must complete before merge; this body makes no all-green or deployment claim.
