### PR TITLE
fix(bcf): name a topic's first viewpoint viewpoint.bcfv, matching BIMcollab

### DIFF
--- a/.changeset/bcf-viewpoint-filename-convention.md
+++ b/.changeset/bcf-viewpoint-filename-convention.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/bcf": patch
+---
+
+Name a topic's first (or only) viewpoint `viewpoint.bcfv`/`snapshot.<ext>` instead of a GUID-prefixed `Viewpoint_<guid>.bcfv`/`Snapshot_<guid>.<ext>`; additional viewpoints in the same topic keep a GUID-qualified name, now as a suffix (`<guid>_viewpoint.bcfv`) rather than a prefix, matching the convention BIMcollab uses. Investigation on #3612 (a BCF export rejected by Solibri while the same topic re-exported by BIMcollab was accepted) narrowed the difference between the two archives to this filename convention -- both forms are schema-legal, since `markup.bcf` names the file explicitly, but a reader that assumes the conventional name rather than following the reference fails on the old prefix form. The markup `<Viewpoint>`/`<Snapshot>` reference and the archive entry are computed from one shared name so the two can never disagree.

--- a/packages/bcf/src/dangling-snapshot-reference.test.ts
+++ b/packages/bcf/src/dangling-snapshot-reference.test.ts
@@ -74,8 +74,13 @@ describe('#3962: dangling snapshot reference', () => {
     // The reference must be gone, not merely the file: this is the whole bug.
     expect(markupContent).not.toContain('<Snapshot>');
 
-    const snapshotEntries = Object.keys(zip.files).filter((name) => name.includes('Snapshot_'));
-    expect(snapshotEntries).toHaveLength(0);
+    // No snapshot entry of any name (the topic's single viewpoint would
+    // otherwise get the plain `snapshot.<ext>` name, not the pre-#3612
+    // `Snapshot_<guid>.<ext>` form) -- only markup.bcf and the .bcfv file.
+    const topicEntries = Object.keys(zip.files).filter(
+      (name) => name.startsWith(`${topicGuid}/`) && !zip.files[name].dir,
+    );
+    expect(topicEntries.sort()).toEqual([`${topicGuid}/markup.bcf`, `${topicGuid}/viewpoint.bcfv`]);
 
     expect(warn).toHaveBeenCalled();
   });

