### PR TITLE
fix(ci): stop false-red revert-oracle failures on Dependabot updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -460,6 +460,8 @@ jobs:
           name: build-output
           path: packages
       - name: Prove the changed tests observe the production change
+        env:
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         run: node scripts/check-test-revert-oracle.mjs --base origin/main --ci --json
 
   typecheck:

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -89,6 +89,7 @@ import {
   UNOBSERVED,
   SURGICAL_ADVICE,
 } from './lib/revert-oracle.mjs';
+import { isDependabotDependencyOnly } from './lib/revert-oracle-dependabot.mjs';
 import { cargoTestOwner } from './lib/revert-oracle-cargo.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 
@@ -299,6 +300,14 @@ if (baseSha === headSha) die(EXIT_NOTHING_CHECKED, 'base and head are the same c
 const mergeBase = gitOrDie(['merge-base', baseSha, headSha]).trim();
 const entries = parseNameStatus(gitOrDie(['diff', '--name-status', `${mergeBase}`, headSha]));
 if (entries.length === 0) die(EXIT_NOTHING_CHECKED, 'the diff is empty; nothing to check.');
+
+if (opts.ci && isDependabotDependencyOnly(process.env.PR_AUTHOR_LOGIN, entries)) {
+  console.log(
+    '  NOT APPLICABLE: Dependabot changed dependency manifests/lockfiles only; ' +
+      'the normal build and test lanes provide the compatibility verdict.',
+  );
+  process.exit(0);
+}
 
 const { production, test: testEntries, ignored, warnings } = classifyDiff(entries);
 for (const w of warnings) console.log(`  WARNING: ${w}`);

--- a/scripts/lib/revert-oracle-dependabot.mjs
+++ b/scripts/lib/revert-oracle-dependabot.mjs
@@ -2,9 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-const MANIFEST_RE = /(^|\/)(package\.json|Cargo\.toml)$/;
+const NPM_MANIFEST_RE = /^(?:package\.json|(?:packages|apps|examples)\/[^/]+\/package\.json)$/;
+const CARGO_MANIFESTS = new Set([
+  'Cargo.toml',
+  'rust/core/Cargo.toml',
+  'rust/geometry/Cargo.toml',
+  'rust/processing/Cargo.toml',
+  'rust/clash/Cargo.toml',
+  'rust/ffi/Cargo.toml',
+  'rust/export/Cargo.toml',
+  'rust/wasm-bindings/Cargo.toml',
+  'apps/server/Cargo.toml',
+]);
 const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'Cargo.lock']);
-const DEPENDABOT_DOCKERFILES = new Set(['apps/server/Dockerfile', 'packages/collab-server/Dockerfile']);
+const DOCKERFILES = new Set([
+  'apps/server/Dockerfile',
+  'packages/collab-server/Dockerfile',
+  'tools/ifcopenshell_reference/Dockerfile',
+]);
 
 /**
  * The normal build and test lanes are the compatibility oracle for a dependency
@@ -13,7 +28,7 @@ const DEPENDABOT_DOCKERFILES = new Set(['apps/server/Dockerfile', 'packages/coll
  */
 export function isDependabotDependencyOnly(login, entries) {
   if (login !== 'dependabot[bot]' || entries.length === 0) return false;
-  return entries.every(
-    ({ path }) => MANIFEST_RE.test(path) || LOCKFILES.has(path) || DEPENDABOT_DOCKERFILES.has(path),
+  return entries.every(({ path }) =>
+    NPM_MANIFEST_RE.test(path) || CARGO_MANIFESTS.has(path) || LOCKFILES.has(path) || DOCKERFILES.has(path)
   );
 }

--- a/scripts/lib/revert-oracle-dependabot.mjs
+++ b/scripts/lib/revert-oracle-dependabot.mjs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+const MANIFEST_RE = /(^|\/)(package\.json|Cargo\.toml)$/;
+const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'Cargo.lock']);
+
+/**
+ * The normal build and test lanes are the compatibility oracle for a dependency
+ * bump. Reverting its manifest without its ignored lockfile is not coherent.
+ * One non-dependency path restores the normal changed-test requirement.
+ */
+export function isDependabotDependencyOnly(login, entries) {
+  if (login !== 'dependabot[bot]' || entries.length === 0) return false;
+  return entries.every(({ path }) => MANIFEST_RE.test(path) || LOCKFILES.has(path));
+}

--- a/scripts/lib/revert-oracle-dependabot.mjs
+++ b/scripts/lib/revert-oracle-dependabot.mjs
@@ -4,6 +4,7 @@
 
 const MANIFEST_RE = /(^|\/)(package\.json|Cargo\.toml)$/;
 const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', 'Cargo.lock']);
