### PR TITLE
perf(parser): retain numeric columns through metadata and cache preparation

### DIFF
--- a/.changeset/borrowed-compact-cache-columns.md
+++ b/.changeset/borrowed-compact-cache-columns.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/parser": minor
+"@ifc-lite/cache": minor
+---
+
+Expose borrowed compact entity columns to compatible consumers and reuse them when writing binary cache indexes. Preserve the existing binary layout, normalized type order, generic iterable inputs and borrowed-buffer ownership while avoiding reference-object reconstruction for valid compact indexes.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1464,13 +1464,7 @@ export function useIfcLoader() {
           if (!useParserWorker || !sharedSource) {
             return Promise.reject(new Error('parser worker disabled (no SAB / native file)'));
           }
-          // NOTE: `deferPropertyAtomIndex` is not enabled here. The current
-          // implementation in `columnar-parser.ts` calls
-          // `entityRefs.filter(...)` to split property atoms out of the
-          // primary index, which costs more on a 14 M-entity file (~3 s
-          // for the filter pass) than the index-build time it saves.
-          // Re-enable once the categorization loop builds the two
-          // ref arrays inline so there is no second O(N) walk.
+          // Keep the existing non-deferred atom policy while qualifying source ownership.
           const worker = new WorkerParser();
           workerParserInstance = worker;
           return worker.parseColumnar(sharedSource, {

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -678,3 +678,9 @@ When working with multiple IFC files (e.g., architectural, structural, and MEP m
 - [Query Guide](querying.md) - Query parsed data
 - [Federation Guide](federation.md) - Load and coordinate multiple models
 - [API Reference](../api/typescript.md) - Complete API docs
+
+### Borrowing compact entity columns
+
+`CompactEntityIndex.getColumns()` exposes the four numeric backing arrays (`expressIds`, `byteOffsets`, `byteLengths`, `typeIndices`) and a copy of the `typeStrings` list. This supports column-aware consumers such as binary cache serialization without creating a reference object for every entity.
+
+The numeric arrays are borrowed and must not be mutated. They remain valid until their owner detaches them. A transport may transfer the arrays when retiring the owning index; cache consumers must not detach them. Changing the returned string list does not change the index. Generic map-compatible indexes remain supported by the parser and cache interfaces.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -124,3 +124,10 @@ See the [API Reference](https://ifclite.dev/docs/api/typescript/#ifc-litecache).
 ## License
 
 [MPL-2.0](../../LICENSE)
+
+
+### Compact entity-index input
+
+`CacheEntityIndex.byId` continues to accept an iterable of entity references. Column-aware producers may additionally implement `getColumns()`, returning `expressIds`, `byteOffsets`, `byteLengths`, `typeIndices` and `typeStrings` with the same rows as iteration. The parser's `CompactEntityIndex` supplies this method; the cache package does not require a parser runtime dependency.
+
+Serialization borrows valid sorted columns synchronously, preserving stable duplicate order, normalized type names and first-row type-table order. It never mutates or detaches input backing. Unsupported column shapes use the iterable representation. Producers must keep borrowed columns stable during serialization and must not expose unrelated columns through this method. The existing binary format and generic iterable behavior are unchanged.

--- a/packages/cache/src/sections/entity-index-columns.test.ts
+++ b/packages/cache/src/sections/entity-index-columns.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { existsSync, readFileSync } from 'node:fs';
+import { deepStrictEqual } from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { CompactEntityIndex, IfcParser } from '@ifc-lite/parser';
+import { writeEntityIndex, readEntityIndex } from './entity-index.js';
+import { BufferReader, BufferWriter } from '../utils/buffer-utils.js';
+import type { CacheEntityIndex, CacheEntityRef } from '../types.js';
+
+function encode(byId: CacheEntityIndex['byId']): ArrayBuffer {
+  const writer = new BufferWriter();
+  writeEntityIndex(writer, { byId });
+  return writer.build();
+}
+function iterableOnly(index: CompactEntityIndex): CacheEntityIndex['byId'] {
+  return { [Symbol.iterator]: () => index[Symbol.iterator]() };
+}
+function checkOracle(index: CompactEntityIndex) {
+  const before = [...index];
+  const expected = encode(iterableOnly(index));
+  const actual = encode(index);
+  // #3985: exact section bytes ARE the binary-cache compatibility contract.
+  // Native strict comparison keeps the 65536-type boundary oracle affordable
+  // under the full parallel suite without shortening its byte/object coverage.
+  deepStrictEqual(new Uint8Array(actual), new Uint8Array(expected));
+  deepStrictEqual([...index], before);
+  const restored = readEntityIndex(new BufferReader(actual));
+  deepStrictEqual(restored, readEntityIndex(new BufferReader(expected)));
+  return restored;
+}
+function compact(ids: number[], types: number[], names: string[]) {
+  return new CompactEntityIndex(Uint32Array.from(ids),
+    Uint32Array.from(ids.map((_, i) => i * 19)),
+    Uint32Array.from(ids.map((_, i) => i + 7)), Uint16Array.from(types), names);
+}
+
+describe('compact cache columns preserve iterable byte layout (#3985)', () => {
+  it('keeps sparse/duplicate IDs, normalized first-row type order and source ownership', () => {
+    const index = compact([0, 0, 2, 0xffffffff], [3, 1, 0, 2],
+      ['ifcwall', 'IFCWALL', 'Ifcſpace', 'IFCSPACE', 'UNREFERENCED']);
+    const columns = index.getColumns();
+    const beforeColumns = structuredClone(columns);
+    const decoded = checkOracle(index);
+    expect(decoded.ids).toEqual(new Uint32Array([0, 0, 2, 0xffffffff]));
+    expect(decoded.typeNames).toEqual(['IFCSPACE', 'IFCWALL']);
+    expect(decoded.typeIndices).toEqual(new Uint16Array([0, 1, 1, 0]));
+    expect(columns).toEqual(beforeColumns);
+    expect(index.get(0xffffffff)?.type).toBe('Ifcſpace');
+    // String lists returned to transport/cache cannot rewrite source type names.
+    columns.typeStrings[2] = 'MUTATED_CONSUMER_TABLE';
+    expect([...index].at(-1)?.[1].type).toBe('Ifcſpace');
+  });
+
+  it('keeps empty and unused-only type tables empty on the wire', () => {
+    expect(checkOracle(compact([], [], ['unused'])).typeNames).toEqual([]);
+  });
+
+  it('retains stable sorting when a public constructor supplies unsorted IDs', () => {
+    const decoded = checkOracle(compact([9, 2, 9, 0], [0, 1, 2, 0], ['IfcWall', 'IfcSlab', 'IfcDoor']));
+    expect(decoded.ids).toEqual(new Uint32Array([0, 2, 9, 9]));
+    expect(decoded.byteOffsets).toEqual(new Uint32Array([57, 19, 0, 38]));
+    expect(decoded.typeNames).toEqual(['IFCWALL', 'IFCSLAB', 'IFCDOOR']);
+  });
+
+  it.each(['shortOffsets', 'longOffsets', 'shortLengths', 'longLengths', 'shortTypes', 'longTypes', 'badTypeIndex', 'nonStringType'])
+  ('preserves iterable coercion for unusual constructor input: %s', kind => {
+    const ids = new Uint32Array([1, 2]);
+    const offsets = new Uint32Array(kind === 'shortOffsets' ? [10] : kind === 'longOffsets' ? [10, 20, 30] : [10, 20]);
+    const lengths = new Uint32Array(kind === 'shortLengths' ? [3] : kind === 'longLengths' ? [3, 4, 5] : [3, 4]);
+    const types = new Uint16Array(kind === 'shortTypes' ? [0] : kind === 'longTypes' ? [0, 0, 0] : kind === 'badTypeIndex' ? [0, 17] : [0, 0]);
+    const names = kind === 'nonStringType' ? [42] as unknown as string[] : ['IfcWall'];
+    checkOracle(new CompactEntityIndex(ids, offsets, lengths, types, names));
+  });
+
+  it('preserves all 65536 distinct referenced source type slots', () => {
+    const n = 0x10000;
+    const ids = Uint32Array.from({ length: n }, (_, i) => i);
+    const types = Uint16Array.from({ length: n }, (_, i) => n - i - 1);
+    const index = new CompactEntityIndex(ids, ids.slice(), ids.slice(), types,
+      Array.from({ length: n }, (_, i) => `IfcVendor${i}`));
+    const restored = checkOracle(index);
+    expect(restored.typeNames.length).toBe(n);
+    expect(restored.typeNames[0]).toBe('IFCVENDOR65535');
+    expect(restored.typeNames[n - 1]).toBe('IFCVENDOR0');
+  });
+
+  it('retains generic iterable overflow rejection at the 65537th unique normalized type', () => {
+    const byId: CacheEntityIndex['byId'] = {
+      *[Symbol.iterator](): IterableIterator<[number, CacheEntityRef]> {
+        for (let id = 0; id <= 0x10000; id++) {
+          yield [id, { expressId: id, type: `IfcVendor${id}`, byteOffset: id, byteLength: 1 }];
+        }
+      },
+    };
+    expect(() => encode(byId)).toThrow('more than 65535 unique IFC type names');
+  });
+});
+
+const realFixture = resolve(__dirname, '../../../../tests/models/ara3d/AC20-FZK-Haus.ifc');
+const hasFixture = existsSync(realFixture);
+if (!hasFixture) console.warn('skip compact cache real IFC oracle: run pnpm fixtures');
+it.skipIf(!hasFixture)('retains real Archicad cache section bytes and properties (#3985)', async () => {
+  const source = Uint8Array.from(readFileSync(realFixture)).buffer;
+  const parsed = await new IfcParser().parseColumnar(source, { disableWorkerScan: true });
+  expect(parsed.entityIndex.byId).toBeInstanceOf(CompactEntityIndex);
+  const index = parsed.entityIndex.byId as CompactEntityIndex;
+  const propertyIds = [...parsed.onDemandPropertyMap!.keys()];
+  expect(propertyIds.length).toBeGreaterThan(0);
+  const sampleId = propertyIds[0];
+  const before = parsed.getProperties(sampleId);
+  expect(before.length).toBeGreaterThan(0);
+  checkOracle(index);
+  expect(parsed.getProperties(sampleId)).toEqual(before);
+});

--- a/packages/cache/src/sections/entity-index-columns.ts
+++ b/packages/cache/src/sections/entity-index-columns.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { CacheEntityIndex, CachedEntityIndexColumns } from '../types.js';
+
+/** #3985: reuse validated numeric backing; retain generic iterable semantics. */
+export function prepareBorrowedEntityColumns(byId: CacheEntityIndex['byId']): CachedEntityIndexColumns | undefined {
+  if (typeof byId.getColumns !== 'function') return undefined;
+  const c = byId.getColumns();
+  if (!(c.expressIds instanceof Uint32Array) || !(c.byteOffsets instanceof Uint32Array)
+    || !(c.byteLengths instanceof Uint32Array) || !(c.typeIndices instanceof Uint16Array)
+    || !Array.isArray(c.typeStrings)) return undefined;
+  const n = c.expressIds.length;
+  if (c.byteOffsets.length !== n || c.byteLengths.length !== n || c.typeIndices.length !== n) return undefined;
+  const remap = new Int32Array(Math.min(c.typeStrings.length, 0x10000)).fill(-1);
+  const seen = new Map<string, number>();
+  const typeNames: string[] = [];
+  const typeIndices = new Uint16Array(n);
+  for (let row = 0; row < n; row++) {
+    if (row && c.expressIds[row] < c.expressIds[row - 1]) return undefined;
+    const rawTypeIndex = c.typeIndices[row];
+    if (rawTypeIndex >= c.typeStrings.length || typeof c.typeStrings[rawTypeIndex] !== 'string') return undefined;
+    let index = remap[rawTypeIndex];
+    if (index === -1) {
+      const name = c.typeStrings[rawTypeIndex].toUpperCase();
+      let existing = seen.get(name);
+      if (existing === undefined) {
+        existing = typeNames.length;
+        if (existing > 0xffff) throw new Error('Entity index has more than 65535 unique IFC type names');
+        typeNames.push(name);
+        seen.set(name, existing);
+      }
+      index = existing;
+      remap[rawTypeIndex] = index;
+    }
+    typeIndices[row] = index;
+  }
+  return { ids: c.expressIds, byteOffsets: c.byteOffsets, byteLengths: c.byteLengths, typeIndices, typeNames };
+}

--- a/packages/cache/src/sections/entity-index.ts
+++ b/packages/cache/src/sections/entity-index.ts
@@ -4,8 +4,14 @@
 
 import type { CacheEntityIndex, CacheEntityRef, CachedEntityIndexColumns } from '../types.js';
 import { BufferReader, BufferWriter } from '../utils/buffer-utils.js';
+import { prepareBorrowedEntityColumns } from './entity-index-columns.js';
 
 export function writeEntityIndex(writer: BufferWriter, entityIndex: CacheEntityIndex): void {
+  const columns = prepareBorrowedEntityColumns(entityIndex.byId);
+  if (columns) {
+    writeColumns(writer, columns);
+    return;
+  }
   const refs = Array.from(entityIndex.byId, ([id, ref]) => normalizeRef(id, ref))
     .sort((a, b) => a.expressId - b.expressId);
 
@@ -34,15 +40,17 @@ export function writeEntityIndex(writer: BufferWriter, entityIndex: CacheEntityI
     typeIndices[i] = typeIndex;
   }
 
-  writer.writeUint32(refs.length);
-  writer.writeUint32(typeNames.length);
-  for (const typeName of typeNames) {
-    writer.writeString(typeName);
-  }
-  writer.writeTypedArray(ids);
-  writer.writeTypedArray(byteOffsets);
-  writer.writeTypedArray(byteLengths);
-  writer.writeTypedArray(typeIndices);
+  writeColumns(writer, { ids, byteOffsets, byteLengths, typeIndices, typeNames });
+}
+
+function writeColumns(writer: BufferWriter, columns: CachedEntityIndexColumns): void {
+  writer.writeUint32(columns.ids.length);
+  writer.writeUint32(columns.typeNames.length);
+  for (const name of columns.typeNames) writer.writeString(name);
+  writer.writeTypedArray(columns.ids);
+  writer.writeTypedArray(columns.byteOffsets);
+  writer.writeTypedArray(columns.byteLengths);
+  writer.writeTypedArray(columns.typeIndices);
 }
 
 export function readEntityIndex(reader: BufferReader): CachedEntityIndexColumns {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -341,7 +341,16 @@ export interface CacheEntityRef {
 }
 
 export interface CacheEntityIndex {
-  byId: Iterable<[number, CacheEntityRef]>;
+  byId: Iterable<[number, CacheEntityRef]> & {
+    /** Optional borrowed columns equivalent to iteration; never mutated/transferred. */
+    getColumns?(): {
+      expressIds: Uint32Array;
+      byteOffsets: Uint32Array;
+      byteLengths: Uint32Array;
+      typeIndices: Uint16Array;
+      typeStrings: string[];
+    };
+  };
 }
 
 export interface CachedEntityIndexColumns {

--- a/packages/parser/src/columnar-entity-preparation.ts
+++ b/packages/parser/src/columnar-entity-preparation.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { EntityRef } from './types.js';
+import type { ScannedEntityColumns } from './entity-refs-from-index.js';
+import { compactEntityIndexFromColumns } from './compact-entity-index-transport.js';
+import { buildCompactEntityIndexAsync } from './compact-entity-index.js';
+import { selectEntityColumns } from './select-entity-columns.js';
+import { getInheritanceChain } from './ifc-schema.js';
+import {
+  GEOMETRY_TYPES, SPATIAL_TYPES, HIERARCHY_REL_TYPES, PROPERTY_REL_TYPES,
+  PROPERTY_ENTITY_TYPES, PROPERTY_CONTAINER_TYPES, ASSOCIATION_REL_TYPES, isIfcTypeLikeEntity,
+} from './columnar-parser-indexes.js';
+
+export type ColumnarEntityInput = EntityRef[] | ScannedEntityColumns;
+
+/** Shared categorization for scanned objects and pre-pass columns. #3985 */
+export async function prepareColumnarEntities(
+  input: ColumnarEntityInput,
+  deferPropertyAtomIndex: boolean,
+  yieldIfNeeded: () => Promise<void>,
+) {
+  // Single pass: build byType index AND categorize entities simultaneously.
+  // Uses a type-name cache to avoid calling .toUpperCase() on 4.4M refs
+  // (only ~776 unique type names in IFC4).
+  const byType = new Map<string, number[]>();
+  const typeUpperCache = new Map<string, string>();
+  const getTypeUpper = (type: string) => {
+      let upper = typeUpperCache.get(type);
+      if (upper === undefined) {
+          upper = type.toUpperCase();
+          typeUpperCache.set(type, upper);
+      }
+      return upper;
+  };
+
+  // Non-product helper entities that on-demand extraction / StepExporter
+  // need addressable in `byId`. These are not IfcProduct subtypes so the
+  // schema-driven IFCPRODUCT subtype check below cannot capture them.
+  // Without them, findPreferredGeometricRepresentationContextId() and
+  // findLengthUnitReference() fail because the entities are missing from
+  // the compact entity index.
+  const RELEVANT_NON_PRODUCT_HELPERS = new Set([
+      'IFCGEOMETRICREPRESENTATIONCONTEXT', 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
+      'IFCUNITASSIGNMENT', 'IFCSIUNIT', 'IFCCONVERSIONBASEDUNIT',
+      'IFCDERIVEDUNIT', 'IFCDERIVEDUNITELEMENT', 'IFCMEASUREWITHUNIT',
+      'IFCDIMENSIONALEXPONENTS',
+      'IFCMAPCONVERSION', 'IFCPROJECTEDCRS',
+      'IFCMATERIALLAYER', 'IFCMATERIALLAYERSET', 'IFCMATERIALLAYERSETUSAGE',
+      'IFCMATERIALCONSTITUENTSET', 'IFCMATERIALCONSTITUENT',
+      'IFCMATERIALPROFILESET', 'IFCMATERIALPROFILE', 'IFCMATERIAL',
+      'IFCCLASSIFICATION', 'IFCCLASSIFICATIONREFERENCE',
+      'IFCDOCUMENTINFORMATION', 'IFCDOCUMENTREFERENCE',
+  ]);
+
+  // Schema-driven inclusion: every IfcProduct subtype belongs in the
+  // EntityTable. The previous hardcoded enumeration of IFC4 building-
+  // element leaves (IFCWALL, IFCSLAB, …) and IFC4x3 infrastructure
+  // leaves (IFCREFERENT, IFCSIGNAL, IFCALIGNMENT, IFCPAVEMENT, …) drifted
+  // with every schema bump — new entities silently became CAT_SKIP and
+  // disappeared from the hierarchy panel. The generated schema registry
+  // already knows the full inheritance chain, so use it.
+  const RELEVANT_PRODUCT_ROOTS = new Set(['IFCPRODUCT']);
+
+  // IfcGroup family (IfcZone, IfcSystem, IfcDistributionSystem,
+  // IfcBuildingSystem, IfcDistributionCircuit, …). These are NOT
+  // IfcProduct subtypes, so without an explicit branch they fall through
+  // to CAT_SKIP and never enter the EntityTable — leaving their Name
+  // unresolvable (`getName` → '') and making them invisible to
+  // `getByType`. The Relationships card then shows "Group #<id>" and the
+  // lens/lists can't surface them. Route them into their own bucket so we
+  // can extract Name/LongName/ObjectType for the group label (#1075).
+  const GROUP_ROOTS = new Set(['IFCGROUP']);
+
+  // Category constants for the lookup cache
+  const CAT_SKIP = 0, CAT_SPATIAL = 1, CAT_GEOMETRY = 2, CAT_HIERARCHY_REL = 3,
+        CAT_PROPERTY_REL = 4, CAT_PROPERTY_ENTITY = 5, CAT_ASSOCIATION_REL = 6,
+        CAT_TYPE_OBJECT = 7, CAT_RELEVANT = 8, CAT_GROUP = 9;
+
+
+  /** Returns true if `upper` (already uppercased) is a subtype of any type in `set`. */
+  function isSubtypeOfAny(upper: string, set: Set<string>): boolean {
+      const chain = getInheritanceChain(upper);
+      return chain.some(ancestor => set.has(ancestor.toUpperCase()));
+  }
+
+  // Cache: type name → category (avoids 4.4M .toUpperCase() calls)
+  const typeCategoryCache = new Map<string, number>();
+  function getCategory(type: string): number {
+      let cat = typeCategoryCache.get(type);
+      if (cat !== undefined) return cat;
+      const upper = getTypeUpper(type);
+      if (SPATIAL_TYPES.has(upper) || isSubtypeOfAny(upper, SPATIAL_TYPES)) cat = CAT_SPATIAL;
+      else if (GEOMETRY_TYPES.has(upper) || isSubtypeOfAny(upper, GEOMETRY_TYPES)) cat = CAT_GEOMETRY;
+      else if (HIERARCHY_REL_TYPES.has(upper)) cat = CAT_HIERARCHY_REL;
+      else if (PROPERTY_REL_TYPES.has(upper)) cat = CAT_PROPERTY_REL;
+      else if (PROPERTY_ENTITY_TYPES.has(upper)) cat = CAT_PROPERTY_ENTITY;
+      else if (ASSOCIATION_REL_TYPES.has(upper)) cat = CAT_ASSOCIATION_REL;
+      else if (isIfcTypeLikeEntity(upper)) cat = CAT_TYPE_OBJECT;
+      else if (isSubtypeOfAny(upper, GROUP_ROOTS)) cat = CAT_GROUP;
+      else if (
+          RELEVANT_NON_PRODUCT_HELPERS.has(upper)
+          || isSubtypeOfAny(upper, RELEVANT_PRODUCT_ROOTS)
+          || upper.startsWith('IFCREL')
+      ) cat = CAT_RELEVANT;
+      else cat = CAT_SKIP;
+      typeCategoryCache.set(type, cat);
+      return cat;
+  }
+
+
+  const refs = Array.isArray(input) ? input : undefined;
+  const columns = Array.isArray(input) ? undefined : input;
+  const count = refs ? refs.length : columns!.expressIds.length;
+  const spatialRefs: EntityRef[] = [];
+  const geometryRefs: EntityRef[] = [];
+  const relationshipRefs: EntityRef[] = [];
+  const propertyRelRefs: EntityRef[] = [];
+  const propertyContainerRefs: EntityRef[] = [];
+  const propertyAtomRefs: EntityRef[] = [];
+  const deferredRows: number[] = [];
+  let propertyAtomCount = 0;
+  const associationRelRefs: EntityRef[] = [];
+  const typeObjectRefs: EntityRef[] = [];
+  const otherRelevantRefs: EntityRef[] = [];
+  const groupRefs: EntityRef[] = [];
+
+  for (let i = 0; i < count; i++) {
+    if ((i & 0x3FF) === 0) await yieldIfNeeded();
+    const type = refs ? refs[i].type : columns!.typeStrings[columns!.typeIndices[i]];
+    const id = refs ? refs[i].expressId : columns!.expressIds[i];
+    const cat = getCategory(type);
+    const atom = cat === CAT_PROPERTY_ENTITY && !PROPERTY_CONTAINER_TYPES.has(getTypeUpper(type));
+    if (!deferPropertyAtomIndex || !atom) {
+      const typeKey = getTypeUpper(type);
+      let list = byType.get(typeKey);
+      if (!list) { list = []; byType.set(typeKey, list); }
+      list.push(id);
+    }
+    if (atom) {
+      propertyAtomCount++;
+      if (deferPropertyAtomIndex) {
+  if (refs) propertyAtomRefs.push(refs[i]);
+  else deferredRows.push(i);
+      }
+      continue;
+    }
+    // Helper records still remain in both complete indexes. They do not need
+    // a transient EntityRef merely to copy their numeric fields back out.
+    if (cat === CAT_SKIP) continue;
+    const ref = refs ? refs[i] : {
+      expressId: id, type, byteOffset: columns!.byteOffsets[i],
+      byteLength: columns!.byteLengths[i], lineNumber: 0,
+    };
+    if (cat === CAT_SPATIAL) spatialRefs.push(ref);
+    else if (cat === CAT_GEOMETRY) geometryRefs.push(ref);
+    else if (cat === CAT_HIERARCHY_REL) relationshipRefs.push(ref);
+    else if (cat === CAT_PROPERTY_REL) propertyRelRefs.push(ref);
+    else if (cat === CAT_PROPERTY_ENTITY) propertyContainerRefs.push(ref);
+    else if (cat === CAT_ASSOCIATION_REL) associationRelRefs.push(ref);
+    else if (cat === CAT_TYPE_OBJECT) typeObjectRefs.push(ref);
+    else if (cat === CAT_GROUP) groupRefs.push(ref);
+    else if (cat === CAT_RELEVANT) otherRelevantRefs.push(ref);
+  }
+
+  const isPrimary = (type: string) => !deferPropertyAtomIndex
+    || getCategory(type) !== CAT_PROPERTY_ENTITY || PROPERTY_CONTAINER_TYPES.has(getTypeUpper(type));
+  const indexedCount = count - (deferPropertyAtomIndex ? propertyAtomCount : 0);
+  return {
+    byType, getTypeUpper, indexedCount, propertyAtomCount,
+    spatialRefs, geometryRefs, relationshipRefs, propertyRelRefs,
+    propertyContainerRefs, associationRelRefs, typeObjectRefs, otherRelevantRefs, groupRefs,
+    async buildPrimaryIndex() {
+      if (refs) return buildCompactEntityIndexAsync(deferPropertyAtomIndex ? refs.filter(ref => isPrimary(ref.type)) : refs);
+      if (!deferPropertyAtomIndex || propertyAtomCount === 0) return compactEntityIndexFromColumns({
+        ...columns!, typeIndices: columns!.typeIndices instanceof Uint16Array
+          ? columns!.typeIndices : Uint16Array.from(columns!.typeIndices),
+      });
+      return selectEntityColumns(columns!, indexedCount, isPrimary);
+    },
+    async buildDeferredIndex() {
+      if (!deferPropertyAtomIndex || propertyAtomCount === 0) return undefined;
+      if (refs) return buildCompactEntityIndexAsync(propertyAtomRefs, undefined, 1024, 2);
+      return selectEntityColumns(columns!, propertyAtomCount, undefined, deferredRows, 1024, 2);
+    },
+  };
+}

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -13,10 +13,9 @@ import type { EntityRef } from './types.js';
 import { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
-import { getInheritanceChain } from './ifc-schema.js';
 import { parsePropertyValueWithComplex } from './on-demand-extractors.js';
 import { readQuantitySet } from './quantity-collect.js';
-import { buildCompactEntityIndexAsync } from './compact-entity-index.js';
+import { prepareColumnarEntities, type ColumnarEntityInput } from './columnar-entity-preparation.js';
 import { yieldToEventLoop } from './yield-to-event-loop.js';
 import {
     StringTable,
@@ -30,15 +29,7 @@ import type { SpatialHierarchy, QuantityTable, PropertyValue, PropertySet, Quant
 import { BufferEntitySource } from './entity-source.js';
 import { batchExtractGlobalIdAndName } from './columnar-parser-attributes.js';
 import {
-    GEOMETRY_TYPES,
     REL_TYPE_MAP,
-    SPATIAL_TYPES,
-    HIERARCHY_REL_TYPES,
-    PROPERTY_REL_TYPES,
-    ASSOCIATION_REL_TYPES,
-    PROPERTY_ENTITY_TYPES,
-    PROPERTY_CONTAINER_TYPES,
-    isIfcTypeLikeEntity,
 } from './columnar-parser-indexes.js';
 import { extractRelFast, extractPropertyRelFast } from './columnar-parser-relationships.js';
 import { detectSchemaVersion, parseSourceHeader } from './source-header.js';
@@ -137,17 +128,10 @@ export interface IfcDataStore extends IfcStoreBase {
     lengthUnitScale?: number;
 }
 
-export class ColumnarParser {
-    /**
-     * Parse IFC file into columnar data store
-     *
-     * Uses fast semicolon-based scanning with on-demand property extraction.
-     * Properties are parsed lazily when accessed, not upfront.
-     * This provides instant UI responsiveness even for very large files.
-     */
-    async parseLite(
+/** Internal implementation shared by public refs and parser-worker columns. */
+export async function parseColumnarInput(
         buffer: ArrayBuffer | SharedArrayBuffer,
-        entityRefs: EntityRef[],
+        input: ColumnarEntityInput,
         options: {
             onProgress?: (progress: { phase: string; percent: number }) => void;
             onDiagnostic?: (message: string) => void;
@@ -158,7 +142,7 @@ export class ColumnarParser {
     ): Promise<IfcDataStore> {
         const startTime = performance.now();
         const uint8Buffer = new Uint8Array(buffer);
-        const totalEntities = entityRefs.length;
+        const totalEntities = Array.isArray(input) ? input.length : input.expressIds.length;
 
         // Phase timing for performance telemetry
         let phaseStart = startTime;
@@ -194,95 +178,6 @@ export class ColumnarParser {
 
         logPhase('init builders');
 
-        // Single pass: build byType index AND categorize entities simultaneously.
-        // Uses a type-name cache to avoid calling .toUpperCase() on 4.4M refs
-        // (only ~776 unique type names in IFC4).
-        const byType = new Map<string, number[]>();
-        const deferPropertyAtomIndex = options.deferPropertyAtomIndex === true;
-        const typeUpperCache = new Map<string, string>();
-        const getTypeUpper = (type: string) => {
-            let upper = typeUpperCache.get(type);
-            if (upper === undefined) {
-                upper = type.toUpperCase();
-                typeUpperCache.set(type, upper);
-            }
-            return upper;
-        };
-
-        // Non-product helper entities that on-demand extraction / StepExporter
-        // need addressable in `byId`. These are not IfcProduct subtypes so the
-        // schema-driven IFCPRODUCT subtype check below cannot capture them.
-        // Without them, findPreferredGeometricRepresentationContextId() and
-        // findLengthUnitReference() fail because the entities are missing from
-        // the compact entity index.
-        const RELEVANT_NON_PRODUCT_HELPERS = new Set([
-            'IFCGEOMETRICREPRESENTATIONCONTEXT', 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
-            'IFCUNITASSIGNMENT', 'IFCSIUNIT', 'IFCCONVERSIONBASEDUNIT',
-            'IFCDERIVEDUNIT', 'IFCDERIVEDUNITELEMENT', 'IFCMEASUREWITHUNIT',
-            'IFCDIMENSIONALEXPONENTS',
-            'IFCMAPCONVERSION', 'IFCPROJECTEDCRS',
-            'IFCMATERIALLAYER', 'IFCMATERIALLAYERSET', 'IFCMATERIALLAYERSETUSAGE',
-            'IFCMATERIALCONSTITUENTSET', 'IFCMATERIALCONSTITUENT',
-            'IFCMATERIALPROFILESET', 'IFCMATERIALPROFILE', 'IFCMATERIAL',
-            'IFCCLASSIFICATION', 'IFCCLASSIFICATIONREFERENCE',
-            'IFCDOCUMENTINFORMATION', 'IFCDOCUMENTREFERENCE',
-        ]);
-
-        // Schema-driven inclusion: every IfcProduct subtype belongs in the
-        // EntityTable. The previous hardcoded enumeration of IFC4 building-
-        // element leaves (IFCWALL, IFCSLAB, …) and IFC4x3 infrastructure
-        // leaves (IFCREFERENT, IFCSIGNAL, IFCALIGNMENT, IFCPAVEMENT, …) drifted
-        // with every schema bump — new entities silently became CAT_SKIP and
-        // disappeared from the hierarchy panel. The generated schema registry
-        // already knows the full inheritance chain, so use it.
-        const RELEVANT_PRODUCT_ROOTS = new Set(['IFCPRODUCT']);
-
-        // IfcGroup family (IfcZone, IfcSystem, IfcDistributionSystem,
-        // IfcBuildingSystem, IfcDistributionCircuit, …). These are NOT
-        // IfcProduct subtypes, so without an explicit branch they fall through
-        // to CAT_SKIP and never enter the EntityTable — leaving their Name
-        // unresolvable (`getName` → '') and making them invisible to
-        // `getByType`. The Relationships card then shows "Group #<id>" and the
-        // lens/lists can't surface them. Route them into their own bucket so we
-        // can extract Name/LongName/ObjectType for the group label (#1075).
-        const GROUP_ROOTS = new Set(['IFCGROUP']);
-
-        // Category constants for the lookup cache
-        const CAT_SKIP = 0, CAT_SPATIAL = 1, CAT_GEOMETRY = 2, CAT_HIERARCHY_REL = 3,
-              CAT_PROPERTY_REL = 4, CAT_PROPERTY_ENTITY = 5, CAT_ASSOCIATION_REL = 6,
-              CAT_TYPE_OBJECT = 7, CAT_RELEVANT = 8, CAT_GROUP = 9;
-
-
-        /** Returns true if `upper` (already uppercased) is a subtype of any type in `set`. */
-        function isSubtypeOfAny(upper: string, set: Set<string>): boolean {
-            const chain = getInheritanceChain(upper);
-            return chain.some(ancestor => set.has(ancestor.toUpperCase()));
-        }
-
-        // Cache: type name → category (avoids 4.4M .toUpperCase() calls)
-        const typeCategoryCache = new Map<string, number>();
-        function getCategory(type: string): number {
-            let cat = typeCategoryCache.get(type);
-            if (cat !== undefined) return cat;
-            const upper = getTypeUpper(type);
-            if (SPATIAL_TYPES.has(upper) || isSubtypeOfAny(upper, SPATIAL_TYPES)) cat = CAT_SPATIAL;
-            else if (GEOMETRY_TYPES.has(upper) || isSubtypeOfAny(upper, GEOMETRY_TYPES)) cat = CAT_GEOMETRY;
-            else if (HIERARCHY_REL_TYPES.has(upper)) cat = CAT_HIERARCHY_REL;
-            else if (PROPERTY_REL_TYPES.has(upper)) cat = CAT_PROPERTY_REL;
-            else if (PROPERTY_ENTITY_TYPES.has(upper)) cat = CAT_PROPERTY_ENTITY;
-            else if (ASSOCIATION_REL_TYPES.has(upper)) cat = CAT_ASSOCIATION_REL;
-            else if (isIfcTypeLikeEntity(upper)) cat = CAT_TYPE_OBJECT;
-            else if (isSubtypeOfAny(upper, GROUP_ROOTS)) cat = CAT_GROUP;
-            else if (
-                RELEVANT_NON_PRODUCT_HELPERS.has(upper)
-                || isSubtypeOfAny(upper, RELEVANT_PRODUCT_ROOTS)
-                || upper.startsWith('IFCREL')
-            ) cat = CAT_RELEVANT;
-            else cat = CAT_SKIP;
-            typeCategoryCache.set(type, cat);
-            return cat;
-        }
-
         // Time-based yielding: yield to the main thread every ~80ms so geometry
         // streaming callbacks can fire. This limits main-thread blocking to short
         // bursts that don't starve geometry, while adding minimal overhead (~15 yields
@@ -299,73 +194,12 @@ export class ColumnarParser {
 
         emitDiagnostic(`parseLite start: totalEntities=${totalEntities} yieldInterval=${YIELD_INTERVAL_MS}ms`);
 
-        const spatialRefs: EntityRef[] = [];
-        const geometryRefs: EntityRef[] = [];
-        const relationshipRefs: EntityRef[] = [];
-        const propertyRelRefs: EntityRef[] = [];
-        const propertyContainerRefs: EntityRef[] = [];
-        const propertyAtomRefs: EntityRef[] = [];
-        const associationRelRefs: EntityRef[] = [];
-        const typeObjectRefs: EntityRef[] = [];
-        const otherRelevantRefs: EntityRef[] = [];
-        const groupRefs: EntityRef[] = [];
-
-        for (let i = 0; i < entityRefs.length; i++) {
-            if ((i & 0x3FF) === 0) await yieldIfNeeded();
-            const ref = entityRefs[i];
-            // Categorize (cached — .toUpperCase() called once per unique type)
-            const cat = getCategory(ref.type);
-            const typeUpper = cat === CAT_PROPERTY_ENTITY ? getTypeUpper(ref.type) : '';
-            // ALL entities must be indexed in byType for on-demand extraction
-            // (e.g. IfcGeometricRepresentationContext, IfcSiUnit, IfcMaterialLayer).
-            // Only property atoms are optionally deferred for huge-file lazy loading.
-            const includeInPrimaryIndex =
-                !deferPropertyAtomIndex || cat !== CAT_PROPERTY_ENTITY || PROPERTY_CONTAINER_TYPES.has(typeUpper);
-            if (includeInPrimaryIndex) {
-                // STEP convention is uppercase entity type names and every
-                // downstream consumer (schedule-extractor, property readers,
-                // test helpers) keys on uppercase. The tokenizer preserves
-                // original case though, so if a STEP writer ever emits
-                // mixed-case or lowercase types the index would miss on
-                // canonical lookups. Normalise once here — `getTypeUpper`
-                // is already cached by type name so the cost is ~0.
-                const typeKey = getTypeUpper(ref.type);
-                let typeList = byType.get(typeKey);
-                if (!typeList) { typeList = []; byType.set(typeKey, typeList); }
-                typeList.push(ref.expressId);
-            }
-            if (cat === CAT_SPATIAL) spatialRefs.push(ref);
-            else if (cat === CAT_GEOMETRY) geometryRefs.push(ref);
-            else if (cat === CAT_HIERARCHY_REL) relationshipRefs.push(ref);
-            else if (cat === CAT_PROPERTY_REL) propertyRelRefs.push(ref);
-            else if (cat === CAT_PROPERTY_ENTITY) {
-                if (PROPERTY_CONTAINER_TYPES.has(typeUpper)) propertyContainerRefs.push(ref);
-                else propertyAtomRefs.push(ref);
-            }
-            else if (cat === CAT_ASSOCIATION_REL) associationRelRefs.push(ref);
-            else if (cat === CAT_TYPE_OBJECT) typeObjectRefs.push(ref);
-            else if (cat === CAT_GROUP) groupRefs.push(ref);
-            else if (cat === CAT_RELEVANT) otherRelevantRefs.push(ref);
-        }
-
-        logPhase(`categorize ${totalEntities} → spatial:${spatialRefs.length} geom:${geometryRefs.length} rel:${relationshipRefs.length} propRel:${propertyRelRefs.length} propContainers:${propertyContainerRefs.length} propAtoms:${propertyAtomRefs.length} assocRel:${associationRelRefs.length} type:${typeObjectRefs.length} group:${groupRefs.length} other:${otherRelevantRefs.length}`);
-
-        // ALL entity refs must be indexed in byId so that on-demand extraction
-        // can look up any entity by expressId (e.g. IfcUnitAssignment,
-        // IfcGeometricRepresentationContext, IfcSiUnit, IfcLocalPlacement, etc.).
-        // Only property atoms are optionally deferred for huge-file lazy loading.
-        const indexedRefs = deferPropertyAtomIndex
-            ? entityRefs.filter(ref => {
-                const cat = getCategory(ref.type);
-                return cat !== CAT_PROPERTY_ENTITY || PROPERTY_CONTAINER_TYPES.has(getTypeUpper(ref.type));
-              })
-            : entityRefs;
-        emitDiagnostic(
-            `index input: indexedRefs=${indexedRefs.length} deferredPropertyAtoms=${deferPropertyAtomIndex ? propertyAtomRefs.length : 0}`
-        );
-
-        // Keep every indexed entity available for on-demand reference resolution.
-        const compactByIdIndex = await buildCompactEntityIndexAsync(indexedRefs);
+        const prepared = await prepareColumnarEntities(input, options.deferPropertyAtomIndex === true, yieldIfNeeded);
+        const { byType, getTypeUpper, spatialRefs, geometryRefs, relationshipRefs, propertyRelRefs,
+            propertyContainerRefs, associationRelRefs, typeObjectRefs, otherRelevantRefs, groupRefs } = prepared;
+        logPhase(`categorize ${totalEntities} → spatial:${spatialRefs.length} geom:${geometryRefs.length} rel:${relationshipRefs.length} propRel:${propertyRelRefs.length} propContainers:${propertyContainerRefs.length} propAtoms:${prepared.propertyAtomCount} assocRel:${associationRelRefs.length} type:${typeObjectRefs.length} group:${groupRefs.length} other:${otherRelevantRefs.length}`);
+        emitDiagnostic(`index input: indexedRefs=${prepared.indexedCount} deferredPropertyAtoms=${options.deferPropertyAtomIndex ? prepared.propertyAtomCount : 0}`);
+        const compactByIdIndex = await prepared.buildPrimaryIndex();
         logPhase('compact entity index');
 
         // Create entity table builder with EXACT capacity (not totalEntities which
@@ -706,14 +540,9 @@ export class ColumnarParser {
         logPhase('relationship graph build()');
 
         let deferredEntityIndex: EntityByIdIndex | undefined;
-        if (deferPropertyAtomIndex && propertyAtomRefs.length > 0) {
+        if (options.deferPropertyAtomIndex && prepared.propertyAtomCount > 0) {
             options.onProgress?.({ phase: 'indexing property atoms', percent: 98 });
-            deferredEntityIndex = await buildCompactEntityIndexAsync(
-                propertyAtomRefs,
-                undefined,
-                1024,
-                2,
-            );
+            deferredEntityIndex = await prepared.buildDeferredIndex();
             logPhase('deferred property atom index');
         }
 
@@ -743,6 +572,28 @@ export class ColumnarParser {
             },
         };
         return finalStore;
+    }
+
+export class ColumnarParser {
+    /**
+     * Parse IFC file into columnar data store
+     *
+     * Uses fast semicolon-based scanning with on-demand property extraction.
+     * Properties are parsed lazily when accessed, not upfront.
+     * This provides instant UI responsiveness even for very large files.
+     */
+    async parseLite(
+        buffer: ArrayBuffer | SharedArrayBuffer,
+        entityRefs: EntityRef[],
+        options: {
+            onProgress?: (progress: { phase: string; percent: number }) => void;
+            onDiagnostic?: (message: string) => void;
+            yieldIntervalMs?: number;
+            deferPropertyAtomIndex?: boolean;
+            onSpatialReady?: (partialStore: IfcDataStore) => void;
+        } = {}
+    ): Promise<IfcDataStore> {
+        return parseColumnarInput(buffer, entityRefs, options);
     }
 
     /**

--- a/packages/parser/src/columnar-prescanned-columns.test.ts
+++ b/packages/parser/src/columnar-prescanned-columns.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser } from './index.js';
+import { prepareColumnarEntities } from './columnar-entity-preparation.js';
+import { ColumnarParser, extractPropertiesOnDemand, type IfcDataStore } from './columnar-parser.js';
+import { buildEntityRefsFromIndex, buildEntityColumnsFromIndex } from './entity-refs-from-index.js';
+import { scanColumnarEntities, type PreScannedEntityIndex } from './entity-scanner.js';
+
+const records = [
+  "#1=IFCPROJECT('0000000000000000000001',$,'Project',$,$,$,$,$,$);",
+  "#30=IFCSPACE('0000000000000000000030',$,'Room',$,$,$,$,$,.ELEMENT.,.INTERNAL.,$);",
+  "#40=IFCPROPERTYSET('0000000000000000000040',$,'Pset_Room',$,(#41));",
+  "#41=IFCPROPERTYSINGLEVALUE('Area',$,IFCAREAMEASURE(12.5),$);",
+  "#50=IFCRELDEFINESBYPROPERTIES('0000000000000000000050',$,$,$,(#30),#40);",
+  '#7=\fIfcCartesianPoint((1.,2.,3.));',
+  '#7=IFCCARTESIANPOINT((4.,5.,6.));',
+  '#9=IFCDIRECTION((0.,0.,1.));',
+];
+const text = [
+  'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+  "FILE_NAME('columns.ifc','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));",
+  'ENDSEC;', 'DATA;', ...records, 'ENDSEC;', 'END-ISO-10303-21;',
+].join('\n');
+const bytes = new TextEncoder().encode(text);
+
+function columns(sorted: boolean): PreScannedEntityIndex {
+  const rows = records.map(record => ({
+    id: Number(record.slice(1, record.indexOf('='))),
+    start: text.indexOf(record), length: record.length,
+  }));
+  if (sorted) rows.sort((a, b) => a.id - b.id);
+  return {
+    ids: Uint32Array.from(rows.map(row => row.id)),
+    starts: Uint32Array.from(rows.map(row => row.start)),
+    lengths: Uint32Array.from(rows.map(row => row.length)),
+    oversizedIdCount: 0, malformedRecordCount: 0,
+  };
+}
+
+function indexEntries(store: IfcDataStore) {
+  return [...store.entityIndex.byId.entries()];
+}
+
+describe('issue #3985 pre-scanned column preparation', () => {
+  it.each([false, true])('preserves all helper spans and stable duplicate rows, sorted=%s', async sorted => {
+    const supplied = columns(sorted);
+    const refs = buildEntityRefsFromIndex(bytes, supplied.ids, supplied.starts, supplied.lengths);
+    const expected = await new ColumnarParser().parseLite(bytes.buffer, refs);
+    const store = await new IfcParser().parseColumnar(bytes.buffer, { preScannedEntityIndex: supplied });
+    expect(indexEntries(store)).toEqual(indexEntries(expected));
+    expect([...store.entityIndex.byType]).toEqual([...expected.entityIndex.byType]);
+    expect(store.entityIndex.byType.get('IFCCARTESIANPOINT')).toEqual([7, 7]);
+    expect(store.entityIndex.byId.get(7)).toEqual(expected.entityIndex.byId.get(7));
+    expect(indexEntries(store).filter(([id]) => id === 7).map(([, ref]) =>
+      new TextDecoder().decode(bytes.subarray(ref.byteOffset, ref.byteOffset + ref.byteLength)),
+    )).toEqual(records.slice(5, 7));
+    expect(store.entityIndex.byId.get(9)?.type).toBe('IFCDIRECTION');
+    // Ownership invariant: a producer releasing/reusing its columns must not
+    // rewrite a published store or corrupt future reference lookups.
+    supplied.ids.fill(0); supplied.starts.fill(0); supplied.lengths.fill(0);
+    store.entityIndex.byId.get(30);
+    expect(indexEntries(store)).toEqual(indexEntries(expected));
+  });
+
+  it.each([false, true])('keeps property values and reference access with deferred atoms=%s', async defer => {
+    let partial: IfcDataStore | undefined;
+    const store = await new IfcParser().parseColumnar(bytes.buffer, {
+      preScannedEntityIndex: columns(false), deferPropertyAtomIndex: defer,
+      onSpatialReady: value => { partial = value; },
+    });
+    expect(partial).toBeDefined();
+    expect(partial!.entityIndex.byId.has(41)).toBe(!defer);
+    expect(store.entityIndex.byId.has(41)).toBe(!defer);
+    expect(store.deferredEntityIndex?.has(41) ?? false).toBe(defer);
+    expect(store.entityIndex.byType.has('IFCPROPERTYSINGLEVALUE')).toBe(!defer);
+    expect(store.entityIndex.byId.get(40)?.type).toBe('IFCPROPERTYSET');
+    expect(extractPropertiesOnDemand(store, 30)).toMatchObject([
+      { name: 'Pset_Room', properties: [{ name: 'Area', value: 12.5 }] },
+    ]);
+    expect(store.onDemandPropertyMap?.get(30)).toEqual([40]);
+  });
+
+  it('rejects both truncated columns and out-of-bounds record spans', async () => {
+    for (const invalid of [
+      { ...columns(true), starts: new Uint32Array(0) },
+      { ...columns(true), lengths: new Uint32Array(0) },
+    ]) {
+      await expect(new IfcParser().parseColumnar(bytes.buffer, {
+        preScannedEntityIndex: invalid,
+      })).rejects.toThrow(/column-length mismatch/);
+    }
+    const outside = columns(true);
+    outside.starts[0] = bytes.length + 1;
+    await expect(new IfcParser().parseColumnar(bytes.buffer, {
+      preScannedEntityIndex: outside,
+    })).rejects.toThrow(/out-of-bounds span/);
+    const overrun = columns(true);
+    overrun.lengths[0] = bytes.length;
+    await expect(new IfcParser().parseColumnar(bytes.buffer, {
+      preScannedEntityIndex: overrun,
+    })).rejects.toThrow(/out-of-bounds span/);
+  });
+
+  it('reports refused and malformed records from the same scanner state machine', async () => {
+    const diagnostics: string[] = [];
+    const result = await scanColumnarEntities(bytes.buffer, {
+      preScannedEntityIndex: { ...columns(true), oversizedIdCount: 2, malformedRecordCount: 1 },
+      onDiagnostic: message => diagnostics.push(message),
+    });
+    expect(result.oversizedIdCount).toBe(2);
+    expect(result.malformedRecordCount).toBe(1);
+    expect(diagnostics.some(message => message.includes('skipped 2 record(s)'))).toBe(true);
+    expect(diagnostics.some(message => message.includes('stopped early'))).toBe(true);
+    const unknown: string[] = [];
+    await scanColumnarEntities(bytes.buffer, {
+      preScannedEntityIndex: { ...columns(true), oversizedIdCount: undefined },
+      onDiagnostic: message => unknown.push(message),
+    });
+    expect(unknown.some(message => message.includes('not proof that none were skipped'))).toBe(true);
+  });
+
+  it('does not lose a recognized type after 65536 distinct file-supplied names', async () => {
+    // Scan-time categorization must see the original name. The existing compact
+    // index narrows type IDs later; narrowing before categorization would drop
+    // this wall from the entity table entirely (#3985).
+    const sourceRecords = Array.from({ length: 0x10000 }, (_, i) => `#${i + 1}=TYPE${i}($);`);
+    sourceRecords.push("#65537=IFCWALL('0000000000000000065537',$,'Wall',$,$,$,$,$,$);");
+    const source = new TextEncoder().encode(sourceRecords.join('\n'));
+    const starts = new Uint32Array(sourceRecords.length);
+    const lengths = Uint32Array.from(sourceRecords.map(record => record.length));
+    for (let i = 1; i < starts.length; i++) starts[i] = starts[i - 1] + lengths[i - 1] + 1;
+    const ids = Uint32Array.from({ length: starts.length }, (_, i) => i + 1);
+    const scanned = buildEntityColumnsFromIndex(source, ids, starts, lengths);
+    const prepared = await prepareColumnarEntities(scanned, false, async () => {});
+    expect(prepared.geometryRefs.map(ref => [ref.expressId, ref.type])).toEqual([[65537, 'IFCWALL']]);
+    expect(prepared.byType.get('IFCWALL')).toEqual([65537]);
+  });
+
+  it('retains empty pre-pass fallback and complete tokenizer reference access', async () => {
+    const store = await new IfcParser().parseColumnar(bytes.buffer, {
+      preScannedEntityIndex: { ids: new Uint32Array(), starts: new Uint32Array(), lengths: new Uint32Array() },
+      disableWorkerScan: true,
+    });
+    expect(store.entityIndex.byId.has(9)).toBe(true);
+    expect(extractPropertiesOnDemand(store, 30)[0].properties[0].value).toBe(12.5);
+  });
+});

--- a/packages/parser/src/compact-entity-index-columns.ts
+++ b/packages/parser/src/compact-entity-index-columns.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Plain-data column representation of a `CompactEntityIndex`. Holds the
+ * four numeric backing arrays plus a copied type-string list. Numeric backing
+ * remains valid until its owner detaches it. Transport may transfer a retired
+ * index; cache consumers must neither mutate nor detach the borrowed columns.
+ */
+export interface CompactEntityIndexColumns {
+  expressIds: Uint32Array;
+  byteOffsets: Uint32Array;
+  byteLengths: Uint32Array;
+  typeIndices: Uint16Array;
+  typeStrings: string[];
+}
+
+/** Intern `type` into the parallel string table/lookup pair, returning the
+ *  index the `Uint16Array` type column stores. */
+export function internType(typeStrings: string[], typeStringMap: Map<string, number>, type: string): number {
+  let index = typeStringMap.get(type);
+  if (index === undefined) {
+    index = typeStrings.length;
+    typeStrings.push(type);
+    typeStringMap.set(type, index);
+  }
+  return index;
+}

--- a/packages/parser/src/compact-entity-index-transport.ts
+++ b/packages/parser/src/compact-entity-index-transport.ts
@@ -12,37 +12,11 @@
 
 import { CompactEntityIndex } from './compact-entity-index.js';
 
-/**
- * Plain-data column representation of a `CompactEntityIndex`. Holds the
- * five backing arrays plus the deduplicated type-string list. All four
- * typed arrays are transferable.
- */
-export interface CompactEntityIndexColumns {
-  expressIds: Uint32Array;
-  byteOffsets: Uint32Array;
-  byteLengths: Uint32Array;
-  typeIndices: Uint16Array;
-  typeStrings: string[];
-}
+import type { CompactEntityIndexColumns } from './compact-entity-index-columns.js';
+export type { CompactEntityIndexColumns } from './compact-entity-index-columns.js';
 
 export function compactEntityIndexToColumns(index: CompactEntityIndex): CompactEntityIndexColumns {
-  // CompactEntityIndex stores its arrays as private fields; access them
-  // through the prototype's documented columns. We rely on the public
-  // constructor's parameter order to define this contract.
-  const internal = index as unknown as {
-    expressIds: Uint32Array;
-    byteOffsets: Uint32Array;
-    byteLengths: Uint32Array;
-    typeIndices: Uint16Array;
-    typeStrings: string[];
-  };
-  return {
-    expressIds: internal.expressIds,
-    byteOffsets: internal.byteOffsets,
-    byteLengths: internal.byteLengths,
-    typeIndices: internal.typeIndices,
-    typeStrings: internal.typeStrings.slice(),
-  };
+  return index.getColumns();
 }
 
 export function compactEntityIndexFromColumns(columns: CompactEntityIndexColumns): CompactEntityIndex {

--- a/packages/parser/src/compact-entity-index.ts
+++ b/packages/parser/src/compact-entity-index.ts
@@ -7,19 +7,8 @@
 
 import { checkedExpressId } from './express-id.js';
 import type { EntityRef } from './types.js';
+import { internType, type CompactEntityIndexColumns } from './compact-entity-index-columns.js';
 import { yieldToEventLoop } from './yield-to-event-loop.js';
-
-/** Intern `type` into the parallel string table/lookup pair, returning the
- *  index the `Uint16Array` type column stores. */
-function internType(typeStrings: string[], typeStringMap: Map<string, number>, type: string): number {
-  let index = typeStringMap.get(type);
-  if (index === undefined) {
-    index = typeStrings.length;
-    typeStrings.push(type);
-    typeStringMap.set(type, index);
-  }
-  return index;
-}
 
 /**
  * Compact read-only entity index backed by sorted typed arrays.
@@ -68,6 +57,13 @@ export class CompactEntityIndex {
     for (let i = 0; i < typeStrings.length; i++) {
       this.typeStringMap.set(typeStrings[i], i);
     }
+  }
+
+  /** Borrow numeric backing, valid until its owner detaches it; do not mutate.
+   * Cache consumers must not detach. Transport may transfer a retired index. */
+  getColumns(): CompactEntityIndexColumns {
+    const { expressIds, byteOffsets, byteLengths, typeIndices, typeStrings } = this;
+    return { expressIds, byteOffsets, byteLengths, typeIndices, typeStrings: typeStrings.slice() };
   }
 
   /**
@@ -413,15 +409,7 @@ export async function buildCompactEntityIndexAsync(
   entityRefs: EntityRef[],
   lruMaxSize?: number,
   chunkSize: number = 8192,
-  // Phase 3c: 8ms was the previous default but caused the parser tail
-  // to balloon under stream-time contention. Each yield under load
-  // costs 10-50ms wall-clock (event-loop backlogged with geometry
-  // batches), and 1700 yields × 4ms avg = 6.5s of pure overhead
-  // (measured: compact entity index 196ms uncontended → 6700ms
-  // contended). 50ms budget cuts yields to ~270 → ~1s overhead, saving
-  // ~5s on the parser path. Trade-off: parser worker briefly
-  // unresponsive between yields, but it's a worker thread so this only
-  // affects message processing back to main, which is buffered anyway.
+  // A worker-local time budget bounds event-loop handoffs under stream contention.
   budgetMs: number = 50,
 ): Promise<CompactEntityIndex> {
   const count = entityRefs.length;

--- a/packages/parser/src/entity-refs-from-index.ts
+++ b/packages/parser/src/entity-refs-from-index.ts
@@ -19,7 +19,15 @@
  */
 
 import type { EntityRef } from './types.js';
+import { EntityTypeByteInterner } from './entity-type-byte-interner.js';
+import type { CompactEntityIndexColumns } from './compact-entity-index-transport.js';
 import { asSourceBytes, type IfcSourceBytes } from './source-bytes.js';
+
+/** Scan-time type IDs retain every spelling before compact-index narrowing. */
+export type ScannedEntityColumns = Omit<CompactEntityIndexColumns, 'typeIndices'> & {
+  typeIndices: Uint16Array | Uint32Array;
+};
+
 
 const EQ = 0x3d;
 const LPAREN = 0x28;
@@ -35,23 +43,14 @@ const CR = 0x0d;
 const FORM_FEED = 0x0c;
 const VTAB = 0x0b;
 
-function bytesToAsciiKey(bytes: Uint8Array, start: number, end: number): string {
-  // String.fromCharCode loop is the fastest portable way to build a short
-  // ASCII string from a byte range without allocating an intermediate
-  // typed-array slice. Type names are ≤ ~30 chars so the loop is tight.
-  let s = '';
-  for (let i = start; i < end; i++) {
-    s += String.fromCharCode(bytes[i]);
-  }
-  return s;
-}
-
-export function buildEntityRefsFromIndex(
+/** The shared record walk owns validation, stable ordering and type lexing. */
+function visitEntityIndex(
   source: Uint8Array | IfcSourceBytes,
   ids: Uint32Array,
   starts: Uint32Array,
   lengths: Uint32Array,
-): EntityRef[] {
+  visit: (row: number, id: number, type: string, start: number, length: number) => void,
+): void {
   const bytes = asSourceBytes(source);
   const n = ids.length;
   // Fail fast on malformed input from the transport layer rather than
@@ -66,8 +65,8 @@ export function buildEntityRefsFromIndex(
     );
   }
   const sourceLen = bytes.byteLength;
-  const refs: EntityRef[] = new Array(n);
-  const intern = new Map<string, string>();
+  const intern = new EntityTypeByteInterner();
+  const contiguous = source instanceof Uint8Array ? source : undefined;
 
   // Current pre-pass columns are already ID-ordered (#1682). Only allocate
   // and sort a permutation for producers that actually send unsorted IDs.
@@ -94,14 +93,14 @@ export function buildEntityRefsFromIndex(
         `buildEntityRefsFromIndex: out-of-bounds span at index ${i} (id=${ids[i]}, start=${start}, len=${len}, source=${sourceLen})`,
       );
     }
-    // Narrow to this record's bytes and scan it with record-relative offsets.
-    // On a contiguous source `slice` is a `subarray`, so this is the same
-    // zero-copy walk the absolute-offset version did.
-    const record = bytes.slice(start, start + len);
-    const limit = record.length;
+    // The parser already supplies a contiguous view. Keep offsets in that
+    // view to avoid constructing one temporary subarray per record. Blocked
+    // source accessors retain their existing one-record read pattern.
+    const record = contiguous ?? bytes.slice(start, start + len);
+    const limit = contiguous ? start + len : record.length;
 
     // Skip past `#<digits>=` to find the type token.
-    let p = 0;
+    let p = contiguous ? start : 0;
     while (p < limit && record[p] !== EQ) p++;
     p++;
     while (
@@ -110,6 +109,7 @@ export function buildEntityRefsFromIndex(
         || record[p] === FORM_FEED || record[p] === VTAB)
     ) p++;
     const typeStart = p;
+    let typeHash = 0x811c9dc5;
     while (
       p < limit
       && record[p] !== LPAREN
@@ -119,27 +119,60 @@ export function buildEntityRefsFromIndex(
       && record[p] !== CR
       && record[p] !== FORM_FEED
       && record[p] !== VTAB
-    ) p++;
-    const typeEnd = p;
-
-    const key = bytesToAsciiKey(record, typeStart, typeEnd);
-    let interned = intern.get(key);
-    if (interned === undefined) {
-      intern.set(key, key);
-      interned = key;
+    ) {
+      typeHash = Math.imul(typeHash ^ record[p], 0x01000193);
+      p++;
     }
+    const typeEnd = p;
+    const interned = intern.intern(record, typeStart, typeEnd, typeHash);
 
-    refs[oi] = {
-      expressId: ids[i],
-      type: interned,
-      byteOffset: start,
-      byteLength: len,
-      // Line numbers aren't computed here — the columnar parser only uses
-      // them in diagnostic output. Skipping the newline-counting pass saves
-      // ~500 ms on 14 M entities. Set to 0 as a sentinel "unknown".
-      lineNumber: 0,
-    };
+    visit(oi, ids[i], interned, start, len);
   }
+}
 
+export function buildEntityRefsFromIndex(
+  source: Uint8Array | IfcSourceBytes,
+  ids: Uint32Array,
+  starts: Uint32Array,
+  lengths: Uint32Array,
+): EntityRef[] {
+  const refs: EntityRef[] = new Array(ids.length);
+  visitEntityIndex(source, ids, starts, lengths, (row, expressId, type, byteOffset, byteLength) => {
+    refs[row] = { expressId, type, byteOffset, byteLength, lineNumber: 0 };
+  });
   return refs;
+}
+
+/** #3985: retain columns instead of allocating a helper object for every record.
+ * Own the output: callers may mutate/release their pre-pass columns after scan.
+ * The public EntityRef[] adapter above uses exactly the same lexical walk.
+ */
+export function buildEntityColumnsFromIndex(
+  source: Uint8Array | IfcSourceBytes,
+  ids: Uint32Array,
+  starts: Uint32Array,
+  lengths: Uint32Array,
+): ScannedEntityColumns {
+  const expressIds = new Uint32Array(ids.length);
+  const byteOffsets = new Uint32Array(ids.length);
+  const byteLengths = new Uint32Array(ids.length);
+  let typeIndices: Uint16Array | Uint32Array = new Uint16Array(ids.length);
+  const typeStrings: string[] = [];
+  const types = new Map<string, number>();
+  visitEntityIndex(source, ids, starts, lengths, (row, id, type, start, length) => {
+    let typeIndex = types.get(type);
+    if (typeIndex === undefined) {
+      typeIndex = typeStrings.length;
+      typeStrings.push(type);
+      types.set(type, typeIndex);
+      // Unrecognized type names are file-supplied too. Keep their original
+      // names for categorization even beyond the final compact u16 surface.
+      if (typeIndex === 0x10000) typeIndices = Uint32Array.from(typeIndices);
+    }
+    expressIds[row] = id;
+    byteOffsets[row] = start;
+    byteLengths[row] = length;
+    typeIndices[row] = typeIndex;
+  });
+  return { expressIds, byteOffsets, byteLengths, typeIndices, typeStrings };
 }

--- a/packages/parser/src/entity-scanner.ts
+++ b/packages/parser/src/entity-scanner.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { safeUtf8Decode } from '@ifc-lite/data';
-import { buildEntityRefsFromIndex } from './entity-refs-from-index.js';
+import { buildEntityRefsFromIndex, buildEntityColumnsFromIndex, type ScannedEntityColumns } from './entity-refs-from-index.js';
 import { MAX_EXPRESS_ID } from './express-id.js';
 import { scanEntitiesInWorker } from './scan-worker-inline.js';
 import { StepTokenizer } from './tokenizer.js';
@@ -104,10 +104,26 @@ type WasmScanFunction = () => unknown;
 
 const HUGE_STRING_SCAN_BYTES = 256 * 1024 * 1024;
 
+/** Internal columnar consumer; public scanIfcEntities still returns EntityRef[]. */
+export function scanColumnarEntities(
+  buffer: ArrayBuffer | SharedArrayBuffer,
+  options: EntityScanOptions = {},
+): Promise<EntityScanResult & { entityColumns?: ScannedEntityColumns }> {
+  return scanEntities(buffer, options, true);
+}
+
 export async function scanIfcEntities(
   buffer: ArrayBuffer | SharedArrayBuffer,
   options: EntityScanOptions = {},
 ): Promise<EntityScanResult> {
+  return scanEntities(buffer, options, false);
+}
+
+async function scanEntities(
+  buffer: ArrayBuffer | SharedArrayBuffer,
+  options: EntityScanOptions,
+  keepColumns: boolean,
+): Promise<EntityScanResult & { entityColumns?: ScannedEntityColumns }> {
   const uint8Buffer = new Uint8Array(buffer);
   const fileSizeMB = buffer.byteLength / (1024 * 1024);
 
@@ -115,6 +131,7 @@ export async function scanIfcEntities(
   const scanStartTime = performance.now();
 
   let entityRefs: EntityRef[] = [];
+  let entityColumns: ScannedEntityColumns | undefined;
   let processed = 0;
   let scanPath: EntityScanPath = 'tokenizer';
   let oversizedIdCount = 0;
@@ -123,8 +140,9 @@ export async function scanIfcEntities(
 
   if (options.preScannedEntityIndex) {
     const { ids, starts, lengths } = options.preScannedEntityIndex;
-    entityRefs = buildEntityRefsFromIndex(uint8Buffer, ids, starts, lengths);
-    processed = entityRefs.length;
+    if (keepColumns) entityColumns = buildEntityColumnsFromIndex(uint8Buffer, ids, starts, lengths);
+    else entityRefs = buildEntityRefsFromIndex(uint8Buffer, ids, starts, lengths);
+    processed = ids.length;
     scanPath = 'pre-scanned';
     // `undefined` means this producer does not report, which the field's own
     // doc says is NOT the claim `0` makes. Coercing it here would turn "not
@@ -140,7 +158,9 @@ export async function scanIfcEntities(
     malformedRecordCount = options.preScannedEntityIndex.malformedRecordCount ?? 0;
   }
 
-  if (entityRefs.length === 0 && !options.disableWorkerScan && typeof Worker !== 'undefined') {
+  if (processed === 0) entityColumns = undefined;
+
+  if (processed === 0 && !options.disableWorkerScan && typeof Worker !== 'undefined') {
     try {
       const scan = await scanEntitiesInWorker(buffer);
       entityRefs = scan.refs;
@@ -158,7 +178,7 @@ export async function scanIfcEntities(
   }
 
   const wasmScanFn = selectWasmScanFunction(options.wasmApi, uint8Buffer);
-  if (entityRefs.length === 0 && wasmScanFn) {
+  if (processed === 0 && wasmScanFn) {
     try {
       entityRefs = normalizeWasmEntityRefs(wasmScanFn());
       processed = entityRefs.length;
@@ -180,7 +200,7 @@ export async function scanIfcEntities(
     }
   }
 
-  if (entityRefs.length === 0) {
+  if (processed === 0) {
     const tokenizer = new StepTokenizer(uint8Buffer);
     const yieldInterval = 5000;
     const estimatedTotalEntities = Math.max(fileSizeMB * 13500, 10000);
@@ -259,7 +279,7 @@ export async function scanIfcEntities(
   options.onDiagnostic?.(`scan complete: entities=${processed} elapsed=${elapsedMs.toFixed(0)}ms`);
   options.onProgress?.({ phase: 'scanning', percent: 100 });
 
-  return { entityRefs, processed, elapsedMs, scanPath, oversizedIdCount, malformedRecordCount };
+  return { entityRefs, ...(entityColumns && processed > 0 && scanPath === 'pre-scanned' ? { entityColumns } : {}), processed, elapsedMs, scanPath, oversizedIdCount, malformedRecordCount };
 }
 
 /**

--- a/packages/parser/src/entity-type-byte-interner.test.ts
+++ b/packages/parser/src/entity-type-byte-interner.test.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it, vi } from 'vitest';
+import { EntityTypeByteInterner } from './entity-type-byte-interner.js';
+import { buildEntityRefsFromIndex } from './entity-refs-from-index.js';
+import { contiguousSourceBytes } from './source-bytes.js';
+
+describe('issue #3985 byte type interning', () => {
+  it('compares every byte on hash collisions, including mixed case and raw non-ASCII', () => {
+    const interner = new EntityTypeByteInterner();
+    const spellings = ['IFCWALL', 'IFCWaLL', 'UNKNOWN', 'IFC\u00ffALL', ''];
+    for (let round = 0; round < 2; round++) {
+      for (const spelling of spellings) {
+        const bytes = Uint8Array.from(spelling, character => character.charCodeAt(0));
+        // Identical caller-supplied hashes represent the collision case. Hash
+        // identity must never replace equality of the underlying type bytes.
+        expect(interner.intern(bytes, 0, bytes.length, 23)).toBe(spelling);
+      }
+    }
+  });
+
+  it('bounds repeated colliding-token byte comparisons rather than growing quadratically', () => {
+    const interner = new EntityTypeByteInterner();
+    for (let i = 0; i < 9; i++) {
+      const name = `TYPE_000${i}`;
+      const bytes = new TextEncoder().encode(name);
+      expect(interner.intern(bytes, 0, bytes.length, 1)).toBe(name);
+    }
+    const name = 'TYPE_0009';
+    const raw = new TextEncoder().encode(name);
+    let reads = 0;
+    const bytes = new Proxy(raw, {
+      get(target, property) {
+        if (typeof property === 'string' && /^\d+$/.test(property)) reads++;
+        return Reflect.get(target, property, target);
+      },
+    });
+    expect(interner.intern(bytes, 0, raw.length, 1)).toBe(name);
+    // The saturated bucket reads this token once to obtain the native Map
+    // key. Removing the collision cap instead repeats the long shared prefix
+    // against every prior token, violating this work bound.
+    expect(reads).toBeLessThanOrEqual(raw.length);
+    expect(interner.intern(raw, 0, raw.length, 1)).toBe(name);
+  });
+
+  it('continues exact lookup after a high-cardinality source exceeds the fast dictionary budget', () => {
+    const interner = new EntityTypeByteInterner();
+    for (let round = 0; round < 2; round++) {
+      for (let i = 0; i < 4200; i++) {
+        const name = `UNKNOWN_${i}`;
+        const bytes = new TextEncoder().encode(name);
+        expect(interner.intern(bytes, 0, bytes.length, i)).toBe(name);
+      }
+    }
+  });
+
+  it('keeps record-relative spans for a sliced input and the source-accessor read path', () => {
+    const recordA = Uint8Array.from([...new TextEncoder().encode('#2=\tIfcWall($);')]);
+    const recordB = Uint8Array.from([35, 49, 61, 73, 70, 67, 255, 40, 36, 41, 59]);
+    const storage = new Uint8Array(recordA.length + recordB.length + 11);
+    storage.set(recordA, 5);
+    storage.set(recordB, 5 + recordA.length);
+    const source = storage.subarray(5, 5 + recordA.length + recordB.length);
+    const ids = Uint32Array.of(2, 1);
+    const starts = Uint32Array.of(0, recordA.length);
+    const lengths = Uint32Array.of(recordA.length, recordB.length);
+    const expected = [
+      { expressId: 1, type: 'IFC\u00ff', byteOffset: recordA.length, byteLength: recordB.length, lineNumber: 0 },
+      { expressId: 2, type: 'IfcWall', byteOffset: 0, byteLength: recordA.length, lineNumber: 0 },
+    ];
+    expect(buildEntityRefsFromIndex(source, ids, starts, lengths)).toEqual(expected);
+    const accessor = contiguousSourceBytes(source);
+    const read = vi.spyOn(accessor, 'slice');
+    expect(buildEntityRefsFromIndex(accessor, ids, starts, lengths)).toEqual(expected);
+    expect(read.mock.calls).toEqual([[recordA.length, source.length], [0, recordA.length]]);
+  });
+});

--- a/packages/parser/src/entity-type-byte-interner.ts
+++ b/packages/parser/src/entity-type-byte-interner.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+const MAX_COLLISION_BUCKET = 8;
+const MAX_FAST_BUCKETS = 4096;
+
+type Bucket = string[] | Map<string, string>;
+
+/** Scan-scoped byte interning (#3985). A hash selects candidates, never identity.
+ * Repeated normal tokens allocate no string; adversarial collisions switch to
+ * native string-key lookup after a bounded number of byte comparisons.
+ */
+export class EntityTypeByteInterner {
+  private readonly buckets = new Map<number, Bucket>();
+  private readonly overflow = new Map<string, string>();
+
+  intern(bytes: Uint8Array, start: number, end: number, hash: number): string {
+    const bucket = this.buckets.get(hash);
+    if (bucket instanceof Map) return this.internString(bucket, bytes, start, end);
+    if (bucket) {
+      const length = end - start;
+      for (const candidate of bucket) {
+        if (candidate.length !== length) continue;
+        let i = 0;
+        while (i < length && candidate.charCodeAt(i) === bytes[start + i]) i++;
+        if (i === length) return candidate;
+      }
+      const value = this.readString(bytes, start, end);
+      if (bucket.length < MAX_COLLISION_BUCKET) bucket.push(value);
+      else {
+        const strings = new Map<string, string>();
+        for (const candidate of bucket) strings.set(candidate, candidate);
+        strings.set(value, value);
+        this.buckets.set(hash, strings);
+      }
+      return value;
+    }
+    // A source containing millions of different type spellings must not gain
+    // an extra array/map per spelling compared with the original interner.
+    if (this.buckets.size >= MAX_FAST_BUCKETS) {
+      return this.internString(this.overflow, bytes, start, end);
+    }
+    const value = this.readString(bytes, start, end);
+    this.buckets.set(hash, [value]);
+    return value;
+  }
+
+  private internString(strings: Map<string, string>, bytes: Uint8Array, start: number, end: number): string {
+    const value = this.readString(bytes, start, end);
+    const previous = strings.get(value);
+    if (previous !== undefined) return previous;
+    strings.set(value, value);
+    return value;
+  }
+
+  private readString(bytes: Uint8Array, start: number, end: number): string {
+    // Deliberately byte→char, matching the existing scanner's raw token
+    // spelling for mixed case, unknown names and non-ASCII bytes.
+    let value = '';
+    for (let i = start; i < end; i++) value += String.fromCharCode(bytes[i]);
+    return value;
+  }
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -191,8 +191,8 @@ import { EntityIndexBuilder } from './entity-index.js';
 import { EntityExtractor } from './entity-extractor.js';
 import { PropertyExtractor } from './property-extractor.js';
 import { RelationshipExtractor } from './relationship-extractor.js';
-import { ColumnarParser, type IfcDataStore } from './columnar-parser.js';
-import { scanIfcEntities, type PreScannedEntityIndex, type WasmScanApi } from './entity-scanner.js';
+import { parseColumnarInput, type IfcDataStore } from './columnar-parser.js';
+import { scanIfcEntities, scanColumnarEntities, type PreScannedEntityIndex, type WasmScanApi } from './entity-scanner.js';
 
 export interface ParseOptions {
   onProgress?: (progress: { phase: string; percent: number }) => void;
@@ -210,10 +210,9 @@ export interface ParseOptions {
   /**
    * Pre-built entity index from another worker (typically the streaming
    * geometry pre-pass). When supplied, `parseColumnar` skips both the
-   * worker-based and WASM scans and synthesizes `EntityRef[]` from the
-   * column arrays directly — saving ~10 s on 1 GB / 14 M-entity files
-   * where the parser would otherwise duplicate the pre-pass scan under
-   * heavy WASM contention with the geometry workers.
+   * worker-based and WASM scans and retains the numeric columns through
+   * entity categorization. Only records needed for metadata extraction
+   * materialize EntityRefs; every record remains addressable in the store.
    */
   preScannedEntityIndex?: PreScannedEntityIndex;
 }
@@ -298,12 +297,11 @@ export class IfcParser {
     buffer: ArrayBuffer | SharedArrayBuffer,
     options: ParseOptions = {},
   ): Promise<IfcDataStore> {
-    const { entityRefs, processed, elapsedMs, scanPath } = await scanIfcEntities(buffer, options);
+    const { entityRefs, entityColumns, processed, elapsedMs, scanPath } = await scanColumnarEntities(buffer, options);
     console.log(`[IfcParser] Fast scan: ${processed} entities in ${elapsedMs.toFixed(0)}ms (path=${scanPath})`);
 
     // Build columnar structures with on-demand property extraction
-    const columnarParser = new ColumnarParser();
-    const dataStore = await columnarParser.parseLite(buffer, entityRefs, options);
+    const dataStore = await parseColumnarInput(buffer, entityColumns ?? entityRefs, options);
     return dataStore;
   }
 }

--- a/packages/parser/src/select-entity-columns.ts
+++ b/packages/parser/src/select-entity-columns.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { ScannedEntityColumns } from './entity-refs-from-index.js';
+import { CompactEntityIndex } from './compact-entity-index.js';
+import { yieldToEventLoop } from './yield-to-event-loop.js';
+
+/** Select a stable subsequence without materializing EntityRefs (#3985).
+ * The input is already sorted and validated by the shared pre-pass record walk.
+ */
+export async function selectEntityColumns(
+  columns: ScannedEntityColumns,
+  count: number,
+  includeType?: (type: string) => boolean,
+  rows?: readonly number[],
+  chunkSize = 8192,
+  budgetMs = 50,
+): Promise<CompactEntityIndex> {
+  const ids = new Uint32Array(count);
+  const starts = new Uint32Array(count);
+  const lengths = new Uint32Array(count);
+  const types = new Uint16Array(count);
+  const typeStrings: string[] = [];
+  const remap = new Map<number, number>();
+  const includedTypes = includeType ? columns.typeStrings.map(includeType) : undefined;
+  const inputCount = rows ? rows.length : columns.expressIds.length;
+  let chunkStart = performance.now();
+  let out = 0;
+  for (let at = 0; at < inputCount; at++) {
+    if (at % chunkSize === 0 && performance.now() - chunkStart >= budgetMs) {
+      await yieldToEventLoop();
+      chunkStart = performance.now();
+    }
+    const row = rows ? rows[at] : at;
+    const sourceType = columns.typeIndices[row];
+    if (includedTypes && !includedTypes[sourceType]) continue;
+    let type = remap.get(sourceType);
+    if (type === undefined) {
+      type = typeStrings.length;
+      typeStrings.push(columns.typeStrings[sourceType]);
+      remap.set(sourceType, type);
+    }
+    ids[out] = columns.expressIds[row];
+    starts[out] = columns.byteOffsets[row];
+    lengths[out] = columns.byteLengths[row];
+    types[out] = type;
+    out++;
+  }
+  return new CompactEntityIndex(ids, starts, lengths, types, typeStrings);
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -593,6 +593,10 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
 - Parity gates: `mesh_determinism` manifests (x86_64 + arm64 + wasm32),
   `styling_parity`, `exact_predicate_determinism`. A real output change re-pins them.
 
+### Retained column-native metadata preparation (#3985)
+
+Keep pre-scanned numeric entity columns through categorization and reuse equivalent borrowed columns during cache index serialization. The shared validated row walk retains stable duplicates, deferred atoms and complete reference access; generic iterable indexes remain supported. This removes transient reference-object reconstruction without adding another loader or dropping metadata. Retained cumulative qualification does not establish an isolated per-layer percentage.
+
 ### Retained cold-load work: search index ownership (#3993)
 
 The viewer shell owns search indexing for the lifetime of each loaded model.


### PR DESCRIPTION
Pre-scanned numeric entity columns became a temporary EntityRef graph before being compacted again; cache serialization repeated equivalent reconstruction. Preserve columns through the existing validated preparation and let the cache writer borrow equivalent compact columns. Stable duplicates, first-encounter normalized type order, malformed spans, deferred atoms and generic iterable inputs remain supported.

Closes #4010; part of umbrella #3985. The borrowed `getColumns` contract and its cache consumer ship together. Borrowed buffers remain valid until the owner detaches them; cache serialization neither mutates nor transfers them.

Behavioral tests cover indexed-span validation, duplicate/type ordering, deferred reference access and cache byte-layout equivalence against the iterable path. Public API documentation, snapshot and changesets accompany the change.

The [shared evidence](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) covers the combined retained stack: native full-call improvement 15.53%; supplemental Chrome full-readiness improvement 28.70%, with Haus +26ms and slower geometry completion on some models. These are combined results, not this layer's isolated gain. Chrome's original strict console audit remains failed; exact-artifact static diagnostics identify the reproduced local analytics 404, while original per-event URLs were not retained. Firefox's strict cohort is invalid; later passing controls do not establish a corpus gain. The 30% target and universal absence of regressions are not established. All pairs and failures are retained.

Final landing-head CI and review remain pending. Prior cumulative checks and functional witnesses do not substitute for those gates; this PR will land only after its prerequisites and applicable exact-head gates are green.

This PR now targets main independently. The recorded measurements retain their original frozen source and parent identities; rebasing does not create a new isolated timing result. The integration preserves main’s extracted root-attribute helpers and server classification behavior.

Landing integration validation at `92cbffc3b`: root `pnpm typecheck` passed, including 1,739 test sources across 48 packages; module-size checks and an independent source-integration review passed. Fresh remote CI and review are still required.
