### PR TITLE
test(perf): preserve runnable PGO qualification harnesses

### DIFF
--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -843,3 +843,17 @@ it does not establish a performance gain or neutrality. Keep endpoint readiness,
 cache completion and offline witness cost separate, and never extrapolate a
 processing-probe gain to the shipping HTTP artifact.
 [Sanitized screen and limitations](evidence/server-json-roundtrip-4064/README.md).
+## Current-source native PGO qualification (#4059, not shipped)
+
+Fresh profile training on five public fixtures produced a broad held-out
+processing-probe improvement across the expanded corpus. The largest model
+has an unresolved median regression and estimator disagreement; physical
+footprint increased across many models. All paired ordered geometry
+fingerprints and counts matched, while the pathological model's CSG census
+varied within both arms. This is neither full-result byte identity nor an
+HTTP, browser, or cross-target shipping result.
+
+The next step is fresh training and qualification of the actual Darwin server
+with its release profile, allocator, features and build-std settings. Do not
+reuse the probe profile as shipping evidence or turn PGO on unconditionally.
+[Sanitized measurements and limits](evidence/native-pgo-current-2026-09-07/README.md).

--- a/scripts/perf/evidence/native-pgo-current-2026-09-07/README.md
+++ b/scripts/perf/evidence/native-pgo-current-2026-09-07/README.md
@@ -1,0 +1,11 @@
+# Native PGO processing-probe qualification
+
+Fresh current-source native profiling qualifies about 9.81% lower aggregate processing-call time across 27 models (9.97% on 22 held out), with exact covered geometry fingerprints/counts in all 135 pairs. This is not an HTTP endpoint or browser benchmark.
+
+The largest model has an unresolved 5.27% median-time penalty despite a faster median paired ratio. Whole-process physical footprint rises 1.39% in aggregate. No no-regression or production-ready claim is supported. Actual-server artifact qualification is a separate next step.
+
+`results.json` contains sanitized labels, numeric results, cohort definitions and source/artifact hashes. It excludes private fixture paths/names, raw geometry, property data and user filesystem paths. Raw evidence remains private. The lesson: compiler profile training can improve common native paths broadly, but a probe win does not transfer automatically to server features, allocators, targets or browser WASM; retain largest-model and memory counterexamples.
+
+The measured pre-squash commit remains recorded unchanged. Public commit [`e40992485`](https://github.com/LTplus-AG/ifc-lite/commit/e40992485dd2a0c845225be237c65fd12603d689) has the identical complete Git tree `497a6155b289d50f083045c12212d119af2bd6f3`; `results.json` records both identities and the tree comparison. Every aggregate now lists its exact member labels, so historical, expanded and independent-large cohorts can be recomputed directly.
+
+The 263 MB model’s CSG failure census varies across runs: baseline values are 194, 195, 197 and 198; candidate values are 194, 195, 196 and 197. Covered ordered geometry fingerprints and counts still match in every pair. This diagnostic variation remains a separate limitation, not a claim of zero or identical CSG failures.

--- a/scripts/perf/evidence/native-pgo-current-2026-09-07/results.json
+++ b/scripts/perf/evidence/native-pgo-current-2026-09-07/results.json
@@ -1,0 +1,1459 @@
+{
+  "sourceCommit": "2a2c0fb555db988230eafad0f196933078d803e7",
+  "target": "aarch64-apple-darwin",
+  "profile": "server-release",
+  "scope": "Predeclared interleaved fresh-process pairs of frozen native PGO/control process_geometry probes; not HTTP endpoint. Complete call excludes source-file read, post-timing fingerprint and result disposal. FNV mesh payload includes identities, exact geometry/normal/index/color/origin/bounds/placement, excludes text metadata/material definitions/UVs/textures/instancing. OS cache uncontrolled.",
+  "cohorts": {
+    "training5": {
+      "models": 5,
+      "completeModels": 5,
+      "geometricMeanMedianPairedRatio": 0.9142285475245959,
+      "geometricMeanMedianTimeRatio": 0.9089750731316599,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "bridge-ifc4x2-15",
+        "large-csg-177",
+        "school-54",
+        "small-haus",
+        "structural-tekla-27"
+      ]
+    },
+    "heldout22": {
+      "models": 22,
+      "completeModels": 22,
+      "geometricMeanMedianPairedRatio": 0.9030494366602873,
+      "geometricMeanMedianTimeRatio": 0.9003467503050537,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "csg-129",
+        "downloads-01-1259mb",
+        "downloads-02-1050mb",
+        "downloads-04-1034mb",
+        "downloads-05-1034mb",
+        "downloads-06-511mb",
+        "downloads-07-283mb",
+        "downloads-08-263mb",
+        "downloads-12-13mb",
+        "downloads-13-13mb",
+        "downloads-14-11mb",
+        "downloads-15-5mb",
+        "downloads-16-1mb",
+        "downloads-17-1mb",
+        "downloads-18-1mb",
+        "downloads-19-0mb",
+        "downloads-20-0mb",
+        "large-architecture-192",
+        "large-architecture-343",
+        "large-mep-1050",
+        "large-sanitary-ifc4-218",
+        "services-73"
+      ]
+    },
+    "all27": {
+      "models": 27,
+      "completeModels": 27,
+      "geometricMeanMedianPairedRatio": 0.9051092789846008,
+      "geometricMeanMedianTimeRatio": 0.9019383853192674,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "bridge-ifc4x2-15",
+        "csg-129",
+        "downloads-01-1259mb",
+        "downloads-02-1050mb",
+        "downloads-04-1034mb",
+        "downloads-05-1034mb",
+        "downloads-06-511mb",
+        "downloads-07-283mb",
+        "downloads-08-263mb",
+        "downloads-12-13mb",
+        "downloads-13-13mb",
+        "downloads-14-11mb",
+        "downloads-15-5mb",
+        "downloads-16-1mb",
+        "downloads-17-1mb",
+        "downloads-18-1mb",
+        "downloads-19-0mb",
+        "downloads-20-0mb",
+        "large-architecture-192",
+        "large-architecture-343",
+        "large-csg-177",
+        "large-mep-1050",
+        "large-sanitary-ifc4-218",
+        "school-54",
+        "services-73",
+        "small-haus",
+        "structural-tekla-27"
+      ]
+    },
+    "historical11": {
+      "models": 11,
+      "completeModels": 11,
+      "geometricMeanMedianPairedRatio": 0.9109357122788614,
+      "geometricMeanMedianTimeRatio": 0.906363540244964,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "bridge-ifc4x2-15",
+        "csg-129",
+        "large-architecture-192",
+        "large-architecture-343",
+        "large-csg-177",
+        "large-mep-1050",
+        "large-sanitary-ifc4-218",
+        "school-54",
+        "services-73",
+        "small-haus",
+        "structural-tekla-27"
+      ]
+    },
+    "expanded16": {
+      "models": 16,
+      "completeModels": 16,
+      "geometricMeanMedianPairedRatio": 0.901125237970689,
+      "geometricMeanMedianTimeRatio": 0.8989086302873085,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "downloads-01-1259mb",
+        "downloads-02-1050mb",
+        "downloads-04-1034mb",
+        "downloads-05-1034mb",
+        "downloads-06-511mb",
+        "downloads-07-283mb",
+        "downloads-08-263mb",
+        "downloads-12-13mb",
+        "downloads-13-13mb",
+        "downloads-14-11mb",
+        "downloads-15-5mb",
+        "downloads-16-1mb",
+        "downloads-17-1mb",
+        "downloads-18-1mb",
+        "downloads-19-0mb",
+        "downloads-20-0mb"
+      ]
+    },
+    "independentNewLarge5": {
+      "models": 5,
+      "completeModels": 5,
+      "geometricMeanMedianPairedRatio": 0.9336249557636461,
+      "geometricMeanMedianTimeRatio": 0.9488345043089882,
+      "geometryFailureLabels": [],
+      "memberLabels": [
+        "downloads-01-1259mb",
+        "downloads-04-1034mb",
+        "downloads-06-511mb",
+        "downloads-07-283mb",
+        "downloads-08-263mb"
+      ]
+    }
+  },
+  "trainingLabels": [
+    "large-csg-177",
+    "small-haus",
+    "structural-tekla-27",
+    "bridge-ifc4x2-15",
+    "school-54"
+  ],
+  "attemptCount": 270,
+  "all135PairsGeometryFingerprintAndCountsExact": true,
+  "failedAttemptCount": 0,
+  "rows": [
+    {
+      "label": "bridge-ifc4x2-15",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8956813206272782,
+      "baseMedianWallMs": 31.516416999999997,
+      "candidateMedianWallMs": 28.694833,
+      "medianTimeRatio": 0.9104725641877375,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -3.2877509999999965,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 14,
+          "geometryMs": 16,
+          "totalMs": 30,
+          "fullLoadWallMs": 32.583,
+          "maximumResidentSetBytes": 101466112,
+          "peakMemoryFootprintBytes": 99778992
+        },
+        "candidate": {
+          "parseMs": 12,
+          "geometryMs": 15,
+          "totalMs": 28,
+          "fullLoadWallMs": 29.811,
+          "maximumResidentSetBytes": 102563840,
+          "peakMemoryFootprintBytes": 100843976
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "csg-129",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9497764772836093,
+      "baseMedianWallMs": 617.414875,
+      "candidateMedianWallMs": 593.064875,
+      "medianTimeRatio": 0.9605613648359217,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -31.008750000000077,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 10,
+          "geometryMs": 601,
+          "totalMs": 612,
+          "fullLoadWallMs": 618.288,
+          "maximumResidentSetBytes": 114933760,
+          "peakMemoryFootprintBytes": 112083376
+        },
+        "candidate": {
+          "parseMs": 8,
+          "geometryMs": 579,
+          "totalMs": 589,
+          "fullLoadWallMs": 594.084,
+          "maximumResidentSetBytes": 116342784,
+          "peakMemoryFootprintBytes": 113426864
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            43
+          ],
+          "degenerateDropped": [
+            6
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            43
+          ],
+          "degenerateDropped": [
+            6
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-01-1259mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9766471864052899,
+      "baseMedianWallMs": 15006.005874999999,
+      "candidateMedianWallMs": 15796.913625000001,
+      "medianTimeRatio": 1.0527060802580155,
+      "candidateSlowerPairs": 2,
+      "medianPairedDeltaMs": -350.4324579999993,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 1191,
+          "geometryMs": 13311,
+          "totalMs": 14500,
+          "fullLoadWallMs": 15096.939,
+          "maximumResidentSetBytes": 6943801344,
+          "peakMemoryFootprintBytes": 6673077696
+        },
+        "candidate": {
+          "parseMs": 1004,
+          "geometryMs": 14192,
+          "totalMs": 15200,
+          "fullLoadWallMs": 15884.247,
+          "maximumResidentSetBytes": 6946013184,
+          "peakMemoryFootprintBytes": 6637540848
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            2238
+          ],
+          "degenerateDropped": [
+            391
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            2238
+          ],
+          "degenerateDropped": [
+            391
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-02-1050mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9048934377623488,
+      "baseMedianWallMs": 1873.247458,
+      "candidateMedianWallMs": 1688.491792,
+      "medianTimeRatio": 0.9013714577799257,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -177.20358299999998,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 716,
+          "geometryMs": 952,
+          "totalMs": 1666,
+          "fullLoadWallMs": 1945.407,
+          "maximumResidentSetBytes": 5198987264,
+          "peakMemoryFootprintBytes": 5182787808
+        },
+        "candidate": {
+          "parseMs": 619,
+          "geometryMs": 879,
+          "totalMs": 1499,
+          "fullLoadWallMs": 1761.689,
+          "maximumResidentSetBytes": 5205819392,
+          "peakMemoryFootprintBytes": 5184164088
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-04-1034mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8767809348478782,
+      "baseMedianWallMs": 2659.880208,
+      "candidateMedianWallMs": 2339.320041,
+      "medianTimeRatio": 0.8794832315997292,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -331.99000000000024,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 900,
+          "geometryMs": 1388,
+          "totalMs": 2295,
+          "fullLoadWallMs": 2733.077,
+          "maximumResidentSetBytes": 3636445184,
+          "peakMemoryFootprintBytes": 3584855208
+        },
+        "candidate": {
+          "parseMs": 746,
+          "geometryMs": 1271,
+          "totalMs": 2011,
+          "fullLoadWallMs": 2412.095,
+          "maximumResidentSetBytes": 3641475072,
+          "peakMemoryFootprintBytes": 3561131128
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            5
+          ],
+          "degenerateDropped": [
+            88
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            5
+          ],
+          "degenerateDropped": [
+            88
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-05-1034mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9037563125951841,
+      "baseMedianWallMs": 1865.219958,
+      "candidateMedianWallMs": 1688.7025,
+      "medianTimeRatio": 0.9053637308335086,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -179.935209,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 716,
+          "geometryMs": 945,
+          "totalMs": 1662,
+          "fullLoadWallMs": 1937.771,
+          "maximumResidentSetBytes": 5179621376,
+          "peakMemoryFootprintBytes": 5156835552
+        },
+        "candidate": {
+          "parseMs": 616,
+          "geometryMs": 871,
+          "totalMs": 1486,
+          "fullLoadWallMs": 1759.95,
+          "maximumResidentSetBytes": 5193302016,
+          "peakMemoryFootprintBytes": 5194191072
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-06-511mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9197622141290872,
+      "baseMedianWallMs": 14911.985083,
+      "candidateMedianWallMs": 13715.480417,
+      "medianTimeRatio": 0.9197622141290872,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -1196.504665999999,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 614,
+          "geometryMs": 14062,
+          "totalMs": 14681,
+          "fullLoadWallMs": 14948.413,
+          "maximumResidentSetBytes": 4065165312,
+          "peakMemoryFootprintBytes": 3982429592
+        },
+        "candidate": {
+          "parseMs": 536,
+          "geometryMs": 12970,
+          "totalMs": 13516,
+          "fullLoadWallMs": 13752.152,
+          "maximumResidentSetBytes": 4057186304,
+          "peakMemoryFootprintBytes": 3840724376
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            2238
+          ],
+          "degenerateDropped": [
+            303
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            2238
+          ],
+          "degenerateDropped": [
+            303
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-07-283mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9326354598912369,
+      "baseMedianWallMs": 2034.0775830000002,
+      "candidateMedianWallMs": 1902.865416,
+      "medianTimeRatio": 0.9354930371896242,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -137.44454199999973,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 182,
+          "geometryMs": 1846,
+          "totalMs": 2025,
+          "fullLoadWallMs": 2052.749,
+          "maximumResidentSetBytes": 939655168,
+          "peakMemoryFootprintBytes": 935101520
+        },
+        "candidate": {
+          "parseMs": 145,
+          "geometryMs": 1749,
+          "totalMs": 1895,
+          "fullLoadWallMs": 1920.893,
+          "maximumResidentSetBytes": 937934848,
+          "peakMemoryFootprintBytes": 900220032
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            84
+          ],
+          "degenerateDropped": [
+            44
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            84
+          ],
+          "degenerateDropped": [
+            44
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-08-263mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9657083147907567,
+      "baseMedianWallMs": 18934.715583999998,
+      "candidateMedianWallMs": 18279.33175,
+      "medianTimeRatio": 0.9653871836050285,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -648.2447920000013,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 296,
+          "geometryMs": 18590,
+          "totalMs": 18887,
+          "fullLoadWallMs": 18954.74,
+          "maximumResidentSetBytes": 4267474944,
+          "peakMemoryFootprintBytes": 3784953360
+        },
+        "candidate": {
+          "parseMs": 244,
+          "geometryMs": 17990,
+          "totalMs": 18234,
+          "fullLoadWallMs": 18299.843,
+          "maximumResidentSetBytes": 4333928448,
+          "peakMemoryFootprintBytes": 3877555824
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            194,
+            195,
+            197,
+            198
+          ],
+          "degenerateDropped": [
+            43
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            194,
+            195,
+            196,
+            197
+          ],
+          "degenerateDropped": [
+            43
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-12-13mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9002708038636965,
+      "baseMedianWallMs": 83.700583,
+      "candidateMedianWallMs": 73.816166,
+      "medianTimeRatio": 0.8819074294858854,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -8.244666999999993,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 23,
+          "geometryMs": 52,
+          "totalMs": 76,
+          "fullLoadWallMs": 84.76,
+          "maximumResidentSetBytes": 108756992,
+          "peakMemoryFootprintBytes": 105939400
+        },
+        "candidate": {
+          "parseMs": 19,
+          "geometryMs": 47,
+          "totalMs": 66,
+          "fullLoadWallMs": 74.844,
+          "maximumResidentSetBytes": 111312896,
+          "peakMemoryFootprintBytes": 108462512
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            2
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            2
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-13-13mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8827032758288088,
+      "baseMedianWallMs": 84.594167,
+      "candidateMedianWallMs": 74.43862499999999,
+      "medianTimeRatio": 0.8799498551714563,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -9.891667000000012,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 24,
+          "geometryMs": 53,
+          "totalMs": 77,
+          "fullLoadWallMs": 85.669,
+          "maximumResidentSetBytes": 108658688,
+          "peakMemoryFootprintBytes": 105841096
+        },
+        "candidate": {
+          "parseMs": 20,
+          "geometryMs": 47,
+          "totalMs": 67,
+          "fullLoadWallMs": 75.479,
+          "maximumResidentSetBytes": 110739456,
+          "peakMemoryFootprintBytes": 107889072
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            2
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            2
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-14-11mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8677732116865061,
+      "baseMedianWallMs": 18.678166,
+      "candidateMedianWallMs": 16.202375,
+      "medianTimeRatio": 0.8674499948228321,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -2.468834000000001,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 8,
+          "geometryMs": 10,
+          "totalMs": 18,
+          "fullLoadWallMs": 19.519,
+          "maximumResidentSetBytes": 64602112,
+          "peakMemoryFootprintBytes": 62898584
+        },
+        "candidate": {
+          "parseMs": 6,
+          "geometryMs": 9,
+          "totalMs": 15,
+          "fullLoadWallMs": 16.99,
+          "maximumResidentSetBytes": 65994752,
+          "peakMemoryFootprintBytes": 64160152
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-15-5mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.903641621104369,
+      "baseMedianWallMs": 98.402208,
+      "candidateMedianWallMs": 89.193416,
+      "medianTimeRatio": 0.9064168153625171,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -9.536376000000004,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 5,
+          "geometryMs": 90,
+          "totalMs": 96,
+          "fullLoadWallMs": 98.804,
+          "maximumResidentSetBytes": 58605568,
+          "peakMemoryFootprintBytes": 55738776
+        },
+        "candidate": {
+          "parseMs": 4,
+          "geometryMs": 83,
+          "totalMs": 87,
+          "fullLoadWallMs": 89.57,
+          "maximumResidentSetBytes": 59375616,
+          "peakMemoryFootprintBytes": 56459672
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            17
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            17
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-16-1mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8591647535834619,
+      "baseMedianWallMs": 8.7555,
+      "candidateMedianWallMs": 7.522417,
+      "medianTimeRatio": 0.8591647535834619,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -1.2330829999999997,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 2,
+          "geometryMs": 5,
+          "totalMs": 8,
+          "fullLoadWallMs": 8.889,
+          "maximumResidentSetBytes": 23199744,
+          "peakMemoryFootprintBytes": 21496168
+        },
+        "candidate": {
+          "parseMs": 1,
+          "geometryMs": 5,
+          "totalMs": 6,
+          "fullLoadWallMs": 7.631,
+          "maximumResidentSetBytes": 24084480,
+          "peakMemoryFootprintBytes": 22348136
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-17-1mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.876288449370318,
+      "baseMedianWallMs": 6.124125,
+      "candidateMedianWallMs": 5.368625,
+      "medianTimeRatio": 0.8766354377155919,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -0.7576250000000009,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 2,
+          "geometryMs": 2,
+          "totalMs": 5,
+          "fullLoadWallMs": 6.207,
+          "maximumResidentSetBytes": 12566528,
+          "peakMemoryFootprintBytes": 10797392
+        },
+        "candidate": {
+          "parseMs": 2,
+          "geometryMs": 2,
+          "totalMs": 4,
+          "fullLoadWallMs": 5.477,
+          "maximumResidentSetBytes": 12926976,
+          "peakMemoryFootprintBytes": 11125072
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-18-1mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8681410005487542,
+      "baseMedianWallMs": 953.316333,
+      "candidateMedianWallMs": 824.5137500000001,
+      "medianTimeRatio": 0.8648899861028606,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -124.88962500000002,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 1,
+          "geometryMs": 951,
+          "totalMs": 953,
+          "fullLoadWallMs": 953.391,
+          "maximumResidentSetBytes": 27525120,
+          "peakMemoryFootprintBytes": 24740200
+        },
+        "candidate": {
+          "parseMs": 1,
+          "geometryMs": 823,
+          "totalMs": 824,
+          "fullLoadWallMs": 824.593,
+          "maximumResidentSetBytes": 28753920,
+          "peakMemoryFootprintBytes": 25739624
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            133
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            133
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-19-0mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8814477244885007,
+      "baseMedianWallMs": 3.988417,
+      "candidateMedianWallMs": 3.4303329999999996,
+      "medianTimeRatio": 0.8600738087316345,
+      "candidateSlowerPairs": 2,
+      "medianPairedDeltaMs": -0.5052499999999993,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 1,
+          "geometryMs": 2,
+          "totalMs": 3,
+          "fullLoadWallMs": 4.026,
+          "maximumResidentSetBytes": 10321920,
+          "peakMemoryFootprintBytes": 8175952
+        },
+        "candidate": {
+          "parseMs": 0,
+          "geometryMs": 2,
+          "totalMs": 3,
+          "fullLoadWallMs": 3.479,
+          "maximumResidentSetBytes": 11075584,
+          "peakMemoryFootprintBytes": 8913232
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "downloads-20-0mb",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9077174243976653,
+      "baseMedianWallMs": 3.254959,
+      "candidateMedianWallMs": 2.757209,
+      "medianTimeRatio": 0.8470794870227244,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -0.30037599999999953,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 0,
+          "geometryMs": 2,
+          "totalMs": 3,
+          "fullLoadWallMs": 3.285,
+          "maximumResidentSetBytes": 9928704,
+          "peakMemoryFootprintBytes": 7782736
+        },
+        "candidate": {
+          "parseMs": 0,
+          "geometryMs": 1,
+          "totalMs": 2,
+          "fullLoadWallMs": 2.799,
+          "maximumResidentSetBytes": 10551296,
+          "peakMemoryFootprintBytes": 8388944
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "large-architecture-192",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9175002844217452,
+      "baseMedianWallMs": 977.1804579999999,
+      "candidateMedianWallMs": 874.8941249999999,
+      "medianTimeRatio": 0.8953250321753774,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -76.41300000000001,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 255,
+          "geometryMs": 626,
+          "totalMs": 881,
+          "fullLoadWallMs": 990.052,
+          "maximumResidentSetBytes": 887160832,
+          "peakMemoryFootprintBytes": 884786232
+        },
+        "candidate": {
+          "parseMs": 221,
+          "geometryMs": 553,
+          "totalMs": 775,
+          "fullLoadWallMs": 888.268,
+          "maximumResidentSetBytes": 888373248,
+          "peakMemoryFootprintBytes": 885769272
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            891
+          ],
+          "degenerateDropped": [
+            963
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            891
+          ],
+          "degenerateDropped": [
+            963
+          ]
+        }
+      }
+    },
+    {
+      "label": "large-architecture-343",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8643733807376618,
+      "baseMedianWallMs": 496.695541,
+      "candidateMedianWallMs": 430.801583,
+      "medianTimeRatio": 0.8673353139685223,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -67.77949899999993,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 305,
+          "geometryMs": 112,
+          "totalMs": 418,
+          "fullLoadWallMs": 518.323,
+          "maximumResidentSetBytes": 892862464,
+          "peakMemoryFootprintBytes": 890504224
+        },
+        "candidate": {
+          "parseMs": 259,
+          "geometryMs": 96,
+          "totalMs": 358,
+          "fullLoadWallMs": 454.484,
+          "maximumResidentSetBytes": 899563520,
+          "peakMemoryFootprintBytes": 897106976
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            88
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            88
+          ]
+        }
+      }
+    },
+    {
+      "label": "large-csg-177",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9095663393106639,
+      "baseMedianWallMs": 736.988791,
+      "candidateMedianWallMs": 650.595791,
+      "medianTimeRatio": 0.8827756933958578,
+      "candidateSlowerPairs": 2,
+      "medianPairedDeltaMs": -67.63687599999992,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 213,
+          "geometryMs": 392,
+          "totalMs": 606,
+          "fullLoadWallMs": 751.162,
+          "maximumResidentSetBytes": 1014169600,
+          "peakMemoryFootprintBytes": 978601112
+        },
+        "candidate": {
+          "parseMs": 176,
+          "geometryMs": 358,
+          "totalMs": 535,
+          "fullLoadWallMs": 664.976,
+          "maximumResidentSetBytes": 1009958912,
+          "peakMemoryFootprintBytes": 1007600792
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "large-mep-1050",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.912528628679462,
+      "baseMedianWallMs": 1845.2810419999998,
+      "candidateMedianWallMs": 1683.6485420000001,
+      "medianTimeRatio": 0.91240765156032,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -162.00937599999997,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 709,
+          "geometryMs": 942,
+          "totalMs": 1658,
+          "fullLoadWallMs": 1915.967,
+          "maximumResidentSetBytes": 5206638592,
+          "peakMemoryFootprintBytes": 5207576776
+        },
+        "candidate": {
+          "parseMs": 619,
+          "geometryMs": 882,
+          "totalMs": 1503,
+          "fullLoadWallMs": 1753.44,
+          "maximumResidentSetBytes": 5197004800,
+          "peakMemoryFootprintBytes": 5197893856
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            2
+          ]
+        }
+      }
+    },
+    {
+      "label": "large-sanitary-ifc4-218",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9301682722575281,
+      "baseMedianWallMs": 574.259167,
+      "candidateMedianWallMs": 534.757833,
+      "medianTimeRatio": 0.9312134028153877,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -39.68179199999997,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 142,
+          "geometryMs": 390,
+          "totalMs": 533,
+          "fullLoadWallMs": 588.528,
+          "maximumResidentSetBytes": 1176059904,
+          "peakMemoryFootprintBytes": 1174914272
+        },
+        "candidate": {
+          "parseMs": 124,
+          "geometryMs": 374,
+          "totalMs": 496,
+          "fullLoadWallMs": 549.4,
+          "maximumResidentSetBytes": 1178386432,
+          "peakMemoryFootprintBytes": 1177191672
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "school-54",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9532488130988038,
+      "baseMedianWallMs": 306.598208,
+      "candidateMedianWallMs": 300.987042,
+      "medianTimeRatio": 0.9816986340637711,
+      "candidateSlowerPairs": 1,
+      "medianPairedDeltaMs": -13.713625000000036,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 95,
+          "geometryMs": 183,
+          "totalMs": 279,
+          "fullLoadWallMs": 310.654,
+          "maximumResidentSetBytes": 406405120,
+          "peakMemoryFootprintBytes": 394166944
+        },
+        "candidate": {
+          "parseMs": 80,
+          "geometryMs": 194,
+          "totalMs": 275,
+          "fullLoadWallMs": 305.026,
+          "maximumResidentSetBytes": 403095552,
+          "peakMemoryFootprintBytes": 396821176
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            6
+          ],
+          "degenerateDropped": [
+            298
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            6
+          ],
+          "degenerateDropped": [
+            298
+          ]
+        }
+      }
+    },
+    {
+      "label": "services-73",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8777161719547897,
+      "baseMedianWallMs": 149.254875,
+      "candidateMedianWallMs": 128.695792,
+      "medianTimeRatio": 0.8622551993695349,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -17.929958,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 56,
+          "geometryMs": 78,
+          "totalMs": 136,
+          "fullLoadWallMs": 154.511,
+          "maximumResidentSetBytes": 463093760,
+          "peakMemoryFootprintBytes": 461587152
+        },
+        "candidate": {
+          "parseMs": 48,
+          "geometryMs": 71,
+          "totalMs": 119,
+          "fullLoadWallMs": 134.48,
+          "maximumResidentSetBytes": 467058688,
+          "peakMemoryFootprintBytes": 465519336
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "small-haus",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.9188793285472973,
+      "baseMedianWallMs": 9.996082999999999,
+      "candidateMedianWallMs": 8.766166,
+      "medianTimeRatio": 0.8769601052732356,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -0.7985420000000012,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 3,
+          "geometryMs": 5,
+          "totalMs": 9,
+          "fullLoadWallMs": 10.237,
+          "maximumResidentSetBytes": 22904832,
+          "peakMemoryFootprintBytes": 20136320
+        },
+        "candidate": {
+          "parseMs": 3,
+          "geometryMs": 5,
+          "totalMs": 8,
+          "fullLoadWallMs": 8.994,
+          "maximumResidentSetBytes": 22921216,
+          "peakMemoryFootprintBytes": 20201856
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    },
+    {
+      "label": "structural-tekla-27",
+      "validPairCount": 5,
+      "allGeometryExact": true,
+      "medianPairedWallRatio": 0.8949963002491477,
+      "baseMedianWallMs": 61.481167000000006,
+      "candidateMedianWallMs": 55.134916,
+      "medianTimeRatio": 0.8967773171904819,
+      "candidateSlowerPairs": 0,
+      "medianPairedDeltaMs": -6.455750000000009,
+      "phaseMedians": {
+        "base": {
+          "parseMs": 19,
+          "geometryMs": 40,
+          "totalMs": 59,
+          "fullLoadWallMs": 63.817,
+          "maximumResidentSetBytes": 306544640,
+          "peakMemoryFootprintBytes": 305054296
+        },
+        "candidate": {
+          "parseMs": 15,
+          "geometryMs": 38,
+          "totalMs": 53,
+          "fullLoadWallMs": 57.558,
+          "maximumResidentSetBytes": 307806208,
+          "peakMemoryFootprintBytes": 306299504
+        }
+      },
+      "diagnosticValues": {
+        "base": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        },
+        "candidate": {
+          "csgFailures": [
+            0
+          ],
+          "degenerateDropped": [
+            0
+          ]
+        }
+      }
+    }
+  ],
+  "artifactSha256": {
+    "base": "6857922d643412e92760a50160c124b9be37617e06b1b4b519b94cd74796aa04",
+    "candidate": "a6ae131d88dc63704043058379e16641e1542cc7ebcbbd276e37d0f56d50721c"
+  },
+  "profileCoverage": {
+    "records": 4029,
+    "missingFunctionWarnings": 309,
+    "hashMismatchWarnings": 0
+  },
+  "limitations": [
+    "Native processing probe only; no HTTP or browser claim.",
+    "Largest (1259 MB) MB model median time +5.27%; median paired ratio -2.34%, unresolved.",
+    "Whole-process physical-footprint aggregate +1.39%.",
+    "No full-result byte identity; fingerprint field coverage is limited.",
+    "No shipping flags changed."
+  ],
+  "publicSourceEquivalent": {
+    "commit": "e40992485dd2a0c845225be237c65fd12603d689",
+    "measuredCommit": "2a2c0fb555db988230eafad0f196933078d803e7",
+    "measuredTree": "497a6155b289d50f083045c12212d119af2bd6f3",
+    "publicTree": "497a6155b289d50f083045c12212d119af2bd6f3",
+    "method": "git rev-parse <commit>^{tree}; exact complete Git tree identity, including perf_probe source",
+    "sourceCommitPreserved": true
+  }
+}

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/README.md
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/README.md
@@ -1,0 +1,40 @@
+# Actual Darwin server PGO qualification: pending
+
+The native processing probe has a qualified corpus result in the [separate record](../native-pgo-current-2026-09-07/README.md). The actual HTTP server screen is still running. No actual-server gain, universal improvement, shipping readiness or profile-use flag change is claimed here.
+
+## What has passed
+
+Five fixed public fixtures trained a fresh instrumented server after the JSON cache roundtrip correction (#4064). Each completed cold geometry/data-model delivery and exact same-process cache replay. Profiles are continuous counter-only, with no value-profile data. All three compiled-source hash maps match despite a later documentation-only commit. Artifact, compiler, source, training and profile evidence is supplied separately in [stack PR #4070](https://github.com/LTplus-AG/ifc-lite/pull/4070), including `pre-screen-provenance.json`; it is not part of this harness-only commit.
+
+LLVM21 value-site warnings do not discard branch profiles: `populateCounters()` and `setBranchWeights()` precede `annotateValueSites()`, whose mismatch returns only from the value annotation helper. The [matching upstream source](https://github.com/llvm/llvm-project/blob/llvmorg-21.1.5/llvm/lib/Transforms/Instrumentation/PGOInstrumentation.cpp) and its digest/line references are recorded. Missing-function diagnostics and value-site warnings remain visible; this is not a warning-free build claim.
+
+## Measurement limits
+
+Cold means a fresh server process, empty application cache and raw IFC upload. The operating-system page cache is not purged; preflight fixture hashing can warm it. Local loopback HTTP includes upload, wire persistence and observer overhead; it does not measure internet latency or physical-disk cold reads. Cold readiness ends at complete data-model receipt; cache publication/replay has separate timestamps. Memory is sampled server RSS, not physical footprint.
+
+Both timed arms finish and their server processes are reaped before offline decoding or evidence retention. The offline child exits before the next pair. One operator owns the timing host; no concurrent builds, profiling, compression or heavy hashing. A single pair is a screen, not a qualified five-pair estimate. The held-out22 cohort is primary; all27 and fixed training5 are secondary.
+
+## Reproduction source
+
+`reproduce/` contains the actual HTTP transport, full wire/data-model witnesses, tests and paired driver, plus parameterized build/training/profile tools. `harness-source-map.json` identifies exact private-origin hashes and published hashes, including explicit path-parameter adaptations. These are manual evidence tools, not production entry points or CI performance gates. User IFC files and generated wire evidence are never committed.
+
+Use Python3.9 or newer and the recorded dependencies in `reproduce/requirements.txt`; use the repository-pinned Rust toolchain and its matching `llvm-profdata`. Darwin training additionally needs the documented16KiB profile section alignment. Do not reuse profiles across source changes or infer other target/compiler behavior.
+
+Provide an experiment `plan.json` with sourceCommit, profileKind and exactly five training rows `{label, path, publicSha256}`. The fixture schema examples are supplied by [stack PR #4070](https://github.com/LTplus-AG/ifc-lite/pull/4070), including `corpus.example.json`; they are not included in this harness-only commit. Replace example paths with local files. The driver requires exactly27 unique fixture hashes and a training subset of5. The same follow-up supplies `capacity-projection.example.json` with label/SHA-linked budgets. Supply an explicitly reviewed PROJECTION file; storage requirements must be re-evaluated for different fixtures.
+
+From this directory, with SOURCE, EXPERIMENT, COMMIT, CORPUS, PROJECTION and PROF_DATA_TOOL set explicitly by the operator:
+
+```bash
+python reproduce/build_server.py --source "$SOURCE" --experiment "$EXPERIMENT" --expected-commit "$COMMIT" control
+python reproduce/build_server.py --source "$SOURCE" --experiment "$EXPERIMENT" --expected-commit "$COMMIT" generate
+python reproduce/train.py --experiment "$EXPERIMENT"
+python reproduce/audit_profile.py --experiment "$EXPERIMENT" --llvm-profdata "$PROF_DATA_TOOL"
+python reproduce/build_server.py --source "$SOURCE" --experiment "$EXPERIMENT" --expected-commit "$COMMIT" use
+python reproduce/screen_http_v2.py --manifest "$CORPUS" --training-plan "$EXPERIMENT/plan.json" --base-provenance "$EXPERIMENT/control-provenance.json" --candidate-provenance "$EXPERIMENT/use-provenance.json" --projection "$PROJECTION" --out "$EXPERIMENT/http-screen" --cpu-window-confirmed
+```
+
+These commands intentionally refuse existing build targets/profiles/output directories. Keep failures instead of silently retrying or overwriting. The APFS retention helper only operates on explicitly released generated evidence; it verifies exact bytes and keeps distinct paths/inodes. Run its tests and inspect capacity permits before use on another filesystem.
+
+Run witness tests with `python -m unittest discover -s reproduce -p 'test_*.py'`; retention tests separately use `-s reproduce/retention`. They encode actual Arrow/Parquet data and mutate payload fields. No source-text assertions or private IFC fixtures are required.
+
+The eventual HTTP verdict will be appended only after all retained output, memory and timing gates have been reviewed. Issue#4059 remains open while that work is active.

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/harness-source-map.json
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/harness-source-map.json
@@ -1,0 +1,87 @@
+{
+  "run.py": {
+    "originalSha256": "8dc81496ca35c578d906b1e8c085268db269fe783d70d7741bbf229c9881db6d",
+    "publishedSha256": "d7556c684657f4075aaca303407d5ceda7c67e14e03c8cbd5a35b2700b32da1f",
+    "adaptation": "MPL header added"
+  },
+  "cache_phase.py": {
+    "originalSha256": "39fc08e9449fcef2c4b41e5c36adef5c904dce40283e60f3d415994e789d5b12",
+    "publishedSha256": "c3b11d5ad06e1a01f60aeab9b0ce8b66649f092d73082b9ef1224fc57b2e3175",
+    "adaptation": "MPL header added"
+  },
+  "wire.py": {
+    "originalSha256": "dd0974bd81c9344870892caa8d9d1311c98c9614b16f0ab54a480969941fd7cb",
+    "publishedSha256": "fac9db1f703935a1fac2f8ba8e037e2442c3ec7269e5b0a8c25d5823b019a8f2",
+    "adaptation": "MPL header added"
+  },
+  "wire_arrow_v2.py": {
+    "originalSha256": "604f3291363df316a7c05a61b1cafa53dd0c719e5d1b6dbbbca3f43ecb705b1c",
+    "publishedSha256": "28a21af46f287ebac4583243f41dacd109576cc420438da6120ac155c49912db",
+    "adaptation": "MPL header added"
+  },
+  "screen_http_v2.py": {
+    "originalSha256": "7fba4e485afc8c15fd3467c7678178fc6d468034e13b33fbb5a71fd3cd8635a7",
+    "publishedSha256": "026944ec9c049b5e70f6d949e2f5056c1dcec752d2483ef604a0260b793bdc56",
+    "adaptation": "MPL header added"
+  },
+  "screen_offline_pair.py": {
+    "originalSha256": "998ba113b7a82372b5945cd7e8be381c92adb387a4fbd456149b93f149640159",
+    "publishedSha256": "b108eecb57abb34b00aca214765a51140e03b1667902744c9db236a815610725",
+    "adaptation": "MPL header added"
+  },
+  "screen_compare_v2.py": {
+    "originalSha256": "b46b00a983a5b49db68301304ca7b758726751da11d0780353f73ec75009a5bc",
+    "publishedSha256": "ac0d7d0b9f2140c3076c948c8a87704b73797c8c0f8f7430fe5ba4444c5b919a",
+    "adaptation": "MPL header added"
+  },
+  "test_wire.py": {
+    "originalSha256": "5f0435b70d14f098e884b6eac60ffc1765406b2dfe469dd75d577c778607f471",
+    "publishedSha256": "ea89aa4c35c29eb59908436ecab9f758d19cb4a2d4a00189dd1263bfd4e12b8d",
+    "adaptation": "MPL header added"
+  },
+  "test_wire_arrow_v2.py": {
+    "originalSha256": "5dbe81aa0f2efafdb46968abe257cecb773479246376a8b6c09769d1bd62554c",
+    "publishedSha256": "a5163d002e725049800a019d420243f6b11f2992652990518aaa54481cb44d15",
+    "adaptation": "MPL header added"
+  },
+  "train.py": {
+    "originalSha256": "daebdf54ff0023e9c83eb59e02a21e30343b62f2e899be082007038920434222",
+    "publishedSha256": "77e9ec5363140ee8bfd7553670e67de4cf4e229cef317d45cadb28b0ed0c684b",
+    "adaptation": "experiment directory supplied by required CLI argument; MPL header added"
+  },
+  "native_pairs.py": {
+    "originalSha256": "ceeeda64f2f717f3c3cc879db54417a5d5f6a299750760a27ccd03337ad68373",
+    "publishedSha256": "0251e4a724f19faa58dc6fa2cc42a16ea9781e6bba133e2ce2eac67d14d6ee30",
+    "adaptation": "manifest path required CLI input; MPL header added"
+  },
+  "build_server.py": {
+    "originalSha256": "8b3d68b2996f2b06663e6c785ef931f6410a7ebf0900e8196c0cf43a87bdbd2c",
+    "publishedSha256": "ce262a0b4ecc8c28b6f7f3a5a6713c7bf636ca788f0c0825baafd113f400a462",
+    "adaptation": "source directory, experiment directory, expected source commit, and build arm are explicit arguments; MPL header added"
+  },
+  "audit_profile.py": {
+    "originalSha256": "8ea1d15f9cd2eacae8013fd197a4b1c897f9bc2e8583dacfedc2b5241da3e5d0",
+    "publishedSha256": "03913c7325301c446a536799f24a0e0f1860426b35e7b33b94ffab0b32c52b99",
+    "adaptation": "CLI paths and source-audited actual streaming serializer selector; MPL header added"
+  },
+  "retention/capacity_guard.py": {
+    "originalSha256": "a8a0a041752c0db3be1746bb2c705faf3e2e0f3c9ef43ef0119b65603aad88c5",
+    "publishedSha256": "27b5f33d3f288ca8e0da2804e4a7a03e7a7d056e5bb5f949ad6e4ac20a4f2b05",
+    "adaptation": "MPL header added; active screen snapshot equality verified for helpers"
+  },
+  "retention/clone_duplicates.py": {
+    "originalSha256": "ddbb62a6ba8f9cde99ae91f3176f6c139dd3c5840bf77a574386fbd7bf9ee3fc",
+    "publishedSha256": "4f24fa429032113cd49943df0ca866881939f41fd82e27cc90f262f6bafa3c84",
+    "adaptation": "MPL header added; active screen snapshot equality verified for helpers"
+  },
+  "retention/test_capacity_guard.py": {
+    "originalSha256": "d7a78019b7be413feb2eed0d2350645e97128458ae57d72e237ab427cf1569e5",
+    "publishedSha256": "93f81e14805801be434e4b7f3b90f6f5f67ece25398db3165a4948e6bac65f34",
+    "adaptation": "MPL header added; active screen snapshot equality verified for helpers"
+  },
+  "retention/test_clone_duplicates.py": {
+    "originalSha256": "3f357a635dda4e7b9608d334d7ff549e8a0f769bb94ed641a41a4951be4f5d4e",
+    "publishedSha256": "e9fbf464e8de94c6f76a05f8a5404c27381243ade7ceac27ea1749f53ec3eaf1",
+    "adaptation": "MPL header added; active screen snapshot equality verified for helpers"
+  }
+}

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/audit_profile.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/audit_profile.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import pathlib,json,subprocess,hashlib,re
+import argparse
+p=argparse.ArgumentParser();p.add_argument('--experiment',type=pathlib.Path,required=True);p.add_argument('--llvm-profdata',required=True);a=p.parse_args();D=a.experiment.resolve();prof=a.llvm_profdata
+raw=sorted((D/'raw').glob('*.profraw'));assert len(raw)==5,[(p.name,p.stat().st_size) for p in raw]
+assert not (D/'merged.profdata').exists()
+for cmd,name in [([prof,'merge','-o',str(D/'merged.profdata'),*[str(p) for p in raw]],'merge'),([prof,'show','--all-functions','--counts',str(D/'merged.profdata')],'functions'),([prof,'show','--detailed-summary',str(D/'merged.profdata')],'summary')]:
+ r=subprocess.run(cmd,capture_output=True,text=True);(D/('profile-'+name+'.stdout.log')).write_text(r.stdout);(D/('profile-'+name+'.stderr.log')).write_text(r.stderr);assert r.returncode==0,(name,r.stderr)
+s=(D/'profile-functions.stdout.log').read_text();records=[]
+for block in re.split(r'(?m)^  (?=\S)',s)[1:]:
+ name=block.splitlines()[0];m=re.search(r'Block counts: \[([^]]*)\]',block)
+ if m:records.append((name,[int(x.strip()) for x in m.group(1).split(',') if x.strip()]))
+coverage={}
+for label,needle in [('scan','next_entity'),('decode','decode_at'),('producer','produce_element_meshes'),('geometrySerialization','build_mesh_tables'),('dataModelSerialization','serialize_data_model_to_parquet')]:
+ hits=[(n,c) for n,c in records if needle in n];coverage[label]={'needle':needle,'records':len(hits),'nonzeroRecords':sum(any(c) for n,c in hits),'maxBlockCount':max([max(c,default=0) for n,c in hits],default=0)}
+assert all(v['nonzeroRecords'] for v in coverage.values()),coverage
+result={'kind':'Continuous counter-only, not full-value profiling','rawSha256':{p.name:hashlib.sha256(p.read_bytes()).hexdigest() for p in raw},'mergedSha256':hashlib.sha256((D/'merged.profdata').read_bytes()).hexdigest(),'recordCount':len(records),'coverage':coverage,'limitation':'IR block counts prove exercised code, not timings or exact function call counts'}
+(D/'coverage-audit.json').write_text(json.dumps(result,indent=2)+'\n');print(json.dumps(result))

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/build_server.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/build_server.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import hashlib,json,os,pathlib,subprocess,sys,time
+import argparse
+p=argparse.ArgumentParser();p.add_argument('--source',type=pathlib.Path,required=True);p.add_argument('--experiment',type=pathlib.Path,required=True);p.add_argument('--expected-commit',required=True);p.add_argument('side',choices=['control','generate','use']);a=p.parse_args()
+D=a.experiment.resolve();D.mkdir(exist_ok=True,parents=True);W=a.source.resolve();SIDE=a.side
+assert SIDE in ['control','generate','use']
+def sha(p):
+ h=hashlib.sha256()
+ with pathlib.Path(p).open('rb') as f:
+  for b in iter(lambda:f.read(8*1024*1024),b''):h.update(b)
+ return h.hexdigest()
+def git(*a):return subprocess.check_output(['git',*a],cwd=W,text=True).strip()
+assert git('rev-parse','HEAD')==a.expected_commit
+assert not git('status','--porcelain')
+unexpected={k:v for k,v in os.environ.items() if v and (k.startswith('CARGO_PROFILE_') or k in ['RUSTFLAGS','CARGO_ENCODED_RUSTFLAGS','RUSTUP_TOOLCHAIN','CARGO_BUILD_TARGET','RUSTC_WRAPPER','RUSTC_WORKSPACE_WRAPPER'])}; assert not unexpected,unexpected
+target=D/('target-'+SIDE);assert not target.exists(); target.mkdir()
+flags={'control':'','generate':'-Cprofile-generate='+str(D/'raw')+' -Clink-arg=-Wl,-sectalign,__DATA,__llvm_prf_cnts,0x4000 -Clink-arg=-Wl,-sectalign,__DATA,__llvm_prf_data,0x4000 -Clink-arg=-Wl,-sectalign,__DATA,__llvm_prf_bits,0x4000','use':'-Cprofile-use='+str(D/'merged.profdata')+' -Cllvm-args=-pgo-warn-missing-function'}[SIDE]
+if SIDE=='use':assert (D/'merged.profdata').exists()
+env=os.environ.copy();env.update(CARGO_TARGET_DIR=str(target),RUSTFLAGS=flags,CARGO_UNSTABLE_BUILD_STD='std,panic_abort')
+cmd=['cargo','build','--release','--package','ifc-lite-server','--target','aarch64-apple-darwin']
+source={f:sha(W/f) for f in git('ls-files','rust','apps/server','Cargo.toml','Cargo.lock','.cargo/config.toml','rust-toolchain.toml','.github/workflows/server-binaries.yml').splitlines()}
+meta={'sourceCommit':git('rev-parse','HEAD'),'sourceTree':git('rev-parse','HEAD^{tree}'),'sourceHashes':source,'command':cmd,'RUSTFLAGS':flags,'CARGO_UNSTABLE_BUILD_STD':'std,panic_abort','features':'default (mimalloc; processing observability)','profile':'release (panic abort)','target':'aarch64-apple-darwin','rustc':subprocess.check_output(['rustc','-Vv'],cwd=W,text=True),'startedUnix':time.time()}
+(D/(SIDE+'-attempt.json')).write_text(json.dumps(meta,indent=2))
+with (D/(SIDE+'.stdout.log')).open('w') as out,(D/(SIDE+'.stderr.log')).open('w') as err:
+ try:r=subprocess.run(cmd,cwd=W,env=env,stdout=out,stderr=err,timeout=1800);meta['exitCode']=r.returncode
+ except subprocess.TimeoutExpired:meta['timeout']=True
+meta['finishedUnix']=time.time();(D/(SIDE+'-result.json')).write_text(json.dumps(meta,indent=2))
+assert meta.get('exitCode')==0
+assert all(sha(W/f)==h for f,h in source.items())
+binary=target/'aarch64-apple-darwin/release/ifc-lite-server';meta.update(binary=str(binary),binarySha256=sha(binary))
+(D/(SIDE+'-provenance.json')).write_text(json.dumps(meta,indent=2)+'\n');print(json.dumps({'binary':str(binary),'sha256':meta['binarySha256'],'seconds':meta['finishedUnix']-meta['startedUnix']}),flush=True)

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/cache_phase.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/cache_phase.py
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Post-cold cache completion/replay witness. Cold readiness is already frozen."""
+import base64,hashlib,io,json,time
+from wire import decode_run
+
+
+def replay(session,url,source_sha,out,now,timeout):
+    start=time.monotonic();polls=[]
+    def check_deadline():
+        if time.monotonic()-start>timeout:raise TimeoutError('Cache readiness/replay deadline')
+    replay_out=out/'cache-replay';replay_out.mkdir()
+    while True:
+        check_deadline()
+        r=session.get(url+'/api/v1/cache/check/'+source_sha+'?parquet_layout=flat',timeout=timeout)
+        polls.append({'ms':now(),'stage':'check','status':r.status_code})
+        if r.status_code not in (200,404):raise RuntimeError(f'Cache check status {r.status_code}')
+        if r.status_code==200:
+            r=session.post(url+'/api/v1/parse/parquet-stream?parquet_layout=flat&sha256='+source_sha,stream=True,timeout=timeout)
+            polls.append({'ms':now(),'stage':'hash-only','status':r.status_code})
+            if r.status_code==200:break
+            if r.status_code!=404:raise RuntimeError(f'Hash-only replay status {r.status_code}')
+            r.close()
+        time.sleep(.05)
+    result={'cacheReadyMs':now(),'polls':polls,'request':'hash-only POST; no source body'}
+    batch=0;complete=False;key=None;payload=[]
+    # urllib3 readinto honors decode_content; BufferedReader avoids quadratic
+    # repeated splitting of a growing multi-megabyte base64 SSE record.
+    r.raw.decode_content=True
+    r.raw.auto_close=False
+    with r, io.BufferedReader(r.raw,buffer_size=64*1024) as buffered, (replay_out/'events.jsonl').open('w') as f:
+        for line in iter(buffered.readline,b''):
+            line=line.rstrip(b'\r\n')
+            check_deadline()
+            if line:
+                if line.startswith(b'data:'):payload.append(line[5:].strip())
+                continue
+            if not payload:continue
+            e=json.loads(b'\n'.join(payload));payload=[]
+            if complete:raise ValueError('Replay event after complete')
+            if e['type']=='start':
+                if key is not None:raise ValueError('Duplicate replay start')
+                key=e['cache_key']
+            elif e['type']=='batch':
+                batch+=1
+                if e['batch_number']!=batch:raise ValueError('Replay batch sequence mismatch')
+                data=base64.b64decode(e.pop('data'),validate=True)
+                e['file']=f'batch-{batch:05}.bin';e['wireSha256']=hashlib.sha256(data).hexdigest()
+                (replay_out/e['file']).write_bytes(data)
+            elif e['type']=='complete':complete=True
+            elif e['type']=='error':raise RuntimeError(e['message'])
+            elif e['type']!='progress':raise ValueError('Unknown replay event')
+            f.write(json.dumps(e)+'\n')
+    if payload or not complete or key is None:raise ValueError('Incomplete cache replay')
+    r=session.get(url+'/api/v1/parse/data-model/'+key,timeout=timeout)
+    if r.status_code!=200:raise RuntimeError('Cached data-model fetch failed')
+    (replay_out/'data-model.bin').write_bytes(r.content)
+    result['replayCompleteMs']=now()
+    return result
+
+
+def compare_replay(out,cold):
+    cached=decode_run(out/'cache-replay',expected_cache=None)
+    fields={k:cold[k]==cached[k] for k in cold}
+    def raw_batches(path):
+        events=[json.loads(line) for line in (path/'events.jsonl').read_text().splitlines()]
+        return [e['wireSha256'] for e in events if e['type']=='batch']
+    report={'exactDecodedFields':fields,'rawBatchBytesMatch':raw_batches(out)==raw_batches(out/'cache-replay'),
+            'rawDataModelBytesMatch':(out/'data-model.bin').read_bytes()==(out/'cache-replay/data-model.bin').read_bytes()}
+    (out/'cache-replay-comparison.json').write_text(json.dumps(report,indent=2)+'\n')
+    if not all(fields.values()):raise ValueError('Cache replay exact semantic mismatch: '+str(fields))

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/native_pairs.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/native_pairs.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Private cold native qualification. Run only in an exclusive measurement window.
+Frozen probe binaries must be built from named source commits before this runs.
+The OS file cache is uncontrolled. Mesh hash excludes UVs/textures/instancing.
+"""
+import argparse, hashlib, json, os, pathlib, subprocess, time, re
+root = pathlib.Path(__file__).parent
+p = argparse.ArgumentParser()
+p.add_argument('--manifest', type=pathlib.Path, required=True)
+p.add_argument('--artifacts', type=pathlib.Path, required=True)
+p.add_argument('--out', type=pathlib.Path, required=True)
+p.add_argument('--pairs', type=int, default=5)
+p.add_argument('labels', nargs='+')
+args = p.parse_args()
+if args.pairs < 1: p.error('--pairs must be positive')
+manifest = json.loads(args.manifest.read_text())
+rows = {row['label']: row for row in manifest['expanded_corpus']}
+if set(args.labels) - rows.keys(): p.error('unknown fixture labels')
+artifacts = json.loads(args.artifacts.read_text())
+for side in ['base', 'candidate']:
+    artifact = artifacts[side]
+    digest = hashlib.sha256(pathlib.Path(artifact['binary']).read_bytes()).hexdigest()
+    if digest != artifact['sha256'] or not artifact['sourceCommit']:
+        raise RuntimeError('Missing or mismatched binary provenance')
+args.out.mkdir(parents=True, exist_ok=True)
+# File hashing is a preflight outside all timed runs; do not claim a cold OS cache.
+for label in args.labels:
+    row = rows[label]
+    digest = hashlib.sha256()
+    with open(row['path'], 'rb') as source:
+        for block in iter(lambda: source.read(8*1024*1024), b''): digest.update(block)
+    if digest.hexdigest() != row['fixture_identity']['sha256']:
+        raise RuntimeError('Fixture identity changed: '+label)
+for repetition in range(args.pairs):
+    for index, label in enumerate(args.labels):
+        row = rows[label]
+        for side in (['base', 'candidate'] if (repetition+index)%2 == 0 else ['candidate', 'base']):
+            out = args.out/f'{label}-pair{repetition+1}-{side}'
+            if out.exists():
+                print(json.dumps({'preservedExistingAttempt': str(out)}), flush=True)
+                continue
+            out.mkdir()
+            command = ['/usr/bin/time', '-l', artifacts[side]['binary'], row['path'], '--cold', '--iters', '1', '--fingerprint', '--json']
+            status = {'label': label, 'pair': repetition+1, 'side': side, 'fixtureSha256': row['fixture_identity']['sha256'], 'artifact': artifacts[side], 'startedUnix': time.time(), 'command': command}
+            (out/'attempt.json').write_text(json.dumps(status, indent=2))
+            with (out/'stdout.json').open('w') as stdout, (out/'stderr.log').open('w') as stderr:
+                try:
+                    result = subprocess.run(command, stdout=stdout, stderr=stderr, timeout=600)
+                    status['exitCode'] = result.returncode
+                except subprocess.TimeoutExpired:
+                    status['timeout'] = True
+            status['finishedUnix'] = time.time()
+            if status.get('exitCode') == 0:
+                try:
+                    values = json.loads((out/'stdout.json').read_text())
+                    if len(values) != 1 or not values[0].get('cold') or len(values[0].get('meshFingerprintsFnv1a64', [])) != 1:
+                        raise ValueError('Missing exact cold single-fixture witness')
+                    status['measurement'] = values[0]
+                    diagnostic = (out/'stderr.log').read_text()
+                    for field, pattern in [('maximumResidentSetBytes', r'([0-9]+)\s+maximum resident set size'), ('peakMemoryFootprintBytes', r'([0-9]+)\s+peak memory footprint')]:
+                        match = re.search(pattern, diagnostic)
+                        if not match: raise ValueError('Missing native process memory witness: '+field)
+                        status['measurement'][field] = int(match.group(1))
+                except (ValueError, KeyError) as error:
+                    status['invalidOutput'] = str(error)
+            (out/'result.json').write_text(json.dumps(status, indent=2))
+            print(json.dumps(status), flush=True)

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/requirements.txt
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/requirements.txt
@@ -1,0 +1,3 @@
+pyarrow==21.0.0
+requests==2.31.0
+psutil==7.1.0

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/capacity_guard.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/capacity_guard.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Pre-pair disk reserve gate; call before launching either timed arm.
+No hashing, compression, deletion or directory walks. Refusal is retained.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import time
+
+
+def check(projection, label, filesystem, output):
+    config=json.loads(Path(projection).read_text())
+    matches=[r for r in config['models'] if r['label']==label]
+    if len(matches)!=1:raise ValueError('Expected one SHA-pinned fixture label')
+    row=matches[0];fs=os.statvfs(filesystem);available=fs.f_bavail*fs.f_frsize
+    required=config['reserveBytes']+row['pairBudgetBytes']
+    result={'protocol':'http-evidence-capacity-v1','time':time.time(),'label':label,
+            'fixtureSha256':row['fixtureSha256'],'availableBytes':available,
+            'reserveBytes':config['reserveBytes'],'pairBudgetBytes':row['pairBudgetBytes'],
+            'requiredBytes':required,'allowPair':available>=required,
+            'scope':'Capacity estimate, not a bound on arbitrary IFC expansion. No retention work may overlap either timed arm.'}
+    with Path(output).open('x') as stream:json.dump(result,stream,indent=2);stream.write('\n')
+    if not result['allowPair']:raise RuntimeError('Insufficient disk for next pair plus reserve; retain evidence and compact only outside timing')
+    return result
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser();p.add_argument('--projection',required=True);p.add_argument('--label',required=True);p.add_argument('--filesystem',required=True);p.add_argument('--output',required=True)
+    a=p.parse_args();print(json.dumps(check(a.projection,a.label,a.filesystem,a.output),indent=2))

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/clone_duplicates.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/clone_duplicates.py
@@ -1,0 +1,202 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Private APFS COW retention for explicitly released generated HTTP evidence.
+No fixture/cache-input selection, hardlinks, or unique-content deletion. Planning
+is read-only; applying verifies every replacement before atomic publication.
+Run only outside timing windows. Independent inode is required before/after.
+"""
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+import time
+import uuid
+
+BLOCK = 2 * 1024 * 1024
+
+
+def signature(path):
+    s = path.lstat()
+    if not stat.S_ISREG(s.st_mode) or s.st_nlink != 1:
+        raise ValueError(f'Expected independently owned regular file: {path}')
+    return {'dev': s.st_dev, 'inode': s.st_ino, 'size': s.st_size,
+            'mtimeNs': s.st_mtime_ns, 'mode': stat.S_IMODE(s.st_mode)}
+
+
+def sha(path):
+    h = hashlib.sha256()
+    with path.open('rb') as stream:
+        while block := stream.read(BLOCK): h.update(block)
+    return h.hexdigest()
+
+
+def same_bytes(a, b):
+    with a.open('rb') as aa, b.open('rb') as bb:
+        while True:
+            x = aa.read(BLOCK); y = bb.read(BLOCK)
+            if x != y: return False
+            if not x: return True
+
+
+def safe_path(root, relative):
+    p = root / relative
+    if p.resolve() != p.absolute() or not p.is_relative_to(root):
+        raise ValueError(f'Path escapes root or traverses symlink: {p}')
+    return p
+
+
+def selected(path):
+    return path.name in ('semantic.json', 'semantic-v2.json', 'data-model.bin') or (path.name.startswith('batch-') and path.suffix == '.bin')
+
+
+def write_new(path, value):
+    with path.open('x') as stream:
+        json.dump(value, stream, indent=2); stream.write('\n'); stream.flush(); os.fsync(stream.fileno())
+
+
+def plan(root, released, output):
+    sizes = {}; inventory = []
+    for relative in released:
+        directory = safe_path(root, relative)
+        if not directory.is_dir(): raise ValueError(directory)
+        for parent, dirs, files in os.walk(directory, followlinks=False):
+            dirs[:] = [name for name in dirs if name != 'cache' and not (Path(parent) / name).is_symlink()]
+            for name in files:
+                p = Path(parent) / name
+                if not selected(p): continue
+                sig = signature(p); rel = str(p.relative_to(root))
+                if any(row['path'] == rel for row in inventory): raise ValueError('Overlapping release scopes')
+                row = {'path': rel, 'before': sig}; inventory.append(row)
+                sizes.setdefault(sig['size'], []).append(row)
+    groups = []
+    for length, rows in sizes.items():
+        if not length or len(rows) < 2: continue
+        hashes = {}
+        for row in rows:
+            p = safe_path(root, row['path']); digest = sha(p)
+            if signature(p) != row['before']: raise ValueError(f'File changed during planning: {p}')
+            row['sha256'] = digest; hashes.setdefault(digest, []).append(row)
+        for digest, matches in hashes.items():
+            if len(matches) > 1:
+                groups.append({'sha256': digest, 'bytesEach': length, 'files': matches})
+    available = os.statvfs(root).f_bavail * os.statvfs(root).f_frsize
+    result = {'protocol': 'apfs-evidence-retention-v1', 'createdUnix': time.time(), 'root': str(root),
+              'releasedScopes': released, 'selection': 'semantic.json / semantic-v2.json / data-model.bin / batch-*.bin; cache directories excluded',
+              'filesInventoried': len(inventory), 'logicalBytes': sum(row['before']['size'] for row in inventory),
+              'availableBytesBefore': available, 'duplicateGroups': groups,
+              'estimatedDuplicateLogicalBytes': sum(g['bytesEach'] * (len(g['files']) - 1) for g in groups),
+              'limit': 'Potential shared extent bytes, not promised physical free space; APFS snapshots and existing clones can retain extents.'}
+    write_new(output, result)
+    print(json.dumps({k: v for k, v in result.items() if k != 'duplicateGroups'}, indent=2))
+
+
+def clone(source, target):
+    libc = ctypes.CDLL('/usr/lib/libSystem.B.dylib', use_errno=True)
+    fn = libc.clonefile; fn.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int); fn.restype = ctypes.c_int
+    if fn(os.fsencode(source), os.fsencode(target), 0) != 0:
+        code = ctypes.get_errno(); raise OSError(code, os.strerror(code), str(target))
+
+
+def xattrs(path):
+    # Apple's system Python omits os.listxattr; use the native macOS API.
+    libc = ctypes.CDLL('/usr/lib/libSystem.B.dylib', use_errno=True)
+    libc.listxattr.argtypes = (ctypes.c_char_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int)
+    libc.listxattr.restype = ctypes.c_ssize_t
+    libc.getxattr.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32, ctypes.c_int)
+    libc.getxattr.restype = ctypes.c_ssize_t
+    encoded = os.fsencode(path); size = libc.listxattr(encoded, None, 0, 0)
+    if size < 0: raise OSError(ctypes.get_errno(), 'listxattr failed')
+    names = ctypes.create_string_buffer(size)
+    actual = libc.listxattr(encoded, names, size, 0)
+    if actual < 0: raise OSError(ctypes.get_errno(), 'listxattr failed')
+    result = {}
+    for key in names.raw[:actual].split(b'\0'):
+        if not key: continue
+        length = libc.getxattr(encoded, key, None, 0, 0, 0)
+        if length < 0: raise OSError(ctypes.get_errno(), 'getxattr failed')
+        data = ctypes.create_string_buffer(length)
+        actual = libc.getxattr(encoded, key, data, length, 0, 0)
+        if actual < 0: raise OSError(ctypes.get_errno(), 'getxattr failed')
+        result[key] = data.raw[:actual]
+    return result
+
+
+def set_xattrs(path, attrs):
+    libc = ctypes.CDLL('/usr/lib/libSystem.B.dylib', use_errno=True)
+    libc.removexattr.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int)
+    libc.setxattr.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_uint32, ctypes.c_int)
+    encoded = os.fsencode(path)
+    for key in xattrs(path):
+        if key not in attrs and libc.removexattr(encoded, key, 0) != 0:
+            raise OSError(ctypes.get_errno(), 'removexattr failed')
+    for key, value in attrs.items():
+        if libc.setxattr(encoded, key, value, len(value), 0, 0) != 0:
+            raise OSError(ctypes.get_errno(), 'setxattr failed')
+    if xattrs(path) != attrs: raise ValueError('Extended attribute preservation failed')
+
+
+def apply(plan_path, output):
+    manifest = json.loads(plan_path.read_text()); root = Path(manifest['root'])
+    if output.exists(): raise FileExistsError(output)
+    # Fail before any mutation if a released file changed after the dry run.
+    for group in manifest['duplicateGroups']:
+        for row in group['files']:
+            if signature(safe_path(root, row['path'])) != row['before']:
+                raise ValueError(f"File changed since plan: {row['path']}")
+    log = output.open('x')
+    def record(item):
+        log.write(json.dumps(item) + '\n'); log.flush(); os.fsync(log.fileno())
+    record({'type': 'start', 'plan': str(plan_path), 'planSha256': sha(plan_path), 'time': time.time()})
+    try:
+        for group in manifest['duplicateGroups']:
+            source_row = group['files'][0]; source = safe_path(root, source_row['path'])
+            if sha(source) != group['sha256']: raise ValueError('Canonical content changed')
+            for row in group['files'][1:]:
+                target = safe_path(root, row['path']); before = signature(target)
+                if before != row['before'] or signature(source) != source_row['before']:
+                    raise ValueError('File changed before replacement')
+                if before['inode'] == source_row['before']['inode']: raise ValueError('Hardlink not allowed')
+                temporary = target.with_name(target.name + '.cow-' + uuid.uuid4().hex)
+                old_stat = target.stat()
+                attrs = xattrs(target)
+                clone(source, temporary)
+                try:
+                    if not same_bytes(temporary, target): raise ValueError('Exact byte comparison failed')
+                    if sha(temporary) != group['sha256']: raise ValueError('Clone hash mismatch')
+                    cloned = signature(temporary)
+                    if cloned['inode'] in (before['inode'], source_row['before']['inode']): raise ValueError('Clone inode not independent')
+                    set_xattrs(temporary, attrs)
+                    os.chmod(temporary, before['mode'])
+                    os.utime(temporary, ns=(old_stat.st_atime_ns, old_stat.st_mtime_ns))
+                    if signature(target) != before or signature(source) != source_row['before']:
+                        raise ValueError('File changed during replacement validation')
+                    record({'type': 'verifiedBeforeReplace', 'source': source_row['path'], 'target': row['path'],
+                            'sha256': group['sha256'], 'before': before, 'cloneInode': cloned['inode'], 'exactByteComparison': True})
+                    os.replace(temporary, target)
+                    after = signature(target)
+                    if after['inode'] != cloned['inode'] or sha(target) != group['sha256']:
+                        raise ValueError('Published clone verification failed')
+                    record({'type': 'replaced', 'target': row['path'], 'after': after,
+                            'sourceInode': source_row['before']['inode'], 'sha256': group['sha256'], 'bytes': group['bytesEach']})
+                finally:
+                    if temporary.exists(): temporary.unlink()  # only our unpublished clone
+        free = os.statvfs(root).f_bavail * os.statvfs(root).f_frsize
+        record({'type': 'complete', 'availableBytesAfter': free, 'time': time.time()})
+    except Exception as error:
+        record({'type': 'failed', 'error': repr(error), 'time': time.time()}); raise
+    finally:
+        log.close()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(); sub = parser.add_subparsers(dest='command', required=True)
+    p = sub.add_parser('plan'); p.add_argument('--root', type=Path, required=True); p.add_argument('--released', nargs='+', required=True); p.add_argument('--output', type=Path, required=True)
+    p = sub.add_parser('apply'); p.add_argument('--plan', type=Path, required=True); p.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    if args.command == 'plan': plan(args.root.absolute(), args.released, args.output)
+    else: apply(args.plan, args.output)

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/test_capacity_guard.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/test_capacity_guard.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Capacity gates preserve SHA identity and refusal records."""
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from capacity_guard import check
+
+
+class CapacityContract(unittest.TestCase):
+    def test_allowed_pair_records_identity_and_refuses_overwrite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);config=root/'projection.json';out=root/'permit.json'
+            config.write_text(json.dumps({'reserveBytes':0,'models':[{'label':'fixture','fixtureSha256':'f'*64,'pairBudgetBytes':1}]}))
+            result=check(config,'fixture',root,out)
+            self.assertTrue(result['allowPair']);self.assertEqual(result['fixtureSha256'],'f'*64)
+            with self.assertRaises(FileExistsError):check(config,'fixture',root,out)
+
+    def test_insufficient_capacity_preserves_refusal_before_launch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory);config=root/'projection.json';out=root/'refusal.json'
+            config.write_text(json.dumps({'reserveBytes':2**62,'models':[{'label':'fixture','fixtureSha256':'f'*64,'pairBudgetBytes':1}]}))
+            with self.assertRaises(RuntimeError):check(config,'fixture',root,out)
+            result=json.loads(out.read_text());self.assertFalse(result['allowPair'])
+            with self.assertRaises(ValueError):check(config,'missing',root,root/'bad.json')
+
+
+if __name__=='__main__':unittest.main()

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/test_clone_duplicates.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/retention/test_clone_duplicates.py
@@ -1,0 +1,64 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Behavioral APFS clone tests on owned synthetic evidence only."""
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from clone_duplicates import plan, apply, sha, set_xattrs, xattrs
+
+
+class RetentionContract(unittest.TestCase):
+    def test_exact_preservation_independent_inodes_and_cow_isolation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory).resolve()
+            payload=b'0123456789abcdef'*8192
+            paths=[]
+            for name in ('a','b','c'):
+                p=root/name/'semantic-v2.json';p.parent.mkdir();p.write_bytes(payload if name!='c' else payload+b'unique');paths.append(p)
+            set_xattrs(paths[0], {b'user.source-only': b'source'})
+            set_xattrs(paths[1], {b'user.target-only': b'target\x00bytes'})
+            before={str(p):{'sha':sha(p),'inode':p.stat().st_ino,'mtime':p.stat().st_mtime_ns} for p in paths}
+            plan(root,['a','b','c'],root/'plan.json')
+            manifest=json.loads((root/'plan.json').read_text())
+            self.assertEqual(manifest['estimatedDuplicateLogicalBytes'],len(payload))
+            apply(root/'plan.json',root/'applied.jsonl')
+            self.assertEqual(len({p.stat().st_ino for p in paths}),3)
+            self.assertEqual(xattrs(paths[0]), {b'user.source-only': b'source'})
+            self.assertEqual(xattrs(paths[1]), {b'user.target-only': b'target\x00bytes'})
+            for p in paths:
+                self.assertEqual(sha(p),before[str(p)]['sha'])
+                self.assertEqual(p.stat().st_mtime_ns,before[str(p)]['mtime'])
+                self.assertEqual(p.stat().st_nlink,1)
+            self.assertEqual(paths[2].stat().st_ino,before[str(paths[2])]['inode'])
+            with paths[1].open('r+b') as stream:stream.write(b'changed')
+            self.assertEqual(sha(paths[0]),before[str(paths[0])]['sha'])
+            self.assertEqual(paths[2].read_bytes(),payload+b'unique')
+
+    def test_stale_plan_stops_before_replacement(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory).resolve()
+            for name in ('a','b'):
+                p=root/name/'data-model.bin';p.parent.mkdir();p.write_bytes(b'identical')
+            plan(root,['a','b'],root/'plan.json')
+            before=(root/'a/data-model.bin').stat().st_ino
+            (root/'b/data-model.bin').write_bytes(b'changed')
+            with self.assertRaises(ValueError):apply(root/'plan.json',root/'applied.jsonl')
+            self.assertEqual((root/'a/data-model.bin').stat().st_ino,before)
+            self.assertFalse((root/'applied.jsonl').exists())
+
+    def test_symlinks_hardlinks_and_overlapping_scopes_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory).resolve();(root/'a').mkdir();(root/'a/data-model.bin').write_bytes(b'x')
+            with self.assertRaises(ValueError):plan(root,['a','a'],root/'bad.json')
+            (root/'b').mkdir();(root/'b/data-model.bin').symlink_to(root/'a/data-model.bin')
+            with self.assertRaises(ValueError):plan(root,['b'],root/'bad.json')
+            (root/'b/data-model.bin').unlink()
+            os.link(root/'a/data-model.bin',root/'b/data-model.bin')
+            with self.assertRaises(ValueError):plan(root,['a','b'],root/'bad.json')
+
+
+if __name__=='__main__':unittest.main()

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/run.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/run.py
@@ -1,0 +1,163 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#!/usr/bin/env python3
+"""Private actual HTTP server qualification. Never a viewer-readiness claim.
+Raw wire persistence and RSS sampling run during timing; decoding runs afterward.
+Fresh process/cache per invocation. No implicit artifact selection or retries.
+"""
+import argparse,base64,hashlib,http.client,json,os,socket,subprocess,threading,time,traceback
+from pathlib import Path
+import psutil,requests,pyarrow,platform
+from wire import decode_run
+from cache_phase import replay,compare_replay
+
+
+def sha(path):
+    h=hashlib.sha256()
+    with open(path,'rb') as f:
+        for b in iter(lambda:f.read(1024*1024),b''):h.update(b)
+    return h.hexdigest()
+
+
+def run(a):
+    out=Path(a.out).resolve();out.mkdir(exist_ok=False,parents=True)
+    fixture=Path(a.fixture).resolve();binary=Path(a.binary).resolve()
+    provenance=json.loads(Path(a.provenance).read_text())
+    actual=sha(binary)
+    if provenance['binarySha256']!=actual:raise ValueError('Frozen binary digest mismatch')
+    (out/'provenance.json').write_text(json.dumps(provenance,indent=2)+'\n')
+    result={'success':False,'binarySha256':actual,'fixtureSha256':sha(fixture),'sourceBytes':fixture.stat().st_size,
+            'harnessSha256':{name:sha(Path(__file__).with_name(name)) for name in ('run.py','wire.py','cache_phase.py')},
+            'dependencies':{'python':platform.python_version(),'pyarrow':pyarrow.__version__,'requests':requests.__version__,'psutil':psutil.__version__},
+            'startedAtUnixSeconds':time.time(),'workers':a.workers,'clock':'monotonic wall; startup and upload/readiness origins reported separately',
+            'limits':'HTTP server readiness, not browser render/search/picking; RSS is not physical footprint',
+            'rawPersistenceDuringTiming':True,'decoderAfterTiming':True}
+    cache=out/'cache';cache.mkdir()
+    with socket.socket() as s:s.bind(('127.0.0.1',0));port=s.getsockname()[1]
+    env=os.environ.copy()
+    # Pin inherited controls that could change admission, cache or geometry batching.
+    settings={'PORT':str(port),'CACHE_DIR':str(cache),'WORKER_THREADS':str(a.workers),
+      'MAX_FILE_SIZE_MB':str(max(16,(fixture.stat().st_size+1048575)//1048576+1)),
+      'REQUEST_TIMEOUT_SECS':str(a.timeout),'IFC_MAX_CONCURRENT_PARSES':str(a.workers),
+      'IFC_MEM_BUDGET_MB':'0','IFC_ADMISSION_QUEUE_DEPTH':str(2*a.workers),
+      'IFC_ADMISSION_QUEUE_TIMEOUT_SECS':'5','IFC_MEM_SHED_PCT':'85','RUST_LOG':'info',
+      'INITIAL_BATCH_SIZE':'100','MAX_BATCH_SIZE':'1000','IFC_SERVER_API_TOKEN':'','API_TOKEN':''}
+    env.update(settings);result['environment']=settings
+    result['instrumentationEnvironment']={k:env[k] for k in ('LLVM_PROFILE_FILE',) if k in env}
+    session=requests.Session();session.trust_env=False
+    start=time.monotonic();now=lambda:round((time.monotonic()-start)*1000,3)
+    log=open(out/'server.log','wb');proc=subprocess.Popen([str(binary)],cwd=out,env=env,stdout=log,stderr=subprocess.STDOUT)
+    stop=threading.Event();samples=[]
+    def sample():
+        p=psutil.Process(proc.pid)
+        while not stop.is_set():
+            try:samples.append({'ms':now(),'rss':p.memory_info().rss})
+            except psutil.NoSuchProcess:break
+            stop.wait(.05)
+    monitor=threading.Thread(target=sample,daemon=True);monitor.start()
+    timed_out=threading.Event()
+    def kill_deadline():
+        timed_out.set()
+        if proc.poll() is None:proc.kill()
+    watchdog=threading.Timer(a.timeout+30,kill_deadline);watchdog.start()
+    try:
+        url=f'http://127.0.0.1:{port}'
+        while True:
+            if proc.poll() is not None:raise RuntimeError('Server exited before readiness')
+            try:
+                response=session.get(url+'/api/v1/ready',timeout=1)
+                if response.status_code==200:break
+            except requests.ConnectionError:pass
+            if now()>30000:raise TimeoutError('Startup deadline')
+            time.sleep(.02)
+        result['startupReadyMs']=now()
+        boundary='ifc-http-qualification-v1'
+        head=(f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="fixture.ifc"\r\nContent-Type: application/octet-stream\r\n\r\n').encode()
+        tail=f'\r\n--{boundary}--\r\n'.encode()
+        conn=http.client.HTTPConnection('127.0.0.1',port,timeout=a.timeout)
+        result['requestStartMs']=now()
+        conn.putrequest('POST','/api/v1/parse/parquet-stream?parquet_layout=flat')
+        conn.putheader('Content-Type',f'multipart/form-data; boundary={boundary}')
+        conn.putheader('Content-Length',len(head)+fixture.stat().st_size+len(tail));conn.endheaders();conn.send(head)
+        with fixture.open('rb') as f:
+            for b in iter(lambda:f.read(1024*1024),b''):conn.send(b)
+        conn.send(tail);result['uploadSentMs']=now()
+        response=conn.getresponse();result['httpStatus']=response.status
+        if response.status!=200:raise RuntimeError(f'Upload status {response.status}: {response.read(4096)!r}')
+        cache_key=None;batch=0;completed=False;payload=[]
+        with (out/'events.jsonl').open('w') as events:
+            while True:
+                line=response.readline()
+                if not line:break
+                if line.strip():
+                    if line.startswith(b'data:'):payload.append(line[5:].strip())
+                    continue
+                if not payload:continue
+                event=json.loads(b'\n'.join(payload));payload=[];kind=event['type']
+                if completed:raise ValueError('Event after complete')
+                if kind=='start':
+                    if cache_key is not None:raise ValueError('Duplicate start')
+                    cache_key=event['cache_key']
+                elif kind=='batch':
+                    batch+=1
+                    if event['batch_number']!=batch:raise ValueError('Batch sequence mismatch')
+                    if batch==1:result['firstBatchMs']=now()
+                    result['lastBatchMs']=now()
+                    data=base64.b64decode(event.pop('data'),validate=True)
+                    event['file']=f'batch-{batch:05}.bin';event['wireSha256']=hashlib.sha256(data).hexdigest()
+                    (out/event['file']).write_bytes(data)
+                elif kind=='complete':completed=True;result['streamCompleteMs']=now()
+                elif kind=='error':raise RuntimeError(event['message'])
+                elif kind!='progress':raise ValueError('Unknown SSE event')
+                events.write(json.dumps(event)+'\n');events.flush()
+        conn.close()
+        if payload or not completed or cache_key is None:raise ValueError('Incomplete SSE')
+        result['sseEofMs']=now();polls=[]
+        while True:
+            r=session.get(url+'/api/v1/parse/data-model/'+cache_key,timeout=a.timeout)
+            polls.append({'ms':now(),'status':r.status_code})
+            if r.status_code==200:
+                result['dataModelReceivedMs']=now();(out/'data-model.bin').write_bytes(r.content);break
+            if r.status_code!=202:raise RuntimeError(f'Data model status {r.status_code}')
+            if timed_out.is_set():raise TimeoutError('Data model deadline')
+            time.sleep(.05)
+        result['dataModelPolls']=polls
+        result['httpFeatureReadyMs']=result['dataModelReceivedMs']-result['requestStartMs']
+        result['loadSuccess']=True
+        result['cacheReplay']=replay(session,url,result['fixtureSha256'],out,now,a.timeout)
+        result['cacheReplaySuccess']=True
+    except Exception as error:
+        result['error']=str(error);result['traceback']=traceback.format_exc()
+    finally:
+        watchdog.cancel();result['deadlineKilled']=timed_out.is_set();result['shutdownStartMs']=now()
+        if proc.poll() is None:proc.terminate()
+        try:result['exitCode']=proc.wait(timeout=10);result['shutdownTimedOut']=False
+        except subprocess.TimeoutExpired:
+            proc.kill();result['exitCode']=proc.wait();result['shutdownTimedOut']=True
+        result['shutdownEndMs']=now();stop.set();monitor.join();log.close();session.close()
+        result['memorySamples']=samples;result['peakSampledRss']=max((s['rss'] for s in samples),default=0)
+        result['peakSampledRssThroughColdReady']=max((s['rss'] for s in samples if s['ms']<=result.get('dataModelReceivedMs',float('inf'))),default=0)
+        result['shutdownNote']='Owned process terminated after response completion; SIGTERM exit does not establish PGO profile flush.'
+    result['transportSuccess']=bool(result.get('loadSuccess') and result.get('cacheReplaySuccess')) and not result['shutdownTimedOut'] and not result['deadlineKilled'] and 'error' not in result
+    result['offlineStatus']='pending' if a.defer_offline else 'running'
+    # Persist complete transport clocks and cleanup BEFORE any offline decoding.
+    (out/'timing-checkpoint.json').write_text(json.dumps(result,indent=2)+'\n')
+    if result.get('loadSuccess') and not a.defer_offline:
+        try:
+            witness=decode_run(out)
+            result['decodedMeshes']=len(witness['geometry'])
+            if result.get('cacheReplaySuccess'):compare_replay(out,witness)
+            result['success']=bool(result.get('cacheReplaySuccess')) and not result['shutdownTimedOut'] and not result['deadlineKilled'] and 'error' not in result
+        except Exception as error:result['decodeError']=str(error);result['traceback']=traceback.format_exc()
+    if not a.defer_offline:result['offlineStatus']='passed' if result['success'] else 'failed'
+    (out/'result.json').write_text(json.dumps(result,indent=2)+'\n')
+    print(json.dumps({k:v for k,v in result.items() if k in ['success','error','decodeError','httpFeatureReadyMs','decodedMeshes']}))
+    return 0 if result['success'] or (a.defer_offline and result['transportSuccess']) else 1
+
+
+if __name__=='__main__':
+    p=argparse.ArgumentParser();p.add_argument('--binary',required=True);p.add_argument('--fixture',required=True)
+    p.add_argument('--out',required=True);p.add_argument('--provenance',required=True);p.add_argument('--workers',type=int,default=15);p.add_argument('--timeout',type=int,default=300);p.add_argument('--defer-offline',action='store_true')
+    raise SystemExit(run(p.parse_args()))

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_compare_v2.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_compare_v2.py
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Strict persisted v2 witness/raw comparison and descriptive pair statistics."""
+import hashlib,json,math,statistics
+from pathlib import Path
+
+def sha(path):
+ h=hashlib.sha256()
+ with Path(path).open('rb') as f:
+  while block:=f.read(2*1024*1024):h.update(block)
+ return h.hexdigest()
+
+def raw(path):
+ events=[json.loads(x) for x in (path/'events.jsonl').read_text().splitlines()]
+ batches=[e for e in events if e['type']=='batch']
+ hashes=[sha(path/e['file']) for e in batches]
+ assert hashes==[e['wireSha256'] for e in batches],'Saved wire changed'
+ return hashes
+
+def compare(a,b):
+ # Persisted canonical JSON encodes all v2 fields and ordering. Exact equality
+ # is stronger than accepting only selected geometry or metadata fields.
+ return {'fullSemanticExact':sha(a/'semantic-v2.json')==sha(b/'semantic-v2.json'),
+         'rawGeometryBatchesExact':raw(a)==raw(b),
+         'rawDataModelExact':sha(a/'data-model.bin')==sha(b/'data-model.bin')}
+
+def qualify(base,candidate,fixture_sha):
+ results=[json.loads((p/'result.json').read_text()) for p in (base,candidate)]
+ comparisons={'coldBaseCandidate':compare(base,candidate),'baseCache':compare(base,base/'cache-replay'),'candidateCache':compare(candidate,candidate/'cache-replay')}
+ gates={'transportSuccess':all(r.get('transportSuccess') for r in results),
+        'fixtureExact':all(r['fixtureSha256']==fixture_sha for r in results),
+        'shutdownComplete':all(not r.get('shutdownTimedOut') and not r.get('deadlineKilled') for r in results),
+        'completeExactChannels':all(all(c.values()) for c in comparisons.values())}
+ def measurements(r):
+  result={k:r.get(k) for k in ('httpFeatureReadyMs','startupReadyMs','peakSampledRss','peakSampledRssThroughColdReady','shutdownStartMs','shutdownEndMs')}
+  peak=r.get('peakSampledRss',0);samples=[x for x in r.get('memorySamples',[]) if x['rss']==peak]
+  first=samples[0]['ms'] if samples else None
+  result['peakFirstMs']=first
+  result['peakPhase']='cold' if first is not None and first<=r.get('dataModelReceivedMs',0) else 'cache/replay/cleanup'
+  return result
+ return {'gates':gates,'passed':all(gates.values()),'comparisons':comparisons,'base':measurements(results[0]),'candidate':measurements(results[1])}
+
+def summary(rows):
+ out={}
+ for name,subset in [('heldOut22',[r for r in rows if not r['training']]),('all27',rows),('training5',[r for r in rows if r['training']])]:
+  valid=[r for r in subset if r.get('qualification',{}).get('passed')]
+  ratios=[r['qualification']['candidate']['httpFeatureReadyMs']/r['qualification']['base']['httpFeatureReadyMs'] for r in valid]
+  out[name]={'attempted':len(subset),'qualified':len(valid),'excludedFailures':[r['label'] for r in subset if r not in valid],
+    'equalWeightGeometricMeanTimeReductionPercent':100*(1-math.exp(statistics.mean(map(math.log,ratios)))) if ratios else None,
+    'qualification':'One pair per model; descriptive screen, no repeated-pair or no-regression claim; failures remain excluded explicitly, never greenwashed.'}
+ return out

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_http_v2.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_http_v2.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Frozen actual-server 27-model screen; operator grants exclusive CPU window.
+One alternating-order fresh-process pair per SHA-unique fixture. Both captures
+finish before any offline witness/retention. No pooled pilots or auto-expansion.
+"""
+import argparse,json,os,subprocess,sys,time
+from pathlib import Path
+from screen_compare_v2 import sha,summary
+from retention.capacity_guard import check
+from retention.clone_duplicates import plan as retention_plan,apply as retention_apply
+
+ROOT=Path(__file__).resolve().parent
+SOURCES=['run.py','cache_phase.py','wire.py','wire_arrow_v2.py','screen_http_v2.py','screen_compare_v2.py','screen_offline_pair.py','retention/capacity_guard.py','retention/clone_duplicates.py']
+
+def write(path,value):
+ with path.open('x') as f:json.dump(value,f,indent=2);f.write('\n')
+
+def main():
+ p=argparse.ArgumentParser()
+ for key in ('manifest','training-plan','base-provenance','candidate-provenance','projection','out'):p.add_argument('--'+key,required=True,type=Path)
+ p.add_argument('--timeout',type=int,default=600)
+ p.add_argument('--cpu-window-confirmed',action='store_true',required=True)
+ a=p.parse_args();a.out.mkdir(exist_ok=False)
+ fixtures=json.loads(a.manifest.read_text())['expanded_corpus']
+ training=json.loads(a.training_plan.read_text())['training']
+ training_hashes={f['publicSha256'] for f in training}
+ hashes=[f['fixture_identity']['sha256'] for f in fixtures]
+ assert len(fixtures)==27 and len(set(hashes))==27 and len(training_hashes)==5 and training_hashes<=set(hashes)
+ assert len({f['label'] for f in fixtures})==27
+ frozen={name:sha(ROOT/name) for name in SOURCES}
+ input_hashes={str(path):sha(path) for path in (a.manifest,a.training_plan,a.base_provenance,a.candidate_provenance,a.projection)}
+ artifacts={side:json.loads(path.read_text()) for side,path in [('base',a.base_provenance),('candidate',a.candidate_provenance)]}
+ for side,artifact in artifacts.items():assert sha(artifact['binary'])==artifact['binarySha256'],side
+ assert artifacts['base']['binarySha256']!=artifacts['candidate']['binarySha256']
+ snapshot=a.out/'driver';snapshot.mkdir()
+ for name in SOURCES:
+  dest=snapshot/name;dest.parent.mkdir(parents=True,exist_ok=True);dest.write_bytes((ROOT/name).read_bytes())
+ write(a.out/'protocol.json',{'protocol':'actual-http-pgo-screen-v2','createdUnix':time.time(),'harnessSha256':frozen,
+   'artifacts':artifacts,'manifestSha256':sha(a.manifest),'projectionSha256':sha(a.projection),
+   'trainingPlanSha256':sha(a.training_plan),'primary':'22 held-out models','secondary':'all27 and fixed training5',
+   'pairsPerModel':1,'order':'manifest order; base/candidate even, candidate/base odd',
+   'offline':'Only after both timed arms and server cleanup; retention afterward before next pair',
+   'expansion':'Five-pair cohort only if heldout22 equal-weight geometric-mean HTTP reduction >=5%, all functional/cache/count/cleanup gates pass, and no clear capacity regression; otherwise report to root. Single-pair timing regressions remain for repeated qualification.',
+   'memory':'50ms sampled server RSS through cold readiness and entire cache/cleanup protocol; not physical footprint',
+   'failures':'Retain failed arms and exact failed channels. No tolerance, normalization waiver, retries or pilot pooling.'})
+ rows=[]
+ for index,fixture in enumerate(fixtures):
+  label=fixture['label'];pair=a.out/label;pair.mkdir()
+  row={'label':label,'fixtureSha256':hashes[index],'training':hashes[index] in training_hashes,'order':['base','candidate'] if index%2==0 else ['candidate','base']}
+  print('PAIR',index+1,label,flush=True)
+  try:
+   permit=check(a.projection,label,a.out,pair/'capacity.json')
+   assert permit['fixtureSha256']==hashes[index],'Capacity projection fixture mismatch'
+  except Exception as error:
+   row['capacityRefusal']=repr(error);rows.append(row);write(pair/'qualification.json',row);break
+  assert all(sha(ROOT/name)==digest for name,digest in frozen.items()),'Harness drift'
+  assert all(sha(path)==digest for path,digest in input_hashes.items()),'Protocol/provenance drift'
+  # Capture an auditable process list outside timing; exclusive host ownership
+  # remains an operator prerequisite, not an unreliable process-name heuristic.
+  (pair/'pre-pair-processes.txt').write_text(subprocess.check_output(['ps','-axo','pid,ppid,%cpu,comm'],text=True))
+  for side in row['order']:
+   artifact=artifacts[side]
+   assert sha(artifact['binary'])==artifact['binarySha256'],'Artifact drift'
+   provenance=a.base_provenance if side=='base' else a.candidate_provenance
+   command=[sys.executable,str(ROOT/'run.py'),'--binary',artifact['binary'],'--provenance',str(provenance),'--fixture',fixture['path'],'--out',str(pair/side),'--timeout',str(a.timeout),'--defer-offline']
+   env=os.environ.copy();env.pop('LLVM_PROFILE_FILE',None)
+   with (pair/(side+'-driver.log')).open('x') as log:
+    row[side+'ExitCode']=subprocess.run(command,env=env,stdout=log,stderr=subprocess.STDOUT).returncode
+  # Both subprocesses reap their owned server before returning. No decode or
+  # retention process exists during either timed arm.
+  offline_start=time.time()
+  with (pair/'offline.log').open('x') as log:
+   offline=subprocess.run([sys.executable,str(ROOT/'screen_offline_pair.py'),str(pair),hashes[index]],stdout=log,stderr=subprocess.STDOUT)
+  row['offlineExitCode']=offline.returncode
+  if (pair/'offline-qualification.json').exists():row['qualification']=json.loads((pair/'offline-qualification.json').read_text())
+  else:row['offlineError']='See retained offline.log'
+  row['offlineSeconds']=time.time()-offline_start
+  rows.append(row);write(pair/'qualification.json',row)
+  # Reclaim duplicate extents only; every path/inode and unique byte survives.
+  released=[str((pair/side).relative_to(a.out)) for side in ('base','candidate') if (pair/side).exists()]
+  try:
+   retention_plan(a.out.absolute(),released,pair/'retention-plan.json')
+   retention_apply(pair/'retention-plan.json',pair/'retention.jsonl')
+  except Exception as error:
+   row['retentionError']=repr(error);write(pair/'retention-failure.json',{'error':repr(error)});break
+  write(a.out/('progress-%02d.json'%(index+1)),{'rows':rows,'summary':summary(rows)})
+ write(a.out/'final.json',{'rows':rows,'summary':summary(rows),'complete':len(rows)==27 and not any('capacityRefusal' in r or 'retentionError' in r for r in rows)})
+
+if __name__=='__main__':main()

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_offline_pair.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/screen_offline_pair.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Isolated offline witness process; all allocations die before next timed pair."""
+import json,sys
+from pathlib import Path
+import wire
+from wire_arrow_v2 import decode_run
+from screen_compare_v2 import qualify
+pair=Path(sys.argv[1]);fixture_sha=sys.argv[2]
+original=wire.data_model;last_data=None;last_witness=None
+
+def exact_reuse(data):
+ global last_data,last_witness
+ if last_data is None or data!=last_data:last_witness=original(data);last_data=data
+ return last_witness
+
+wire.data_model=exact_reuse
+for side in ('base','candidate'):
+ decode_run(pair/side,False);decode_run(pair/side/'cache-replay',None)
+result=qualify(pair/'base',pair/'candidate',fixture_sha)
+with (pair/'offline-qualification.json').open('x') as f:json.dump(result,f,indent=2);f.write('\n')
+raise SystemExit(0 if result['passed'] else 1)

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/test_wire.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/test_wire.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Private HTTP witness contract: real Parquet encoding, exact field mutations."""
+import copy,io,struct,unittest
+import pyarrow as pa
+import pyarrow.parquet as pq
+from wire import geometry,digest,sections
+
+def pack(tables):
+    result=b''
+    for rows in tables:
+        sink=io.BytesIO();pq.write_table(pa.Table.from_pylist(rows),sink)
+        data=sink.getvalue();result+=struct.pack('<I',len(data))+data
+    return result
+
+class WireContract(unittest.TestCase):
+    def setUp(self):
+        self.mesh={'express_id':42,'ifc_type':'IFCWALL','vertex_start':0,'vertex_count':3,'index_start':0,'index_count':3,
+                   'color_r':.2,'color_g':.3,'color_b':.4,'color_a':1.,'origin_x':0.,'origin_y':0.,'origin_z':0.,
+                   'geometry_class':0,'geometry_item_id':9,'material_id':4}
+        self.vertices=[dict(x=x,y=y,z=0.,nx=0.,ny=0.,nz=1.) for x,y in [(0.,0.),(1.,0.),(0.,1.)]]
+        self.tris=[dict(i0=0,i1=1,i2=2)]
+    def test_each_payload_group_and_duplicate_occurrences_are_observed(self):
+        tables=[[self.mesh],self.vertices,self.tris];base=geometry(pack(tables))
+        for group,key in [(0,'color_r'),(0,'geometry_item_id'),(0,'origin_x'),(1,'nx'),(1,'x'),(2,'i1')]:
+            changed=copy.deepcopy(tables);changed[group][0][key]+=1
+            self.assertNotEqual(base,geometry(pack(changed)),(group,key))
+        doubled=geometry(pack([[self.mesh,self.mesh],self.vertices,self.tris]))
+        self.assertEqual(len(doubled),2);self.assertEqual(doubled[0],doubled[1])
+    def test_signed_zero_and_finite_exactness(self):
+        self.assertNotEqual(digest(-0.),digest(0.))
+        with self.assertRaises(ValueError):digest(float('nan'))
+    def test_bad_frame_and_bad_geometry_span_fail(self):
+        with self.assertRaises(ValueError):sections(b'\xff\xff\xff\xff',1)
+        self.mesh['index_count']=4
+        with self.assertRaises(ValueError):geometry(pack([[self.mesh],self.vertices,self.tris]))
+
+if __name__=='__main__':unittest.main()

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/test_wire_arrow_v2.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/test_wire_arrow_v2.py
@@ -1,0 +1,167 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Offline v1/v2 equality-decision oracle using actual Parquet, not source text."""
+import hashlib
+import io
+import math
+import struct
+import unittest
+import pyarrow as pa
+import pyarrow.parquet as pq
+import wire as v1
+import wire_arrow_v2 as v2
+
+
+def tables():
+    mesh = {'express_id': 42, 'ifc_type': 'IFCWALL', 'vertex_start': 0, 'vertex_count': 3,
+            'index_start': 0, 'index_count': 3, 'color_r': .2, 'color_g': .3,
+            'color_b': .4, 'color_a': 1., 'origin_x': 0., 'origin_y': 0., 'origin_z': 0.,
+            'geometry_class': 0, 'geometry_item_id': 9, 'material_id': 4,
+            'rot0': 1., 'source_extra': 'retained', 'bounds_extra': 1.}
+    vertices = [dict(x=x, y=y, z=0., nx=0., ny=0., nz=1.) for x, y in [(0., 0.), (1., 0.), (0., 1.)]]
+    ms = pa.Table.from_pylist([mesh])
+    vs = pa.Table.from_pylist(vertices, schema=pa.schema([(k, pa.float32()) for k in vertices[0]]))
+    ts = pa.Table.from_pylist([dict(i0=0, i1=1, i2=2)], schema=pa.schema([(k, pa.uint32()) for k in ('i0', 'i1', 'i2')]))
+    return [ms, vs, ts]
+
+
+def pack(ts):
+    out = bytearray()
+    for table in ts:
+        sink = io.BytesIO(); pq.write_table(table, sink)
+        data = sink.getvalue(); out.extend(struct.pack('<I', len(data))); out.extend(data)
+    return bytes(out)
+
+
+def changed(ts, group, key, value, row=0):
+    ts = list(ts); rows = ts[group].to_pylist(); rows[row][key] = value
+    ts[group] = pa.Table.from_pylist(rows, schema=ts[group].schema)
+    return ts
+
+
+def witness(fn, ts):
+    return sorted(fn(pack(ts)), key=lambda row: (row['entity'], row['digest']))
+
+
+class GeometryEquivalence(unittest.TestCase):
+    def assertDecision(self, left, right, equal):
+        for fn in (v1.geometry, v2.geometry):
+            self.assertEqual(witness(fn, left) == witness(fn, right), equal, fn.__module__)
+
+    def test_every_field_is_observed(self):
+        base = tables()
+        for group, table in enumerate(base):
+            for field in table.schema:
+                if field.name in ('vertex_start', 'index_start', 'vertex_count', 'index_count'):
+                    continue
+                value = table[field.name][0].as_py()
+                replacement = value + '-changed' if isinstance(value, str) else (0 if group == 2 and value else value + 1)
+                with self.subTest(group=group, field=field.name):
+                    self.assertDecision(base, changed(base, group, field.name, replacement), False)
+
+    def test_one_ulp_signed_zero_and_nonfinite(self):
+        base = tables()
+        next_f32 = struct.unpack('<f', struct.pack('<I', 0x3f800001))[0]
+        self.assertDecision(base, changed(base, 1, 'x', next_f32, 1), False)
+        self.assertDecision(base, changed(base, 1, 'z', -0.), False)
+        self.assertDecision(base, changed(base, 0, 'origin_x', -0.), False)
+        self.assertDecision(base, changed(base, 0, 'bounds_extra', math.nextafter(1., 2.)), False)
+        for group, field in [(0, 'origin_x'), (1, 'x')]:
+            for value in (float('nan'), float('inf'), float('-inf')):
+                for fn in (v1.geometry, v2.geometry):
+                    with self.subTest(group=group, value=value, fn=fn.__module__):
+                        with self.assertRaises(ValueError):
+                            fn(pack(changed(base, group, field, value)))
+
+    def test_local_order_and_duplicate_occurrences(self):
+        base = tables(); swapped = list(base)
+        swapped[1] = base[1].take(pa.array([1, 0, 2]))
+        self.assertDecision(base, swapped, False)
+        self.assertDecision(base, changed(base, 2, 'i1', 2), False)
+        double = list(base); double[0] = pa.concat_tables([base[0], base[0]])
+        self.assertDecision(base, double, False)
+        for fn in (v1.geometry, v2.geometry):
+            rows = fn(pack(double)); self.assertEqual(len(rows), 2); self.assertEqual(rows[0], rows[1])
+        two_triangles = changed(base, 0, 'index_count', 6)
+        two_triangles[2] = pa.concat_tables([base[2], changed(base, 2, 'i1', 2)[2]])
+        reordered = list(two_triangles); reordered[2] = two_triangles[2].take(pa.array([1, 0]))
+        self.assertDecision(two_triangles, reordered, False)
+        different = changed(base, 0, 'express_id', 99)
+        a = list(base); b = list(base)
+        a[0] = pa.concat_tables([base[0], different[0]])
+        b[0] = pa.concat_tables([different[0], base[0]])
+        self.assertDecision(a, b, True)
+
+    def test_storage_offsets_normalize_but_coverage_remains(self):
+        base = tables()
+        other = changed(base, 0, 'express_id', 99)
+        other = changed(other, 1, 'x', 2.)
+        a = list(base); b = list(base)
+        shifted_other = changed(other, 0, 'vertex_start', 3)
+        shifted_other = changed(shifted_other, 0, 'index_start', 3)
+        shifted_base = changed(base, 0, 'vertex_start', 3)
+        shifted_base = changed(shifted_base, 0, 'index_start', 3)
+        a[0] = pa.concat_tables([base[0], shifted_other[0]])
+        b[0] = pa.concat_tables([other[0], shifted_base[0]])
+        a[1] = pa.concat_tables([base[1], other[1]])
+        b[1] = pa.concat_tables([other[1], base[1]])
+        a[2] = b[2] = pa.concat_tables([base[2], other[2]])
+        self.assertDecision(a, b, True)
+        invalid = [changed(base, 0, 'index_count', 4), changed(base, 0, 'vertex_count', 2),
+                   changed(base, 0, 'vertex_start', 1), changed(base, 2, 'i2', 3)]
+        extra = list(base); extra[1] = pa.concat_tables([base[1], base[1].slice(0, 1)]); invalid.append(extra)
+        extra = list(base); extra[2] = pa.concat_tables([base[2], base[2]]); invalid.append(extra)
+        for ts in invalid:
+            for fn in (v1.geometry, v2.geometry):
+                with self.assertRaises(ValueError): fn(pack(ts))
+
+    def test_chunk_slices_and_schema(self):
+        base = tables(); sliced = []
+        for table in base:
+            padded = pa.concat_tables([table, table, table])
+            selected = padded.slice(len(table), len(table))
+            sliced.append(pa.concat_tables([selected.slice(0, 1), selected.slice(1)]))
+        self.assertEqual(v2.geometry_tables(*base), v2.geometry_tables(*sliced))
+        self.assertDecision(base, sliced, True)
+        changed_schema = list(base)
+        changed_schema[1] = base[1].cast(pa.schema([(f.name, f.type, False) for f in base[1].schema]))
+        self.assertDecision(base, changed_schema, False)
+        reordered = list(base); reordered[1] = base[1].select(list(reversed(base[1].column_names)))
+        self.assertDecision(base, reordered, False)
+
+    def test_slice_prefix_and_suffix_are_not_values(self):
+        raw = pa.array([float('nan'), 1., -0., float('inf')], type=pa.float32())
+        columns = [pa.chunked_array([raw.slice(1, 2)]),
+                   pa.chunked_array([pa.array([1.], type=pa.float32()), pa.array([-0.], type=pa.float32())])]
+        hashes = []
+        for column in columns:
+            h = hashlib.sha256(); v2.hash_column(h, 'position', column); hashes.append(h.digest())
+        self.assertEqual(*hashes)
+
+    def test_null_payloads_and_future_columns(self):
+        base = tables()
+        base[1] = base[1].append_column('optional', pa.array([None, -0., 1.], type=pa.float32()))
+        base[1] = base[1].append_column('label', pa.array([None, '', 'hello']))
+        self.assertDecision(base, changed(base, 1, 'optional', 0., 1), False)
+        self.assertDecision(base, changed(base, 1, 'label', '', 0), False)
+        # Null payload bits are not logical values and must not affect hashes.
+        arrays = [pa.Array.from_buffers(pa.float32(), 3,
+                  [pa.py_buffer(bytes([6])), pa.py_buffer(struct.pack('<fff', hidden, -0., 1.))])
+                  for hidden in (3., 99.)]
+        hashes = []
+        for array in arrays:
+            h = hashlib.sha256(); v2.hash_column(h, 'optional', pa.chunked_array([array])); hashes.append(h.digest())
+        self.assertEqual(*hashes)
+        bad = changed(base, 1, 'optional', float('nan'), 2)
+        for fn in (v1.geometry, v2.geometry):
+            with self.assertRaises(ValueError): fn(pack(bad))
+        # Nullable slices with different physical chunks have equal logical hashes.
+        column = pa.chunked_array([arrays[0].slice(0, 1), arrays[0].slice(1)])
+        h = hashlib.sha256(); v2.hash_column(h, 'optional', column)
+        self.assertEqual(h.digest(), hashes[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/train.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/train.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Declared five actual-HTTP training fixtures; no performance claim."""
+import hashlib,json,os,shutil,subprocess,sys,time
+from pathlib import Path
+from wire_arrow_v2 import decode_run
+root=Path(__file__).resolve().parent
+import argparse
+p=argparse.ArgumentParser();p.add_argument('--experiment',type=Path,required=True);a=p.parse_args()
+out=a.experiment.resolve()
+plan=json.loads((out/'plan.json').read_text())
+raw=out/'raw';raw.mkdir(exist_ok=False)
+training=out/'training';training.mkdir(exist_ok=False)
+provenance=out/'generate-provenance.json'
+binary=out/'target-generate/aarch64-apple-darwin/release/ifc-lite-server'
+rows=[]
+for fixture in plan['training']:
+ label=fixture['label'];dest=training/label
+ assert shutil.disk_usage(out).free>40*1024**3,'Reserve gate: <40GiB free'
+ env=os.environ.copy();env['LLVM_PROFILE_FILE']=str(raw/(label+'-%p-%c.profraw'))
+ command=[sys.executable,str(root/'run.py'),'--binary',str(binary),'--provenance',str(provenance),'--fixture',fixture['path'],'--out',str(dest),'--timeout','600','--defer-offline']
+ print('START',label,flush=True)
+ completed=subprocess.run(command,env=env)
+ result=json.loads((dest/'result.json').read_text())
+ assert completed.returncode==0 and result['transportSuccess'],result
+ assert result['fixtureSha256']==fixture['publicSha256']
+ logs='\n'.join(p.read_text(errors='replace') for p in dest.glob('*.log'))
+ assert 'LLVM Profile Error' not in logs and 'LLVM Profile Warning' not in logs
+ decode_run(dest,False);decode_run(dest/'cache-replay',None)
+ cold=json.loads((dest/'semantic-v2.json').read_text());cached=json.loads((dest/'cache-replay/semantic-v2.json').read_text())
+ assert cold==cached,'Exact cache semantic gate failed: '+label
+ profiles=[{'file':p.name,'bytes':p.stat().st_size,'sha256':hashlib.sha256(p.read_bytes()).hexdigest()} for p in raw.glob(label+'-*.profraw')]
+ assert profiles and all(p['bytes']>0 for p in profiles)
+ rows.append({'label':label,'transportSuccess':True,'exactCacheSemanticMatch':True,'profiles':profiles,'instrumentationEnvironment':result['instrumentationEnvironment']})
+ (training/'qualification.json').write_text(json.dumps({'sourceCommit':plan['sourceCommit'],'profileKind':plan['profileKind'],'rows':rows,'complete':len(rows)==5},indent=2)+'\n')
+ print('DONE',label,flush=True)

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/wire.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/wire.py
@@ -1,0 +1,104 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Private HTTP witness v1. Exact decoded values; no geometry tolerance.
+All wire columns are retained. Only batch storage offsets/order are normalized;
+per-occurrence vertex/triangle order and duplicate occurrence multiplicity remain.
+Nonfinite values fail closed rather than accidentally canonicalizing NaN payloads.
+"""
+import base64, hashlib, io, json, math, struct
+import pyarrow.parquet as pq
+
+
+def encode(x):
+    if isinstance(x, float):
+        if not math.isfinite(x):
+            raise ValueError('Nonfinite value: exact bit witness requires extension')
+        return {'float64le': struct.pack('<d', x).hex()}
+    if isinstance(x, bytes): return {'bytes': base64.b64encode(x).decode()}
+    if isinstance(x, dict): return {k: encode(v) for k,v in sorted(x.items())}
+    if isinstance(x, (tuple,list)): return [encode(v) for v in x]
+    if x is None or isinstance(x,(str,bool,int)): return x
+    raise TypeError(type(x).__name__)
+
+
+def digest(x):
+    return hashlib.sha256(json.dumps(encode(x),sort_keys=True,separators=(',',':')).encode()).hexdigest()
+
+
+def sections(data, count, tail=0):
+    out=[]; at=0
+    for _ in range(count):
+        if at+4>len(data): raise ValueError('Truncated section length')
+        n=struct.unpack_from('<I',data,at)[0]; at+=4
+        if at+n>len(data): raise ValueError('Truncated section')
+        out.append(data[at:at+n]); at+=n
+    if at+tail!=len(data): raise ValueError('Unexpected section remainder')
+    return out,data[at:]
+
+
+def table(data):
+    t=pq.read_table(io.BytesIO(data))
+    schema=[(f.name,str(f.type),f.nullable) for f in t.schema]
+    return schema,t.to_pylist()
+
+
+def row_witness(data):
+    parquet=pq.ParquetFile(io.BytesIO(data))
+    schema=[(f.name,str(f.type),f.nullable) for f in parquet.schema_arrow]
+    hashes=[]
+    for batch in parquet.iter_batches(batch_size=1024):
+        hashes.extend(digest(r) for r in batch.to_pylist())
+    return {'schema':schema,'rows':len(hashes),'rowDigests':sorted(hashes)}
+
+
+def geometry(data):
+    parts,_=sections(data,3)
+    (ms,meshes),(vs,vertices),(ts,triangles)=map(table,parts)
+    out=[]; usedv=set(); usedt=set()
+    for mesh in meshes:
+        m=dict(mesh); v=m.pop('vertex_start'); n=m['vertex_count']; i=m.pop('index_start'); k=m['index_count']
+        if i%3 or k%3 or v+n>len(vertices) or (i+k)//3>len(triangles): raise ValueError('Mesh span invalid')
+        vv=vertices[v:v+n]; tt=triangles[i//3:(i+k)//3]
+        for tri in tt:
+            if any(tri[x]>=n for x in ('i0','i1','i2')): raise ValueError('Triangle index out of range')
+        usedv.update(range(v,v+n));usedt.update(range(i//3,(i+k)//3))
+        out.append({'entity':m['express_id'],'digest':digest([ms,vs,ts,m,vv,tt]),'vertices':n,'triangles':k//3})
+    if len(usedv)!=len(vertices) or len(usedt)!=len(triangles): raise ValueError('Unreferenced wire rows')
+    return out
+
+
+def data_model(data):
+    parts,_=sections(data,8)
+    names=['entities','properties','quantities','relationships','spatial','classifications','materials','documents']
+    out={}
+    for name,part in zip(names,parts):
+        if name=='spatial':
+            chunks,tail=sections(part,5,4)
+            out[name]={'projectId':struct.unpack('<I',tail)[0], 'tables':[row_witness(c) for c in chunks]}
+        else: out[name]=row_witness(part)
+    return out
+
+
+def decode_run(path,expected_cache=False):
+    events=[json.loads(line) for line in (path/'events.jsonl').read_text().splitlines()]
+    complete=[e for e in events if e['type']=='complete']
+    if len(complete)!=1: raise ValueError('Expected one complete event')
+    meshes=[]
+    for e in events:
+        if e['type']=='batch':
+            rows=geometry((path/e['file']).read_bytes())
+            if len(rows)!=e['mesh_count']: raise ValueError('Batch mesh count differs')
+            meshes.extend(rows)
+    stats=complete[0]['stats']
+    expected={'total_meshes':len(meshes),'total_vertices':sum(m['vertices'] for m in meshes),'total_triangles':sum(m['triangles'] for m in meshes)}
+    if any(stats[k]!=v for k,v in expected.items()): raise ValueError('Complete geometry totals disagree with wire')
+    if expected_cache is not None and stats['from_cache']!=expected_cache: raise ValueError('Unexpected cache disposition')
+    diagnostics={k:v for k,v in stats.items() if not k.endswith('_time_ms') and k not in ('point_cache_hits','point_cache_misses','from_cache')}
+    result={'protocol':'http-wire-v1','geometry':sorted(meshes,key=lambda r:(r['entity'],r['digest'])),
+            'metadataDigest':digest(complete[0]['metadata']),'diagnostics':diagnostics,
+            'symbolicDigest':digest(complete[0].get('symbolic_data')),
+            'dataModel':data_model((path/'data-model.bin').read_bytes())}
+    (path/'semantic.json').write_text(json.dumps(result,indent=2)+'\n')
+    return result

--- a/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/wire_arrow_v2.py
+++ b/scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/wire_arrow_v2.py
@@ -1,0 +1,139 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Offline HTTP witness v2; geometry equivalence is v1, encoding is different.
+Never replaces the active wire.py. Metadata tables deliberately retain v1.
+Equivalence applies to valid server wire (unsigned offsets/counts/indices).
+Malformed signed-negative spans/indices additionally fail closed, unlike v1.
+"""
+import hashlib
+import json
+import struct
+import sys
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+import wire as v1
+
+
+def frame(h, name, payload):
+    name = name.encode('utf8')
+    h.update(struct.pack('<Q', len(name))); h.update(name)
+    h.update(struct.pack('<Q', len(payload))); h.update(payload)
+
+
+def canonical(value):
+    return json.dumps(v1.encode(value), sort_keys=True, separators=(',', ':')).encode()
+
+
+def schema(table):
+    return [(f.name, str(f.type), f.nullable) for f in table.schema]
+
+
+def hash_column(h, name, column):
+    """Logical values only: no chunk markers, offset prefixes, or null garbage."""
+    dtype = column.type
+    numeric = pa.types.is_integer(dtype) or pa.types.is_float32(dtype) or pa.types.is_float64(dtype)
+    if not numeric or column.null_count:
+        # Rare nullable/future columns retain exact v1 logical-value semantics.
+        frame(h, name + ':values', canonical(column.to_pylist()))
+        return
+    frame(h, name + ':type', str(dtype).encode())
+    frame(h, name + ':count', struct.pack('<Q', len(column)))
+    width = dtype.bit_width // 8
+    # A single framed payload, independent of physical chunk boundaries.
+    label = (name + ':little-endian-values').encode()
+    h.update(struct.pack('<Q', len(label))); h.update(label)
+    h.update(struct.pack('<Q', len(column) * width))
+    for chunk in column.chunks:
+        if pa.types.is_floating(dtype) and len(chunk):
+            if not pc.all(pc.is_finite(chunk)).as_py():
+                raise ValueError('Nonfinite value: exact bit witness requires extension')
+        buf = chunk.buffers()[1]
+        if not len(chunk):
+            continue
+        logical = memoryview(buf)[chunk.offset * width:(chunk.offset + len(chunk)) * width]
+        if sys.byteorder == 'little':
+            h.update(logical)
+        else:
+            # Explicit byte order; never reinterpret floating values numerically.
+            h.update(chunk.to_numpy(zero_copy_only=True).byteswap().tobytes())
+
+
+def covered(intervals, length):
+    end = 0
+    for start, stop in sorted(intervals):
+        if start > end:
+            return False
+        end = max(end, stop)
+    return end == length
+
+
+def geometry_tables(meshes, vertices, triangles):
+    schemas = [schema(t) for t in (meshes, vertices, triangles)]
+    out = []; usedv = []; usedt = []
+    for original in meshes.to_pylist():
+        mesh = dict(original)
+        v = mesh.pop('vertex_start'); n = mesh['vertex_count']
+        i = mesh.pop('index_start'); k = mesh['index_count']
+        if min(v, n, i, k) < 0 or i % 3 or k % 3 or v + n > len(vertices) or (i + k) // 3 > len(triangles):
+            raise ValueError('Mesh span invalid')
+        vv = vertices.slice(v, n); tt = triangles.slice(i // 3, k // 3)
+        for key in ('i0', 'i1', 'i2'):
+            column = tt[key]
+            if column.null_count:
+                raise ValueError('Null triangle index')
+            if len(column) and (pc.min(column).as_py() < 0 or pc.max(column).as_py() >= n):
+                raise ValueError('Triangle index out of range')
+        h = hashlib.sha256()
+        frame(h, 'protocol', b'http-wire-geometry-v2')
+        frame(h, 'schemas', canonical(schemas))
+        frame(h, 'mesh', canonical(mesh))
+        for label, table in (('vertices', vv), ('triangles', tt)):
+            frame(h, label + ':rows', struct.pack('<Q', len(table)))
+            for field, column in zip(table.schema, table.columns):
+                hash_column(h, label + ':' + field.name, column)
+        usedv.append((v, v + n)); usedt.append((i // 3, (i + k) // 3))
+        out.append({'entity': mesh['express_id'], 'digest': h.hexdigest(), 'vertices': n, 'triangles': k // 3})
+    if not covered(usedv, len(vertices)) or not covered(usedt, len(triangles)):
+        raise ValueError('Unreferenced wire rows')
+    return out
+
+
+def geometry(data):
+    parts, _ = v1.sections(memoryview(data), 3)
+    return geometry_tables(*(pq.read_table(pa.BufferReader(part)) for part in parts))
+
+
+def decode_run(path, expected_cache=False):
+    """Same v1 event gates; writes a separate semantic-v2.json artifact."""
+    output = path / 'semantic-v2.json'
+    if output.exists():
+        raise FileExistsError(output)
+    events = [json.loads(line) for line in (path / 'events.jsonl').read_text().splitlines()]
+    complete = [e for e in events if e['type'] == 'complete']
+    if len(complete) != 1:
+        raise ValueError('Expected one complete event')
+    meshes = []
+    for event in events:
+        if event['type'] == 'batch':
+            rows = geometry((path / event['file']).read_bytes())
+            if len(rows) != event['mesh_count']:
+                raise ValueError('Batch mesh count differs')
+            meshes.extend(rows)
+    stats = complete[0]['stats']
+    expected = {'total_meshes': len(meshes), 'total_vertices': sum(m['vertices'] for m in meshes),
+                'total_triangles': sum(m['triangles'] for m in meshes)}
+    if any(stats[k] != value for k, value in expected.items()):
+        raise ValueError('Complete geometry totals disagree with wire')
+    if expected_cache is not None and stats['from_cache'] != expected_cache:
+        raise ValueError('Unexpected cache disposition')
+    diagnostics = {k: value for k, value in stats.items() if not k.endswith('_time_ms') and k not in ('point_cache_hits', 'point_cache_misses', 'from_cache')}
+    result = {'protocol': 'http-wire-v2', 'geometry': sorted(meshes, key=lambda r: (r['entity'], r['digest'])),
+              'metadataDigest': v1.digest(complete[0]['metadata']), 'diagnostics': diagnostics,
+              'symbolicDigest': v1.digest(complete[0].get('symbolic_data')),
+              'dataModel': v1.data_model((path / 'data-model.bin').read_bytes())}
+    with output.open('x') as stream:
+        stream.write(json.dumps(result, indent=2) + '\n')
+    return result


### PR DESCRIPTION
Make the PGO evidence reproducible without private scripts: publish parameterized fresh-artifact build/training tools, HTTP transport and exact Arrow/Parquet witnesses, paired execution and bounded verified evidence retention. The source map records each original and published digest and any path-only adaptation. No private model paths or payloads are included.

Validation: the published copy passes 10 wire tests and 5 retention tests; AST, JSON, source-map digest and privacy checks passed. These are explicitly manual evidence tools, with no production or shipping configuration changes.

Stack 2/4, based on the native evidence branch. Refs #4059; no issue closure while the full-value HTTP successor remains active.

Validation scope: `revert-oracle-exempt` applies to this evidence/harness stack. The oracle classified retained measurement JSON as production code and failed because it has no changed application test. These commits change no application runtime or shipping flags. The published Python witness/retention tests passed (10 wire tests and five retention tests); cohort arithmetic and source identity were independently checked. All other CI gates remain required.