+const DEPENDABOT_DOCKERFILES = new Set(['apps/server/Dockerfile', 'packages/collab-server/Dockerfile']);
 
 /**
  * The normal build and test lanes are the compatibility oracle for a dependency
@@ -12,5 +13,7 @@ const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'yarn.lock', '
  */
 export function isDependabotDependencyOnly(login, entries) {
   if (login !== 'dependabot[bot]' || entries.length === 0) return false;
-  return entries.every(({ path }) => MANIFEST_RE.test(path) || LOCKFILES.has(path));
+  return entries.every(
+    ({ path }) => MANIFEST_RE.test(path) || LOCKFILES.has(path) || DEPENDABOT_DOCKERFILES.has(path),
+  );
 }

--- a/scripts/lib/revert-oracle-dependabot.test.mjs
+++ b/scripts/lib/revert-oracle-dependabot.test.mjs
@@ -12,7 +12,15 @@ test('#4080: Dependabot-only dependency manifests and lockfiles use the normal t
   assert.equal(
     isDependabotDependencyOnly(
       'dependabot[bot]',
-      entries('package.json', 'packages/viewer/package.json', 'rust/geometry/Cargo.toml', 'pnpm-lock.yaml', 'Cargo.lock'),
+      entries(
+        'package.json',
+        'packages/viewer/package.json',
+        'rust/geometry/Cargo.toml',
+        'pnpm-lock.yaml',
+        'Cargo.lock',
+        'apps/server/Dockerfile',
+        'packages/collab-server/Dockerfile',
+      ),
     ),
     true,
   );
@@ -27,4 +35,5 @@ test('#4080: the exception cannot swallow authored or mixed changes', () => {
     false,
   );
   assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('packages/viewer/not-package.json')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('apps/viewer/Dockerfile')), false);
 });

--- a/scripts/lib/revert-oracle-dependabot.test.mjs
+++ b/scripts/lib/revert-oracle-dependabot.test.mjs
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isDependabotDependencyOnly } from './revert-oracle-dependabot.mjs';
+
+const entries = (...paths) => paths.map((path) => ({ status: 'M', path }));
+
+test('#4080: Dependabot-only dependency manifests and lockfiles use the normal test lanes', () => {
+  assert.equal(
+    isDependabotDependencyOnly(
+      'dependabot[bot]',
+      entries('package.json', 'packages/viewer/package.json', 'rust/geometry/Cargo.toml', 'pnpm-lock.yaml', 'Cargo.lock'),
+    ),
+    true,
+  );
+});
+
+test('#4080: the exception cannot swallow authored or mixed changes', () => {
+  assert.equal(isDependabotDependencyOnly('BIMvoice', entries('package.json')), false);
+  assert.equal(isDependabotDependencyOnly('app/dependabot', entries('package.json')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', []), false);
+  assert.equal(
+    isDependabotDependencyOnly('dependabot[bot]', entries('package.json', 'packages/viewer/src/index.ts')),
+    false,
+  );
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('packages/viewer/not-package.json')), false);
+});

--- a/scripts/lib/revert-oracle-dependabot.test.mjs
+++ b/scripts/lib/revert-oracle-dependabot.test.mjs
@@ -20,6 +20,7 @@ test('#4080: Dependabot-only dependency manifests and lockfiles use the normal t
         'Cargo.lock',
         'apps/server/Dockerfile',
         'packages/collab-server/Dockerfile',
+        'tools/ifcopenshell_reference/Dockerfile',
       ),
     ),
     true,
@@ -35,5 +36,9 @@ test('#4080: the exception cannot swallow authored or mixed changes', () => {
     false,
   );
   assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('packages/viewer/not-package.json')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('fixtures/package.json')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('packages/viewer/fixture/package.json')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('rust/python/Cargo.toml')), false);
+  assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('rust/csg-thread-bench/Cargo.toml')), false);
   assert.equal(isDependabotDependencyOnly('dependabot[bot]', entries('apps/viewer/Dockerfile')), false);
 });


### PR DESCRIPTION
Dependabot dependency-only PRs currently fail `Changed tests observe production` by construction: manifests are treated as production, lockfiles are ignored, and the bot cannot add a behavior-specific regression test. This makes the required aggregate red even when every compatibility test passes.

This adds a narrow classifier that applies only to GitHub's `dependabot[bot]` identity and only when every changed path is a package/Cargo manifest, recognized lockfile, or one of the two Dockerfiles configured in `.github/dependabot.yml`. It reports an explicit not-applicable verdict and leaves build, typecheck, and all executable test lanes intact. Any authored PR or any mixed source/config change follows the normal revert-oracle path.

Validation:
- `node --test scripts/lib/revert-oracle.test.mjs scripts/lib/revert-oracle-dependabot.test.mjs` — 54 passed
- `node scripts/check-module-size.mjs` — passed
- `node scripts/check-test-wiring.mjs` — passed
- `pnpm test` under Node 22.14.0 — 98/98 Turbo tasks passed (viewer: 7,008 passed, 6 skipped)
- Real #4077 checkout with `PR_AUTHOR_LOGIN=dependabot[bot]` — explicit dependency-only verdict, exit 0

Closes #4080
