### PR TITLE
fix(review): stop one-ended-numeric-bound firing on nested TS generics

### DIFF
--- a/scripts/review/lib/class-applicability.mjs
+++ b/scripts/review/lib/class-applicability.mjs
@@ -111,14 +111,38 @@ function firstPathMatch(input, re) {
  * be mistaken for the comparisons it MAKES. Arrow functions, Rust arrows, JSX
  * closers, shift operators and generic parameters go the same way, or every
  * TypeScript diff in the repository would fire on `=>` alone.
+ *
+ * GENERIC PARAMETERS ARE PEELED TO A FIXPOINT, BEFORE `>>` IS STRIPPED AS A
+ * SHIFT OPERATOR. A single pass of the generic-parameter strip only removes
+ * one level of nesting, so a two-level generic like `Promise<Map<string,
+ * string>>` left its OUTER `<` behind after the inner `<string, string>` was
+ * consumed -- and if the shift-operator strip ran first instead, it reads the
+ * closing `>>` as a right-shift token, orphaning that same outer `<` a
+ * different way.
+ * Either order left one bracket of an ordinary type annotation unpartnered.
+ *
+ * MEASURED, on two unrelated PRs the same day: `Promise<Map<string, string>>`
+ * in a test file's function signature, and `Array<ReturnType<typeof
+ * Rule.model>>` in another. Neither line contains a comparison of any kind,
+ * and both fired `one-ended-numeric-bound` on the strength of an un-consumed
+ * `<` alone. Looping the generic strip first consumes any depth of nesting
+ * before shift/arrow tokens are touched, which also incidentally fixes the
+ * `<Dialog open={open} />` case this file already documents: the whole tag
+ * matches the generic-parameter shape (`<`, a name, non-`<>` body, `>`) before
+ * `/>` is ever stripped, so it is removed as one unit instead of losing its
+ * closing `>` to the JSX-closer strip first.
  */
 function unpartneredComparison(text) {
-  const stripped = String(text)
+  let stripped = String(text)
     .replace(/\\./g, ' ')                          // escapes, before any quote matching
     .replace(/`[^`]*`|'[^']*'|"[^"]*"/g, ' ')      // string and template CONTENTS
-    .replace(/\/\/.*$|\/\*.*?\*\//g, ' ')            // comments
-    .replace(/=>|->|<<|>>|<\/|\/>/g, ' ')
-    .replace(/<[A-Za-z_$][^<>]*>/g, ' ');          // generic parameters, not comparisons
+    .replace(/\/\/.*$|\/\*.*?\*\//g, ' ');           // comments
+  let previous;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(/<[A-Za-z_$][^<>]*>/g, ' '); // generic parameters, not comparisons
+  } while (stripped !== previous);
+  stripped = stripped.replace(/=>|->|<<|>>|<\/|\/>/g, ' ');
   const lower = (stripped.match(/(?:^|[^<>=!])(<=?)(?![=<])/g) || []).length;
   const upper = (stripped.match(/(?:^|[^<>=!])(>=?)(?![=>])/g) || []).length;
   return (lower > 0) !== (upper > 0);

--- a/scripts/review/lib/class-applicability.test.mjs
+++ b/scripts/review/lib/class-applicability.test.mjs
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `one-ended-numeric-bound` must not fire on a nested generic type annotation.
+ *
+ * MEASURED as a live CLASS_PASS_INCOMPLETE on two unrelated PRs the same day:
+ * a test file's `Promise<Map<string, string>>` return type, and another's
+ * `Array<ReturnType<typeof Rule.model>>` variable annotation. Neither line
+ * contains a comparison of any kind. `unpartneredComparison`'s single-pass
+ * generic-parameter strip only consumed the innermost `<...>`, leaving the
+ * outer `<` (or, if the shift-operator strip ran first, the outer `<` after
+ * `>>` was read as a right-shift token) counted as an unpartnered bracket, so
+ * the predicate declared the class applicable on ordinary TypeScript with no
+ * numeric bound in it at all -- a class the model could not honestly answer
+ * `not-applicable` for and got refused, retry after retry, on the same line.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applicableClasses } from './class-applicability.mjs';
+
+/** A minimal single-file, single-hunk `input.files` map, as production builds it. */
+function inputFor(path, addedLines) {
+  const hunk = `@@ -1,0 +1,${addedLines.length} @@\n${addedLines.map((l) => `+${l}`).join('\n')}`;
+  return { files: new Map([[path, { patch: hunk }]]), contextPack: null };
+}
+
+test('does not fire on a two-level nested generic (Promise<Map<string, string>>)', () => {
+  const input = inputFor('packages/bcf/src/schema-validation.test.ts', [
+    'async function realArchiveEntries(fileName: string): Promise<Map<string, string>> {',
+  ]);
+  const applicable = applicableClasses(input);
+  assert.equal(
+    applicable.has('one-ended-numeric-bound'),
+    false,
+    `expected no site, got ${JSON.stringify(applicable.get('one-ended-numeric-bound'))}`,
+  );
+});
+
+test('does not fire on a two-level nested generic (Array<ReturnType<...>>)', () => {
+  const input = inputFor('apps/viewer/src/components/viewer/ClashSetFilterEditor.wiring.test.tsx', [
+    'const commits: Array<ReturnType<typeof Rule.model>> = [];',
+  ]);
+  const applicable = applicableClasses(input);
+  assert.equal(applicable.has('one-ended-numeric-bound'), false);
+});
+
+test('does not fire on a three-level nested generic', () => {
+  const input = inputFor('src/x.ts', ['const x: Foo<Bar<Baz<string>>> = y;']);
+  const applicable = applicableClasses(input);
+  assert.equal(applicable.has('one-ended-numeric-bound'), false);
+});
+
+test('still fires on a genuine one-ended numeric bound', () => {
+  const input = inputFor('src/x.ts', ['if (x > 5) {']);
+  const applicable = applicableClasses(input);
+  assert.equal(applicable.has('one-ended-numeric-bound'), true);
+});
+
+test('still does not fire when both ends are bounded on the same line', () => {
+  const input = inputFor('src/x.ts', ['if (a > b && a < c) {']);
+  const applicable = applicableClasses(input);
+  assert.equal(applicable.has('one-ended-numeric-bound'), false);
+});


### PR DESCRIPTION
## Summary

- The `Claude review` check went red today with `CLASS_PASS_INCOMPLETE` on `one-ended-numeric-bound` on two unrelated PRs, both times because `class-applicability.mjs`'s `unpartneredComparison` misparsed a nested TypeScript generic (`Promise<Map<string, string>>`, `Array<ReturnType<typeof Rule.model>>`) as an unpartnered comparison operator -- neither line contains a comparison.
- Root cause: the generic-parameter strip only peeled one level of `<...>` and ran after the `>>`/shift-operator strip, so a two-level generic's outer `<` always survived as unpartnered.
- Fix: loop the generic-parameter strip to a fixpoint, before the shift/arrow strip runs, so nesting of any depth is fully consumed in one pass.
- This is a different, separate bug from the "names a different class each retry" shape that #3990 already fixed (confirmed present and working on main today) -- this one is the applicability heuristic itself being wrong, not the reviewer under-reporting.

Closes #4045

## Test plan

- [x] `node --test scripts/review/*.test.mjs scripts/review/lib/*.test.mjs` -- 461 passed, 0 failed (adds `class-applicability.test.mjs`: 5 new tests, confirmed RED against the pre-fix code, GREEN after)
- [x] `node scripts/check-module-size.mjs` -- OK
- [x] `node scripts/check-test-wiring.mjs` -- OK
- [x] `node scripts/check-source-text-assertions.mjs` -- OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparison analysis for nested generic TypeScript annotations, preventing them from being incorrectly flagged.
  - Preserved detection of genuine one-ended numeric comparisons while excluding fully bounded comparisons.

- **Tests**
  - Added coverage for nested generic annotations at multiple levels and numeric comparison scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->