### PR TITLE
fix(ci): let a pure version-bump manifest diff pass the revert oracle

### DIFF
--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -87,6 +87,7 @@ import {
   SURGICAL_ADVICE,
 } from './lib/revert-oracle.mjs';
 import { isDependabotDependencyOnly } from './lib/revert-oracle-dependabot.mjs';
+import { isVersionOnlyManifestDiff } from './lib/revert-oracle-version-bump.mjs';
 import { requiredFeaturePlanOrDie, EXIT_UNHANDLED_CFG_SHAPE } from './lib/revert-oracle-rust-features.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 import { planRuns } from './lib/revert-oracle-plan-runs.mjs';
@@ -265,6 +266,25 @@ if (opts.ci && isDependabotDependencyOnly(process.env.PR_AUTHOR_LOGIN, entries))
 
 const { production, test: testEntries, ignored, warnings } = classifyDiff(entries);
 for (const w of warnings) console.log(`  WARNING: ${w}`);
+
+// The changesets release PR ("chore: version packages") changes only
+// package.json `"version"` fields and the matching Cargo.toml version
+// literals — no test can observe a version bump. `isVersionOnlyManifestDiff`
+// checks the actual diff content of every `production` file (not just its
+// name), so a real dependency/scripts/exports edit in the same file still
+// requires a test as before. See revert-oracle-version-bump.mjs for the
+// full rationale and the false-negative it is written against.
+if (
+  opts.ci &&
+  production.length > 0 &&
+  production.every((e) => isVersionOnlyManifestDiff(e.path, gitOrDie(['diff', '-U0', mergeBase, headSha, '--', e.path])))
+) {
+  console.log(
+    '  NOT APPLICABLE: every production file is a package.json/Cargo.toml version-only bump ' +
+      '(release PR shape); nothing a test could observe.',
+  );
+  process.exit(0);
+}
 
 let prodPaths = production.map((e) => e.path);
 if (opts.only.length > 0) {

--- a/scripts/lib/revert-oracle-version-bump.mjs
+++ b/scripts/lib/revert-oracle-version-bump.mjs
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The automated changesets release PR (`chore: version packages`) touches
+ * only `package.json` `"version"` fields, the workspace `Cargo.toml`'s own
+ * `version = "..."` and the matching version literal on each internal
+ * `ifc-lite-*` path-dependency line, plus generated `CHANGELOG.md` /
+ * `.changeset/*.md` (already `ignored` by `classifyPath`). No test can
+ * observe a version literal, so `check-test-revert-oracle.mjs` aborts every
+ * release cycle with "changes production code and adds/changes NO test
+ * file" — a standing false positive, not a real finding (see the release-PR
+ * cluster: #3357, #4018 both failed here; #3950 needed a manual
+ * `revert-oracle-exempt` label to get through).
+ *
+ * THE DANGER THIS MODULE IS WRITTEN AGAINST. `package.json` and `Cargo.toml`
+ * also carry dependency versions, `scripts`, and `exports` — a change to any
+ * of those IS production and must keep counting. In particular Cargo.toml
+ * writes plenty of external deps in the same `{ version = "...", features =
+ * [...] }` table form as the internal path deps (axum, tokio, serde, ...), so
+ * "only a version literal changed on this line" is NOT enough by itself: an
+ * external dependency bump (axum 0.8 -> 0.9) has the exact same line shape as
+ * an internal workspace crate bump (ifc-lite-core 9.3.0 -> 9.4.0). The
+ * discriminator is `path = "..."` on the same line: only the workspace's own
+ * crates are referenced via a path dependency, so a line lacking `path =` is
+ * never treated as version-only here.
+ *
+ * Pure functions over diff text, same shape as `revert-oracle.mjs`, so this
+ * is tested against synthetic fixtures without touching git.
+ */
+
+const NPM_MANIFEST_RE = /(^|\/)package\.json$/;
+const CARGO_MANIFEST_RE = /(^|\/)Cargo\.toml$/;
+
+/** Split zero-context (`git diff -U0`) output into per-hunk removed/added line groups. */
+function extractHunks(diffText) {
+  const hunks = [];
+  let removed = [];
+  let added = [];
+  const flush = () => {
+    if (removed.length > 0 || added.length > 0) hunks.push({ removed, added });
+    removed = [];
+    added = [];
+  };
+  for (const line of diffText.split('\n')) {
+    if (line.startsWith('@@')) {
+      flush();
+      continue;
+    }
+    if (line.startsWith('--- ') || line.startsWith('+++ ')) continue;
+    if (line.startsWith('-')) removed.push(line.slice(1));
+    else if (line.startsWith('+')) added.push(line.slice(1));
+  }
+  flush();
+  return hunks;
+}
+
+/** `"version": "1.40.0"` -> `"version": "1.40.1"`, nothing else on the line. */
+function npmVersionOnly(oldLine, newLine) {
+  const RE = /^(\s*"version":\s*")([^"]*)("\s*,?\s*)$/;
+  const om = oldLine.match(RE);
+  const nm = newLine.match(RE);
+  if (!om || !nm) return false;
+  return om[1] === nm[1] && om[3] === nm[3];
+}
+
+/** A bare `version = "9.3.0"` line (the workspace's own `[workspace.package]` version). */
+function cargoBareVersionOnly(oldLine, newLine) {
+  const RE = /^(\s*)version(\s*=\s*")([^"]*)("\s*)$/;
+  const om = oldLine.match(RE);
+  const nm = newLine.match(RE);
+  if (!om || !nm) return false;
+  return om[1] === nm[1] && om[2] === nm[2] && om[4] === nm[4];
+}
+
+/**
+ * A `name = { version = "9.3.0", path = "...", ... }` line. Requires `path =`
+ * on the SAME line — the discriminator that keeps a real external dependency
+ * bump (which never carries `path =`) from matching.
+ */
+function cargoPathVersionOnly(oldLine, newLine) {
+  const PATH_RE = /\bpath\s*=\s*"/;
+  const VERSION_KV = /version\s*=\s*"[^"]*"/;
+  if (!PATH_RE.test(oldLine) || !PATH_RE.test(newLine)) return false;
+  if (!VERSION_KV.test(oldLine) || !VERSION_KV.test(newLine)) return false;
+  const oldNorm = oldLine.replace(VERSION_KV, 'version = "#"');
+  const newNorm = newLine.replace(VERSION_KV, 'version = "#"');
+  return oldNorm === newNorm;
+}
+
+/**
+ * @param {string} path repo-relative path of the changed file
+ * @param {string} diffText `git diff -U0 <base> <head> -- <path>` output
+ * @returns {boolean} true only if every changed line is a version-literal
+ *   substitution in a position this module recognizes as the file's own (or,
+ *   for Cargo.toml, a path-dependency's) version — never a dependency add/
+ *   remove, script, export, or any other field.
+ */
+export function isVersionOnlyManifestDiff(path, diffText) {
+  const isNpm = NPM_MANIFEST_RE.test(path);
+  const isCargo = CARGO_MANIFEST_RE.test(path);
+  if (!isNpm && !isCargo) return false;
+  const hunks = extractHunks(diffText);
+  if (hunks.length === 0) return false;
+  for (const { removed, added } of hunks) {
+    if (removed.length === 0 || added.length === 0) return false;
+    if (removed.length !== added.length) return false;
+    for (let i = 0; i < removed.length; i++) {
+      const ok = isNpm
+        ? npmVersionOnly(removed[i], added[i])
+        : cargoBareVersionOnly(removed[i], added[i]) || cargoPathVersionOnly(removed[i], added[i]);
+      if (!ok) return false;
+    }
+  }
+  return true;
+}

