### PR TITLE
feat(query,viewer): read IfcOpenShell selector syntax in the Filter tab

### DIFF
--- a/.changeset/selector-parser.md
+++ b/.changeset/selector-parser.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/query": minor
+---
+
+Add `parseSelector`, a parser for the IfcOpenShell selector (filter) syntax, plus its AST types. It reads the whole grammar — class and GlobalId terms with `!` subtraction, attribute and `Pset.Prop` comparisons over `= != > >= < <= *= !*=`, `type=` / `material=` / `classification=` / `location=` / `parent=` keywords, `query:` key paths, quoted values, `/regex/` literals and `+` unions — and answers with either an AST or an error carrying the character offset that broke. Accepting more than any one surface can evaluate is deliberate: an adapter names what it dropped instead of matching nothing in silence.

--- a/apps/viewer/src/components/ui/toast.tsx
+++ b/apps/viewer/src/components/ui/toast.tsx
@@ -93,7 +93,11 @@ export function Toaster() {
   if (items.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none max-w-sm">
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-[9999] flex flex-col gap-2 pointer-events-none max-w-sm"
+    >
       {items.map((t) => {
         const Icon = iconMap[t.type];
         return (

--- a/apps/viewer/src/components/viewer/SearchInline.empty-state.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.empty-state.test.tsx
@@ -65,6 +65,26 @@ describe('SearchInline — the empty popover names selector syntax', () => {
     assert.doesNotMatch(text, /selector syntax/i);
   });
 
+  it('a class name nobody knows is not worth sending anyone to the Filter tab for', () => {
+    // `IfcWaall` parses as a class term, so a hint keyed on parsing alone fired
+    // and pointed the user at a tab that then refuses the query — the same
+    // dead end #4091 is about, one surface further on.
+    const container = mountWithQuery('IfcWaall');
+    const text = container.textContent ?? '';
+    assert.match(text, /No results/);
+    assert.doesNotMatch(text, /selector syntax/i);
+  });
+
+  it('an unmatched GlobalId is a search term the box already understands', () => {
+    // A GlobalId parses as a selector term and the adapter has no rule for it
+    // (#4094), so the Filter tab would refuse it too. This box is where
+    // GlobalIds ARE searched, which makes "go elsewhere" the wrong advice.
+    const container = mountWithQuery('325Q7Fhnf67OZC$$r43uzK');
+    const text = container.textContent ?? '';
+    assert.match(text, /No results/);
+    assert.doesNotMatch(text, /selector syntax/i);
+  });
+
   it('a bare class name is a selector too, and is named as one', () => {
     // It also happens to match the seeded wall by TYPE, so this asserts the
     // hint reaches the empty state only — with rows present there is no

--- a/apps/viewer/src/components/viewer/SearchInline.empty-state.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.empty-state.test.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The toolbar search box is where #4091's reporter typed a selector, and it
+ * answered "No results — try a name, IFC type, or full GlobalId." That is the
+ * reported shape in miniature: a valid selector, an empty list, and nothing
+ * saying the box does not read that language.
+ *
+ * It still does not read it — routing tier-0 search through the parser would
+ * change an existing surface's result set and is its own issue (#4094). What
+ * it does now is NAME the syntax and point at the tab that runs it.
+ */
+
+import '@/test/setup-dom.js';
+
+import { after, afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { SearchInline } from './SearchInline.js';
+
+const MODEL_ID = 'model-a';
+
+let initialState: ReturnType<typeof useViewerStore.getState>;
+
+/** Seed a loaded model whose only entity matches nothing the tests type. */
+function mountWithQuery(searchQuery: string): HTMLElement {
+  useViewerStore.setState({
+    ...fixtureModels(
+      fixtureModel(MODEL_ID, {
+        idOffset: 1_000_000,
+        entities: [{ expressId: 42, type: 'IfcWall', name: 'Wall A' }],
+      }),
+    ),
+    searchQuery,
+    searchOpen: true,
+    // Pin the search to the tier-0 scan: a 'building' record makes
+    // `useSearchIndex` skip the model rather than resolve a tier-1 build
+    // outside `act()`. `indexingCount` counts these, so the popover would
+    // show its indexing line instead — 'ready' keeps it at zero.
+    searchIndexes: new Map([[MODEL_ID, { status: 'ready', progress: 1 }]]) as never,
+  });
+  return render(<SearchInline />);
+}
+
+describe('SearchInline — the empty popover names selector syntax', () => {
+  before(() => { initialState = useViewerStore.getState(); });
+  afterEach(cleanup);
+  after(() => { useViewerStore.setState(initialState, true); });
+
+  it('a selector that finds nothing says where selectors are run', () => {
+    const container = mountWithQuery('IfcWall, Pset_WallCommon.FireRating=2HR');
+    const text = container.textContent ?? '';
+    assert.match(text, /selector syntax/i);
+    assert.match(text, /Filter tab/i);
+  });
+
+  it('plain text that finds nothing keeps the advice it always had', () => {
+    const container = mountWithQuery('Zzz Nothing Here');
+    const text = container.textContent ?? '';
+    assert.match(text, /No results/);
+    assert.doesNotMatch(text, /selector syntax/i);
+  });
+
+  it('a bare class name is a selector too, and is named as one', () => {
+    // It also happens to match the seeded wall by TYPE, so this asserts the
+    // hint reaches the empty state only — with rows present there is no
+    // empty state to read.
+    const container = mountWithQuery('IfcSlab');
+    assert.match(container.textContent ?? '', /selector syntax/i);
+  });
+});

--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -27,6 +27,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Search, Clock, X, SlidersHorizontal } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
+import { parseSelector } from '@ifc-lite/query';
 import { Input } from '@/components/ui/input';
 import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
@@ -528,6 +529,7 @@ export function SearchInline() {
       {showPopover && !showRecents && (
         <SearchPopover
           results={results}
+          query={searchQuery}
           highlightIndex={searchHighlightIndex}
           modelsCount={models.size}
           indexingCount={indexingCount}
@@ -635,6 +637,7 @@ function RecentsPopover({ recents, onPick, onClear }: RecentsPopoverProps) {
 
 interface SearchPopoverProps {
   results: SearchResult[];
+  query: string;
   highlightIndex: number;
   modelsCount: number;
   indexingCount: number;
@@ -645,6 +648,7 @@ interface SearchPopoverProps {
 
 function SearchPopover({
   results,
+  query,
   highlightIndex,
   modelsCount,
   indexingCount,
@@ -661,7 +665,7 @@ function SearchPopover({
       >
         {indexingCount > 0
           ? `Indexing ${indexingCount} model${indexingCount === 1 ? '' : 's'}… results appear as rows become searchable.`
-          : 'No results — try a name, IFC type, or full GlobalId.'}
+          : parseSelector(query).ok ? 'That reads as selector syntax. This box searches names, IFC types and GlobalIds — run a selector from the Filter tab (Advanced, below).' : 'No results — try a name, IFC type, or full GlobalId.'}
       </div>
     );
   }

--- a/apps/viewer/src/components/viewer/SearchInline.tsx
+++ b/apps/viewer/src/components/viewer/SearchInline.tsx
@@ -27,7 +27,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Search, Clock, X, SlidersHorizontal } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
-import { parseSelector } from '@ifc-lite/query';
+import { selectorYieldsRules } from '@/lib/search/selector-to-rules';
 import { Input } from '@/components/ui/input';
 import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
@@ -665,7 +665,7 @@ function SearchPopover({
       >
         {indexingCount > 0
           ? `Indexing ${indexingCount} model${indexingCount === 1 ? '' : 's'}… results appear as rows become searchable.`
-          : parseSelector(query).ok ? 'That reads as selector syntax. This box searches names, IFC types and GlobalIds — run a selector from the Filter tab (Advanced, below).' : 'No results — try a name, IFC type, or full GlobalId.'}
+          : selectorYieldsRules(query) ? 'That reads as selector syntax. This box searches names, IFC types and GlobalIds — run a selector from the Filter tab (Advanced, below).' : 'No results — try a name, IFC type, or full GlobalId.'}
       </div>
     );
   }

--- a/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
@@ -39,11 +39,16 @@ import {
 } from '@/lib/search/saved-filters';
 import { toast } from '@/components/ui/toast';
 import { RuleRow } from './SearchModal.filter.editors';
+import { SearchModalFilterSelector } from './SearchModal.filter.selector';
+import { parseSelector } from '@ifc-lite/query';
+import { selectorToFilterRules } from '@/lib/search/selector-to-rules';
 
 export function SearchModalFilterBuilder() {
   const {
     filter,
     searchQuery,
+    models,
+    activeModelId,
     setFilterCombinator,
     setFilterLimit,
     addFilterRule,
@@ -55,6 +60,8 @@ export function SearchModalFilterBuilder() {
     useShallow((s) => ({
       filter: s.searchFilter,
       searchQuery: s.searchQuery,
+      models: s.models,
+      activeModelId: s.activeModelId,
       setFilterCombinator: s.setFilterCombinator,
       setFilterLimit: s.setFilterLimit,
       addFilterRule: s.addFilterRule,
@@ -76,11 +83,28 @@ export function SearchModalFilterBuilder() {
     [addFilterRule],
   );
 
+  /**
+   * The search bar's text as rules. It reads as a selector when it parses
+   * cleanly AND the adapter can carry all of it — `IfcWall, Name=/D[0-9]{2}/`
+   * becomes a type rule and a Name rule. Anything else, including a plain
+   * `Wand`, stays the `Name contains` it has always been: falling back is the
+   * predictable answer, and a partial selector reading would drop the part it
+   * could not carry without saying so.
+   */
   const promoteSearchQuery = useCallback(() => {
     const q = searchQuery.trim();
     if (!q) return;
+    const parsed = parseSelector(q);
+    if (parsed.ok) {
+      const schemaVersion = (activeModelId ? models.get(activeModelId) : undefined)?.schemaVersion;
+      const { rules, unsupported } = selectorToFilterRules(parsed.query, { schemaVersion });
+      if (rules.length > 0 && unsupported.length === 0) {
+        for (const rule of rules) addFilterRule(rule);
+        return;
+      }
+    }
     addFilterRule(Rule.name('contains', q));
-  }, [addFilterRule, searchQuery]);
+  }, [activeModelId, addFilterRule, models, searchQuery]);
 
   // ── Preset handlers ─────────────────────────────────────────────────
 
@@ -115,88 +139,91 @@ export function SearchModalFilterBuilder() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-3 p-4">
-      {/* ── Toolbar: AND/OR · Limit · promote-query · Presets · Save · Reset ── */}
-      <div className="flex flex-wrap items-center gap-2 text-xs">
-        <CombinatorToggle value={filter.combinator} onChange={setFilterCombinator} />
+    <div className="flex flex-col">
+      <SearchModalFilterSelector />
+      <div className="flex flex-col gap-3 p-4">
+        {/* ── Toolbar: AND/OR · Limit · promote-query · Presets · Save · Reset ── */}
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <CombinatorToggle value={filter.combinator} onChange={setFilterCombinator} />
 
-        <div className="ml-1 flex items-center gap-1">
-          <label className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Limit
-          </label>
-          <Input
-            type="number"
-            min={0}
-            value={filter.limit}
-            onChange={(e) => setFilterLimit(Number.parseInt(e.target.value, 10) || 0)}
-            className="h-7 w-20 text-xs"
-          />
-          <span className="text-[10px] text-muted-foreground">0 = none</span>
-        </div>
+          <div className="ml-1 flex items-center gap-1">
+            <label className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Limit
+            </label>
+            <Input
+              type="number"
+              min={0}
+              value={filter.limit}
+              onChange={(e) => setFilterLimit(Number.parseInt(e.target.value, 10) || 0)}
+              className="h-7 w-20 text-xs"
+            />
+            <span className="text-[10px] text-muted-foreground">0 = none</span>
+          </div>
 
-        {searchQuery.trim().length > 0 && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={promoteSearchQuery}
-            className="h-7 gap-1 text-[11px]"
-            title="Add a Name contains rule from the search bar query"
-          >
-            <Plus className="h-3 w-3" />
-            Add &ldquo;{truncate(searchQuery.trim(), 18)}&rdquo; as rule
-          </Button>
-        )}
-
-        <div className="ml-auto flex items-center gap-1">
-          <PresetMenu
-            presets={savedPresets}
-            onLoad={handleLoadPreset}
-            onDelete={handleDeletePreset}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleSavePreset}
-            disabled={filter.rules.length === 0}
-            className="h-7 gap-1 text-[11px]"
-            title="Save the current rules as a named preset"
-          >
-            <Save className="h-3 w-3" /> Save
-          </Button>
-          {filter.rules.length > 0 && (
+          {searchQuery.trim().length > 0 && (
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              onClick={clearFilterRules}
-              className="h-7 gap-1 text-[11px] text-muted-foreground"
+              onClick={promoteSearchQuery}
+              className="h-7 gap-1 text-[11px]"
+              title="Turn the search bar query into filter rules"
             >
-              <X className="h-3 w-3" /> Reset
+              <Plus className="h-3 w-3" />
+              Add &ldquo;{truncate(searchQuery.trim(), 18)}&rdquo; as rule
             </Button>
           )}
-        </div>
-      </div>
 
-      {/* ── Rules list ──────────────────────────────────────────────────── */}
-      <div className="flex flex-col gap-2">
-        {filter.rules.length === 0 && (
-          <p className="rounded border border-dashed border-zinc-300 bg-zinc-50 px-3 py-3 text-center text-xs italic text-muted-foreground dark:border-zinc-800 dark:bg-zinc-900/30">
-            Add a rule to start filtering — pick by model, storey, IFC type, name,
-            property, quantity, material, classification, or elevation.
-          </p>
-        )}
-        {filter.rules.map((rule, i) => (
-          <RuleRow
-            key={i}
-            rule={rule}
-            {...ruleOptions}
-            onChange={(next) => updateFilterRule(i, next)}
-            onRemove={() => removeFilterRule(i)}
-          />
-        ))}
-        <AddRuleMenu onAdd={addRuleOfKind} />
+          <div className="ml-auto flex items-center gap-1">
+            <PresetMenu
+              presets={savedPresets}
+              onLoad={handleLoadPreset}
+              onDelete={handleDeletePreset}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={handleSavePreset}
+              disabled={filter.rules.length === 0}
+              className="h-7 gap-1 text-[11px]"
+              title="Save the current rules as a named preset"
+            >
+              <Save className="h-3 w-3" /> Save
+            </Button>
+            {filter.rules.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={clearFilterRules}
+                className="h-7 gap-1 text-[11px] text-muted-foreground"
+              >
+                <X className="h-3 w-3" /> Reset
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* ── Rules list ──────────────────────────────────────────────────── */}
+        <div className="flex flex-col gap-2">
+          {filter.rules.length === 0 && (
+            <p className="rounded border border-dashed border-zinc-300 bg-zinc-50 px-3 py-3 text-center text-xs italic text-muted-foreground dark:border-zinc-800 dark:bg-zinc-900/30">
+              Add a rule to start filtering — pick by model, storey, IFC type, name,
+              property, quantity, material, classification, or elevation.
+            </p>
+          )}
+          {filter.rules.map((rule, i) => (
+            <RuleRow
+              key={i}
+              rule={rule}
+              {...ruleOptions}
+              onChange={(next) => updateFilterRule(i, next)}
+              onRemove={() => removeFilterRule(i)}
+            />
+          ))}
+          <AddRuleMenu onAdd={addRuleOfKind} />
+        </div>
       </div>
     </div>
   );

--- a/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
@@ -80,20 +80,34 @@ export function SearchModalFilterBuilder() {
   );
 
   /**
-   * The search bar's text as rules. It reads as a selector when it parses
-   * cleanly AND the adapter can carry all of it — `IfcWall, Name=/D[0-9]{2}/`
-   * becomes a type rule and a Name rule. Anything else, including a plain
-   * `Wand`, stays the `Name contains` it has always been.
+   * The search bar's text as rules, through the same reading the Selector
+   * field uses. `IfcWall, Name=/D[0-9]{2}/` becomes a type rule and a Name
+   * rule; text that is not a selector at all — a plain `Wand` — stays the
+   * `Name contains` it has always been.
+   *
+   * A selector the adapter can only partly carry now applies the part it can
+   * and NAMES the rest. It used to fall through to `Name contains` on the
+   * whole string, so `IfcWall, type=WT01` silently added a rule matching zero
+   * elements with nothing to read: the defect #4091 reported, reached from the
+   * other entry point. Two surfaces reading the same text cannot disagree
+   * about whether the user is owed an explanation.
    */
   const promoteSearchQuery = useCallback(() => {
     const q = searchQuery.trim();
     if (!q) return;
     const reading = readSelector(q, { schemaVersion });
-    if (reading.ok && reading.rules.length > 0 && reading.unsupported.length === 0) {
-      for (const rule of reading.rules) addFilterRule(rule);
+    if (!reading.ok) {
+      addFilterRule(Rule.name('contains', q));
       return;
     }
-    addFilterRule(Rule.name('contains', q));
+    if (reading.rules.length === 0) {
+      toast.error(`Nothing in that selector maps to a filter rule yet: ${reading.unsupported.join('; ')}`);
+      return;
+    }
+    for (const rule of reading.rules) addFilterRule(rule);
+    if (reading.unsupported.length > 0) {
+      toast.info(`Added without these parts: ${reading.unsupported.join('; ')}`);
+    }
   }, [addFilterRule, schemaVersion, searchQuery]);
 
   // ── Preset handlers ─────────────────────────────────────────────────

--- a/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
@@ -91,12 +91,18 @@ export function SearchModalFilterBuilder() {
    * elements with nothing to read: the defect #4091 reported, reached from the
    * other entry point. Two surfaces reading the same text cannot disagree
    * about whether the user is owed an explanation.
+   *
+   * The fallback survives for text that PARSES but names nothing — `IFC`,
+   * `IFC-Export`, `Level=1`. Those reach here as a successful parse with no
+   * rule, and reporting them cost the button its oldest behaviour on the most
+   * ordinary input there is: `readsAsPlainText` is how the adapter separates
+   * them from a selector whose construct it genuinely cannot run.
    */
   const promoteSearchQuery = useCallback(() => {
     const q = searchQuery.trim();
     if (!q) return;
     const reading = readSelector(q, { schemaVersion });
-    if (!reading.ok) {
+    if (!reading.ok || reading.readsAsPlainText) {
       addFilterRule(Rule.name('contains', q));
       return;
     }

--- a/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.builder.tsx
@@ -39,16 +39,13 @@ import {
 } from '@/lib/search/saved-filters';
 import { toast } from '@/components/ui/toast';
 import { RuleRow } from './SearchModal.filter.editors';
-import { SearchModalFilterSelector } from './SearchModal.filter.selector';
-import { parseSelector } from '@ifc-lite/query';
-import { selectorToFilterRules } from '@/lib/search/selector-to-rules';
+import { SearchModalFilterSelector, useActiveSchemaVersion } from './SearchModal.filter.selector';
+import { readSelector } from '@/lib/search/selector-to-rules';
 
 export function SearchModalFilterBuilder() {
   const {
     filter,
     searchQuery,
-    models,
-    activeModelId,
     setFilterCombinator,
     setFilterLimit,
     addFilterRule,
@@ -60,8 +57,6 @@ export function SearchModalFilterBuilder() {
     useShallow((s) => ({
       filter: s.searchFilter,
       searchQuery: s.searchQuery,
-      models: s.models,
-      activeModelId: s.activeModelId,
       setFilterCombinator: s.setFilterCombinator,
       setFilterLimit: s.setFilterLimit,
       addFilterRule: s.addFilterRule,
@@ -71,6 +66,7 @@ export function SearchModalFilterBuilder() {
       setSearchFilter: s.setSearchFilter,
     })),
   );
+  const schemaVersion = useActiveSchemaVersion();
 
   const [savedPresets, setSavedPresets] = useState<SavedFilterPreset[]>(() => loadSavedFilters());
 
@@ -87,24 +83,18 @@ export function SearchModalFilterBuilder() {
    * The search bar's text as rules. It reads as a selector when it parses
    * cleanly AND the adapter can carry all of it — `IfcWall, Name=/D[0-9]{2}/`
    * becomes a type rule and a Name rule. Anything else, including a plain
-   * `Wand`, stays the `Name contains` it has always been: falling back is the
-   * predictable answer, and a partial selector reading would drop the part it
-   * could not carry without saying so.
+   * `Wand`, stays the `Name contains` it has always been.
    */
   const promoteSearchQuery = useCallback(() => {
     const q = searchQuery.trim();
     if (!q) return;
-    const parsed = parseSelector(q);
-    if (parsed.ok) {
-      const schemaVersion = (activeModelId ? models.get(activeModelId) : undefined)?.schemaVersion;
-      const { rules, unsupported } = selectorToFilterRules(parsed.query, { schemaVersion });
-      if (rules.length > 0 && unsupported.length === 0) {
-        for (const rule of rules) addFilterRule(rule);
-        return;
-      }
+    const reading = readSelector(q, { schemaVersion });
+    if (reading.ok && reading.rules.length > 0 && reading.unsupported.length === 0) {
+      for (const rule of reading.rules) addFilterRule(rule);
+      return;
     }
     addFilterRule(Rule.name('contains', q));
-  }, [activeModelId, addFilterRule, models, searchQuery]);
+  }, [addFilterRule, schemaVersion, searchQuery]);
 
   // ── Preset handlers ─────────────────────────────────────────────────
 

--- a/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
@@ -346,7 +346,7 @@ function PropertyEditor({ rule, psetQto, valueSchema, onChange }: PropertyEditor
         value={rule.setName}
         options={psetNames}
         className="h-7 w-52 text-xs font-mono"
-        onChange={(next) => onChange({ ...rule, setName: next, propertyName: '' })}
+        onChange={(next) => onChange({ ...rule, setName: next, setNameKind: undefined, propertyName: '', propertyNameKind: undefined })}
       />
       <span className="text-muted-foreground">.</span>
       <ComboInput
@@ -354,7 +354,7 @@ function PropertyEditor({ rule, psetQto, valueSchema, onChange }: PropertyEditor
         value={rule.propertyName}
         options={propNames}
         className="h-7 w-44 text-xs font-mono"
-        onChange={(next) => onChange({ ...rule, propertyName: next })}
+        onChange={(next) => onChange({ ...rule, propertyName: next, propertyNameKind: undefined })}
       />
       <OpDropdown ops={VALUE_OPS} value={rule.op} onChange={(next) => onChange({ ...rule, op: next })} />
       {!valueless && (
@@ -363,7 +363,7 @@ function PropertyEditor({ rule, psetQto, valueSchema, onChange }: PropertyEditor
           value={rule.value}
           options={valueOptions}
           className="h-7 w-44 text-xs font-mono"
-          onChange={(value) => onChange({ ...rule, value })}
+          onChange={(value) => onChange({ ...rule, value, valueKind: undefined })}
         />
       )}
     </>
@@ -391,7 +391,7 @@ function QuantityEditor({ rule, psetQto, onChange }: QuantityEditorProps) {
         value={rule.setName}
         options={qsetNames}
         className="h-7 w-56 text-xs font-mono"
-        onChange={(next) => onChange({ ...rule, setName: next, quantityName: '' })}
+        onChange={(next) => onChange({ ...rule, setName: next, setNameKind: undefined, quantityName: '', quantityNameKind: undefined })}
       />
       <span className="text-muted-foreground">.</span>
       <ComboInput
@@ -399,7 +399,7 @@ function QuantityEditor({ rule, psetQto, onChange }: QuantityEditorProps) {
         value={rule.quantityName}
         options={qtyNames}
         className="h-7 w-44 text-xs font-mono"
-        onChange={(next) => onChange({ ...rule, quantityName: next })}
+        onChange={(next) => onChange({ ...rule, quantityName: next, quantityNameKind: undefined })}
       />
       <OpDropdown ops={NUMERIC_OPS} value={rule.op} onChange={(next) => onChange({ ...rule, op: next })} />
       <Input

--- a/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
@@ -38,20 +38,20 @@ const NO_OPTIONS: readonly string[] = [];
 // ── Op constants ──────────────────────────────────────────────────────
 
 const SET_OPS: SetOp[] = ['in', 'notIn'];
-const STRING_OPS: StringOp[] = ['eq', 'ne', 'contains', 'notContains', 'startsWith'];
+const STRING_OPS: StringOp[] = ['eq', 'ne', 'contains', 'notContains', 'startsWith', 'matches', 'notMatches'];
 const VALUE_OPS: ValueOp[] = [
-  'eq', 'ne', 'contains', 'notContains', 'gt', 'gte', 'lt', 'lte', 'isSet', 'isNotSet',
+  'eq', 'ne', 'contains', 'notContains', 'matches', 'notMatches', 'gt', 'gte', 'lt', 'lte', 'isSet', 'isNotSet',
 ];
 const NUMERIC_OPS: NumericOp[] = ['eq', 'ne', 'gt', 'gte', 'lt', 'lte'];
 const CLASSIFICATION_OPS: ClassificationOp[] = [
-  'contains', 'eq', 'ne', 'notContains', 'isSet', 'isNotSet',
+  'contains', 'eq', 'ne', 'notContains', 'matches', 'notMatches', 'isSet', 'isNotSet',
 ];
 
 const OP_LABEL: Record<string, string> = {
   in: 'is one of',  notIn: 'is not one of',
   eq: '=', ne: '≠',
   contains: 'contains', notContains: 'does not contain',
-  startsWith: 'starts with',
+  startsWith: 'starts with', matches: 'matches /regex/', notMatches: 'does not match /regex/',
   gt: '>', gte: '≥', lt: '<', lte: '≤',
   isSet: 'is set', isNotSet: 'is not set',
 };

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -48,6 +48,20 @@ function promote(container: HTMLElement): void {
 
 const rules = () => useViewerStore.getState().searchFilter.rules;
 
+/**
+ * The most recent toast's text, scoped to the toast region rather than read off
+ * the whole container. The promote BUTTON renders the query too — its label is
+ * `Add "IfcWall, type=WT01" as rule` — so a container-wide match cannot tell a
+ * toast that named the dropped part from the button's own text: deleting the
+ * `toast.info` / `toast.error` call left both assertions green.
+ *
+ * Read as "the last one": toasts live in a module-level store with a timed
+ * dismissal, so an earlier test's toast can still be on screen.
+ */
+function latestToast(container: HTMLElement): string {
+  return container.querySelector('[role="status"]')?.lastElementChild?.textContent ?? '';
+}
+
 describe('Filter tab — promoting the search bar query', () => {
   afterEach(cleanup);
 
@@ -82,13 +96,13 @@ describe('Filter tab — promoting the search bar query', () => {
     assert.deepEqual(rules(), [
       Rule.ifcType(['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'], 'in'),
     ]);
-    assert.match(container.textContent ?? '', /type=WT01/);
+    assert.match(latestToast(container), /type=WT01/);
   });
 
   it('a selector with no rule at all reports instead of adding a guaranteed miss', () => {
     const container = mountWithQuery('parent=Foo');
     promote(container);
     assert.deepEqual(rules(), []);
-    assert.match(container.textContent ?? '', /parent=Foo/);
+    assert.match(latestToast(container), /parent=Foo/);
   });
 });

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -88,6 +88,21 @@ describe('Filter tab — promoting the search bar query', () => {
     assert.deepEqual(rules(), [Rule.name('contains', 'Wand')]);
   });
 
+  it('text that parses but names nothing keeps the Name contains it always had', () => {
+    // These all PARSE — `IFC` and `IFC-Export` as class terms, `Level=1` and
+    // `Ø=100` as attribute terms — and none of them names a class we know or an
+    // attribute we can filter, which is what a plain search term looks like
+    // after parsing. Reporting instead of falling back cost the search box its
+    // oldest behaviour on the most ordinary input there is.
+    for (const q of ['IFC', 'ifc', 'IFC-Export', 'Level=1', 'Ø=100']) {
+      const container = mountWithQuery(q);
+      promote(container);
+      assert.deepEqual(rules(), [Rule.name('contains', q)], q);
+      assert.equal(latestToast(container), '', q);
+      cleanup();
+    }
+  });
+
   it('a selector the adapter can only partly carry applies the rest and says so', () => {
     const container = mountWithQuery('IfcWall, type=WT01');
     promote(container);

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -3,13 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * "Add <query> as rule" in the Filter tab now reads the search bar as a
- * selector when the whole thing maps cleanly, and keeps the historical
- * `Name contains` otherwise (#4091).
+ * "Add <query> as rule" in the Filter tab reads the search bar as a selector,
+ * and keeps the historical `Name contains` for text that is not one (#4091).
  *
- * The fallback is the half worth pinning: a partial selector reading would
- * drop the part it could not carry, which is the silent-empty-result shape
- * this change exists to remove.
+ * The half worth pinning is the partial reading: it applies what it can and
+ * NAMES what it cannot, the same policy the Selector field above it uses.
+ * Falling back to `Name contains` on the whole string, as this used to, added
+ * a rule matching zero elements with nothing to read — the silent empty result
+ * this change exists to remove, reached from the other entry point.
  */
 
 import '@/test/setup-dom.js';
@@ -17,6 +18,7 @@ import '@/test/setup-dom.js';
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { render, cleanup, click } from '@/test/render.js';
+import { Toaster } from '@/components/ui/toast';
 import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
 import { useViewerStore } from '@/store';
 import { Rule } from '@/lib/search/filter-rules';
@@ -28,7 +30,12 @@ function mountWithQuery(searchQuery: string): HTMLElement {
     searchQuery,
     searchFilter: { rules: [], combinator: 'AND', limit: 500 },
   });
-  return render(<SearchModalFilterBuilder />);
+  return render(
+    <>
+      <SearchModalFilterBuilder />
+      <Toaster />
+    </>,
+  );
 }
 
 function promote(container: HTMLElement): void {
@@ -67,9 +74,21 @@ describe('Filter tab — promoting the search bar query', () => {
     assert.deepEqual(rules(), [Rule.name('contains', 'Wand')]);
   });
 
-  it('a selector the adapter cannot fully carry falls back rather than dropping a part', () => {
+  it('a selector the adapter can only partly carry applies the rest and says so', () => {
     const container = mountWithQuery('IfcWall, type=WT01');
     promote(container);
-    assert.deepEqual(rules(), [Rule.name('contains', 'IfcWall, type=WT01')]);
+    // The type rule is real and is applied; the `type=` term is named, not
+    // dropped and not turned into a Name-contains that matches nothing.
+    assert.deepEqual(rules(), [
+      Rule.ifcType(['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'], 'in'),
+    ]);
+    assert.match(container.textContent ?? '', /type=WT01/);
+  });
+
+  it('a selector with no rule at all reports instead of adding a guaranteed miss', () => {
+    const container = mountWithQuery('parent=Foo');
+    promote(container);
+    assert.deepEqual(rules(), []);
+    assert.match(container.textContent ?? '', /parent=Foo/);
   });
 });

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -57,7 +57,7 @@ describe('Filter tab — promoting the search bar query', () => {
     promote(container);
     assert.deepEqual(rules(), [
       Rule.ifcType(['IfcDoor', 'IfcDoorStandardCase'], 'in'),
-      Rule.name('matches', 'D[0-9]{2}'),
+      Rule.name('matches', 'D[0-9]{2}', 'regex'),
     ]);
   });
 

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Add <query> as rule" in the Filter tab now reads the search bar as a
+ * selector when the whole thing maps cleanly, and keeps the historical
+ * `Name contains` otherwise (#4091).
+ *
+ * The fallback is the half worth pinning: a partial selector reading would
+ * drop the part it could not carry, which is the silent-empty-result shape
+ * this change exists to remove.
+ */
+
+import '@/test/setup-dom.js';
+
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click } from '@/test/render.js';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { useViewerStore } from '@/store';
+import { Rule } from '@/lib/search/filter-rules';
+import { SearchModalFilterBuilder } from './SearchModal.filter.builder.js';
+
+function mountWithQuery(searchQuery: string): HTMLElement {
+  useViewerStore.setState({
+    ...fixtureModels({ ...fixtureModel('m1'), schemaVersion: 'IFC4' }),
+    searchQuery,
+    searchFilter: { rules: [], combinator: 'AND', limit: 500 },
+  });
+  return render(<SearchModalFilterBuilder />);
+}
+
+function promote(container: HTMLElement): void {
+  const button = Array.from(container.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('as rule'),
+  );
+  assert.ok(button, 'no "add as rule" button rendered');
+  click(button);
+}
+
+const rules = () => useViewerStore.getState().searchFilter.rules;
+
+describe('Filter tab — promoting the search bar query', () => {
+  afterEach(cleanup);
+
+  it('a class name becomes an expanded type rule, not a Name contains', () => {
+    const container = mountWithQuery('IfcWall');
+    promote(container);
+    assert.deepEqual(rules(), [
+      Rule.ifcType(['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'], 'in'),
+    ]);
+  });
+
+  it('a full selector becomes every rule it means', () => {
+    const container = mountWithQuery('IfcDoor, Name=/D[0-9]{2}/');
+    promote(container);
+    assert.deepEqual(rules(), [
+      Rule.ifcType(['IfcDoor', 'IfcDoorStandardCase'], 'in'),
+      Rule.name('matches', 'D[0-9]{2}'),
+    ]);
+  });
+
+  it('plain text that is not a selector keeps the Name contains it always was', () => {
+    const container = mountWithQuery('Wand');
+    promote(container);
+    assert.deepEqual(rules(), [Rule.name('contains', 'Wand')]);
+  });
+
+  it('a selector the adapter cannot fully carry falls back rather than dropping a part', () => {
+    const container = mountWithQuery('IfcWall, type=WT01');
+    promote(container);
+    assert.deepEqual(rules(), [Rule.name('contains', 'IfcWall, type=WT01')]);
+  });
+});

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
@@ -58,7 +58,7 @@ describe('SearchModalFilterSelector', () => {
     type(field(container), 'IfcWall, Name=/W.*/');
     click(applyButton(container));
 
-    assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in'), Rule.name('matches', 'W.*')]);
+    assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in'), Rule.name('matches', 'W.*', 'regex')]);
     assert.equal(useViewerStore.getState().searchFilter.combinator, 'AND');
     assert.equal(alertText(container), '');
   });

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The selector field, driven the way a user drives it (#4091): type into the
+ * real input, press the real button, read the store back.
+ *
+ * The assertions are on the OUTPUT — the rules that land in `searchFilter` and
+ * the text that appears — never on the component merely being mounted. A field
+ * wired to a handler nothing reaches renders identically, and #4091 is exactly
+ * a case of something looking like it worked while doing nothing.
+ */
+
+import '@/test/setup-dom.js';
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click, type, press } from '@/test/render.js';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { useViewerStore } from '@/store';
+import { Rule } from '@/lib/search/filter-rules';
+import { SearchModalFilterSelector } from './SearchModal.filter.selector.js';
+
+const WALLS = ['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'];
+
+function mount(): HTMLElement {
+  useViewerStore.setState({
+    ...fixtureModels({ ...fixtureModel('m1'), schemaVersion: 'IFC4' }),
+    searchFilter: { rules: [], combinator: 'AND', limit: 500 },
+  });
+  return render(<SearchModalFilterSelector />);
+}
+
+function field(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector('input[aria-label="Selector syntax"]');
+  assert.ok(el instanceof window.HTMLInputElement, 'no selector input rendered');
+  return el;
+}
+
+function applyButton(container: HTMLElement): Element {
+  const el = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('Apply'));
+  assert.ok(el, 'no Apply button rendered');
+  return el;
+}
+
+const rulesInStore = () => useViewerStore.getState().searchFilter.rules;
+const alertText = (container: HTMLElement) => container.querySelector('[role="alert"]')?.textContent ?? '';
+
+describe('SearchModalFilterSelector', () => {
+  beforeEach(() => {
+    useViewerStore.setState({ searchFilter: { rules: [], combinator: 'AND', limit: 500 } });
+  });
+  afterEach(cleanup);
+
+  it('applying a selector replaces the rule list with what it means', () => {
+    const container = mount();
+    type(field(container), 'IfcWall, Name=/W.*/');
+    click(applyButton(container));
+
+    assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in'), Rule.name('matches', 'W.*')]);
+    assert.equal(useViewerStore.getState().searchFilter.combinator, 'AND');
+    assert.equal(alertText(container), '');
+  });
+
+  it('Enter applies it too', () => {
+    const container = mount();
+    const input = field(container);
+    type(input, 'IfcDoor');
+    press(input, 'Enter');
+    assert.deepEqual(rulesInStore(), [Rule.ifcType(['IfcDoor', 'IfcDoorStandardCase'], 'in')]);
+  });
+
+  it('a parse error applies NOTHING and says where it broke', () => {
+    const container = mount();
+    // The reported symptom: `IfcWall` found 15 elements and `IfcWall*` found 0.
+    type(field(container), 'IfcWall*');
+    click(applyButton(container));
+
+    assert.deepEqual(rulesInStore(), []);
+    const message = alertText(container);
+    assert.match(message, /Character 8/);
+    assert.match(message, /\*=/);
+  });
+
+  it('a selector with an unsupported part applies the rest AND names what it dropped', () => {
+    const container = mount();
+    type(field(container), 'IfcWall, type=WT01');
+    click(applyButton(container));
+
+    assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in')]);
+    assert.match(alertText(container), /type=WT01/);
+  });
+
+  it('a selector that maps to no rule at all applies nothing and explains', () => {
+    const container = mount();
+    type(field(container), 'query:types.count=0');
+    click(applyButton(container));
+
+    assert.deepEqual(rulesInStore(), []);
+    assert.match(alertText(container), /query:types\.count=0/);
+  });
+
+  it('a successful apply clears a previous complaint', () => {
+    const container = mount();
+    type(field(container), 'IfcWall, type=WT01');
+    click(applyButton(container));
+    assert.notEqual(alertText(container), '');
+
+    type(field(container), 'IfcWall');
+    click(applyButton(container));
+    assert.equal(alertText(container), '');
+    assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in')]);
+  });
+
+  it('an empty field does nothing at all', () => {
+    const container = mount();
+    useViewerStore.setState({ searchFilter: { rules: [Rule.name('eq', 'keep me')], combinator: 'OR', limit: 500 } });
+    press(field(container), 'Enter');
+    assert.deepEqual(rulesInStore(), [Rule.name('eq', 'keep me')]);
+  });
+});

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Type a selector, get filter rules.
+ *
+ * The Filter tab had no text entry at all, so anyone arriving with the
+ * IfcOpenShell syntax in hand had nowhere to put it (#4091). This is that
+ * place: parse, adapt, and replace the rule list — or apply nothing and say
+ * what stopped it. It never applies a partial reading silently, because
+ * "matched nothing, said nothing" is the defect being fixed.
+ */
+
+import { useCallback, useState } from 'react';
+import { HelpCircle, Wand2 } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { parseSelector } from '@ifc-lite/query';
+import { useViewerStore } from '@/store';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { selectorToFilterRules } from '@/lib/search/selector-to-rules';
+
+const DOCS_URL = 'https://ifclite.dev/docs/guide/selector-syntax/';
+const PLACEHOLDER = 'IfcWall, Pset_WallCommon.FireRating=/REI.*/';
+
+interface Feedback {
+  tone: 'error' | 'warning';
+  lines: string[];
+}
+
+export function SearchModalFilterSelector() {
+  const { limit, models, activeModelId, setSearchFilter } = useViewerStore(
+    useShallow((s) => ({
+      limit: s.searchFilter.limit,
+      models: s.models,
+      activeModelId: s.activeModelId,
+      setSearchFilter: s.setSearchFilter,
+    })),
+  );
+  const [text, setText] = useState('');
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const apply = useCallback(() => {
+    const query = text.trim();
+    if (!query) return;
+
+    const parsed = parseSelector(query);
+    if (!parsed.ok) {
+      setFeedback({ tone: 'error', lines: [describeParseError(query, parsed.error)] });
+      return;
+    }
+
+    const schemaVersion = (activeModelId ? models.get(activeModelId) : undefined)?.schemaVersion;
+    const { combinator, rules, unsupported } = selectorToFilterRules(parsed.query, { schemaVersion });
+
+    if (rules.length === 0) {
+      setFeedback({
+        tone: 'error',
+        lines: ['Nothing in this selector maps to a filter rule yet:', ...unsupported],
+      });
+      return;
+    }
+
+    setSearchFilter({ rules, combinator, limit });
+    setFeedback(
+      unsupported.length > 0
+        ? { tone: 'warning', lines: ['Applied without these parts:', ...unsupported] }
+        : null,
+    );
+  }, [activeModelId, limit, models, setSearchFilter, text]);
+
+  return (
+    <div className="flex flex-col gap-1.5 border-b border-zinc-200 px-4 pb-3 pt-4 dark:border-zinc-800">
+      <div className="flex items-center gap-2">
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') apply(); }}
+          placeholder={PLACEHOLDER}
+          aria-label="Selector syntax"
+          spellCheck={false}
+          className="h-7 flex-1 font-mono text-xs"
+        />
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={apply}
+          disabled={text.trim().length === 0}
+          className="h-7 gap-1 text-[11px]"
+          title="Replace the rules below with this selector"
+        >
+          <Wand2 className="h-3 w-3" /> Apply
+        </Button>
+        <a
+          href={DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Selector syntax reference"
+          title="Selector syntax reference"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <HelpCircle className="h-3.5 w-3.5" />
+        </a>
+      </div>
+
+      {feedback && (
+        <ul
+          role="alert"
+          className={`flex flex-col gap-0.5 text-[11px] ${
+            feedback.tone === 'error' ? 'text-destructive' : 'text-amber-600 dark:text-amber-500'
+          }`}
+        >
+          {feedback.lines.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** "…at character 7: …" plus the offending tail, so the caret is findable. */
+function describeParseError(query: string, error: { message: string; offset: number }): string {
+  const tail = query.slice(error.offset, error.offset + 24);
+  const at = tail.length > 0 ? ` (at ${JSON.stringify(tail)})` : ' (at the end)';
+  return `Character ${error.offset + 1}${at}: ${error.message}`;
+}

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
@@ -15,7 +15,7 @@
 import { useCallback, useState } from 'react';
 import { HelpCircle, Wand2 } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
-import { parseSelector } from '@ifc-lite/query';
+import { parseSelector, type SelectorParseError } from '@ifc-lite/query';
 import { useViewerStore } from '@/store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -122,7 +122,7 @@ export function SearchModalFilterSelector() {
 }
 
 /** "…at character 7: …" plus the offending tail, so the caret is findable. */
-function describeParseError(query: string, error: { message: string; offset: number }): string {
+function describeParseError(query: string, error: SelectorParseError): string {
   const tail = query.slice(error.offset, error.offset + 24);
   const at = tail.length > 0 ? ` (at ${JSON.stringify(tail)})` : ' (at the end)';
   return `Character ${error.offset + 1}${at}: ${error.message}`;

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.tsx
@@ -14,12 +14,11 @@
 
 import { useCallback, useState } from 'react';
 import { HelpCircle, Wand2 } from 'lucide-react';
-import { useShallow } from 'zustand/react/shallow';
-import { parseSelector, type SelectorParseError } from '@ifc-lite/query';
+import type { SelectorParseError } from '@ifc-lite/query';
 import { useViewerStore } from '@/store';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { selectorToFilterRules } from '@/lib/search/selector-to-rules';
+import { readSelector } from '@/lib/search/selector-to-rules';
 
 const DOCS_URL = 'https://ifclite.dev/docs/guide/selector-syntax/';
 const PLACEHOLDER = 'IfcWall, Pset_WallCommon.FireRating=/REI.*/';
@@ -29,15 +28,21 @@ interface Feedback {
   lines: string[];
 }
 
-export function SearchModalFilterSelector() {
-  const { limit, models, activeModelId, setSearchFilter } = useViewerStore(
-    useShallow((s) => ({
-      limit: s.searchFilter.limit,
-      models: s.models,
-      activeModelId: s.activeModelId,
-      setSearchFilter: s.setSearchFilter,
-    })),
+/**
+ * The active model's IFC schema version, which is what decides how far a class
+ * term expands. Both selector surfaces need it and neither needs the model
+ * map, so the subscription lives here once.
+ */
+export function useActiveSchemaVersion(): string | undefined {
+  return useViewerStore(
+    (s) => (s.activeModelId ? s.models.get(s.activeModelId) : undefined)?.schemaVersion,
   );
+}
+
+export function SearchModalFilterSelector() {
+  const limit = useViewerStore((s) => s.searchFilter.limit);
+  const setSearchFilter = useViewerStore((s) => s.setSearchFilter);
+  const schemaVersion = useActiveSchemaVersion();
   const [text, setText] = useState('');
   const [feedback, setFeedback] = useState<Feedback | null>(null);
 
@@ -45,14 +50,13 @@ export function SearchModalFilterSelector() {
     const query = text.trim();
     if (!query) return;
 
-    const parsed = parseSelector(query);
-    if (!parsed.ok) {
-      setFeedback({ tone: 'error', lines: [describeParseError(query, parsed.error)] });
+    const reading = readSelector(query, { schemaVersion });
+    if (!reading.ok) {
+      setFeedback({ tone: 'error', lines: [describeParseError(query, reading.error)] });
       return;
     }
 
-    const schemaVersion = (activeModelId ? models.get(activeModelId) : undefined)?.schemaVersion;
-    const { combinator, rules, unsupported } = selectorToFilterRules(parsed.query, { schemaVersion });
+    const { combinator, rules, unsupported } = reading;
 
     if (rules.length === 0) {
       setFeedback({
@@ -68,7 +72,7 @@ export function SearchModalFilterSelector() {
         ? { tone: 'warning', lines: ['Applied without these parts:', ...unsupported] }
         : null,
     );
-  }, [activeModelId, limit, models, setSearchFilter, text]);
+  }, [limit, schemaVersion, setSearchFilter, text]);
 
   return (
     <div className="flex flex-col gap-1.5 border-b border-zinc-200 px-4 pb-3 pt-4 dark:border-zinc-800">

--- a/apps/viewer/src/lib/search/filter-evaluate.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { StringTable, EntityTableBuilder } from '@ifc-lite/data';
-import type { IfcDataStore } from '@ifc-lite/parser';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import { evaluateFilterRules, evaluateFilterRulesFederated, __internal } from './filter-evaluate.js';
 import { Rule } from './filter-rules.js';
 
@@ -814,5 +814,95 @@ describe('evaluateFilterRulesFederated — async chunking, abort, progress', () 
     assert.strictEqual(out.length, 1);
     // We should have stopped before scanning all four entities.
     assert.ok(lastScanned < rows.length, `expected early termination, scanned ${lastScanned}`);
+  });
+});
+
+/**
+ * How far does a `storey` rule reach? — the question the IfcOpenShell
+ * selector's `location="Level 3"` asks, and the one #4091's docs page has to
+ * answer without guessing.
+ *
+ * The page says `location=` matches an element contained directly OR
+ * INDIRECTLY in a spatial element of that name, and gives `IfcPump,
+ * location="Level 3"` for a pump sitting in a space on Level 3. ifc-lite's
+ * `storey` rule reads `spatialHierarchy.elementToStorey`, which is a different
+ * map, so the answer is measured here against a REAL parse rather than
+ * reasoned about: a pump in a space, a wall directly in the storey, one
+ * `Rule.storey(['Level 3'])`, and whatever comes back is what the docs matrix
+ * says.
+ */
+const SPATIAL_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('0Proj000000000000000001',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCSITE('0Site00000000000000001',$,'Site',$,$,#40,$,$,.ELEMENT.,$,$,$,$,$);
+#42= IFCBUILDING('0Bldg00000000000000001',$,'Building',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCBUILDINGSTOREY('0Storey00000000000001',$,'Level 3',$,$,#40,$,$,.ELEMENT.,9.);
+#44= IFCSPACE('0Space000000000000001',$,'Room 301',$,$,#40,$,$,.ELEMENT.,.INTERNAL.,$);
+#50= IFCPUMP('0Pump0000000000000001',$,'Pump-01',$,$,#40,$,'tag',$);
+#51= IFCWALL('0Wall0000000000000001',$,'Wall-01',$,$,#40,$,'tag',$);
+#60= IFCRELAGGREGATES('0Agg00000000000000001',$,$,$,#1,(#41));
+#61= IFCRELAGGREGATES('0Agg00000000000000002',$,$,$,#41,(#42));
+#62= IFCRELAGGREGATES('0Agg00000000000000003',$,$,$,#42,(#43));
+#63= IFCRELAGGREGATES('0Agg00000000000000004',$,$,$,#43,(#44));
+#70= IFCRELCONTAINEDINSPATIALSTRUCTURE('0Cont0000000000000001',$,$,$,(#50),#44);
+#71= IFCRELCONTAINEDINSPATIALSTRUCTURE('0Cont0000000000000002',$,$,$,(#51),#43);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const PUMP_IN_SPACE = 50;
+const WALL_IN_STOREY = 51;
+
+async function parseSpatialStore(): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(SPATIAL_IFC);
+  return new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+}
+
+describe('storey rule reach — what location="Level 3" resolves to (#4091)', () => {
+  it('the fixture really holds a pump in a space and a wall in the storey', async () => {
+    const store = await parseSpatialStore();
+    const ids = evaluateFilterRules('m1', store, [Rule.ifcType(['IfcPump', 'IfcWall'])], 'AND')
+      .map((e) => e.expressId).sort((a, b) => a - b);
+    assert.deepStrictEqual(ids, [PUMP_IN_SPACE, WALL_IN_STOREY]);
+    assert.strictEqual(store.spatialHierarchy?.getContainingSpace(PUMP_IN_SPACE), 44);
+  });
+
+  it('MEASURED: a storey rule matches the directly-contained wall', async () => {
+    const store = await parseSpatialStore();
+    const out = evaluateFilterRules('m1', store, [Rule.storey(['Level 3'])], 'AND');
+    assert.deepStrictEqual(out.map((e) => e.expressId), [WALL_IN_STOREY]);
+  });
+
+  it('MEASURED: it does NOT reach the pump one level down, inside the space', async () => {
+    const store = await parseSpatialStore();
+    const out = evaluateFilterRules(
+      'm1',
+      store,
+      [Rule.ifcType(['IfcPump']), Rule.storey(['Level 3'])],
+      'AND',
+    );
+    // Documented consequence, not an aspiration: the viewer's storey rule is
+    // direct containment (plus aggregated parts), so IfcOpenShell example 17
+    // is only partly answered until a spatial-ancestor rule lands (#4094).
+    assert.deepStrictEqual(out.map((e) => e.expressId), []);
+    assert.strictEqual(store.spatialHierarchy?.elementToStorey.get(PUMP_IN_SPACE), undefined);
+  });
+
+  it('MEASURED: the space itself IS mapped to its storey', async () => {
+    const store = await parseSpatialStore();
+    assert.strictEqual(store.spatialHierarchy?.elementToStorey.get(44), 43);
   });
 });

--- a/apps/viewer/src/lib/search/filter-evaluate.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.ts
@@ -49,13 +49,15 @@ import { RelationshipType } from '@ifc-lite/data';
 
 import {
   combineRuleResults,
+  type Combinator,
+  type FilterRule,
+} from './filter-rules.js';
+import {
   setOpMatches,
   stringOpMatches,
   matchStringAnyNone,
   numericOpMatches,
-  type Combinator,
-  type FilterRule,
-} from './filter-rules.js';
+} from './filter-ops.js';
 import {
   isNumericArrayLike,
   materialiseNumericIterable,
@@ -563,7 +565,7 @@ function evaluateRule(
       return setOpMatches(rule.op, pt, rule.values);
     }
     case 'name': {
-      return stringOpMatches(rule.op, ctx.table.getName(expressId), rule.value);
+      return stringOpMatches(rule.op, ctx.table.getName(expressId), rule.value, rule.valueKind);
     }
     case 'property': {
       if (!psetsFor) return false;
@@ -575,7 +577,7 @@ function evaluateRule(
     }
     case 'material': {
       if (!matNamesFor) return false;
-      return matchStringAnyNone(rule.op, matNamesFor(), rule.value);
+      return matchStringAnyNone(rule.op, matNamesFor(), rule.value, rule.valueKind);
     }
     case 'classification': {
       if (!classFor) return false;

--- a/apps/viewer/src/lib/search/filter-match.test.ts
+++ b/apps/viewer/src/lib/search/filter-match.test.ts
@@ -5,7 +5,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { parsePropertyValue } from '@ifc-lite/encoding';
-import { stringifyValue } from './filter-match.js';
+import { stringifyValue, nameMatches, matchPropertyRule, matchQuantityRule } from './filter-match.js';
+import { Rule } from './filter-rules.js';
 
 /**
  * `discoverFilterValues` (filter-schema.ts) populates the List Builder /
@@ -37,5 +38,79 @@ describe('stringifyValue — boolean rendering matches the display/compare side'
   it('null/undefined still stringify to empty string', () => {
     assert.strictEqual(stringifyValue(null), '');
     assert.strictEqual(stringifyValue(undefined), '');
+  });
+});
+
+/**
+ * `/Pset_.*Common/.FireRating` — the selector syntax's regex property-set and
+ * property names (#4091). Only `nameMatches` decides which rows a property or
+ * quantity rule can see, so this is where one rule reaches several sets.
+ */
+describe('nameMatches — regex property-set / property names', () => {
+  it('a /…/ literal matches several real set names', () => {
+    assert.strictEqual(nameMatches('/Pset_.*Common/', 'Pset_WallCommon'), true);
+    assert.strictEqual(nameMatches('/Pset_.*Common/', 'Pset_SlabCommon'), true);
+    assert.strictEqual(nameMatches('/Pset_.*Common/', 'Qto_WallBaseQuantities'), false);
+  });
+
+  it('a plain name stays an exact, case-insensitive compare', () => {
+    assert.strictEqual(nameMatches('Pset_WallCommon', 'PSET_WALLCOMMON'), true);
+    assert.strictEqual(nameMatches('Pset_WallCommon', 'Pset_WallCommonExtra'), false);
+  });
+
+  it('an invalid pattern matches nothing rather than throwing', () => {
+    assert.doesNotThrow(() => nameMatches('/Pset_[/', 'Pset_WallCommon'));
+    assert.strictEqual(nameMatches('/Pset_[/', 'Pset_WallCommon'), false);
+  });
+});
+
+describe('matchPropertyRule / matchQuantityRule read names through nameMatches', () => {
+  const psetRows = [
+    { setName: 'Pset_WallCommon', propertyName: 'FireRating', value: 'REI 60' },
+    { setName: 'Pset_SlabCommon', propertyName: 'LoadBearing', value: 'True' },
+  ];
+
+  it('one regex set name reaches a property in a differently-named set', () => {
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Pset_.*Common/', 'LoadBearing', 'eq', 'True'), psetRows),
+      true,
+    );
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('Pset_WallCommon', 'LoadBearing', 'eq', 'True'), psetRows),
+      false,
+    );
+  });
+
+  it('isSet / isNotSet honour the same regex set name', () => {
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Pset_.*Common/', 'FireRating', 'isSet', ''), psetRows),
+      true,
+    );
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Qto_.*/', 'FireRating', 'isSet', ''), psetRows),
+      false,
+    );
+  });
+
+  it('a regex property VALUE op runs against the matched row, unanchored', () => {
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Pset_.*Common/', 'FireRating', 'matches', 'REI.*'), psetRows),
+      true,
+    );
+    // Unanchored, so a substring is a match: 'REI 60' contains 'EI 60'.
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Pset_.*Common/', 'FireRating', 'matches', 'EI [0-9]+$'), psetRows),
+      true,
+    );
+    assert.strictEqual(
+      matchPropertyRule(Rule.property('/Pset_.*Common/', 'FireRating', 'matches', '^EI [0-9]+$'), psetRows),
+      false,
+    );
+  });
+
+  it('quantity rules take the same regex set names', () => {
+    const qtyRows = [{ setName: 'Qto_WallBaseQuantities', quantityName: 'NetVolume', value: 2.5 }];
+    assert.strictEqual(matchQuantityRule(Rule.quantity('/Qto_.*/', 'NetVolume', 'gt', 1), qtyRows), true);
+    assert.strictEqual(matchQuantityRule(Rule.quantity('/Qto_.*/', 'NetVolume', 'gt', 9), qtyRows), false);
   });
 });

--- a/apps/viewer/src/lib/search/filter-match.test.ts
+++ b/apps/viewer/src/lib/search/filter-match.test.ts
@@ -64,6 +64,25 @@ describe('nameMatches — regex property-set / property names', () => {
   });
 });
 
+describe('nameMatches — the rule says which kind of name it holds', () => {
+  it("a 'literal' name is text even when it is spelled with slashes", () => {
+    // The selector grammar's only escape hatch for a literal name is quoting
+    // it, so `"/Wall/".FireRating` must not swallow Pset_WallCommon (#4091).
+    assert.strictEqual(nameMatches('/Wall/', 'Pset_WallCommon', 'literal'), false);
+    assert.strictEqual(nameMatches('/Wall/', '/Wall/', 'literal'), true);
+    // The same string with no declared kind is free text, and there the
+    // slashes are the chip editor's only way to say "pattern".
+    assert.strictEqual(nameMatches('/Wall/', 'Pset_WallCommon'), true);
+  });
+
+  it("a 'regex' name is a SOURCE, so it needs no slashes of its own", () => {
+    assert.strictEqual(nameMatches('Pset_.*Common', 'Pset_SlabCommon', 'regex'), true);
+    assert.strictEqual(nameMatches('Pset_.*Common', 'Qto_WallBaseQuantities', 'regex'), false);
+    // A source whose own text contains slashes keeps them.
+    assert.strictEqual(nameMatches('/Wall/', 'a/Wall/b', 'regex'), true);
+  });
+});
+
 describe('matchPropertyRule / matchQuantityRule read names through nameMatches', () => {
   const psetRows = [
     { setName: 'Pset_WallCommon', propertyName: 'FireRating', value: 'REI 60' },

--- a/apps/viewer/src/lib/search/filter-match.ts
+++ b/apps/viewer/src/lib/search/filter-match.ts
@@ -20,14 +20,13 @@ import {
 } from '@ifc-lite/parser';
 
 import {
-  valueOpMatches,
-  numericOpMatches,
-  matchStringAnyNone,
   type PropertyRule,
   type QuantityRule,
   type ClassificationRule,
   type StoreyRule,
+  type TextKind,
 } from './filter-rules.js';
+import { valueOpMatches, numericOpMatches, matchStringAnyNone } from './filter-ops.js';
 import { lensMaterialNames } from '../lens-material-names.js';
 import { parsePropertyValue } from '@ifc-lite/encoding';
 import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
@@ -35,15 +34,20 @@ import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
 /**
  * Compare a rule's property-set / property name against a row's.
  *
- * A `/…/` literal is a regular expression (case-sensitive, the Lists-panel
- * convention from #1591), which is what makes the selector syntax's
- * `/Pset_.*Common/.FireRating` reach `Pset_WallCommon` and `Pset_SlabCommon`
- * in one rule. Anything else keeps the historical case-insensitive equality.
- * IFC set and property names never contain slashes, so the form is
- * unambiguous.
+ * `kind` is the rule saying what it holds (see {@link TextKind}). A `'regex'`
+ * name is a SOURCE and the whole string is the pattern, which is what makes
+ * the selector syntax's `/Pset_.*Common/.FireRating` reach `Pset_WallCommon`
+ * and `Pset_SlabCommon` in one rule; a `'literal'` name is compared as text
+ * even when it is spelled with slashes, which is what the grammar's quoting
+ * means and the only reason `"/Wall/".FireRating` can be asked for at all.
+ *
+ * A name with no declared kind was typed into a chip field, where the
+ * Lists-panel `/…/` convention (#1591) is the user's only way to say
+ * "pattern"; anything else there is the historical case-insensitive equality.
  */
-export function nameMatches(rulePattern: string, rowName: string): boolean {
-  if (isNamePattern(rulePattern)) return compileNameMatcher(rulePattern)(rowName);
+export function nameMatches(rulePattern: string, rowName: string, kind?: TextKind): boolean {
+  if (kind === 'regex') return compileNameMatcher(`/${rulePattern}/`)(rowName);
+  if (kind === undefined && isNamePattern(rulePattern)) return compileNameMatcher(rulePattern)(rowName);
   return rowName.toLowerCase() === rulePattern.toLowerCase();
 }
 
@@ -107,25 +111,25 @@ export function matchPropertyRule(rule: PropertyRule, rows: PsetRows): boolean {
   if (rule.op === 'isSet' || rule.op === 'isNotSet') {
     const present = rows.some(
       (r) =>
-        nameMatches(rule.setName, r.setName) &&
-        nameMatches(rule.propertyName, r.propertyName),
+        nameMatches(rule.setName, r.setName, rule.setNameKind) &&
+        nameMatches(rule.propertyName, r.propertyName, rule.propertyNameKind),
     );
     return rule.op === 'isSet' ? present : !present;
   }
 
   return rows.some(
     (r) =>
-      nameMatches(rule.setName, r.setName) &&
-      nameMatches(rule.propertyName, r.propertyName) &&
-      valueOpMatches(rule.op, r.value, rule.value),
+      nameMatches(rule.setName, r.setName, rule.setNameKind) &&
+      nameMatches(rule.propertyName, r.propertyName, rule.propertyNameKind) &&
+      valueOpMatches(rule.op, r.value, rule.value, rule.valueKind),
   );
 }
 
 export function matchQuantityRule(rule: QuantityRule, rows: QtyRows): boolean {
   return rows.some(
     (r) =>
-      nameMatches(rule.setName, r.setName) &&
-      nameMatches(rule.quantityName, r.quantityName) &&
+      nameMatches(rule.setName, r.setName, rule.setNameKind) &&
+      nameMatches(rule.quantityName, r.quantityName, rule.quantityNameKind) &&
       numericOpMatches(rule.op, r.value, rule.value),
   );
 }
@@ -206,7 +210,7 @@ export function matchClassificationRule(
     if (r.name) candidates.push(r.name);
   }
   // rule.op is now eq | ne | contains | notContains — a StringOp subset.
-  return matchStringAnyNone(rule.op, candidates, rule.value);
+  return matchStringAnyNone(rule.op, candidates, rule.value, rule.valueKind);
 }
 
 /** Element elevation in metres, derived from its building storey's

--- a/apps/viewer/src/lib/search/filter-match.ts
+++ b/apps/viewer/src/lib/search/filter-match.ts
@@ -30,6 +30,22 @@ import {
 } from './filter-rules.js';
 import { lensMaterialNames } from '../lens-material-names.js';
 import { parsePropertyValue } from '@ifc-lite/encoding';
+import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
+
+/**
+ * Compare a rule's property-set / property name against a row's.
+ *
+ * A `/…/` literal is a regular expression (case-sensitive, the Lists-panel
+ * convention from #1591), which is what makes the selector syntax's
+ * `/Pset_.*Common/.FireRating` reach `Pset_WallCommon` and `Pset_SlabCommon`
+ * in one rule. Anything else keeps the historical case-insensitive equality.
+ * IFC set and property names never contain slashes, so the form is
+ * unambiguous.
+ */
+export function nameMatches(rulePattern: string, rowName: string): boolean {
+  if (isNamePattern(rulePattern)) return compileNameMatcher(rulePattern)(rowName);
+  return rowName.toLowerCase() === rulePattern.toLowerCase();
+}
 
 // ── Pset / Qto matching ──────────────────────────────────────────────────────
 
@@ -91,16 +107,16 @@ export function matchPropertyRule(rule: PropertyRule, rows: PsetRows): boolean {
   if (rule.op === 'isSet' || rule.op === 'isNotSet') {
     const present = rows.some(
       (r) =>
-        r.setName.toLowerCase() === rule.setName.toLowerCase() &&
-        r.propertyName.toLowerCase() === rule.propertyName.toLowerCase(),
+        nameMatches(rule.setName, r.setName) &&
+        nameMatches(rule.propertyName, r.propertyName),
     );
     return rule.op === 'isSet' ? present : !present;
   }
 
   return rows.some(
     (r) =>
-      r.setName.toLowerCase() === rule.setName.toLowerCase() &&
-      r.propertyName.toLowerCase() === rule.propertyName.toLowerCase() &&
+      nameMatches(rule.setName, r.setName) &&
+      nameMatches(rule.propertyName, r.propertyName) &&
       valueOpMatches(rule.op, r.value, rule.value),
   );
 }
@@ -108,8 +124,8 @@ export function matchPropertyRule(rule: PropertyRule, rows: PsetRows): boolean {
 export function matchQuantityRule(rule: QuantityRule, rows: QtyRows): boolean {
   return rows.some(
     (r) =>
-      r.setName.toLowerCase() === rule.setName.toLowerCase() &&
-      r.quantityName.toLowerCase() === rule.quantityName.toLowerCase() &&
+      nameMatches(rule.setName, r.setName) &&
+      nameMatches(rule.quantityName, r.quantityName) &&
       numericOpMatches(rule.op, r.value, rule.value),
   );
 }

--- a/apps/viewer/src/lib/search/filter-ops.ts
+++ b/apps/viewer/src/lib/search/filter-ops.ts
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure operator matching for the filter rule taxonomy (ported verbatim from
+ * the Tauri-side `filter.rs` engine).
+ *
+ * Split out of `filter-rules.ts` at the op seam so both stay under the module
+ * size cap: that file owns the rule SHAPES, their constructors and the JSON
+ * guards, this one owns what an operator MEANS. Nothing here reads a rule —
+ * each function takes an operator, a candidate and the rule's operand, which
+ * is what makes them testable without a model.
+ */
+
+import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
+import type { NumericOp, SetOp, StringOp, TextKind, ValueOp } from './filter-rules.js';
+
+/** Lower-case a candidate that may be undefined at runtime (e.g. an untyped
+ *  entity's `getTypeName`) — calling `.toLowerCase()` on that crashed filtering
+ *  by type/name (#1195). Coercing nullish to '' is a no-op for real strings. */
+function lower(s: string | null | undefined): string {
+  return (s ?? '').toLowerCase();
+}
+
+/**
+ * Regex matching for the `matches` / `notMatches` ops, shared by every rule
+ * kind that owns them.
+ *
+ * `kind` is the producer speaking (see {@link TextKind}). A declared operand is
+ * a regular-expression SOURCE and the WHOLE string is the pattern, slashes
+ * included — that is what makes the selector `Name=/\/tmp\//` look for `/tmp/`
+ * rather than `tmp`. An operand with no declared kind is free text under the
+ * Lists-panel convention (#1591): a `/body/flags` literal is a pattern, flags
+ * and all, and anything else is a bare source. That is the spelling the chip
+ * editors ask for, and there the slashes ARE the user's only way to say
+ * "pattern", so reading them is the grammar rather than a guess.
+ *
+ * Case-SENSITIVE, unlike every other op here: the selector grammar's `/…/` is
+ * a Python regular expression, and those do not fold case. Write JavaScript's
+ * equivalent of `(?i)` by adding an `i` flag to a full literal (`/wand/i`).
+ *
+ * An empty operand never matches; an invalid pattern never matches either
+ * (`compileNameMatcher` logs it and falls back to an exact compare against the
+ * literal text, which no property value equals).
+ */
+export function regexOpMatches(candidate: string, value: string, kind: TextKind | undefined): boolean {
+  if (value.length === 0) return false;
+  const literal = kind === undefined && isNamePattern(value) ? value : `/${value}/`;
+  return compileNameMatcher(literal)(candidate ?? '');
+}
+
+export function setOpMatches(op: SetOp, candidate: string, values: readonly string[]): boolean {
+  const c = lower(candidate);
+  const hit = values.some((v) => lower(v) === c);
+  return op === 'in' ? hit : !hit;
+}
+
+export function stringOpMatches(
+  op: StringOp,
+  candidate: string,
+  value: string,
+  valueKind?: TextKind,
+): boolean {
+  const a = lower(candidate);
+  const b = lower(value);
+  switch (op) {
+    case 'eq':          return a === b;
+    case 'ne':          return a !== b;
+    case 'contains':    return a.includes(b);
+    case 'notContains': return !a.includes(b);
+    case 'startsWith':  return a.startsWith(b);
+    case 'matches':     return regexOpMatches(candidate, value, valueKind);
+    case 'notMatches':  return !regexOpMatches(candidate, value, valueKind);
+  }
+}
+
+/**
+ * Match a StringOp against a *set* of candidate strings — used for
+ * multi-valued dimensions (an element's material names, a classification's
+ * code+name pair). Positive ops (eq / contains / startsWith) match if ANY
+ * candidate satisfies them; negative ops (ne / notContains) match only if
+ * NO candidate violates them. An empty candidate set never matches: an
+ * element with no materials/classifications shouldn't satisfy a filter on
+ * that dimension (including the negative ops).
+ */
+export function matchStringAnyNone(
+  op: StringOp,
+  candidates: readonly string[],
+  value: string,
+  valueKind?: TextKind,
+): boolean {
+  if (candidates.length === 0) return false;
+  switch (op) {
+    case 'eq':
+    case 'contains':
+    case 'startsWith':
+    case 'matches':
+      return candidates.some((c) => stringOpMatches(op, c, value, valueKind));
+    case 'ne':
+      return candidates.every((c) => stringOpMatches('eq', c, value) === false);
+    case 'notContains':
+      return candidates.every((c) => stringOpMatches('contains', c, value) === false);
+    case 'notMatches':
+      return candidates.every((c) => stringOpMatches('matches', c, value, valueKind) === false);
+  }
+}
+
+export function numericOpMatches(op: NumericOp, candidate: number, value: number): boolean {
+  // The Rust side uses 1e-9 as the epsilon for eq/ne. Match it here for
+  // IDS-style parity — IFC quantities are stored as IFC4 IfcReal so the
+  // tolerance is large enough to absorb f32→f64 rounding from the parser.
+  const EPS = 1e-9;
+  switch (op) {
+    case 'eq':  return Math.abs(candidate - value) < EPS;
+    case 'ne':  return Math.abs(candidate - value) >= EPS;
+    case 'gt':  return candidate > value;
+    case 'gte': return candidate >= value;
+    case 'lt':  return candidate < value;
+    case 'lte': return candidate <= value;
+  }
+}
+
+/**
+ * Evaluate a Property ValueOp against the candidate's raw stringified
+ * value. `isSet`/`isNotSet` are presence checks and the property layer
+ * (filter-evaluate.ts) decides them before calling here — but we still
+ * accept them so the function is total.
+ */
+export function valueOpMatches(
+  op: ValueOp,
+  psetVal: string,
+  ruleVal: string,
+  valueKind?: TextKind,
+): boolean {
+  switch (op) {
+    case 'isSet':       return (psetVal ?? '').length > 0;
+    case 'isNotSet':    return (psetVal ?? '').length === 0;
+    case 'eq':          return lower(psetVal) === lower(ruleVal);
+    case 'ne':          return lower(psetVal) !== lower(ruleVal);
+    case 'contains':    return lower(psetVal).includes(lower(ruleVal));
+    case 'notContains': return !lower(psetVal).includes(lower(ruleVal));
+    case 'matches':     return regexOpMatches(psetVal, ruleVal, valueKind);
+    case 'notMatches':  return !regexOpMatches(psetVal, ruleVal, valueKind);
+    case 'gt':
+    case 'gte':
+    case 'lt':
+    case 'lte': {
+      const cv = Number.parseFloat(psetVal);
+      const rv = Number.parseFloat(ruleVal);
+      if (!Number.isFinite(cv) || !Number.isFinite(rv)) return false;
+      return numericOpMatches(op, cv, rv);
+    }
+  }
+}

--- a/apps/viewer/src/lib/search/filter-rules.test.ts
+++ b/apps/viewer/src/lib/search/filter-rules.test.ts
@@ -212,3 +212,87 @@ describe('isFilterRule / parseFilterRules', () => {
     assert.strictEqual(parsed[0].kind, 'ifcType');
   });
 });
+
+/**
+ * `matches` / `notMatches` — the regex ops the selector syntax's `/…/` form
+ * lands on (#4091). Everything else in this file compares case-insensitively;
+ * these two do not, because the grammar's `/…/` is a Python regular
+ * expression and those are case-sensitive by default.
+ */
+describe('stringOpMatches — matches / notMatches', () => {
+  it('matches on the regex source, anchored nowhere', () => {
+    assert.strictEqual(stringOpMatches('matches', 'D01', 'D[0-9]{2}'), true);
+    assert.strictEqual(stringOpMatches('matches', 'Door-D01-A', 'D[0-9]{2}'), true);
+    assert.strictEqual(stringOpMatches('matches', 'DA1', 'D[0-9]{2}'), false);
+  });
+
+  it('notMatches is its complement', () => {
+    assert.strictEqual(stringOpMatches('notMatches', 'D01', 'D[0-9]{2}'), false);
+    assert.strictEqual(stringOpMatches('notMatches', 'DA1', 'D[0-9]{2}'), true);
+  });
+
+  it('a value already written as a /…/ literal is honoured as one, flags included', () => {
+    assert.strictEqual(stringOpMatches('matches', 'D01', '/D[0-9]{2}/'), true);
+    assert.strictEqual(stringOpMatches('matches', 'wand', '/WAND/i'), true);
+  });
+
+  it('is case-sensitive without an explicit flag, unlike every other op here', () => {
+    assert.strictEqual(stringOpMatches('matches', 'wand', 'WAND'), false);
+    assert.strictEqual(stringOpMatches('eq', 'wand', 'WAND'), true);
+  });
+
+  it('an invalid pattern never matches, and never throws', () => {
+    assert.doesNotThrow(() => stringOpMatches('matches', 'D01', 'D[0-9'));
+    assert.strictEqual(stringOpMatches('matches', 'D01', 'D[0-9'), false);
+    // notMatches on a broken pattern rejects nothing rather than everything.
+    assert.strictEqual(stringOpMatches('notMatches', 'D01', 'D[0-9'), true);
+  });
+
+  it('an empty pattern never matches (it would otherwise match everything)', () => {
+    assert.strictEqual(stringOpMatches('matches', 'D01', ''), false);
+  });
+
+  it('a global flag does not alternate between calls', () => {
+    for (let i = 0; i < 4; i++) {
+      assert.strictEqual(stringOpMatches('matches', 'D01', '/D[0-9]{2}/g'), true, `call ${i}`);
+    }
+  });
+
+  it('does not throw on an undefined candidate (#1195)', () => {
+    const undef = undefined as unknown as string;
+    assert.doesNotThrow(() => stringOpMatches('matches', undef, 'D[0-9]{2}'));
+    assert.strictEqual(stringOpMatches('matches', undef, 'D[0-9]{2}'), false);
+  });
+});
+
+describe('valueOpMatches / matchStringAnyNone — matches / notMatches', () => {
+  it('matches a property value by regex', () => {
+    assert.strictEqual(valueOpMatches('matches', 'REI 60', 'REI.*'), true);
+    assert.strictEqual(valueOpMatches('matches', 'EI 60', 'REI.*'), false);
+    assert.strictEqual(valueOpMatches('notMatches', 'EI 60', 'REI.*'), true);
+  });
+
+  it('multi-valued matches when ANY candidate matches', () => {
+    assert.strictEqual(matchStringAnyNone('matches', ['Beton', 'Stahl'], 'Bet.*'), true);
+    assert.strictEqual(matchStringAnyNone('matches', ['Holz', 'Stahl'], 'Bet.*'), false);
+  });
+
+  it('multi-valued notMatches holds only when NO candidate matches', () => {
+    assert.strictEqual(matchStringAnyNone('notMatches', ['Holz', 'Stahl'], 'Bet.*'), true);
+    assert.strictEqual(matchStringAnyNone('notMatches', ['Beton', 'Stahl'], 'Bet.*'), false);
+  });
+
+  it('an empty candidate set never matches, negative ops included', () => {
+    assert.strictEqual(matchStringAnyNone('matches', [], 'Bet.*'), false);
+    assert.strictEqual(matchStringAnyNone('notMatches', [], 'Bet.*'), false);
+  });
+});
+
+describe('a rule carrying a regex op survives the saved-filter JSON guard', () => {
+  it('isFilterRule accepts it and parseFilterRules keeps it', () => {
+    const rule = Rule.name('matches', 'D[0-9]{2}');
+    const roundTripped = JSON.parse(JSON.stringify([rule])) as unknown;
+    assert.strictEqual(isFilterRule(rule), true);
+    assert.deepStrictEqual(parseFilterRules(roundTripped), [rule]);
+  });
+});

--- a/apps/viewer/src/lib/search/filter-rules.test.ts
+++ b/apps/viewer/src/lib/search/filter-rules.test.ts
@@ -5,17 +5,19 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import {
-  setOpMatches,
-  stringOpMatches,
-  matchStringAnyNone,
-  numericOpMatches,
-  valueOpMatches,
   combineRuleResults,
   isFilterRule,
   parseFilterRules,
   Rule,
   addHierarchyStoreyToRule,
 } from './filter-rules.js';
+import {
+  setOpMatches,
+  stringOpMatches,
+  matchStringAnyNone,
+  numericOpMatches,
+  valueOpMatches,
+} from './filter-ops.js';
 
 describe('op helpers tolerate an undefined candidate (#1195)', () => {
   // getTypeName / property accessors are typed `string` but return undefined
@@ -234,6 +236,16 @@ describe('stringOpMatches — matches / notMatches', () => {
   it('a value already written as a /…/ literal is honoured as one, flags included', () => {
     assert.strictEqual(stringOpMatches('matches', 'D01', '/D[0-9]{2}/'), true);
     assert.strictEqual(stringOpMatches('matches', 'wand', '/WAND/i'), true);
+  });
+
+  it('a DECLARED regex source is compiled whole, slashes and all', () => {
+    // #4091: the selector `Name=/\/tmp\//` is the source `/tmp/`. Re-read for
+    // delimiters it compiles to `tmp` and matches far too much.
+    assert.strictEqual(stringOpMatches('matches', 'C:/tmp/x', '/tmp/', 'regex'), true);
+    assert.strictEqual(stringOpMatches('matches', 'tmp', '/tmp/', 'regex'), false);
+    // Without a declared kind the same string is free text, where the slashes
+    // are the chip editor's only way to say "pattern".
+    assert.strictEqual(stringOpMatches('matches', 'tmp', '/tmp/'), true);
   });
 
   it('is case-sensitive without an explicit flag, unlike every other op here', () => {

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -13,13 +13,22 @@
  * collides with the IFC `type` attribute name on element rows.
  */
 
+import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
+
 // ── Operator enums ────────────────────────────────────────────────────────────
 
 /** Set-membership: storey, ifcType, predefinedType. */
 export type SetOp = 'in' | 'notIn';
 
 /** String comparisons (Name rule). */
-export type StringOp = 'eq' | 'ne' | 'contains' | 'notContains' | 'startsWith';
+export type StringOp =
+  | 'eq'
+  | 'ne'
+  | 'contains'
+  | 'notContains'
+  | 'startsWith'
+  | 'matches'
+  | 'notMatches';
 
 /** Numeric comparisons (Quantity rule). */
 export type NumericOp = 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
@@ -34,13 +43,23 @@ export type ValueOp =
   | 'lte'
   | 'contains'
   | 'notContains'
+  | 'matches'
+  | 'notMatches'
   | 'isSet'
   | 'isNotSet';
 
 /** Classification value+presence ops. A classification is matched against
  *  its code / name string, so this is the StringOp comparison subset plus
  *  presence — numeric ops don't apply. */
-export type ClassificationOp = 'eq' | 'ne' | 'contains' | 'notContains' | 'isSet' | 'isNotSet';
+export type ClassificationOp =
+  | 'eq'
+  | 'ne'
+  | 'contains'
+  | 'notContains'
+  | 'matches'
+  | 'notMatches'
+  | 'isSet'
+  | 'isNotSet';
 
 /** Top-level rule combinator. */
 export type Combinator = 'AND' | 'OR';
@@ -161,6 +180,30 @@ function lower(s: string | null | undefined): string {
   return (s ?? '').toLowerCase();
 }
 
+/**
+ * Regex matching for the `matches` / `notMatches` ops, shared by every rule
+ * kind that owns them.
+ *
+ * The rule value is the regex SOURCE (`D[0-9]{2}`), which is what the selector
+ * parser hands over and what the chip editor asks for, but a value already
+ * written as a `/…/` literal is honoured as one — that is the spelling the
+ * Lists panel established in this app (#1591) and the one the IfcOpenShell
+ * syntax uses, so a user who types the slashes gets what they meant rather
+ * than a regex hunting for literal slashes.
+ *
+ * Case-SENSITIVE, unlike every other op here: the selector grammar's `/…/` is
+ * a Python regular expression, and those do not fold case. Write `/(?i)…/`'s
+ * JavaScript equivalent by adding an `i` flag to a full literal (`/wand/i`).
+ *
+ * An empty value never matches; an invalid pattern never matches either
+ * (`compileNameMatcher` logs it and falls back to an exact compare against the
+ * literal text, which no property value equals).
+ */
+function regexOpMatches(candidate: string, value: string): boolean {
+  if (value.length === 0) return false;
+  return compileNameMatcher(isNamePattern(value) ? value : `/${value}/`)(candidate ?? '');
+}
+
 export function setOpMatches(op: SetOp, candidate: string, values: readonly string[]): boolean {
   const c = lower(candidate);
   const hit = values.some((v) => lower(v) === c);
@@ -176,6 +219,8 @@ export function stringOpMatches(op: StringOp, candidate: string, value: string):
     case 'contains':    return a.includes(b);
     case 'notContains': return !a.includes(b);
     case 'startsWith':  return a.startsWith(b);
+    case 'matches':     return regexOpMatches(candidate, value);
+    case 'notMatches':  return !regexOpMatches(candidate, value);
   }
 }
 
@@ -198,11 +243,14 @@ export function matchStringAnyNone(
     case 'eq':
     case 'contains':
     case 'startsWith':
+    case 'matches':
       return candidates.some((c) => stringOpMatches(op, c, value));
     case 'ne':
       return candidates.every((c) => stringOpMatches('eq', c, value) === false);
     case 'notContains':
       return candidates.every((c) => stringOpMatches('contains', c, value) === false);
+    case 'notMatches':
+      return candidates.every((c) => stringOpMatches('matches', c, value) === false);
   }
 }
 
@@ -235,6 +283,8 @@ export function valueOpMatches(op: ValueOp, psetVal: string, ruleVal: string): b
     case 'ne':          return lower(psetVal) !== lower(ruleVal);
     case 'contains':    return lower(psetVal).includes(lower(ruleVal));
     case 'notContains': return !lower(psetVal).includes(lower(ruleVal));
+    case 'matches':     return regexOpMatches(psetVal, ruleVal);
+    case 'notMatches':  return !regexOpMatches(psetVal, ruleVal);
     case 'gt':
     case 'gte':
     case 'lt':

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -13,8 +13,6 @@
  * collides with the IFC `type` attribute name on element rows.
  */
 
-import { compileNameMatcher, isNamePattern } from '@ifc-lite/lists';
-
 // ── Operator enums ────────────────────────────────────────────────────────────
 
 /** Set-membership: storey, ifcType, predefinedType. */
@@ -64,6 +62,30 @@ export type ClassificationOp =
 /** Top-level rule combinator. */
 export type Combinator = 'AND' | 'OR';
 
+/**
+ * How a rule reads one of its strings — the producer saying so, because the
+ * string itself cannot.
+ *
+ * `'regex'` is a regular-expression SOURCE: the WHOLE string is the pattern,
+ * slashes included. `'literal'` is exact text that is never a pattern, however
+ * it happens to be spelled. Absent means free text a human typed into a chip
+ * field, which keeps the Lists-panel convention (#1591): a `/body/flags`
+ * literal is a pattern, anything else is plain text.
+ *
+ * Guessing this back out of the text is the #4091 defect class — matched the
+ * wrong thing, said nothing — reappearing at the adapter seam. The selector
+ * grammar knows which it parsed: quoting is its ONLY escape hatch for a
+ * literal name, so `"/Wall/".FireRating` is the plain name `/Wall/`, and
+ * `Name=/\/tmp\//` is the source `/tmp/`. Sniffed for slashes, the first
+ * matches every `…Wall…` set and the second matches `tmp`.
+ *
+ * A property-set or property NAME has no operator beside it, so both kinds
+ * have to be declared. A VALUE's op already says whether it is a pattern, so
+ * only `'regex'` is ever recorded there.
+ */
+export type TextKind = 'literal' | 'regex';
+
+
 // ── Rule discriminated union ──────────────────────────────────────────────────
 
 export interface StoreyRule {
@@ -109,21 +131,34 @@ export interface NameRule {
   kind: 'name';
   op: StringOp;
   value: string;
+  /** How `value` reads. Only consulted by the `matches` / `notMatches` ops. */
+  valueKind?: TextKind;
 }
 
 export interface PropertyRule {
   kind: 'property';
   setName: string;
+  /** How `setName` reads — a regex set name is what lets one rule reach both
+   *  `Pset_WallCommon` and `Pset_SlabCommon`. */
+  setNameKind?: TextKind;
   propertyName: string;
+  /** How `propertyName` reads. */
+  propertyNameKind?: TextKind;
   op: ValueOp;
   /** Raw user input. Numeric ops parse as f64; isSet/isNotSet ignore. */
   value: string;
+  /** How `value` reads. Only consulted by the `matches` / `notMatches` ops. */
+  valueKind?: TextKind;
 }
 
 export interface QuantityRule {
   kind: 'quantity';
   setName: string;
+  /** How `setName` reads. */
+  setNameKind?: TextKind;
   quantityName: string;
+  /** How `quantityName` reads. */
+  quantityNameKind?: TextKind;
   op: NumericOp;
   value: number;
 }
@@ -136,6 +171,8 @@ export interface MaterialRule {
   kind: 'material';
   op: StringOp;
   value: string;
+  /** How `value` reads. Only consulted by the `matches` / `notMatches` ops. */
+  valueKind?: TextKind;
 }
 
 /** Match against an element's classification references (e.g. Uniclass,
@@ -148,6 +185,8 @@ export interface ClassificationRule {
   op: ClassificationOp;
   /** Matched against identification (code) OR name. Ignored for isSet/isNotSet. */
   value: string;
+  /** How `value` reads. Only consulted by the `matches` / `notMatches` ops. */
+  valueKind?: TextKind;
 }
 
 /** Match against an element's elevation in metres — derived from the
@@ -170,132 +209,6 @@ export type FilterRule =
   | MaterialRule
   | ClassificationRule
   | ElevationRule;
-
-// ── Pure op helpers (ported verbatim from filter.rs) ──────────────────────────
-
-/** Lower-case a candidate that may be undefined at runtime (e.g. an untyped
- *  entity's `getTypeName`) — calling `.toLowerCase()` on that crashed filtering
- *  by type/name (#1195). Coercing nullish to '' is a no-op for real strings. */
-function lower(s: string | null | undefined): string {
-  return (s ?? '').toLowerCase();
-}
-
-/**
- * Regex matching for the `matches` / `notMatches` ops, shared by every rule
- * kind that owns them.
- *
- * The rule value is the regex SOURCE (`D[0-9]{2}`), which is what the selector
- * parser hands over and what the chip editor asks for, but a value already
- * written as a `/…/` literal is honoured as one — that is the spelling the
- * Lists panel established in this app (#1591) and the one the IfcOpenShell
- * syntax uses, so a user who types the slashes gets what they meant rather
- * than a regex hunting for literal slashes.
- *
- * Case-SENSITIVE, unlike every other op here: the selector grammar's `/…/` is
- * a Python regular expression, and those do not fold case. Write `/(?i)…/`'s
- * JavaScript equivalent by adding an `i` flag to a full literal (`/wand/i`).
- *
- * An empty value never matches; an invalid pattern never matches either
- * (`compileNameMatcher` logs it and falls back to an exact compare against the
- * literal text, which no property value equals).
- */
-function regexOpMatches(candidate: string, value: string): boolean {
-  if (value.length === 0) return false;
-  return compileNameMatcher(isNamePattern(value) ? value : `/${value}/`)(candidate ?? '');
-}
-
-export function setOpMatches(op: SetOp, candidate: string, values: readonly string[]): boolean {
-  const c = lower(candidate);
-  const hit = values.some((v) => lower(v) === c);
-  return op === 'in' ? hit : !hit;
-}
-
-export function stringOpMatches(op: StringOp, candidate: string, value: string): boolean {
-  const a = lower(candidate);
-  const b = lower(value);
-  switch (op) {
-    case 'eq':          return a === b;
-    case 'ne':          return a !== b;
-    case 'contains':    return a.includes(b);
-    case 'notContains': return !a.includes(b);
-    case 'startsWith':  return a.startsWith(b);
-    case 'matches':     return regexOpMatches(candidate, value);
-    case 'notMatches':  return !regexOpMatches(candidate, value);
-  }
-}
-
-/**
- * Match a StringOp against a *set* of candidate strings — used for
- * multi-valued dimensions (an element's material names, a classification's
- * code+name pair). Positive ops (eq / contains / startsWith) match if ANY
- * candidate satisfies them; negative ops (ne / notContains) match only if
- * NO candidate violates them. An empty candidate set never matches: an
- * element with no materials/classifications shouldn't satisfy a filter on
- * that dimension (including the negative ops).
- */
-export function matchStringAnyNone(
-  op: StringOp,
-  candidates: readonly string[],
-  value: string,
-): boolean {
-  if (candidates.length === 0) return false;
-  switch (op) {
-    case 'eq':
-    case 'contains':
-    case 'startsWith':
-    case 'matches':
-      return candidates.some((c) => stringOpMatches(op, c, value));
-    case 'ne':
-      return candidates.every((c) => stringOpMatches('eq', c, value) === false);
-    case 'notContains':
-      return candidates.every((c) => stringOpMatches('contains', c, value) === false);
-    case 'notMatches':
-      return candidates.every((c) => stringOpMatches('matches', c, value) === false);
-  }
-}
-
-export function numericOpMatches(op: NumericOp, candidate: number, value: number): boolean {
-  // The Rust side uses 1e-9 as the epsilon for eq/ne. Match it here for
-  // IDS-style parity — IFC quantities are stored as IFC4 IfcReal so the
-  // tolerance is large enough to absorb f32→f64 rounding from the parser.
-  const EPS = 1e-9;
-  switch (op) {
-    case 'eq':  return Math.abs(candidate - value) < EPS;
-    case 'ne':  return Math.abs(candidate - value) >= EPS;
-    case 'gt':  return candidate > value;
-    case 'gte': return candidate >= value;
-    case 'lt':  return candidate < value;
-    case 'lte': return candidate <= value;
-  }
-}
-
-/**
- * Evaluate a Property ValueOp against the candidate's raw stringified
- * value. `isSet`/`isNotSet` are presence checks and the property layer
- * (filter-evaluate.ts) decides them before calling here — but we still
- * accept them so the function is total.
- */
-export function valueOpMatches(op: ValueOp, psetVal: string, ruleVal: string): boolean {
-  switch (op) {
-    case 'isSet':       return (psetVal ?? '').length > 0;
-    case 'isNotSet':    return (psetVal ?? '').length === 0;
-    case 'eq':          return lower(psetVal) === lower(ruleVal);
-    case 'ne':          return lower(psetVal) !== lower(ruleVal);
-    case 'contains':    return lower(psetVal).includes(lower(ruleVal));
-    case 'notContains': return !lower(psetVal).includes(lower(ruleVal));
-    case 'matches':     return regexOpMatches(psetVal, ruleVal);
-    case 'notMatches':  return !regexOpMatches(psetVal, ruleVal);
-    case 'gt':
-    case 'gte':
-    case 'lt':
-    case 'lte': {
-      const cv = Number.parseFloat(psetVal);
-      const rv = Number.parseFloat(ruleVal);
-      if (!Number.isFinite(cv) || !Number.isFinite(rv)) return false;
-      return numericOpMatches(op, cv, rv);
-    }
-  }
-}
 
 // ── Combinator helpers ────────────────────────────────────────────────────────
 
@@ -354,14 +267,31 @@ export const Rule = {
   ifcType: (values: string[], op: SetOp = 'in'): IfcTypeRule => ({ kind: 'ifcType', values, op }),
   predefinedType: (values: string[], op: SetOp = 'in'): PredefinedTypeRule =>
     ({ kind: 'predefinedType', values, op }),
-  name: (op: StringOp, value: string): NameRule => ({ kind: 'name', op, value }),
-  property: (setName: string, propertyName: string, op: ValueOp, value: string): PropertyRule =>
-    ({ kind: 'property', setName, propertyName, op, value }),
-  quantity: (setName: string, quantityName: string, op: NumericOp, value: number): QuantityRule =>
-    ({ kind: 'quantity', setName, quantityName, op, value }),
-  material: (op: StringOp, value: string): MaterialRule => ({ kind: 'material', op, value }),
-  classification: (system: string, op: ClassificationOp, value: string): ClassificationRule =>
-    ({ kind: 'classification', system: system || undefined, op, value }),
+  name: (op: StringOp, value: string, valueKind?: TextKind): NameRule =>
+    ({ kind: 'name', op, value, ...(valueKind ? { valueKind } : {}) }),
+  property: (
+    setName: string,
+    propertyName: string,
+    op: ValueOp,
+    value: string,
+    kinds: Pick<PropertyRule, 'setNameKind' | 'propertyNameKind' | 'valueKind'> = {},
+  ): PropertyRule => ({ kind: 'property', setName, propertyName, op, value, ...kinds }),
+  quantity: (
+    setName: string,
+    quantityName: string,
+    op: NumericOp,
+    value: number,
+    kinds: Pick<QuantityRule, 'setNameKind' | 'quantityNameKind'> = {},
+  ): QuantityRule => ({ kind: 'quantity', setName, quantityName, op, value, ...kinds }),
+  material: (op: StringOp, value: string, valueKind?: TextKind): MaterialRule =>
+    ({ kind: 'material', op, value, ...(valueKind ? { valueKind } : {}) }),
+  classification: (
+    system: string,
+    op: ClassificationOp,
+    value: string,
+    valueKind?: TextKind,
+  ): ClassificationRule =>
+    ({ kind: 'classification', system: system || undefined, op, value, ...(valueKind ? { valueKind } : {}) }),
   elevation: (op: NumericOp, value: number): ElevationRule => ({ kind: 'elevation', op, value }),
 } as const;
 

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -1,0 +1,304 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The same seventeen IfcOpenShell examples the parser pins, carried one step
+ * further: what filter rules does each one become, and what does the adapter
+ * refuse to guess at (#4091)?
+ *
+ * The `unsupported` assertions matter as much as the rules. A selector that
+ * produced no rule and no complaint is the reported defect — the user typed a
+ * valid query and got an empty result with nothing to read.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseSelector } from '@ifc-lite/query';
+import { selectorToFilterRules } from './selector-to-rules.js';
+import { Rule, type FilterRule } from './filter-rules.js';
+
+const GUID = '325Q7Fhnf67OZC$$r43uzK';
+
+function adapt(text: string, schemaVersion = 'IFC4') {
+  const result = parseSelector(text);
+  if (!result.ok) throw new Error(`${text} did not parse: ${result.error.message}`);
+  return selectorToFilterRules(result.query, { schemaVersion });
+}
+
+/** Rules only, for the cases whose `unsupported` list must be empty. */
+function rulesOf(text: string, schemaVersion = 'IFC4'): FilterRule[] {
+  const out = adapt(text, schemaVersion);
+  assert.deepEqual(out.unsupported, [], `expected nothing unsupported in ${text}`);
+  assert.equal(out.combinator, 'AND');
+  return out.rules;
+}
+
+const WALLS = ['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'];
+const SLABS = ['IfcSlab', 'IfcSlabElementedCase', 'IfcSlabStandardCase'];
+const DOORS = ['IfcDoor', 'IfcDoorStandardCase'];
+
+describe('selectorToFilterRules — the documented examples', () => {
+  it('1. a class expands to its subclasses', () => {
+    const rules = rulesOf('IfcWall');
+    assert.deepEqual(rules, [Rule.ifcType(WALLS, 'in')]);
+    // The point of the expansion, stated so deleting it fails here: a file
+    // full of IfcWallStandardCase answers a query for IfcWall.
+    assert.ok(rules[0] && 'values' in rules[0] && rules[0].values.includes('IfcWallStandardCase'));
+  });
+
+  it('1b. an abstract supertype reaches its whole branch', () => {
+    const rules = rulesOf('IfcElement');
+    assert.equal(rules.length, 1);
+    const values = rules[0] && 'values' in rules[0] ? rules[0].values : [];
+    assert.ok(values.length > 100, `IfcElement expanded to only ${values.length} names`);
+    assert.ok(values.includes('IfcPump'));
+    assert.ok(values.includes('IfcWallStandardCase'));
+  });
+
+  it('2. several classes fold into ONE rule, which is the OR the grammar means', () => {
+    assert.deepEqual(rulesOf('IfcWall, IfcSlab'), [Rule.ifcType([...WALLS, ...SLABS], 'in')]);
+  });
+
+  it('3. classes plus a material', () => {
+    assert.deepEqual(rulesOf('IfcWall, IfcSlab, material=concrete'), [
+      Rule.ifcType([...WALLS, ...SLABS], 'in'),
+      Rule.material('eq', 'concrete'),
+    ]);
+  });
+
+  it('4. a GlobalId has no rule kind yet, and says so', () => {
+    const out = adapt(GUID);
+    assert.deepEqual(out.rules, []);
+    assert.equal(out.unsupported.length, 1);
+    assert.match(out.unsupported[0] ?? '', /GlobalId/);
+    assert.match(out.unsupported[0] ?? '', /325Q7Fhnf67OZC/);
+  });
+
+  it('5. the wall rule survives, the GlobalId subtraction is reported with its "!"', () => {
+    const out = adapt(`IfcWall, ! ${GUID}`);
+    assert.deepEqual(out.rules, [Rule.ifcType(WALLS, 'in')]);
+    assert.equal(out.unsupported.length, 1);
+    assert.ok(out.unsupported[0]?.includes(`! ${GUID}`), out.unsupported[0]);
+  });
+
+  it('6. a class subtraction becomes a notIn rule over the expanded subtree', () => {
+    assert.deepEqual(rulesOf('IfcElement, ! IfcWall'), [
+      Rule.ifcType(rulesOf('IfcElement').flatMap((r) => ('values' in r ? r.values : [])), 'in'),
+      Rule.ifcType(WALLS, 'notIn'),
+    ]);
+  });
+
+  it('7. Name equality', () => {
+    assert.deepEqual(rulesOf('IfcDoor, Name=D01'), [
+      Rule.ifcType(DOORS, 'in'),
+      Rule.name('eq', 'D01'),
+    ]);
+  });
+
+  it('8. Name by regular expression', () => {
+    assert.deepEqual(rulesOf('IfcDoor, Name=/D[0-9]{2}/'), [
+      Rule.ifcType(DOORS, 'in'),
+      Rule.name('matches', 'D[0-9]{2}'),
+    ]);
+  });
+
+  it('9. a property in a named set', () => {
+    assert.deepEqual(rulesOf('IfcWall, Pset_WallCommon.FireRating=2HR'), [
+      Rule.ifcType(WALLS, 'in'),
+      Rule.property('Pset_WallCommon', 'FireRating', 'eq', '2HR'),
+    ]);
+  });
+
+  it('10. four classes and a regex property-set name, which travels as a /…/ literal', () => {
+    assert.deepEqual(rulesOf('IfcWall, IfcColumn, IfcBeam, IfcFooting, /Pset_.*Common/.LoadBearing=TRUE'), [
+      Rule.ifcType([
+        ...WALLS,
+        'IfcColumn', 'IfcColumnStandardCase',
+        'IfcBeam', 'IfcBeamStandardCase',
+        'IfcFooting',
+      ], 'in'),
+      Rule.property('/Pset_.*Common/', 'LoadBearing', 'eq', 'TRUE'),
+    ]);
+  });
+
+  it('11. != NULL is the isSet presence check', () => {
+    const rules = rulesOf('IfcElement, /Pset_.*Common/.FireRating != NULL');
+    assert.deepEqual(rules[1], Rule.property('/Pset_.*Common/', 'FireRating', 'isSet', ''));
+  });
+
+  it('11b. = NULL is isNotSet', () => {
+    assert.deepEqual(
+      rulesOf('Pset_WallCommon.FireRating = NULL'),
+      [Rule.property('Pset_WallCommon', 'FireRating', 'isNotSet', '')],
+    );
+  });
+
+  it('12. location becomes a storey rule; type= is reported', () => {
+    const out = adapt('IfcWall, type=WT01, location="Level 3"');
+    assert.deepEqual(out.rules, [Rule.ifcType(WALLS, 'in'), Rule.storey(['Level 3'], 'in')]);
+    assert.equal(out.unsupported.length, 1);
+    assert.ok(out.unsupported[0]?.includes('type=WT01'), out.unsupported[0]);
+  });
+
+  it('13. a classification matched by a regular expression', () => {
+    const rules = rulesOf('IfcElement, classification=/Pr_.*/');
+    assert.deepEqual(rules[1], Rule.classification('', 'matches', 'Pr_.*'));
+  });
+
+  it('14. everything at once — four rules kept, the GlobalId reported', () => {
+    const out = adapt(`IfcWall, IfcSlab, ! ${GUID}, material=concrete, /Pset_.*Common/.FireRating=2HR`);
+    assert.deepEqual(out.rules, [
+      Rule.ifcType([...WALLS, ...SLABS], 'in'),
+      Rule.material('eq', 'concrete'),
+      Rule.property('/Pset_.*Common/', 'FireRating', 'eq', '2HR'),
+    ]);
+    assert.equal(out.unsupported.length, 1);
+    assert.match(out.unsupported[0] ?? '', /GlobalId/);
+  });
+
+  it('15. a union keeps the FIRST group and names the rest', () => {
+    const out = adapt('IfcSlab, material=concrete + IfcDoor');
+    assert.deepEqual(out.rules, [Rule.ifcType(SLABS, 'in'), Rule.material('eq', 'concrete')]);
+    assert.equal(out.unsupported.length, 1);
+    assert.ok(out.unsupported[0]?.includes('IfcDoor'), out.unsupported[0]);
+    assert.match(out.unsupported[0] ?? '', /\+/);
+  });
+
+  it('16. two dropped groups produce two entries, each quoting its own filters', () => {
+    const out = adapt(`IfcDoor, IfcWindow + IfcWall, IfcSlab, material=concrete + ${GUID}`);
+    assert.deepEqual(out.rules, [Rule.ifcType([...DOORS, 'IfcWindow', 'IfcWindowStandardCase'], 'in')]);
+    assert.equal(out.unsupported.length, 2);
+    assert.ok(out.unsupported[0]?.includes('IfcWall, IfcSlab, material=concrete'), out.unsupported[0]);
+    assert.ok(out.unsupported[1]?.includes(GUID), out.unsupported[1]);
+  });
+
+  it('17. location reaches a storey by name — and only that far, see filter-evaluate.test.ts', () => {
+    assert.deepEqual(rulesOf('IfcPump, location="Level 3"'), [
+      Rule.ifcType(['IfcPump'], 'in'),
+      Rule.storey(['Level 3'], 'in'),
+    ]);
+  });
+});
+
+describe('selectorToFilterRules — operators and value shapes', () => {
+  it('maps every property operator', () => {
+    const cases: Array<[string, FilterRule]> = [
+      ['A.B=x', Rule.property('A', 'B', 'eq', 'x')],
+      ['A.B!=x', Rule.property('A', 'B', 'ne', 'x')],
+      ['A.B*=x', Rule.property('A', 'B', 'contains', 'x')],
+      ['A.B!*=x', Rule.property('A', 'B', 'notContains', 'x')],
+      ['A.B>1', Rule.property('A', 'B', 'gt', '1')],
+      ['A.B>=1', Rule.property('A', 'B', 'gte', '1')],
+      ['A.B<1', Rule.property('A', 'B', 'lt', '1')],
+      ['A.B<=1', Rule.property('A', 'B', 'lte', '1')],
+    ];
+    for (const [text, expected] of cases) assert.deepEqual(rulesOf(text), [expected], text);
+  });
+
+  it('maps every Name operator, regex included', () => {
+    assert.deepEqual(rulesOf('Name!=D01'), [Rule.name('ne', 'D01')]);
+    assert.deepEqual(rulesOf('Name*=Wand'), [Rule.name('contains', 'Wand')]);
+    assert.deepEqual(rulesOf('Name!*=Wand'), [Rule.name('notContains', 'Wand')]);
+    assert.deepEqual(rulesOf('Name!=/D[0-9]{2}/'), [Rule.name('notMatches', 'D[0-9]{2}')]);
+  });
+
+  it('a Qto_ set with a numeric value becomes a quantity rule, not a property rule', () => {
+    assert.deepEqual(
+      rulesOf('Qto_WallBaseQuantities.NetVolume>1.5'),
+      [Rule.quantity('Qto_WallBaseQuantities', 'NetVolume', 'gt', 1.5)],
+    );
+    assert.deepEqual(
+      rulesOf('/Qto_.*/.NetVolume>1.5'),
+      [Rule.quantity('/Qto_.*/', 'NetVolume', 'gt', 1.5)],
+    );
+  });
+
+  it('a Qto_ set with a NON-numeric value stays a property rule', () => {
+    assert.deepEqual(
+      rulesOf('Qto_WallBaseQuantities.Note=draft'),
+      [Rule.property('Qto_WallBaseQuantities', 'Note', 'eq', 'draft')],
+    );
+  });
+
+  it('a Pset_ set with a numeric value stays a property rule', () => {
+    assert.deepEqual(
+      rulesOf('Pset_WallCommon.ThermalTransmittance>1.5'),
+      [Rule.property('Pset_WallCommon', 'ThermalTransmittance', 'gt', '1.5')],
+    );
+  });
+
+  it('PredefinedType maps onto its set rule', () => {
+    assert.deepEqual(rulesOf('PredefinedType=SOLIDWALL'), [Rule.predefinedType(['SOLIDWALL'], 'in')]);
+    assert.deepEqual(rulesOf('PredefinedType!=SOLIDWALL'), [Rule.predefinedType(['SOLIDWALL'], 'notIn')]);
+  });
+
+  it('classification != NULL is the presence check', () => {
+    assert.deepEqual(rulesOf('classification != NULL'), [Rule.classification('', 'isSet', '')]);
+  });
+
+  it('a quoted value keeps its spaces and unescaped quotes', () => {
+    assert.deepEqual(rulesOf('Name="Wand \\"A\\" 1"'), [Rule.name('eq', 'Wand "A" 1')]);
+  });
+
+  it('the schema decides the expansion', () => {
+    const valuesFor = (schema: string): string[] => {
+      const [rule] = rulesOf('IfcBuildingElement', schema);
+      return rule && 'values' in rule ? rule.values : [];
+    };
+    // IFC2X3 parents IfcReinforcingBar under IfcBuildingElement; IFC4 moved it
+    // out. The wrong table is a wrong answer, so the version has to reach
+    // `expandTypes` rather than being left to the union fallback.
+    assert.ok(valuesFor('IFC2X3').includes('IfcReinforcingBar'));
+    assert.ok(!valuesFor('IFC4').includes('IfcReinforcingBar'));
+  });
+});
+
+describe('selectorToFilterRules — nothing is dropped in silence', () => {
+  const reported = (text: string): string[] => adapt(text).unsupported;
+
+  it('an attribute other than Name / PredefinedType', () => {
+    const out = adapt('IfcWall, Description=Foo');
+    assert.deepEqual(out.rules, [Rule.ifcType(WALLS, 'in')]);
+    assert.ok(out.unsupported[0]?.includes('Description=Foo'), out.unsupported[0]);
+  });
+
+  it('an unknown class name', () => {
+    const out = adapt('IfcWaall');
+    assert.deepEqual(out.rules, []);
+    assert.match(out.unsupported[0] ?? '', /IfcWaall/);
+  });
+
+  it('parent= and query:', () => {
+    assert.match(reported('parent=Foo')[0] ?? '', /parent=Foo/);
+    assert.match(reported('query:types.count=0')[0] ?? '', /query:types\.count=0/);
+  });
+
+  it('an operator the dimension cannot take', () => {
+    assert.match(reported('Name>1')[0] ?? '', /Name>1/);
+    assert.match(reported('location*=Level')[0] ?? '', /location\*=Level/);
+    assert.match(reported('PredefinedType=/SOLID.*/')[0] ?? '', /regular expression/);
+    assert.match(reported('Pset.Prop > NULL')[0] ?? '', /NULL/);
+  });
+
+  it('a regular expression JavaScript cannot compile is refused up front, not at match time', () => {
+    const out = adapt('Name=/D[0-9/');
+    assert.deepEqual(out.rules, []);
+    assert.match(out.unsupported[0] ?? '', /not a valid regular expression/);
+    // A pattern the RegExp constructor rejects would otherwise match nothing,
+    // which reads exactly like a correct pattern with no hits.
+    assert.match(out.unsupported[0] ?? '', /D\[0-9/);
+  });
+
+  it('an invalid regular expression in a property-set NAME is caught too', () => {
+    assert.match(reported('/Pset_[/.FireRating=2HR')[0] ?? '', /not a valid regular expression/);
+  });
+
+  it('every unsupported entry quotes the text the user typed', () => {
+    const out = adapt(`IfcWall, ! ${GUID}, type=WT01, parent=Foo, Description=x + IfcDoor`);
+    assert.equal(out.unsupported.length, 5);
+    for (const entry of out.unsupported) {
+      assert.match(entry, /^"/, `entry does not start with the quoted source: ${entry}`);
+    }
+  });
+});

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -294,6 +294,16 @@ describe('selectorToFilterRules — nothing is dropped in silence', () => {
     assert.match(out.unsupported[0] ?? '', /IfcWaall/);
   });
 
+  it('an unknown class reads back with the "!" the user typed', () => {
+    // Every other entry quotes `filter.text`, the exact source substring. This
+    // one quoted `filter.name`, so `! IfcWaall` came back without its "!" and
+    // the reader could not tell which of two terms was rejected.
+    const out = adapt('IfcWall, ! IfcWaall');
+    assert.deepEqual(out.rules, [Rule.ifcType(WALLS, 'in')]);
+    assert.equal(out.unsupported.length, 1);
+    assert.ok(out.unsupported[0]?.startsWith('"! IfcWaall"'), out.unsupported[0]);
+  });
+
   it('parent= and query:', () => {
     assert.match(reported('parent=Foo')[0] ?? '', /parent=Foo/);
     assert.match(reported('query:types.count=0')[0] ?? '', /query:types\.count=0/);

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -239,6 +239,17 @@ describe('selectorToFilterRules — operators and value shapes', () => {
     );
   });
 
+  it('the Qto_ test is case-SENSITIVE, like every other one in the repo', () => {
+    // `Qto_` is a buildingSMART prefix with a fixed spelling, and the six
+    // other places that test for it (SDK, lists, ids, ifcx) all compare it
+    // case-sensitively. A selector that answered differently for the same set
+    // name would be a surface disagreeing with the rest of the app.
+    assert.deepEqual(
+      rulesOf('qto_wallbasequantities.NetVolume>1.5'),
+      [prop('qto_wallbasequantities', 'NetVolume', 'gt', '1.5')],
+    );
+  });
+
   it('a Qto_ set with a NON-numeric value stays a property rule', () => {
     assert.deepEqual(
       rulesOf('Qto_WallBaseQuantities.Note=draft'),

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -250,11 +250,41 @@ describe('selectorToFilterRules — operators and value shapes', () => {
     );
   });
 
-  it('a Qto_ set with a NON-numeric value stays a property rule', () => {
+  it('a regex naming quantity sets by ALTERNATION is a quantity rule too', () => {
+    // `Qto_` opens an alternative here rather than the pattern, so a
+    // starts-with test misses it and used to emit a property rule instead.
     assert.deepEqual(
-      rulesOf('Qto_WallBaseQuantities.Note=draft'),
-      [prop('Qto_WallBaseQuantities', 'Note', 'eq', 'draft')],
+      rulesOf('/(Qto_Wall|Qto_Slab)BaseQuantities/.NetVolume>1'),
+      [qty('(Qto_Wall|Qto_Slab)BaseQuantities', 'NetVolume', 'gt', 1, { setNameKind: 'regex' })],
     );
+  });
+
+  it('a Qto_ term the quantity rule cannot carry is REPORTED, not routed to property sets', () => {
+    // A property rule reads IFCPROPERTYSET rows and quantities live in their
+    // own table, so each of these used to become a rule that could not match.
+    // `= NULL` was worse than a miss: `isNotSet` against a set no property row
+    // ever carries matched EVERY element in the model (#4091).
+    for (const text of [
+      'Qto_WallBaseQuantities.NetVolume=NULL',
+      'Qto_WallBaseQuantities.NetVolume!=NULL',
+      'Qto_WallBaseQuantities.NetVolume*=1',
+      'Qto_WallBaseQuantities.Note=draft',
+      '/Qto_.*/.NetVolume=/1.*/',
+    ]) {
+      const out = adapt(text);
+      assert.deepEqual(out.rules, [], text);
+      assert.equal(out.unsupported.length, 1, text);
+      assert.match(out.unsupported[0] ?? '', /quantity table/, text);
+    }
+  });
+
+  it('a quantity set with no Qto_ prefix is out of reach, and stays that way here', () => {
+    // Revit IFC2x3 writes `BaseQuantities` and ArchiCAD writes
+    // `ArchiCADQuantities`, neither carrying the prefix, so both stay property
+    // rules against a table that holds no such row. Named in
+    // docs/guide/selector-syntax.md rather than silently approximated; letting
+    // property rules read quantity rows is #4094, and this pin turns red there.
+    assert.deepEqual(rulesOf('BaseQuantities.NetVolume>1'), [prop('BaseQuantities', 'NetVolume', 'gt', '1')]);
   });
 
   it('a Pset_ set with a numeric value stays a property rule', () => {

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -17,8 +17,33 @@ import assert from 'node:assert/strict';
 import { parseSelector } from '@ifc-lite/query';
 import { selectorToFilterRules } from './selector-to-rules.js';
 import { Rule, type FilterRule } from './filter-rules.js';
+import { matchPropertyRule } from './filter-match.js';
+import { stringOpMatches } from './filter-ops.js';
 
 const GUID = '325Q7Fhnf67OZC$$r43uzK';
+
+/**
+ * A property / quantity rule as the adapter builds it. Both names carry the
+ * AST's string-or-regex discriminator, so every expectation states it rather
+ * than leaving the matcher to sniff the text back out (#4091).
+ */
+const prop = (
+  set: string,
+  name: string,
+  op: Parameters<typeof Rule.property>[2],
+  value: string,
+  kinds: Parameters<typeof Rule.property>[4] = {},
+): FilterRule =>
+  Rule.property(set, name, op, value, { setNameKind: 'literal', propertyNameKind: 'literal', ...kinds });
+
+const qty = (
+  set: string,
+  name: string,
+  op: Parameters<typeof Rule.quantity>[2],
+  value: number,
+  kinds: Parameters<typeof Rule.quantity>[4] = {},
+): FilterRule =>
+  Rule.quantity(set, name, op, value, { setNameKind: 'literal', quantityNameKind: 'literal', ...kinds });
 
 function adapt(text: string, schemaVersion = 'IFC4') {
   const result = parseSelector(text);
@@ -99,14 +124,14 @@ describe('selectorToFilterRules — the documented examples', () => {
   it('8. Name by regular expression', () => {
     assert.deepEqual(rulesOf('IfcDoor, Name=/D[0-9]{2}/'), [
       Rule.ifcType(DOORS, 'in'),
-      Rule.name('matches', 'D[0-9]{2}'),
+      Rule.name('matches', 'D[0-9]{2}', 'regex'),
     ]);
   });
 
   it('9. a property in a named set', () => {
     assert.deepEqual(rulesOf('IfcWall, Pset_WallCommon.FireRating=2HR'), [
       Rule.ifcType(WALLS, 'in'),
-      Rule.property('Pset_WallCommon', 'FireRating', 'eq', '2HR'),
+      prop('Pset_WallCommon', 'FireRating', 'eq', '2HR'),
     ]);
   });
 
@@ -118,19 +143,19 @@ describe('selectorToFilterRules — the documented examples', () => {
         'IfcBeam', 'IfcBeamStandardCase',
         'IfcFooting',
       ], 'in'),
-      Rule.property('/Pset_.*Common/', 'LoadBearing', 'eq', 'TRUE'),
+      prop('Pset_.*Common', 'LoadBearing', 'eq', 'TRUE', { setNameKind: 'regex' }),
     ]);
   });
 
   it('11. != NULL is the isSet presence check', () => {
     const rules = rulesOf('IfcElement, /Pset_.*Common/.FireRating != NULL');
-    assert.deepEqual(rules[1], Rule.property('/Pset_.*Common/', 'FireRating', 'isSet', ''));
+    assert.deepEqual(rules[1], prop('Pset_.*Common', 'FireRating', 'isSet', '', { setNameKind: 'regex' }));
   });
 
   it('11b. = NULL is isNotSet', () => {
     assert.deepEqual(
       rulesOf('Pset_WallCommon.FireRating = NULL'),
-      [Rule.property('Pset_WallCommon', 'FireRating', 'isNotSet', '')],
+      [prop('Pset_WallCommon', 'FireRating', 'isNotSet', '')],
     );
   });
 
@@ -143,7 +168,7 @@ describe('selectorToFilterRules — the documented examples', () => {
 
   it('13. a classification matched by a regular expression', () => {
     const rules = rulesOf('IfcElement, classification=/Pr_.*/');
-    assert.deepEqual(rules[1], Rule.classification('', 'matches', 'Pr_.*'));
+    assert.deepEqual(rules[1], Rule.classification('', 'matches', 'Pr_.*', 'regex'));
   });
 
   it('14. everything at once — four rules kept, the GlobalId reported', () => {
@@ -151,7 +176,7 @@ describe('selectorToFilterRules — the documented examples', () => {
     assert.deepEqual(out.rules, [
       Rule.ifcType([...WALLS, ...SLABS], 'in'),
       Rule.material('eq', 'concrete'),
-      Rule.property('/Pset_.*Common/', 'FireRating', 'eq', '2HR'),
+      prop('Pset_.*Common', 'FireRating', 'eq', '2HR', { setNameKind: 'regex' }),
     ]);
     assert.equal(out.unsupported.length, 1);
     assert.match(out.unsupported[0] ?? '', /GlobalId/);
@@ -184,14 +209,14 @@ describe('selectorToFilterRules — the documented examples', () => {
 describe('selectorToFilterRules — operators and value shapes', () => {
   it('maps every property operator', () => {
     const cases: Array<[string, FilterRule]> = [
-      ['A.B=x', Rule.property('A', 'B', 'eq', 'x')],
-      ['A.B!=x', Rule.property('A', 'B', 'ne', 'x')],
-      ['A.B*=x', Rule.property('A', 'B', 'contains', 'x')],
-      ['A.B!*=x', Rule.property('A', 'B', 'notContains', 'x')],
-      ['A.B>1', Rule.property('A', 'B', 'gt', '1')],
-      ['A.B>=1', Rule.property('A', 'B', 'gte', '1')],
-      ['A.B<1', Rule.property('A', 'B', 'lt', '1')],
-      ['A.B<=1', Rule.property('A', 'B', 'lte', '1')],
+      ['A.B=x', prop('A', 'B', 'eq', 'x')],
+      ['A.B!=x', prop('A', 'B', 'ne', 'x')],
+      ['A.B*=x', prop('A', 'B', 'contains', 'x')],
+      ['A.B!*=x', prop('A', 'B', 'notContains', 'x')],
+      ['A.B>1', prop('A', 'B', 'gt', '1')],
+      ['A.B>=1', prop('A', 'B', 'gte', '1')],
+      ['A.B<1', prop('A', 'B', 'lt', '1')],
+      ['A.B<=1', prop('A', 'B', 'lte', '1')],
     ];
     for (const [text, expected] of cases) assert.deepEqual(rulesOf(text), [expected], text);
   });
@@ -200,31 +225,31 @@ describe('selectorToFilterRules — operators and value shapes', () => {
     assert.deepEqual(rulesOf('Name!=D01'), [Rule.name('ne', 'D01')]);
     assert.deepEqual(rulesOf('Name*=Wand'), [Rule.name('contains', 'Wand')]);
     assert.deepEqual(rulesOf('Name!*=Wand'), [Rule.name('notContains', 'Wand')]);
-    assert.deepEqual(rulesOf('Name!=/D[0-9]{2}/'), [Rule.name('notMatches', 'D[0-9]{2}')]);
+    assert.deepEqual(rulesOf('Name!=/D[0-9]{2}/'), [Rule.name('notMatches', 'D[0-9]{2}', 'regex')]);
   });
 
   it('a Qto_ set with a numeric value becomes a quantity rule, not a property rule', () => {
     assert.deepEqual(
       rulesOf('Qto_WallBaseQuantities.NetVolume>1.5'),
-      [Rule.quantity('Qto_WallBaseQuantities', 'NetVolume', 'gt', 1.5)],
+      [qty('Qto_WallBaseQuantities', 'NetVolume', 'gt', 1.5)],
     );
     assert.deepEqual(
       rulesOf('/Qto_.*/.NetVolume>1.5'),
-      [Rule.quantity('/Qto_.*/', 'NetVolume', 'gt', 1.5)],
+      [qty('Qto_.*', 'NetVolume', 'gt', 1.5, { setNameKind: 'regex' })],
     );
   });
 
   it('a Qto_ set with a NON-numeric value stays a property rule', () => {
     assert.deepEqual(
       rulesOf('Qto_WallBaseQuantities.Note=draft'),
-      [Rule.property('Qto_WallBaseQuantities', 'Note', 'eq', 'draft')],
+      [prop('Qto_WallBaseQuantities', 'Note', 'eq', 'draft')],
     );
   });
 
   it('a Pset_ set with a numeric value stays a property rule', () => {
     assert.deepEqual(
       rulesOf('Pset_WallCommon.ThermalTransmittance>1.5'),
-      [Rule.property('Pset_WallCommon', 'ThermalTransmittance', 'gt', '1.5')],
+      [prop('Pset_WallCommon', 'ThermalTransmittance', 'gt', '1.5')],
     );
   });
 
@@ -300,5 +325,114 @@ describe('selectorToFilterRules — nothing is dropped in silence', () => {
     for (const entry of out.unsupported) {
       assert.match(entry, /^"/, `entry does not start with the quoted source: ${entry}`);
     }
+  });
+});
+
+
+/**
+ * The selector #4091 was reported with, pinned by name so it cannot regress
+ * quietly. Two things had to be true for it to work: a class list hoists into
+ * one expanded `in` rule, and a quoted property name is accepted after a
+ * property set — which for the regex spelling it always was, and for the
+ * literal spelling `Pset_BeamCommon."IsExternal"` it was not.
+ */
+describe('the reporter\'s selector (#4091)', () => {
+  const SELECTOR =
+    'IfcBeam, IfcColumn, IfcFooting, IfcMember, IfcPlate, IfcSlab, IfcStair, IfcWall, /Pset_.*Common/."Tragendes_Element" = TRUE';
+
+  it('becomes one expanded type rule and one property rule, with nothing unsupported', () => {
+    const out = adapt(SELECTOR);
+    assert.deepEqual(out.unsupported, []);
+    assert.equal(out.combinator, 'AND');
+    assert.equal(out.rules.length, 2);
+
+    const [types, property] = out.rules;
+    assert.ok(types && types.kind === 'ifcType');
+    assert.equal(types.op, 'in');
+    assert.equal(types.values.length, 16);
+    for (const name of ['IfcBeam', 'IfcColumn', 'IfcFooting', 'IfcMember', 'IfcPlate', 'IfcSlab', 'IfcStair', 'IfcWall']) {
+      assert.ok(types.values.includes(name), `${name} missing from the expansion`);
+    }
+    // The expansion is the point: a file full of IfcBeamStandardCase answers.
+    assert.ok(types.values.includes('IfcBeamStandardCase'));
+
+    assert.deepEqual(
+      property,
+      prop('Pset_.*Common', 'Tragendes_Element', 'eq', 'TRUE', { setNameKind: 'regex' }),
+    );
+  });
+
+  it('the property rule really reaches a German Pset_…Common set', () => {
+    const rule = adapt(SELECTOR).rules[1];
+    assert.ok(rule && rule.kind === 'property');
+    assert.equal(
+      matchPropertyRule(rule, [{ setName: 'Pset_BeamCommon', propertyName: 'Tragendes_Element', value: 'TRUE' }]),
+      true,
+    );
+    assert.equal(
+      matchPropertyRule(rule, [{ setName: 'Pset_BeamCommon', propertyName: 'Tragendes_Element', value: 'FALSE' }]),
+      false,
+    );
+  });
+
+  it('the same filter written with a LITERAL property set parses and adapts too', () => {
+    assert.deepEqual(
+      rulesOf('Pset_BeamCommon."Tragendes_Element" = TRUE'),
+      [prop('Pset_BeamCommon', 'Tragendes_Element', 'eq', 'TRUE')],
+    );
+  });
+});
+
+/**
+ * The AST's string/regex discriminator has to survive the adapter. Re-deriving
+ * it from the rule's text downstream is #4091's own defect class — matched the
+ * wrong thing, said nothing — moved one layer along.
+ */
+describe('selectorToFilterRules — a name or value keeps the kind the grammar gave it', () => {
+  it('a QUOTED name that looks like a regex stays literal, and matches nothing else', () => {
+    const [rule] = rulesOf('"/Wall/".FireRating=2HR');
+    assert.deepEqual(rule, prop('/Wall/', 'FireRating', 'eq', '2HR'));
+    assert.ok(rule && rule.kind === 'property');
+
+    // Quoting is the grammar's only way to ask for a literal name. Read as a
+    // pattern, `/Wall/` would swallow every set whose name contains "Wall".
+    assert.equal(
+      matchPropertyRule(rule, [{ setName: 'Pset_WallCommon', propertyName: 'FireRating', value: '2HR' }]),
+      false,
+    );
+    assert.equal(
+      matchPropertyRule(rule, [{ setName: '/Wall/', propertyName: 'FireRating', value: '2HR' }]),
+      true,
+    );
+  });
+
+  it('a regex VALUE containing an escaped slash keeps its slashes', () => {
+    const [rule] = rulesOf('Name=/\\/tmp\\//');
+    assert.deepEqual(rule, Rule.name('matches', '/tmp/', 'regex'));
+    assert.ok(rule && rule.kind === 'name');
+
+    // The source IS `/tmp/`, so the slashes are part of the pattern. Sniffed
+    // for delimiters it would compile to `tmp` and match every name with
+    // "tmp" anywhere in it.
+    assert.equal(stringOpMatches(rule.op, 'C:/tmp/x', rule.value, rule.valueKind), true);
+    assert.equal(stringOpMatches(rule.op, 'tmp', rule.value, rule.valueKind), false);
+  });
+
+  it('a regex property SET name is still a pattern, declared rather than spelled', () => {
+    const [rule] = rulesOf('/Pset_.*Common/.FireRating=2HR');
+    assert.deepEqual(rule, prop('Pset_.*Common', 'FireRating', 'eq', '2HR', { setNameKind: 'regex' }));
+    assert.ok(rule && rule.kind === 'property');
+    assert.equal(
+      matchPropertyRule(rule, [{ setName: 'Pset_SlabCommon', propertyName: 'FireRating', value: '2HR' }]),
+      true,
+    );
+  });
+
+  it('a quoted VALUE spelled like a regex is compared as text', () => {
+    const [rule] = rulesOf('Name="/D[0-9]/"');
+    assert.deepEqual(rule, Rule.name('eq', '/D[0-9]/'));
+    assert.ok(rule && rule.kind === 'name');
+    assert.equal(stringOpMatches(rule.op, '/D[0-9]/', rule.value, rule.valueKind), true);
+    assert.equal(stringOpMatches(rule.op, 'D01', rule.value, rule.valueKind), false);
   });
 });

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -318,10 +318,16 @@ function regexProblem(value: SelectorText | SelectorValue): string | undefined {
   }
 }
 
-/** A set the quantity rule owns: `Qto_WallBaseQuantities`, or a regex over it. */
+/**
+ * A set the quantity rule owns: `Qto_WallBaseQuantities`, or a regex over it.
+ * Case-SENSITIVE, like the six other `Qto_` prefix tests in this repo (SDK,
+ * lists, ids, ifcx): `Qto_` is a buildingSMART prefix with a fixed spelling,
+ * and a selector answering differently from the rest of the app for the same
+ * set name would be a surface disagreeing with itself.
+ */
 function looksLikeQuantitySet(pset: SelectorText): boolean {
   const text = pset.kind === 'regex' ? pset.source.replace(/^\^/, '') : pset.text;
-  return text.toLowerCase().startsWith('qto_');
+  return text.startsWith('Qto_');
 }
 
 function unsupportedOp(text: string, op: SelectorOp, value: SelectorValue): string {

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -1,0 +1,317 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Adapter: IfcOpenShell selector AST → the viewer's `FilterRule[]`.
+ *
+ * `parseSelector` (`@ifc-lite/query`) understands the whole grammar; this
+ * turns the part of it the path-B evaluator can answer into rules, and names
+ * every part it cannot in `unsupported`. Nothing is dropped quietly — a
+ * selector that silently matched zero elements is the defect #4091 reported,
+ * so a construct this adapter has no rule for has to come back as text the
+ * user can read, with the original spelling they typed.
+ *
+ * The follow-up (#4094) adds the rule kinds and the union support that would
+ * empty most of the `unsupported` list; a second adapter onto the CLI/MCP/SDK
+ * query descriptor reads the same AST rather than a second grammar.
+ */
+
+import { expandTypes, isKnownType, normalizeIfcTypeName } from '@ifc-lite/parser';
+import type {
+  SelectorFilter,
+  SelectorOp,
+  SelectorQuery,
+  SelectorText,
+  SelectorValue,
+} from '@ifc-lite/query';
+import {
+  Rule,
+  type FilterRule,
+  type NumericOp,
+  type SetOp,
+  type ValueOp,
+} from './filter-rules.js';
+
+/**
+ * The comparison ops every string-ish dimension shares — Name, material and
+ * classification alike. Deliberately narrower than `StringOp`: it omits
+ * `startsWith`, which the grammar has no spelling for, and it is assignable to
+ * `ClassificationOp` as well, so nothing here needs a cast.
+ */
+type SharedStringOp = 'eq' | 'ne' | 'contains' | 'notContains' | 'matches' | 'notMatches';
+
+export interface SelectorAdaptOptions {
+  /** The model's IFC schema, so class expansion picks the right subtype table. */
+  schemaVersion?: string;
+}
+
+export interface SelectorAdaptResult {
+  /** Filters within a group narrow left to right, which is the AND combinator. */
+  combinator: 'AND';
+  rules: FilterRule[];
+  /** One entry per construct that produced no rule, quoting what was typed. */
+  unsupported: string[];
+}
+
+/** `= != > >= < <= *= !*=` onto the property `ValueOp` set. */
+const VALUE_OPS: Partial<Record<SelectorOp, ValueOp>> = {
+  '=': 'eq', '!=': 'ne', '>': 'gt', '>=': 'gte', '<': 'lt', '<=': 'lte',
+  '*=': 'contains', '!*=': 'notContains',
+};
+
+/** The subset that survives onto a string-only dimension (Name, material). */
+const STRING_OPS: Partial<Record<SelectorOp, SharedStringOp>> = {
+  '=': 'eq', '!=': 'ne', '*=': 'contains', '!*=': 'notContains',
+};
+
+const NUMERIC_OPS: Partial<Record<SelectorOp, NumericOp>> = {
+  '=': 'eq', '!=': 'ne', '>': 'gt', '>=': 'gte', '<': 'lt', '<=': 'lte',
+};
+
+/** A regex value only has a meaning for equality and its negation. */
+const REGEX_OPS: Partial<Record<SelectorOp, 'matches' | 'notMatches'>> = {
+  '=': 'matches', '!=': 'notMatches',
+};
+
+export function selectorToFilterRules(
+  query: SelectorQuery,
+  options: SelectorAdaptOptions = {},
+): SelectorAdaptResult {
+  const unsupported: string[] = [];
+  const [group, ...extraGroups] = query.groups;
+
+  for (const extra of extraGroups) {
+    unsupported.push(
+      `${quote(extra.filters.map((f) => f.text).join(', '))}: unioning groups with "+" is not supported yet, run it as a second filter`,
+    );
+  }
+
+  const classAdds: string[] = [];
+  const classSubtracts: string[] = [];
+  const rules: FilterRule[] = [];
+
+  for (const filter of group?.filters ?? []) {
+    if (filter.kind === 'class') {
+      if (!isKnownType(filter.name)) {
+        unsupported.push(`${quote(filter.name)}: not an entity name in IFC2X3, IFC4 or IFC4X3`);
+        continue;
+      }
+      (filter.negate ? classSubtracts : classAdds).push(filter.name);
+      continue;
+    }
+    const adapted = adaptFilter(filter);
+    if (typeof adapted === 'string') unsupported.push(adapted);
+    else rules.push(adapted);
+  }
+
+  const head: FilterRule[] = [];
+  if (classAdds.length > 0) head.push(Rule.ifcType(expandClasses(classAdds, options), 'in'));
+  if (classSubtracts.length > 0) head.push(Rule.ifcType(expandClasses(classSubtracts, options), 'notIn'));
+
+  return { combinator: 'AND', rules: [...head, ...rules], unsupported };
+}
+
+/**
+ * A class names its subclasses too, which is the whole difference between
+ * `IfcWall` here and `IfcWall` in the chip dropdown: `expandTypes` walks the
+ * schema's subtype table, so `IfcWall` reaches `IfcWallStandardCase` and
+ * `IfcElement` reaches all 180 of its descendants. It answers in the STEP
+ * file's UPPERCASE spelling; matching folds case either way, but the chips
+ * show these values, so they are normalised back to PascalCase.
+ */
+function expandClasses(names: string[], options: SelectorAdaptOptions): string[] {
+  return expandTypes(names, options.schemaVersion).map(normalizeIfcTypeName);
+}
+
+/** One non-class filter: a rule, or the sentence explaining why there isn't one. */
+function adaptFilter(filter: SelectorFilter): FilterRule | string {
+  switch (filter.kind) {
+    case 'globalId':
+      return `${quote(filter.text)}: GlobalId terms are not supported yet, search for the GlobalId instead (#4094)`;
+    case 'attribute':
+      return adaptAttribute(filter.name, filter.op, filter.value, filter.text);
+    case 'property':
+      return adaptProperty(filter.pset, filter.prop, filter.op, filter.value, filter.text);
+    case 'material':
+      return adaptMaterial(filter.op, filter.value, filter.text);
+    case 'classification':
+      return adaptClassification(filter.op, filter.value, filter.text);
+    case 'location':
+      return adaptLocation(filter.op, filter.value, filter.text);
+    case 'type':
+      return `${quote(filter.text)}: matching an element's type by name is not supported yet (#4094)`;
+    case 'parent':
+      return `${quote(filter.text)}: "parent=" is not supported`;
+    case 'query':
+      return `${quote(filter.text)}: "query:" value queries are not supported`;
+    case 'class':
+      // Folded into the ifcType rules by the caller; unreachable here.
+      return `${quote(filter.text)}: unexpected class filter`;
+  }
+}
+
+function adaptAttribute(
+  name: string,
+  op: SelectorOp,
+  value: SelectorValue,
+  text: string,
+): FilterRule | string {
+  const attribute = name.toLowerCase();
+  if (attribute !== 'name' && attribute !== 'predefinedtype') {
+    return `${quote(text)}: only the Name and PredefinedType attributes are filterable (#4094)`;
+  }
+  if (value.kind === 'null') return `${quote(text)}: an attribute cannot be compared to NULL`;
+
+  if (attribute === 'predefinedtype') {
+    const setOp = setOpFor(op);
+    if (!setOp) return `${quote(text)}: PredefinedType takes only "=" and "!="`;
+    if (value.kind === 'regex') return `${quote(text)}: PredefinedType cannot be matched by a regular expression`;
+    return Rule.predefinedType([value.text], setOp);
+  }
+
+  const stringOp = stringOpFor(op, value);
+  if (!stringOp) return unsupportedOp(text, op, value);
+  const invalid = regexProblem(value);
+  if (invalid) return `${quote(text)}: ${invalid}`;
+  return Rule.name(stringOp, literalOf(value));
+}
+
+function adaptProperty(
+  pset: SelectorText,
+  prop: SelectorText,
+  op: SelectorOp,
+  value: SelectorValue,
+  text: string,
+): FilterRule | string {
+  for (const part of [pset, prop]) {
+    const invalid = regexProblem(part);
+    if (invalid) return `${quote(text)}: ${invalid}`;
+  }
+  const setName = nameLiteral(pset);
+  const propName = nameLiteral(prop);
+
+  if (value.kind === 'null') {
+    if (op === '=') return Rule.property(setName, propName, 'isNotSet', '');
+    if (op === '!=') return Rule.property(setName, propName, 'isSet', '');
+    return `${quote(text)}: NULL can only be compared with "=" or "!="`;
+  }
+
+  if (value.kind === 'regex') {
+    const regexOp = REGEX_OPS[op];
+    if (!regexOp) return unsupportedOp(text, op, value);
+    const invalid = regexProblem(value);
+    if (invalid) return `${quote(text)}: ${invalid}`;
+    return Rule.property(setName, propName, regexOp, value.source);
+  }
+
+  const numeric = Number.parseFloat(value.text);
+  const numericOp = NUMERIC_OPS[op];
+  if (looksLikeQuantitySet(pset) && numericOp && Number.isFinite(numeric) && value.text.trim() !== '') {
+    return Rule.quantity(setName, propName, numericOp, numeric);
+  }
+
+  const valueOp = VALUE_OPS[op];
+  if (!valueOp) return unsupportedOp(text, op, value);
+  return Rule.property(setName, propName, valueOp, value.text);
+}
+
+function adaptMaterial(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
+  if (value.kind === 'null') return `${quote(text)}: "material=" cannot be compared to NULL`;
+  const stringOp = stringOpFor(op, value);
+  if (!stringOp) return unsupportedOp(text, op, value);
+  const invalid = regexProblem(value);
+  if (invalid) return `${quote(text)}: ${invalid}`;
+  // Matched against each material NAME the element exposes. IfcOpenShell also
+  // accepts a material Category here; ifc-lite does not read Category yet
+  // (#4094), so a Category-only match still finds nothing — stated in the docs
+  // rather than silently approximated.
+  return Rule.material(stringOp, literalOf(value));
+}
+
+function adaptClassification(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
+  if (value.kind === 'null') {
+    if (op === '=') return Rule.classification('', 'isNotSet', '');
+    if (op === '!=') return Rule.classification('', 'isSet', '');
+    return `${quote(text)}: NULL can only be compared with "=" or "!="`;
+  }
+  const stringOp = stringOpFor(op, value);
+  if (!stringOp) return unsupportedOp(text, op, value);
+  const invalid = regexProblem(value);
+  if (invalid) return `${quote(text)}: ${invalid}`;
+  return Rule.classification('', stringOp, literalOf(value));
+}
+
+function adaptLocation(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
+  if (value.kind !== 'string') {
+    return `${quote(text)}: "location=" takes a plain storey name, not a regular expression or NULL`;
+  }
+  const setOp = setOpFor(op);
+  if (!setOp) return `${quote(text)}: "location=" takes only "=" and "!="`;
+  // Storey NAME only, and only for elements the storey contains directly (or
+  // their aggregated parts) — measured in `filter-evaluate.test.ts`. An element
+  // inside a space on that storey does NOT match, which is where this differs
+  // from IfcOpenShell's "directly or indirectly" (#4094).
+  return Rule.storey([value.text], setOp);
+}
+
+// ── Small shared pieces ──────────────────────────────────────────────────────
+
+function setOpFor(op: SelectorOp): SetOp | undefined {
+  if (op === '=') return 'in';
+  if (op === '!=') return 'notIn';
+  return undefined;
+}
+
+function stringOpFor(op: SelectorOp, value: SelectorValue): SharedStringOp | undefined {
+  return value.kind === 'regex' ? REGEX_OPS[op] : STRING_OPS[op];
+}
+
+/**
+ * A comparison OPERAND. A regex travels as its bare source, because the rule's
+ * `matches` / `notMatches` op is already what says "this is a pattern".
+ */
+function literalOf(value: SelectorText): string {
+  return value.kind === 'regex' ? value.source : value.text;
+}
+
+/**
+ * A property-set or property NAME. There is no op beside a name, so the `/…/`
+ * literal is what marks it as a pattern — that is exactly what `nameMatches`
+ * keys on, and what keeps a plain `Pset_WallCommon` an equality rather than a
+ * regex that would also swallow `Pset_WallCommonExtra`.
+ */
+function nameLiteral(name: SelectorText): string {
+  return name.kind === 'regex' ? `/${name.source}/` : name.text;
+}
+
+/**
+ * A `/…/` that JavaScript cannot compile, reported here rather than at match
+ * time. `stringOpMatches` treats an uncompilable pattern as "matches nothing",
+ * which is indistinguishable from a correct pattern with no hits — the shape
+ * this whole change exists to remove.
+ */
+function regexProblem(value: SelectorText | SelectorValue): string | undefined {
+  if (value.kind !== 'regex') return undefined;
+  try {
+    new RegExp(value.source);
+    return undefined;
+  } catch (err) {
+    return `/${value.source}/ is not a valid regular expression: ${(err as Error).message}`;
+  }
+}
+
+/** A set the quantity rule owns: `Qto_WallBaseQuantities`, or a regex over it. */
+function looksLikeQuantitySet(pset: SelectorText): boolean {
+  const text = pset.kind === 'regex' ? pset.source.replace(/^\^/, '') : pset.text;
+  return text.toLowerCase().startsWith('qto_');
+}
+
+function unsupportedOp(text: string, op: SelectorOp, value: SelectorValue): string {
+  const shape = value.kind === 'regex' ? 'a regular expression' : 'this value';
+  return `${quote(text)}: "${op}" is not supported against ${shape} here`;
+}
+
+function quote(text: string): string {
+  return JSON.stringify(text);
+}

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -104,6 +104,13 @@ export function readSelector(text: string, options: SelectorAdaptOptions = {}): 
   return { ok: true, ...selectorToFilterRules(parsed.query, options) };
 }
 
+/** Text reading as a selector the Filter tab can RUN. An unknown class or a bare
+ *  GlobalId parses but yields no rule, so parsing alone is the wrong hint (#4091). */
+export function selectorYieldsRules(text: string): boolean {
+  const reading = readSelector(text);
+  return reading.ok && reading.rules.length > 0;
+}
+
 export function selectorToFilterRules(
   query: SelectorQuery,
   options: SelectorAdaptOptions = {},
@@ -144,11 +151,9 @@ export function selectorToFilterRules(
   return { combinator: 'AND', rules: all, unsupported, readsAsPlainText };
 }
 
-/**
- * A term carrying nothing selector-specific: a class name no schema knows
- * (`IFC-Export`), or an attribute with no rule behind it (`Level=1`). Text made
- * only of these is a search term that happens to parse.
- */
+/** A term carrying nothing selector-specific: a class name no schema knows
+ *  (`IFC-Export`), or an attribute with no rule behind it (`Level=1`). Text
+ *  made only of these is a search term that happens to parse. */
 function isPlainTextTerm(filter: SelectorFilter): boolean {
   if (filter.kind === 'class') return !isKnownType(filter.name);
   return filter.kind === 'attribute' && !FILTERABLE_ATTRIBUTES.has(filter.name.toLowerCase());
@@ -236,9 +241,8 @@ function adaptProperty(
 
   // A `Qto_` set names the QUANTITY table, which a property rule does not read,
   // so a term the quantity rule cannot carry is reported rather than aimed at
-  // rows it can never find: `Qto_….NetVolume=NULL` did not merely miss, its
-  // `isNotSet` matched every element (#4091). Property rules reading quantity
-  // rows is #4094.
+  // rows it can never find — `Qto_….NetVolume=NULL` matched EVERY element
+  // (#4091). Property rules reading quantity rows is #4094.
   const quantitySet = looksLikeQuantitySet(pset);
 
   if (value.kind === 'null') {
@@ -370,18 +374,15 @@ function regexProblem(value: SelectorText | SelectorValue): string | undefined {
 /**
  * A set the quantity rule owns: `Qto_WallBaseQuantities`, or a regex over it.
  * Case-SENSITIVE, like the six other `Qto_` prefix tests in this repo (SDK,
- * lists, ids, ifcx): `Qto_` is a buildingSMART prefix with a fixed spelling,
- * and a selector answering differently from the rest of the app for the same
- * set name would be a surface disagreeing with itself. Quantities written
- * under a set with no such prefix (Revit's `BaseQuantities`, ArchiCAD's
- * `ArchiCADQuantities`) are out of reach; `docs/guide/selector-syntax.md`
- * says so rather than guessing.
+ * lists, ids, ifcx): `Qto_` is a buildingSMART prefix with a fixed spelling, and
+ * a selector answering differently for the same set name would be a surface
+ * disagreeing with itself. Sets carrying quantities under another name are out
+ * of reach; see the guide.
  */
 function looksLikeQuantitySet(pset: SelectorText): boolean {
   if (pset.kind !== 'regex') return pset.text.startsWith('Qto_');
-  // A PATTERN names quantity sets when `Qto_` opens it or opens one of its
-  // alternatives: `/^Qto_.*/`, `/(Qto_Wall|Qto_Slab)BaseQuantities/`. One that
-  // continues a longer word (`/Pset_Qto.*/`) is naming something else.
+  // A PATTERN names them when `Qto_` opens it or opens one of its alternatives
+  // (`/(Qto_Wall|Qto_Slab)…/`); one continuing a word (`/Pset_Qto.*/`) does not.
   return /(?:^|[^A-Za-z0-9_])Qto_/.test(pset.source);
 }
 

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -18,9 +18,11 @@
  */
 
 import { expandTypes, isKnownType, normalizeIfcTypeName } from '@ifc-lite/parser';
+import { parseSelector } from '@ifc-lite/query';
 import type {
   SelectorFilter,
   SelectorOp,
+  SelectorParseError,
   SelectorQuery,
   SelectorText,
   SelectorValue,
@@ -74,6 +76,26 @@ const NUMERIC_OPS: Partial<Record<SelectorOp, NumericOp>> = {
 const REGEX_OPS: Partial<Record<SelectorOp, 'matches' | 'notMatches'>> = {
   '=': 'matches', '!=': 'notMatches',
 };
+
+/** A parse that failed, or a parse that was adapted. */
+export type SelectorReading =
+  | { ok: false; error: SelectorParseError }
+  | ({ ok: true } & SelectorAdaptResult);
+
+/**
+ * Selector text as filter rules: parse, then adapt, in one call.
+ *
+ * Both surfaces that accept selector text — the Filter tab's Selector field
+ * and its "add the search query as a rule" button — go through here, so the
+ * two cannot read the same string differently. What each does with the answer
+ * is deliberately NOT shared: one replaces the rule list and one appends to
+ * it, and only the caller knows which.
+ */
+export function readSelector(text: string, options: SelectorAdaptOptions = {}): SelectorReading {
+  const parsed = parseSelector(text);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+  return { ok: true, ...selectorToFilterRules(parsed.query, options) };
+}
 
 export function selectorToFilterRules(
   query: SelectorQuery,

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -215,13 +215,22 @@ function adaptProperty(
   const propName = literalOf(prop);
   const names = { setNameKind: nameKind(pset), propertyNameKind: nameKind(prop) };
 
+  // A `Qto_` set names the QUANTITY table, which a property rule does not read.
+  // So a term the quantity rule cannot carry is reported rather than emitted as
+  // a property rule against rows it can never find: `Qto_….NetVolume=NULL` did
+  // not merely miss, its `isNotSet` matched every element (#4091). Teaching
+  // property rules to read quantity rows is #4094.
+  const quantitySet = looksLikeQuantitySet(pset);
+
   if (value.kind === 'null') {
+    if (quantitySet) return quantityNeedsNumber(text);
     if (op === '=') return Rule.property(setName, propName, 'isNotSet', '', names);
     if (op === '!=') return Rule.property(setName, propName, 'isSet', '', names);
     return `${quote(text)}: NULL can only be compared with "=" or "!="`;
   }
 
   if (value.kind === 'regex') {
+    if (quantitySet) return quantityNeedsNumber(text);
     const regexOp = REGEX_OPS[op];
     if (!regexOp) return unsupportedOp(text, op, value);
     const invalid = regexProblem(value);
@@ -229,9 +238,10 @@ function adaptProperty(
     return Rule.property(setName, propName, regexOp, value.source, { ...names, valueKind: 'regex' });
   }
 
-  const numeric = Number.parseFloat(value.text);
-  const numericOp = NUMERIC_OPS[op];
-  if (looksLikeQuantitySet(pset) && numericOp && Number.isFinite(numeric) && value.text.trim() !== '') {
+  if (quantitySet) {
+    const numeric = Number.parseFloat(value.text);
+    const numericOp = NUMERIC_OPS[op];
+    if (!numericOp || !Number.isFinite(numeric)) return quantityNeedsNumber(text);
     return Rule.quantity(setName, propName, numericOp, numeric, {
       setNameKind: names.setNameKind,
       quantityNameKind: names.propertyNameKind,
@@ -346,10 +356,22 @@ function regexProblem(value: SelectorText | SelectorValue): string | undefined {
  * lists, ids, ifcx): `Qto_` is a buildingSMART prefix with a fixed spelling,
  * and a selector answering differently from the rest of the app for the same
  * set name would be a surface disagreeing with itself.
+ *
+ * Sets carrying quantities under another name — Revit IFC2x3's
+ * `BaseQuantities`, ArchiCAD's `ArchiCADQuantities` — are out of reach from a
+ * selector, which `docs/guide/selector-syntax.md` says rather than guessing.
  */
 function looksLikeQuantitySet(pset: SelectorText): boolean {
-  const text = pset.kind === 'regex' ? pset.source.replace(/^\^/, '') : pset.text;
-  return text.startsWith('Qto_');
+  if (pset.kind !== 'regex') return pset.text.startsWith('Qto_');
+  // A PATTERN names quantity sets when `Qto_` opens it or opens one of its
+  // alternatives: `/^Qto_.*/`, `/(Qto_Wall|Qto_Slab)BaseQuantities/`. One that
+  // continues a longer word (`/Pset_Qto.*/`) is naming something else.
+  return /(?:^|[^A-Za-z0-9_])Qto_/.test(pset.source);
+}
+
+/** The sentence a `Qto_` term gets when it cannot become a quantity rule. */
+function quantityNeedsNumber(text: string): string {
+  return `${quote(text)}: a Qto_ set is read from the quantity table, so it takes a numeric comparison against a number — not NULL, not "*=", not text`;
 }
 
 function unsupportedOp(text: string, op: SelectorOp, value: SelectorValue): string {

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -55,6 +55,10 @@ export interface SelectorAdaptResult {
   rules: FilterRule[];
   /** One entry per construct that produced no rule, quoting what was typed. */
   unsupported: string[];
+  /** No rule came out and every term is an unknown class or a non-filterable
+   *  attribute — what a plain search term (`IFC-Export`, `Level=1`) parses
+   *  into. A caller holding a free-text fallback keeps it here. */
+  readsAsPlainText: boolean;
 }
 
 /** `= != > >= < <= *= !*=` onto the property `ValueOp` set. */
@@ -71,6 +75,9 @@ const STRING_OPS: Partial<Record<SelectorOp, SharedStringOp>> = {
 const NUMERIC_OPS: Partial<Record<SelectorOp, NumericOp>> = {
   '=': 'eq', '!=': 'ne', '>': 'gt', '>=': 'gte', '<': 'lt', '<=': 'lte',
 };
+
+/** The two attributes with a rule behind them; `isPlainTextTerm` reads it too. */
+const FILTERABLE_ATTRIBUTES = new Set(['name', 'predefinedtype']);
 
 /** A regex value only has a meaning for equality and its negation. */
 const REGEX_OPS: Partial<Record<SelectorOp, 'matches' | 'notMatches'>> = {
@@ -132,7 +139,19 @@ export function selectorToFilterRules(
   if (classAdds.length > 0) head.push(Rule.ifcType(expandClasses(classAdds, options), 'in'));
   if (classSubtracts.length > 0) head.push(Rule.ifcType(expandClasses(classSubtracts, options), 'notIn'));
 
-  return { combinator: 'AND', rules: [...head, ...rules], unsupported };
+  const all = [...head, ...rules];
+  const readsAsPlainText = all.length === 0 && extraGroups.length === 0 && (group?.filters ?? []).every(isPlainTextTerm);
+  return { combinator: 'AND', rules: all, unsupported, readsAsPlainText };
+}
+
+/**
+ * A term carrying nothing selector-specific: a class name no schema knows
+ * (`IFC-Export`), or an attribute with no rule behind it (`Level=1`). Text made
+ * only of these is a search term that happens to parse.
+ */
+function isPlainTextTerm(filter: SelectorFilter): boolean {
+  if (filter.kind === 'class') return !isKnownType(filter.name);
+  return filter.kind === 'attribute' && !FILTERABLE_ATTRIBUTES.has(filter.name.toLowerCase());
 }
 
 /**
@@ -181,7 +200,7 @@ function adaptAttribute(
   text: string,
 ): FilterRule | string {
   const attribute = name.toLowerCase();
-  if (attribute !== 'name' && attribute !== 'predefinedtype') {
+  if (!FILTERABLE_ATTRIBUTES.has(attribute)) {
     return `${quote(text)}: only the Name and PredefinedType attributes are filterable (#4094)`;
   }
   if (value.kind === 'null') return `${quote(text)}: an attribute cannot be compared to NULL`;
@@ -215,11 +234,11 @@ function adaptProperty(
   const propName = literalOf(prop);
   const names = { setNameKind: nameKind(pset), propertyNameKind: nameKind(prop) };
 
-  // A `Qto_` set names the QUANTITY table, which a property rule does not read.
-  // So a term the quantity rule cannot carry is reported rather than emitted as
-  // a property rule against rows it can never find: `Qto_….NetVolume=NULL` did
-  // not merely miss, its `isNotSet` matched every element (#4091). Teaching
-  // property rules to read quantity rows is #4094.
+  // A `Qto_` set names the QUANTITY table, which a property rule does not read,
+  // so a term the quantity rule cannot carry is reported rather than aimed at
+  // rows it can never find: `Qto_….NetVolume=NULL` did not merely miss, its
+  // `isNotSet` matched every element (#4091). Property rules reading quantity
+  // rows is #4094.
   const quantitySet = looksLikeQuantitySet(pset);
 
   if (value.kind === 'null') {
@@ -242,10 +261,8 @@ function adaptProperty(
     const numeric = Number.parseFloat(value.text);
     const numericOp = NUMERIC_OPS[op];
     if (!numericOp || !Number.isFinite(numeric)) return quantityNeedsNumber(text);
-    return Rule.quantity(setName, propName, numericOp, numeric, {
-      setNameKind: names.setNameKind,
-      quantityNameKind: names.propertyNameKind,
-    });
+    const kinds = { setNameKind: names.setNameKind, quantityNameKind: names.propertyNameKind };
+    return Rule.quantity(setName, propName, numericOp, numeric, kinds);
   }
 
   const valueOp = VALUE_OPS[op];
@@ -355,11 +372,10 @@ function regexProblem(value: SelectorText | SelectorValue): string | undefined {
  * Case-SENSITIVE, like the six other `Qto_` prefix tests in this repo (SDK,
  * lists, ids, ifcx): `Qto_` is a buildingSMART prefix with a fixed spelling,
  * and a selector answering differently from the rest of the app for the same
- * set name would be a surface disagreeing with itself.
- *
- * Sets carrying quantities under another name — Revit IFC2x3's
- * `BaseQuantities`, ArchiCAD's `ArchiCADQuantities` — are out of reach from a
- * selector, which `docs/guide/selector-syntax.md` says rather than guessing.
+ * set name would be a surface disagreeing with itself. Quantities written
+ * under a set with no such prefix (Revit's `BaseQuantities`, ArchiCAD's
+ * `ArchiCADQuantities`) are out of reach; `docs/guide/selector-syntax.md`
+ * says so rather than guessing.
  */
 function looksLikeQuantitySet(pset: SelectorText): boolean {
   if (pset.kind !== 'regex') return pset.text.startsWith('Qto_');
@@ -369,7 +385,6 @@ function looksLikeQuantitySet(pset: SelectorText): boolean {
   return /(?:^|[^A-Za-z0-9_])Qto_/.test(pset.source);
 }
 
-/** The sentence a `Qto_` term gets when it cannot become a quantity rule. */
 function quantityNeedsNumber(text: string): string {
   return `${quote(text)}: a Qto_ set is read from the quantity table, so it takes a numeric comparison against a number — not NULL, not "*=", not text`;
 }

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -30,6 +30,7 @@ import {
   type FilterRule,
   type NumericOp,
   type SetOp,
+  type TextKind,
   type ValueOp,
 } from './filter-rules.js';
 
@@ -174,7 +175,7 @@ function adaptAttribute(
   if (!stringOp) return unsupportedOp(text, op, value);
   const invalid = regexProblem(value);
   if (invalid) return `${quote(text)}: ${invalid}`;
-  return Rule.name(stringOp, literalOf(value));
+  return Rule.name(stringOp, literalOf(value), regexValueKind(value));
 }
 
 function adaptProperty(
@@ -188,12 +189,13 @@ function adaptProperty(
     const invalid = regexProblem(part);
     if (invalid) return `${quote(text)}: ${invalid}`;
   }
-  const setName = nameLiteral(pset);
-  const propName = nameLiteral(prop);
+  const setName = literalOf(pset);
+  const propName = literalOf(prop);
+  const names = { setNameKind: nameKind(pset), propertyNameKind: nameKind(prop) };
 
   if (value.kind === 'null') {
-    if (op === '=') return Rule.property(setName, propName, 'isNotSet', '');
-    if (op === '!=') return Rule.property(setName, propName, 'isSet', '');
+    if (op === '=') return Rule.property(setName, propName, 'isNotSet', '', names);
+    if (op === '!=') return Rule.property(setName, propName, 'isSet', '', names);
     return `${quote(text)}: NULL can only be compared with "=" or "!="`;
   }
 
@@ -202,18 +204,21 @@ function adaptProperty(
     if (!regexOp) return unsupportedOp(text, op, value);
     const invalid = regexProblem(value);
     if (invalid) return `${quote(text)}: ${invalid}`;
-    return Rule.property(setName, propName, regexOp, value.source);
+    return Rule.property(setName, propName, regexOp, value.source, { ...names, valueKind: 'regex' });
   }
 
   const numeric = Number.parseFloat(value.text);
   const numericOp = NUMERIC_OPS[op];
   if (looksLikeQuantitySet(pset) && numericOp && Number.isFinite(numeric) && value.text.trim() !== '') {
-    return Rule.quantity(setName, propName, numericOp, numeric);
+    return Rule.quantity(setName, propName, numericOp, numeric, {
+      setNameKind: names.setNameKind,
+      quantityNameKind: names.propertyNameKind,
+    });
   }
 
   const valueOp = VALUE_OPS[op];
   if (!valueOp) return unsupportedOp(text, op, value);
-  return Rule.property(setName, propName, valueOp, value.text);
+  return Rule.property(setName, propName, valueOp, value.text, names);
 }
 
 function adaptMaterial(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
@@ -226,7 +231,7 @@ function adaptMaterial(op: SelectorOp, value: SelectorValue, text: string): Filt
   // accepts a material Category here; ifc-lite does not read Category yet
   // (#4094), so a Category-only match still finds nothing — stated in the docs
   // rather than silently approximated.
-  return Rule.material(stringOp, literalOf(value));
+  return Rule.material(stringOp, literalOf(value), regexValueKind(value));
 }
 
 function adaptClassification(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
@@ -239,7 +244,7 @@ function adaptClassification(op: SelectorOp, value: SelectorValue, text: string)
   if (!stringOp) return unsupportedOp(text, op, value);
   const invalid = regexProblem(value);
   if (invalid) return `${quote(text)}: ${invalid}`;
-  return Rule.classification('', stringOp, literalOf(value));
+  return Rule.classification('', stringOp, literalOf(value), regexValueKind(value));
 }
 
 function adaptLocation(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
@@ -267,22 +272,34 @@ function stringOpFor(op: SelectorOp, value: SelectorValue): SharedStringOp | und
   return value.kind === 'regex' ? REGEX_OPS[op] : STRING_OPS[op];
 }
 
-/**
- * A comparison OPERAND. A regex travels as its bare source, because the rule's
- * `matches` / `notMatches` op is already what says "this is a pattern".
- */
+/** The bare text of a name or operand: a regex travels as its own source. */
 function literalOf(value: SelectorText): string {
   return value.kind === 'regex' ? value.source : value.text;
 }
 
 /**
- * A property-set or property NAME. There is no op beside a name, so the `/…/`
- * literal is what marks it as a pattern — that is exactly what `nameMatches`
- * keys on, and what keeps a plain `Pset_WallCommon` an equality rather than a
- * regex that would also swallow `Pset_WallCommonExtra`.
+ * A property-set or property NAME's kind, handed to the rule instead of being
+ * re-encoded into a spelling the matcher has to guess back out. A name has no
+ * operator beside it, so BOTH kinds have to be stated.
+ *
+ * Re-encoding was the #4091 defect class at this seam. A quoted name is the
+ * grammar's only way to ask for a LITERAL, so `"/Wall/".FireRating` written
+ * back as `/Wall/` became a pattern matching `Pset_WallCommon`; and a regex
+ * source can itself start and end with a slash, so `Name=/\/tmp\//` written
+ * back bare became the pattern `tmp`. Both matched the wrong elements and
+ * said nothing.
  */
-function nameLiteral(name: SelectorText): string {
-  return name.kind === 'regex' ? `/${name.source}/` : name.text;
+function nameKind(name: SelectorText): TextKind {
+  return name.kind === 'regex' ? 'regex' : 'literal';
+}
+
+/**
+ * The same discriminator for a comparison OPERAND, where only one half needs
+ * saying: a value reaches a regex op only by having been written as `/…/`, so
+ * a rule with no `valueKind` is one whose op already rules a pattern out.
+ */
+function regexValueKind(value: SelectorText): TextKind | undefined {
+  return value.kind === 'regex' ? 'regex' : undefined;
 }
 
 /**

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -95,7 +95,7 @@ export function selectorToFilterRules(
   for (const filter of group?.filters ?? []) {
     if (filter.kind === 'class') {
       if (!isKnownType(filter.name)) {
-        unsupported.push(`${quote(filter.name)}: not an entity name in IFC2X3, IFC4 or IFC4X3`);
+        unsupported.push(`${quote(filter.text)}: not an entity name in IFC2X3, IFC4 or IFC4X3`);
         continue;
       }
       (filter.negate ? classSubtracts : classAdds).push(filter.name);

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -285,6 +285,10 @@ ifc-lite query model.ifc --type IfcWall --limit 10 --offset 20
 | `--offset <N>` | Skip first N results |
 | `--json` | JSON output |
 
+`--type` and `--where` are the CLI's own filter surface, not the IfcOpenShell
+selector syntax. See [Selector Syntax](selector-syntax.md) for how each selector
+construct is spelled here, and for what accepting selector text on the CLI would take.
+
 ---
 
 ### `props` — Entity Properties

--- a/docs/guide/querying.md
+++ b/docs/guide/querying.md
@@ -441,5 +441,6 @@ const alsoExternalWalls = query
 
 ## Next Steps
 
+- [Selector Syntax](selector-syntax.md) - the IfcOpenShell one-line filter syntax, and what each construct maps to here
 - [Export Guide](exporting.md) - Export query results
 - [API Reference](../api/typescript.md) - Complete API docs

--- a/docs/guide/selector-syntax.md
+++ b/docs/guide/selector-syntax.md
@@ -42,6 +42,10 @@ Values, and property-set and property names, come in three spellings:
 | quoted | `"Level 3"` | `\"` and `\\` escape inside |
 | regular expression | `/D[0-9]{2}/` | unanchored, **case-sensitive** |
 
+Quoting is what forces a **literal**: `"/Wall/".FireRating` looks for a property
+set actually named `/Wall/`, not a pattern. It works in either position, so
+`Pset_BeamCommon."IsExternal"` and `/Pset_.*Common/."IsExternal"` are both valid.
+
 `NULL` (any case, unquoted) is the null literal, so `FireRating != NULL` means "has a
 FireRating". `TRUE` and `FALSE` are compared as the strings IFC property sets render
 them (`True` / `False`), case-insensitively.
@@ -60,7 +64,7 @@ exists only as part of `*=`. Use a regular expression for wildcards.
 | `Pset.Prop` with all eight operators | ✅ | |
 | `Pset.Prop = NULL` / `!= NULL` | ✅ | becomes "is not set" / "is set" |
 | `/Pset_.*Common/.Prop` regex set or property name | ✅ | one rule reaches several sets |
-| `Qto_….Quantity > 10` | ✅ | a `Qto_` set with a numeric value becomes a quantity rule |
+| `Qto_….Quantity > 10` | ✅ | a `Qto_` set with a numeric value becomes a quantity rule; the prefix is case-sensitive, as everywhere else in ifc-lite |
 | `material=` | ⚠️ | matches material **names**; Category is not read yet |
 | `classification=`, `= NULL`, `!= NULL` | ✅ | matches the code or the name |
 | `location="Level 3"` | ⚠️ | see below |

--- a/docs/guide/selector-syntax.md
+++ b/docs/guide/selector-syntax.md
@@ -1,0 +1,131 @@
+# Selector Syntax
+
+IFClite reads the [IfcOpenShell selector (filter) syntax](https://docs.ifcopenshell.org/ifcopenshell-python/selector_syntax.html)
+— the one-line form used by Bonsai and by `ifcopenshell.util.selector` — and turns it
+into filter rules.
+
+Type it into the **Selector** field at the top of the viewer's Filter tab, or parse it
+yourself with `parseSelector` from `@ifc-lite/query`.
+
+Not every construct has a rule behind it yet. The ones that do not are listed back to you
+by name; nothing is dropped in silence. What is missing is tracked in
+[issue #4094](https://github.com/LTplus-AG/ifc-lite/issues/4094).
+
+## The grammar
+
+```text
+selector := group ("+" group)*        groups are unioned
+group    := filter ("," filter)*      filters narrow left to right
+```
+
+| Filter | Example | Means |
+|---|---|---|
+| Class | `IfcWall` | the class **and all its subclasses** |
+| Class, subtracted | `! IfcWall` | remove that class and its subclasses |
+| GlobalId | `325Q7Fhnf67OZC$$r43uzK` | one element, by GlobalId |
+| Attribute | `Name=D01` | an IFC attribute of the element |
+| Property | `Pset_WallCommon.FireRating=2HR` | a property in a property set |
+| Type | `type=WT01` | the relating type's Name |
+| Material | `material=concrete` | a material Name or Category |
+| Classification | `classification=Pr_25` | a classification reference |
+| Location | `location="Level 3"` | the spatial element containing it |
+| Parent | `parent=Foo` | a descendant of the element named Foo |
+| Value query | `query:types.count=0` | a value-query key path |
+
+Operators: `=`, `!=`, `>`, `>=`, `<`, `<=`, `*=` (contains), `!*=` (does not contain).
+
+Values, and property-set and property names, come in three spellings:
+
+| Spelling | Example | Notes |
+|---|---|---|
+| bare | `concrete` | no spaces, no `,` `+` `=` `!` `<` `>` `*` `"` `/` |
+| quoted | `"Level 3"` | `\"` and `\\` escape inside |
+| regular expression | `/D[0-9]{2}/` | unanchored, **case-sensitive** |
+
+`NULL` (any case, unquoted) is the null literal, so `FireRating != NULL` means "has a
+FireRating". `TRUE` and `FALSE` are compared as the strings IFC property sets render
+them (`True` / `False`), case-insensitively.
+
+There is **no `*` wildcard**. `IfcWall*` is a syntax error, not a match-nothing: `*`
+exists only as part of `*=`. Use a regular expression for wildcards.
+
+## What works in the viewer today
+
+| Construct | Viewer Filter tab | Notes |
+|---|---|---|
+| `IfcWall`, several classes, `!` subtraction | ✅ | subclasses included, per the model's schema |
+| `Name=`, `!=`, `*=`, `!*=` | ✅ | case-insensitive |
+| `Name=/regex/` | ✅ | case-sensitive |
+| `PredefinedType=`, `!=` | ✅ | no regex |
+| `Pset.Prop` with all eight operators | ✅ | |
+| `Pset.Prop = NULL` / `!= NULL` | ✅ | becomes "is not set" / "is set" |
+| `/Pset_.*Common/.Prop` regex set or property name | ✅ | one rule reaches several sets |
+| `Qto_….Quantity > 10` | ✅ | a `Qto_` set with a numeric value becomes a quantity rule |
+| `material=` | ⚠️ | matches material **names**; Category is not read yet |
+| `classification=`, `= NULL`, `!= NULL` | ✅ | matches the code or the name |
+| `location="Level 3"` | ⚠️ | see below |
+| GlobalId terms, `! <GlobalId>` | ❌ | reported, not applied |
+| `type=WT01` | ❌ | reported, not applied |
+| attributes other than `Name` and `PredefinedType` | ❌ | reported, not applied |
+| `parent=`, `query:` | ❌ | reported, not applied |
+| `+` unions of groups | ❌ | the first group is applied, the rest reported |
+
+### How far `location=` reaches
+
+`location="Level 3"` becomes a storey-name rule, and that rule matches an element the
+storey **contains directly**, plus the parts aggregated under such an element.
+
+It does **not** reach an element one level further down, inside an `IfcSpace` on that
+storey. So IfcOpenShell's example `IfcPump, location="Level 3"` — a pump in a room on
+Level 3 — finds the pump in IfcOpenShell and not in IFClite. This is measured, not
+assumed: see `storey rule reach` in `apps/viewer/src/lib/search/filter-evaluate.test.ts`.
+A spatial-ancestor rule is part of #4094.
+
+## Where else can I filter?
+
+Only the viewer's Filter tab accepts selector text today. The other surfaces have their
+own structured filters, and this is how the same intent is spelled in each:
+
+| Selector | CLI | MCP `query_entities` | SDK / sandbox |
+|---|---|---|---|
+| `IfcWall, IfcSlab` | `--type IfcWall,IfcSlab` | `types: ['IfcWall','IfcSlab']` | `bim.query().byType('IfcWall')` |
+| `Pset_WallCommon.FireRating=2HR` | `--where "Pset_WallCommon.FireRating=2HR"` | `property: { pset, name, op: '=', value }` | `.where('Pset_WallCommon','FireRating','=','2HR')` |
+| `…FireRating*=REI` | `--where "Pset_WallCommon.FireRating~REI"` | `op: 'contains'` | `.where(…, 'contains', 'REI')` |
+| `…FireRating != NULL` | `--where "Pset_WallCommon.FireRating"` | `op: 'exists'` | — |
+| `/Pset_.*Common/.FireRating` | — | — | `bim.query.property(entity, '/Pset_.*Common/', 'FireRating')` |
+| `IfcWall*` (a wildcard) | `--a "IfcWall*"` (clash selectors only) | — | — |
+
+Note the last row: the clash rule selectors (`ifc-lite clash --a "IfcDuct*|IfcPipe*"`) are
+a **different, older mini-language** with a suffix `*` glob. That grammar is unchanged and
+is not the one on this page.
+
+Accepting selector text in the CLI, MCP and the scripting API is tracked in #4094; the
+parser already lives in `@ifc-lite/query`, so those surfaces adapt the same AST rather
+than growing a second grammar.
+
+## Parsing it yourself
+
+```typescript
+import { parseSelector } from '@ifc-lite/query';
+
+const result = parseSelector('IfcWall, Pset_WallCommon.FireRating=/REI.*/');
+if (result.ok === false) {
+  console.error(`${result.error.message} at character ${result.error.offset + 1}`);
+} else {
+  for (const group of result.query.groups) {
+    for (const filter of group.filters) {
+      console.log(filter.kind, filter.text);
+    }
+  }
+}
+```
+
+`parseSelector` reads the **whole** grammar, including the constructs no surface can
+evaluate yet. That is deliberate: a caller adapts the AST onto its own filter model and
+reports what it could not carry, instead of matching nothing and saying nothing.
+
+## See also
+
+- [Querying Data](querying.md) — the fluent API, SQL, and the property lookups behind these rules
+- [CLI Toolkit](cli.md) — `--type` and `--where`
+- [Clash Detection](clash-detection.md) — the separate `IfcDuct*|IfcPipe*` selector language

--- a/docs/guide/selector-syntax.md
+++ b/docs/guide/selector-syntax.md
@@ -64,7 +64,7 @@ exists only as part of `*=`. Use a regular expression for wildcards.
 | `Pset.Prop` with all eight operators | ✅ | |
 | `Pset.Prop = NULL` / `!= NULL` | ✅ | becomes "is not set" / "is set" |
 | `/Pset_.*Common/.Prop` regex set or property name | ✅ | one rule reaches several sets |
-| `Qto_….Quantity > 10` | ✅ | a `Qto_` set with a numeric value becomes a quantity rule; the prefix is case-sensitive, as everywhere else in ifc-lite |
+| `Qto_….Quantity > 10` | ⚠️ | only a `Qto_` set, and only a numeric comparison — see below |
 | `material=` | ⚠️ | matches material **names**; Category is not read yet |
 | `classification=`, `= NULL`, `!= NULL` | ✅ | matches the code or the name |
 | `location="Level 3"` | ⚠️ | see below |
@@ -73,6 +73,27 @@ exists only as part of `*=`. Use a regular expression for wildcards.
 | attributes other than `Name` and `PredefinedType` | ❌ | reported, not applied |
 | `parent=`, `query:` | ❌ | reported, not applied |
 | `+` unions of groups | ❌ | the first group is applied, the rest reported |
+
+### Which quantities a selector can reach
+
+Quantities are a separate table from property sets, and the two rules do not read
+each other's rows. A term reaches the quantity table only when **both** halves hold:
+
+- the set name starts with `Qto_` (case-sensitive), or is a pattern whose `Qto_`
+  opens it or opens one of its alternatives — `/^Qto_.*/`,
+  `/(Qto_Wall|Qto_Slab)BaseQuantities/`;
+- the comparison is `=`, `!=`, `>`, `>=`, `<` or `<=` against a number.
+
+A `Qto_` term failing the second half is **reported, not applied**:
+`Qto_WallBaseQuantities.NetVolume = NULL`, `…NetVolume *= 1` and
+`…Note = draft` all come back named rather than silently run against property
+sets, where they would find nothing (`= NULL` was worse still — "is not set"
+against a set no property row carries matched every element).
+
+Quantities written under a set with no `Qto_` prefix are **not reachable** from a
+selector today: Revit's IFC2x3 export writes `BaseQuantities` and ArchiCAD writes
+`ArchiCADQuantities`, so `BaseQuantities.NetVolume > 1` becomes a property rule and
+finds nothing. Reading quantity rows from a property term is part of #4094.
 
 ### How far `location=` reaches
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
     - Geometry Processing: guide/geometry.md
     - Rendering: guide/rendering.md
     - Querying Data: guide/querying.md
+    - Selector Syntax: guide/selector-syntax.md
     - Exporting Data: guide/exporting.md
     - Multi-Model Federation: guide/federation.md
     - BCF Collaboration: guide/bcf.md

--- a/packages/lens/src/types.ts
+++ b/packages/lens/src/types.ts
@@ -156,7 +156,7 @@ export interface ClassificationInfo {
  * `operator` exactly as they did before.
  *
  * Comparison semantics mirror the viewer's search rule model
- * (`apps/viewer/src/lib/search/filter-rules.ts`, `valueOpMatches`): `gt` / `gte`
+ * (`apps/viewer/src/lib/search/filter-ops.ts`, `valueOpMatches`): `gt` / `gte`
  * / `lt` / `lte` parse both sides with `Number.parseFloat` and match only when
  * both parse finite; `ne` is a case-insensitive string comparison, not a
  * numeric one (unlike `equals`, which stays case-sensitive except for the

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -16,3 +16,21 @@ export { QueryResultEntity } from './query-result-entity.js';
 export { DuckDBIntegration, type SQLResult } from './duckdb-integration.js';
 export { findPropertyInSets, findQuantityInSets, findAllPropertiesInSets, findAllQuantitiesInSets } from './pset-lookup.js';
 export { normalizeBooleanValue, compareFilterValue, type FilterComparisonOp } from './filter-predicate.js';
+export { parseSelector } from './selector/parse.js';
+export type {
+  SelectorOp,
+  SelectorText,
+  SelectorValue,
+  SelectorKeywordKind,
+  SelectorClassFilter,
+  SelectorGlobalIdFilter,
+  SelectorAttributeFilter,
+  SelectorPropertyFilter,
+  SelectorKeywordFilter,
+  SelectorQueryFilter,
+  SelectorFilter,
+  SelectorGroup,
+  SelectorQuery,
+  SelectorParseError,
+  SelectorParseResult,
+} from './selector/ast.js';

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -25,7 +25,6 @@ export type {
   SelectorText,
   SelectorValue,
   SelectorFilter,
-  SelectorGroup,
   SelectorQuery,
   SelectorParseError,
   SelectorParseResult,

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -17,17 +17,13 @@ export { DuckDBIntegration, type SQLResult } from './duckdb-integration.js';
 export { findPropertyInSets, findQuantityInSets, findAllPropertiesInSets, findAllQuantitiesInSets } from './pset-lookup.js';
 export { normalizeBooleanValue, compareFilterValue, type FilterComparisonOp } from './filter-predicate.js';
 export { parseSelector } from './selector/parse.js';
+// The union and the result types only: a caller narrows on `filter.kind`
+// rather than naming each member interface, so those stay module-internal
+// until something actually consumes one.
 export type {
   SelectorOp,
   SelectorText,
   SelectorValue,
-  SelectorKeywordKind,
-  SelectorClassFilter,
-  SelectorGlobalIdFilter,
-  SelectorAttributeFilter,
-  SelectorPropertyFilter,
-  SelectorKeywordFilter,
-  SelectorQueryFilter,
   SelectorFilter,
   SelectorGroup,
   SelectorQuery,

--- a/packages/query/src/selector/ast.ts
+++ b/packages/query/src/selector/ast.ts
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * AST for the IfcOpenShell selector (filter) syntax.
+ *
+ * The AST is the seam: {@link parseSelector} understands the whole grammar,
+ * and each surface (the viewer's rule builder today, the CLI/MCP/SDK query
+ * descriptor next) is an adapter from this tree onto its own representation.
+ * The parser therefore accepts constructs no adapter can evaluate yet — an
+ * adapter reports those back rather than dropping them, which is why every
+ * node carries {@link SelectorFilterBase.text}, the exact source substring the
+ * user typed.
+ */
+
+/** Comparison operators the grammar defines. `*=` is "contains". */
+export type SelectorOp = '=' | '!=' | '>' | '>=' | '<' | '<=' | '*=' | '!*=';
+
+/** A literal name or value: a plain string, or a `/…/` regular expression. */
+export type SelectorText =
+  | { kind: 'string'; text: string }
+  | { kind: 'regex'; source: string };
+
+/** A comparison right-hand side. Bare `NULL` (any case) is the null literal. */
+export type SelectorValue = SelectorText | { kind: 'null' };
+
+/** Keyword filters that compare one derived attribute of an element. */
+export type SelectorKeywordKind =
+  | 'type'
+  | 'material'
+  | 'classification'
+  | 'location'
+  | 'parent';
+
+interface SelectorFilterBase {
+  /** The exact source substring this filter was parsed from. */
+  text: string;
+}
+
+/** `IfcWall` / `! IfcWall` — the class and all its subclasses. */
+export interface SelectorClassFilter extends SelectorFilterBase {
+  kind: 'class';
+  name: string;
+  negate: boolean;
+}
+
+/** `325Q7Fhnf67OZC$$r43uzK` / `! 325Q7Fhnf67OZC$$r43uzK` — one element. */
+export interface SelectorGlobalIdFilter extends SelectorFilterBase {
+  kind: 'globalId';
+  id: string;
+  negate: boolean;
+}
+
+/** `Name=Foo` — an IFC attribute of the element itself. */
+export interface SelectorAttributeFilter extends SelectorFilterBase {
+  kind: 'attribute';
+  name: string;
+  op: SelectorOp;
+  value: SelectorValue;
+}
+
+/** `Pset_WallCommon.FireRating=2HR` — a property in a property set. */
+export interface SelectorPropertyFilter extends SelectorFilterBase {
+  kind: 'property';
+  pset: SelectorText;
+  prop: SelectorText;
+  op: SelectorOp;
+  value: SelectorValue;
+}
+
+/** `type=WT01`, `material=concrete`, `location="Level 3"`, … */
+export interface SelectorKeywordFilter extends SelectorFilterBase {
+  kind: SelectorKeywordKind;
+  op: SelectorOp;
+  value: SelectorValue;
+}
+
+/** `query:types.count=0` — a value-query key path. */
+export interface SelectorQueryFilter extends SelectorFilterBase {
+  kind: 'query';
+  keys: string;
+  op: SelectorOp;
+  value: SelectorValue;
+}
+
+export type SelectorFilter =
+  | SelectorClassFilter
+  | SelectorGlobalIdFilter
+  | SelectorAttributeFilter
+  | SelectorPropertyFilter
+  | SelectorKeywordFilter
+  | SelectorQueryFilter;
+
+/** Filters chained with `,`. They narrow left to right (AND). */
+export interface SelectorGroup {
+  filters: SelectorFilter[];
+}
+
+/** Groups joined with `+`. Their results are unioned. */
+export interface SelectorQuery {
+  groups: SelectorGroup[];
+}
+
+export interface SelectorParseError {
+  message: string;
+  /** 0-based character offset into the input where the problem starts. */
+  offset: number;
+}
+
+export type SelectorParseResult =
+  | { ok: true; query: SelectorQuery }
+  | { ok: false; error: SelectorParseError };

--- a/packages/query/src/selector/ast.ts
+++ b/packages/query/src/selector/ast.ts
@@ -98,7 +98,13 @@ export type SelectorFilter =
   | SelectorKeywordFilter
   | SelectorQueryFilter;
 
-/** Filters chained with `,`. They narrow left to right (AND). */
+/**
+ * Filters chained with `,`. They narrow left to right (AND).
+ *
+ * Not re-exported from the package index: a caller reaches one through
+ * {@link SelectorQuery.groups}, and an export nothing consumes is permanent
+ * semver liability.
+ */
 export interface SelectorGroup {
   filters: SelectorFilter[];
 }

--- a/packages/query/src/selector/ast.ts
+++ b/packages/query/src/selector/ast.ts
@@ -39,21 +39,21 @@ interface SelectorFilterBase {
 }
 
 /** `IfcWall` / `! IfcWall` — the class and all its subclasses. */
-export interface SelectorClassFilter extends SelectorFilterBase {
+interface SelectorClassFilter extends SelectorFilterBase {
   kind: 'class';
   name: string;
   negate: boolean;
 }
 
 /** `325Q7Fhnf67OZC$$r43uzK` / `! 325Q7Fhnf67OZC$$r43uzK` — one element. */
-export interface SelectorGlobalIdFilter extends SelectorFilterBase {
+interface SelectorGlobalIdFilter extends SelectorFilterBase {
   kind: 'globalId';
   id: string;
   negate: boolean;
 }
 
 /** `Name=Foo` — an IFC attribute of the element itself. */
-export interface SelectorAttributeFilter extends SelectorFilterBase {
+interface SelectorAttributeFilter extends SelectorFilterBase {
   kind: 'attribute';
   name: string;
   op: SelectorOp;
@@ -61,7 +61,7 @@ export interface SelectorAttributeFilter extends SelectorFilterBase {
 }
 
 /** `Pset_WallCommon.FireRating=2HR` — a property in a property set. */
-export interface SelectorPropertyFilter extends SelectorFilterBase {
+interface SelectorPropertyFilter extends SelectorFilterBase {
   kind: 'property';
   pset: SelectorText;
   prop: SelectorText;
@@ -70,20 +70,26 @@ export interface SelectorPropertyFilter extends SelectorFilterBase {
 }
 
 /** `type=WT01`, `material=concrete`, `location="Level 3"`, … */
-export interface SelectorKeywordFilter extends SelectorFilterBase {
+interface SelectorKeywordFilter extends SelectorFilterBase {
   kind: SelectorKeywordKind;
   op: SelectorOp;
   value: SelectorValue;
 }
 
 /** `query:types.count=0` — a value-query key path. */
-export interface SelectorQueryFilter extends SelectorFilterBase {
+interface SelectorQueryFilter extends SelectorFilterBase {
   kind: 'query';
   keys: string;
   op: SelectorOp;
   value: SelectorValue;
 }
 
+/**
+ * Every filter the grammar can express. The member interfaces stay
+ * module-internal: a consumer narrows on `filter.kind` off this union rather
+ * than naming one, and an exported type nothing consumes is semver liability
+ * with no reader.
+ */
 export type SelectorFilter =
   | SelectorClassFilter
   | SelectorGlobalIdFilter

--- a/packages/query/src/selector/parse.ts
+++ b/packages/query/src/selector/parse.ts
@@ -1,0 +1,270 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Recursive-descent parser for the IfcOpenShell selector syntax.
+ *
+ *     query  := group ("+" group)*        groups are unioned
+ *     group  := filter ("," filter)*      filters narrow left to right
+ *     filter := "!"? (class | globalId)
+ *             | word ("." name)? op value
+ *             | (string | regex) "." name op value
+ *
+ * The parser is deliberately more capable than any single adapter: it accepts
+ * every construct the page documents, so an adapter can name what it cannot
+ * evaluate instead of silently matching nothing — the defect behind #4091.
+ *
+ * See {@link tokenizeSelector} for the lexical rules and where they are ifc-lite's
+ * reading rather than the page's words.
+ */
+
+import type {
+  SelectorFilter,
+  SelectorGroup,
+  SelectorKeywordKind,
+  SelectorOp,
+  SelectorParseError,
+  SelectorParseResult,
+  SelectorText,
+  SelectorValue,
+} from './ast.js';
+import { tokenizeSelector, type Token } from './tokenize.js';
+
+const KEYWORDS = new Map<string, SelectorKeywordKind>([
+  ['type', 'type'],
+  ['material', 'material'],
+  ['classification', 'classification'],
+  ['location', 'location'],
+  ['parent', 'parent'],
+]);
+
+const QUERY_PREFIX = 'query:';
+const GLOBAL_ID = /^[0-9A-Za-z_$]{22}$/;
+
+class ParseFailure extends Error {
+  constructor(readonly error: SelectorParseError) {
+    super(error.message);
+    this.name = 'ParseFailure';
+  }
+}
+
+export function parseSelector(text: string): SelectorParseResult {
+  const lexed = tokenizeSelector(text);
+  if (!lexed.ok) return { ok: false, error: lexed.error };
+  if (lexed.tokens.length === 0) {
+    return {
+      ok: false,
+      error: { message: 'empty selector: type a class name such as IfcWall', offset: 0 },
+    };
+  }
+  try {
+    return { ok: true, query: { groups: new Parser(text, lexed.tokens).parseQuery() } };
+  } catch (err) {
+    if (err instanceof ParseFailure) return { ok: false, error: err.error };
+    throw err;
+  }
+}
+
+class Parser {
+  private pos = 0;
+
+  constructor(private readonly source: string, private readonly tokens: Token[]) {}
+
+  parseQuery(): SelectorGroup[] {
+    const groups: SelectorGroup[] = [this.parseGroup()];
+    while (this.peek()?.kind === 'plus') {
+      this.advance();
+      groups.push(this.parseGroup());
+    }
+    const trailing = this.peek();
+    if (trailing) this.fail(`unexpected "${trailing.value}"`, trailing.start);
+    return groups;
+  }
+
+  private parseGroup(): SelectorGroup {
+    const filters: SelectorFilter[] = [this.parseFilter()];
+    while (this.peek()?.kind === 'comma') {
+      this.advance();
+      filters.push(this.parseFilter());
+    }
+    return { filters };
+  }
+
+  private parseFilter(): SelectorFilter {
+    const first = this.require('expected a filter');
+    let negate = false;
+    let head = first;
+    if (first.kind === 'bang') {
+      negate = true;
+      this.advance();
+      head = this.require('expected a class name or GlobalId after "!"');
+    }
+
+    if (head.kind !== 'word' && head.kind !== 'string' && head.kind !== 'regex') {
+      this.fail(`unexpected "${head.value}"`, head.start);
+    }
+    this.advance();
+
+    const after = this.peek();
+
+    if (after?.kind === 'dot') {
+      if (negate) this.failNegate(first);
+      this.advance();
+      return this.finishProperty(first, nameOf(head));
+    }
+
+    if (after?.kind === 'op') {
+      if (negate) this.failNegate(first);
+      if (head.kind !== 'word') {
+        this.fail(
+          'a quoted name or regular expression is only valid as a property-set or property name, e.g. /Pset_.*Common/.FireRating=2HR',
+          head.start,
+        );
+      }
+      return this.finishKeyed(first, head);
+    }
+
+    return this.finishBare(first, head, negate);
+  }
+
+  /** `<pset> . <prop> <op> <value>`, the pset already consumed. */
+  private finishProperty(first: Token, pset: SelectorText): SelectorFilter {
+    const propTok = this.require('expected a property name after "."');
+    if (propTok.kind !== 'word' && propTok.kind !== 'string' && propTok.kind !== 'regex') {
+      this.fail(`expected a property name after "." but found "${propTok.value}"`, propTok.start);
+    }
+    this.advance();
+    const op = this.requireOp();
+    const value = this.requireValue(op);
+    return {
+      kind: 'property',
+      pset,
+      prop: nameOf(propTok),
+      op: op.value as SelectorOp,
+      value,
+      text: this.spanFrom(first),
+    };
+  }
+
+  /** `<word> <op> <value>` — property with an inline dot, keyword, query or attribute. */
+  private finishKeyed(first: Token, head: Token): SelectorFilter {
+    const key = head.value;
+    const op = this.requireOp();
+    const value = this.requireValue(op);
+    const text = this.spanFrom(first);
+
+    if (key.toLowerCase().startsWith(QUERY_PREFIX)) {
+      const keys = key.slice(QUERY_PREFIX.length);
+      if (keys.length === 0) this.fail('expected a key path after "query:"', head.start);
+      return { kind: 'query', keys, op: op.value as SelectorOp, value, text };
+    }
+
+    const dot = key.indexOf('.');
+    if (dot >= 0) {
+      const pset = key.slice(0, dot);
+      const prop = key.slice(dot + 1);
+      if (pset.length === 0 || prop.length === 0) {
+        this.fail(`"${key}" is not a property set and property name, e.g. Pset_WallCommon.FireRating`, head.start);
+      }
+      return {
+        kind: 'property',
+        pset: { kind: 'string', text: pset },
+        prop: { kind: 'string', text: prop },
+        op: op.value as SelectorOp,
+        value,
+        text,
+      };
+    }
+
+    const keyword = KEYWORDS.get(key.toLowerCase());
+    if (keyword) return { kind: keyword, op: op.value as SelectorOp, value, text };
+
+    return { kind: 'attribute', name: key, op: op.value as SelectorOp, value, text };
+  }
+
+  /** A filter with no operator: a class name or a GlobalId. */
+  private finishBare(first: Token, head: Token, negate: boolean): SelectorFilter {
+    if (head.kind !== 'word') {
+      this.fail(
+        `"${head.value}" is not a filter: a quoted value or regular expression needs an attribute or property to compare, e.g. Name=${head.kind === 'regex' ? `/${head.value}/` : `"${head.value}"`}`,
+        head.start,
+      );
+    }
+    const text = this.spanFrom(first);
+    if (head.value.includes('.')) {
+      this.fail(
+        `"${head.value}" reads as a property set and property name, so it needs one of the operators = != > >= < <= *= !*= and a value`,
+        head.start,
+      );
+    }
+    if (head.value.toLowerCase().startsWith('ifc')) {
+      return { kind: 'class', name: head.value, negate, text };
+    }
+    if (GLOBAL_ID.test(head.value)) {
+      return { kind: 'globalId', id: head.value, negate, text };
+    }
+    this.fail(
+      `"${head.value}" is not an IFC class name (those start with "Ifc"), a 22-character GlobalId, or a comparison such as Name=${head.value}`,
+      head.start,
+    );
+  }
+
+  // ── Token helpers ───────────────────────────────────────────────────────
+
+  private peek(): Token | undefined {
+    return this.tokens[this.pos];
+  }
+
+  private advance(): void {
+    this.pos += 1;
+  }
+
+  private require(message: string): Token {
+    const tok = this.peek();
+    if (!tok || tok.kind === 'comma' || tok.kind === 'plus') {
+      this.fail(message, tok ? tok.start : this.source.length);
+    }
+    return tok;
+  }
+
+  private requireOp(): Token {
+    const tok = this.peek();
+    if (!tok || tok.kind !== 'op') {
+      this.fail(
+        'expected one of the operators = != > >= < <= *= !*=',
+        tok ? tok.start : this.source.length,
+      );
+    }
+    this.advance();
+    return tok;
+  }
+
+  private requireValue(op: Token): SelectorValue {
+    const tok = this.peek();
+    if (!tok || (tok.kind !== 'word' && tok.kind !== 'string' && tok.kind !== 'regex')) {
+      this.fail(`expected a value after "${op.value}"`, tok ? tok.start : this.source.length);
+    }
+    this.advance();
+    if (tok.kind === 'word' && tok.value.toUpperCase() === 'NULL') return { kind: 'null' };
+    return nameOf(tok);
+  }
+
+  /** The source text from `first` through the token just consumed. */
+  private spanFrom(first: Token): string {
+    const last = this.tokens[this.pos - 1] as Token;
+    return this.source.slice(first.start, last.end);
+  }
+
+  private failNegate(first: Token): never {
+    this.fail('"!" may only negate a class name or a GlobalId', first.start);
+  }
+
+  private fail(message: string, offset: number): never {
+    throw new ParseFailure({ message, offset });
+  }
+}
+
+function nameOf(tok: Token): SelectorText {
+  return tok.kind === 'regex' ? { kind: 'regex', source: tok.value } : { kind: 'string', text: tok.value };
+}

--- a/packages/query/src/selector/parse.ts
+++ b/packages/query/src/selector/parse.ts
@@ -10,6 +10,7 @@
  *     filter := "!"? (class | globalId)
  *             | word ("." name)? op value
  *             | (string | regex) "." name op value
+ *             | word "." (string | regex) op value
  *
  * The parser is deliberately more capable than any single adapter: it accepts
  * every construct the page documents, so an adapter can name what it cannot
@@ -112,6 +113,22 @@ class Parser {
       if (negate) this.failNegate(first);
       this.advance();
       return this.finishProperty(first, nameOf(head));
+    }
+
+    // `Pset_BeamCommon."IsExternal"` — a bare-word property set keeps its '.'
+    // inside the word (that is what keeps a decimal like `1.5` one token), so
+    // the separator never reaches the branch above and the quoted property
+    // name arrives as the NEXT token. Without this, only the regex spelling
+    // `/Pset_.*Common/."IsExternal"` parsed, and the literal one failed with a
+    // message about a missing operator (#4091).
+    if (
+      head.kind === 'word' &&
+      head.value.length > 1 &&
+      head.value.endsWith('.') &&
+      (after?.kind === 'string' || after?.kind === 'regex')
+    ) {
+      if (negate) this.failNegate(first);
+      return this.finishProperty(first, { kind: 'string', text: head.value.slice(0, -1) });
     }
 
     if (after?.kind === 'op') {

--- a/packages/query/src/selector/tokenize.ts
+++ b/packages/query/src/selector/tokenize.ts
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lexer for the IfcOpenShell selector syntax.
+ *
+ * The rules below are ifc-lite's reading of
+ * <https://docs.ifcopenshell.org/ifcopenshell-python/selector_syntax.html>,
+ * stated here because the page describes the language in prose rather than a
+ * grammar:
+ *
+ * - Whitespace is insignificant outside quotes.
+ * - `,` separates filters within a group, `+` separates groups.
+ * - `!` immediately followed by `=` is the `!=` operator, followed by `*=` is
+ *   `!*=`, and otherwise negates the class or GlobalId that follows.
+ * - `*` is only ever part of `*=`. A trailing `*` is NOT a glob in this
+ *   grammar, so `IfcWall*` is a lexical error rather than a silent no-match —
+ *   the exact shape reported in #4091.
+ * - `"…"` quotes a value; `\"` and `\\` escape inside it.
+ * - `/…/` is a regular expression; `\/` escapes a slash inside the body. No
+ *   trailing flags: the grammar has none, so `/foo/i` is a lexical error at
+ *   the `i` rather than a silently different match.
+ * - A bare word runs until whitespace or one of `,+=!<>*"/`, and may not start
+ *   with `.`; a `.` in that leading position is the property-set separator, so
+ *   both `Pset_WallCommon.FireRating` (one word, split by the parser) and
+ *   `/Pset_.*Common/.FireRating` (regex, dot, word) read correctly while a
+ *   decimal value such as `1.5` stays one word.
+ */
+
+import type { SelectorParseError } from './ast.js';
+
+export type TokenKind =
+  | 'word'
+  | 'string'
+  | 'regex'
+  | 'op'
+  | 'comma'
+  | 'plus'
+  | 'bang'
+  | 'dot';
+
+export interface Token {
+  kind: TokenKind;
+  /** Word text, string/regex body, or the operator spelling. */
+  value: string;
+  /** 0-based offset of the token's first character. */
+  start: number;
+  /** 0-based offset one past the token's last character. */
+  end: number;
+}
+
+export type TokenizeResult =
+  | { ok: true; tokens: Token[] }
+  | { ok: false; error: SelectorParseError };
+
+/** Characters that end a bare word. */
+const WORD_BREAK = new Set([',', '+', '=', '!', '<', '>', '*', '"', '/']);
+
+function isSpace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f' || ch === '\v';
+}
+
+function fail(message: string, offset: number): TokenizeResult {
+  return { ok: false, error: { message, offset } };
+}
+
+export function tokenizeSelector(text: string): TokenizeResult {
+  const tokens: Token[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    const ch = text[i] as string;
+
+    if (isSpace(ch)) { i += 1; continue; }
+
+    if (ch === ',') { tokens.push({ kind: 'comma', value: ',', start: i, end: i + 1 }); i += 1; continue; }
+    if (ch === '+') { tokens.push({ kind: 'plus', value: '+', start: i, end: i + 1 }); i += 1; continue; }
+    if (ch === '.') { tokens.push({ kind: 'dot', value: '.', start: i, end: i + 1 }); i += 1; continue; }
+
+    if (ch === '!') {
+      if (text[i + 1] === '=') {
+        tokens.push({ kind: 'op', value: '!=', start: i, end: i + 2 });
+        i += 2;
+      } else if (text[i + 1] === '*' && text[i + 2] === '=') {
+        tokens.push({ kind: 'op', value: '!*=', start: i, end: i + 3 });
+        i += 3;
+      } else {
+        tokens.push({ kind: 'bang', value: '!', start: i, end: i + 1 });
+        i += 1;
+      }
+      continue;
+    }
+
+    if (ch === '*') {
+      if (text[i + 1] !== '=') {
+        return fail(
+          `"*" is only valid as part of the "*=" (contains) operator; this grammar has no "*" wildcard. Use a regular expression such as /Ifc.*Wall/ instead.`,
+          i,
+        );
+      }
+      tokens.push({ kind: 'op', value: '*=', start: i, end: i + 2 });
+      i += 2;
+      continue;
+    }
+
+    if (ch === '=') { tokens.push({ kind: 'op', value: '=', start: i, end: i + 1 }); i += 1; continue; }
+
+    if (ch === '<' || ch === '>') {
+      const two = text[i + 1] === '=';
+      const value = two ? `${ch}=` : ch;
+      tokens.push({ kind: 'op', value, start: i, end: i + value.length });
+      i += value.length;
+      continue;
+    }
+
+    if (ch === '"') {
+      const quoted = readQuoted(text, i);
+      if (!quoted.ok) return quoted;
+      tokens.push(quoted.token);
+      i = quoted.token.end;
+      continue;
+    }
+
+    if (ch === '/') {
+      const regex = readRegex(text, i);
+      if (!regex.ok) return regex;
+      tokens.push(regex.token);
+      i = regex.token.end;
+      continue;
+    }
+
+    const start = i;
+    while (i < text.length) {
+      const c = text[i] as string;
+      if (isSpace(c) || WORD_BREAK.has(c)) break;
+      i += 1;
+    }
+    tokens.push({ kind: 'word', value: text.slice(start, i), start, end: i });
+  }
+
+  return { ok: true, tokens };
+}
+
+type ReadResult = { ok: true; token: Token } | { ok: false; error: SelectorParseError };
+
+/** `"foo \"bar\" baz"` — the token value is the unescaped body. */
+function readQuoted(text: string, start: number): ReadResult {
+  let out = '';
+  let i = start + 1;
+  while (i < text.length) {
+    const c = text[i] as string;
+    if (c === '\\') {
+      const next = text[i + 1];
+      if (next === undefined) break;
+      out += next;
+      i += 2;
+      continue;
+    }
+    if (c === '"') {
+      return { ok: true, token: { kind: 'string', value: out, start, end: i + 1 } };
+    }
+    out += c;
+    i += 1;
+  }
+  return { ok: false, error: { message: 'unterminated quoted value: no closing "', offset: start } };
+}
+
+/** `/foo\/bar/` — the token value is the regex source with `\/` unescaped. */
+function readRegex(text: string, start: number): ReadResult {
+  let out = '';
+  let i = start + 1;
+  while (i < text.length) {
+    const c = text[i] as string;
+    if (c === '\\') {
+      const next = text[i + 1];
+      if (next === undefined) break;
+      // Only `\/` is about the delimiter; every other escape belongs to the
+      // regular expression and is handed through untouched.
+      out += next === '/' ? '/' : `\\${next}`;
+      i += 2;
+      continue;
+    }
+    if (c === '/') {
+      if (out.length === 0) {
+        return { ok: false, error: { message: 'empty regular expression: // matches nothing', offset: start } };
+      }
+      return { ok: true, token: { kind: 'regex', value: out, start, end: i + 1 } };
+    }
+    out += c;
+    i += 1;
+  }
+  return { ok: false, error: { message: 'unterminated regular expression: no closing /', offset: start } };
+}

--- a/packages/query/src/selector/tokenize.ts
+++ b/packages/query/src/selector/tokenize.ts
@@ -30,7 +30,8 @@
 
 import type { SelectorParseError } from './ast.js';
 
-export type TokenKind =
+/** Lexeme classes. Not exported: `Token` is the only shape callers name. */
+type TokenKind =
   | 'word'
   | 'string'
   | 'regex'

--- a/packages/query/test/selector-parse.test.ts
+++ b/packages/query/test/selector-parse.test.ts
@@ -248,6 +248,32 @@ describe('parseSelector — lexical detail', () => {
     });
   });
 
+  it('a quoted PROPERTY name works after a literal property set, not only after a regex one', () => {
+    // #4091: `Pset_BeamCommon."IsExternal"` was a parse error while
+    // `/Pset_.*Common/."IsExternal"` parsed, because the lexer keeps the '.'
+    // inside a bare word and only the regex spelling reached the property
+    // branch. One character from the shape the issue reported.
+    expect(parsed('Pset_BeamCommon."IsExternal" = FALSE').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'property',
+      pset: { kind: 'string', text: 'Pset_BeamCommon' },
+      prop: { kind: 'string', text: 'IsExternal' },
+      op: '=',
+      value: { kind: 'string', text: 'FALSE' },
+      text: 'Pset_BeamCommon."IsExternal" = FALSE',
+    });
+  });
+
+  it('a regex PROPERTY name works after a literal property set too', () => {
+    expect(parsed('Pset_BeamCommon./IsExt.*/=TRUE').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'property',
+      pset: { kind: 'string', text: 'Pset_BeamCommon' },
+      prop: { kind: 'regex', source: 'IsExt.*' },
+      op: '=',
+      value: { kind: 'string', text: 'TRUE' },
+      text: 'Pset_BeamCommon./IsExt.*/=TRUE',
+    });
+  });
+
   it('a decimal value stays one word, the leading dot is a separator', () => {
     expect(parsed('Qto_WallBaseQuantities.NetVolume>1.5').groups[0]?.filters[0]).toStrictEqual({
       kind: 'property',

--- a/packages/query/test/selector-parse.test.ts
+++ b/packages/query/test/selector-parse.test.ts
@@ -1,0 +1,354 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The seventeen worked examples on the IfcOpenShell selector-syntax page, each
+ * pinned to the exact AST it must produce (#4091). The page is the spec, so a
+ * case here that drifts is a case where ifc-lite stopped reading the same
+ * language — the failure mode the issue reported, where a valid selector
+ * matched nothing and said nothing.
+ *
+ * https://docs.ifcopenshell.org/ifcopenshell-python/selector_syntax.html
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSelector } from '../src/selector/parse.js';
+import type { SelectorFilter, SelectorParseResult, SelectorQuery } from '../src/selector/ast.js';
+
+const GUID = '325Q7Fhnf67OZC$$r43uzK';
+const GUID2 = '2VlJ7nbF5AFfQQuRvSWexT';
+
+function parsed(text: string): SelectorQuery {
+  const result = parseSelector(text);
+  if (!result.ok) throw new Error(`expected a parse, got: ${result.error.message} @${result.error.offset}`);
+  return result.query;
+}
+
+function error(text: string): { message: string; offset: number } {
+  const result: SelectorParseResult = parseSelector(text);
+  if (result.ok) throw new Error(`expected a parse error for ${JSON.stringify(text)}`);
+  return result.error;
+}
+
+function one(filters: SelectorFilter[]): SelectorQuery {
+  return { groups: [{ filters }] };
+}
+
+const cls = (name: string, text = name, negate = false): SelectorFilter =>
+  ({ kind: 'class', name, negate, text });
+const guid = (id: string, text = id, negate = false): SelectorFilter =>
+  ({ kind: 'globalId', id, negate, text });
+
+describe('parseSelector — the documented examples', () => {
+  it('1. a single class', () => {
+    expect(parsed('IfcElement')).toStrictEqual(one([cls('IfcElement')]));
+  });
+
+  it('2. two classes chained with a comma', () => {
+    expect(parsed('IfcWall, IfcSlab')).toStrictEqual(one([cls('IfcWall'), cls('IfcSlab')]));
+  });
+
+  it('3. classes plus a material keyword', () => {
+    expect(parsed('IfcWall, IfcSlab, material=concrete')).toStrictEqual(one([
+      cls('IfcWall'),
+      cls('IfcSlab'),
+      { kind: 'material', op: '=', value: { kind: 'string', text: 'concrete' }, text: 'material=concrete' },
+    ]));
+  });
+
+  it('4. GlobalIds, alone and chained', () => {
+    expect(parsed(GUID)).toStrictEqual(one([guid(GUID)]));
+    expect(parsed(`${GUID}, ${GUID2}`)).toStrictEqual(one([guid(GUID), guid(GUID2)]));
+  });
+
+  it('5. a class minus one GlobalId', () => {
+    expect(parsed(`IfcWall, ! ${GUID}`)).toStrictEqual(one([
+      cls('IfcWall'),
+      guid(GUID, `! ${GUID}`, true),
+    ]));
+  });
+
+  it('6. a class minus a subclass', () => {
+    expect(parsed('IfcElement, ! IfcWall')).toStrictEqual(one([
+      cls('IfcElement'),
+      cls('IfcWall', '! IfcWall', true),
+    ]));
+  });
+
+  it('7. an attribute equality', () => {
+    expect(parsed('IfcDoor, Name=D01')).toStrictEqual(one([
+      cls('IfcDoor'),
+      { kind: 'attribute', name: 'Name', op: '=', value: { kind: 'string', text: 'D01' }, text: 'Name=D01' },
+    ]));
+  });
+
+  it('8. an attribute matched by a regular expression', () => {
+    expect(parsed('IfcDoor, Name=/D[0-9]{2}/')).toStrictEqual(one([
+      cls('IfcDoor'),
+      { kind: 'attribute', name: 'Name', op: '=', value: { kind: 'regex', source: 'D[0-9]{2}' }, text: 'Name=/D[0-9]{2}/' },
+    ]));
+  });
+
+  it('9. a property in a named property set', () => {
+    expect(parsed('IfcWall, Pset_WallCommon.FireRating=2HR')).toStrictEqual(one([
+      cls('IfcWall'),
+      {
+        kind: 'property',
+        pset: { kind: 'string', text: 'Pset_WallCommon' },
+        prop: { kind: 'string', text: 'FireRating' },
+        op: '=',
+        value: { kind: 'string', text: '2HR' },
+        text: 'Pset_WallCommon.FireRating=2HR',
+      },
+    ]));
+  });
+
+  it('10. four classes and a regex property-set name', () => {
+    expect(parsed('IfcWall, IfcColumn, IfcBeam, IfcFooting, /Pset_.*Common/.LoadBearing=TRUE')).toStrictEqual(one([
+      cls('IfcWall'),
+      cls('IfcColumn'),
+      cls('IfcBeam'),
+      cls('IfcFooting'),
+      {
+        kind: 'property',
+        pset: { kind: 'regex', source: 'Pset_.*Common' },
+        prop: { kind: 'string', text: 'LoadBearing' },
+        op: '=',
+        value: { kind: 'string', text: 'TRUE' },
+        text: '/Pset_.*Common/.LoadBearing=TRUE',
+      },
+    ]));
+  });
+
+  it('11. "is set" spelled as != NULL', () => {
+    expect(parsed('IfcElement, /Pset_.*Common/.FireRating != NULL')).toStrictEqual(one([
+      cls('IfcElement'),
+      {
+        kind: 'property',
+        pset: { kind: 'regex', source: 'Pset_.*Common' },
+        prop: { kind: 'string', text: 'FireRating' },
+        op: '!=',
+        value: { kind: 'null' },
+        text: '/Pset_.*Common/.FireRating != NULL',
+      },
+    ]));
+  });
+
+  it('12. type and a quoted location', () => {
+    expect(parsed('IfcWall, type=WT01, location="Level 3"')).toStrictEqual(one([
+      cls('IfcWall'),
+      { kind: 'type', op: '=', value: { kind: 'string', text: 'WT01' }, text: 'type=WT01' },
+      { kind: 'location', op: '=', value: { kind: 'string', text: 'Level 3' }, text: 'location="Level 3"' },
+    ]));
+  });
+
+  it('13. a classification matched by a regular expression', () => {
+    expect(parsed('IfcElement, classification=/Pr_.*/')).toStrictEqual(one([
+      cls('IfcElement'),
+      { kind: 'classification', op: '=', value: { kind: 'regex', source: 'Pr_.*' }, text: 'classification=/Pr_.*/' },
+    ]));
+  });
+
+  it('14. classes, a subtraction, a material and a regex property', () => {
+    const text = `IfcWall, IfcSlab, ! ${GUID}, material=concrete, /Pset_.*Common/.FireRating=2HR`;
+    expect(parsed(text)).toStrictEqual(one([
+      cls('IfcWall'),
+      cls('IfcSlab'),
+      guid(GUID, `! ${GUID}`, true),
+      { kind: 'material', op: '=', value: { kind: 'string', text: 'concrete' }, text: 'material=concrete' },
+      {
+        kind: 'property',
+        pset: { kind: 'regex', source: 'Pset_.*Common' },
+        prop: { kind: 'string', text: 'FireRating' },
+        op: '=',
+        value: { kind: 'string', text: '2HR' },
+        text: '/Pset_.*Common/.FireRating=2HR',
+      },
+    ]));
+  });
+
+  it('15. two groups unioned with +', () => {
+    expect(parsed('IfcSlab, material=concrete + IfcDoor')).toStrictEqual({
+      groups: [
+        {
+          filters: [
+            cls('IfcSlab'),
+            { kind: 'material', op: '=', value: { kind: 'string', text: 'concrete' }, text: 'material=concrete' },
+          ],
+        },
+        { filters: [cls('IfcDoor')] },
+      ],
+    });
+  });
+
+  it('16. three groups unioned with +', () => {
+    expect(parsed(`IfcDoor, IfcWindow + IfcWall, IfcSlab, material=concrete + ${GUID}`)).toStrictEqual({
+      groups: [
+        { filters: [cls('IfcDoor'), cls('IfcWindow')] },
+        {
+          filters: [
+            cls('IfcWall'),
+            cls('IfcSlab'),
+            { kind: 'material', op: '=', value: { kind: 'string', text: 'concrete' }, text: 'material=concrete' },
+          ],
+        },
+        { filters: [guid(GUID)] },
+      ],
+    });
+  });
+
+  it('17. a class inside a named location', () => {
+    expect(parsed('IfcPump, location="Level 3"')).toStrictEqual(one([
+      cls('IfcPump'),
+      { kind: 'location', op: '=', value: { kind: 'string', text: 'Level 3' }, text: 'location="Level 3"' },
+    ]));
+  });
+});
+
+describe('parseSelector — lexical detail', () => {
+  it('unescapes \\" and \\\\ inside a quoted value', () => {
+    expect(parsed('Name="foo \\"bar\\" baz"').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'attribute',
+      name: 'Name',
+      op: '=',
+      value: { kind: 'string', text: 'foo "bar" baz' },
+      text: 'Name="foo \\"bar\\" baz"',
+    });
+  });
+
+  it('a slash inside quotes is data, not a regular expression', () => {
+    expect(parsed('Name="a/b"').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'attribute',
+      name: 'Name',
+      op: '=',
+      value: { kind: 'string', text: 'a/b' },
+      text: 'Name="a/b"',
+    });
+  });
+
+  it('an escaped slash inside a regular expression stays in the source', () => {
+    expect(parsed('Name=/a\\/b/').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'attribute',
+      name: 'Name',
+      op: '=',
+      value: { kind: 'regex', source: 'a/b' },
+      text: 'Name=/a\\/b/',
+    });
+  });
+
+  it('a quoted property-set name carries spaces', () => {
+    expect(parsed('"My Set".SomeProp=1').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'property',
+      pset: { kind: 'string', text: 'My Set' },
+      prop: { kind: 'string', text: 'SomeProp' },
+      op: '=',
+      value: { kind: 'string', text: '1' },
+      text: '"My Set".SomeProp=1',
+    });
+  });
+
+  it('a decimal value stays one word, the leading dot is a separator', () => {
+    expect(parsed('Qto_WallBaseQuantities.NetVolume>1.5').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'property',
+      pset: { kind: 'string', text: 'Qto_WallBaseQuantities' },
+      prop: { kind: 'string', text: 'NetVolume' },
+      op: '>',
+      value: { kind: 'string', text: '1.5' },
+      text: 'Qto_WallBaseQuantities.NetVolume>1.5',
+    });
+  });
+
+  it('*= and !*= win over = and !=', () => {
+    expect(parsed('Name*=Wand, Name!*=Fenster').groups[0]?.filters).toStrictEqual([
+      { kind: 'attribute', name: 'Name', op: '*=', value: { kind: 'string', text: 'Wand' }, text: 'Name*=Wand' },
+      { kind: 'attribute', name: 'Name', op: '!*=', value: { kind: 'string', text: 'Fenster' }, text: 'Name!*=Fenster' },
+    ]);
+  });
+
+  it('every comparison operator lexes', () => {
+    for (const op of ['=', '!=', '>', '>=', '<', '<='] as const) {
+      expect(parsed(`Pset.Prop${op}1`).groups[0]?.filters[0]).toMatchObject({ kind: 'property', op });
+    }
+  });
+
+  it('NULL is a null literal in any case, but "NULL" quoted is a string', () => {
+    expect(parsed('Pset.Prop=NULL').groups[0]?.filters[0]).toMatchObject({ value: { kind: 'null' } });
+    expect(parsed('Pset.Prop=null').groups[0]?.filters[0]).toMatchObject({ value: { kind: 'null' } });
+    expect(parsed('Pset.Prop="NULL"').groups[0]?.filters[0]).toMatchObject({
+      value: { kind: 'string', text: 'NULL' },
+    });
+  });
+
+  it('TRUE and FALSE stay strings — the adapter decides how to compare them', () => {
+    expect(parsed('Pset.LoadBearing=TRUE').groups[0]?.filters[0]).toMatchObject({
+      value: { kind: 'string', text: 'TRUE' },
+    });
+  });
+
+  it('a query: key path keeps its dots', () => {
+    expect(parsed('query:types.count=0').groups[0]?.filters[0]).toStrictEqual({
+      kind: 'query',
+      keys: 'types.count',
+      op: '=',
+      value: { kind: 'string', text: '0' },
+      text: 'query:types.count=0',
+    });
+  });
+});
+
+describe('parseSelector — errors name the offset', () => {
+  it('a trailing * is rejected instead of matching nothing (#4091)', () => {
+    const err = error('IfcWall*');
+    expect(err.offset).toBe(7);
+    expect(err.message).toContain('*=');
+  });
+
+  it('an unknown bare word points at the word', () => {
+    const err = error('IfcWall, Wand');
+    expect(err.offset).toBe(9);
+    expect(err.message).toContain('"Wand"');
+  });
+
+  it('empty input', () => {
+    expect(error('')).toStrictEqual({ message: 'empty selector: type a class name such as IfcWall', offset: 0 });
+    expect(error('   ').offset).toBe(0);
+  });
+
+  it('a trailing comma', () => {
+    expect(error('IfcWall,').offset).toBe(8);
+  });
+
+  it('an empty group either side of +', () => {
+    expect(error('IfcWall +').offset).toBe(9);
+    expect(error('+ IfcWall').offset).toBe(0);
+  });
+
+  it('an unterminated quote or regular expression', () => {
+    expect(error('Name="abc').message).toContain('unterminated quoted value');
+    expect(error('Name=/abc').message).toContain('unterminated regular expression');
+  });
+
+  it('"!" cannot negate a comparison', () => {
+    const err = error('IfcWall, !Name=D01');
+    expect(err.offset).toBe(9);
+    expect(err.message).toContain('may only negate');
+  });
+
+  it('a missing value after an operator', () => {
+    expect(error('Name=').offset).toBe(5);
+    expect(error('Name=, IfcWall').offset).toBe(5);
+  });
+
+  it('a missing operator after a property name', () => {
+    expect(error('Pset_WallCommon.FireRating').message).toContain('operators');
+  });
+
+  it('a regular expression on its own is not a filter', () => {
+    expect(error('/D[0-9]{2}/').message).toContain('needs an attribute or property');
+  });
+
+  it('an empty regular expression', () => {
+    expect(error('Name=//').message).toContain('empty regular expression');
+  });
+});

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3908,12 +3908,21 @@
     "QueryInterface: class",
     "QueryResultEntity: class",
     "SQLResult: interface",
+    "SelectorFilter: type",
+    "SelectorGroup: interface",
+    "SelectorOp: type",
+    "SelectorParseError: interface",
+    "SelectorParseResult: type",
+    "SelectorQuery: interface",
+    "SelectorText: type",
+    "SelectorValue: type",
     "compareFilterValue: function",
     "findAllPropertiesInSets: function",
     "findAllQuantitiesInSets: function",
     "findPropertyInSets: function",
     "findQuantityInSets: function",
-    "normalizeBooleanValue: function"
+    "normalizeBooleanValue: function",
+    "parseSelector: function"
   ],
   "@ifc-lite/renderer": [
     "AdapterInfoSnapshot: interface",

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3909,7 +3909,6 @@
     "QueryResultEntity: class",
     "SQLResult: interface",
     "SelectorFilter: type",
-    "SelectorGroup: interface",
     "SelectorOp: type",
     "SelectorParseError: interface",
     "SelectorParseResult: type",


### PR DESCRIPTION
Closes #4091

A BIM coordinator typed IfcOpenShell selector syntax into ifc-lite's object filter and got nothing back. I reproduced it in the running viewer on AC20-FZK-Haus (275 elements) before writing any code:

| query | results |
|---|---|
| `Wand` | 13 |
| `IfcWall` | 15 |
| `IfcWall*` | **0** |
| `IfcWall, IfcSlab` | **0** |
| `IfcWall[Name*=Wand]` | **0** |

The search box is a plain substring matcher, so every selector character is matched literally and adding syntax makes it match **less**. The Advanced Filter is a structured rule builder whose Name operators are only eq / ne / contains / notContains / startsWith. There is no text grammar on either surface, and ifc-lite disagrees with itself: the CLI's clash selectors already accept `--a "IfcDuct*|IfcPipe*"`.

## What this adds

`parseSelector` in `@ifc-lite/query`: a tokenizer plus recursive-descent parser over the whole IfcOpenShell filter grammar, answering with an AST or an error carrying the character offset that broke. Plus `selectorToFilterRules` in the viewer adapting that AST onto the existing `FilterRule` model, a selector field in the Filter tab, regex ops in the rule model, and a docs page.

The parser lives in the query package, not the viewer, because the CLI, MCP and SDK all already depend on it and should adapt the same AST rather than growing a second grammar. Accepting more than any one surface can evaluate is deliberate: the adapter **names what it dropped** instead of matching nothing in silence.

Working today: `IfcWall, IfcSlab` with subclasses, `IfcElement, ! IfcWall`, `Name=D01` and `Name=/D[0-9]{2}/`, `Pset_WallCommon.FireRating=2HR` across all eight operators, `/Pset_.*Common/.LoadBearing=TRUE`, `… != NULL`, `material=`, `classification=/Pr_.*/`, `location="Level 3"`.

## Verified by driving the UI, not by asserting

`IfcWall*` now answers: *Character 8 (at "\*"): "\*" is only valid as part of the "\*=" (contains) operator; this grammar has no "\*" wildcard. Use a regular expression such as /Ifc.\*Wall/ instead.* Rules untouched.

`IfcWall, /Pset_.*Common/.ThermalTransmittance>1` becomes two visible, editable rules (IFC TYPE expanded to IfcWall + IfcWallElementedCase + IfcWallStandardCase, plus the property rule) and returns 5 rows in 16 ms.

`IfcDoor, Name=/T.*/, type=WT01` applies the first two and reports *"type=WT01": matching an element's type by name is not supported yet (#4094)*.

The reporter's own selector is pinned by name in the test set, as promised in the thread.

## Two review rounds, and what they caught

`/simplify` (4 agents) found the AST's string/regex discriminator was flattened back into ambiguous text and re-derived downstream, so a **quoted** literal name compiled as a regex and `Name=/\\/tmp\\//` silently lost its slashes. That is this issue's own defect class reappearing at the adapter seam. Fixed by carrying an explicit `TextKind`.

`/code-review` then found `Qto_WallBaseQuantities.NetVolume=NULL` produced a property rule reading the pset table, which **matched every element in the model**. Also that promote had lost its `Name contains` fallback for plain text that happens to parse, and that two tests passed with the toast deleted. All fixed, each with a before/after mutation count.

## Measured limitation, documented not guessed

`location="Level 3"` matches an element contained **directly** in the storey but not one inside a space on that storey (`elementToStorey.get(pump)` is `undefined`), so IfcOpenShell's example 17 does not carry over. A test measures this rather than asserting it, and the docs matrix says so. #4094 tracks it, correctly scoped as a fix to the existing storey rule rather than a new rule kind.

Revit's unprefixed `BaseQuantities` and ArchiCAD's `ArchiCADQuantities` are unreachable from a selector; documented, with a test pinning the gap so it turns red when #4094 closes it.

## Notes for the reviewer

`apps/viewer/src/lib/search/selector-to-rules.ts` is at exactly **400 lines, the limit, with no allowlist row**. I had it judged rather than split reflexively: it is a deep module (two public functions over 400 lines of implementation), and each candidate seam was measured and rejected. An op-map module needs 11 crossings and would import the rule vocabulary anyway; the `unsupported` messages are 17 inline literals whose value is sitting on the branch that detects the condition; a per-kind split is 4 files and 12+ crossings. When #4094 forces growth, the plan is to absorb `regexProblem` into `filter-ops.ts` first (one crossing, and it co-locates two compiles of the same source that can currently disagree), then split `adaptProperty` only if still over.

Deferred on record: NameEditor / MaterialEditor / ClassificationEditor drop the `kind` on an op-only toggle, which bites only when the value is itself `/…/`-shaped.

## Gates, real exit codes

typecheck 89/89 · test 98/98 · lint (4,281 files, no errors) · check-module-size (0 new over 400) · check-api-surface · docs:check-samples (380 snippets). `@ifc-lite/query` minor changeset + api-surface snapshot committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for IfcOpenShell selector syntax in the viewer’s Filter tab, including classes, properties, quantities, materials, locations, unions, negation, quoted values, and regular expressions.
  - Search queries can be converted into filter rules, with clear feedback for unsupported or invalid selector parts.
  - Added regex matching and presence-aware filter operators.
  - Exposed selector parsing through the query package.

- **Accessibility**
  - Improved screen-reader announcements for toast notifications.

- **Documentation**
  - Added a comprehensive selector syntax guide and navigation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->