### PR TITLE
test(parser): assert once after the loop instead of 40k times inside it

### DIFF
--- a/packages/parser/src/compact-entity-index-cache.test.ts
+++ b/packages/parser/src/compact-entity-index-cache.test.ts
@@ -10,16 +10,41 @@ function index(capacity: number, count = 20_000): CompactEntityIndex {
     new Uint16Array(count), ['IFCWALL'], capacity);
 }
 
+/** How many offending ids a failure names before it falls back to a count. */
+const PREVIEW = 10;
+
 describe('entity cache eviction after long scans (#3983)', () => {
   it('preserves reference contents and hot entries across eviction and clearing', () => {
     const data = index(3);
     const hot = data.get(1);
     data.get(2);
     const cold = data.get(3);
+    // #4110: the 20k-entry scan is the point of this test (it is what forces
+    // eviction), but asserting inside it cost ~40k expect() calls and lost the
+    // race against the 5000ms timeout on a loaded runner. Record what went
+    // wrong and assert once, which also names many bad ids instead of aborting
+    // on the first.
+    const evictedAt: number[] = [];
+    const wrong: string[] = [];
     for (let id = 4; id <= 20_000; id++) {
-      expect(data.get(1)).toBe(hot);
-      expect(data.get(id)).toEqual({ expressId: id, type: 'IFCWALL', byteOffset: id * 80, byteLength: 80, lineNumber: 0 });
+      if (data.get(1) !== hot) evictedAt.push(id);
+      const got = data.get(id);
+      if (got?.expressId !== id || got.type !== 'IFCWALL' || got.byteOffset !== id * 80
+        || got.byteLength !== 80 || got.lineNumber !== 0) {
+        wrong.push(`#${id} was ${JSON.stringify(got)}`);
+      }
     }
+    expect({
+      hotEntryReallocations: evictedAt.length,
+      firstHotEntryReallocations: evictedAt.slice(0, PREVIEW),
+      wrongEntries: wrong.length,
+      firstWrongEntries: wrong.slice(0, PREVIEW),
+    }).toEqual({
+      hotEntryReallocations: 0,
+      firstHotEntryReallocations: [],
+      wrongEntries: 0,
+      firstWrongEntries: [],
+    });
     expect(data.get(3)).not.toBe(cold);
     data.clearCache();
     const renewed = data.get(1);

--- a/packages/parser/src/entity-type-byte-interner.test.ts
+++ b/packages/parser/src/entity-type-byte-interner.test.ts
@@ -47,13 +47,18 @@ describe('issue #3985 byte type interning', () => {
 
   it('continues exact lookup after a high-cardinality source exceeds the fast dictionary budget', () => {
     const interner = new EntityTypeByteInterner();
+    // #4110: assert once. 8400 in-loop assertions dominated the interning they
+    // check, and a failure named only the first bad token.
+    const wrong: string[] = [];
     for (let round = 0; round < 2; round++) {
       for (let i = 0; i < 4200; i++) {
         const name = `UNKNOWN_${i}`;
         const bytes = new TextEncoder().encode(name);
-        expect(interner.intern(bytes, 0, bytes.length, i)).toBe(name);
+        const interned = interner.intern(bytes, 0, bytes.length, i);
+        if (interned !== name) wrong.push(`round ${round} ${name} -> ${interned}`);
       }
     }
+    expect({ count: wrong.length, first: wrong.slice(0, 10) }).toEqual({ count: 0, first: [] });
   });
 
   it('keeps record-relative spans for a sliced input and the source-accessor read path', () => {

--- a/packages/parser/test/deterministic-global-id.test.ts
+++ b/packages/parser/test/deterministic-global-id.test.ts
@@ -76,10 +76,16 @@ describe('deterministicGlobalId', () => {
     // A GUID whose first char used the full 6-bit alphabet decodes to >128 bits
     // and cannot survive uuid -> guid re-encoding. Round-tripping through the
     // canonical compressor proves every emitted char carries only valid bits.
+    // #4110: assert once. Inside the loop the assertion machinery cost more
+    // than the round trip it checks, and a failure named only the first seed.
+    // The scan stays at 10,000 seeds; only the assertion density changes.
+    const broken: string[] = [];
     for (let i = 0; i < 10_000; i++) {
       const id = deterministicGlobalId(`seed-${i}`);
-      expect(uuidToIfcGuid(ifcGuidToUuid(id))).toBe(id);
+      const roundTripped = uuidToIfcGuid(ifcGuidToUuid(id));
+      if (roundTripped !== id) broken.push(`seed-${i}: ${id} -> ${roundTripped}`);
     }
+    expect({ count: broken.length, first: broken.slice(0, 10) }).toEqual({ count: 0, first: [] });
   });
 
   it('produces no collisions across 10,000 sequential seeds', () => {


### PR DESCRIPTION
Closes #4110.

`packages/parser/src/compact-entity-index-cache.test.ts` intermittently failed with `Error: Test timed out in 5000ms.`, reddening whatever PR happened to be running. It hit #4024, whose entire diff was a **Rust** test file with no path to this code, and cost a diagnosis before anyone could tell it was noise.

## Cause

The loop asserted per iteration:

```js
for (let id = 4; id <= 20_000; id++) {
  expect(data.get(1)).toBe(hot);
  expect(data.get(id)).toEqual({ expressId: id, type: 'IFCWALL', byteOffset: id * 80, byteLength: 80, lineNumber: 0 });
}
```

~40,000 `expect()` calls, half of them a deep `toEqual` against a freshly allocated object literal. The **assertion machinery**, not the code under test, dominated the runtime, measured against a fixed 5000ms timeout. Under CI load it lost the race.

## Fix

Collect mismatches in the loop, assert once after it. `testTimeout` deliberately untouched: raising it picks a number that is wrong on the next slower runner.

| test | before | after |
|---|---|---|
| cache eviction scan | 183-190 ms | **8-9 ms** |
| GlobalId 10k round trip | 72-76 ms | 25-28 ms |
| interner high-cardinality | 47-50 ms | 2.5-6 ms |

The 20,000-iteration scan is **kept** — it is what forces eviction at capacity 3, per #3983. Only assertion density changed. `data.get(1)` is still called every iteration, since that is what keeps entry 1 hot; dropping it would have changed the workload rather than the measurement.

Coverage went **up**, not down: the old `toEqual` and the new check both cover all five `EntityRef` fields, and the issue's own sketch only checked two.

## Proof it still catches what it caught

The failure mode of fixing a flaky test is producing a test that can no longer fail, so each was mutated and reverted:

1. **Break the LRU touch** (delete the recency refresh in `CompactEntityIndex.get`) -> FAILS: `hotEntryReallocations: 19996`, first offenders `[5, 6, 7, ...]`. Consistent with the code: without the refresh, id 1 is the first key evicted when id 4 is inserted.
2. **Skew a `byteOffset`** (+8 on every 977th id) -> FAILS: `wrongEntries: 20`, naming `#977`, `#1954`, ... with actual values.
3. **Unmutated** -> passes, 10 consecutive full parser-suite runs green.

Both siblings were mutation-checked too: skewing the GlobalId first character fails with `count: 1437`; dropping a byte past the interner budget fails with `count: 208` and named tokens.

Reference identity is preserved, which is the point of the cache test: `data.get(1) !== hot` is strict inequality, the same semantics as `toBe`, and the post-loop `not.toBe(cold)` / `not.toBe(hot)` / `toBe(renewed)` assertions are byte-identical to before. A cache returning fresh objects every call still fails, with ~19,997 recorded reallocations.

## Siblings

Scanned every parser test for loops containing `expect(`, ~110 loop bodies. Three were in the risk band:

- **Fixed** `test/deterministic-global-id.test.ts:75` (10,000 expects).
- **Fixed** `src/entity-type-byte-interner.test.ts:48` (8,400 expects; assertions were ~94% of the cost).
- **Left alone** `test/blocked-source-equivalence.test.ts:93`, the slowest at ~510 ms. It is **not** this defect: it already carries an explicit `{ timeout: 60_000 }` and a `compares > 400` vacuity guard, and its ~900 assertions each drive real block decompression, so collecting instead of asserting would not move it. Not the next flake.

## Failure messages are better, not just faster

Each assert reports a count plus the first ten offenders, so a real failure says `wrongEntries: 20` with ten named ids rather than aborting on the first mismatch. The cap trims the list, never the count.

Three test files, +40/-4. No production source. No changeset (test-only; precedent #4020).

Gates, real exit codes: typecheck 0 (1761/1761), test 0 (98/98), lint 0, module-size 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved failure reporting for parser stress and round-trip tests.
  - Test results now aggregate mismatches and provide concise summaries with representative examples, making failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->