--- a/scripts/lib/revert-oracle-version-bump.test.mjs
+++ b/scripts/lib/revert-oracle-version-bump.test.mjs
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isVersionOnlyManifestDiff } from './revert-oracle-version-bump.mjs';
+
+test('npm: a bare version bump is version-only', () => {
+  const diff = [
+    '--- a/packages/cli/package.json',
+    '+++ b/packages/cli/package.json',
+    '@@ -3 +3 @@',
+    '-  "version": "0.28.0",',
+    '+  "version": "0.28.1",',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('packages/cli/package.json', diff), true);
+});
+
+test('npm: a script change alongside the version bump is NOT version-only', () => {
+  const diff = [
+    '--- a/packages/cli/package.json',
+    '+++ b/packages/cli/package.json',
+    '@@ -3 +3 @@',
+    '-  "version": "0.28.0",',
+    '+  "version": "0.28.1",',
+    '@@ -20 +20 @@',
+    '-    "build": "pnpm exec tsc",',
+    '+    "build": "pnpm exec tsc --sourcemap",',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('packages/cli/package.json', diff), false);
+});
+
+test('npm: a dependency version literal under a non-"version" key is NOT version-only', () => {
+  // Not this repo's convention (internal deps use workspace:^), but any file
+  // where a dependency happens to pin a literal version must still count.
+  const diff = [
+    '--- a/apps/server/package.json',
+    '+++ b/apps/server/package.json',
+    '@@ -10 +10 @@',
+    '-    "left-pad": "1.3.0",',
+    '+    "left-pad": "1.3.1",',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('apps/server/package.json', diff), false);
+});
+
+test('cargo: the bare [workspace.package] version bump is version-only', () => {
+  const diff = [
+    '--- a/Cargo.toml',
+    '+++ b/Cargo.toml',
+    '@@ -7 +7 @@',
+    '-version = "9.3.0"',
+    '+version = "9.4.0"',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('Cargo.toml', diff), true);
+});
+
+test('cargo: an internal path-dependency version bump is version-only', () => {
+  const diff = [
+    '--- a/Cargo.toml',
+    '+++ b/Cargo.toml',
+    '@@ -14 +14 @@',
+    '-ifc-lite-core = { version = "9.3.0", path = "rust/core" }',
+    '+ifc-lite-core = { version = "9.4.0", path = "rust/core" }',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('Cargo.toml', diff), true);
+});
+
+test('cargo: an EXTERNAL dependency version bump (same {version=..} shape, no path=) is NOT version-only', () => {
+  // The exact false-negative this module is written against: axum has no
+  // `path =`, so it must never be swept up with the internal crate bumps.
+  const diff = [
+    '--- a/apps/server/Cargo.toml',
+    '+++ b/apps/server/Cargo.toml',
+    '@@ -30 +30 @@',
+    '-axum = { version = "0.8", features = ["multipart", "tokio"] }',
+    '+axum = { version = "0.9", features = ["multipart", "tokio"] }',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('apps/server/Cargo.toml', diff), false);
+});
+
+test('cargo: rust-version (MSRV) is not mistaken for the bare version key', () => {
+  const diff = [
+    '--- a/Cargo.toml',
+    '+++ b/Cargo.toml',
+    '@@ -8 +8 @@',
+    '-rust-version = "1.75"',
+    '+rust-version = "1.80"',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('Cargo.toml', diff), false);
+});
+
+test('cargo: a features change hiding behind a version bump on the same line is NOT version-only', () => {
+  const diff = [
+    '--- a/rust/wasm-bindings/Cargo.toml',
+    '+++ b/rust/wasm-bindings/Cargo.toml',
+    '@@ -45 +45 @@',
+    '-ifc-lite-geometry = { version = "9.3.0", path = "../geometry", default-features = false, features = [] }',
+    '+ifc-lite-geometry = { version = "9.4.0", path = "../geometry", default-features = false, features = ["extra"] }',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('rust/wasm-bindings/Cargo.toml', diff), false);
+});
+
+test('cargo: a wholly new dependency line (add, no matching removal) is NOT version-only', () => {
+  const diff = [
+    '--- a/Cargo.toml',
+    '+++ b/Cargo.toml',
+    '@@ -19 +19,2 @@',
+    ' ifc-lite-wasm = { version = "9.3.0", path = "rust/wasm-bindings" }',
+    '+ifc-lite-new = { version = "9.3.0", path = "rust/new" }',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('Cargo.toml', diff), false);
+});
+
+test('cargo: one line replaced by two (mismatched nonzero remove/add counts) is NOT version-only', () => {
+  const diff = [
+    '--- a/Cargo.toml',
+    '+++ b/Cargo.toml',
+    '@@ -14 +14,2 @@',
+    '-ifc-lite-core = { version = "9.3.0", path = "rust/core" }',
+    '+ifc-lite-core = { version = "9.4.0", path = "rust/core" }',
+    '+ifc-lite-new = { version = "9.4.0", path = "rust/new" }',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('Cargo.toml', diff), false);
+});
+
+test('a non-manifest file is never version-only regardless of content', () => {
+  const diff = ['--- a/packages/cli/src/index.ts', '+++ b/packages/cli/src/index.ts', '@@ -1 +1 @@', '-1.0.0', '+1.0.1'].join(
+    '\n',
+  );
+  assert.equal(isVersionOnlyManifestDiff('packages/cli/src/index.ts', diff), false);
+});
+
+test('an empty diff (no hunks) is not version-only', () => {
+  assert.equal(isVersionOnlyManifestDiff('package.json', ''), false);
+});

