### PR TITLE
perf(test): derive the census RTC frame once per model, not once per host (#4127)

### DIFF
--- a/rust/geometry/tests/census_rtc/mod.rs
+++ b/rust/geometry/tests/census_rtc/mod.rs
@@ -1,10 +1,109 @@
 //! Match the loader's coordinate-frame choice before producing f32 meshes.
 //! Survey coordinates must not become geometry-loss goldens (#3925).
+//!
+//! The frame is a pure function of the file, so it is derived ONCE per model and
+//! reused for every host the sweep walks (#4127). Deriving it per host made each
+//! `process()` call walk the whole file twice unconditionally: an entity index
+//! over every record, then a second walk calling `has_geometry_by_name` on each
+//! to collect the geometry jobs. Placement sampling rides on that second walk and
+//! is capped at 50 usable jobs, so it is only a third full pass when nearly every
+//! job abstains. If EVERY job abstains, the `scan_placement_bounds` fallback adds
+//! two more whole-file walks on top, so the real worst case is five.
+//! `triangulation_invariance`
+//! makes two of those calls per void host and a third for a torn one, which is
+//! what stopped the heavy lane fitting the 60 minutes
+//! `.github/workflows/geometry-census-heavy.yml` budgets it (`timeout-minutes: 60`).
+//! The before/after timings are in #4127 and in the commit that made this change.
+//!
+//! # What is still per host, and what is still O(file)
+//!
+//! ONLY the frame is shared. Every host still gets its own [`GeometryRouter`]
+//! and its own [`EntityDecoder`], so the router's mapped-item, dedup,
+//! geometry-hash and diagnostic state stays per host exactly as it was. A
+//! shared router would carry one host's cached mapped items and its
+//! consumed-void bookkeeping into the next host, which is a question about
+//! census rows rather than about speed. The two things that ARE shared are pure
+//! functions of the content: the entity index (id -> byte span) and the RTC
+//! offset.
+//!
+//! That leaves ONE per-host walk in place, and this note does not claim
+//! otherwise: [`ModelFrame::router`] calls `GeometryRouter::with_units`, whose
+//! `scan_unit_scale` (`rust/geometry/src/router/mod.rs`) scans entities from the
+//! start of the file until it hits `IFCPROJECT`. On most models that stops in
+//! the first few KB and costs nothing measurable. On some it does not, because
+//! the exporter emitted `IFCPROJECT` last; measured on this corpus:
+//!
+//! | fixture | first `IFCPROJECT` | file size |
+//! |---|---|---|
+//! | `ara3d/duplex.ifc` | byte 2,380,634 | 2,380,763 |
+//! | `ara3d/dental_clinic.ifc` | byte 9,496,389 | 13,003,205 |
+//! | `various/01_BIMcollab_Example_ARC.ifc` | byte 6,252,152 (line 100819) | 18,230,149 |
+//!
+//! All three are in `manifest.json` under `MAX_FIXTURE_BYTES`, so the default
+//! sweep walks them, and on those the per-host cost is still effectively
+//! O(file).
+//!
+//! The unit scale is NOT hoisted here, deliberately. It could only be reused by
+//! building the per-host router from `GeometryRouter::with_scale_and_rtc`, which
+//! unlike `with_units` does NOT call `arm_content_dedup()`. Swapping it in would
+//! silently turn item content-dedup off for the census and could move the rows,
+//! which is the one thing this change must not do. Hoisting the scale is a
+//! separate change that has to argue about dedup, not about speed.
 
-use ifc_lite_core::{has_geometry_by_name, EntityDecoder, EntityScanner};
+use ifc_lite_core::{
+    build_entity_index, has_geometry_by_name, EntityDecoder, EntityIndex, EntityScanner,
+};
 use ifc_lite_geometry::GeometryRouter;
-pub fn router(content: &str, decoder: &mut EntityDecoder) -> GeometryRouter {
-    let mut router = GeometryRouter::with_units(content, decoder);
+use std::sync::Arc;
+
+/// One model's re-derivable, host-independent inputs to the census.
+///
+/// The frame STORES the content it was built from and hands it back out itself.
+/// That, not the lifetime, is what makes a wrong pairing unrepresentable: two
+/// distinct `String`s can both yield `&'a str` for one `'a`, so a `content`
+/// parameter on the methods below would type-check against a DIFFERENT string.
+/// Do not re-add one. The index holds absolute byte spans into `content` and
+/// [`EntityDecoder`] slices them unchecked, so the wrong pairing decodes the
+/// wrong entities or panics out of bounds.
+pub struct ModelFrame<'a> {
+    /// The exact content the index and the offset were derived from.
+    content: &'a str,
+    /// Read-only entity id -> byte span map. `EntityDecoder::with_index` already
+    /// wraps its argument in an `Arc` internally, so handing every host the same
+    /// `Arc` is the identical store, built once.
+    index: Arc<EntityIndex>,
+    /// The RTC offset the loader would pick for this file.
+    offset: (f64, f64, f64),
+}
+
+impl<'a> ModelFrame<'a> {
+    pub fn new(content: &'a str) -> Self {
+        let index = Arc::new(build_entity_index(content));
+        let mut decoder = EntityDecoder::with_arc_index(content, Arc::clone(&index));
+        let offset = detect_rtc_offset(content, &mut decoder);
+        Self { content, index, offset }
+    }
+
+    /// A FRESH decoder over this model. Only the read-only index is shared; the
+    /// entity, point and placement caches are new for every host.
+    pub fn decoder(&self) -> EntityDecoder<'a> {
+        EntityDecoder::with_arc_index(self.content, Arc::clone(&self.index))
+    }
+
+    /// A FRESH router carrying this model's frame, per host. See the module note
+    /// on why the router itself is not the thing that gets hoisted, and on the
+    /// unit scan this still repeats per host.
+    pub fn router(&self, decoder: &mut EntityDecoder) -> GeometryRouter {
+        let mut router = GeometryRouter::with_units(self.content, decoder);
+        router.set_rtc_offset(self.offset);
+        router
+    }
+}
+
+/// The loader's offset choice: the site placement's translation when it is not
+/// at the origin, otherwise the sampled/bounds fallback over every geometry job.
+fn detect_rtc_offset(content: &str, decoder: &mut EntityDecoder) -> (f64, f64, f64) {
+    let router = GeometryRouter::with_units(content, decoder);
     let mut scan = EntityScanner::new(content);
     let mut jobs = Vec::new();
     let mut site = None;
@@ -22,9 +121,6 @@ pub fn router(content: &str, decoder: &mut EntityDecoder) -> GeometryRouter {
         let t = (m[12], m[13], m[14]);
         (t.0.abs() > 1e-9 || t.1.abs() > 1e-9 || t.2.abs() > 1e-9).then_some(t)
     });
