### PR TITLE
fix(processing): correct CSG diagnostic mislabel, add #4067 non-determinism reproduction

### DIFF
--- a/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
+++ b/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
@@ -107,6 +107,32 @@ fn kernel_error_count(router: &GeometryRouter) -> usize {
         .count()
 }
 
+/// Feature-agnostic count of "this open-topology union was flagged at all".
+///
+/// `record_topology_tear` (default build, and the `csg_manifold_gate`-only
+/// build, which never touches `topology_gate_reject`) records this as
+/// `KernelError`. Under `csg_topology_gate`, `union.rs`'s
+/// `accept_gates_reject` intercepts the SAME tear first and records
+/// `OpenTopologyRejected` instead, returning early WITHOUT also calling
+/// `record_topology_tear` (see the comment on that call site) — so under that
+/// feature `kernel_error_count` alone reads 0 even though the fixture tore
+/// exactly as designed. This control only needs to know the tear was
+/// recorded SOME way; which `BoolFailureReason` variant carries it is the
+/// accept-gate's choice, not this fixture's.
+fn open_topology_incident_count(router: &GeometryRouter) -> usize {
+    router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .filter(|f| {
+            matches!(
+                f.reason,
+                BoolFailureReason::KernelError(_) | BoolFailureReason::OpenTopologyRejected
+            )
+        })
+        .count()
+}
+
 fn mesh_signature(mesh: &ifc_lite_geometry::Mesh) -> (usize, usize, u64) {
     let bits_sum: u64 = mesh
         .positions
@@ -116,9 +142,20 @@ fn mesh_signature(mesh: &ifc_lite_geometry::Mesh) -> (usize, usize, u64) {
     (mesh.positions.len(), mesh.indices.len(), bits_sum)
 }
 
-/// Sanity control: with NO cache at all, the union really does record
-/// `KernelError` — otherwise every assertion below would trivially pass for
-/// the wrong reason (the geometry never tearing in the first place).
+/// Sanity control: with NO cache at all, the union really does get flagged as
+/// an open-topology accept — otherwise every assertion below would trivially
+/// pass for the wrong reason (the geometry never tearing in the first place).
+///
+/// This test is NOT `#[ignore]`d — the CI "CSG accept gates (feature builds)"
+/// job (`.github/workflows/test.yml`) runs `cargo test -p ifc-lite-geometry
+/// --features csg_topology_gate` (and the `csg_manifold_gate,csg_topology_gate`
+/// combination) directly, with no `--ignored`, so this control compiles and
+/// runs under those features too. It therefore reads
+/// `open_topology_incident_count` (either `BoolFailureReason::KernelError` or
+/// `OpenTopologyRejected`), not the narrower `kernel_error_count` the two
+/// `#[ignore]`d #4083 reproductions below use — those only ever run under the
+/// default feature set (`cargo test -p ifc-lite-geometry -- --ignored`),
+/// where `KernelError` is the only variant this fixture can produce.
 #[test]
 fn open_union_records_kernel_error_uncached() {
     let mut decoder = fresh_decoder(WALL_WITH_OPEN_UNION);
@@ -128,11 +165,12 @@ fn open_union_records_kernel_error_uncached() {
         .process_element(&entity, &mut decoder)
         .expect("mesh the open-union wall");
     assert!(!mesh.positions.is_empty(), "union must produce geometry, not an empty mesh");
-    let count = kernel_error_count(&router);
+    let count = open_topology_incident_count(&router);
     assert_eq!(
         count, 1,
-        "expected exactly one KernelError (open-topology accept) from the uncached union; \
-         if this is 0 the fixture no longer tears and the repro below is vacuous"
+        "expected exactly one open-topology accept (KernelError, or OpenTopologyRejected under \
+         csg_topology_gate) from the uncached union; if this is 0 the fixture no longer tears \
+         and the repro below is vacuous"
     );
 }
 

--- a/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
+++ b/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
@@ -143,7 +143,14 @@ fn open_union_records_kernel_error_uncached() {
 /// on the second router is empty. Independent (unshared) caches do NOT show
 /// this: both builds MISS and BOTH record — proving the omission is caused
 /// specifically by cache SHARING, not by processing the wall twice.
+// #4083: this reproduces the STILL-OPEN determinism half of #4067 — it fails
+// against current code by design (see the module doc above) and is not a
+// regression this branch introduces or fixes. `#[ignore]`d so `cargo test
+// --workspace` (the default CI "Rust tests" job) stays green; run it
+// explicitly with `cargo test -p ifc-lite-geometry -- --ignored` to see the
+// live reproduction. Remove the attribute once #4083 lands a real fix.
 #[test]
+#[ignore = "known-bug reproduction for #4083 (open determinism half of #4067); fails by design until #4083 is fixed"]
 fn cache_hit_omits_the_kernel_error_the_cache_miss_recorded() {
     // Control: two INDEPENDENT (unshared) caches — both MISS, both record.
     {
@@ -225,7 +232,10 @@ fn cache_hit_omits_the_kernel_error_the_cache_miss_recorded() {
 /// `KernelError` for what is, logically, one operation on one structural
 /// item. Run several iterations and report the observed split honestly
 /// (scheduling races are not guaranteed to reproduce on every run).
+// #4083: see the #[ignore] note on `cache_hit_omits_the_kernel_error_the_cache_miss_recorded`
+// above — same reproduction contract, same reason.
 #[test]
+#[ignore = "known-bug reproduction for #4083 (open determinism half of #4067); fails by design until #4083 is fixed"]
 fn barrier_controlled_concurrent_miss_does_not_double_count() {
     const ITERATIONS: usize = 25;
     let mut double_counted = 0usize;

--- a/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
+++ b/rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs
@@ -1,0 +1,286 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #4067 behavioral reproduction: CSG diagnostic counts depend on cache
+//! execution order.
+//!
+//! `ItemDedupCache` (the "structural boolean cache" #4067 names) stores only
+//! `(Mesh, Option<u128>)` — see `rust/geometry/src/router/mod.rs`'s
+//! `ItemDedupCache` alias and `router/processing.rs`'s
+//! `process_representation_item` — never the `BoolFailure` diagnostics the
+//! uncached (MISS) build recorded via `record_topology_tear`
+//! (`csg/topology_diagnostic.rs`). A cache HIT for the same structural item
+//! therefore returns byte-identical geometry while silently omitting the
+//! diagnostic the first build recorded.
+//!
+//! `WALL_WITH_OPEN_UNION` below is a real, parsed `IfcWall` whose Body item is
+//! `IFCBOOLEANRESULT(.UNION., openFacetedBrep, extrudedBox)`, where
+//! `openFacetedBrep` is a unit cube missing its top face (5 of 6 faces) — a
+//! deliberately malformed but syntactically valid `IfcFacetedBrep`, the same
+//! shape `csg/csg_tests.rs`'s in-code `open_box_mesh` fixture uses, expressed
+//! as real IFC text so it goes through the router's actual
+//! `process_representation_item` / `ItemDedupCache` path rather than calling
+//! `ClippingProcessor::union_meshes` directly. Its union with the overlapping
+//! box leaves the 4 edges bordering the missing face unmatched, so
+//! `validate_mesh` (finite + in-bounds only — no closure check) accepts the
+//! result and `record_topology_tear` records a `KernelError` for it.
+
+use ifc_lite_core::EntityDecoder;
+use ifc_lite_geometry::{BoolFailureReason, GeometryRouter, ItemDedupCache};
+use std::sync::Barrier;
+
+/// `IfcWall` #10, Body item #170 = `IFCBOOLEANRESULT(.UNION., #150, #164)`:
+/// - `#150` = `IfcFacetedBrep` unit cube (0,0,0)-(1,1,1) missing its top
+///   (z=1) face — 5 of the box's 6 quad faces.
+/// - `#164` = `IfcExtrudedAreaSolid`, a 1x1 box extruded along Z from
+///   (0.5,0.5,0.5), spanning roughly (0,0,0.5)-(1,1,1.5) — overlapping the
+///   open box so the union is a single connected (but torn) solid rather than
+///   two disjoint pieces.
+const WALL_WITH_OPEN_UNION: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('4067 open-topology union'),'2;1');
+FILE_NAME('g.ifc','2026-09-07T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6f',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCWALL('1OpenTopologyUnionWall1',$,'Wall',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#170));
+#100=IFCCARTESIANPOINT((0.,0.,0.));
+#101=IFCCARTESIANPOINT((1.,0.,0.));
+#102=IFCCARTESIANPOINT((1.,1.,0.));
+#103=IFCCARTESIANPOINT((0.,1.,0.));
+#104=IFCCARTESIANPOINT((0.,0.,1.));
+#105=IFCCARTESIANPOINT((1.,0.,1.));
+#106=IFCCARTESIANPOINT((1.,1.,1.));
+#107=IFCCARTESIANPOINT((0.,1.,1.));
+#110=IFCPOLYLOOP((#100,#103,#102,#101));
+#111=IFCPOLYLOOP((#100,#101,#105,#104));
+#112=IFCPOLYLOOP((#101,#102,#106,#105));
+#113=IFCPOLYLOOP((#102,#103,#107,#106));
+#114=IFCPOLYLOOP((#103,#100,#104,#107));
+#120=IFCFACEOUTERBOUND(#110,.T.);
+#121=IFCFACEOUTERBOUND(#111,.T.);
+#122=IFCFACEOUTERBOUND(#112,.T.);
+#123=IFCFACEOUTERBOUND(#113,.T.);
+#124=IFCFACEOUTERBOUND(#114,.T.);
+#130=IFCFACE((#120));
+#131=IFCFACE((#121));
+#132=IFCFACE((#122));
+#133=IFCFACE((#123));
+#134=IFCFACE((#124));
+#140=IFCCLOSEDSHELL((#130,#131,#132,#133,#134));
+#150=IFCFACETEDBREP(#140);
+#161=IFCCARTESIANPOINT((0.5,0.5,0.5));
+#160=IFCAXIS2PLACEMENT3D(#161,$,$);
+#162=IFCRECTANGLEPROFILEDEF(.AREA.,$,$,1.0,1.0);
+#163=IFCDIRECTION((0.,0.,1.));
+#164=IFCEXTRUDEDAREASOLID(#162,#160,#163,1.0);
+#170=IFCBOOLEANRESULT(.UNION.,#150,#164);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn wall_entity(decoder: &mut EntityDecoder) -> ifc_lite_core::DecodedEntity {
+    decoder.decode_by_id(10).expect("decode #10 IfcWall")
+}
+
+fn fresh_decoder(content: &'static str) -> EntityDecoder<'static> {
+    let index = ifc_lite_core::build_entity_index(content.as_bytes());
+    EntityDecoder::with_index(content.as_bytes(), index)
+}
+
+fn kernel_error_count(router: &GeometryRouter) -> usize {
+    router
+        .take_csg_failures()
+        .values()
+        .flatten()
+        .filter(|f| matches!(f.reason, BoolFailureReason::KernelError(_)))
+        .count()
+}
+
+fn mesh_signature(mesh: &ifc_lite_geometry::Mesh) -> (usize, usize, u64) {
+    let bits_sum: u64 = mesh
+        .positions
+        .iter()
+        .map(|f| f.to_bits() as u64)
+        .fold(0u64, |a, b| a.wrapping_add(b));
+    (mesh.positions.len(), mesh.indices.len(), bits_sum)
+}
+
+/// Sanity control: with NO cache at all, the union really does record
+/// `KernelError` — otherwise every assertion below would trivially pass for
+/// the wrong reason (the geometry never tearing in the first place).
+#[test]
+fn open_union_records_kernel_error_uncached() {
+    let mut decoder = fresh_decoder(WALL_WITH_OPEN_UNION);
+    let router = GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut decoder);
+    let entity = wall_entity(&mut decoder);
+    let mesh = router
+        .process_element(&entity, &mut decoder)
+        .expect("mesh the open-union wall");
+    assert!(!mesh.positions.is_empty(), "union must produce geometry, not an empty mesh");
+    let count = kernel_error_count(&router);
+    assert_eq!(
+        count, 1,
+        "expected exactly one KernelError (open-topology accept) from the uncached union; \
+         if this is 0 the fixture no longer tears and the repro below is vacuous"
+    );
+}
+
+/// #4067's core mechanism: two structurally-identical builds of the SAME
+/// item, one sharing `ItemDedupCache` with the other. The first (MISS)
+/// records `KernelError`; the second (HIT) returns the byte-identical mesh
+/// but the shared cache carries no diagnostic payload, so `take_csg_failures`
+/// on the second router is empty. Independent (unshared) caches do NOT show
+/// this: both builds MISS and BOTH record — proving the omission is caused
+/// specifically by cache SHARING, not by processing the wall twice.
+#[test]
+fn cache_hit_omits_the_kernel_error_the_cache_miss_recorded() {
+    // Control: two INDEPENDENT (unshared) caches — both MISS, both record.
+    {
+        let mut decoder_a = fresh_decoder(WALL_WITH_OPEN_UNION);
+        let router_a = GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut decoder_a);
+        let entity_a = wall_entity(&mut decoder_a);
+        let _ = router_a
+            .process_element(&entity_a, &mut decoder_a)
+            .expect("mesh independent build A");
+        let count_a = kernel_error_count(&router_a);
+
+        let mut decoder_b = fresh_decoder(WALL_WITH_OPEN_UNION);
+        let router_b = GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut decoder_b);
+        let entity_b = wall_entity(&mut decoder_b);
+        let _ = router_b
+            .process_element(&entity_b, &mut decoder_b)
+            .expect("mesh independent build B");
+        let count_b = kernel_error_count(&router_b);
+
+        assert_eq!(
+            (count_a, count_b),
+            (1, 1),
+            "control: two independently-cached builds of the same item must each record \
+             their own KernelError (no sharing, no omission)"
+        );
+    }
+
+    // WARM: a router with a SHARED cache, first to process the item -> MISS -> records.
+    let shared: ItemDedupCache = GeometryRouter::new_dedup_cache();
+
+    let mut warm_decoder = fresh_decoder(WALL_WITH_OPEN_UNION);
+    let mut warm_router = GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut warm_decoder);
+    warm_router.enable_content_dedup_shared(shared.clone());
+    let warm_entity = wall_entity(&mut warm_decoder);
+    let warm_mesh = warm_router
+        .process_element(&warm_entity, &mut warm_decoder)
+        .expect("mesh warm (cache-populating) build");
+    let warm_count = kernel_error_count(&warm_router);
+    assert_eq!(warm_count, 1, "warm (cache MISS) build must record the KernelError");
+
+    // HIT: a second, fresh router sharing the SAME cache. Same structural
+    // item -> same dedup key -> served from the WARM build's cache entry.
+    let mut hit_decoder = fresh_decoder(WALL_WITH_OPEN_UNION);
+    let mut hit_router = GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut hit_decoder);
+    hit_router.enable_content_dedup_shared(shared.clone());
+    let hit_entity = wall_entity(&mut hit_decoder);
+    let hit_mesh = hit_router
+        .process_element(&hit_entity, &mut hit_decoder)
+        .expect("mesh hit (cache-served) build");
+    let hit_count = kernel_error_count(&hit_router);
+
+    assert_eq!(
+        mesh_signature(&hit_mesh),
+        mesh_signature(&warm_mesh),
+        "the cache-served mesh must be byte-identical to the build that populated the cache \
+         (a divergence here would be a correctness bug, not #4067)"
+    );
+
+    // THE BUG, asserted as the CORRECT invariant so this fails RED on today's
+    // code: a diagnostic that describes a real, structurally-present
+    // open-topology result must not depend on whether this particular caller
+    // happened to hit or miss an unrelated mesh cache. `warm_count` (1) is
+    // ground truth — the item genuinely tears — so `hit_count` must match it,
+    // not silently report zero.
+    assert_eq!(
+        hit_count, warm_count,
+        "#4067: a shared-cache HIT returned the byte-identical open-topology mesh the warm \
+         build (count={warm_count}) flagged, but recorded {hit_count} KernelError diagnostics \
+         — the cache omits the diagnostic payload on a hit"
+    );
+}
+
+/// #4067's second mechanism: "concurrent misses may compute outside the
+/// mutex and each record the same diagnostic." A `Barrier` forces both
+/// threads to reach `process_element` at the same instant (no elapsed-time
+/// assertion — the race is on ordering, not on wall-clock duration): with an
+/// empty shared cache, both threads' cache lookups can miss before either has
+/// inserted, so BOTH independently run the union and BOTH record
+/// `KernelError` for what is, logically, one operation on one structural
+/// item. Run several iterations and report the observed split honestly
+/// (scheduling races are not guaranteed to reproduce on every run).
+#[test]
+fn barrier_controlled_concurrent_miss_does_not_double_count() {
+    const ITERATIONS: usize = 25;
+    let mut double_counted = 0usize;
+    let mut single_counted = 0usize;
+    let mut other = 0usize;
+
+    for _ in 0..ITERATIONS {
+        let shared: ItemDedupCache = GeometryRouter::new_dedup_cache();
+        let barrier = Barrier::new(2);
+        let total = std::thread::scope(|scope| {
+            let counts: Vec<usize> = [(); 2]
+                .map(|_| {
+                    let shared = shared.clone();
+                    let barrier = &barrier;
+                    scope.spawn(move || {
+                        let mut decoder = fresh_decoder(WALL_WITH_OPEN_UNION);
+                        let mut router =
+                            GeometryRouter::with_units(WALL_WITH_OPEN_UNION.as_bytes(), &mut decoder);
+                        router.enable_content_dedup_shared(shared);
+                        let entity = wall_entity(&mut decoder);
+                        barrier.wait();
+                        let _ = router
+                            .process_element(&entity, &mut decoder)
+                            .expect("mesh concurrent build");
+                        kernel_error_count(&router)
+                    })
+                })
+                .into_iter()
+                .map(|h| h.join().expect("thread panicked"))
+                .collect();
+            counts.iter().sum::<usize>()
+        });
+        match total {
+            2 => double_counted += 1,
+            1 => single_counted += 1,
+            n => {
+                other += 1;
+                eprintln!("issue-4067 repro: unexpected total KernelError count {n} this iteration");
+            }
+        }
+    }
+
+    eprintln!(
+        "issue-4067 concurrent-miss repro over {ITERATIONS} iterations: \
+         double-counted={double_counted} single-counted={single_counted} other={other}"
+    );
+    // THE BUG, asserted as the CORRECT invariant so this fails RED on today's
+    // code: one logical union of one structural item must be counted once,
+    // regardless of how many threads raced to compute it. `single_counted`
+    // must equal `ITERATIONS`.
+    assert_eq!(
+        single_counted, ITERATIONS,
+        "#4067: {double_counted}/{ITERATIONS} barrier-synchronized concurrent-miss iterations \
+         double-counted a single logical union (both racing threads missed the empty shared \
+         cache and each independently recorded its own KernelError) — \
+         single_counted={single_counted} other={other}"
+    );
+}

--- a/rust/processing/src/processor/csg_summary.rs
+++ b/rust/processing/src/processor/csg_summary.rs
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #4067: the per-load CSG diagnostics summary `tracing::warn!` in
+//! `processor/mod.rs` used to describe EVERY recorded `CsgFailure` as
+//! "cut dropped, host kept uncut." That is false for a `KernelError` record —
+//! `rust/geometry/src/csg/topology_diagnostic.rs` is the sole production
+//! emitter, and its doc comment is explicit that it "record[s] accepted
+//! nonempty open-topology results without changing the returned mesh" — the
+//! mesh the caller returns is the SAME one that was about to be returned
+//! anyway, not a dropped cut replaced by an un-cut host.
+//!
+//! Pulled the message choice out into its own pure function so the text can
+//! be asserted directly, without standing up a tracing-subscriber capture
+//! harness just to check a string literal.
+
+/// Choose the summary phrase for the CSG diagnostics warning, given how many
+/// of this load's records are genuine drops (host kept uncut) versus
+/// `KernelError` accepts (mesh unchanged, informational open-topology
+/// finding — see module doc above). `dropped` and `open_topology_accepted`
+/// are disjoint partitions of the same failure list, so exactly one of the
+/// three arms applies.
+pub(super) fn csg_summary_message(dropped: usize, open_topology_accepted: usize) -> &'static str {
+    if dropped == 0 && open_topology_accepted > 0 {
+        "CSG diagnostics during geometry extraction (accepted result(s) recorded an open-topology audit finding; mesh unchanged, non-gating)"
+    } else if open_topology_accepted == 0 {
+        "CSG failures during geometry extraction (cut dropped, host kept uncut)"
+    } else {
+        "CSG diagnostics during geometry extraction (mix of cuts dropped with host kept uncut, and accepted results that recorded an open-topology audit finding with mesh unchanged)"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::csg_summary_message;
+
+    /// RED before #4067's fix: every record described as a drop, even when
+    /// `open_topology_accepted` (KernelError — mesh unchanged) accounts for
+    /// all of them.
+    #[test]
+    fn all_open_topology_accepts_are_not_described_as_dropped() {
+        let msg = csg_summary_message(0, 3);
+        assert!(
+            !msg.contains("cut dropped"),
+            "an accepted open-topology result must not be described as a dropped cut: {msg:?}"
+        );
+        assert!(
+            msg.contains("open-topology"),
+            "message should name what was actually recorded: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn all_drops_keep_the_original_wording() {
+        let msg = csg_summary_message(4, 0);
+        assert_eq!(
+            msg,
+            "CSG failures during geometry extraction (cut dropped, host kept uncut)"
+        );
+    }
+
+    #[test]
+    fn mixed_records_name_both_kinds() {
+        let msg = csg_summary_message(2, 1);
+        assert!(msg.contains("dropped"), "mixed message drops half: {msg:?}");
+        assert!(
+            msg.contains("open-topology"),
+            "mixed message should still name the accepted half: {msg:?}"
+        );
+    }
+}

--- a/rust/processing/src/processor/csg_summary.rs
+++ b/rust/processing/src/processor/csg_summary.rs
@@ -14,6 +14,14 @@
 //! Pulled the message choice out into its own pure function so the text can
 //! be asserted directly, without standing up a tracing-subscriber capture
 //! harness just to check a string literal.
+//!
+//! Its tests live in the sibling `csg_summary_tests.rs`, declared from
+//! `processor/mod.rs` (same pattern as `determinism_tests.rs` /
+//! `simplify_session_tests.rs` off `lib.rs`), rather than as an inline
+//! `#[cfg(test)] mod tests` here: an inline `mod tests` lives inside the
+//! same file `scripts/check-test-revert-oracle.mjs` reverts to prove a
+//! changed test observes the production change it covers, so it would be
+//! deleted along with the code on that revert.
 
 /// Choose the summary phrase for the CSG diagnostics warning, given how many
 /// of this load's records are genuine drops (host kept uncut) versus
@@ -28,45 +36,5 @@ pub(super) fn csg_summary_message(dropped: usize, open_topology_accepted: usize)
         "CSG failures during geometry extraction (cut dropped, host kept uncut)"
     } else {
         "CSG diagnostics during geometry extraction (mix of cuts dropped with host kept uncut, and accepted results that recorded an open-topology audit finding with mesh unchanged)"
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::csg_summary_message;
-
-    /// RED before #4067's fix: every record described as a drop, even when
-    /// `open_topology_accepted` (KernelError — mesh unchanged) accounts for
-    /// all of them.
-    #[test]
-    fn all_open_topology_accepts_are_not_described_as_dropped() {
-        let msg = csg_summary_message(0, 3);
-        assert!(
-            !msg.contains("cut dropped"),
-            "an accepted open-topology result must not be described as a dropped cut: {msg:?}"
-        );
-        assert!(
-            msg.contains("open-topology"),
-            "message should name what was actually recorded: {msg:?}"
-        );
-    }
-
-    #[test]
-    fn all_drops_keep_the_original_wording() {
-        let msg = csg_summary_message(4, 0);
-        assert_eq!(
-            msg,
-            "CSG failures during geometry extraction (cut dropped, host kept uncut)"
-        );
-    }
-
-    #[test]
-    fn mixed_records_name_both_kinds() {
-        let msg = csg_summary_message(2, 1);
-        assert!(msg.contains("dropped"), "mixed message drops half: {msg:?}");
-        assert!(
-            msg.contains("open-topology"),
-            "mixed message should still name the accepted half: {msg:?}"
-        );
     }
 }

--- a/rust/processing/src/processor/csg_summary_tests.rs
+++ b/rust/processing/src/processor/csg_summary_tests.rs
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for `csg_summary::csg_summary_message` (#4067/#4081). Split
+//! into its own `_tests.rs` sibling file, declared from `processor/mod.rs`
+//! rather than from inside `csg_summary.rs` itself — see that file's module
+//! doc for why: `csg_summary.rs` is one of the files
+//! `scripts/check-test-revert-oracle.mjs` reverts to prove these tests
+//! observe the production change, so an inline `#[cfg(test)] mod tests`
+//! would be deleted along with the code it checks.
+
+use super::csg_summary::csg_summary_message;
+
+/// RED before #4067's fix: every record described as a drop, even when
+/// `open_topology_accepted` (KernelError — mesh unchanged) accounts for all
+/// of them.
+#[test]
+fn all_open_topology_accepts_are_not_described_as_dropped() {
+    let msg = csg_summary_message(0, 3);
+    assert!(
+        !msg.contains("cut dropped"),
+        "an accepted open-topology result must not be described as a dropped cut: {msg:?}"
+    );
+    assert!(
+        msg.contains("open-topology"),
+        "message should name what was actually recorded: {msg:?}"
+    );
+}
+
+#[test]
+fn all_drops_keep_the_original_wording() {
+    let msg = csg_summary_message(4, 0);
+    assert_eq!(
+        msg,
+        "CSG failures during geometry extraction (cut dropped, host kept uncut)"
+    );
+}
+
+#[test]
+fn mixed_records_name_both_kinds() {
+    let msg = csg_summary_message(2, 1);
+    assert!(msg.contains("dropped"), "mixed message drops half: {msg:?}");
+    assert!(
+        msg.contains("open-topology"),
+        "mixed message should still name the accepted half: {msg:?}"
+    );
+}

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -23,6 +23,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 mod color_layer;
+mod csg_summary;
 mod diagnostics;
 mod entity_index;
 use entity_index::{IndexBuilder, ProcessingIndex};
@@ -1511,6 +1512,12 @@ pub fn process_geometry_streaming_filtered_with_options(
                 *by_reason.entry(f.reason.label()).or_insert(0) += 1;
             }
         }
+        // #4067: `KernelError` (the sole production emitter is
+        // `topology_diagnostic.rs`) records an ACCEPTED open-topology result —
+        // the returned mesh is unchanged — not a dropped cut. Partition the
+        // count before it's consumed into `breakdown` below.
+        let open_topology_accepted = *by_reason.get("KernelError").unwrap_or(&0);
+        let dropped = total_csg_failures - open_topology_accepted;
         let mut breakdown: Vec<(&'static str, usize)> = by_reason.into_iter().collect();
         breakdown.sort_by(|a, b| b.1.cmp(&a.1));
         let breakdown = breakdown
@@ -1521,8 +1528,11 @@ pub fn process_geometry_streaming_filtered_with_options(
         tracing::warn!(
             total_csg_failures,
             products_with_failures,
+            dropped,
+            open_topology_accepted,
             %breakdown,
-            "CSG failures during geometry extraction (cut dropped, host kept uncut)"
+            "{}",
+            csg_summary::csg_summary_message(dropped, open_topology_accepted)
         );
     }
 

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -24,6 +24,9 @@ use std::sync::Arc;
 
 mod color_layer;
 mod csg_summary;
+#[cfg(test)]
+#[path = "csg_summary_tests.rs"]
+mod csg_summary_tests;
 mod diagnostics;
 mod entity_index;
 use entity_index::{IndexBuilder, ProcessingIndex};


### PR DESCRIPTION
## Summary

Issue #4067 has two parts. This PR fixes the small one (A) and adds a reliable, quoted behavioral reproduction for the substantial one (B), scoping B's actual fix to a follow-up per the issue's own guidance.

**(A) Mislabel fix.** `rust/geometry/src/csg/topology_diagnostic.rs` is the sole production emitter of `BoolFailureReason::KernelError`: it records an ACCEPTED nonempty open-topology boolean result without changing the mesh returned — not a dropped cut. The native pipeline's per-load `tracing::warn!` in `rust/processing/src/processor/mod.rs` described *every* recorded CSG failure as "cut dropped, host kept uncut," which is false for that record.

Fix: pulled the message choice into a small, independently-testable function, `csg_summary_message()` in the new `rust/processing/src/processor/csg_summary.rs`, which partitions a load's failures into `dropped` (host kept uncut) vs `open_topology_accepted` (`KernelError` — mesh unchanged) and picks wording accordingly:

- all drops → unchanged: `"CSG failures during geometry extraction (cut dropped, host kept uncut)"`
- all open-topology accepts → `"CSG diagnostics during geometry extraction (accepted result(s) recorded an open-topology audit finding; mesh unchanged, non-gating)"`
- mixed → both are named

**RED before the fix** (all three arms forced to the old blanket string): 2 of 3 unit tests fail, e.g.

```
all_open_topology_accepts_are_not_described_as_dropped:
  "an accepted open-topology result must not be described as a dropped cut:
  \"CSG failures during geometry extraction (cut dropped, host kept uncut)\""
```

**GREEN after**: 3 passed, 0 failed. Mutated the wording-choice condition (`== 0` → `!= 0`) and confirmed 2 of 3 tests catch it.

**(B) Reproduction.** The larger half: a fresh A/B load of the same 263 MB model produced byte-identical geometry yet the CSG diagnostic count moved 195 → 196. Root cause per the issue's own mechanism: `ItemDedupCache` (the "structural boolean cache") stores only `(Mesh, Option<u128>)` — never the `BoolFailure` a cache MISS recorded.

Added `rust/geometry/tests/issue_4067_diagnostic_cache_repro.rs`: a real, parsed `IfcWall` whose Body item is `IFCBOOLEANRESULT(.UNION., openFacetedBrep, overlappingBox)` where `openFacetedBrep` is a unit cube missing one face — a genuine open-topology accept, confirmed by an uncached control (`open_union_records_kernel_error_uncached`). Two reproductions **fail reliably** on current code:

- `cache_hit_omits_the_kernel_error_the_cache_miss_recorded` — a second router sharing the same `ItemDedupCache` with a first (warm, MISS, records 1) returns the byte-identical mesh but 0 diagnostics. An independent-cache control confirms both sides record correctly when NOT sharing a cache, isolating the omission to cache *sharing*.
- `barrier_controlled_concurrent_miss_does_not_double_count` — two threads synchronized on a `Barrier` (no elapsed-time assertion) race an empty shared cache. Over 25 iterations: **double-counted=25 single-counted=0** (100%) — both threads missed and independently recorded `KernelError` for one logical operation.

Both fail deterministically, not intermittently — reran twice, same result both times.

**Scope decision.** The natural fix (making `ItemDedupCache`/mapped-item cache diagnostic-aware, and/or counting unique logical operation identities instead of summing record vectors in the collector) touches shared cache value types consumed across the native and wasm pipelines, plus the wasm console diagnostics surface. That's larger than this PR — scoped for a follow-up, shipping the mislabel fix plus a verified reproduction here per the issue's explicit guidance.

## Controls (run individually, all passing with real fixture numbers)

- `issue_960_segmented_roof_clip`: `segmented_roof_walls_render_without_slivers_or_drops ... ok`
- `issue_1007_real_opening_no_bridge`: `[1007-metrics] host #1112: worst_rim_incident_aspect=7.74 worst_aspect=25.90 open_boundary_edges=0 out_tris=98` — ok
- `issue_3353_near_coplanar_rotated_overlap`: 4/4 ok
- `a_three_operand_near_coplanar_union_stays_closed` (lib target): ok

## Gates

- `cargo clippy -p ifc-lite-geometry -- -D warnings`: clean
- `cargo clippy -p ifc-lite-processing -- -D warnings`: clean
- `cargo test -p ifc-lite-processing --test module_size_ratchet`: 6/6 passed
- `node scripts/check-module-size.mjs`: OK
- `node scripts/check-test-wiring.mjs`: OK
- `node scripts/check-source-text-assertions.mjs`: OK

Closes #4067

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CSG diagnostics to distinguish accepted open-topology results from genuinely dropped cuts.
  - Warning messages now report separate counts for accepted open-topology results and dropped cuts, reducing misleading failure summaries.
  - Preserved geometry while providing more accurate diagnostic information for supported open-topology cases.

- **Tests**
  - Added regression coverage for diagnostic caching, geometry consistency, and concurrent processing scenarios.
  - Added tests for CSG summaries covering accepted results, dropped cuts, and mixed outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->