--- a/scripts/lib/revert-oracle-version-bump.test.mjs
+++ b/scripts/lib/revert-oracle-version-bump.test.mjs
@@ -135,3 +135,20 @@ test('a non-manifest file is never version-only regardless of content', () => {
 test('an empty diff (no hunks) is not version-only', () => {
   assert.equal(isVersionOnlyManifestDiff('package.json', ''), false);
 });
+
+test('a non-manifest file whose diff has the bare cargo version-line shape is NOT version-only', () => {
+  // Pins the `if (!isNpm && !isCargo) return false;` guard: this line shape
+  // (`version = "9.3.0"` -> `version = "9.4.0"`) is exactly what
+  // cargoBareVersionOnly() accepts on Cargo.toml, so without the guard a
+  // non-manifest file (e.g. a Rust source file that happens to define its
+  // own build-time version constant) would fall into the cargo matcher and
+  // be wrongly exempted from the revert oracle.
+  const diff = [
+    '--- a/rust/core/src/build_info.rs',
+    '+++ b/rust/core/src/build_info.rs',
+    '@@ -12 +12 @@',
+    '-version = "9.3.0"',
+    '+version = "9.4.0"',
+  ].join('\n');
+  assert.equal(isVersionOnlyManifestDiff('rust/core/src/build_info.rs', diff), false);
+});


### PR DESCRIPTION
## Summary

The automated changesets release PR (`chore: version packages`, e.g. #4018, #3357) fails `Changed tests observe production` every cycle:

```
[revert-oracle] does this branch's test actually observe this branch's change?
  files: 22 production, 0 test, 48 ignored
[revert-oracle] ABORT: this branch changes production code and adds/changes NO test file.
```

I verified the actual diff content of #4018 (and prior release PRs) — every `production`-classified file is a `package.json`/`Cargo.toml` with only its own `"version"` field changed. Nothing a test could observe. #3950 got past this only because a maintainer manually applied the `revert-oracle-exempt` label; #3357 was merged with the check failing outright. This is a standing false positive on a PR that carries no reviewable behavior, not a real finding.

## Fix

- `scripts/lib/revert-oracle-version-bump.mjs` (new): `isVersionOnlyManifestDiff(path, diffText)` classifies a manifest diff as version-only by inspecting the **changed lines themselves**, not the filename — a bare `"version"` key (npm, or Cargo's `[workspace.package]`), or a version literal on a Cargo.toml line that also carries `path = "..."` (the shape unique to this workspace's own path-dependency cross-references).

  **The danger this guards against**: `package.json`/`Cargo.toml` also carry dependency versions, `scripts`, and `exports` — a change to those is real production and must keep requiring a test. Cargo.toml in particular writes plenty of *external* deps in the same `{ version = "...", features = [...] }` table shape as the internal `ifc-lite-*` crates (axum, tokio, serde, ...). A line without `path =` is never treated as version-only, so an external dependency bump (`axum = { version = "0.8", ... }` -> `"0.9"`) — which has the exact same line shape as an internal crate bump — still counts as production and still needs a test. Any scripts/exports/dependency edit sharing a file with a version bump still aborts as before.

- `scripts/check-test-revert-oracle.mjs`: one new early exit, placed right next to the existing `isDependabotDependencyOnly` check it mirrors — only when **every** `production`-classified file is a version-only manifest diff does it print `NOT APPLICABLE` and exit 0. A single real code change anywhere in the diff makes `.every()` false and the branch falls through to the normal (correct) abort.

## Why not the existing `revert-oracle-exempt` label?

That mechanism exists and works (used on #3950), but it requires a human to notice and apply it to a machine-generated, auto-updating PR branch every release cycle — and #3357/#4018 show that doesn't happen reliably. This fix makes the release PR shape unconditionally pass the check on its own evidence, no manual step needed, while leaving the label mechanism untouched for everything else it's used for.

## Testing

`node --test scripts/lib/revert-oracle-version-bump.test.mjs` — 12/12 pass, including the negative case for the exact false-negative described above (external dep bump, MSRV `rust-version`, a features change riding along with a version bump, mismatched add/remove line counts). Verified against the **real diff content of PR #4018** (`packages/cli/package.json`, root `Cargo.toml`) — both correctly classify as version-only.

Mutation-tested: removing the `path =` guard turns 2 tests red; removing the remove/add line-count-equality guard turns 1 test red. Both restored to green after confirming red.

`node scripts/check-module-size.mjs`: OK (`check-test-revert-oracle.mjs` at 585/621 lines, `revert-oracle.mjs` untouched at its 528-line budget). `node scripts/check-test-wiring.mjs`: OK. Full `scripts/lib/*.test.mjs` suite: 541/541 pass.

## Scope / conflicts

Does **not** touch `scripts/lib/revert-oracle.mjs` (the 528-line-budgeted classifier) or `classifyPath`/`classifyDiff` at all — this is a new sibling module plus a ~20-line early-exit in `check-test-revert-oracle.mjs`. It will very likely **textually conflict** with #4140 and #4141 (both also edit `check-test-revert-oracle.mjs` around related "inert"/classification logic) — I did not touch their insertion points, but a rebase will probably be needed once one of them lands. #4131, #4142, #4145 only touch `revert-oracle.mjs`/`revert-oracle.test.mjs` and shouldn't conflict.

## Issue queue

I could not find an open `ready` issue covering this specific failure (checked #4137, #4142 and the general revert-oracle cluster — related but about different classification gaps). Refs #3357 #4018 as the observed failures. Requesting `unqueued` from @louistrue since this doesn't close a `ready` issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- unqueued label applied; re-firing the pull_request `edited` event so the gate sees a payload containing it. A label alone fires nothing, and a rerun replays the stale payload. -->
