### PR TITLE
fix(geometry): split boolean/mod.rs back under its module-size ratchet

### DIFF
--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::*;
+use crate::router::GeometryProcessor;
 
 /// A self-referential clipping result: `#10`'s FirstOperand is `#10` again,
 /// with `#20` an `IfcPolygonalBoundedHalfSpace` cutter. Before the visited-id

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -30,6 +30,7 @@ mod single_cutter_gate;
 use single_cutter_gate::SingleCutterSubtract;
 mod polygonal_union;
 mod polygonal_removal;
+mod router_impl;
 use cut_heuristics::{
     cutter_below_skip_ratio, plane_is_coincident_with_host_face, quality_skips_small_cuts,
 };
@@ -911,8 +912,6 @@ impl BooleanClippingProcessor {
         Ok(mesh)
     }
 }
-
-mod router_impl;
 
 #[cfg(test)]
 mod halfspace_cap_tests;

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -20,7 +20,6 @@ use super::extrusion::ExtrudedAreaSolidProcessor;
 use super::helpers::parse_axis2_placement_3d;
 use super::swept::{RevolvedAreaSolidProcessor, SweptDiskSolidProcessor};
 use super::tessellated::TriangulatedFaceSetProcessor;
-use crate::router::GeometryProcessor;
 
 mod cut_heuristics;
 mod failures;
@@ -913,33 +912,7 @@ impl BooleanClippingProcessor {
     }
 }
 
-impl GeometryProcessor for BooleanClippingProcessor {
-    fn process(
-        &self,
-        entity: &DecodedEntity,
-        decoder: &mut EntityDecoder,
-        schema: &IfcSchema,
-        quality: TessellationQuality,
-    ) -> Result<Mesh> {
-        let mut visited = OperandPath::default();
-        self.process_with_depth(entity, decoder, schema, 0, quality, &mut visited)
-    }
-
-    fn supported_types(&self) -> Vec<IfcType> {
-        vec![IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult]
-    }
-
-    /// Hand the log to the router (#3821); rationale on the trait method.
-    fn take_bool_failures(&self) -> Vec<BoolFailure> {
-        self.take_failures()
-    }
-}
-
-impl Default for BooleanClippingProcessor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+mod router_impl;
 
 #[cfg(test)]
 mod halfspace_cap_tests;

--- a/rust/geometry/src/processors/boolean/router_impl.rs
+++ b/rust/geometry/src/processors/boolean/router_impl.rs
@@ -6,7 +6,7 @@
 
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
 
-use super::super::super::diagnostics::BoolFailure;
+use crate::diagnostics::BoolFailure;
 use super::BooleanClippingProcessor;
 use super::OperandPath;
 use crate::router::GeometryProcessor;

--- a/rust/geometry/src/processors/boolean/router_impl.rs
+++ b/rust/geometry/src/processors/boolean/router_impl.rs
@@ -1,4 +1,6 @@
-// SPDX-License-Identifier: MPL-2.0
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //! `GeometryProcessor` wiring for `BooleanClippingProcessor`.
 //!
 //! Split out of `mod.rs` so that file stays inside its module-size ratchet

