### PR TITLE
docs(perf): record rejected owned server mesh batches

### DIFF
--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -843,6 +843,19 @@ it does not establish a performance gain or neutrality. Keep endpoint readiness,
 cache completion and offline witness cost separate, and never extrapolate a
 processing-probe gain to the shipping HTTP artifact.
 [Sanitized screen and limitations](evidence/server-json-roundtrip-4064/README.md).
+### Rejected owned server mesh-batch transfer (#4066)
+
+An owned sink in the canonical processing loop removed the server bridge's deep
+mesh-buffer copy while preserving borrowed callers, retained output, batching,
+progress, styling and cancellation. Exact output and actual cache replay passed,
+but the prespecified HTTP readiness continuation gate failed: the small and MEP
+models were slower in their single pairs, and the largest model's modest time
+improvement accompanied higher sampled RSS. The implementation was not landed
+or expanded to the wider corpus. A source-level copy removal is not an
+end-to-end gain; unbounded downstream ownership and other pipeline work remain
+relevant costs. This screen does not establish precise attribution or a physical
+memory benefit. [Complete verdict, limits and reproducible rejected source](evidence/rejected-owned-batches-2026-09-07/README.md).
+
 ## Current-source native PGO qualification (#4059, not shipped)
 
 Fresh profile training on five public fixtures produced a broad held-out

--- a/scripts/perf/evidence/rejected-owned-batches-2026-09-07/README.md
+++ b/scripts/perf/evidence/rejected-owned-batches-2026-09-07/README.md
@@ -1,0 +1,55 @@
+# Rejected owned server mesh batches (#4066)
+
+The candidate transferred non-retained mesh batches into the existing server
+channel instead of cloning their owned buffers. It used the same canonical
+processing loop and preserved the borrowed API, retained output, batch/progress
+boundaries, styling and cancellation. It was rejected by the prespecified actual
+HTTP continuation rule. No production implementation or wider corpus run landed.
+
+[screen.json](screen.json) contains every arm of the initial three-model screen,
+its exact gates, separate startup/readiness clocks, sampled RSS, continuation
+rule, source/artifact/compiler identities and validation limits. The small model
+and MEP model were slower in their single pairs; the largest model improved
+modestly while its sampled RSS increased. These observations neither establish
+precise causal contributions nor justify a general claim that ownership transfer
+cannot help. Removing a real copy does not by itself establish an end-to-end win.
+
+All three models passed the declared complete semantic witness, strict raw
+geometry/data-model comparisons, actual hash-only cache replay and cleanup gates.
+No diagnostic mismatch was waived. The primary clock ends when complete SSE and
+data-model receipt both finish; startup is separate. This is HTTP qualification,
+not browser readiness or physical-footprint evidence. Every offline decode and
+retention operation occurred after both timed arms. The isolated verifier reused
+only complete byte-equal inputs with validated witness/version identities;
+current completion and transport fields were independently checked.
+
+The workspace tests and strict workspace/all-target Clippy passed on the exact
+candidate. Downloaded external fixtures were absent: the preserved test evidence
+records ignored tests and fixture-skip messages. Inline/committed-fixture tests
+exercise ownership, both APIs, retained output, styling/progress/bootstrap
+sequences and cancellation. They complement the actual HTTP cases and are not a
+substitute for corpus qualification.
+
+## Reproduce the rejected source
+
+[measured-candidate.patch](measured-candidate.patch) archives the complete local
+candidate, including its tests and Rust API documentation. It uses zero-context
+full-index Git format so patch-context blank lines do not trigger the repository
+whitespace gate. In an isolated checkout at the public base recorded in
+[source-archive.json](source-archive.json), run:
+
+```sh
+git apply --unidiff-zero /path/to/measured-candidate.patch
+```
+
+Temporary-index application reconstructed the **exact measured candidate tree**.
+The public base's Rust/server/Cargo source also matches the measured control.
+The archive records these identities and the patch digest; applying it is not a
+new build or performance measurement. The candidate used the same pinned
+compiler, explicit standard-library build configuration, target and release
+profile as the control, with no PGO inputs.
+
+Raw captures and complete private logs remain retained; repository evidence
+contains sanitized measurements and their hash references, not those large
+payloads. Exact duplicate evidence files share APFS extents while retaining
+separate paths and inodes. No unique raw evidence was removed.

