### PR TITLE
perf(parser): reuse index publications during hydration

### DIFF
--- a/.changeset/cold-load-parser-publication.md
+++ b/.changeset/cold-load-parser-publication.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": minor
+---
+
+Reuse immutable entity-index publications across parser worker messages, terminate completed workers before receiver hydration, and expose constant-time maxExpressId for model ingestion without scanning all references.

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.maxId.test.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.maxId.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCompactEntityIndex, createSyntheticDataStore, type EntityRef } from '@ifc-lite/parser';
+import { FederationRegistry } from '@ifc-lite/renderer';
+import type { MeshData } from '@ifc-lite/geometry';
+import { getMaxExpressId } from './viewerModelIngest.js';
+
+function storeFor(ids: number[], compact: boolean) {
+  const refs: EntityRef[] = ids.map((expressId) => ({
+    expressId, type: 'IFCWALL', byteOffset: 0, byteLength: 0, lineNumber: 0,
+  }));
+  const store = createSyntheticDataStore({ schemaVersion: 'IFC4', fileSize: 0, entityCount: ids.length });
+  store.entityIndex.byId = compact ? buildCompactEntityIndex(refs) : new Map(refs.map(ref => [ref.expressId, ref]));
+  return store;
+}
+
+function mesh(expressId: number): MeshData {
+  return { expressId, positions: new Float32Array(), normals: new Float32Array(), indices: new Uint32Array(), color: [1, 1, 1, 1] };
+}
+
+describe('maximum model ID after metadata hydration (#3985)', () => {
+  it('matches a full-key oracle for unsorted maps, duplicate compact IDs and unsigned boundaries', () => {
+    for (const ids of [[], [0], [8, 2, 8, 3], [0xffffffff, 0, 0xffffffff, 42]]) {
+      for (const compact of [false, true]) {
+        const store = storeFor(ids, compact);
+        for (const meshes of [[], [mesh(12)], [mesh(0xffffffff)]]) {
+          let expected = 0;
+          for (const id of store.entityIndex.byId.keys()) expected = Math.max(expected, id);
+          for (const m of meshes) expected = Math.max(expected, m.expressId);
+          assert.equal(getMaxExpressId(store, meshes), expected);
+        }
+      }
+    }
+    assert.equal(getMaxExpressId(null, []), 0);
+    assert.equal(getMaxExpressId(null, [mesh(19)]), 19);
+  });
+
+  it('preserves map-only IDs outside the compact unsigned domain', () => {
+    assert.equal(getMaxExpressId(storeFor([2 ** 40, -1, 4], false), []), 2 ** 40);
+  });
+
+  it('reserves non-mesh entity IDs when registering one and multiple federated models', () => {
+    const registry = new FederationRegistry();
+    const first = storeFor([900, 2, 900], true);
+    registry.registerModel('first', getMaxExpressId(first, [mesh(2)]));
+    assert.equal(registry.toGlobalId('first', 900), 900);
+    assert.deepEqual(registry.fromGlobalId(900), { modelId: 'first', expressId: 900 });
+    const second = storeFor([40, 1], false);
+    registry.registerModel('second', getMaxExpressId(second, [mesh(80)]));
+    const secondId = registry.toGlobalId('second', 80);
+    assert.ok(secondId > 900);
+    assert.deepEqual(registry.fromGlobalId(secondId), { modelId: 'second', expressId: 80 });
+    assert.deepEqual(registry.fromGlobalId(900), { modelId: 'first', expressId: 900 });
+  });
+});

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { parseIfcx, createSyntheticDataStore, attachDataStoreAccessors, contiguousSourceBytes, type IfcDataStore, type IfcSourceBytes, type IfcStoreData, type PointCloudExtraction } from '@ifc-lite/parser';
+import { CompactEntityIndex, parseIfcx, createSyntheticDataStore, attachDataStoreAccessors, contiguousSourceBytes, type IfcDataStore, type IfcSourceBytes, type IfcStoreData, type PointCloudExtraction } from '@ifc-lite/parser';
 import { type GeometryResult, type MeshData, type PointCloudAsset } from '@ifc-lite/geometry';
 import { loadGLBToMeshData } from '@ifc-lite/cache';
 import type { SchemaVersion } from '../../store/types.js';