-    let offset = site_offset.unwrap_or_else(|| {
-        router.detect_rtc_offset_with_fallback(&jobs, decoder, content.as_bytes())
-    });
-    router.set_rtc_offset(offset);
-    router
+    site_offset
+        .unwrap_or_else(|| router.detect_rtc_offset_with_fallback(&jobs, decoder, content.as_bytes()))
 }

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -128,7 +128,8 @@ mod census_golden;
 mod census_rtc;
 
 use census_golden::{is_closed_solid, totals, Delta, HostRow, PreVoid};
-use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use census_rtc::ModelFrame;
+use ifc_lite_core::{EntityDecoder, EntityScanner};
 use ifc_lite_geometry::kernel::mesh_volume::mesh_volume;
 use ifc_lite_geometry::take_plane_weld_stats;
 use ifc_lite_geometry::{propagate_voids_to_parts, Mesh};
@@ -244,19 +245,17 @@ fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
 }
 
 /// Same element with NO voids applied: isolates solid construction from CSG.
-fn process_no_voids(content: &str, host_id: u32) -> Option<Mesh> {
-    let ei = build_entity_index(content);
-    let mut decoder = EntityDecoder::with_index(content, ei);
+fn process_no_voids(frame: &ModelFrame, host_id: u32) -> Option<Mesh> {
+    let mut decoder = frame.decoder();
     let entity = decoder.decode_by_id(host_id).ok()?;
-    let router = census_rtc::router(content, &mut decoder);
+    let router = frame.router(&mut decoder);
     router.process_element(&entity, &mut decoder).ok()
 }
 
-fn process(content: &str, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Option<Mesh> {
-    let ei = build_entity_index(content);
-    let mut decoder = EntityDecoder::with_index(content, ei);
+fn process(frame: &ModelFrame, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Option<Mesh> {
+    let mut decoder = frame.decoder();
     let entity = decoder.decode_by_id(host_id).ok()?;
-    let router = census_rtc::router(content, &mut decoder);
+    let router = frame.router(&mut decoder);
     router.process_element_with_voids(&entity, &mut decoder, voids).ok()
 }
 
@@ -818,14 +817,20 @@ fn sweep(models: &[(String, PathBuf)]) -> (Vec<HostRow>, BTreeSet<String>) {
             continue; // nothing to index the lines for
         }
         let lines = line_index(&content);
+        // #4127: the entity index and the RTC offset, ONCE per model rather
+        // than once per host. Both are pure functions of `content` (see
+        // `census_rtc`), and re-deriving them inside the loop is what put the
+        // heavy lane past its CI budget. The router and the decoder are still
+        // built per host.
+        let frame = ModelFrame::new(&content);
 
         for id in hosts {
             set_alt(false);
-            let Some(base) = process(&content, id, &voids) else {
+            let Some(base) = process(&frame, id, &voids) else {
                 continue;
             };
             set_alt(true);
-            let alt = process(&content, id, &voids);
+            let alt = process(&frame, id, &voids);
             set_alt(false);
 
             let stats = edge_stats(&base);
@@ -840,7 +845,7 @@ fn sweep(models: &[(String, PathBuf)]) -> (Vec<HostRow>, BTreeSet<String>) {
             let pre = if open == 0 {
                 PreVoid::NotTaken
             } else {
-                match process_no_voids(&content, id).map(|m| open_boundary_edges(&m)) {
+                match process_no_voids(&frame, id).map(|m| open_boundary_edges(&m)) {
                     Some(v) => PreVoid::Open(v),
                     None => PreVoid::Failed,
                 }
@@ -1638,8 +1643,9 @@ fn an_over_cut_on_a_watertight_host_requires_a_bless() {
     for (scale, tris_grow) in [(1.4, false), (1.6, true)] {
         let ifc = over_cut_fixture(scale);
         let voids = void_index(&ifc);
-        let authored = process(&ifc, 50, &voids).expect("authored wall meshes");
-        let over_cut = process(&ifc, 150, &voids).expect("over-cut wall meshes");
+        let frame = ModelFrame::new(&ifc);
+        let authored = process(&frame, 50, &voids).expect("authored wall meshes");
+        let over_cut = process(&frame, 150, &voids).expect("over-cut wall meshes");
 
         let (a, b) = (edge_stats(&authored), edge_stats(&over_cut));
         // The rows exactly as the sweep records a host, through the same
@@ -1739,7 +1745,7 @@ fn one_vertex_rounding_the_other_way_moves_the_reading_by_more_than_the_toleranc
     const STEP: f32 = 1.0 / 65536.0;
     let ifc = over_cut_fixture(1.4);
     let voids = void_index(&ifc);
-    let mesh = process(&ifc, 50, &voids).expect("authored wall meshes");
+    let mesh = process(&ModelFrame::new(&ifc), 50, &voids).expect("authored wall meshes");
     let base = volume_cm3(&mesh);
 
     let mut worst = 0i64;
@@ -2176,7 +2182,8 @@ fn census_rebases_real_covering_before_f32_geometry_3925() {
         return;
     }
     let content = std::fs::read_to_string(path).expect("read rvt01 fixture");
-    let mesh = process(&content, 11232, &void_index(&content)).expect("mesh covering");
+    let frame = ModelFrame::new(&content);
+    let mesh = process(&frame, 11232, &void_index(&content)).expect("mesh covering");
     assert_eq!(edge_stats(&mesh).strict, 0, "covering must remain closed without doubled edges");
     assert!((39_200..=39_500).contains(&volume_cm3(&mesh)),
         "covering volume must agree with the independent solid: {} cm³", volume_cm3(&mesh));
@@ -2196,7 +2203,8 @@ fn repaired_office_covering_matches_independent_solid_3925() {
         return;
     }
     let content = std::fs::read_to_string(path).expect("read office fixture");
-    let mesh = process(&content, 91291, &void_index(&content)).expect("mesh office covering");
+    let frame = ModelFrame::new(&content);
+    let mesh = process(&frame, 91291, &void_index(&content)).expect("mesh office covering");
     assert_eq!(edge_stats(&mesh).strict, 0);
     assert!((75_500..=75_900).contains(&volume_cm3(&mesh)),
         "office covering volume must agree with the independent solid: {} cm³", volume_cm3(&mesh));


### PR DESCRIPTION
Part of #4127.

The heavy census lane has never completed. Both runs it has ever had were cancelled at
the 60-minute cap with no census row emitted. The cause is a performance regression in
the test harness, and this is the fix for it. The workflow-side reporting change is a
separate PR.

## Measured

Exact workflow invocation, `cargo test -p ifc-lite-geometry --features triangulation-alt
--test triangulation_invariance -- --ignored --nocapture --test-threads=1 heavy_fixture`:

    before   751.21 s
    after      6.76 s

Both fixtures. That is faster than the pre-regression baseline too, because #3933 was
not the only per-host cost.

## Cause

`sweep()` calls `process()` twice per void host and a third time for a torn one, roughly
1300 times across the two heavy fixtures. Since #3933 each call went through
`census_rtc::router`, which per call built an entity index over every record and then
walked every record again calling `has_geometry_by_name` to collect the geometry jobs.
On ISSUE_053 that is 2.8 M entities, twice, per call.

## Fix

The frame is a pure function of the file, so derive it ONCE per model. `ModelFrame` holds
the `Arc<EntityIndex>` and the RTC offset; `sweep()` builds one before the host loop.

**The router is deliberately NOT hoisted.** It carries per-host state (`mapped_item_cache`,
`item_dedup_cache`, `geometry_hash_cache`, `content_sig_memo`, `voids_consumed_hosts`,
plus the CSG-failure and host-opening diagnostics), and sharing it would let information
carry from host N to host N+1. Every host still gets a fresh `GeometryRouter::with_units`
and a fresh `EntityDecoder`; only the read-only index and the offset are shared.

That is what answers the golden question by construction rather than by hoping.

## The golden did not move

- Census run rows are byte-identical before and after, md5-matched, on BOTH fixtures.
- ISSUE_053: 289 void hosts, 0 torn. ISSUE_068: 363 hosts, 26 torn, matching
  `ISSUE_068_KNOWN_TORN_HOSTS`.
- Both: `regressed : 0`, `coverage loss : 0`, `added : 0`, `reclassified : 0`,
  `retessellated : 0`, `volume moved : 0`.
- The committed golden is untouched. Bless mode was never armed.

An independent reviewer reproduced this: their HEAD rows md5-match mine, and they
separately measured the pre-change code's ISSUE_053 rows as identical to the post-change
rows.

## Why dropping the per-host offset pass is safe

`resolve_scaled_placement`, `sample_element_translation`,
`detect_rtc_offset_with_fallback` and `get_placement_transform_from_element` are all
`&self` with no `borrow_mut`; they mutate only the decoder's id-keyed memos. The subtle
case: the old pass warmed `placement_transform_cache` BEFORE `set_rtc_offset` was called.
Had it baked the offset into a cached transform, the old harness would have been carrying
rtc-less transforms into meshing. It does not: `rtc_offset` is read at mesh-transform
time, so the cache is a pure function of placement id and a warm cache equals a cold one.

The offset is also independent of the alt-triangulator toggle (neither sampler
tessellates), which matters because the frame is now built outside the base/alt toggling.

## `ModelFrame` binds its index to its content

`ModelFrame<'a>` STORES the content; `decoder()` and `router()` take no content
parameter. That, not the lifetime, is what makes a wrong pairing unrepresentable: two
distinct `String`s can both yield `&'a str` for one `'a`, so a re-added parameter would
type-check against a different string, and the index holds absolute byte spans that
`EntityDecoder` slices unchecked. Demonstrated by compiling the bad shape, not argued.

## What is still per host, stated because the first draft did not

`with_units` calls `scan_unit_scale`, which walks to the first `IFCPROJECT`. On the two
heavy fixtures that is byte 4,246 and 5,070, so it costs nothing on the lane this fixes.
But some exporters emit `IFCPROJECT` last, and three corpus fixtures under
`MAX_FIXTURE_BYTES` do: `duplex.ifc` at 2,380,634 of 2,380,763; `dental_clinic.ifc` at
9,496,389 of 13,003,205; `01_BIMcollab_Example_ARC.ifc` at 6,252,152 of 18,230,149.

Hoisting the unit scale is declined here on purpose: `with_scale_and_rtc` does not call
`arm_content_dedup()` the way `with_units` does, so a naive swap silently disarms item
content-dedup for the census, which is exactly the class of change this PR must not make.

## Verification

    cargo test --workspace --no-fail-fast                    exit 0
    cargo clippy --workspace --all-targets -- -D warnings    exit 0
    per-PR census lane                                       64 passed, regressed : 0

Test harness only. No kernel change, no changeset (no `packages/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K
