### PR TITLE
fix(ci): discover Rust sibling tests in revert oracle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -438,7 +438,7 @@ jobs:
     needs: [changes, build]
     if: >-
       github.event_name == 'pull_request' &&
-      needs.changes.outputs.frontend == 'true' &&
+      (needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true') &&
       !contains(github.event.pull_request.labels.*.name, 'revert-oracle-exempt')
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -37,12 +37,12 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     mkdirSync(join(root, 'tests'));
     writeFileSync(join(root, 'tests/later_target.rs'),
       '#[test]\nfn version_stays_supported() { assert!((1..=2).contains(&oracle_rust_siblings::value::value())); }\n');
-    function writeVersion(value) {
+    const writeVersion = (value) => {
       writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n`);
       for (const file of ['value_tests.rs', 'tests.rs']) {
         writeFileSync(join(root, 'src', file), `#[test]\nfn observes_value() { assert_eq!(crate::value::value(), ${value}); }\n`);
       }
-    }
+    };
     writeVersion(1);
     // Generate/commit the lock before oracle's clean-tree check.
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const oracle = resolve(dirname(fileURLToPath(import.meta.url)), '../check-test-revert-oracle.mjs');
+
+test('#4016: the complete oracle executes changed Rust sibling assertions and restores production', { timeout: 120_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), 'oracle-rust-siblings-'));
+  const env = { ...process.env, CARGO_TARGET_DIR: join(root, 'target') };
+  delete env.RUSTFLAGS;
+  delete env.CARGO_ENCODED_RUSTFLAGS;
+  function run(bin, args) {
+    const result = spawnSync(bin, args, { cwd: root, env, encoding: 'utf8', timeout: 100_000, maxBuffer: 16 * 1024 * 1024 });
+    assert.equal(result.error, undefined, `${bin}: ${result.error?.message}`);
+    assert.equal(result.status, 0, `${bin} ${args.join(' ')}\n${result.stdout}\n${result.stderr}`);
+    return result.stdout;
+  }
+  try {
+    // Real Cargo, no fake runner or handwritten output. No external crate deps.
+    run('cargo', ['--version']);
+    run('git', ['init', '-q']);
+    run('git', ['config', 'user.name', 'Revert oracle fixture']);
+    run('git', ['config', 'user.email', 'oracle@example.invalid']);
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, '.gitignore'), '/target/\n');
+    writeFileSync(join(root, 'Cargo.toml'), '[package]\nname = "oracle-rust-siblings"\nversion = "0.1.0"\nedition = "2021"\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'mod value;\n#[cfg(test)] mod value_tests;\n#[cfg(test)] mod tests;\n');
+    function writeVersion(value) {
+      writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n`);
+      for (const file of ['value_tests.rs', 'tests.rs']) {
+        writeFileSync(join(root, 'src', file), `#[test]\nfn observes_value() { assert_eq!(crate::value::value(), ${value}); }\n`);
+      }
+    }
+    writeVersion(1);
+    // Generate/commit the lock before oracle's clean-tree check.
+    run('cargo', ['generate-lockfile', '--offline']);
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'control']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+    writeVersion(2);
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'change production and both sibling assertions']);
+    const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
+    assert.match(output, /OBSERVED/);
+    assert.match(output, /2 assertion\(s\) RED out of 2 collected/);
+    assert.equal(readFileSync(join(root, 'src/value.rs'), 'utf8'), 'pub fn value() -> u32 { 2 }\n');
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -31,7 +31,12 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname = "oracle-rust-siblings"\nversion = "0.1.0"\nedition = "2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'mod value;\n#[cfg(test)] mod value_tests;\n#[cfg(test)] mod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub mod value;\n#[cfg(test)] mod value_tests;\n#[cfg(test)] mod tests;\n');
+    // A later Cargo target must still execute after the library target fails.
+    // Its supported-version invariant holds for both production revisions.
+    mkdirSync(join(root, 'tests'));
+    writeFileSync(join(root, 'tests/later_target.rs'),
+      '#[test]\nfn version_stays_supported() { assert!((1..=2).contains(&oracle_rust_siblings::value::value())); }\n');
     function writeVersion(value) {
       writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n`);
       for (const file of ['value_tests.rs', 'tests.rs']) {
@@ -49,7 +54,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     run('git', ['commit', '-qm', 'change production and both sibling assertions']);
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
-    assert.match(output, /2 assertion\(s\) RED out of 2 collected/);
+    assert.match(output, /2 assertion\(s\) RED out of 3 collected/);
     assert.equal(readFileSync(join(root, 'src/value.rs'), 'utf8'), 'pub fn value() -> u32 { 2 }\n');
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -79,7 +79,7 @@ export function classifyPath(path) {
   for (const p of IGNORED_PREFIXES) if (path.startsWith(p)) return 'ignored';
   for (const s of IGNORED_SUFFIXES) if (path.endsWith(s)) return 'ignored';
   if (DEPLOY_CONFIG_RE.test(path)) return 'ignored';
-  if (TEST_FILE_RE.test(path)) return 'test';
+  if (TEST_FILE_RE.test(path) || /(^|\/)(?:[^/]+_tests|tests)\.rs$/.test(path)) return 'test';
   if (TEST_DIR_RE.test(path)) return 'test';
   if (TEST_SEGMENT_RE.test(path)) return 'test';
   return 'production';

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -186,7 +186,7 @@ export function rootScriptsRunner(files) {
 /** Cargo test invocation for a crate. */
 export function cargoRunner(crate) {
   if (!crate) return null;
-  return { family: 'cargo', bin: 'cargo', args: ['test', '-p', crate] };
+  return { family: 'cargo', bin: 'cargo', args: ['test', '--no-fail-fast', '-p', crate] };
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -411,6 +411,18 @@ test('classifyPath: test sources', () => {
   assert.equal(classifyPath('packages/core/src/__snapshots__/a.snap'), 'test');
 });
 
+test('#4016: separate Rust sibling modules are tests; inline production stays production', () => {
+  for (const path of ['rust/geometry/src/router/processor_registry_tests.rs',
+    'rust/geometry/src/router/tests.rs', 'rust/core/src/parser/scanner_tests.rs']) {
+    assert.equal(classifyPath(path), 'test');
+  }
+  for (const path of ['rust/geometry/src/router/processor_registry.rs',
+    'rust/geometry/src/router/mod.rs', 'rust/core/src/parser/scanner.rs',
+    'rust/core/src/testing.rs', 'rust/core/src/test_utils.rs']) {
+    assert.equal(classifyPath(path), 'production');
+  }
+});
+
 test('classifyPath: a `test-utils.ts` is production, not a test', () => {
   // Distinct subject from the `test/` SEGMENT case below: a hyphenated
   // filename must not be swallowed by the directory rule.

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -599,7 +599,7 @@ test('cargoRunner targets one crate and refuses an unnamed one', () => {
   assert.deepEqual(cargoRunner('ifc-lite-geom'), {
     family: 'cargo',
     bin: 'cargo',
-    args: ['test', '-p', 'ifc-lite-geom'],
+    args: ['test', '--no-fail-fast', '-p', 'ifc-lite-geom'],
   });
   assert.equal(cargoRunner(null), null);
 });


### PR DESCRIPTION
The changed-test oracle classifies conventional Rust sibling modules (`*_tests.rs` and `tests.rs`) as production, so PR #4002 reports no changed tests despite adding Cargo assertions. Recognize those test filenames and route them through the existing Cargo runner. The workflow also runs for Rust-only changes. Cargo uses `--no-fail-fast` to collect later targets after an earlier assertion failure; otherwise the gate mistakes Cargo’s early stop for vanished tests. Inline tests remain part of their production module; compile failures, vanished suites, restoration and CI verdict rules are unchanged.

Adds filename-boundary coverage and a real temporary Cargo/git fixture: both changed sibling assertions pass at the branch, fail after reversing production, a later integration target still runs, and the original source and clean tree are restored. The existing Node test glob runs this fixture; no mocked Cargo output or gate exemption is involved.

Validation at ec55e1a34 under Node 22: 53 local tests passed with zero skips. The actual self-revert oracle is OBSERVED (53 baseline passes; 50 passes and three assertion failures after production reversal, with all 53 still collected). Applied to the corrected router tests in #4002, the full Cargo oracle collects 1,265 tests on both revisions and observes the warmed-construction allocation assertion fail on the eager implementation. CI subsequently caught a nested function declaration in the new fixture. The follow-up changes it to a block-scoped function expression; runtime behavior and assertions are unchanged. At follow-up `061e1377e4c2eb654855d4311ce983a380f7da26`, the 53 relevant Node tests and full root `pnpm lint` pass. The preceding remote suite passed every applicable job except the corrected lint error and its dependent aggregate. Final-head remote CI and review remain required. No runtime or performance claim.

Closes #4016


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust test handling so test-related files are identified correctly.
  - Rust test runs now continue after individual failures, providing more complete results.

- **Tests**
  - Added regression and integration coverage for Rust revert validation, including multiple failing assertions, restored changes, and clean repository state.

- **Chores**
  - Revert validation now runs for pull requests that modify frontend or Rust files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->