@@ -70,8 +70,11 @@ export function createMinimalGlbDataStore(buffer: ArrayBuffer, meshCount: number
 export function getMaxExpressId(dataStore: IfcDataStore | null, meshes: MeshData[]): number {
   const maxExpressIdFromMeshes = meshes.reduce((max, mesh) => Math.max(max, mesh.expressId), 0);
   let maxExpressIdFromEntities = 0;
-  if (dataStore?.entityIndex?.byId) {
-    for (const key of dataStore.entityIndex.byId.keys()) {
+  const entityIndex = dataStore?.entityIndex?.byId;
+  if (entityIndex instanceof CompactEntityIndex) {
+    maxExpressIdFromEntities = entityIndex.maxExpressId;
+  } else if (entityIndex) {
+    for (const key of entityIndex.keys()) {
       if (key > maxExpressIdFromEntities) {
         maxExpressIdFromEntities = key;
       }

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -448,7 +448,8 @@ canvas.addEventListener('click', async (e) => {
 
 `EntityRef` carries the byte range along with the type. When you hold the index as its
 concrete `CompactEntityIndex`, `getByteRange(id)` returns `{ byteOffset, byteLength }`
-on its own, without building an `EntityRef`.
+on its own, without building an `EntityRef`. Its `maxExpressId` getter reads the
+highest indexed ID in constant time and returns `0` for an empty index.
 
 #### When `geometryItemId` is absent
 

--- a/packages/parser/src/compact-entity-index.ts
+++ b/packages/parser/src/compact-entity-index.ts
@@ -220,6 +220,11 @@ export class CompactEntityIndex {
     }
   }
 
+  /** Highest indexed ID in constant time; zero for an empty index. */
+  get maxExpressId(): number {
+    return this.expressIds[this.size - 1] ?? 0;
+  }
+
   /**
    * Clear the LRU cache (e.g., on model unload).
    */

--- a/packages/parser/src/data-store-transport.ts
+++ b/packages/parser/src/data-store-transport.ts
@@ -349,9 +349,12 @@ function sumBytes(payload: DataStoreTransport): number {
  * thread both view the same upstream `SharedArrayBuffer`. Callers must
  * reattach `source` on the receiving side when calling `fromTransport`.
  */
-export function toTransport(store: IfcDataStore): DataStoreTransportEnvelope {
+export function toTransport(
+  store: IfcDataStore,
+  indexOverride?: DataStoreTransport['entityIndex'],
+): DataStoreTransportEnvelope {
   const byTypeEntries: Array<[string, number[]]> = [];
-  for (const [key, value] of store.entityIndex.byType) {
+  for (const [key, value] of indexOverride ? [] : store.entityIndex.byType) {
     byTypeEntries.push([key, [...value]]);
   }
 
@@ -368,7 +371,7 @@ export function toTransport(store: IfcDataStore): DataStoreTransportEnvelope {
     parseTime: store.parseTime,
     lengthUnitScale: store.lengthUnitScale,
 
-    entityIndex: {
+    entityIndex: indexOverride ?? {
       byId: compactEntityIndexToColumns(compactById),
       byType: byTypeEntries,
     },
@@ -414,6 +417,7 @@ export function toTransport(store: IfcDataStore): DataStoreTransportEnvelope {
 export function fromTransport(
   payload: DataStoreTransport,
   source: Uint8Array | IfcSourceBytes,
+  byTypeOverride?: Map<string, number[]>,
 ): IfcDataStore {
   const strings: DataStringTable = StringTable.fromArray(payload.strings);
   const entities = entityTableFromColumns(payload.entities, strings);
@@ -422,7 +426,7 @@ export function fromTransport(
   const relationships = relationshipGraphFromColumns(payload.relationships);
 
   const byIdIndex = compactEntityIndexFromColumns(payload.entityIndex.byId);
-  const byType = new Map<string, number[]>(
+  const byType = byTypeOverride ?? new Map<string, number[]>(
     payload.entityIndex.byType.map(([k, v]) => [k, [...v]]),
   );
   const deferredEntityIndex = payload.deferredEntityIndex

--- a/packages/parser/src/parser-worker-malformed-handoff.test.ts
+++ b/packages/parser/src/parser-worker-malformed-handoff.test.ts
@@ -25,6 +25,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { WorkerIndexReceiver, type WorkerStorePayload } from './worker-index-publication.js';
 import { fromTransport, type DataStoreTransport } from './data-store-transport.js';
 import { extractGeoreferencingOnDemand } from './on-demand-georeferencing.js';
 import { contiguousSourceBytes } from './source-bytes.js';
@@ -212,4 +213,37 @@ it('prepares render metadata before publishing partial and complete stores (#398
     expect(lookups).not.toHaveBeenCalled();
     lookups.mockRestore();
   }
+}, 30_000);
+
+
+it('negotiates one immutable index through the real worker handler and transfer boundary (#3985)', async () => {
+  (globalThis as Record<string, unknown>).postMessage = (message: unknown, transfers: Transferable[] = []) => {
+    postedMessages.push(structuredClone(message, { transfer: transfers }));
+  };
+  const records = [...IFC.matchAll(/#(\d+)=[^;]+;/g)];
+  post({ type: 'set-entity-index',
+    ids: Uint32Array.from(records, record => Number(record[1])),
+    starts: Uint32Array.from(records, record => record.index!),
+    lengths: Uint32Array.from(records, record => record[0].length),
+  });
+  const source = sharedSource();
+  post({ type: 'parse', id: 'packed-req', source, waitForEntityIndex: true, indexTransport: 'packed-index-v1' });
+  await settle();
+  assertParsed();
+  const messages = postedMessages.filter((message): message is { type: string; payload: WorkerStorePayload } =>
+    ['partial-store', 'complete'].includes((message as { type: string }).type));
+  expect(messages).toHaveLength(2);
+  expect(messages[0].payload.entityIndex).toHaveProperty('format', 'packed-index-v1');
+  expect(messages[1].payload.entityIndex).toEqual({ format: 'published-index-v1' });
+  const receiver = new WorkerIndexReceiver();
+  receiver.capturePartial(messages[0].payload);
+  const sourceBytes = contiguousSourceBytes(new Uint8Array(source), messages[0].payload.sourceContentKey ?? undefined);
+  const early = receiver.hydrate(messages[0].payload, sourceBytes);
+  early.entityIndex.byType.get('IFCWALL')!.push(999);
+  early.entityIndex.byId.get(2)!.byteOffset = 0;
+  const final = receiver.hydrate(messages[1].payload, sourceBytes);
+  expect(final.entityIndex.byType.get('IFCWALL')).toEqual([2]);
+  expect(final.getEntity(2)?.attributes[2]).toBe('Wall2');
+  expect(final.source).toBe(early.source);
+  expect(extractGeoreferencingOnDemand(final)?.projectedCRS?.name).toBe('EPSG:4326');
 }, 30_000);

--- a/packages/parser/src/parser.worker.ts
+++ b/packages/parser/src/parser.worker.ts
@@ -21,17 +21,14 @@ import { IfcParser } from './index.js';
 import { extractGeoreferencingOnDemand } from './on-demand-georeferencing.js';
 import type { IfcDataStore } from './columnar-parser.js';
 import type { WasmScanApi } from './entity-scanner.js';
-import {
-  toTransport,
-  transportByteSize,
-  type DataStoreTransport,
-  type ParserMemorySnapshot,
-} from './data-store-transport.js';
+import type { ParserMemorySnapshot } from './data-store-transport.js';
+import { WorkerIndexPublisher, type WorkerStorePayload } from './worker-index-publication.js';
 import { takeWasmPanicStash } from './wasm-panic-forward.js';
 
 /** Input message: pass the SAB-backed source bytes and an opaque request id. */
 export interface ParserWorkerInputMessage {
   type: 'parse';
+  indexTransport?: 'packed-index-v1';
   id: string;
   source: SharedArrayBuffer;
   /** Optional yieldIntervalMs override (forwarded to parseColumnar). */
@@ -87,14 +84,14 @@ export interface ParserWorkerDiagnosticMessage {
 export interface ParserWorkerPartialStoreMessage {
   type: 'partial-store';
   id: string;
-  payload: DataStoreTransport;
+  payload: WorkerStorePayload;
 }
 
 /** Full data store is ready. */
 export interface ParserWorkerCompleteMessage {
   type: 'complete';
   id: string;
-  payload: DataStoreTransport;
+  payload: WorkerStorePayload;
   memory: ParserMemorySnapshot;
 }
 
@@ -292,6 +289,7 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
     // index were somehow empty, the scanner falls through to the JS tokeniser.
     const wasmApi = wasmApiPromise ? await wasmApiPromise : undefined;
     const parser = new IfcParser();
+    const indexPublisher = new WorkerIndexPublisher(data.indexTransport === 'packed-index-v1');
     let georeferencing: ReturnType<typeof extractGeoreferencingOnDemand> | undefined;
     // `source` is the SAB-backed payload — `parseColumnar` accepts
     // `ArrayBuffer | SharedArrayBuffer` so no cast is needed.
@@ -310,7 +308,7 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
       },
       onSpatialReady: (partialStore) => {
         try {
-          const { payload } = toTransport(partialStore);
+          const { payload, transfers } = indexPublisher.serialize(partialStore, false);
           // #3983: overlays and Cesium availability read these during React
           // rendering. Do the full-source/hash and property-set walks here.
           payload.sourceContentKey = partialStore.source.contentKey;
@@ -318,12 +316,10 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
             georeferencing = extractGeoreferencingOnDemand(partialStore);
             payload.georeferencing = georeferencing;
           }
-          // We intentionally do NOT transfer the partial typed-array
-          // buffers. The worker keeps using them for the rest of the parse
-          // (entityIndex.byId.get(...) etc. all read from these arrays).
-          // Structured-clone copy is acceptable for the partial because
-          // the hierarchy panel is small relative to the full store.
-          postOutput({ type: 'partial-store', id, payload });
+          // The packed byType snapshot is worker-independent; primary numeric
+          // columns still clone because parsing continues to read them.
+          postOutput({ type: 'partial-store', id, payload }, transfers);
+          indexPublisher.publishedPartial(partialStore);
         } catch (err) {
           postOutput({
             type: 'error',
@@ -333,7 +329,7 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
         }
       },
     });
-    const { payload, transfers } = toTransport(dataStore);
+    const { payload, transfers, transportBytes } = indexPublisher.serialize(dataStore, true);
     payload.sourceContentKey = dataStore.source.contentKey;
     payload.georeferencing = georeferencing === undefined
       ? extractGeoreferencingOnDemand(dataStore) : georeferencing;
@@ -346,7 +342,7 @@ self.onmessage = async (event: MessageEvent<ParserInbound>) => {
     // value (uaMemoryBytes) was never read by any consumer, so it is simply dropped.
     const memory: ParserMemorySnapshot = {
       jsHeapBytes: readJsHeapBytes(),
-      transportBytes: transportByteSize(payload),
+      transportBytes,
       sourceBytes: source.byteLength,
       parseTimeMs: performance.now() - startedAt,
     };

--- a/packages/parser/src/worker-index-publication.ts
+++ b/packages/parser/src/worker-index-publication.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IfcDataStore } from './columnar-parser.js';
+import { CompactEntityIndex } from './compact-entity-index.js';
+import { compactEntityIndexToColumns, type CompactEntityIndexColumns } from './compact-entity-index-transport.js';
+import { fromTransport, toTransport, transportByteSize, type DataStoreTransport } from './data-store-transport.js';
+import type { IfcSourceBytes } from './source-bytes.js';
+
+interface PackedIndex {
+  format: 'packed-index-v1';
+  byId: CompactEntityIndexColumns;
+  names: string[];
+  offsets: Uint32Array;
+  ids: Uint32Array | Float64Array;
+}
+interface IndexReference { format: 'published-index-v1' }
+export type WorkerStorePayload = Omit<DataStoreTransport, 'entityIndex'> & {
+  entityIndex: DataStoreTransport['entityIndex'] | PackedIndex | IndexReference;
+};
+
+function packIndex(store: IfcDataStore, byId: CompactEntityIndexColumns): PackedIndex {
+  const entries = [...store.entityIndex.byType];
+  let count = 0;
+  let u32 = true;
+  for (const [, values] of entries) {
+    count += values.length;
+    for (const id of values) {
+      if (!Number.isInteger(id) || id < 0 || id > 0xffffffff || Object.is(id, -0)) u32 = false;
+    }
+  }
+  if (count > 0xffffffff) throw new Error('Packed byType index exceeds u32 offset capacity');
+  // Arbitrary number[] producers retain their numbers, including NaN/-0 and
+  // IDs above u32. Canonical parser IDs use the compact representation.
+  const ids = u32 ? new Uint32Array(count) : new Float64Array(count);
+  const offsets = new Uint32Array(entries.length + 1);
+  let offset = 0;
+  for (let i = 0; i < entries.length; i++) {
+    offsets[i] = offset;
+    ids.set(entries[i][1], offset);
+    offset += entries[i][1].length;
+  }
+  offsets[entries.length] = offset;
+  return { format: 'packed-index-v1', byId, names: entries.map(([name]) => name), offsets, ids };
+}
+
+/** #3985: canonical parser primary columns/byType are immutable after the
+ * spatial callback. Deferred atoms get a separate final index. This publisher
+ * must not be used by a producer that edits published numeric columns in place.
+ * Public receiver arrays and LRU entries are never the retained wire seed.
+ */
+export class WorkerIndexPublisher {
+  private published?: {
+    index: IfcDataStore['entityIndex'];
+    columns: CompactEntityIndexColumns;
+    entries: Array<[string, number[], number]>;
+  };
+
+  constructor(private readonly enabled: boolean) {}
+
+  serialize(store: IfcDataStore, final: boolean): { payload: WorkerStorePayload; transfers: Transferable[]; transportBytes: number } {
+    // TODO(remove-by: all supported parser-worker clients negotiate packed-index-v1, parser maintainers), #3985.
+    if (!this.enabled) {
+      const envelope = toTransport(store);
+      return { ...envelope, transfers: final ? envelope.transfers : [], transportBytes: transportByteSize(envelope.payload) };
+    }
+    if (!(store.entityIndex.byId instanceof CompactEntityIndex)) {
+      throw new Error('Worker publication requires CompactEntityIndex');
+    }
+    const byId = compactEntityIndexToColumns(store.entityIndex.byId);
+    const previous = this.published;
+    const entries = [...store.entityIndex.byType];
+    const reference = final && previous && previous.index === store.entityIndex
+      && previous.columns.expressIds === byId.expressIds
+      && previous.columns.byteOffsets === byId.byteOffsets
+      && previous.columns.byteLengths === byId.byteLengths
+      && previous.columns.typeIndices === byId.typeIndices
+      && previous.columns.typeStrings.length === byId.typeStrings.length
+      && previous.columns.typeStrings.every((name, i) => name === byId.typeStrings[i])
+      && previous.entries.length === store.entityIndex.byType.size
+      && previous.entries.every(([name, values, length], i) => entries[i][0] === name && entries[i][1] === values && values.length === length);
+    const envelope = toTransport(store, { byId, byType: [] });
+    const entityIndex: PackedIndex | IndexReference = reference
+      ? { format: 'published-index-v1' } : packIndex(store, byId);
+    const primaryBuffers = new Set<ArrayBufferLike>([
+      byId.expressIds.buffer, byId.byteOffsets.buffer, byId.byteLengths.buffer, byId.typeIndices.buffer,
+    ]);
+    // #3985: even a referenced index keeps its original ABs in this final
+    // transfer list. Unreachable transfers detach/dispose worker ownership at
+    // successful publication, without adding another main-thread index.
+    // This does not promise when the browser reclaims physical backing.
+    const transfers = final ? envelope.transfers : [];
+    if (entityIndex.format === 'packed-index-v1') transfers.push(entityIndex.ids.buffer as ArrayBuffer, entityIndex.offsets.buffer as ArrayBuffer);
+    // Count reachable payload bytes, excluding detached disposal-only backing.
+    const transportBytes = transportByteSize(envelope.payload)
+      - (reference ? [...primaryBuffers].reduce((sum, buffer) => sum + (buffer instanceof ArrayBuffer ? buffer.byteLength : 0), 0) : 0)
+      + (entityIndex.format === 'packed-index-v1' ? entityIndex.ids.byteLength + entityIndex.offsets.byteLength : 0);
+    return { payload: { ...envelope.payload, entityIndex }, transfers, transportBytes };
+  }
+
+  /** Call only after the partial postMessage succeeds. */
+  publishedPartial(store: IfcDataStore): void {
+    if (!this.enabled || !(store.entityIndex.byId instanceof CompactEntityIndex)) return;
+    this.published = {
+      index: store.entityIndex,
+      columns: compactEntityIndexToColumns(store.entityIndex.byId),
+      entries: [...store.entityIndex.byType].map(([name, values]) => [name, values, values.length]),
+    };
+  }
+}
+
+/** One instance per parse request, never a federation/global cache. */
+export class WorkerIndexReceiver {
+  private seed?: PackedIndex;
+
+  capturePartial(payload: WorkerStorePayload): void {
+    if ('format' in payload.entityIndex && payload.entityIndex.format === 'packed-index-v1') {
+      this.seed = payload.entityIndex;
+    }
+  }
+
+  hydrate(payload: WorkerStorePayload, source: IfcSourceBytes): IfcDataStore {
+    const index = payload.entityIndex;
+    if (!('format' in index)) return fromTransport({ ...payload, entityIndex: index }, source);
+    const packed = index.format === 'published-index-v1' ? this.seed : index;
+    if (!packed) throw new Error('Final parser index references a missing partial publication');
+    if (packed.offsets.length !== packed.names.length + 1 || packed.offsets[0] !== 0
+      || packed.offsets[packed.names.length] !== packed.ids.length) {
+      throw new Error('Invalid packed parser index offsets');
+    }
+    const byType = new Map<string, number[]>();
+    for (let i = 0; i < packed.names.length; i++) {
+      const start = packed.offsets[i], end = packed.offsets[i + 1];
+      if (end < start || end > packed.ids.length || byType.has(packed.names[i])) {
+        throw new Error('Invalid packed parser index range or duplicate type');
+      }
+      const values = new Array<number>(end - start);
+      for (let row = start; row < end; row++) values[row - start] = packed.ids[row];
+      byType.set(packed.names[i], values);
+    }
+    return fromTransport({ ...payload, entityIndex: { byId: packed.byId, byType: [] } }, source, byType);
+  }
+
+  clear(): void { this.seed = undefined; }
+}

--- a/packages/parser/src/worker-parser-complete-lifetime.test.ts
+++ b/packages/parser/src/worker-parser-complete-lifetime.test.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IfcParser } from './index.js';
+import { WorkerParser } from './worker-parser.js';
+import { WorkerIndexPublisher, WorkerIndexReceiver, type WorkerStorePayload } from './worker-index-publication.js';
+import type { IfcDataStore } from './columnar-parser.js';
+
+class BoundaryWorker {
+  static latest: BoundaryWorker;
+  id = '';
+  terminated = false;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  constructor() { BoundaryWorker.latest = this; }
+  postMessage(message: { type: string; id?: string }) {
+    if (message.type === 'parse') this.id = message.id!;
+  }
+  terminate() { this.terminated = true; }
+  emit(type: string, payload?: WorkerStorePayload, id = this.id) {
+    this.onmessage?.({ data: { type, id, payload,
+      memory: { transportBytes: 0, sourceBytes: 0, parseTimeMs: 0 } } });
+  }
+}
+
+beforeEach(() => { vi.stubGlobal('Worker', BoundaryWorker); });
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+async function publication() {
+  const bytes = new TextEncoder().encode('ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n'
+    + "#1=IFCWALL('0YvCT2_$X3_xJG3rzD8L_8',$,'Wall-A',$,$,$,$,$,$);\n"
+    + "#2=IFCPROPERTYSINGLEVALUE('Example',$,IFCLABEL('present'),$);\n"
+    + "#3=IFCPROPERTYSET('0YvCT2_$X3_xJG3rzD8L_9',$,'Pset_Example',$,(#2));\n"
+    + "#4=IFCRELDEFINESBYPROPERTIES('0YvCT2_$X3_xJG3rzD8L_A',$,$,$,(#1),#3);\n"
+    + 'ENDSEC;\nEND-ISO-10303-21;\n');
+  const publisher = new WorkerIndexPublisher(true);
+  let partial: WorkerStorePayload | undefined;
+  const store = await new IfcParser().parseColumnar(bytes.buffer, {
+    disableWorkerScan: true, deferPropertyAtomIndex: true,
+    onSpatialReady: value => {
+      const envelope = publisher.serialize(value, false);
+      partial = structuredClone(envelope.payload, { transfer: envelope.transfers });
+      publisher.publishedPartial(value);
+    },
+  });
+  const properties = store.getProperties(1);
+  expect(properties.length).toBeGreaterThan(0);
+  const envelope = publisher.serialize(store, true);
+  const final = structuredClone(envelope.payload, { transfer: envelope.transfers });
+  expect(final.entityIndex).toEqual({ format: 'published-index-v1' });
+  const source = new SharedArrayBuffer(bytes.length);
+  new Uint8Array(source).set(bytes);
+  return { source, partial: partial!, final, properties };
+}
+
+describe('completed parser ownership (#3985)', () => {
+  it.each([false, true])('terminates before real hydration and preserves the seed, callback=%s', async callback => {
+    const fixture = await publication();
+    let partial: IfcDataStore | undefined;
+    const parser = new WorkerParser();
+    const pending = parser.parseColumnar(fixture.source, {
+      onSpatialReady: callback ? value => { partial = value; } : undefined,
+      onMemorySnapshot: () => expect(BoundaryWorker.latest.terminated).toBe(true),
+    });
+    const worker = BoundaryWorker.latest;
+    worker.emit('complete', fixture.final, 'stale-request');
+    expect(worker.terminated).toBe(false);
+    worker.emit('partial-store', fixture.partial);
+    const original = WorkerIndexReceiver.prototype.hydrate;
+    vi.spyOn(WorkerIndexReceiver.prototype, 'hydrate').mockImplementation(function (this: WorkerIndexReceiver, payload, source) {
+      expect(worker.terminated).toBe(true);
+      return original.call(this, payload, source);
+    });
+    worker.emit('complete', fixture.final);
+    const result = await pending;
+    expect(result.getProperties(1)).toEqual(fixture.properties);
+    expect(result.deferredEntityIndex?.get(2)).toBeDefined();
+    expect(result.entityIndex.byId.get(3)?.type).toBe('IFCPROPERTYSET');
+    if (partial) expect(result.source).toBe(partial.source);
+    expect(result.source.slice(0, fixture.source.byteLength)).toEqual(new Uint8Array(fixture.source));
+    expect(worker.onmessage).toBeNull();
+    parser.terminate();
+  });
+
+  it('rejects a final missing its index seed after releasing the sender', async () => {
+    const fixture = await publication();
+    const pending = new WorkerParser().parseColumnar(fixture.source);
+    const worker = BoundaryWorker.latest;
+    worker.emit('complete', fixture.final);
+    await expect(pending).rejects.toThrow('missing partial publication');
+    expect(worker.terminated).toBe(true);
+    expect(worker.onmessage).toBeNull();
+  });
+
+  it('continues after partial callback failure and rejects a final callback failure', async () => {
+    const fixture = await publication();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const pending = new WorkerParser().parseColumnar(fixture.source, {
+      onSpatialReady: () => { throw new Error('partial consumer failed'); },
+      onMemorySnapshot: () => { throw new Error('memory consumer failed'); },
+    });
+    const worker = BoundaryWorker.latest;
+    worker.emit('partial-store', fixture.partial);
+    expect(warning).toHaveBeenCalledOnce();
+    worker.emit('complete', fixture.final);
+    await expect(pending).rejects.toThrow('memory consumer failed');
+    expect(worker.terminated).toBe(true);
+    expect(worker.onmessage).toBeNull();
+  });
+});

--- a/packages/parser/src/worker-parser.ts
+++ b/packages/parser/src/worker-parser.ts
@@ -12,7 +12,8 @@
  *   2. Caller constructs a `WorkerParser` and calls `parseColumnar(sab, …)`.
  *   3. The worker emits `progress`, `diagnostic`, optional `partial-store`,
  *      then `complete` (or `error`). This wrapper resolves the returned
- *      Promise on `complete` and self-terminates afterward.
+ *      Promise after receiving `complete` and hydrating the result. The
+ *      completed worker is terminated before receiver reconstruction.
  *
  * On `partial-store` the wrapper invokes `options.onSpatialReady` so the
  * viewer can render the spatial-hierarchy panel before the full parse
@@ -21,11 +22,8 @@
 
 import type { IfcDataStore } from './columnar-parser.js';
 import type { ParseOptions } from './index.js';
-import {
-  fromTransport,
-  type DataStoreTransport,
-  type ParserMemorySnapshot,
-} from './data-store-transport.js';
+import { WorkerIndexReceiver, type WorkerStorePayload } from './worker-index-publication.js';
+import type { ParserMemorySnapshot } from './data-store-transport.js';
 import { contiguousSourceBytes, type IfcSourceBytes } from './source-bytes.js';
 import type {
   ParserWorkerInputMessage,
@@ -120,14 +118,16 @@ export class WorkerParser {
       // memoising on the shared Uint8Array; sharing the accessor is the same
       // guarantee without the side table.
       let sourceBytes: IfcSourceBytes | undefined;
-      const hydrate = (payload: DataStoreTransport) => {
+      const indexReceiver = new WorkerIndexReceiver();
+      const hydrate = (payload: WorkerStorePayload) => {
         // #3983: the worker hashes the source before the first UI publication.
         // Retain one accessor across partial/full stores and compression swaps.
         sourceBytes ??= contiguousSourceBytes(new Uint8Array(source), payload.sourceContentKey ?? undefined);
-        return fromTransport(payload, sourceBytes);
+        return indexReceiver.hydrate(payload, sourceBytes);
       };
 
       const settle = (cleanup: () => void) => {
+        indexReceiver.clear();
         worker.onmessage = null;
         worker.onerror = null;
         worker.onmessageerror = null;
@@ -148,8 +148,9 @@ export class WorkerParser {
             return;
 
           case 'partial-store': {
-            if (!options.onSpatialReady) return;
             try {
+              indexReceiver.capturePartial(msg.payload);
+              if (!options.onSpatialReady) return;
               const partial = hydrate(msg.payload);
               options.onSpatialReady(partial);
             } catch (err) {
@@ -162,17 +163,18 @@ export class WorkerParser {
 
           case 'complete': {
             try {
+              // #3985: the received message owns its transferred columns. Stop
+              // the completed sender before allocating receiver collections;
+              // retain indexReceiver's partial seed until hydration completes.
+              worker.terminate();
+              if (this.worker === worker) this.worker = null;
               const dataStore = hydrate(msg.payload);
               options.onMemorySnapshot?.(msg.memory);
-              settle(() => {
-                worker.terminate();
-                this.worker = null;
-              });
+              settle(() => {});
               resolve(dataStore);
             } catch (err) {
               settle(() => {
-                worker.terminate();
-                this.worker = null;
+                if (this.worker === worker) this.worker = null;
               });
               reject(new Error(`complete hydrate failed: ${err instanceof Error ? err.message : String(err)}`));
             }
@@ -233,6 +235,7 @@ export class WorkerParser {
 
       const input: ParserWorkerInputMessage = {
         type: 'parse',
+        indexTransport: 'packed-index-v1',
         id,
         source,
         yieldIntervalMs: options.yieldIntervalMs,
@@ -301,6 +304,10 @@ export class WorkerParser {
   /** Terminate the worker if running. Safe to call repeatedly. */
   terminate(): void {
     if (this.worker) {
+      // Drop the per-request hydration closure, including its packed index seed.
+      this.worker.onmessage = null;
+      this.worker.onerror = null;
+      this.worker.onmessageerror = null;
       this.worker.terminate();
       this.worker = null;
     }

--- a/packages/parser/test/worker-index-publication.test.ts
+++ b/packages/parser/test/worker-index-publication.test.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { IfcParser } from '../src/index.js';
+import type { IfcDataStore } from '../src/columnar-parser.js';
+import { compactEntityIndexToColumns } from '../src/compact-entity-index-transport.js';
+import { CompactEntityIndex } from '../src/compact-entity-index.js';
+import { WorkerIndexPublisher, WorkerIndexReceiver } from '../src/worker-index-publication.js';
+import { toTransport } from '../src/data-store-transport.js';
+import { contiguousSourceBytes } from '../src/source-bytes.js';
+
+function source(name = 'Wall-A'): ArrayBuffer {
+  return new TextEncoder().encode('ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n'
+    + `#1=IFCWALL('0YvCT2_$X3_xJG3rzD8L_8',$,'${name}',$,$,$,$,$,$);\n`
+    + "#2=IFCPROPERTYSINGLEVALUE('Example',$,IFCLABEL('present'),$);\n"
+    + "#3=IFCPROPERTYSET('0YvCT2_$X3_xJG3rzD8L_9',$,'Pset_Example',$,(#2));\n"
+    + "#4=IFCRELDEFINESBYPROPERTIES('0YvCT2_$X3_xJG3rzD8L_A',$,$,$,(#1),#3);\n"
+    + 'ENDSEC;\nEND-ISO-10303-21;\n').buffer as ArrayBuffer;
+}
+
+describe('immutable worker index publication (#3985)', () => {
+  let store: IfcDataStore;
+  beforeAll(async () => { store = await new IfcParser().parseColumnar(source(), { disableWorkerScan: true }); });
+
+  it('preserves every generic number and byType insertion/list order', () => {
+    const numbers = [0, -0, 0xffffffff, 0x100000000, -1, 1.5, NaN, Infinity, -Infinity];
+    const generic = { ...store, entityIndex: { ...store.entityIndex, byType: new Map([
+      ['ARBITRARY', numbers], ['SECOND', [3, 1, 3]],
+    ]) } };
+    const envelope = new WorkerIndexPublisher(true).serialize(generic, true);
+    const hydrated = new WorkerIndexReceiver().hydrate(structuredClone(envelope.payload), store.source);
+    const actual = hydrated.entityIndex.byType.get('ARBITRARY')!;
+    expect(actual.length).toBe(numbers.length);
+    numbers.forEach((value, i) => expect(Object.is(actual[i], value)).toBe(true));
+    expect([...hydrated.entityIndex.byType.keys()]).toEqual(['ARBITRARY', 'SECOND']);
+    expect(hydrated.entityIndex.byType.get('SECOND')).toEqual([3, 1, 3]);
+    expect(toTransport(generic).payload.entityIndex.byType[0][1]).toEqual(numbers);
+  });
+
+  it('keeps legacy requests/envelopes complete and never references an unpublished index', () => {
+    for (const enabled of [false, true]) {
+      const envelope = new WorkerIndexPublisher(enabled).serialize(store, true);
+      const receiver = new WorkerIndexReceiver();
+      const rebuilt = receiver.hydrate(structuredClone(envelope.payload), store.source);
+      expect(rebuilt.getEntity(1)).toEqual(store.getEntity(1));
+      expect(rebuilt.getProperties(1)).toEqual(store.getProperties(1));
+    }
+  });
+
+  it('publishes a full index when the canonical primary index is replaced', () => {
+    const publisher = new WorkerIndexPublisher(true);
+    publisher.publishedPartial(store);
+    const columns = compactEntityIndexToColumns(store.entityIndex.byId as CompactEntityIndex);
+    const replaced = { ...store, entityIndex: { ...store.entityIndex, byId: new CompactEntityIndex(
+      columns.expressIds.slice(), columns.byteOffsets.slice(), columns.byteLengths.slice(),
+      columns.typeIndices.slice(), [...columns.typeStrings],
+    ) } };
+    const final = publisher.serialize(replaced, true);
+    const rebuilt = new WorkerIndexReceiver().hydrate(structuredClone(final.payload), store.source);
+    expect(rebuilt.getEntity(1)).toEqual(store.getEntity(1));
+  });
+
+  it('keeps overlapping model IDs and source accessors isolated across receiver sessions', async () => {
+    const other = await new IfcParser().parseColumnar(source('Wall-B'), { disableWorkerScan: true });
+    const results = [store, other].map(model => {
+      const publisher = new WorkerIndexPublisher(true);
+      const receiver = new WorkerIndexReceiver();
+      receiver.capturePartial(structuredClone(publisher.serialize(model, false).payload));
+      publisher.publishedPartial(model);
+      return receiver.hydrate(structuredClone(publisher.serialize(model, true).payload), model.source);
+    });
+    expect(results[0].getEntity(1)).toEqual(store.getEntity(1));
+    expect(results[1].getEntity(1)).toEqual(other.getEntity(1));
+    expect(results[0].getEntity(1)).not.toEqual(results[1].getEntity(1));
+    expect(results[0].source).not.toBe(results[1].source);
+  });
+
+  it('retains complete deferred property/reference access through real transfers', async () => {
+    const input = source();
+    const publisher = new WorkerIndexPublisher(true);
+    const receiver = new WorkerIndexReceiver();
+    const sourceBytes = contiguousSourceBytes(new Uint8Array(input));
+    let partial: IfcDataStore | undefined;
+    const parsed = await new IfcParser().parseColumnar(input, {
+      disableWorkerScan: true, deferPropertyAtomIndex: true,
+      onSpatialReady: early => {
+        const envelope = publisher.serialize(early, false);
+        const payload = structuredClone(envelope.payload, { transfer: envelope.transfers });
+        receiver.capturePartial(payload);
+        partial = receiver.hydrate(payload, sourceBytes);
+        publisher.publishedPartial(early);
+      },
+    });
+    const expectedProperties = parsed.getProperties(1);
+    expect(expectedProperties.length).toBeGreaterThan(0);
+    const workerColumns = compactEntityIndexToColumns(parsed.entityIndex.byId as CompactEntityIndex);
+    expect(workerColumns.expressIds.byteLength).toBeGreaterThan(0);
+    const envelope = publisher.serialize(parsed, true);
+    const finalPayload = structuredClone(envelope.payload, { transfer: envelope.transfers });
+    // The final message references main's earlier seed; the original worker
+    // backing is disposed by the SAME transfer even though absent from payload.
+    for (const column of [workerColumns.expressIds, workerColumns.byteOffsets,
+      workerColumns.byteLengths, workerColumns.typeIndices]) expect(column.byteLength).toBe(0);
+    const final = receiver.hydrate(finalPayload, sourceBytes);
+    expect(final.deferredEntityIndex?.get(2)).toBeDefined();
+    expect(final.entityIndex.byId.get(2)).toBeUndefined();
+    expect(final.getProperties(1)).toEqual(expectedProperties);
+    expect(final.getEntity(3)).toBeDefined();
+    expect(partial!.entityIndex.byId.get(1)).toEqual(final.entityIndex.byId.get(1));
+    expect(final.source).toBe(partial!.source);
+    expect(final.entityIndex.byId).not.toBe(partial!.entityIndex.byId);
+  });
+});
+
+// Archicad Haus contains real IfcRelDefinesByProperties and property atoms;
+// IfcOpenHouse has no property associations and cannot exercise this contract.
+const fixture = [
+  resolve(__dirname, '../../../tests/models/ara3d/AC20-FZK-Haus.ifc'),
+  '/Users/louistrue/Development/ifc-lite-fixtures-wt/tests/models/ara3d/AC20-FZK-Haus.ifc',
+].find(existsSync);
+if (!fixture) console.warn('skip: immutable transport real IFC fixture missing — run pnpm fixtures');
+it.skipIf(!fixture)('retains real-model properties, all references and byType lists (#3985)', async () => {
+  const input = Uint8Array.from(readFileSync(fixture!)).buffer;
+  const publisher = new WorkerIndexPublisher(true);
+  const receiver = new WorkerIndexReceiver();
+  const parsed = await new IfcParser().parseColumnar(input, {
+    disableWorkerScan: true, deferPropertyAtomIndex: true,
+    onSpatialReady: early => {
+      receiver.capturePartial(structuredClone(publisher.serialize(early, false).payload));
+      publisher.publishedPartial(early);
+    },
+  });
+  const rebuilt = receiver.hydrate(structuredClone(publisher.serialize(parsed, true).payload), parsed.source);
+  expect([...rebuilt.entityIndex.byType]).toEqual([...parsed.entityIndex.byType]);
+  for (const id of parsed.entityIndex.byId.keys()) expect(rebuilt.getEntity(id)).toEqual(parsed.getEntity(id));
+  const propertyIds = [...parsed.onDemandPropertyMap!.keys()];
+  expect(propertyIds.length).toBeGreaterThan(0);
+  let propertySetCount = 0;
+  for (const id of propertyIds) {
+    const expected = parsed.getProperties(id);
+    propertySetCount += expected.length;
+    expect(rebuilt.getProperties(id)).toEqual(expected);
+  }
+  expect(propertySetCount).toBeGreaterThan(0);
+  expect(rebuilt.deferredEntityIndex?.size).toBeGreaterThan(0);
+}, 120_000);

--- a/packages/parser/test/worker-parser-source-sharing.test.ts
+++ b/packages/parser/test/worker-parser-source-sharing.test.ts
@@ -30,6 +30,7 @@ import { beforeAll, afterEach, describe, expect, it } from 'vitest';
 
 import { IfcParser } from '../src/index.js';
 import { WorkerParser } from '../src/worker-parser.js';
+import { WorkerIndexPublisher } from '../src/worker-index-publication.js';
 import { toTransport } from '../src/data-store-transport.js';
 import type { IfcDataStore } from '../src/columnar-parser.js';
 
@@ -124,6 +125,92 @@ describe('WorkerParser shares one source accessor across partial + final (#2183)
     if (partial === null) throw new Error('onSpatialReady never fired');
     return { partial, final };
   }
+
+  // #3985: exercise the real publisher, structured clone, and client hydration;
+  // the stub supplies only worker scheduling, never fabricated store results.
+  for (const callback of ['absent', 'throws', 'mutates'] as const) {
+    it(`retains the private packed seed when the partial callback ${callback} (#3985)`, async () => {
+      (globalThis as { Worker?: unknown }).Worker = StubWorker;
+      const encoded = new TextEncoder().encode(STEP);
+      const source = new SharedArrayBuffer(encoded.length);
+      new Uint8Array(source).set(encoded);
+      let partial: IfcDataStore | undefined;
+      const done = new WorkerParser().parseColumnar(source, {
+        onSpatialReady: callback === 'absent' ? undefined : store => {
+          partial = store;
+          if (callback === 'throws') throw new Error('consumer callback failure');
+          store.entityIndex.byType.get('IFCWALL')!.push(999);
+          store.entityIndex.byId.get(1)!.byteOffset = 0;
+        },
+      });
+      const worker = StubWorker.last!;
+      const { id } = worker.posted[0];
+      const publisher = new WorkerIndexPublisher(true);
+      const early = publisher.serialize(parsed, false);
+      worker.deliver({ id, type: 'partial-store', payload: structuredClone(early.payload, { transfer: early.transfers }) });
+      publisher.publishedPartial(parsed);
+      const final = publisher.serialize(parsed, true);
+      worker.deliver({ id, type: 'complete', payload: structuredClone(final.payload), memory: undefined });
+      const store = await done;
+      expect(store.entityIndex.byType.get('IFCWALL')).toEqual([1]);
+      expect(store.getEntity(1)?.attributes).toEqual(parsed.getEntity(1)?.attributes);
+      expect(store.entityIndex.byId.get(1)?.byteOffset).toBeGreaterThan(0);
+      if (partial) {
+        expect(store.source).toBe(partial.source);
+        expect(store.entityIndex.byId).not.toBe(partial.entityIndex.byId);
+        expect(store.entityIndex.byType.get('IFCWALL')).not.toBe(partial.entityIndex.byType.get('IFCWALL'));
+      }
+      expect(worker.terminated).toBe(true);
+    });
+  }
+
+  it('contains malformed partial envelopes and rejects a final missing seed cleanly (#3985)', async () => {
+    (globalThis as { Worker?: unknown }).Worker = StubWorker;
+    const done = new WorkerParser().parseColumnar(new SharedArrayBuffer(64));
+    const worker = StubWorker.last!;
+    const { id } = worker.posted[0];
+    // No callback: capturing the optional early publication must still stay
+    // inside error handling, never leak an uncaught message-handler exception.
+    expect(() => worker.deliver({ id, type: 'partial-store', payload: {} })).not.toThrow();
+    const publisher = new WorkerIndexPublisher(true);
+    publisher.publishedPartial(parsed);
+    worker.deliver({ id, type: 'complete', payload: publisher.serialize(parsed, true).payload });
+    await expect(done).rejects.toThrow('missing partial publication');
+    expect(worker.terminated).toBe(true);
+    expect(worker.onmessage).toBeNull();
+  });
+
+  it('drops an aborted request seed before another model starts (#3985)', async () => {
+    (globalThis as { Worker?: unknown }).Worker = StubWorker;
+    const parser = new WorkerParser();
+    void parser.parseColumnar(new SharedArrayBuffer(64));
+    const abandoned = StubWorker.last!;
+    const publisher = new WorkerIndexPublisher(true);
+    const early = publisher.serialize(parsed, false);
+    abandoned.deliver({ id: abandoned.posted[0].id, type: 'partial-store', payload: structuredClone(early.payload) });
+    publisher.publishedPartial(parsed);
+    parser.terminate();
+    expect(abandoned.terminated).toBe(true);
+    expect(abandoned.onmessage).toBeNull();
+    const done = parser.parseColumnar(new SharedArrayBuffer(64));
+    const current = StubWorker.last!;
+    // A new request cannot resolve an index reference using the old model seed.
+    current.deliver({ id: current.posted[0].id, type: 'complete', payload: publisher.serialize(parsed, true).payload });
+    await expect(done).rejects.toThrow('missing partial publication');
+    expect(current.terminated).toBe(true);
+  });
+
+  it('rejects a missing publication reference and terminates its worker (#3985)', async () => {
+    (globalThis as { Worker?: unknown }).Worker = StubWorker;
+    const done = new WorkerParser().parseColumnar(new SharedArrayBuffer(64));
+    const worker = StubWorker.last!;
+    const publisher = new WorkerIndexPublisher(true);
+    publisher.publishedPartial(parsed);
+    const final = publisher.serialize(parsed, true);
+    worker.deliver({ id: worker.posted[0].id, type: 'complete', payload: final.payload, memory: undefined });
+    await expect(done).rejects.toThrow('missing partial publication');
+    expect(worker.terminated).toBe(true);
+  });
 
   it('retains the worker fingerprint without hashing on first UI read (#3983)', async () => {
     const { partial, final } = await runStreamingParse(true);

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -632,6 +632,10 @@ throughput gain. No universal absence of performance regressions or target
 corpus gain is claimed. Original failures and private exploratory work remain
 archived; the published projections identify their source records by hash.
 
+### Retained parser publication and receiver ownership (#3985)
+
+Pack immutable type-index publication once and reuse partial columns on complete, retaining legacy transport and shared source access. Terminate the completed parser worker before receiver hydration and use the compact maximum ID during ingestion. Retained as cumulative cold-load work, with no isolated percentage attributed. Qualification must include full property/reference access, federation and memory through cache completion; worker completion alone is not readiness.
+
 ### Retained cold-load work: exact LOD keys (#3991)
 
 Bounded LOD cell neighborhoods use exact integer keys containing all three cell


### PR DESCRIPTION
Partial and complete parser messages reconstructed the same immutable index collections, and hydration overlapped the completed parser worker's retained graph. Reuse packed publications, terminate the completed sender before receiver hydration, and use the compact maximum ID during ingestion. Preserve old transport compatibility, shared source-accessor identity, callbacks/errors and complete reference access.

Closes #4011; part of umbrella #3985. Builds on the column-native preparation layer (#4012), now on main. Its extraction keeps the compact-index module within the existing size budget (467 production lines, budget 474). Behavioral tests cover partial/final publications, termination/error paths, shared source access and maximum-ID edge cases.

The [shared evidence](https://github.com/LTplus-AG/ifc-lite/blob/f1e4ce01ff1e9e65cb983a4e0fb9f81e2e409e9f/scripts/perf/evidence/retained-cold-load-2026-09-06/README.md) covers the combined retained stack: native full-call improvement 15.53%; supplemental Chrome full-readiness improvement 28.70%, with Haus +26ms and slower geometry completion on some models. These are combined results, not this layer's isolated gain. Chrome's original strict console audit remains failed; exact-artifact static diagnostics identify the reproduced local analytics 404, while original per-event URLs were not retained. Firefox's strict cohort is invalid; later passing controls do not establish a corpus gain. The 30% target and universal absence of regressions are not established. All pairs and failures are retained.

The maintainer authorized combined local CI for landing, followed by monitoring main. The combined source passed root build, typecheck, tests, lint, real-WASM contracts and Node/static/docs checks. Remote checks retain their actual statuses; pending runs are not represented as green. Remaining Rust qualification is being completed before further landing.

This landing head contains only G on current main, including merged F. The earlier standalone head failed the module-size gate; inheriting F fixes that failure without changing the budget. No new performance measurement is claimed. Retained source changes match the combined validation tree.
