### PR TITLE
ci: put the CI-silent verdict on the PRs, not on a red main

### DIFF
--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -60,7 +60,15 @@ permissions:
   # `gh run list`, for the cadence report below. Without it that step 403s.
   actions: read
   contents: read
-  pull-requests: read
+  # WRITE, not read: the scan now puts its verdict ON the offending PRs as a
+  # label instead of reddening main. Labelling a PR is the `pull-requests`
+  # scope, never `issues` -- they look interchangeable on the REST surface and
+  # are not.
+  pull-requests: write
+  # ONLY for `gh label create`: a label is an issues-scope resource even though
+  # it is applied to a PR. Applying it is `pull-requests`. The two are not
+  # interchangeable -- label-authority.yml carries the measured evidence.
+  issues: write
   # Declaring ANY `permissions:` block sets every scope not listed to `none`,
   # and this scan's whole verdict rests on `statusCheckRollup` -- check-run and
   # commit-status data, neither of which `pull-requests: read` covers. Without
@@ -100,8 +108,89 @@ jobs:
       # in the script rather than a shell step here so the arithmetic is a
       # tested pure function (`cadenceReport`) instead of untested YAML, and so
       # it reaches the same summary file as the findings.
+      # A RED MAIN IS THE WRONG PLACE FOR THIS VERDICT, and this is the same
+      # argument review-lane-canary.yml already makes: "a failed scheduled
+      # workflow is a row in a tab nobody opens". It is worse here, because the
+      # condition is about OPEN PRs -- nobody can clear it by changing `main`,
+      # and the PR authors who CAN clear it never see the red at all.
+      #
+      # Measured before this change: the scan failed 10 of 39 pushes to main,
+      # and 8 of the last 9, on one unchanged set of PRs. A main that is red by
+      # default is a main nobody reads -- which is how a flaky parser test
+      # produced 12 of the 15 `Test` failures in that same window unnoticed.
+      #
+      # DETECTION IS UNCHANGED. Only the delivery moves: onto the PRs the scan
+      # names, plus the job summary the scanner already writes.
       - name: Scan open PRs
+        id: scan
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-        run: node scripts/scan-dirty-prs.mjs --repo "${{ github.repository }}"
+        run: |
+          set -uo pipefail
+          node scripts/scan-dirty-prs.mjs --repo "${{ github.repository }}" \
+            2>&1 | tee "$RUNNER_TEMP/scan.log"
+          rc=${PIPESTATUS[0]}
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          # 2 IS "COULD NOT LOOK" AND STILL FAILS THE JOB. Only the FINDING (1)
+          # stops reddening main; an API error must not be quietly absorbed,
+          # and it must not reach the label step, where an empty silent set
+          # would read as "nothing is silent any more" and strip the label off
+          # PRs that are still broken.
+          if [ "$rc" -ge 2 ]; then
+            echo "::error::The scan could not complete; not touching any label."
+            exit "$rc"
+          fi
+          exit 0
+
+      # THE VERDICT LANDS ON THE PRs IT NAMES. A label is visible to the author,
+      # survives new pushes, and is removed in the same run that finds the PR
+      # fixed -- so a stale label cannot outlive the condition the way an old
+      # red run does.
+      #
+      # Reads the scanner's own `silent-prs=` line rather than scraping the
+      # human report: those lines also carry the `unknownAdvisory` block, which
+      # the scanner deliberately keeps OUT of `silent` because those PRs
+      # re-check themselves, so scraping labelled and unlabelled every freshly
+      # opened PR twice an hour.
+      - name: Mark the PRs the scan named
+        if: steps.scan.outputs.rc == '0' || steps.scan.outputs.rc == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LABEL=ci-silent
+          gh label create "$LABEL" --repo "$REPO" --color d93f0b \
+            --description "No pull_request CI can run on this PR's current head (stacked base, or conflicted)." 2>/dev/null || true
+
+          named="$(grep -oE '^silent-prs=.*' "$RUNNER_TEMP/scan.log" | tail -1 | cut -d= -f2 | tr ',' ' ')"
+          echo "silent set: ${named:-<none>}"
+
+          # `--limit 100` to match the scanner's own page size: the default 30
+          # would leave a 31st labelled PR with nothing able to clear it.
+          # Hoisted out of the `for` list because `set -e` does NOT fire on a
+          # failed command substitution there -- a failed read would silently
+          # iterate zero times and look like "nothing to clear".
+          labelled="$(gh pr list --repo "$REPO" --state open --label "$LABEL" --limit 100 --json number --jq '.[].number')"
+
+          failures=0
+          for pr in $labelled; do
+            case " $named " in
+              *" $pr "*) ;;
+              *) echo "  clearing $LABEL from #$pr"
+                 gh pr edit "$pr" --repo "$REPO" --remove-label "$LABEL" || failures=$((failures + 1)) ;;
+            esac
+          done
+          for pr in $named; do
+            echo "  labelling #$pr"
+            gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL" || failures=$((failures + 1))
+          done
+
+          # READ BACK. Silencing these and printing "labelling #N" regardless
+          # would let the whole mechanism die -- a revoked scope, an org policy
+          # -- with the log still claiming it worked.
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::$failures label write(s) failed; the verdict did not reach those PRs."
+            exit 1
+          fi

