### PR TITLE
fix(ci): capture scan findings before Bash errexit

### DIFF
--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -128,9 +128,15 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -uo pipefail
+          # GitHub starts Bash with -e: capture expected findings before
+          # errexit can abort the step (#4062). Keep log-write failures fatal.
+          statuses=(0 0)
           node scripts/scan-dirty-prs.mjs --repo "${{ github.repository }}" \
-            2>&1 | tee "$RUNNER_TEMP/scan.log"
-          rc=${PIPESTATUS[0]}
+            2>&1 | tee "$RUNNER_TEMP/scan.log" || statuses=("${PIPESTATUS[@]}")
+          rc=${statuses[0]}
+          if [ "${statuses[1]}" -ne 0 ]; then
+            exit "${statuses[1]}"
+          fi
           echo "rc=$rc" >> "$GITHUB_OUTPUT"
           # 2 IS "COULD NOT LOOK" AND STILL FAILS THE JOB. Only the FINDING (1)
           # stops reddening main; an API error must not be quietly absorbed,


### PR DESCRIPTION
Main's CI-visibility scan exits before recording an expected finding because GitHub invokes Bash with `-e`. Put the scanner/tee pipeline in an explicit status-capture list so scanner exit 1 can reach the existing label/report path. Scanner errors (exit 2+) and log-write failures still fail the job.

Closes #4062. No scanner classification, PR targeting or application behavior changes.

Validation executed the actual parent and candidate workflow step bodies under `bash -e`, with controlled scanner exits and real `tee`:

| Case | Parent step / recorded status | Candidate step / recorded status |
|---|---|---|
| Scanner 0 | 0 / 0 | 0 / 0 |
| Scanner 1 | 1 / missing | 0 / 1 |
| Scanner 2 | 2 / missing | 2 / 2 |
| Log-write failure, scanner 0 or 1 | 1 / missing | 1 / missing |

All ten expected outcomes passed; `git diff --check` passed. The production failure is visible in [main run 34067337181](https://github.com/LTplus-AG/ifc-lite/actions/runs/34067337181). A post-merge workflow run will verify the live label/report behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated security scan handling to reliably record scan results.
  - Scan findings now continue through the expected review workflow, while genuine scanner errors still correctly fail validation.
  - Failures writing scan logs remain properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->