### PR TITLE
fix(ci): install Python toolchain for revert-oracle's pytest lane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,14 +262,27 @@ jobs:
               # corpus change moves its pinned counts even with no code change.
               - 'tests/models/manifest.json'
             # `scripts/lib/revert-oracle-python.mjs` (#4079) routes any
-            # `test_*.py` / `*_test.py` under here through `python3 -m
-            # pytest`, but the `revert-oracle` job's runner ships no Python
-            # toolchain of its own — installing one unconditionally would pay
-            # that cost on every PR for a lane most never touch. This gates
-            # that install: true only when the oracle could actually be asked
-            # to run a Python test.
+            # `test_*.py` / `*_test.py` ANYWHERE in the repo through `python3
+            # -m pytest` — `pythonTestOwner` walks up from the test file to
+            # the nearest project marker (requirements.lock/.txt,
+            # pyproject.toml, setup.py/.cfg, Pipfile) with no directory
+            # restriction, so the routing is repo-wide, not scoped to
+            # tools/ifcopenshell_reference. The `revert-oracle` job's runner
+            # ships no Python toolchain of its own — installing one
+            # unconditionally would pay that cost on every PR for a lane most
+            # never touch. This gates that install: true only when the diff
+            # could actually be asked to run a Python test. The two globs
+            # mirror `TEST_FILE_RE`'s python alternatives in
+            # scripts/lib/revert-oracle.mjs byte-for-byte (any `test_*.py` /
+            # `*_test.py`, any depth) rather than naming known marker
+            # directories by hand, so a NEW Python test tree can never fall
+            # outside this filter the way rust/python's and
+            # scripts/perf/evidence's Python test fixtures did before this
+            # fix — both already existed unfiltered when this comment was
+            # written.
             python:
-              - 'tools/ifcopenshell_reference/**'
+              - '**/test_*.py'
+              - '**/*_test.py'
               - '.github/workflows/test.yml'
             plato:
               - 'tools/plato/**'
@@ -471,8 +484,10 @@ jobs:
           name: build-output
           path: packages
       # #4079 taught scripts/lib/revert-oracle-python.mjs to route a changed
-      # `test_*.py` / `*_test.py` under tools/ifcopenshell_reference through
-      # `python3 -m pytest`, but this runner's base image ships python3 with
+      # `test_*.py` / `*_test.py` ANYWHERE in the repo (routing is
+      # marker-based — `pythonTestOwner` walks up to the nearest project
+      # marker, not scoped to any one directory) through `python3 -m
+      # pytest`, but this runner's base image ships python3 with
       # NO pytest module — an oracle run over such a diff exits BASELINE-BROKEN
       # (`No module named pytest`), not a real verdict. Installed only when
       # the `changes` job's `python` filter says this diff could reach that
@@ -483,7 +498,7 @@ jobs:
       # them as silent skips instead of the real assertions the oracle needs
       # to revert against.
       - if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - if: needs.changes.outputs.python == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
       geometry: ${{ steps.filter.outputs.geometry }}
+      python: ${{ steps.filter.outputs.python }}
       plato: ${{ steps.filter.outputs.plato }}
       docs: ${{ steps.filter.outputs.docs }}
       agents_md: ${{ steps.filter.outputs.agents_md }}
@@ -260,6 +261,16 @@ jobs:
               # The watertightness census sweeps the fixture set named here, so a
               # corpus change moves its pinned counts even with no code change.
               - 'tests/models/manifest.json'
+            # `scripts/lib/revert-oracle-python.mjs` (#4079) routes any
+            # `test_*.py` / `*_test.py` under here through `python3 -m
+            # pytest`, but the `revert-oracle` job's runner ships no Python
+            # toolchain of its own — installing one unconditionally would pay
+            # that cost on every PR for a lane most never touch. This gates
+            # that install: true only when the oracle could actually be asked
+            # to run a Python test.
+            python:
+              - 'tools/ifcopenshell_reference/**'
+              - '.github/workflows/test.yml'
             plato:
               - 'tools/plato/**'
               - 'rust/clash/src/generated/**'
@@ -459,6 +470,25 @@ jobs:
         with:
           name: build-output
           path: packages
+      # #4079 taught scripts/lib/revert-oracle-python.mjs to route a changed
+      # `test_*.py` / `*_test.py` under tools/ifcopenshell_reference through
+      # `python3 -m pytest`, but this runner's base image ships python3 with
+      # NO pytest module — an oracle run over such a diff exits BASELINE-BROKEN
+      # (`No module named pytest`), not a real verdict. Installed only when
+      # the `changes` job's `python` filter says this diff could reach that
+      # lane, mirroring ifcopenshell-parity.yml's own `full` job: the full
+      # requirements.lock, not bare pytest, because test_validate_export.py's
+      # SchemaConformanceHasTeeth cases (#4043) import ifcopenshell and are
+      # `unittest.skipUnless(HAVE_IFCOPENSHELL, ...)` — bare pytest would run
+      # them as silent skips instead of the real assertions the oracle needs
+      # to revert against.
+      - if: needs.changes.outputs.python == 'true'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+        with:
+          python-version: "3.12"
+      - if: needs.changes.outputs.python == 'true'
+        name: Install the Python toolchain the oracle's pytest lane needs
+        run: pip install -r tools/ifcopenshell_reference/requirements.lock pytest
       - name: Prove the changed tests observe the production change
         env:
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
## What