--- a/packages/bcf/src/schema-validation.test.ts
+++ b/packages/bcf/src/schema-validation.test.ts
@@ -240,8 +240,8 @@ describe('BCF output validates against the official buildingSMART XSDs', () => {
         // If the writer stops emitting one of these, the per-entry validation
         // below would vacuously pass on the ones that remain.
         expect(names).toEqual([
-          `${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`,
           `${TOPIC_GUID}/markup.bcf`,
+          `${TOPIC_GUID}/viewpoint.bcfv`,
           'bcf.version',
           'project.bcfp',
         ]);
@@ -285,7 +285,7 @@ describe('BCF output validates against the official buildingSMART XSDs', () => {
         const { valid, messages } = await validate(
           version,
           'visinfo.xsd',
-          entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!
+          entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!
         );
         expect(messages).toEqual([]);
         expect(valid).toBe(true);
@@ -397,7 +397,7 @@ describe('BCF 3.0 AspectRatio', () => {
     const entries = await writeAndUnzip(maximalProject('2.1'));
     // The 2.1 fixture DOES set `aspectRatio` (see maximalTopic), so this
     // distinguishes "correctly suppressed for 2.1" from "never written".
-    expect(entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)).not.toContain(
+    expect(entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)).not.toContain(
       'AspectRatio'
     );
   });
@@ -432,7 +432,7 @@ describe('BCF 3.0 FieldOfView range', () => {
       topic.viewpoints[0].perspectiveCamera!.fieldOfView = good;
       const project: BCFProject = { version: '3.0', topics: new Map([[TOPIC_GUID, topic]]) };
       const entries = await writeAndUnzip(project);
-      const xml = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+      const xml = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
       const { valid, messages } = await validate('3.0', 'visinfo.xsd', xml);
       expect(messages.join('\n')).toBe('');
       expect(valid).toBe(true);
@@ -448,7 +448,7 @@ describe('BCF 3.0 FieldOfView range', () => {
     topic.viewpoints[0].perspectiveCamera!.fieldOfView = 90;
     const project: BCFProject = { version: '2.1', topics: new Map([[TOPIC_GUID, topic]]) };
     const entries = await writeAndUnzip(project);
-    expect(entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)).toContain(
+    expect(entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)).toContain(
       '<FieldOfView>90</FieldOfView>'
     );
   });
@@ -582,7 +582,7 @@ describe('non-finite numbers never reach the archive', () => {
    */
   it('would have failed XSD validation had Infinity been emitted (the reported defect)', async () => {
     const entries = await writeAndUnzip(maximalProject('3.0'));
-    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const good = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
     expect((await validate('3.0', 'visinfo.xsd', good)).valid).toBe(true);
 
     const broken = good.replace(
@@ -609,7 +609,7 @@ describe('non-finite numbers never reach the archive', () => {
    */
   it('accepts NaN as a schema-valid xs:double, which is exactly why the schema cannot be the guard', async () => {
     const entries = await writeAndUnzip(maximalProject('3.0'));
-    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const good = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
     const withNaN = good.replace('<X>1.5</X>', '<X>NaN</X>');
     expect(withNaN).not.toEqual(good);
 
@@ -653,7 +653,7 @@ describe('non-finite numbers never reach the archive', () => {
 describe('BCF 3.0 places ViewSetupHints inside <Visibility>', () => {
   it('keeps the hints, with their values, nested in Visibility rather than at Components level', async () => {
     const entries = await writeAndUnzip(maximalProject('3.0'));
-    const bcfv = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const bcfv = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
 
     // Present at all — the mutation that deleted it left the file schema-valid.
     expect(bcfv).toContain('<ViewSetupHints');
@@ -705,7 +705,7 @@ describe('the validator can fail (mutation proof)', () => {
 
   it('rejects a misspelled enum value', async () => {
     const entries = await writeAndUnzip(maximalProject('2.1'));
-    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const good = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
     // 2.1's BitmapFormat enum is {PNG, JPG} — uppercase. 3.0's is {png, jpg}.
     // Lowercasing it is exactly the cross-version mistake this catches.
     const broken = good.replace('>PNG<', '>png<');
@@ -718,7 +718,7 @@ describe('the validator can fail (mutation proof)', () => {
 
   it('rejects a wrong-typed attribute', async () => {
     const entries = await writeAndUnzip(maximalProject('2.1'));
-    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const good = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
     // `DefaultVisibility` is xs:boolean; "sometimes" is not a boolean.
     const broken = good.replace(
       /DefaultVisibility="[^"]*"/,
@@ -733,7 +733,7 @@ describe('the validator can fail (mutation proof)', () => {
 
   it('rejects a value outside a schema facet range', async () => {
     const entries = await writeAndUnzip(maximalProject('2.1'));
-    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const good = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`)!;
     // 2.1 restricts FieldOfView to [45, 60]; the fixture sits on 60.
     const broken = good.replace(
       /<FieldOfView>[^<]*<\/FieldOfView>/,
@@ -834,7 +834,7 @@ describe('BCF camera cardinality and order', () => {
     cameras: { perspective: boolean; orthogonal: boolean }
   ): Promise<string> {
     const entries = await writeAndUnzip(project(version, cameras));
-    const xml = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`);
+    const xml = entries.get(`${TOPIC_GUID}/viewpoint.bcfv`);
     // Anti-vacuity: every assertion below reads this string, so a writer that
     // stopped emitting the viewpoint entry must fail here, not pass silently.
     expect(xml).toBeDefined();

--- a/packages/bcf/src/writer-viewpoint-filename.ts
+++ b/packages/bcf/src/writer-viewpoint-filename.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** A viewpoint's resolved archive file-name components. */
+export interface ViewpointFileName {
+  /** Full `.bcfv` file name, e.g. `viewpoint.bcfv` or `<guid>_viewpoint.bcfv`. */
+  viewpointFile: string;
+  /** Snapshot base name WITHOUT extension (extension is per-viewpoint format-detected by `snapshotExt` in writer.ts), e.g. `snapshot` or `<guid>_snapshot`. */
+  snapshotBase: string;
+}
+
+/**
+ * Name a viewpoint's archive files. A topic's FIRST viewpoint gets the
+ * conventional names several BCF consumers (e.g. BIMcollab) expect and
+ * assume rather than reading from markup.bcf -- `viewpoint.bcfv` /
+ * `snapshot.<ext>`. Every ADDITIONAL viewpoint in the same topic keeps a
+ * GUID-qualified name, as a SUFFIX (matching BIMcollab's own convention for
+ * a topic's non-primary viewpoints) rather than the previous
+ * `Viewpoint_<guid>.bcfv` prefix form, so multiple viewpoints in one topic
+ * never collide on the plain name (#3612).
+ *
+ * Takes the already-sanitized per-topic base name (see
+ * `sanitizeZipComponent`'s zip-slip guard in writer.ts's `writeTopicFolder`),
+ * not the raw GUID, so a hostile GUID can't escape the topic folder here
+ * either. Names are scoped per topic folder (`writeTopicFolder`'s
+ * `folderName`), so `viewpoint.bcfv` reused across two different topics'
+ * first viewpoints does not collide -- they land in different zip
+ * directories.
+ *
+ * `writeTopicFolder` calls this ONCE per viewpoint and threads the result
+ * through both the markup `<Viewpoint>`/`<Snapshot>` reference writer
+ * (`viewpointXml` in writer.ts) and the archive entry writer
+ * (`writeViewpointFiles`), so the two can never disagree on a name.
+ */
+export function viewpointFileName(baseName: string, index: number): ViewpointFileName {
+  if (index === 0) {
+    return { viewpointFile: 'viewpoint.bcfv', snapshotBase: 'snapshot' };
+  }
+  return { viewpointFile: `${baseName}_viewpoint.bcfv`, snapshotBase: `${baseName}_snapshot` };
+}

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -101,12 +101,13 @@ describe('BCF Writer', () => {
     const blob = await writeBCF(project);
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
 
-    // Check markup references
+    // Check markup references. A topic's FIRST (only) viewpoint gets the
+    // conventional plain name, not a GUID-qualified one (#3612).
     const markupContent = await zip.file(`${topicGuid}/markup.bcf`)?.async('string');
-    expect(markupContent).toContain(`<Viewpoint>Viewpoint_${viewpointGuid}.bcfv</Viewpoint>`);
+    expect(markupContent).toContain(`<Viewpoint>viewpoint.bcfv</Viewpoint>`);
 
     // Check actual viewpoint file exists with same name
-    const viewpointFile = zip.file(`${topicGuid}/Viewpoint_${viewpointGuid}.bcfv`);
+    const viewpointFile = zip.file(`${topicGuid}/viewpoint.bcfv`);
     expect(viewpointFile).not.toBeNull();
 
     const viewpointContent = await viewpointFile?.async('string');
@@ -149,12 +150,13 @@ describe('BCF Writer', () => {
     const blob = await writeBCF(project);
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
 
-    // Check markup references snapshot with correct name
+    // Check markup references snapshot with correct name. First (only)
+    // viewpoint in the topic -> conventional plain name (#3612).
     const markupContent = await zip.file(`${topicGuid}/markup.bcf`)?.async('string');
-    expect(markupContent).toContain(`<Snapshot>Snapshot_${viewpointGuid}.png</Snapshot>`);
+    expect(markupContent).toContain(`<Snapshot>snapshot.png</Snapshot>`);
 
     // Check actual snapshot file exists with same name
-    const snapshotFile = zip.file(`${topicGuid}/Snapshot_${viewpointGuid}.png`);
+    const snapshotFile = zip.file(`${topicGuid}/snapshot.png`);
     expect(snapshotFile).not.toBeNull();
   });
 
@@ -200,14 +202,15 @@ describe('BCF Writer', () => {
     const blob = await writeBCF(project);
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
 
-    // Check both viewpoints exist
-    expect(zip.file(`${topicGuid}/Viewpoint_${viewpoint1Guid}.bcfv`)).not.toBeNull();
-    expect(zip.file(`${topicGuid}/Viewpoint_${viewpoint2Guid}.bcfv`)).not.toBeNull();
+    // The FIRST viewpoint gets the conventional plain name; additional
+    // viewpoints keep a GUID-qualified name, as a SUFFIX (#3612).
+    expect(zip.file(`${topicGuid}/viewpoint.bcfv`)).not.toBeNull();
+    expect(zip.file(`${topicGuid}/${viewpoint2Guid}_viewpoint.bcfv`)).not.toBeNull();
 
     // Check markup references both
     const markupContent = await zip.file(`${topicGuid}/markup.bcf`)?.async('string');
-    expect(markupContent).toContain(`<Viewpoint>Viewpoint_${viewpoint1Guid}.bcfv</Viewpoint>`);
-    expect(markupContent).toContain(`<Viewpoint>Viewpoint_${viewpoint2Guid}.bcfv</Viewpoint>`);
+    expect(markupContent).toContain(`<Viewpoint>viewpoint.bcfv</Viewpoint>`);
+    expect(markupContent).toContain(`<Viewpoint>${viewpoint2Guid}_viewpoint.bcfv</Viewpoint>`);
   });
 
   it('should write components in BCF 2.1 schema order', async () => {
@@ -249,7 +252,7 @@ describe('BCF Writer', () => {
     const blob = await writeBCF(project);
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
 
-    const viewpointContent = await zip.file(`${topicGuid}/Viewpoint_${viewpointGuid}.bcfv`)?.async('string');
+    const viewpointContent = await zip.file(`${topicGuid}/viewpoint.bcfv`)?.async('string');
     expect(viewpointContent).toBeDefined();
 
     // BCF 2.1 schema requires: Selection BEFORE Visibility
@@ -612,8 +615,11 @@ describe('BCF Writer', () => {
   it('sanitizes a path-traversal viewpoint GUID so no zip entry escapes the archive root (zip-slip), and markup agrees with the entry name', async () => {
     // A viewpoint GUID is parsed unvalidated from untrusted markup XML on read
     // (reader.ts parseViewpointContent), so it can carry the same `../` hazard
-    // as a topic GUID. Using it verbatim in `Viewpoint_${guid}.bcfv` would let
+    // as a topic GUID. Using it verbatim in `<guid>_viewpoint.bcfv` would let
     // a crafted GUID write outside the archive root on a read-modify-save.
+    // A topic's FIRST viewpoint no longer embeds the GUID at all (#3612 --
+    // it gets the plain `viewpoint.bcfv` name), so the sanitizer is only
+    // exercised by the filename here through the SECOND (suffixed) viewpoint.
     const evilGuid = '../../evil';
     const topic: BCFTopic = {
       guid: generateUuid(),
@@ -621,6 +627,7 @@ describe('BCF Writer', () => {
       creationDate: new Date().toISOString(),
       creationAuthor: 'attacker@example.com',
       viewpoints: [
+        { guid: 'first-vp' } as BCFViewpoint,
         {
           guid: evilGuid,
         } as BCFViewpoint,
@@ -653,19 +660,28 @@ describe('BCF Writer', () => {
     const markup = await zip.file(markupPath!)?.async('string');
     expect(markup).toContain(`Guid="${evilGuid}"`);
 
-    const viewpointFilenameMatch = markup?.match(/<Viewpoint>([^<]+)<\/Viewpoint>/);
-    expect(viewpointFilenameMatch).toBeTruthy();
-    const referencedFilename = viewpointFilenameMatch![1];
-
-    // The referenced filename must not itself carry a traversal segment...
-    expect(referencedFilename).not.toContain('..');
-    expect(referencedFilename).not.toContain('/');
-
-    // ...and the archive must actually contain an entry under this topic's
-    // folder with that exact filename (markup reference and zip entry agree).
+    // Two viewpoints -> two <Viewpoint>filename</Viewpoint> references; check
+    // BOTH, since the sanitizer only shows up in the SECOND (suffixed) one.
+    const viewpointFilenameMatches = [...(markup?.matchAll(/<Viewpoint>([^<]+)<\/Viewpoint>/g) ?? [])];
+    expect(viewpointFilenameMatches).toHaveLength(2);
     const topicFolder = markupPath!.slice(0, markupPath!.length - 'markup.bcf'.length);
-    const viewpointEntry = zip.file(`${topicFolder}${referencedFilename}`);
-    expect(viewpointEntry).not.toBeNull();
+    for (const match of viewpointFilenameMatches) {
+      const referencedFilename = match[1];
+
+      // The referenced filename must not itself carry a traversal segment...
+      expect(referencedFilename).not.toContain('..');
+      expect(referencedFilename).not.toContain('/');
+
+      // ...and the archive must actually contain an entry under this topic's
+      // folder with that exact filename (markup reference and zip entry agree).
+      const viewpointEntry = zip.file(`${topicFolder}${referencedFilename}`);
+      expect(viewpointEntry).not.toBeNull();
+    }
+    // The first viewpoint gets the plain conventional name; the SANITIZED
+    // (not the raw) evil GUID shows up as a SUFFIX on the second -- no `..`
+    // or `/` reached the file name, only the sanitizer's safe-character output.
+    expect(viewpointFilenameMatches[0][1]).toBe('viewpoint.bcfv');
+    expect(viewpointFilenameMatches[1][1]).toMatch(/^_+evil-[0-9a-f]{8}_viewpoint\.bcfv$/);
   });
 
   it('keeps distinct GUIDs that sanitize identically in distinct folders (no silent overwrite)', async () => {
@@ -769,7 +785,7 @@ describe('BCF Writer', () => {
     const topic = baseTopic({ viewpoints: [vp] });
     const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
-    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    const content = await zip.file(`${topic.guid}/viewpoint.bcfv`)?.async('string');
 
     expect(content).toContain('DefaultVisibility="true"');
     expect(content).not.toContain('DefaultVisibility="false"');
@@ -787,7 +803,7 @@ describe('BCF Writer', () => {
     const topic = baseTopic({ viewpoints: [vp] });
     const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
-    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    const content = await zip.file(`${topic.guid}/viewpoint.bcfv`)?.async('string');
 
     expect(content).toContain('DefaultVisibility="false"');
   });
@@ -833,11 +849,13 @@ describe('BCF Writer', () => {
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
     const markup = await zip.file(`${topic.guid}/markup.bcf`)?.async('string');
 
-    expect(markup).toContain(`<Snapshot>Snapshot_${jpegVp.guid}.jpg</Snapshot>`);
-    expect(markup).toContain(`<Snapshot>Snapshot_${pngVp.guid}.png</Snapshot>`);
+    // jpegVp is the topic's first viewpoint -> plain conventional name;
+    // pngVp is the second -> GUID-qualified suffix name (#3612).
+    expect(markup).toContain(`<Snapshot>snapshot.jpg</Snapshot>`);
+    expect(markup).toContain(`<Snapshot>${pngVp.guid}_snapshot.png</Snapshot>`);
     // The referenced entries must actually exist under those names.
-    expect(zip.file(`${topic.guid}/Snapshot_${jpegVp.guid}.jpg`)).not.toBeNull();
-    expect(zip.file(`${topic.guid}/Snapshot_${pngVp.guid}.png`)).not.toBeNull();
+    expect(zip.file(`${topic.guid}/snapshot.jpg`)).not.toBeNull();
+    expect(zip.file(`${topic.guid}/${pngVp.guid}_snapshot.png`)).not.toBeNull();
   });
 
   it('falls back to CreationAuthor for ModifiedAuthor, which the schema requires alongside ModifiedDate', async () => {
@@ -891,7 +909,7 @@ describe('BCF Writer', () => {
     const topic = baseTopic({ viewpoints: [vp] });
     const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(await writeBCF(project)));
-    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    const content = await zip.file(`${topic.guid}/viewpoint.bcfv`)?.async('string');
 
     // Exact spec spellings — a typo'd attribute is silently ignored by consumers.
     expect(content).toContain('SpacesVisible="true"');
@@ -916,7 +934,7 @@ describe('BCF Writer', () => {
     const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
     const blob = await writeBCF(project);
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
-    const content = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    const content = await zip.file(`${topic.guid}/viewpoint.bcfv`)?.async('string');
     expect(content).toContain('<Color Color="FFFF0000">');
 
     const readVp = (await readBCF(await blob.arrayBuffer())).topics.get(topic.guid)!.viewpoints[0];
@@ -1466,7 +1484,7 @@ describe('BCF Writer', () => {
 
     // The written form really is the element form, not attributes.
     const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
-    const bcfv = await zip.file(`${topic.guid}/Viewpoint_${vp.guid}.bcfv`)?.async('string');
+    const bcfv = await zip.file(`${topic.guid}/viewpoint.bcfv`)?.async('string');
     expect(bcfv).toContain('<OriginatingSystem>Acme Modeller 2026</OriginatingSystem>');
     expect(bcfv).toContain('<AuthoringToolId>wall-4711</AuthoringToolId>');
 
@@ -1675,6 +1693,137 @@ describe('BCF Writer', () => {
     const readProject = await readBCF(await blobToArrayBuffer(blob));
     expect(readProject.name).toBe(name);
     expect(readProject.projectId).toBe(project.projectId);
+  });
+
+  describe('#3612: viewpoint file naming (Solibri/BIMcollab interop)', () => {
+    // Solibri rejected ifc-lite BCF exports while accepting the same topic
+    // re-exported by BIMcollab. Investigation on #3612 narrowed the
+    // difference to viewpoint/snapshot file naming: BIMcollab writes the
+    // conventional `viewpoint.bcfv`/`snapshot.<ext>` for a topic's first (or
+    // only) viewpoint, and a GUID-qualified SUFFIX (`<guid>_viewpoint.bcfv`)
+    // for any additional viewpoint in the same topic -- where ifc-lite wrote
+    // a GUID PREFIX (`Viewpoint_<guid>.bcfv`) for every viewpoint including
+    // the first. Both forms are schema-legal (markup.bcf names the file), but
+    // a reader that assumes the conventional name rather than reading the
+    // reference fails exactly where the prefix form differs from it.
+
+    it('a single-viewpoint topic emits the plain conventional names, matching in markup and archive', async () => {
+      const vp: BCFViewpoint = {
+        guid: generateUuid(),
+        perspectiveCamera: {
+          cameraViewPoint: { x: 0, y: 0, z: 10 },
+          cameraDirection: { x: 0, y: 0, z: -1 },
+          cameraUpVector: { x: 0, y: 1, z: 0 },
+          fieldOfView: 60,
+        },
+        snapshotData: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+      };
+      const topic = baseTopic({ viewpoints: [vp] });
+      const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+
+      const blob = await writeBCF(project);
+      const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+      const markup = await zip.file(`${topic.guid}/markup.bcf`)?.async('string');
+
+      expect(markup).toContain('<Viewpoint>viewpoint.bcfv</Viewpoint>');
+      expect(markup).toContain('<Snapshot>snapshot.png</Snapshot>');
+      expect(zip.file(`${topic.guid}/viewpoint.bcfv`)).not.toBeNull();
+      expect(zip.file(`${topic.guid}/snapshot.png`)).not.toBeNull();
+      // The old prefix form must be gone entirely.
+      expect(markup).not.toContain('Viewpoint_');
+      expect(markup).not.toContain('Snapshot_');
+    });
+
+    it('a multi-viewpoint topic emits the plain names for the first viewpoint and GUID-suffixed names for the rest', async () => {
+      const vp1: BCFViewpoint = { guid: generateUuid(), snapshot: 'data:image/png;base64,AAAA' };
+      const vp2: BCFViewpoint = { guid: generateUuid(), snapshot: 'data:image/png;base64,AAAA' };
+      const vp3: BCFViewpoint = { guid: generateUuid(), snapshot: 'data:image/png;base64,AAAA' };
+      const topic = baseTopic({ viewpoints: [vp1, vp2, vp3] });
+      const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+
+      const blob = await writeBCF(project);
+      const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+      const markup = await zip.file(`${topic.guid}/markup.bcf`)?.async('string');
+
+      // First: plain conventional name.
+      expect(markup).toContain('<Viewpoint>viewpoint.bcfv</Viewpoint>');
+      expect(markup).toContain('<Snapshot>snapshot.png</Snapshot>');
+      expect(zip.file(`${topic.guid}/viewpoint.bcfv`)).not.toBeNull();
+      expect(zip.file(`${topic.guid}/snapshot.png`)).not.toBeNull();
+
+      // Second and third: GUID SUFFIX, not the old PREFIX form.
+      for (const vp of [vp2, vp3]) {
+        expect(markup).toContain(`<Viewpoint>${vp.guid}_viewpoint.bcfv</Viewpoint>`);
+        expect(markup).toContain(`<Snapshot>${vp.guid}_snapshot.png</Snapshot>`);
+        expect(zip.file(`${topic.guid}/${vp.guid}_viewpoint.bcfv`)).not.toBeNull();
+        expect(zip.file(`${topic.guid}/${vp.guid}_snapshot.png`)).not.toBeNull();
+        expect(markup).not.toContain(`Viewpoint_${vp.guid}`);
+        expect(markup).not.toContain(`Snapshot_${vp.guid}`);
+      }
+
+      // Exactly one plain 'viewpoint.bcfv' -- vp2/vp3 must not also collapse to it.
+      const plainCount = (markup!.match(/<Viewpoint>viewpoint\.bcfv<\/Viewpoint>/g) ?? []).length;
+      expect(plainCount).toBe(1);
+    });
+
+    it('two topics each with one viewpoint both emit viewpoint.bcfv in their own directories, without collision', async () => {
+      const vp1: BCFViewpoint = { guid: generateUuid() };
+      const vp2: BCFViewpoint = { guid: generateUuid() };
+      const topicA = baseTopic({ title: 'Topic A', viewpoints: [vp1] });
+      const topicB = baseTopic({ title: 'Topic B', viewpoints: [vp2] });
+      const project: BCFProject = {
+        version: '2.1',
+        topics: new Map([
+          [topicA.guid, topicA],
+          [topicB.guid, topicB],
+        ]),
+      };
+
+      const blob = await writeBCF(project);
+      const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+
+      expect(zip.file(`${topicA.guid}/viewpoint.bcfv`)).not.toBeNull();
+      expect(zip.file(`${topicB.guid}/viewpoint.bcfv`)).not.toBeNull();
+
+      const markupA = await zip.file(`${topicA.guid}/markup.bcf`)?.async('string');
+      const markupB = await zip.file(`${topicB.guid}/markup.bcf`)?.async('string');
+      expect(markupA).toContain('<Viewpoint>viewpoint.bcfv</Viewpoint>');
+      expect(markupB).toContain('<Viewpoint>viewpoint.bcfv</Viewpoint>');
+
+      const vpA = await zip.file(`${topicA.guid}/viewpoint.bcfv`)?.async('string');
+      const vpB = await zip.file(`${topicB.guid}/viewpoint.bcfv`)?.async('string');
+      // Each directory's viewpoint.bcfv carries ITS OWN topic's viewpoint GUID
+      // -- confirming no cross-topic overwrite happened despite the shared name.
+      expect(vpA).toContain(`Guid="${vp1.guid}"`);
+      expect(vpB).toContain(`Guid="${vp2.guid}"`);
+    });
+
+    it('round trip: literal expected filenames survive write -> read, not merely resolvable (a self round-trip alone cannot see an interop naming bug)', async () => {
+      const vp1: BCFViewpoint = { guid: generateUuid(), snapshotData: new Uint8Array([1, 2, 3]) };
+      const vp2: BCFViewpoint = { guid: generateUuid(), snapshotData: new Uint8Array([4, 5, 6]) };
+      const topic = baseTopic({ viewpoints: [vp1, vp2] });
+      const project: BCFProject = { version: '2.1', topics: new Map([[topic.guid, topic]]) };
+
+      const blob = await writeBCF(project);
+      const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+
+      // Assert the LITERAL archive filenames first -- this is what a
+      // convention-based external reader actually looks at, and what a pure
+      // round trip through our own reader cannot distinguish from any other
+      // consistent-with-itself naming scheme.
+      expect(zip.file(`${topic.guid}/viewpoint.bcfv`)).not.toBeNull();
+      expect(zip.file(`${topic.guid}/snapshot.png`)).not.toBeNull();
+      expect(zip.file(`${topic.guid}/${vp2.guid}_viewpoint.bcfv`)).not.toBeNull();
+      expect(zip.file(`${topic.guid}/${vp2.guid}_snapshot.png`)).not.toBeNull();
+
+      // THEN confirm our own reader still resolves both viewpoints correctly.
+      const readTopic = (await readBCF(await blobToArrayBuffer(blob))).topics.get(topic.guid)!;
+      expect(readTopic.viewpoints).toHaveLength(2);
+      const readVp1 = readTopic.viewpoints.find((v) => v.guid === vp1.guid)!;
+      const readVp2 = readTopic.viewpoints.find((v) => v.guid === vp2.guid)!;
+      expect(readVp1.snapshot).toMatch(/^data:image\/png;base64,/);
+      expect(readVp2.snapshot).toMatch(/^data:image\/png;base64,/);
+    });
   });
 
 });

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -42,6 +42,7 @@ import {
   xsdRequiredString,
 } from './xsd-required-string.js';
 import { generateUuid } from '@ifc-lite/encoding';
+import { viewpointFileName, type ViewpointFileName } from './writer-viewpoint-filename.js';
 
 /**
  * Write a BCFProject to a .bcfzip file
@@ -205,6 +206,10 @@ async function writeTopicFolder(
     sanitizeZipComponent(vp.guid, usedViewpointNames, 'viewpoint'),
   );
 
+  // Derive the actual archive file names ONCE, so viewpointXml (markup) and
+  // writeViewpointFiles (archive entry) can never disagree (#3612).
+  const viewpointFileNames = viewpointBaseNames.map((baseName, i) => viewpointFileName(baseName, i));
+
   // Resolve each viewpoint's snapshot ONCE, before markup.bcf is written, so
   // the `<Snapshot>` reference and the archive entry it names are driven off
   // the SAME decode attempt and can never disagree (#3962): previously the
@@ -214,11 +219,11 @@ async function writeTopicFolder(
   const snapshotBytes = topic.viewpoints.map((vp) => resolveSnapshotBytes(vp));
 
   // Write markup.bcf
-  writeMarkupFile(zip, folderName, topic, version, viewpointBaseNames, snapshotBytes);
+  writeMarkupFile(zip, folderName, topic, version, viewpointFileNames, snapshotBytes);
 
   // Write viewpoints
   for (let i = 0; i < topic.viewpoints.length; i++) {
-    await writeViewpointFiles(zip, folderName, topic.viewpoints[i], viewpointBaseNames[i], version, snapshotBytes[i]);
+    await writeViewpointFiles(zip, folderName, topic.viewpoints[i], viewpointFileNames[i], version, snapshotBytes[i]);
   }
 }
 
@@ -279,7 +284,7 @@ function writeMarkupFile(
   zip: JSZip, folderName: string,
   topic: BCFTopic,
   version: '2.1' | '3.0',
-  viewpointBaseNames: string[],
+  viewpointFileNames: ViewpointFileName[],
   snapshotBytes: (Uint8Array | undefined)[],
 ): void {
   // BCF 3.0's markup.xsd tightens `Topic/@TopicType` and `Topic/@TopicStatus`
@@ -454,14 +459,11 @@ function writeMarkupFile(
   const viewpointXml = (indent: string) =>
     topic.viewpoints
       .map((viewpoint, i) => {
-        // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv,
-        // but the file name component is the sanitized base name (zip-slip
-        // guard) -- the SAME one writeViewpointFiles uses for the actual entry,
-        // so the markup reference and the archive agree. The real GUID is still
-        // written verbatim as the Guid attribute below.
-        const baseName = viewpointBaseNames[i];
-        const filename = `Viewpoint_${baseName}.bcfv`;
-        const snapshotName = `Snapshot_${baseName}.${snapshotExt(viewpoint)}`;
+        // Shared viewpointFileName() result (#3612) -- the SAME one
+        // writeViewpointFiles uses, so the two can never disagree. The real
+        // GUID is still written verbatim as the Guid attribute below.
+        const filename = viewpointFileNames[i].viewpointFile;
+        const snapshotName = `${viewpointFileNames[i].snapshotBase}.${snapshotExt(viewpoint)}`;
 
         let v = `\n${indent}<${viewpointEntryTag} Guid="${escapeXml(viewpoint.guid)}">`;
         v += `\n${indent}  <Viewpoint>${filename}</Viewpoint>`;
@@ -511,16 +513,14 @@ function writeMarkupFile(
 async function writeViewpointFiles(
   zip: JSZip, folderName: string,
   viewpoint: BCFViewpoint,
-  baseName: string,
+  fileNames: ViewpointFileName,
   version: '2.1' | '3.0',
   snapshot: Uint8Array | undefined,
 ): Promise<void> {
-  // Use standard buildingSMART naming convention: Viewpoint_<guid>.bcfv, but
-  // the file name component is the sanitized base name (zip-slip guard) --
-  // the SAME one the caller wrote into the markup <Viewpoint> reference, so
-  // the archive entry and the markup agree. See sanitizeZipComponent.
-  const filename = `Viewpoint_${baseName}.bcfv`;
-  const snapshotName = `Snapshot_${baseName}.${snapshotExt(viewpoint)}`;
+  // Shared viewpointFileName() result (#3612) -- the SAME one the caller
+  // wrote into the markup reference, so the two can never disagree.
+  const filename = fileNames.viewpointFile;
+  const snapshotName = `${fileNames.snapshotBase}.${snapshotExt(viewpoint)}`;
 
   // Write viewpoint XML - use buildingSMART standard format
   let content = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Status — relative to #3612

This addresses ONE of the two hypotheses currently under test on #3612 for why Solibri rejects an ifc-lite BCF export while accepting the same topic re-exported by BIMcollab: the viewpoint/snapshot **filename convention**. The other hypothesis (`TopicStatus`/`Priority` vocabulary) is untouched here and is being tested in parallel on the issue.

Not closing #3612: nobody has yet confirmed against Solibri which of the two remaining candidates is the actual trigger.

Refs #3612

Requesting the `unqueued` label from @louistrue below, since this should not auto-close the issue on merge — no longer needed once #4161 (which accepts a line-starting `Refs #N`) lands, since this reference will then qualify on its own.

## The evidence

Both the rejected ifc-lite archive and the accepted BIMcollab archive are schema-valid, and every markup reference in both resolves to a real zip entry — so this isn't a conformance defect on either side. Comparing the same topic (same topic GUID, same viewpoint GUIDs) re-exported by both tools narrows the difference to naming:

- BIMcollab: a topic's first (or only) viewpoint gets the plain conventional names `viewpoint.bcfv` / `snapshot.<ext>`; an additional viewpoint in the same topic gets a GUID-qualified **suffix** (`<guid>_viewpoint.bcfv`).
- ifc-lite (before this PR): every viewpoint, including a topic's first, got a GUID **prefix** (`Viewpoint_<guid>.bcfv`).

Both forms are schema-legal — `markup.bcf` names the file explicitly — but a reader that assumes the conventional plain name rather than following the reference would fail exactly on the prefix form and succeed on the suffix form, which is consistent with what was observed.

## The fix

`writeTopicFolder` (`packages/bcf/src/writer.ts`) now computes each viewpoint's archive file name **once**, via a new `viewpointFileName()` helper, and threads the same array through both:
- `writeMarkupFile` (the markup `<Viewpoint>`/`<Snapshot>` reference), and
- `writeViewpointFiles` (the actual archive entry).

Previously each site independently formatted `Viewpoint_${baseName}.bcfv` from a shared base name — two separate string-formatting call sites computing what should always be the same value. The invariant (markup reference and archive entry must always agree) is preserved, and is now structurally harder to violate since there's one function computing the name rather than two call sites formatting it identically by convention.

`viewpointFileName()` lives in a new sibling module, `packages/bcf/src/writer-viewpoint-filename.ts`, because `writer.ts` sits at its allowlisted module-size budget.

Viewpoint/snapshot names are scoped per topic folder, so two different topics each naming their first viewpoint `viewpoint.bcfv` do not collide — confirmed by a dedicated test.

## Tests

Added a `#3612` test block to `writer.test.ts` covering:
1. A single-viewpoint topic emits `viewpoint.bcfv`/`snapshot.png`, matching in markup and archive.
2. A multi-viewpoint topic emits the plain names for the first viewpoint and GUID-suffixed names for the rest.
3. Two topics, each with one viewpoint, both emit `viewpoint.bcfv` in their own directories without collision.
4. A round trip that asserts the **literal** archive file names first, then confirms the package's own reader still resolves both viewpoints — a pure round trip alone can't see this class of bug, since the reader already tries several naming conventions as a fallback when a reference doesn't resolve as given.

Updated every pre-existing assertion in `writer.test.ts`, `schema-validation.test.ts`, and `dangling-snapshot-reference.test.ts` that hardcoded the old `Viewpoint_<guid>.bcfv`/`Snapshot_<guid>.<ext>` form for a topic's (previously only) viewpoint.

**Mutation check:** reverting `viewpointFileName()` to the old prefix form for every viewpoint turns 36 tests red (434/470 passing); restoring the fix returns to 470/470 green. Confirmed the mutation actually applied via `diff` against the pre-mutation file before running tests.

## Verification run

- `turbo build test typecheck --filter=@ifc-lite/bcf`: 470/470 tests passing, typecheck clean (test sources included).
- `node scripts/check-module-size.mjs`: exit 0 (`writer.ts` at exactly its 753-line allowlisted budget after extracting the new naming logic to a sibling module).
- `node scripts/check-changesets.mjs`: passes; changeset added (`@ifc-lite/bcf` patch).

## Scope

Deliberately does not touch `TopicStatus`/`Priority` vocabulary — that's the other hypothesis under test on #3612, and mixing the two would make the reporter's confirmation uninterpretable.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected BCF viewpoint and snapshot filenames to follow standard naming conventions.
  - Ensured viewpoint references consistently match the corresponding files in exported archives.
  - Improved handling of multiple viewpoints, including safer names and GUID-based suffixes.
  - Fixed cases where snapshot references could point to unavailable archive entries.

- **Compatibility**
  - Updated generated archives to use conventional names such as `viewpoint.bcfv` and `snapshot.<ext>`, improving interoperability with compatible BCF tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- unqueued label applied; re-firing the pull_request `edited` event so the gate sees a payload containing it. A label alone fires nothing, and a rerun replays the stale payload. -->
