### PR TITLE
fix(ci): derive root test entrypoints without discarding scaffolding

### DIFF
--- a/scripts/lib/revert-oracle-root-scaffolding.test.mjs
+++ b/scripts/lib/revert-oracle-root-scaffolding.test.mjs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const oracle = resolve(dirname(fileURLToPath(import.meta.url)), '../check-test-revert-oracle.mjs');
+
+test('#4036: root Node assertions run through retained benchmark scaffolding after production revert', { timeout: 30_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), 'oracle-root-scaffolding-'));
+  const env = { ...process.env };
+  // The nested fixture owns a separate Node test run, not this test runner's IPC.
+  delete env.NODE_TEST_CONTEXT;
+  const run = (bin, args, expected = 0) => {
+    const result = spawnSync(bin, args, { cwd: root, env, encoding: 'utf8', timeout: 20_000 });
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, expected, `${result.stdout}\n${result.stderr}`);
+    return result.stdout + result.stderr;
+  };
+  try {
+    run('git', ['init', '-q']);
+    run('git', ['config', 'user.name', 'Revert oracle fixture']);
+    run('git', ['config', 'user.email', 'oracle@example.invalid']);
+    for (const dir of ['src', 'scripts', 'tests/benchmark']) mkdirSync(join(root, dir), { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ type: 'module', scripts: { test: 'turbo test' } }));
+    writeFileSync(join(root, 'src/value.mjs'), 'export const value = 1;\n');
+    writeFileSync(join(root, 'tests/benchmark/helper.mjs'), 'export const oldHelper = true;\n');
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'control']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+    writeFileSync(join(root, 'src/value.mjs'), 'export const value = 2;\n');
+    // This new helper export must survive reversion. Reverting scaffolding
+    // would produce a load failure instead of the required assertion failure.
+    writeFileSync(join(root, 'tests/benchmark/helper.mjs'), "export { value as observedValue } from '../../src/value.mjs';\n");
+    writeFileSync(join(root, 'scripts/value.test.mjs'),
+      "import test from 'node:test';\nimport assert from 'node:assert/strict';\nimport { observedValue } from '../tests/benchmark/helper.mjs';\ntest('observes production through helper', () => assert.equal(observedValue, 2));\n");
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'change production, helper and assertion']);
+    const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
+    assert.match(output, /OBSERVED/);
+    assert.match(output, /1 assertion\(s\) RED out of 1 collected/);
+    assert.equal(readFileSync(join(root, 'src/value.mjs'), 'utf8'), 'export const value = 2;\n');
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+
+    // A real unsupported entrypoint must not disappear when helpers are filtered.
+    writeFileSync(join(root, 'tests/benchmark/unsupported.spec.ts'), 'throw new Error("requires a declared runner");\n');
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'add unsupported actual root test']);
+    const rejected = spawnSync(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], { cwd: root, env, encoding: 'utf8', timeout: 20_000 });
+    assert.equal(rejected.error, undefined);
+    assert.notEqual(rejected.status, 0);
+    assert.match(rejected.stdout + rejected.stderr, /no runner could be derived/);
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -174,22 +174,22 @@ export function extractNodeFlags(script) {
  * `scripts/**` has no package of its own: the root `scripts.test` is
  * `turbo test`, which runs the workspace and not these files. CI runs each one
  * with an explicit `node --test scripts/<x>.test.mjs` step, so that is what we
- * reproduce. Only plain-JS test files qualify — anything needing a loader must
- * declare a runner rather than be guessed at.
+ * reproduce. Loader-dependent entrypoints require a declared runner.
  */
 export function rootScriptsRunner(files) {
   if (!Array.isArray(files) || files.length === 0) return null;
-  if (!files.every((f) => /^scripts\/.*\.test\.(mjs|js|cjs)$/.test(f))) return null;
-  return { family: 'node-test', bin: 'node', args: ['--test', ...files] };
+  // #4036: retain scaffolding during reversion, but execute only test entrypoints.
+  if (!files.every((f) => classifyPath(f) === 'test')) return null;
+  const entries = files.filter((f) => /\.(test|spec)\.[^/]+$/.test(f));
+  if (entries.length === 0 || !entries.every((f) => /^scripts\/.*\.test\.(mjs|js|cjs)$/.test(f))) return null;
+  return { family: 'node-test', bin: 'node', args: ['--test', ...entries] };
 }
-
 /** Cargo test invocation for a crate. */
 export function cargoRunner(crate) {
   if (!crate) return null;
   return { family: 'cargo', bin: 'cargo', args: ['test', '--no-fail-fast', '-p', crate] };
 }
 
-// ---------------------------------------------------------------------------
 // Runner output parsing — the core of the tool
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What and why

Closes #4036.

A root change containing both `scripts/*.test.mjs` entrypoints and `tests/benchmark/*` helpers aborted the production-revert oracle before running any tests. Root runner selection now excludes retained scaffolding from the executable file list while preserving its existing test classification and retention during reversion. Actual unsupported root `.test`/`.spec` entrypoints still abort.

## How it was verified

- Node 22: `node --test scripts/lib/revert-oracle*.test.mjs` — 55 passed. The new temporary Git repository runs a real assertion through a changed benchmark helper, observes the reverted production value, restores cleanly, and rejects an unsupported root TypeScript spec.
- This PR's actual production-revert gate reports **OBSERVED**: the new test passes before reversion and fails by assertion with the fix removed; the worktree is restored clean.
- Full root `pnpm lint`, module-size, test-wiring, glob-coverage and source-text-assertion gates pass. The library remains within its existing line budget.
- Replaying the originally blocked #4035 group with the corrected gate runs all 27 baseline assertions. Its production revert is **INCONCLUSIVE**, because removing newly introduced production helpers causes a module-load failure. That separate limitation is preserved; this PR changes neither verdict parsing nor CI acceptance policy.

The initial nested fixture run inherited Node's test IPC context and was corrected to give the child runner an independent environment. The first lint run lacked built workspace declarations; rerunning after reusing verified source-equal sibling build outputs passed. No model data, package API, runtime loading behavior or geometry changed.
