### PR TITLE
fix(cli): never keep a phantom id, and keep a relation-private IfcOwnerHistory instead of dropping containment (#4128, #4126)

### DIFF
--- a/.changeset/tidy-eels-refuse.md
+++ b/.changeset/tidy-eels-refuse.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`extract-entities` no longer loses spatial containment when a relation owns a
+private `IfcOwnerHistory`, and no longer emits a reference to an id the source
+file never defines.
+
+The relation planner now reports the unkept references that block a relation
+which would otherwise survive, and `buildSubset` keeps them and replans, so an
+exporter that writes one `IfcOwnerHistory` per relationship keeps its storey
+contents instead of extracting an orphaned storey (#4126). The forward closure
+no longer adds an id that is referenced but never defined, which is what stops a
+phantom id, such as `#999` read out of a `'C1 see #999'` Name, from surviving
+into a rewritten `RelatedElements` set (#4128).

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -406,9 +406,92 @@ describe('buildSubset: a relation reference outside the rewritten SET', () => {
   const p = parseStep(STOREY_MODEL_REL_OWNED);
   const { keep, rewritten } = buildSubset(new Set([70, 72]), p);
 
-  it('drops the relation rather than emitting a dangling OwnerHistory', () => {
-    // #6 is reachable from nothing the subset keeps, and the rewrite only
-    // touches RelatedElements, so emitting #80 would leave `#6` undefined.
+  it('keeps the private OwnerHistory instead of dropping the containment', () => {
+    // This used to assert that #80 was DROPPED, on the reasoning that a
+    // dangling `#6` is worse than a missing relation. Both are avoidable: #6 is
+    // reachable from nothing else the subset keeps, so the plan reports it as
+    // the one thing blocking #80, `buildSubset` closes over it and replans, and
+    // the storey keeps its contents (#4126).
+    expect(keep.has(6)).toBe(true);
+    expect(keep.has(80)).toBe(true);
+    expect(rewritten.get(80)).toContain('(#70,#72)');
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset({ keep, rewritten }, p);
+    expectNoDanglingRefs(out);
+    expect(out).toContain('#6=');
+    expect(out).toContain('#80=');
+  });
+});
+
+// The same shape, but the private OwnerHistory owns a SUBTREE. Closing over the
+// blocking id alone would keep #6 and dangle on the four records it names.
+const STOREY_MODEL_REL_OWNED_SUBTREE = STOREY_MODEL.replace(
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#5,",
+  "#6= IFCOWNERHISTORY(#7,#8,$,.ADDED.,$,$,$,0);\n" +
+    '#7= IFCPERSONANDORGANIZATION(#9,#10,$);\n' +
+    "#9= IFCPERSON($,'p',$,$,$,$,$,$);\n" +
+    "#10= IFCORGANIZATION($,'o',$,$,$);\n" +
+    "#8= IFCAPPLICATION(#10,'1','app','app');\n" +
+    "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#6,",
+);
+
+describe('buildSubset: a private OwnerHistory that owns a subtree', () => {
+  const p = parseStep(STOREY_MODEL_REL_OWNED_SUBTREE);
+  const { keep, rewritten } = buildSubset(new Set([70, 72]), p);
+
+  it('keeps the whole OwnerHistory subtree, not just the blocking id', () => {
+    expect(keep.has(80)).toBe(true);
+    for (const id of [6, 7, 8, 9, 10]) expect(keep.has(id)).toBe(true);
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset({ keep, rewritten }, p);
+    expectNoDanglingRefs(out);
+    expect(out).toContain('#80=');
+  });
+});
+
+// The OTHER storey's containment carries the private OwnerHistory, and the
+// selection touches neither of its products. #82's relating parent #45 IS kept
+// (every storey is a force-kept context root), so only the empty member
+// intersection stands between #82 and the blocked path.
+const STOREY_MODEL_UNRELATED_REL_OWNED = STOREY_MODEL.replace(
+  "#82= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000002',#5,",
+  "#7= IFCOWNERHISTORY($,$,$,.ADDED.,$,$,$,0);\n" +
+    "#82= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000002',#7,",
+);
+
+describe('buildSubset: a dropped relation does not drag its OwnerHistory in', () => {
+  const p = parseStep(STOREY_MODEL_UNRELATED_REL_OWNED);
+  const { keep } = buildSubset(new Set([70, 72]), p);
+
+  it('reports nothing for a relation the kept intersection already dropped', () => {
+    // The intersection is tested BEFORE the OwnerHistory loop for this reason.
+    // Reversed, #7 is reported as blocking, force-kept, and emitted into the
+    // file as an IfcOwnerHistory nothing references.
+    expect(keep.has(82)).toBe(false);
+    expect(keep.has(7)).toBe(false);
+  });
+});
+
+// The PHANTOM variant, and the reason the two fixes are one change: #80 names an
+// OwnerHistory #6 that no line DEFINES. The replan asks `forwardClosure` for #6,
+// and if the closure could add an undefined id to `keep` (the #4128 defect), the
+// second plan would find every reference "kept" and emit #80 with a dangling
+// `#6`, a worse output than the drop this replaces. Keeping the subset to
+// DEFINED ids is what makes #6 stay unkept and #80 stay dropped.
+const STOREY_MODEL_REL_PHANTOM_OWNER = STOREY_MODEL.replace(
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#5,",
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#6,",
+);
+
+describe('buildSubset: a relation whose OwnerHistory is never defined', () => {
+  const p = parseStep(STOREY_MODEL_REL_PHANTOM_OWNER);
+  const { keep, rewritten } = buildSubset(new Set([70, 72]), p);
+
+  it('drops the relation rather than emitting a reference to nothing', () => {
     expect(keep.has(6)).toBe(false);
     expect(keep.has(80)).toBe(false);
   });
@@ -416,6 +499,7 @@ describe('buildSubset: a relation reference outside the rewritten SET', () => {
   it('serializes with zero dangling references', () => {
     const out = serializeSubset({ keep, rewritten }, p);
     expectNoDanglingRefs(out);
+    expect(out).not.toContain('#80=');
   });
 });
 
@@ -431,7 +515,7 @@ describe('planSpatialRelations: a record it cannot scan, or cannot read as six a
   const emit = (inst: ReturnType<typeof record>, keep: Set<number>): string => {
     const plan = planSpatialRelations([inst], keep);
     return serializeSubset(
-      { keep: new Set([...plan.add]), rewritten: plan.rewritten },
+      { keep: new Set(plan.add), rewritten: plan.rewritten },
       { header: 'DATA;\n', instances: new Map([[inst.id, inst]]), guidToId: new Map() },
     );
   };

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -362,6 +362,38 @@ describe('buildSubset: a `#` inside a relation Name is TEXT, not a reference', (
   // case above is the one that fails if `#71` is read out of the name.
 });
 
+// Same shape as the fixture above, but the `#` in the Name names an id the file
+// never DEFINES, and the containment's SET names it too. That is invalid STEP,
+// and it is the input that separates "kept" from "defined": `forwardClosure`
+// used to add #999 to `keep` on the way to looking it up, after which the SET
+// intersection (which tests `keep` alone) saw a full house and re-emitted
+// `(#70,#999)` verbatim, naming an id no line defines (#4128).
+const STOREY_MODEL_PHANTOM_MEMBER = STOREY_MODEL.replace("'Chair 1'", "'C1 see #999'").replace(
+  '(#70,#71,#72,#73),#41)',
+  '(#70,#999),#41)',
+);
+
+describe('buildSubset: an id that is REFERENCED but never DEFINED', () => {
+  const p = parseStep(STOREY_MODEL_PHANTOM_MEMBER);
+
+  it('forwardClosure keeps only ids the file defines', () => {
+    const keep = new Set<number>();
+    forwardClosure([70], p, keep);
+    expect(keep.has(70)).toBe(true);
+    expect(keep.has(999)).toBe(false);
+  });
+
+  it('rewrites the phantom out of the SET instead of emitting it', () => {
+    const { keep, rewritten } = buildSubset(new Set([70]), p);
+    expect(keep.has(999)).toBe(false);
+    expect(rewritten.get(80)).toContain('(#70)');
+    expect(rewritten.get(80)).not.toContain('#999');
+    // The Name still carries its literal `#999`; only the SET was filtered.
+    expect(rewritten.get(80)).toContain("'L01 contents'");
+    expectNoDanglingRefs(serializeSubset({ keep, rewritten }, p));
+  });
+});
+
 // Same model, but the storey containment carries a DEDICATED IfcOwnerHistory
 // (#6) that nothing else in the file references.
 const STOREY_MODEL_REL_OWNED = STOREY_MODEL.replace(

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -140,17 +140,8 @@ export function resolveToId(token: string, parsed: ParsedStep): number {
 
 const REF_RE = /#(\d+)/g;
 
-/**
- * Forward reference closure: every instance transitively referenced by `seeds`.
- *
- * An id a record NAMES but the file never DEFINES (a phantom: `#999` read out
- * of a `'C1 see #999'` Name, or a genuinely broken reference) is NOT added.
- * `keep` is therefore a subset of the defined ids, which is the property the
- * consumers assume: `serializeSubset` skips a phantom, but `subset-relations`
- * intersects a rewritten SET's members against `keep` alone and would emit one
- * as a dangling `#id` (#4128). It also makes the printed instance count the
- * number of records actually written.
- */
+/** Forward closure over `seeds`. An id NAMED but never DEFINED is not added, or
+ * a rewritten SET would emit it as a dangling `#id` (#4128). */
 export function forwardClosure(seeds: Iterable<number>, parsed: ParsedStep, into: Set<number>): void {
   const stack = [...seeds];
   while (stack.length) {
@@ -305,7 +296,18 @@ export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Subs
   // relation's member SET filtered down to the kept ids rather than the whole
   // relation being dropped. `subset-relations.ts` owns that rule and the
   // no-dangling-reference invariant it preserves.
-  const spatial = planSpatialRelations(parsed.instances.values(), keep);
+  let spatial = planSpatialRelations(parsed.instances.values(), keep);
+  // A relation-private IfcOwnerHistory is reachable from nothing else, so the
+  // plan drops the relation and reports what blocked it. Keep those and replan
+  // (#4126). ONE replan suffices for a SCHEMA-VALID record: an IfcOwnerHistory
+  // subtree names no product, container or relation. On invalid input a second
+  // round is discarded and the relation stays dropped (pre-#4126 behaviour,
+  // never a dangling id). A `while` does NOT terminate here: a phantom blocker
+  // closes over nothing and is reported every round.
+  if (spatial.blockedOn.length > 0) {
+    forwardClosure(spatial.blockedOn, parsed, keep);
+    spatial = planSpatialRelations(parsed.instances.values(), keep);
+  }
   for (const id of spatial.add) keep.add(id);
   return { keep, rewritten: spatial.rewritten };
 }

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -140,15 +140,25 @@ export function resolveToId(token: string, parsed: ParsedStep): number {
 
 const REF_RE = /#(\d+)/g;
 
-/** Forward reference closure: every instance transitively referenced by `seeds`. */
+/**
+ * Forward reference closure: every instance transitively referenced by `seeds`.
+ *
+ * An id a record NAMES but the file never DEFINES (a phantom: `#999` read out
+ * of a `'C1 see #999'` Name, or a genuinely broken reference) is NOT added.
+ * `keep` is therefore a subset of the defined ids, which is the property the
+ * consumers assume: `serializeSubset` skips a phantom, but `subset-relations`
+ * intersects a rewritten SET's members against `keep` alone and would emit one
+ * as a dangling `#id` (#4128). It also makes the printed instance count the
+ * number of records actually written.
+ */
 export function forwardClosure(seeds: Iterable<number>, parsed: ParsedStep, into: Set<number>): void {
   const stack = [...seeds];
   while (stack.length) {
     const id = stack.pop()!;
     if (into.has(id)) continue;
-    into.add(id);
     const rec = parsed.instances.get(id);
     if (!rec) continue;
+    into.add(id);
     REF_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = REF_RE.exec(rec.body)) !== null) {

--- a/packages/cli/src/commands/subset-relations.ts
+++ b/packages/cli/src/commands/subset-relations.ts
@@ -14,8 +14,12 @@
  * storey with nothing under it. So the `RelatedElements` SET is rewritten down
  * to the kept members instead of the relation being dropped.
  *
- * The no-dangling-reference invariant is unchanged (every `#id` in an emitted
- * record is an id the subset keeps), which is what the rest of the rules are:
+ * The no-dangling-reference invariant is unchanged: every `#id` in an emitted
+ * record is an id the subset keeps, and since #4128 the caller's forward
+ * closure keeps only ids the file DEFINES, so kept implies defined. That covers
+ * the ids this module CHOOSES; it does not cover the references inside a kept
+ * record, which are emitted verbatim, so a source file that already dangles
+ * still dangles. That is the rest of the rules:
  *   - the RELATING object (`RelatingStructure` / `RelatingObject`, the spatial
  *     parent) is a hard requirement. A containment with no parent is
  *     meaningless, and it would dangle. A KNOWN residual gap follows from that,
@@ -28,17 +32,24 @@
  *     product up its containment and aggregation edges, which keeps exactly the
  *     seeds' ancestors and needs no type list at all. Either way it is a change
  *     to how `buildSubset` seeds, not to the rule here. Filed as #4124.
- *   - every other non-set reference must be kept too. That is attribute 1,
- *     `OwnerHistory`; in practice it already is, because each kept product's
- *     own body names the same shared `IfcOwnerHistory` and the products'
- *     forward closure keeps it. A second REACHABLE residual lives here: an
- *     exporter that writes a PER-RELATIONSHIP `IfcOwnerHistory` referenced by
- *     nothing else hits this rule every time, and the relation is dropped, which
- *     is the orphaned-storey symptom again. `buildSubset` already has the remedy
- *     for that shape (it runs `forwardClosure` over the voids/fills relations it
- *     pulls in, for exactly this reason), but this function takes no `parsed`,
- *     so dropping is the only safe answer available HERE. Filed as #4126.
  *   - an empty intersection drops the relation.
+ *   - every other non-set reference must be kept too. That is attribute 1,
+ *     `OwnerHistory`; usually it already is, because each kept product's own
+ *     body names the same shared `IfcOwnerHistory` and the products' forward
+ *     closure keeps it. An exporter that writes a PER-RELATIONSHIP
+ *     `IfcOwnerHistory` referenced by nothing else hits this rule every time,
+ *     and dropping there was the orphaned-storey symptom again (#4126). This
+ *     function still takes no `parsed`, so it cannot close over such a
+ *     reference; it REPORTS it in {@link SpatialRelationPlan.blockedOn} and the
+ *     caller, which does have `parsed`, keeps it and replans. Purity is intact:
+ *     `blockedOn` is a finding, not a mutation.
+ *
+ * A KNOWN gap: {@link keepWhole}, the fallback for a record this module could
+ * not read as its six attributes, still drops on the same private
+ * `OwnerHistory` and reports nothing. That is deliberate. Its references are
+ * read off the raw body with no established string boundaries, so a `#6` it
+ * names may be text rather than a reference, and forward-closing over it would
+ * re-create the hash-in-a-Name bug the scanner exists to avoid.
  *
  * A relation that loses NO member re-emits its source line verbatim, so an
  * extraction that happened to keep every member does not churn.
@@ -99,6 +110,15 @@ export interface SpatialRelationPlan {
   add: number[];
   /** Relation id → rewritten record text, for the ones that lost a member. */
   rewritten: Map<number, string>;
+  /**
+   * Unkept non-SET references, in practice a relation-private `OwnerHistory`,
+   * of the relations that this plan dropped for THAT reason alone: their
+   * relating parent is kept and their member intersection is non-empty, so
+   * keeping these ids is all that stands between them and surviving. A caller
+   * holding the parsed model can close over them and replan (#4126). Every
+   * other drop is final and reports nothing here.
+   */
+  blockedOn: number[];
 }
 
 /**
@@ -156,25 +176,29 @@ export function planSpatialRelations(
 ): SpatialRelationPlan {
   const add: number[] = [];
   const rewritten = new Map<number, string>();
+  const blockedOn: number[] = [];
   for (const inst of instances) {
     const slots = STRUCTURE_RELATIONS[inst.type];
     if (slots === undefined) continue;
-    const line = relationLine(inst, slots, keep);
+    const line = relationLine(inst, slots, keep, blockedOn);
     if (line === null) continue;
     add.push(inst.id);
     if (line !== inst.full) rewritten.set(inst.id, line);
   }
-  return { add, rewritten };
+  return { add, rewritten, blockedOn };
 }
 
 /**
  * The record text this relation contributes to the subset, or null to drop it.
- * Returns `inst.full` unchanged when nothing was filtered out.
+ * Returns `inst.full` unchanged when nothing was filtered out. Appends to
+ * `blocked` when the ONLY thing standing in the way is an unkept non-SET
+ * reference; see {@link SpatialRelationPlan.blockedOn}.
  */
 function relationLine(
   inst: StepRecord,
   [relatingIdx, relatedIdx]: [number, number],
   keep: ReadonlySet<number>,
+  blocked: number[],
 ): string | null {
   // A null is a REJECTED scan, not an empty list: its parts are wherever the
   // scanner happened to be, so reading `args[relatingIdx]` or writing
@@ -201,17 +225,25 @@ function relationLine(
   const relating = SINGLE_REF_RE.exec(args[relatingIdx]);
   if (relating === null || !keep.has(Number(relating[1]))) return null;
 
+  const kept = memberIds.filter((id) => keep.has(id));
+  if (kept.length === 0) return null;
+
   // Every other non-set reference (OwnerHistory) must be kept or the emitted
-  // record dangles.
+  // record dangles. Ordered AFTER the intersection so `blocked` names only the
+  // references of a relation that would OTHERWISE survive; both checks drop the
+  // relation, so which one runs first changes no verdict.
+  const unkept: number[] = [];
   for (let i = 0; i < args.length; i++) {
     if (i === relatedIdx) continue;
     for (const id of refsOutsideStrings(args[i])) {
-      if (!keep.has(id)) return null;
+      if (!keep.has(id)) unkept.push(id);
     }
   }
+  if (unkept.length > 0) {
+    blocked.push(...unkept);
+    return null;
+  }
 
-  const kept = memberIds.filter((id) => keep.has(id));
-  if (kept.length === 0) return null;
   if (kept.length === memberIds.length) return inst.full;
   return spliceArgument(inst, args, relatedIdx, `(${kept.map((id) => `#${id}`).join(',')})`);
 }


### PR DESCRIPTION
Closes #4128. Closes #4126.

Two output-corruption bugs in the subset rules #4120 rewrote. Both reproduced on
`origin/main` before fixing, and the commits are ordered because the second needs the
first.

## #4128, a phantom id reaches the output

`forwardClosure` added an id to `keep` BEFORE looking it up, so an id a record NAMES but
the file never DEFINES landed in the kept set. `serializeSubset` filters phantoms out of
emitted LINES, but `relationLine` intersects SET members against `keep` alone, so the
phantom survived into a rewritten SET and was emitted.

Reproduced: a kept product whose Name is `'C1 see #999'` puts phantom 999 into `keep`,
and a containment `(#70,#999)` is re-emitted with a dangling `#999`.

Fix: look the id up first. That makes `keep` a subset of defined ids at the source, so
the intersection cannot admit a phantom.

## #4126, a relation-private IfcOwnerHistory loses containment

An exporter that writes one `IfcOwnerHistory` per relationship, referenced by nothing
else, hit the "every non-SET reference must be kept" rule every time, and the relation
was dropped. That is the orphaned-storey symptom #4113 reported, from a different cause.

Reproduced: `#6= IFCOWNERHISTORY(...)` referenced only by `#80`, and `--product 70`
emits no containment at all.

Fix: `SpatialRelationPlan.blockedOn` reports what blocked a relation that would otherwise
survive; `buildSubset` forward-closes those and replans once.
`planSpatialRelations(instances, keep)` keeps its signature and its documented purity:
`blockedOn` is a finding, not a mutation.

## Why one PR and why this order

They are not separable. The #4126 replan alone OPENS a hole: an undefined OwnerHistory
gets added to `keep` by `forwardClosure`, the replan then accepts the relation, and the
output dangles. Measured: `dangling=[6]` with #4126 alone, `dangling=[]` with #4128
first.

So: two commits, #4128 first. Mutation-checked, and this is the row that pins the
ordering:

| Mutation | Result |
|---|---|
| revert #4128 alone | 2 fail, both new phantom-member tests |
| revert #4128 with #4126 present | 4 fail, the 2 above PLUS both phantom-owner tests |
| remove the #4126 replan | 4 fail, the flipped pair and the subtree pair |
| move the intersection test after the refs loop | 1 fail, no verdicts changed |

## One replan, and the limit of that claim

One replan suffices for a schema-valid record: the only non-SET, non-relating slot these
three six-attribute types carry is `OwnerHistory`, and an `IfcOwnerHistory` subtree
(`IfcPersonAndOrganization`, `IfcPerson`, `IfcOrganization`, `IfcApplication`) reaches no
product, container or relation, so round 1's growth cannot flip another relation's
verdict. Verified against `IFC4_ADD2_TC1.exp`.

On schema-INVALID input a second round can be needed, and it is discarded. The relation
then stays dropped, which is the pre-#4126 behaviour, and never dangles. A `while` is NOT
the fix: a phantom blocker closes over nothing and is reported every round, so it does
not terminate. Measured, and stated in the comment.

## Evidence

`hello-wall.ifc` with `#1223`'s OwnerHistory made private (`#9000` plus person, org and
application):

- `origin/main`: 120 records, **no `#1223` at all**, the wall extracts orphaned.
- this PR: 126 records, `#1223=IFCRELCONTAINEDINSPATIALSTRUCTURE('1wCUC...',#9000,$,$,(#1262),#42);`
  plus the whole `#9000` subtree, zero dangling refs, and the printed instance count
  matches the emitted record count.

## Verification

    pnpm --filter @ifc-lite/cli test    46 in this file, 825 in the package, 8 skipped
    pnpm typecheck                      90/90
    pnpm lint                           0 errors
    node scripts/check-module-size.mjs  OK

`extract-entities.ts` 505 -> 517 against its existing 518 budget, allowlist untouched.
One line of headroom left, which is why the deferral below is a deferral.

## Deferred, filed rather than dropped

- #4150: `blockedOn` is force-kept unconditionally, so on schema-invalid input a
  non-OwnerHistory blocker drags unrelated products in, and blockers are kept even when
  the replan still drops the relation. Over-extraction, never invalid output, impossible
  on valid IFC. The fix is 3 lines and there is 1 line of budget; the issue carries both
  halves, including where the space comes from.
- #4148: `forwardClosure` reads an `#id` out of a STEP string literal, so a product Name
  containing `#71` over-extracts on VALID input. Pre-existing, identical on `bea417a49`,
  and the same hazard `refsOutsideStrings` exists to avoid.

Review outcomes on the record: the one-replan claim was scoped to schema-valid input
after a reviewer built the counterexample, and "kept implies defined" was corrected to say
it covers the ids this module chooses, not the references inside a kept record, which are
emitted verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed entity extraction so spatial containment is preserved when relationships use private ownership data.
  - Prevented extracted files from containing references to undefined entities or phantom identifiers.
  - Ensured required ownership information is retained when rebuilding spatial relationships.
  - Improved handling of invalid or incomplete relationships to avoid orphaned storeys and unintended ownership data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->