--- a/scripts/scan-dirty-prs.mjs
+++ b/scripts/scan-dirty-prs.mjs
@@ -248,6 +248,10 @@ async function main() {
 
   const results = scanPrs(prs, required, baseBranches, aliases);
   const { ok, lines } = report(results, required, baseBranches);
+  // The SAME set the report calls silent -- deliberately not `unknownAdvisory`,
+  // which the scanner keeps out of `silent` because those PRs re-check
+  // themselves.
+  const silentNumbers = results.filter((r) => r.silent).map((r) => r.number);
 
   // Live mode only: offline `--state-file` runs are the regression harness,
   // which has no run history to ask about and must not shell out to `gh`.
@@ -276,6 +280,13 @@ async function main() {
     }
   }
 
+  // THE SILENT SET, FOR MACHINES. Screen-scraping the human lines picked up
+  // the `unknownAdvisory` block too -- PRs the scanner deliberately keeps OUT
+  // of `silent` because they re-check themselves -- so a freshly opened PR got
+  // labelled and unlabelled every 30 minutes. Emitting the set the scanner
+  // actually computed removes the second, divergent derivation.
+  console.log(`silent-prs=${silentNumbers.join(',')}`);
+
   process.exit(ok ? 0 : 1);
 }
 
@@ -285,7 +296,12 @@ if (process.argv[1] && process.argv[1].endsWith('scan-dirty-prs.mjs')) {
   } catch (err) {
     if (err instanceof DirtyPrScanError) {
       console.error(`❌ ${err.reason}: ${err.message}`);
-      process.exit(1);
+      // EXIT 2, NOT 1. `1` means "the scan looked and found silent PRs"; this
+      // means "the scan could not look". A caller that acts on the finding --
+      // labelling the PRs it named, clearing the label from the rest -- must
+      // be able to tell those apart, or a transient HTTP 502 reads as "no PR
+      // is silent any more" and clears correct state.
+      process.exit(2);
     }
     throw err;
   }

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -127,13 +127,13 @@ test('the harness does not leak fixture findings into the ambient GITHUB_STEP_SU
 
 test('fails closed rather than silently passing when the state file is not an array', () => {
   const { code, output } = run({ not: 'an array' });
-  assert.equal(code, 1, output);
+  assert.equal(code, 2, output);
   assert.match(output, /BAD_INPUT/);
 });
 
 test('requires --repo or --state-file', () => {
   const r = spawnSync(process.execPath, [GATE], { encoding: 'utf8', env: { ...process.env, GITHUB_REPOSITORY: '' } });
-  assert.equal(r.status, 1);
+  assert.equal(r.status, 2);
   assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
 });
 
@@ -229,8 +229,44 @@ test('fails closed rather than guessing a remedy when `baseRefName` is absent', 
   const { code, output } = run([
     { number: 3411, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', statusCheckRollup: [] },
   ]);
-  assert.equal(code, 1, output);
+  assert.equal(code, 2, output);
   assert.match(output, /NO_BASE_REF/);
+});
+
+// ── 1 MEANS "LOOKED AND FOUND"; 2 MEANS "COULD NOT LOOK" ──────────────────
+//
+// The whole point of the split. A caller acts on the finding -- it labels the
+// PRs the scan named and CLEARS the label from every PR it did not -- so
+// conflating the two lets a transient HTTP 502 read as "no PR is silent any
+// more" and strip the label off PRs that are still broken. Pinned in both
+// directions, because a split that only ever produces one of the codes is not
+// a split.
+test('exit 1 is a FINDING and exit 2 is a FAILURE TO LOOK, and they never collide', () => {
+  const finding = run([
+    { number: 1, baseRefName: 'feature/x', mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', statusCheckRollup: [] },
+  ]);
+  assert.equal(finding.code, 1, finding.output);
+  assert.match(finding.output, /silent-prs=1/);
+
+  const cannotLook = run({ not: 'an array' });
+  assert.equal(cannotLook.code, 2, cannotLook.output);
+  // And it must NOT publish a silent set, because it never computed one. An
+  // empty `silent-prs=` here would be read as "nothing is silent".
+  assert.doesNotMatch(cannotLook.output, /silent-prs=/);
+});
+
+// ── THE MACHINE LINE IS THE SET THE REPORT CALLS SILENT ───────────────────
+//
+// Not the human lines. Screen-scraping those also picked up the
+// `unknownAdvisory` block -- PRs deliberately excluded from `silent` because
+// they re-check themselves -- so a freshly opened PR was labelled and
+// unlabelled every 30 minutes.
+test('silent-prs excludes the advisory UNKNOWN class the report prints separately', () => {
+  const { code, output } = run([
+    { number: 77, baseRefName: 'main', mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN', statusCheckRollup: [] },
+  ]);
+  assert.equal(code, 0, output);
+  assert.match(output, /silent-prs=$/m);
 });
 
 // ------------------------------------- a matrix job skipped BEFORE expanding (#3584 shape)


### PR DESCRIPTION
`main` was red on **8 of its last 9 pushes**, and this scan caused **10 of the last 39**. Not once because anything on `main` was broken.

The scan reports that *open PRs* cannot run `pull_request` CI — and it reported that by failing the push-to-main run. That's the wrong place for the verdict, twice over:

- nobody can clear it by changing `main`, and
- the PR authors who **can** clear it never see the red.

`review-lane-canary.yml` already makes this argument for a scheduled workflow — *"a failed scheduled workflow is a row in a tab nobody opens"*. It's stronger here, because the row names PRs whose authors aren't looking at it.

And a `main` that is red by default is a `main` nobody reads. That isn't theoretical: a flaky parser test caused **12 of the 15 `Test` failures in the same window** and went unnoticed, because red main had stopped carrying information. (#4020 fixes that test.)

## Detection is unchanged; only delivery moves

Onto the PRs the scan names, as a `ci-silent` label the author sees and that is **removed in the same run that finds the PR fixed** — so a stale label can't outlive the condition the way an old red run does. Plus the job summary the scanner already writes.

## The split that makes this safe

`scan-dirty-prs.mjs` exited `1` both for *"looked and found silent PRs"* and for *"could not look"*. The caller **clears the label from every PR it did not name**. Conflated, a transient HTTP 502 reads as "no PR is silent any more" and strips the label off PRs that are still broken — **worse than the red run it replaces**.

So a `DirtyPrScanError` now exits `2`, the workflow still **fails** on `2`, and the label step runs only on `0` or `1`. Pinned in both directions, because a split that only ever produces one code is not a split.

## No screen-scraping

The scanner emits `silent-prs=` — the set it actually computed. Parsing the human report also caught the `unknownAdvisory` block, which the scanner deliberately keeps *out* of `silent` because those PRs re-check themselves, so a freshly opened PR would have been labelled and unlabelled every 30 minutes.

## No ops issue

An earlier draft opened one. Measured against the real run history (45 runs / 46 hours, and the condition flaps by construction since every merge to `main` is what conflicts the next PR), it would have created **5 issues, closed 4, appended 11 comments** in two days. The scanner already writes the full report to `$GITHUB_STEP_SUMMARY`, and the label reaches whoever can act.

## Verification

Label-step logic driven with stubs:

| case | result |
|---|---|
| 2 silent + 1 stale label | labels both, clears the stale one |
| scan clean | clears every label |
| nothing silent, nothing labelled | no-op |
| label write 403s | `::error::2 label write(s) failed` → **exit 1** |

Also: `--limit 100` on the label query to match the scanner's page size so a 31st labelled PR isn't stranded; the query hoisted out of a `for` list where `set -e` does **not** fire on a failed command substitution; 56/56 scan tests pass, including two new ones pinning the exit-code split and the advisory exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9