#4079 taught `scripts/lib/revert-oracle.mjs` to classify `test_*.py` / `*_test.py` as tests and route them through `python3 -B -m pytest` (`scripts/lib/revert-oracle-python.mjs`). That classification is correct and works wherever pytest is present.

But the `revert-oracle` job in `.github/workflows/test.yml` installs no Python toolchain at all — checkout, pnpm, node, a build-artifact download, then the oracle. GitHub's `ubuntu-latest` image ships `python3` but not `pytest`, so any diff that reaches this lane now fails with `BASELINE-BROKEN` instead of a real verdict, blocking a required gate.

The live case is #4048, whose diff includes `tools/ifcopenshell_reference/test_validate_export.py`.

## Fix

- Added a `python` output to the `changes` job's `dorny/paths-filter`, matching `**/test_*.py` and `**/*_test.py` (byte-for-byte the same two basename patterns `TEST_FILE_RE`'s python alternatives use in `scripts/lib/revert-oracle.mjs`, so the filter can't drift out of sync with the classifier the oracle actually runs) plus this workflow file (the same pattern the existing `agents_md`/`plato` filters use to name the workflow that defines their own job). An earlier version of this filter matched only `tools/ifcopenshell_reference/**`, which undercounted: `pythonTestOwner` walks up from ANY changed `.py` test file to the nearest project marker (`requirements.lock`, `requirements.txt`, `pyproject.toml`, `setup.py`, `setup.cfg`, `Pipfile`) with no directory restriction, and this repo already has Python test fixtures outside that one directory (`scripts/perf/evidence/**/reproduce/test_*.py`, plus `rust/python/tests/test_bindings.py` — though that one is actually claimed by `cargoTestOwner`'s Cargo.toml-first walk before `pythonTestOwner` is ever tried, so it never reaches the pytest lane in practice; it's covered here anyway since the glob doesn't need to know that).
- Added two steps to `revert-oracle`, gated on `needs.changes.outputs.python == 'true'`: `actions/setup-python` (3.12, matching `ifcopenshell-parity.yml`), then `pip install -r tools/ifcopenshell_reference/requirements.lock pytest`.

**Why the full `requirements.lock`, not bare `pytest`.** `test_validate_export.py`'s `SchemaConformanceHasTeeth` cases (#4043) `import ifcopenshell` and are declared `unittest.skipUnless(HAVE_IFCOPENSHELL, ...)`. A bare-pytest install wouldn't crash — the module-level `import ifcopenshell` is wrapped in `try/except ImportError` — but it would silently skip the tests that actually exercise `validate_export.py`'s logic, which defeats the point of asking the oracle to revert against them. Installing the full lock (mirroring `ifcopenshell-parity.yml`'s `full` job, which already does this successfully) gets ifcopenshell into the same interpreter so those tests run for real. `pytest` is appended explicitly on the command line because it is not yet listed in `requirements.lock` on `main` — it's added there by #4048, not merged yet — so the install stays correct in either order.

**Why a conditional step, not a job-level `if`/`needs` change.** The job's own `if` (`frontend || rust`) is left untouched. Widening it to include `python` would additionally make the job trigger for a diff touching *only* `tools/ifcopenshell_reference/**` — but that job also depends on `needs: [changes, build]`, and `build` only runs when `frontend || rust` is true; a python-only diff would leave `build` skipped while asking `revert-oracle` to run, an untested interaction with GitHub's skip propagation I didn't want to introduce without being able to verify it end-to-end. So: a diff touching only `tools/ifcopenshell_reference/**` with nothing under `packages/`, `apps/`, or `rust/` still won't trigger this job at all today. That's a narrower, separate gap from the one this PR closes (which is: the job already runs, per #4048's diff, and fails on a missing toolchain).

## Scope