--- a/scripts/perf/evidence/rejected-owned-batches-2026-09-07/measured-candidate.patch
+++ b/scripts/perf/evidence/rejected-owned-batches-2026-09-07/measured-candidate.patch
@@ -1,0 +1,372 @@
+diff --git a/apps/server/src/services/streaming.rs b/apps/server/src/services/streaming.rs
+index ab0569fadd8c27238ca860ef0719cbc53af3d2ca..3efc1fd2c0de4203e6a6e77770c8aeb96777084c 100644
+--- a/apps/server/src/services/streaming.rs
++++ b/apps/server/src/services/streaming.rs
+@@ -8 +8 @@
+-//! blocking task runs `process_geometry_streaming_filtered_with_options`
++//! blocking task runs `process_geometry_streaming_filtered_with_owned_batches`
+@@ -27 +27 @@ use ifc_lite_processing::{
+-    extract_symbolic_data, process_geometry_streaming_filtered_with_options, OpeningFilterMode,
++    extract_symbolic_data, process_geometry_streaming_filtered_with_owned_batches, OpeningFilterMode,
+@@ -109 +109 @@ pub fn process_streaming(
+-        let result = process_geometry_streaming_filtered_with_options(
++        let result = process_geometry_streaming_filtered_with_owned_batches(
+@@ -144 +144 @@ pub fn process_streaming(
+-                        meshes: meshes.to_vec(),
++                        meshes,
+diff --git a/docs/api/rust.md b/docs/api/rust.md
+index 8302d5fada23993800fb0d4e037d5ee1fbb6d20f..30eeb5e9f49378d15303b644a66219370008f95c 100644
+--- a/docs/api/rust.md
++++ b/docs/api/rust.md
+@@ -496,0 +497 @@ pub use processor::{
++    process_geometry_streaming_filtered_with_owned_batches,
+@@ -512,0 +514,8 @@ pub use parallel_scan::build_entity_index_parallel;
++`process_geometry_streaming_filtered_with_owned_batches` delivers each batch as
++`Vec<MeshData>` to a callback receiving the processed and total job counts. With
++`StreamingOptions.retain_emitted_meshes = false`, mesh buffers transfer to that
++callback. With retention enabled, batches are cloned so the callback and returned
++`ProcessingResult` each own their meshes. The existing borrowed callbacks remain
++available; both forms use the same processing loop, batch boundaries, styling
++callbacks and cooperative cancellation checks.
++
+diff --git a/rust/processing/src/lib.rs b/rust/processing/src/lib.rs
+index 9fe4074a684bd8ec3215a2c9542e770193ecfe92..58861ee59f16f75de2ab256fad7963ff1d5e49bb 100644
+--- a/rust/processing/src/lib.rs
++++ b/rust/processing/src/lib.rs
+@@ -77,0 +78 @@ pub use processor::{
++    process_geometry_streaming_filtered_with_owned_batches,
+diff --git a/rust/processing/src/processor/batch_sink.rs b/rust/processing/src/processor/batch_sink.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..0814d2663f47ba063db0f5cba6fcfdcf8b831d0d
+--- /dev/null
++++ b/rust/processing/src/processor/batch_sink.rs
+@@ -0,0 +1,92 @@
++// This Source Code Form is subject to the terms of the Mozilla Public
++// License, v. 2.0. If a copy of the MPL was not distributed with this
++// file, You can obtain one at https://mozilla.org/MPL/2.0/.
++
++//! Batch ownership adapters for the single canonical processing loop.
++
++use super::{MeshData, OpeningFilterMode, ProcessingResult, QuickMetadataBootstrap, StreamingOptions};
++
++pub(super) trait BatchSink {
++    fn emit(
++        &mut self,
++        meshes: &mut Vec<MeshData>,
++        size: usize,
++        processed: usize,
++        total: usize,
++        retain: bool,
++    );
++}
++
++struct BorrowedBatch<F>(F);
++
++impl<F: FnMut(&[MeshData], usize, usize)> BatchSink for BorrowedBatch<F> {
++    fn emit(&mut self, meshes: &mut Vec<MeshData>, size: usize, processed: usize, total: usize, _retain: bool) {
++        for batch in meshes.chunks(size) {
++            (self.0)(batch, processed, total);
++        }
++    }
++}
++
++struct OwnedBatch<F>(F);
++
++impl<F: FnMut(Vec<MeshData>, usize, usize)> BatchSink for OwnedBatch<F> {
++    fn emit(&mut self, meshes: &mut Vec<MeshData>, size: usize, processed: usize, total: usize, retain: bool) {
++        if retain {
++            // Dual ownership requires a copy. Preserve returned meshes and the
++            // borrowed API's callback-before-retention order for these callers.
++            for batch in meshes.chunks(size) {
++                (self.0)(batch.to_vec(), processed, total);
++            }
++            return;
++        }
++        let owned = std::mem::take(meshes);
++        if owned.is_empty() {
++            return;
++        }
++        if owned.len() <= size {
++            // Common case: move even the outer allocation into the receiver.
++            (self.0)(owned, processed, total);
++            return;
++        }
++        let mut remaining = owned.into_iter();
++        while remaining.len() > 0 {
++            // Only MeshData descriptors move. Positions, normals, indices and
++            // optional payload buffers retain their allocations and order.
++            (self.0)(remaining.by_ref().take(size).collect(), processed, total);
++        }
++    }
++}
++
++/// Process IFC content with parallel geometry extraction and configurable streaming behavior.
++pub fn process_geometry_streaming_filtered_with_options(
++    content: &[u8],
++    opening_filter: OpeningFilterMode,
++    options: StreamingOptions,
++    on_batch: impl FnMut(&[MeshData], usize, usize),
++    on_color_update: impl FnMut(&[(u32, [f32; 4])]),
++    on_quick_metadata_bootstrap: impl FnMut(&QuickMetadataBootstrap),
++) -> ProcessingResult {
++    super::process_geometry_with_sink(content, opening_filter, options, BorrowedBatch(on_batch), on_color_update, on_quick_metadata_bootstrap)
++}
++
++/// Emit owned batches from the canonical processing loop.
++///
++/// With `retain_emitted_meshes = false`, mesh buffers move to the callback
++/// without cloning. With retention enabled, batches are copied so both the
++/// callback and the returned result own their meshes. Batch boundaries,
++/// callback progress, styling and cooperative cancellation match
++/// [`process_geometry_streaming_filtered_with_options`].
++pub fn process_geometry_streaming_filtered_with_owned_batches(
++    content: &[u8],
++    opening_filter: OpeningFilterMode,
++    options: StreamingOptions,
++    on_batch: impl FnMut(Vec<MeshData>, usize, usize),
++    on_color_update: impl FnMut(&[(u32, [f32; 4])]),
++    on_quick_metadata_bootstrap: impl FnMut(&QuickMetadataBootstrap),
++) -> ProcessingResult {
++    super::process_geometry_with_sink(content, opening_filter, options, OwnedBatch(on_batch), on_color_update, on_quick_metadata_bootstrap)
++}
++
++#[cfg(test)]
++#[path = "batch_sink_tests.rs"]
++mod tests;
+diff --git a/rust/processing/src/processor/batch_sink_tests.rs b/rust/processing/src/processor/batch_sink_tests.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..0daa413a894348d3242bde72201308339e7f9e2e
+--- /dev/null
++++ b/rust/processing/src/processor/batch_sink_tests.rs
+@@ -0,0 +1,68 @@
++// This Source Code Form is subject to the terms of the Mozilla Public
++// License, v. 2.0. If a copy of the MPL was not distributed with this
++// file, You can obtain one at https://mozilla.org/MPL/2.0/.
++
++//! #4066: ownership transfer must retain buffer identity and batch boundaries.
++
++use super::{BatchSink, BorrowedBatch, MeshData, OwnedBatch};
++
++fn mesh(id: u32) -> MeshData {
++    let mut mesh = MeshData::new(id, "IfcWall".into(), vec![id as f32, -0.0, 1.0], vec![0.0, 0.0, 1.0], vec![0, 0, 0], [0.2, 0.3, 0.4, 1.0]);
++    mesh.uvs = Some(vec![0.25, 0.75]);
++    mesh
++}
++
++#[test]
++fn owned_nonretained_split_moves_every_inner_buffer_without_copying() {
++    let mut input: Vec<_> = (0..5).map(mesh).collect();
++    let pointers: Vec<_> = input.iter().map(|m| (m.positions.as_ptr(), m.normals.as_ptr(), m.indices.as_ptr(), m.uvs.as_ref().unwrap().as_ptr())).collect();
++    let mut batches = Vec::new();
++    OwnedBatch(|batch: Vec<MeshData>, processed, total| batches.push((batch, processed, total)))
++        .emit(&mut input, 2, 7, 11, false);
++    assert!(input.is_empty());
++    assert_eq!(batches.iter().map(|(b, _, _)| b.len()).collect::<Vec<_>>(), [2, 2, 1]);
++    assert!(batches.iter().all(|(_, processed, total)| (*processed, *total) == (7, 11)));
++    let emitted: Vec<_> = batches.iter().flat_map(|(b, _, _)| b).collect();
++    assert_eq!(emitted.iter().map(|m| m.express_id).collect::<Vec<_>>(), [0, 1, 2, 3, 4]);
++    for (index, m) in emitted.iter().enumerate() {
++        assert_eq!((m.positions.as_ptr(), m.normals.as_ptr(), m.indices.as_ptr(), m.uvs.as_ref().unwrap().as_ptr()), pointers[index]);
++        assert_eq!(m.positions[1].to_bits(), (-0.0_f32).to_bits());
++    }
++}
++
++#[test]
++fn owned_single_batch_moves_outer_allocation_too() {
++    let mut input: Vec<_> = (0..3).map(mesh).collect();
++    let pointer = input.as_ptr();
++    let mut received = None;
++    OwnedBatch(|batch: Vec<MeshData>, _, _| received = Some(batch)).emit(&mut input, 3, 3, 3, false);
++    let received = received.unwrap();
++    assert_eq!(received.as_ptr(), pointer);
++    assert!(input.is_empty());
++}
++
++#[test]
++fn retained_owned_batches_keep_two_independent_owners_and_borrowed_stays_borrowed() {
++    let mut input = vec![mesh(1), mesh(2)];
++    let pointer = input[0].positions.as_ptr();
++    let mut received = Vec::new();
++    OwnedBatch(|batch: Vec<MeshData>, _, _| received.extend(batch)).emit(&mut input, 1, 2, 2, true);
++    assert_eq!(input.len(), 2);
++    assert_eq!(input[0].positions.as_ptr(), pointer);
++    assert_ne!(received[0].positions.as_ptr(), pointer);
++    received[0].positions[0] = 99.0;
++    assert_eq!(input[0].positions[0], 1.0);
++    let mut seen = Vec::new();
++    BorrowedBatch(|batch: &[MeshData], _, _| seen.push(batch[0].positions.as_ptr()))
++        .emit(&mut input, 1, 2, 2, false);
++    assert_eq!(seen[0], pointer);
++    assert_eq!(input.len(), 2);
++}
++
++#[test]
++fn empty_chunks_never_emit_callbacks_in_either_ownership_mode() {
++    let mut empty = Vec::new();
++    OwnedBatch(|_: Vec<MeshData>, _, _| panic!("empty owned callback")).emit(&mut empty, 1, 0, 0, false);
++    OwnedBatch(|_: Vec<MeshData>, _, _| panic!("empty retained callback")).emit(&mut empty, 1, 0, 0, true);
++    BorrowedBatch(|_: &[MeshData], _, _| panic!("empty borrowed callback")).emit(&mut empty, 1, 0, 0, false);
++}
+diff --git a/rust/processing/src/processor/mod.rs b/rust/processing/src/processor/mod.rs
+index ce3265d2767ebdbb822c430d4f32781aa4f5d10c..f36707077d486f5bd1ab49f278142af6ea556afb 100644
+--- a/rust/processing/src/processor/mod.rs
++++ b/rust/processing/src/processor/mod.rs
+@@ -24,0 +25,2 @@ use std::sync::Arc;
++mod batch_sink;
++pub use batch_sink::{process_geometry_streaming_filtered_with_options, process_geometry_streaming_filtered_with_owned_batches};
+@@ -461,2 +463,2 @@ pub fn process_geometry_streaming_filtered(
+-/// Process IFC content with parallel geometry extraction and configurable streaming behavior.
+-pub fn process_geometry_streaming_filtered_with_options(
++/// Shared orchestrator; batch adapters change ownership only.
++fn process_geometry_with_sink(
+@@ -466 +468 @@ pub fn process_geometry_streaming_filtered_with_options(
+-    mut on_batch: impl FnMut(&[MeshData], usize, usize),
++    mut on_batch: impl batch_sink::BatchSink,
+@@ -1371 +1373 @@ pub fn process_geometry_streaming_filtered_with_options(
+-        let chunk_meshes: Vec<MeshData> = jobs_chunk
++        let mut chunk_meshes: Vec<MeshData> = jobs_chunk
+@@ -1448,3 +1450 @@ pub fn process_geometry_streaming_filtered_with_options(
+-            for emitted_meshes in chunk_meshes.chunks(emit_mesh_chunk_size) {
+-                on_batch(emitted_meshes, processed_jobs, total_jobs);
+-            }
++            on_batch.emit(&mut chunk_meshes, emit_mesh_chunk_size, processed_jobs, total_jobs, options.retain_emitted_meshes);
+diff --git a/rust/processing/tests/issue_4066_owned_streaming.rs b/rust/processing/tests/issue_4066_owned_streaming.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..eace9049f242ed5d84b7f73a97887deb0317753e
+--- /dev/null
++++ b/rust/processing/tests/issue_4066_owned_streaming.rs
+@@ -0,0 +1,134 @@
++// This Source Code Form is subject to the terms of the Mozilla Public
++// License, v. 2.0. If a copy of the MPL was not distributed with this
++// file, You can obtain one at https://mozilla.org/MPL/2.0/.
++
++//! #4066: both ownership adapters must traverse the same canonical pipeline.
++
++use ifc_lite_processing::{
++    process_geometry_streaming_filtered_with_options,
++    process_geometry_streaming_filtered_with_owned_batches,
++    MeshData, OpeningFilterMode, ProcessingResult, StreamingOptions,
++};
++use std::cell::RefCell;
++use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
++
++const IFC: &str = r#"ISO-10303-21;
++HEADER;
++FILE_DESCRIPTION(('4066 owned batch invariant'),'2;1');
++FILE_NAME('owned.ifc','2026-09-07T00:00:00',(''),(''),'','','');
++FILE_SCHEMA(('IFC4'));
++ENDSEC;
++DATA;
++#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
++#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
++#3=IFCUNITASSIGNMENT((#6));
++#4=IFCCARTESIANPOINT((0.,0.,0.));
++#5=IFCAXIS2PLACEMENT3D(#4,$,$);
++#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
++#10=IFCBUILDINGELEMENTPROXY('1ProxyOwned0000000001',$,'One',$,$,#11,#12,$,$);
++#20=IFCBUILDINGELEMENTPROXY('1ProxyOwned0000000002',$,'Two',$,$,#11,#12,$,$);
++#21=IFCBUILDINGELEMENTPROXY('1ProxyOwned0000000003',$,'Three',$,$,#11,#12,$,$);
++#22=IFCBUILDINGELEMENTPROXY('1ProxyOwned0000000004',$,'Four',$,$,#11,#12,$,$);
++#23=IFCBUILDINGELEMENTPROXY('1ProxyOwned0000000005',$,'Five',$,$,#11,#12,$,$);
++#11=IFCLOCALPLACEMENT($,#5);
++#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
++#13=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#14));
++#14=IFCTRIANGULATEDFACESET(#15,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
++#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
++#30=IFCSTYLEDITEM(#14,(#31),$);
++#31=IFCSURFACESTYLE('Blue',.BOTH.,(#32));
++#32=IFCSURFACESTYLERENDERING(#33,$,$,$,$,$,$,$,.FLAT.);
++#33=IFCCOLOURRGB($,0.2,0.3,0.8);
++ENDSEC;
++END-ISO-10303-21;
++"#;
++
++#[derive(Debug, PartialEq)]
++enum Event {
++    Batch(Vec<u32>, usize, usize),
++    Colors(Vec<(u32, [u32; 4])>),
++    Bootstrap(serde_json::Value),
++}
++
++fn run(owned: bool, retain: bool, fast: bool, cancel_after_batch: bool) -> (ProcessingResult, Vec<MeshData>, Vec<Event>) {
++    let events = RefCell::new(Vec::new());
++    let delivered = RefCell::new(Vec::new());
++    let cancel = Arc::new(AtomicBool::new(false));
++    let options = StreamingOptions {
++        initial_batch_size: 1,
++        throughput_batch_size: 2,
++        fast_first_batch: fast,
++        include_presentation_layers: false,
++        emit_quick_metadata_bootstrap: true,
++        retain_emitted_meshes: retain,
++        cancel: Some(Arc::clone(&cancel)),
++        ..StreamingOptions::default()
++    };
++    let record = |batch: Vec<MeshData>, processed, total| {
++        events.borrow_mut().push(Event::Batch(batch.iter().map(|m| m.express_id).collect(), processed, total));
++        delivered.borrow_mut().extend(batch);
++        if cancel_after_batch { cancel.store(true, Ordering::Relaxed); }
++    };
++    let colors = |updates: &[(u32, [f32; 4])]| {
++        events.borrow_mut().push(Event::Colors(updates.iter().map(|(id, color)| (*id, color.map(f32::to_bits))).collect()));
++    };
++    let bootstrap = |value: &ifc_lite_processing::QuickMetadataBootstrap| {
++        events.borrow_mut().push(Event::Bootstrap(serde_json::to_value(value).unwrap()));
++    };
++    let result = if owned {
++        process_geometry_streaming_filtered_with_owned_batches(IFC.as_bytes(), OpeningFilterMode::Default, options, record, colors, bootstrap)
++    } else {
++        process_geometry_streaming_filtered_with_options(IFC.as_bytes(), OpeningFilterMode::Default, options, |batch, processed, total| record(batch.to_vec(), processed, total), colors, bootstrap)
++    };
++    (result, delivered.into_inner(), events.into_inner())
++}
++
++fn assert_meshes_exact(left: &[MeshData], right: &[MeshData]) {
++    assert_eq!(left.len(), right.len());
++    for (a, b) in left.iter().zip(right) {
++        assert_eq!(serde_json::to_value(a).unwrap(), serde_json::to_value(b).unwrap());
++        assert_eq!(a.positions.iter().map(|x| x.to_bits()).collect::<Vec<_>>(), b.positions.iter().map(|x| x.to_bits()).collect::<Vec<_>>());
++        assert_eq!(a.normals.iter().map(|x| x.to_bits()).collect::<Vec<_>>(), b.normals.iter().map(|x| x.to_bits()).collect::<Vec<_>>());
++        assert_eq!(a.local_bounds.map(|v| v.map(f32::to_bits)), b.local_bounds.map(|v| v.map(f32::to_bits)));
++        assert_eq!(a.local_to_world.map(|v| v.map(f64::to_bits)), b.local_to_world.map(|v| v.map(f64::to_bits)));
++    }
++}
++
++#[test]
++fn borrowed_owned_retention_and_deferred_event_sequences_match() {
++    for retain in [false, true] {
++        for fast in [false, true] {
++            let (a, am, ae) = run(false, retain, fast, false);
++            let (b, bm, be) = run(true, retain, fast, false);
++            assert_eq!(ae, be);
++            assert_meshes_exact(&am, &bm);
++            assert_meshes_exact(&a.meshes, &b.meshes);
++            assert_eq!(bm.len(), 5);
++            assert_eq!((a.stats.total_meshes, a.stats.total_vertices, a.stats.total_triangles), (b.stats.total_meshes, b.stats.total_vertices, b.stats.total_triangles));
++            assert_eq!(b.stats.total_meshes, bm.len());
++            assert_eq!(b.meshes.len(), if retain { 5 } else { 0 });
++            assert_eq!(serde_json::to_value(&a.metadata).unwrap(), serde_json::to_value(&b.metadata).unwrap());
++            assert!(matches!(be.first(), Some(Event::Bootstrap(_))));
++            let batches: Vec<_> = be.iter().filter_map(|e| match e { Event::Batch(ids, processed, total) => Some((ids.len(), *processed, *total)), _ => None }).collect();
++            assert_eq!(batches, [(1, 1, 5), (2, 3, 5), (2, 5, 5)]);
++            if fast {
++                let color = be.iter().position(|e| matches!(e, Event::Colors(_))).expect("deferred style callback missing");
++                assert!(matches!(be[color - 1], Event::Batch(_, 1, 5)));
++            }
++        }
++    }
++}
++
++#[test]
++fn cancellation_stops_at_the_same_job_boundary_without_losing_emitted_meshes() {
++    for retain in [false, true] {
++        let (a, am, ae) = run(false, retain, true, true);
++        let (b, bm, be) = run(true, retain, true, true);
++        assert_eq!(ae, be);
++        assert_meshes_exact(&am, &bm);
++        assert_meshes_exact(&a.meshes, &b.meshes);
++        assert_eq!(bm.len(), 1);
++        assert_eq!(b.meshes.len(), usize::from(retain));
++        assert_eq!(be.iter().filter(|e| matches!(e, Event::Batch(_, _, _))).count(), 1);
++    }
++}

--- a/scripts/perf/evidence/rejected-owned-batches-2026-09-07/screen.json
+++ b/scripts/perf/evidence/rejected-owned-batches-2026-09-07/screen.json
@@ -1,0 +1,371 @@
+{
+  "verdict": "rejected; no production implementation landed and no 27-model expansion",
+  "issue": 4066,
+  "attempts": 6,
+  "pairsPerModel": 1,
+  "modelCount": 3,
+  "allAttemptsRetained": true,
+  "allThreeExactGatesPassed": true,
+  "predeclaredContinuationRule": {
+    "allThreeExactGatesMustPass": true,
+    "equalWeightThreeModelGeometricMeanTimeReductionAtLeastPercent": 5,
+    "bothLargeModelsMustHavePositiveTimeReduction": true,
+    "atLeastOneLargeModelTimeReductionAtLeastPercent": 5,
+    "holdIfAnyLargeColdOrWholeProtocolSampledRssIncreaseExceedsPercent": 10,
+    "smallModelTimingRegressions": "Retain and require repeated qualification; one pair cannot establish no regressions.",
+    "action": "Only eligibility for wider27 qualification; no automatic landing/merge; no threshold revision after observing results."
+  },
+  "continuationGates": {
+    "threeModelGM": false,
+    "bothLargePositive": false,
+    "oneLargeAtLeastFivePercent": false,
+    "noLargeCapacityWarning": true
+  },
+  "equalWeightThreeModelTimeReductionPercent": -16.903651949857903,
+  "eligibleFor27": false,
+  "models": [
+    {
+      "label": "small-haus",
+      "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+      "sourceBytes": 2526544,
+      "order": [
+        "base",
+        "candidate"
+      ],
+      "arms": {
+        "base": {
+          "httpFeatureReadyMs": 29.768,
+          "startupReadyMs": 34.268,
+          "peakSampledRss": 113410048,
+          "peakSampledRssThroughColdReady": 113410048,
+          "shutdownStartMs": 79.788,
+          "shutdownEndMs": 84.363,
+          "peakFirstMs": 58.428,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 285,
+            "total_vertices": 35940,
+            "total_triangles": 19456
+          }
+        },
+        "candidate": {
+          "httpFeatureReadyMs": 48.42399999999998,
+          "startupReadyMs": 381.502,
+          "peakSampledRss": 85032960,
+          "peakSampledRssThroughColdReady": 85032960,
+          "shutdownStartMs": 448.755,
+          "shutdownEndMs": 451.946,
+          "peakFirstMs": 405.866,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 285,
+            "total_vertices": 35940,
+            "total_triangles": 19456
+          }
+        }
+      },
+      "offlineExitCode": 0,
+      "gates": {
+        "transportSuccess": true,
+        "fixtureExact": true,
+        "shutdownComplete": true,
+        "completeExactChannels": true
+      },
+      "comparisons": {
+        "coldBaseCandidate": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "baseCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "candidateCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        }
+      },
+      "descriptiveRatios": {
+        "label": "small-haus",
+        "qualified": true,
+        "timeReductionPercent": -62.67132491265781,
+        "timeRatio": 1.626713249126578,
+        "coldSampledRssIncreasePercent": -25.021670037561393,
+        "wholeProtocolSampledRssIncreasePercent": -25.021670037561393
+      }
+    },
+    {
+      "label": "large-mep-1050",
+      "fixtureSha256": "ce0510a0117b88b34b7c52c4234254155def73d860f5acecbf1f47559f00c5cd",
+      "sourceBytes": 1050352883,
+      "order": [
+        "candidate",
+        "base"
+      ],
+      "arms": {
+        "base": {
+          "httpFeatureReadyMs": 9040.139,
+          "startupReadyMs": 34.324,
+          "peakSampledRss": 19604652032,
+          "peakSampledRssThroughColdReady": 19604652032,
+          "shutdownStartMs": 17657.925,
+          "shutdownEndMs": 17804.007,
+          "peakFirstMs": 4239.319,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "ce0510a0117b88b34b7c52c4234254155def73d860f5acecbf1f47559f00c5cd",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 227352,
+            "total_vertices": 54578002,
+            "total_triangles": 32358126
+          }
+        },
+        "candidate": {
+          "httpFeatureReadyMs": 9161.886,
+          "startupReadyMs": 24.974,
+          "peakSampledRss": 19817119744,
+          "peakSampledRssThroughColdReady": 19817119744,
+          "shutdownStartMs": 17634.918,
+          "shutdownEndMs": 17783.628,
+          "peakFirstMs": 4563.459,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "ce0510a0117b88b34b7c52c4234254155def73d860f5acecbf1f47559f00c5cd",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 227352,
+            "total_vertices": 54578002,
+            "total_triangles": 32358126
+          }
+        }
+      },
+      "offlineExitCode": 0,
+      "gates": {
+        "transportSuccess": true,
+        "fixtureExact": true,
+        "shutdownComplete": true,
+        "completeExactChannels": true
+      },
+      "comparisons": {
+        "coldBaseCandidate": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "baseCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "candidateCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        }
+      },
+      "descriptiveRatios": {
+        "label": "large-mep-1050",
+        "qualified": true,
+        "timeReductionPercent": -1.3467381419688396,
+        "timeRatio": 1.0134673814196884,
+        "coldSampledRssIncreasePercent": 1.0837617094819896,
+        "wholeProtocolSampledRssIncreasePercent": 1.0837617094819896
+      }
+    },
+    {
+      "label": "downloads-01-1259mb",
+      "fixtureSha256": "887c68571ac721e40c9c0d98a5ca889c3b8ad037a1012c06314a674a798ddc9a",
+      "sourceBytes": 1259429221,
+      "order": [
+        "base",
+        "candidate"
+      ],
+      "arms": {
+        "base": {
+          "httpFeatureReadyMs": 39830.367,
+          "startupReadyMs": 27.93,
+          "peakSampledRss": 20331020288,
+          "peakSampledRssThroughColdReady": 20331020288,
+          "shutdownStartMs": 55805.916,
+          "shutdownEndMs": 55936.391,
+          "peakFirstMs": 5325.726,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "887c68571ac721e40c9c0d98a5ca889c3b8ad037a1012c06314a674a798ddc9a",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 434750,
+            "total_vertices": 79174542,
+            "total_triangles": 36271975
+          }
+        },
+        "candidate": {
+          "httpFeatureReadyMs": 38599.152,
+          "startupReadyMs": 29.449,
+          "peakSampledRss": 20950876160,
+          "peakSampledRssThroughColdReady": 20950876160,
+          "shutdownStartMs": 54667.114,
+          "shutdownEndMs": 54808.109,
+          "peakFirstMs": 4860.282,
+          "peakPhase": "cold",
+          "wrapperExitCode": 0,
+          "fixtureSha256": "887c68571ac721e40c9c0d98a5ca889c3b8ad037a1012c06314a674a798ddc9a",
+          "transportSuccess": true,
+          "cacheReplaySuccess": true,
+          "cacheReplayRequest": "hash-only POST; no source body",
+          "serverExitCode": -15,
+          "shutdownTimedOut": false,
+          "deadlineKilled": false,
+          "counts": {
+            "total_meshes": 434750,
+            "total_vertices": 79174542,
+            "total_triangles": 36271975
+          }
+        }
+      },
+      "offlineExitCode": 0,
+      "gates": {
+        "transportSuccess": true,
+        "fixtureExact": true,
+        "shutdownComplete": true,
+        "completeExactChannels": true
+      },
+      "comparisons": {
+        "coldBaseCandidate": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "baseCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        },
+        "candidateCache": {
+          "fullSemanticExact": true,
+          "rawGeometryBatchesExact": true,
+          "rawDataModelExact": true
+        }
+      },
+      "descriptiveRatios": {
+        "label": "downloads-01-1259mb",
+        "qualified": true,
+        "timeReductionPercent": 3.091146511404219,
+        "timeRatio": 0.9690885348859578,
+        "coldSampledRssIncreasePercent": 3.0488183240162225,
+        "wholeProtocolSampledRssIncreasePercent": 3.0488183240162225
+      }
+    }
+  ],
+  "build": {
+    "publicControlSource": "1b95c6652f49409ed102a693e67c8cba7da4f3ae",
+    "measuredControlSource": "cf38caabaca57ffe8be54b534da884787e2f5fb8",
+    "publicControlAllRustServerCargoSourceExact": true,
+    "measuredCandidateSource": "3e675edea949456561f23e3112123b69fd6198ab",
+    "measuredCandidateTree": "1c406b6732365e873aa00af6a113b9ca860102d6",
+    "controlBinarySha256": "ea55315adb1f781d51fc0f1e70e5125a58d021ccf0e736e6ce1d0c86531b5169",
+    "candidateBinarySha256": "29524964a99461bd08cd9dc834be6c4fc137ed3584a4ae3c1e4e5935cf9b3468",
+    "command": [
+      "cargo",
+      "build",
+      "--release",
+      "--package",
+      "ifc-lite-server",
+      "--target",
+      "aarch64-apple-darwin"
+    ],
+    "RUSTFLAGS": "",
+    "CARGO_UNSTABLE_BUILD_STD": "std,panic_abort",
+    "features": "default (mimalloc; processing observability)",
+    "profile": "release (panic abort)",
+    "target": "aarch64-apple-darwin",
+    "rustc": "rustc 1.93.0-nightly (b6d7ff3aa 2025-11-14)\nbinary: rustc\ncommit-hash: b6d7ff3aa71e48e2901b0900f8b5d98126b537ed\ncommit-date: 2025-11-14\nhost: aarch64-apple-darwin\nrelease: 1.93.0-nightly\nLLVM version: 21.1.5\n",
+    "PGO": false
+  },
+  "validation": {
+    "focusedOwnershipTestsPassed": 4,
+    "canonicalIfcPipelineTestsPassed": 2,
+    "workspaceCommand": "cargo test --workspace -- --show-output",
+    "workspacePassed": 2851,
+    "workspaceFailed": 0,
+    "workspaceIgnored": 36,
+    "fixtureSkipGuidanceLines": 182,
+    "externalDownloadedFixturesPresent": false,
+    "strictClippyCommand": "cargo clippy --workspace --all-targets -- -D warnings",
+    "strictClippyExitCode": 0,
+    "countsOverlap": "Focused tests are included in workspace totals; counts must not be added."
+  },
+  "evidenceHashes": {
+    "prespecifiedProtocol": "00b54fd5ea5f13bc8fa498da0f4077fa5209bb8729952795ade1efdfaecd9af9",
+    "driverAndInputFreeze": "2edf868325b8afa21bbf512785c3434b14e7bff574515e57ec81de21c12b10c6",
+    "privateFinalReport": "b668fe2f7759bb64d3f82172ed20d8aa913c040142edad34fbb427564d298b82",
+    "workspaceTestLog": "ef640a360922fb5798616edbfc0065f63aab86353b8f5d59fbdfa08dff9f62ec",
+    "clippyLog": "b94bfe6acb23f0f9a1ddf5461727d33b4628e4503b3f5ce9b814d75e184138dd",
+    "candidateBuildLog": "aeb877bd6d7bb0c392ff21c6b1b9f12cf1ad8b10b84d2ecde2947de6124a0f5d"
+  },
+  "scope": [
+    "Actual HTTP complete-SSE-plus-data-model readiness from request start; startup separate. Fresh server process for each arm; operating-system caches uncontrolled.",
+    "Actual bodyless hash-only cache replay in every arm; all raw geometry/data-model bytes and full declared witness fields checked. No diagnostic waiver or geometry tolerance.",
+    "Offline v3 reuses only fully byte-validated pure-input fragments with verifier identity; current Complete metadata/diagnostics/counts/cleanup are rechecked. It produced exact v2 bytes on small and largest validation captures.",
+    "All offline decoding and COW retention run after both timed arms. No PGO inputs, prior-pilot timings or unrelated source changes pooled.",
+    "RSS is sampled every 50 ms; cold-readiness and whole-protocol peaks reported separately. It is not physical footprint or an exact peak.",
+    "Single-pair observations cannot attribute exact causal contributions or establish general regressions, wins, or no-regression behavior. Haus absolute penalty and separate startup anomaly are retained.",
+    "Downloaded external Rust fixtures were absent; early skips/ignored tests remain documented. Inline and committed fixtures ran. HTTP inputs are independently SHA-pinned.",
+    "Clone removal is a real source mechanism, but does not establish a material end-to-end improvement. No further corpus screen or production change was justified."
+  ],
+  "witnessDefinition": {
+    "fields": [
+      "geometry occurrence records and schemas",
+      "metadataDigest",
+      "non-timing diagnostics",
+      "symbolicDigest",
+      "all eight data-model tables including spatial sub-tables"
+    ],
+    "diagnosticExclusions": [
+      "*_time_ms",
+      "point_cache_hits",
+      "point_cache_misses",
+      "from_cache"
+    ],
+    "rawGates": [
+      "ordered raw geometry batch files",
+      "complete raw data-model binary"
+    ],
+    "limit": "Exact equality of the declared semantic witness and raw geometry/data-model payloads; not byte identity of every HTTP event including timing/cache identifiers."
+  }
+}

--- a/scripts/perf/evidence/rejected-owned-batches-2026-09-07/source-archive.json
+++ b/scripts/perf/evidence/rejected-owned-batches-2026-09-07/source-archive.json
@@ -1,0 +1,22 @@
+{
+  "patch": "measured-candidate.patch",
+  "sha256": "f2007feaf8dafc7cc3777f280af3bf2642afa7930ddfb17e03395ddd14ed61f0",
+  "encoding": "git diff --binary --full-index --unified=0; apply with git apply --unidiff-zero",
+  "publicApplyBase": "1b95c6652f49409ed102a693e67c8cba7da4f3ae",
+  "measuredPrivateParent": "6aec7b6a08510b7a87dc88f8d1a6fb9467a5506c",
+  "measuredCandidate": "3e675edea949456561f23e3112123b69fd6198ab",
+  "reconstructedTree": "1c406b6732365e873aa00af6a113b9ca860102d6",
+  "checkedSourceScopes": [
+    "rust",
+    "apps/server",
+    "Cargo.toml",
+    "Cargo.lock",
+    ".cargo/config.toml"
+  ],
+  "compiledSourceDifferencesFromMeasuredCandidate": [],
+  "allSevenChangedFileBlobsExact": true,
+  "otherTreeDifferencesFromMeasuredCandidate": [],
+  "limit": "Temporary-index application on the public base reconstructs the exact measured candidate tree. This is source reconstruction, not a fresh build or repeated performance measurement.",
+  "measuredCandidateTree": "1c406b6732365e873aa00af6a113b9ca860102d6",
+  "fullMeasuredTreeExact": true
+}


### PR DESCRIPTION
The owned server mesh-batch candidate failed its prespecified three-model HTTP continuation rule despite passing every declared exact-output, raw payload, cache-replay and cleanup gate. Record the rejection and its lesson without landing the implementation or expanding to the wider corpus.

The evidence retains all six fresh-process arms, startup separately from complete-SSE-plus-data-model readiness, sampled RSS, the frozen thresholds, and exact source/compiler/artifact identities. Single-pair results establish neither precise causality nor a physical-footprint change. Downloaded-fixture skips and ignored Rust tests remain explicit.

Validation: the candidate passed all six new ownership/pipeline tests, the full Rust workspace (2,851 passed, 36 ignored; external-fixture skip output retained), and `cargo clippy --workspace --all-targets -- -D warnings`. For this documentation-only change, JSON arithmetic/gates, privacy scanning, patch digests and `git diff --check` pass. Temporary-index application of the archived zero-context patch on public main `1b95c6652` reconstructs the exact measured candidate tree. No new performance measurement is implied by that source reconstruction.

Revert-oracle exemption: this PR changes only the performance ledger and non-executed evidence (JSON, Markdown and an archived patch). The oracle classifies evidence JSON as production code, but there is no application implementation to revert or regression test to make red. The maintainer-authorized `revert-oracle-exempt` label covers that artifact-classification false positive; all other checks and reviews remain required.

Closes #4066.