--- a/rust/geometry/src/processors/boolean/router_impl.rs
+++ b/rust/geometry/src/processors/boolean/router_impl.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+//! `GeometryProcessor` wiring for `BooleanClippingProcessor`.
+//!
+//! Split out of `mod.rs` so that file stays inside its module-size ratchet
+//! budget. Pure move: no behaviour change.
+
+use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
+
+use super::super::super::diagnostics::BoolFailure;
+use super::BooleanClippingProcessor;
+use super::OperandPath;
+use crate::router::GeometryProcessor;
+use crate::{Mesh, Result, TessellationQuality};
+
+impl GeometryProcessor for BooleanClippingProcessor {
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        schema: &IfcSchema,
+        quality: TessellationQuality,
+    ) -> Result<Mesh> {
+        let mut visited = OperandPath::default();
+        self.process_with_depth(entity, decoder, schema, 0, quality, &mut visited)
+    }
+
+    fn supported_types(&self) -> Vec<IfcType> {
+        vec![IfcType::IfcBooleanResult, IfcType::IfcBooleanClippingResult]
+    }
+
+    /// Hand the log to the router (#3821); rationale on the trait method.
+    fn take_bool_failures(&self) -> Vec<BoolFailure> {
+        self.take_failures()
+    }
+}
+
+impl Default for BooleanClippingProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/scripts/check-server-browser-type-parity.mjs
+++ b/scripts/check-server-browser-type-parity.mjs
@@ -184,7 +184,6 @@ export const ALLOWLIST = {
   'relationships:IFCRELASSIGNSTOPRODUCT': { status: 'pending', note: '#3964, tracked with #3969' },
   'relationships:IFCRELREFERENCEDINSPATIALSTRUCTURE': { status: 'pending', note: '#3964, tracked with #3969' },
 
-
   // #3254: IfcPhysicalComplexQuantity groups other quantities instead of
   // carrying a measure itself, so neither side resolves it to a Quantity —
   // this is a DELIBERATE, tracked trade-off, not an in-flight fix. The

--- a/scripts/check-server-browser-type-parity.mjs
+++ b/scripts/check-server-browser-type-parity.mjs
@@ -184,19 +184,6 @@ export const ALLOWLIST = {
   'relationships:IFCRELASSIGNSTOPRODUCT': { status: 'pending', note: '#3964, tracked with #3969' },
   'relationships:IFCRELREFERENCEDINSPATIALSTRUCTURE': { status: 'pending', note: '#3964, tracked with #3969' },
 
-  // #3965: server never promotes a *contained* (not aggregated) spatial
-  // element into its own hierarchy node. TS treats IfcSpatialZone (the
-  // Revit Family+Dynamo pattern), IfcMarinePart and IfcFacilityPartCommon as
-  // spatial-structure nodes; the server's `is_spatial_type` does not yet.
-  // Open PR #3973 closes #3965.
-  'spatialTypes:IFCSPATIALZONE': { status: 'pending', note: '#3965, open PR #3973' },
-  'spatialTypes:IFCMARINEPART': { status: 'pending', note: '#3965, tracked with #3973' },
-  'spatialTypes:IFCFACILITYPARTCOMMON': { status: 'pending', note: '#3965, tracked with #3973' },
-
-  // #3963: the server has no IFCCOMPLEXPROPERTY arm at all and drops the
-  // whole containing PropertySet; the browser path resolves it via
-  // parsePropertyValueWithComplex. Open PR #3971 closes #3963.
-  'properties:IFCCOMPLEXPROPERTY': { status: 'pending', note: '#3963, open PR #3971' },
 
   // #3254: IfcPhysicalComplexQuantity groups other quantities instead of
   // carrying a measure itself, so neither side resolves it to a Quantity —

--- a/scripts/check-server-browser-type-parity.test.mjs
+++ b/scripts/check-server-browser-type-parity.test.mjs
@@ -128,6 +128,11 @@ test('RELATIONSHIPS: RED when a type not on the allowlist is removed from the TS
   assert.match(out, /Rust server .* handles `IFCRELDEFINESBYPROPERTIES` but the TS parser .* does not/);
 });
 
+// The spatialTypes (#3965) and properties (#3963) allowlist entries used to
+// carry their own copies of this test. #3973 and #3971 closed those
+// divergences, the gate's stale-entry check demanded the entries go, and
+// suppression is concept-agnostic, so this test and the `deliberate` one
+// below cover the mechanism for every concept.
 test('RELATIONSHIPS: an allowlisted divergence (IFCRELCONNECTSELEMENTS) does not fail on its own', () => {
   // IFCRELNESTS/IFCRELASSIGNSTOGROUP(BYFACTOR)/IFCRELCONNECTSPATHELEMENTS
   // used to be the entries checked here, but #3969 merged and added all four
@@ -178,17 +183,6 @@ test('SPATIAL TYPES: RED when a type is removed from the Rust is_spatial_type ar
   assert.match(out, /TS parser .* handles `IFCBUILDINGSTOREY` but the Rust server .* does not/);
 });
 
-test('ALLOWLIST: a `pending` divergence does not fail on its own', () => {
-  // #3965's spatialTypes entries and #3963's properties entry used to be the
-  // fixtures here; #3973 and #3971 closed those divergences, so the gate's
-  // own stale-entry check demanded their removal. Repointed at a divergence
-  // that is still genuinely open rather than deleting the coverage.
-  assert.ok(Object.hasOwn(ALLOWLIST, 'relationships:IFCRELCONNECTSELEMENTS'));
-  assert.equal(ALLOWLIST['relationships:IFCRELCONNECTSELEMENTS'].status, 'pending');
-  const { status, out } = runOn({});
-  assert.equal(status, 0, out);
-});
-
 test('SPATIAL TYPES: removing IfcSite from the TS enum list surfaces as a TS-side gap', () => {
   const ts = replaceOnce(real.TS_SPATIAL, '  IfcTypeEnum.IfcSite,\n', '');
   const { status, out } = runOn({ TS_SPATIAL: ts });
@@ -197,16 +191,6 @@ test('SPATIAL TYPES: removing IfcSite from the TS enum list surfaces as a TS-sid
 });
 
 // -- properties -----------------------------------------------------------
-
-test('ALLOWLIST: a `deliberate` divergence does not fail on its own', () => {
-  // The sibling of the test above, for the other allowlist status: a settled
-  // trade-off rather than an in-flight fix. Together they prove suppression
-  // works for both statuses the allowlist can carry.
-  assert.ok(Object.hasOwn(ALLOWLIST, 'quantities:IFCPHYSICALCOMPLEXQUANTITY'));
-  assert.equal(ALLOWLIST['quantities:IFCPHYSICALCOMPLEXQUANTITY'].status, 'deliberate');
-  const { status, out } = runOn({});
-  assert.equal(status, 0, out);
-});
 
 test('PROPERTIES: RED when a value-shape arm is removed from the Rust match', () => {
   const rust = replaceOnce(

--- a/scripts/check-server-browser-type-parity.test.mjs
+++ b/scripts/check-server-browser-type-parity.test.mjs
@@ -178,8 +178,13 @@ test('SPATIAL TYPES: RED when a type is removed from the Rust is_spatial_type ar
   assert.match(out, /TS parser .* handles `IFCBUILDINGSTOREY` but the Rust server .* does not/);
 });
 
-test('SPATIAL TYPES: an allowlisted divergence (IfcSpatialZone, #3965/#3973) does not fail on its own', () => {
-  assert.ok(Object.hasOwn(ALLOWLIST, 'spatialTypes:IFCSPATIALZONE'));
+test('ALLOWLIST: a `pending` divergence does not fail on its own', () => {
+  // #3965's spatialTypes entries and #3963's properties entry used to be the
+  // fixtures here; #3973 and #3971 closed those divergences, so the gate's
+  // own stale-entry check demanded their removal. Repointed at a divergence
+  // that is still genuinely open rather than deleting the coverage.
+  assert.ok(Object.hasOwn(ALLOWLIST, 'relationships:IFCRELCONNECTSELEMENTS'));
+  assert.equal(ALLOWLIST['relationships:IFCRELCONNECTSELEMENTS'].status, 'pending');
   const { status, out } = runOn({});
   assert.equal(status, 0, out);
 });
@@ -193,8 +198,12 @@ test('SPATIAL TYPES: removing IfcSite from the TS enum list surfaces as a TS-sid
 
 // -- properties -----------------------------------------------------------
 
-test('PROPERTIES: an allowlisted divergence (IFCCOMPLEXPROPERTY, #3963/#3971) does not fail on its own', () => {
-  assert.ok(Object.hasOwn(ALLOWLIST, 'properties:IFCCOMPLEXPROPERTY'));
+test('ALLOWLIST: a `deliberate` divergence does not fail on its own', () => {
+  // The sibling of the test above, for the other allowlist status: a settled
+  // trade-off rather than an in-flight fix. Together they prove suppression
+  // works for both statuses the allowlist can carry.
+  assert.ok(Object.hasOwn(ALLOWLIST, 'quantities:IFCPHYSICALCOMPLEXQUANTITY'));
+  assert.equal(ALLOWLIST['quantities:IFCPHYSICALCOMPLEXQUANTITY'].status, 'deliberate');
   const { status, out } = runOn({});
   assert.equal(status, 0, out);
 });


### PR DESCRIPTION
Closes #4100

`main` is red. `rust/processing/tests/module_size_ratchet.rs` fails:

```
Allowlisted file(s) grew PAST their recorded budget. Shrink or split instead of raising the budget:
  rust/geometry/src/processors/boolean/mod.rs: 948 lines, budget 936
```

**Cause.** #3922 was merged from a base 88 commits behind main and was green against that older base. Against current main it is 12 lines over. `git log 95f29e4f3..origin/main -- rust/geometry/src/processors/boolean/mod.rs` names #3922 as the only commit touching the file. My mistake: I merged it before the integration run I had started for exactly this purpose had finished.

**Why no other gate caught it.** On the merged tree, typecheck (90/90), TS tests (98/98), lint, the *TypeScript* module-size check, api-surface and `cargo clippy --workspace --all-targets -D warnings` are all green. The Rust ratchet lives in `cargo test`, the slowest gate.

**Fix.** Move `impl GeometryProcessor for BooleanClippingProcessor` and `impl Default` into a sibling `router_impl.rs`. `mod.rs` goes 948 -> 920, sixteen lines under budget. No allowlist row added and no budget raised, per the ratchet's own remedy text. Pure move: the extracted block is byte-identical to what was deleted.

`chain_cycle_tests.rs` reached `GeometryProcessor` through `use super::*`, inheriting a private import in `mod.rs` it never named. It now imports the trait directly, which is what `operand.rs` already does.

**Verification** (fresh `CARGO_TARGET_DIR`, so not a cached green):

| check | result |
|---|---|
| `cargo test -p ifc-lite-processing --test module_size_ratchet` | 6/6, was the failing gate |
| `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` | exit 0, zero warnings |
| `cargo test -p ifc-lite-geometry --lib boolean` | 38/38 |
| `cargo test --workspace --no-fail-fast` | 0 failures |

Pre-flight `/simplify` and `/code-review` both ran against this commit. Review confirmed the move cannot fail silently: dropping the `mod` declaration would be a compile error at `router/processor_registry.rs:74`, which coerces the processor to `Rc<dyn GeometryProcessor>`.

**Note for #4024:** its `mod.rs` hunk is net +14, which lands at 934 against the 936 budget. It passes, with two lines to spare. Do not add lines to `mod.rs` while resolving its rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Reorganized boolean geometry processing components without changing user-visible behavior.
  - Preserved existing processing, supported file types, error handling, and default behavior.

- **Tests**
  - Updated type-parity checks to reflect current coverage.
  - Removed obsolete exceptions for spatial and complex property cases while retaining deliberate coverage for known gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also on this PR: main is red a second time, on the parity gate

After the first fix, `Node tests` still failed on `Check server/browser type parity`. That is a **separate** breakage of the same shape.

#3979 added `scripts/check-server-browser-type-parity.mjs` with an ALLOWLIST of known server/browser divergences. #3971 and #3973 then **fixed four of them**, two of which said so in their own notes (`open PR #3973`, `open PR #3971`). The gate refuses a dead entry, correctly:

```
check-server-browser-type-parity: stale ALLOWLIST entries
  [spatialTypes:IFCSPATIALZONE]        the divergence this entry mutes is gone
  [spatialTypes:IFCMARINEPART]
  [spatialTypes:IFCFACILITYPARTCOMMON]
  [properties:IFCCOMPLEXPROPERTY]
```

A stale row is not clutter, it stays primed to mute a future unrelated regression. All three PRs were green alone; only the merged tree is red.

Fix: remove the four entries. Gate exits 0, its regression suite is 42/42.

Two of those entries were fixtures for the gate own tests. My first attempt "repointed" them; pre-flight review found the repointed tests were **duplicates** of tests already at lines 131 and 236, so the claim of added coverage in that commit message was wrong. Corrected by deleting them and leaving a note on the surviving test. Recorded here rather than quietly amended.

**Why both fixes share one PR:** main cannot go green without both, they touch disjoint trees (`rust/geometry/` vs `scripts/`), and a second PR would queue behind the same CI for no isolation benefit.