**Not fixed here — same class of problem, mentioned for the maintainer's judgment:** the same `revert-oracle` job also can't run feature-gated Rust tests because it never fetches fixtures (see #4090's thread), which makes #4024 fail the same way. Different lane, different fixture-fetch mechanism — left out to keep this PR to the Python toolchain gap.

## Verification

**RED** — reproduced the failure: simulated the CI environment (`python3` present, `pytest` absent, via a venv) and ran the oracle over a diff containing `test_validate_export.py`:

```
[baseline] tools/ifcopenshell_reference (python) -> runner-missing (pass ?, fail ?, total ?, exit 1, 17ms)
  ...
  | /private/tmp/ci-sim-nopytest/bin/python3: No module named pytest
==============================================================================
  ! BASELINE-BROKEN
==============================================================================
  the branch's own tests do not pass before any revert (runner-missing: No module named pytest). Nothing can be concluded from reverting on top of a red baseline.
```
`ciExitCode` maps this to exit 3.

**GREEN** — with `pytest` installed into that same simulated environment (standing in for the new install step; ifcopenshell itself is a Linux/py3.12-only wheel per `requirements.lock`, not reproducible on this darwin/arm64 host, so this leg exercises the pytest-presence half of the mechanism, which is what removes `BASELINE-BROKEN`):

```
[baseline] tools/ifcopenshell_reference (python) -> pass (pass 2, fail 0, total 2, exit 0, 149ms)
[reverted] tools/ifcopenshell_reference (python) -> assertion-failure (pass 0, fail 2, total 2, exit 1, 121ms)
==============================================================================
  ✔ OBSERVED
==============================================================================
```
Exit 0.

**Non-Python regression check** — the diff against the pre-fix workflow is purely additive: one new `changes` output, one new filter block, two new steps gated on `if: needs.changes.outputs.python == 'true'`. No existing step, the job's `if`, or its `needs` were touched, so a diff with no Python files renders both new steps as no-ops and the job graph is unchanged from before this PR.

**actionlint**: `actionlint .github/workflows/test.yml` — clean, no findings.

Also ran the repo's structural gates from root: `check-module-size.mjs`, `check-test-wiring.mjs`, `check-source-text-assertions.mjs`, `check-ci-path-coverage.mjs` — all pass.

## Update — adversarial review of this PR's own fix

Follow-up review found the `python` filter above was itself narrower than the routing logic it gates, plus two prose/label issues. Fixed in a later commit on this branch:

1. **Filter too narrow** — as described in the `Fix` section above, replaced the `tools/ifcopenshell_reference/**` glob with `**/test_*.py` / `**/*_test.py`, mirroring `TEST_FILE_RE` exactly. RED: with a fresh venv that has `python3` but no `pytest`, running the oracle over a diff that changes `rust/core/src/columnar_index.rs` (production) and `scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce/test_wire.py` (test) — a location the old filter did not cover — reproduces the same `BASELINE-BROKEN` / exit 3 this PR exists to eliminate:
   ```
   [baseline] scripts/perf/evidence/server-pgo-darwin-2026-09-07/reproduce (python) -> runner-missing (pass ?, fail ?, total ?, exit 1, 15ms)
   ...
   | /private/tmp/repro-nopytest-venv/bin/python3: No module named pytest
   ! BASELINE-BROKEN
   ```
   The new filter sets `python: true` for that same diff (verified against `minimatch` with the exact two glob strings — `dorny/paths-filter` bundles a different but glob-semantically-equivalent matcher, and this repo's own filter list already relies on the identical `**/`-prefixed convention elsewhere, e.g. `**/AGENTS.md`), while a diff with no `.py` files anywhere still matches neither pattern, so the two new steps stay no-ops for the PRs that don't touch Python.
2. **Comment overclaimed scope** — both comments describing the `python` filter said routing happens "under tools/ifcopenshell_reference"; routing is actually marker-based and repo-wide (see point 1). Corrected both comments to say so.
3. **Version-label typo** — `actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97` was labelled `# v5` in this workflow; that SHA is `v7.0.0` (this repo's own `docs.yml` already labels the identical SHA correctly). Fixed the label in `test.yml` only; the SHA itself was already correct and unchanged. `ifcopenshell-parity.yml` and `python-wheels.yml` carry the same wrong `# v5` label on the same SHA — left alone, out of scope for this PR.

Known residual gap, unchanged by this update: `pythonTestOwner`'s Cargo.toml-first-wins ordering means `rust/python/tests/test_bindings.py` is (and always was) routed to `cargo test -p ifc-lite-python`, not pytest — and that crate is excluded from the root Cargo workspace (`exclude = ["rust/python"]`), so that specific route already fails for an unrelated, pre-existing reason (`cargo test -p` can't find an excluded package without `--manifest-path`). Confirmed by direct run, out of scope here.

## Refs

Refs #4079 (the merge that created this gap), refs #4048 (the PR currently blocked by it).

No issue exists for this; this PR carries `unqueued`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated validation for Python-based reference components across the repository.
  - Python test environments now automatically install required dependencies, including pytest, helping prevent setup-related failures in continuous integration.

- **Chores**
  - Updated workflow conditions so Python validation runs when relevant test files or workflow configuration changes.
  - Python validation now uses Python 3.12 in the automated test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #4107
