### PR TITLE
fix(cli): locate mutate's STEP records with the parser's own scan

### DIFF
--- a/.changeset/mutate-multiline-record-scan.md
+++ b/.changeset/mutate-multiline-record-scan.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`mutate --set`'s attribute rewrite located a target entity's STEP record with a regex anchored to one line, plus `indexOf('(')` / `lastIndexOf(')')`. A record an exporter wrapped across several lines, or one whose class keyword was followed by a comment before its `(`, did not match the regex at all: the line was skipped in silence, and the run still reported the mutation as done. Record location now uses the parser's own balanced-parenthesis, string- and comment-aware entity scan to get each target record's exact byte span, and the argument list inside it is split with the same validating splitter `mutate --set` already refuses a mis-scanned record with, so a record this rewrite cannot read safely is still refused rather than guessed at. A record whose located span turns out not to be followed by the STEP record terminator `;` — the sign that a stray, unmatched `)` inside a malformed record fooled the byte scan into stopping early — is refused for the same reason, instead of being partially rewritten with corrupted bytes left trailing it.

--- a/packages/cli/src/commands/mutate-step-record.ts
+++ b/packages/cli/src/commands/mutate-step-record.ts
@@ -1,0 +1,276 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `mutate.ts`'s STEP-text rewrite path: finding an entity record's exact
+ * bytes in the exported output and splicing a new attribute value into it.
+ *
+ * Split out of `mutate.ts` (a sibling, not a growth of that file) to stay
+ * under the repo's module-size budget.
+ *
+ * Record LOCATION on main is a per-line regex plus `indexOf('(')` /
+ * `lastIndexOf(')')`. That silently drops a mutation -- reporting success
+ * with an unwritten edit -- on a record wrapped across several lines, or on
+ * one with a comment between its class keyword and `(`
+ * (LTplus-AG/ifc-lite#4163): the regex simply does not match, the line is
+ * `continue`d past, and nothing marks the mutation as failed.
+ *
+ * This module locates the record with `StepTokenizer.scanEntities()`
+ * (`@ifc-lite/parser`) -- the same balanced-parenthesis, string- and
+ * comment-aware scan the parser itself indexes entities with -- to get each
+ * target record's exact byte span, wherever it falls relative to line
+ * breaks. A record the scan cannot find is now a NAMED failure instead of a
+ * silent no-op.
+ *
+ * The argument list inside that span is split with `splitTopLevelStepArgs`
+ * from `./step-args.js` -- the SAME validating splitter `mutate.ts` uses on
+ * main: every part must be exactly one STEP token, checked at every depth,
+ * or the split is refused (LTplus-AG/ifc-lite#4125 / #2470 -- an undoubled
+ * apostrophe inside a string swallows top-level commas, and a by-index
+ * write on a mis-scanned split lands on the wrong attribute while reporting
+ * success). An earlier version of this module carried its own
+ * non-validating splitter and reintroduced exactly that corruption; it is
+ * gone.
+ *
+ * `scanEntities()`'s own balanced-paren scan can itself be fooled: a stray,
+ * unmatched `)` inside a malformed record's argument list brings the depth
+ * back to 0 early, so the scan reports a record that ends there -- silently
+ * TRUNCATED, well short of the record's real (malformed) extent, with the
+ * rest of the same record's bytes left looking like orphaned text after it.
+ * The truncated span is internally well-formed (it is exactly as long as it
+ * is balanced), so a validating splitter given only that span cannot see
+ * the truncation either. The guard is structural, not lexical: a located
+ * record's closing `)` must be followed (modulo STEP trivia) by `;`, the
+ * record terminator. A genuine record always has one there; a truncated one
+ * does not, because the bytes that would carry it are still unconsumed
+ * argument text.
+ */
+
+import { StepTokenizer } from '@ifc-lite/parser';
+import { splitTopLevelStepArgs } from './step-args.js';
+
+/**
+ * IFC entity attribute indices (0-based positions in STEP argument list).
+ * Standard for all IfcRoot subtypes: GlobalId(0), OwnerHistory(1), Name(2), Description(3).
+ * IfcObject subtypes add ObjectType(4). Tag varies by entity type.
+ */
+export const ATTRIBUTE_INDEX: Record<string, number> = {
+  name: 2,
+  description: 3,
+  objecttype: 4,
+};
+
+/**
+ * ISO 10303-21 trivia: whitespace or a `/* ... *\/` comment, either one
+ * repeated any number of times. A comment is legal wherever whitespace is,
+ * including between a record's class keyword and its `(` -- the gap the
+ * line regex on main cannot see past (#4163) -- and between a record's
+ * closing `)` and its terminating `;`, which is what the truncation guard
+ * below has to skip past.
+ */
+const TRIVIA_RE = /^(?:[ \t\r\n\f\v]|\/\*[\s\S]*?\*\/)*/;
+
+function skipTrivia(text: string, i: number): number {
+  const m = TRIVIA_RE.exec(text.slice(i));
+  return i + (m ? m[0].length : 0);
+}
+
+/**
+ * Walk `recordText` (exactly `#<id><trivia>=<trivia><TYPE><trivia>(...)`, the
+ * span `StepTokenizer.scanEntities()` yields) to find where the argument
+ * list opens.
+ *
+ * Composed from the same trivia rule the byte-level scan uses rather than a
+ * single `indexOf('(')`, so a comment between the id, the `=` and the class
+ * keyword cannot be mistaken for the record's own text -- and a `(` written
+ * INSIDE such a comment cannot be mistaken for the argument list's open
+ * paren (#4163's first symptom).
+ *
+ * Returns the index of the record's own `(`, or -1 if `recordText` is not
+ * shaped the way the scan promises.
+ */
+function findArgsOpen(recordText: string): number {
+  if (recordText[0] !== '#') return -1;
+  let i = 1;
+  const idStart = i;
+  while (i < recordText.length && recordText[i] >= '0' && recordText[i] <= '9') i++;
+  if (i === idStart) return -1;
+
+  i = skipTrivia(recordText, i);
+  if (recordText[i] !== '=') return -1;
+  i++;
+
+  i = skipTrivia(recordText, i);
+  const typeStart = i;
+  while (i < recordText.length && /[A-Za-z0-9_]/.test(recordText[i])) i++;
+  if (i === typeStart) return -1;
+
+  i = skipTrivia(recordText, i);
+  return recordText[i] === '(' ? i : -1;
+}
+
+/** One target record, once its span (and terminator) has been confirmed good. */
+interface ReadableRecord {
+  expressId: number;
+  type: string;
+  argsStart: number; // index of the char right after the record's own '(', within recordText
+  recordText: string; // "#id=TYPE(...)" without the trailing ';'
+  offset: number; // byte offset of recordText within the original content
+  length: number; // byte length of recordText
+}
+
+/**
+ * Apply attribute mutations to STEP content via text replacement.
+ *
+ * For each target entity, locates the record's exact bytes with
+ * `StepTokenizer.scanEntities()` (multi-line records, and records with a
+ * comment before their `(`, included) and rewrites the attribute at its
+ * known slot index using the validating splitter (`splitTopLevelStepArgs`,
+ * `./step-args.js`) -- the same one `mutate.ts` uses on main, so a
+ * mis-scanned argument list is refused here exactly as it would be there
+ * (#4125).
+ *
+ * Every record this call was asked to mutate is read and validated FIRST;
+ * only if every one of them is readable does any rewriting happen, and the
+ * function returns the fully rewritten content. If ANY of them cannot be
+ * located, its span isn't followed by the STEP record terminator `;`
+ * (the truncation guard -- see the module header), or its argument list
+ * cannot be split unambiguously, nothing is rewritten and one error names
+ * every record that failed. The alternative -- writing the records that
+ * were fine and skipping the rest -- is a run that reports success over a
+ * file that carries only part of the requested edit.
+ */
+export function applyAttributeMutations(
+  content: string,
+  mutations: { entity: any; propName: string; value: string }[],
+  objectTypeEntities: ReadonlySet<string>,
+): string {
+  const mutationsByEntity = new Map<number, { propName: string; value: string }[]>();
+  for (const m of mutations) {
+    const id = m.entity.ref.expressId;
+    const list = mutationsByEntity.get(id) ?? [];
+    list.push({ propName: m.propName, value: m.value });
+    mutationsByEntity.set(id, list);
+  }
+  if (mutationsByEntity.size === 0) return content;
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const bytes = encoder.encode(content);
+
+  const located = new Map<number, { offset: number; length: number; type: string }>();
+  for (const rec of new StepTokenizer(bytes).scanEntities()) {
+    if (mutationsByEntity.has(rec.expressId) && !located.has(rec.expressId)) {
+      located.set(rec.expressId, { offset: rec.offset, length: rec.length, type: rec.type.toUpperCase() });
+    }
+  }
+
+  // Every entity is located, guarded and split in ORIGINAL request order, so
+  // a run naming several unreadable records lists them in the order they
+  // were asked for, not the order the failure happened to be detected in.
+  const unreadable: string[] = [];
+  const readable: ReadableRecord[] = [];
+
+  for (const [expressId] of mutationsByEntity) {
+    const rec = located.get(expressId);
+    if (!rec) {
+      unreadable.push(`#${expressId}`);
+      continue;
+    }
+
+    // Truncation guard: a genuine record's closing ')' is followed (modulo
+    // trivia) by ';'. If it is not, `scanEntities()`'s balanced-paren scan
+    // closed this span early -- typically a stray, unmatched ')' inside a
+    // malformed argument list -- and the span is shorter than the record
+    // actually is.
+    const tailStart = rec.offset + rec.length;
+    const tail = decoder.decode(bytes.subarray(tailStart, Math.min(tailStart + 256, bytes.length)));
+    const afterTrivia = skipTrivia(tail, 0);
+    if (tail[afterTrivia] !== ';') {
+      unreadable.push(`#${expressId}=${rec.type}`);
+      continue;
+    }
+
+    const recordText = decoder.decode(bytes.subarray(rec.offset, rec.offset + rec.length));
+    const argsOpen = findArgsOpen(recordText);
+    if (argsOpen === -1 || recordText[recordText.length - 1] !== ')') {
+      unreadable.push(`#${expressId}=${rec.type}`);
+      continue;
+    }
+
+    const argsText = recordText.slice(argsOpen + 1, recordText.length - 1);
+    const args = splitTopLevelStepArgs(argsText);
+    if (args === null) {
+      unreadable.push(`#${expressId}=${rec.type}`);
+      continue;
+    }
+
+    readable.push({
+      expressId,
+      type: rec.type,
+      argsStart: argsOpen + 1,
+      recordText,
+      offset: rec.offset,
+      length: rec.length,
+    });
+  }
+
+  const rewrites = new Map<number, string>();
+  for (const rec of readable) {
+    const argsText = rec.recordText.slice(rec.argsStart, rec.recordText.length - 1);
+    // Re-split rather than threading the result through: cheap (records are
+    // short), and keeps this loop free of anything that can itself fail --
+    // every possible failure was already surfaced, in order, above.
+    const args = splitTopLevelStepArgs(argsText)!;
+
+    const entityMuts = mutationsByEntity.get(rec.expressId)!;
+    for (const mut of entityMuts) {
+      const attrIdx = ATTRIBUTE_INDEX[mut.propName.toLowerCase()];
+      if (attrIdx !== undefined && attrIdx < args.length) {
+        if (mut.propName.toLowerCase() === 'objecttype' && !objectTypeEntities.has(rec.type)) {
+          process.stderr.write(`Warning: attribute "ObjectType" not applicable to ${rec.type} #${rec.expressId}, skipping\n`);
+          continue;
+        }
+        const escaped = mut.value.replace(/\\/g, '\\\\').replace(/'/g, "''");
+        args[attrIdx] = `'${escaped}'`;
+      } else {
+        process.stderr.write(`Warning: attribute "${mut.propName}" not recognized for entity #${rec.expressId}\n`);
+      }
+    }
+
+    const prefix = rec.recordText.slice(0, rec.argsStart);
+    rewrites.set(rec.expressId, prefix + args.join(',') + ')');
+  }
+
+  if (unreadable.length > 0) {
+    throw new Error(
+      `refusing to rewrite ${unreadable.length} record(s) whose STEP text could not be read as a ` +
+        `complete argument list: ${unreadable.join(', ')}. Attributes are written by index, so a ` +
+        `mis-scanned list would put the value on the wrong attribute and drop the ones it swallowed ` +
+        `(LTplus-AG/ifc-lite#4125). Usual causes: an undoubled apostrophe inside a quoted string, an ` +
+        `unbalanced parenthesis, a comment inside the argument list, or a record this scan could not ` +
+        `locate at all. No output file was written.`,
+    );
+  }
+
+  // Rewrite from the highest byte offset down, so a length change from an
+  // earlier (in file order) edit cannot invalidate an offset recorded for a
+  // record not yet processed.
+  let outBytes = bytes;
+  const ordered = readable
+    .filter((r) => rewrites.has(r.expressId) && rewrites.get(r.expressId) !== r.recordText)
+    .sort((a, b) => b.offset - a.offset);
+  for (const rec of ordered) {
+    const rewritten = rewrites.get(rec.expressId)!;
+    const rewrittenBytes = encoder.encode(rewritten);
+    const tailStart = rec.offset + rec.length;
+    const merged = new Uint8Array(rec.offset + rewrittenBytes.length + (outBytes.length - tailStart));
+    merged.set(outBytes.subarray(0, rec.offset), 0);
+    merged.set(rewrittenBytes, rec.offset);
+    merged.set(outBytes.subarray(tailStart), rec.offset + rewrittenBytes.length);
+    outBytes = merged;
+  }
+
+  return decoder.decode(outBytes);
+}

--- a/packages/cli/src/commands/mutate-step-record.ts
+++ b/packages/cli/src/commands/mutate-step-record.ts
@@ -184,9 +184,31 @@ export function applyAttributeMutations(
     // closed this span early -- typically a stray, unmatched ')' inside a
     // malformed argument list -- and the span is shorter than the record
     // actually is.
+    //
+    // The lookahead window starts at 256 bytes but doubles (capped at 1 MiB)
+    // whenever `skipTrivia` stops at a block comment opener (`/*`) that has
+    // no closer within the window fetched so far -- that is the signature of
+    // a legal comment still open at the window's edge, not of a genuine
+    // truncation (`TRIVIA_RE`'s non-greedy `*\/` cannot match past the slice
+    // it is given, so the repetition stops BEFORE consuming that comment at
+    // all rather than consuming up to the window's end). Refusing on a
+    // too-small window would false-refuse a record whose trailing comment
+    // merely runs long.
     const tailStart = rec.offset + rec.length;
-    const tail = decoder.decode(bytes.subarray(tailStart, Math.min(tailStart + 256, bytes.length)));
-    const afterTrivia = skipTrivia(tail, 0);
+    let windowSize = 256;
+    let tail: string;
+    let afterTrivia: number;
+    for (;;) {
+      tail = decoder.decode(bytes.subarray(tailStart, Math.min(tailStart + windowSize, bytes.length)));
+      afterTrivia = skipTrivia(tail, 0);
+      const openCommentAtWindowEdge =
+        tail[afterTrivia] === '/' &&
+        tail[afterTrivia + 1] === '*' &&
+        !tail.slice(afterTrivia + 2).includes('*/');
+      const moreBytesAvailable = tailStart + windowSize < bytes.length;
+      if (!(openCommentAtWindowEdge && moreBytesAvailable) || windowSize >= 1 << 20) break;
+      windowSize *= 2;
+    }
     if (tail[afterTrivia] !== ';') {
       unreadable.push(`#${expressId}=${rec.type}`);
       continue;

--- a/packages/cli/src/commands/mutate.test.ts
+++ b/packages/cli/src/commands/mutate.test.ts
@@ -414,11 +414,15 @@ describe('applyAttributeMutations', () => {
     ).toThrow(/refusing to rewrite 1 record/);
   });
 
-  it('refuses a record that does not close on its own line instead of reporting a mutation it never made', () => {
-    // The exporter re-emits source lines verbatim, so a wrapped record from the
-    // input file arrives here split across two array entries. Measured against
-    // the real command before the fix: exit 0, "Mutated 1 entities: Name =
-    // NewName", and the wall's Name still 'Old' in the output file.
+  it('rewrites a record wrapped across lines, byte-exact record location instead of a per-line regex (LTplus-AG/ifc-lite#4163)', () => {
+    // The exporter re-emits source lines verbatim, so a record wrapped across
+    // several lines by the original file (100% of product records on some
+    // real exporters) arrives here split across array entries. The per-line
+    // regex + `lastIndexOf(')')` on main cannot see past the line break: it
+    // either refuses the whole run (a real record could not be rewritten) or,
+    // pre-#4125, silently reported success while leaving 'Old' untouched.
+    // Locating the record by its own balanced-paren span (not a line) fixes
+    // both: the edit actually happens.
     const before = [
       'ISO-10303-21;',
       'DATA;',
@@ -426,22 +430,27 @@ describe('applyAttributeMutations', () => {
       '$,$,$,$);',
       'ENDSEC;',
     ].join('\n');
-    expect(() =>
-      applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities),
-    ).toThrow(/#2=IFCWALL/);
+    const after = applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities);
+    expect(after).toBe(
+      ['ISO-10303-21;', 'DATA;', "#2=IFCWALL('guid',$,'NewName',$,$,", '$,$,$,$);', 'ENDSEC;'].join('\n'),
+    );
   });
 
-  it('refuses a wrapped record whose first line happens to close a nested list', () => {
-    // `lastIndexOf(')')` finds the `)` of the (#3,#4) set, so this line looks
-    // complete to a scan that only hunts for a closing paren.
+  it('rewrites a wrapped record whose first line happens to close a nested list', () => {
+    // On main, `lastIndexOf(')')` finds the `)` of the (#3,#4) set, so this
+    // line looks complete to a scan that only hunts for a closing paren --
+    // the record is misread as ending mid-argument-list and refused. Locating
+    // by the record's own balanced-paren span (its `(` closes on the `)`
+    // right before `;`, not the nested set's) reads it correctly.
     const before = [
       'DATA;',
       "#5=IFCRELDEFINESBYPROPERTIES('guid',$,'Old',$,(#3,#4),",
       '#6);',
     ].join('\n');
-    expect(() =>
-      applyAttributeMutations(before, [mutation(5, 'Name', 'NewName')], objectTypeEntities),
-    ).toThrow(/#5=IFCRELDEFINESBYPROPERTIES/);
+    const after = applyAttributeMutations(before, [mutation(5, 'Name', 'NewName')], objectTypeEntities);
+    expect(after).toBe(
+      ['DATA;', "#5=IFCRELDEFINESBYPROPERTIES('guid',$,'NewName',$,(#3,#4),", '#6);'].join('\n'),
+    );
   });
 
   it('collects every unreadable record into one error', () => {
@@ -472,6 +481,37 @@ describe('applyAttributeMutations', () => {
     const after = applyAttributeMutations(before, [mutation(2, 'Name', 'New')], objectTypeEntities);
     expect(after.split('\n')[2]).toBe(before.split('\n')[2]);
     expect(after.split('\n')[1]).toContain("'New'");
+  });
+
+  it('rewrites a record with a comment between the class keyword and "(" (LTplus-AG/ifc-lite#4163)', () => {
+    // On main, `/^#(\d+)\s*=\s*(\w+)\s*\(/` requires the class keyword's own
+    // '(' to follow only whitespace. A comment there makes the regex not
+    // match the line at all, so the scan `continue`s past it silently: no
+    // warning, no throw, "Mutated 1 entities" still prints, and the output
+    // file carries none of the edit. Locating the record by a trivia-aware
+    // walk (the same rule `StepTokenizer` itself uses) reads past the
+    // comment instead of being fooled by it.
+    const before = "#1=IFCWALL/* edited */('guid',$,'Old','D',$,$,$,$,.NOTDEFINED.);\n";
+    const after = applyAttributeMutations(before, [mutation(1, 'Name', 'NewName')], objectTypeEntities);
+    expect(after).toBe("#1=IFCWALL/* edited */('guid',$,'NewName','D',$,$,$,$,.NOTDEFINED.);\n");
+  });
+
+  it('refuses a record whose byte-exact span was truncated by a stray unmatched ")" rather than silently splicing into the truncated slice', () => {
+    // Emergent hazard: locating a record by its own balanced-paren span (not
+    // a line) can itself be fooled. A stray ')' inside a malformed argument
+    // list -- not inside a string or comment -- brings the scan's paren depth
+    // back to 0 early, so it reports the record as ending there: shorter than
+    // the malformed text actually is. That truncated span is internally
+    // well-formed (it IS balanced), so a validating splitter given only that
+    // span cannot see the cut either, and would happily write into
+    // "'a',$,B" as if it were the whole record, leaving ",$,$,$,$,$,$);"
+    // dangling in the output as orphaned bytes. The guard: a genuine
+    // record's ')' is followed (modulo trivia) by ';'; this one is followed
+    // by ',' instead, so it is refused rather than partially rewritten.
+    const before = "#6=IFCWALL('a',$,B),$,$,$,$,$,$);\n";
+    expect(() =>
+      applyAttributeMutations(before, [mutation(6, 'Name', 'X')], objectTypeEntities),
+    ).toThrow(/#6=IFCWALL/);
   });
 
   it('rewrites a well-formed record with a # and a comma inside its Name, byte-for-byte elsewhere', () => {

--- a/packages/cli/src/commands/mutate.test.ts
+++ b/packages/cli/src/commands/mutate.test.ts
@@ -453,6 +453,32 @@ describe('applyAttributeMutations', () => {
     );
   });
 
+  it('refuses a record whose line wrap drops the comma between two bare tokens (LTplus-AG/ifc-lite#4163/#4168)', () => {
+    // `step-args.ts`'s header names this exact accident: `splitTopLevelStepArgs`
+    // widened `\t`-only whitespace to space-and-tab, safe only because ITS
+    // caller used to pre-split on newlines. This PR's byte-exact record
+    // location feeds it raw, un-pre-split `argsText`, so a record wrapped
+    // across lines with the comma DROPPED at the wrap merges the two bare
+    // tokens either side of the break into one part. Before `\n`/`\r` joined
+    // `countWhitespace`/`isTokenBreak`, this was accepted as 8 parts for 9
+    // attributes -- exit 0, "Mutated 1 entities", and every attribute past
+    // the merge written to the wrong slot.
+    const before = ["#2=IFCWALL('guid',$,'Old',$", '$,$,$,$,.NOTDEFINED.);'].join('\n');
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities),
+    ).toThrow(/#2=IFCWALL/);
+  });
+
+  it('rewrites a well-formed record wrapped across a line break between two bare tokens, comma kept', () => {
+    // The positive control for the test above: the same shape, correctly
+    // comma-separated. This is the actual multi-line feature this PR adds,
+    // so widening the whitespace sets to refuse the malformed case above
+    // must not also refuse this one.
+    const before = ["#2=IFCWALL('guid',$,'Old',$,", '$,$,$,$,.NOTDEFINED.);'].join('\n');
+    const after = applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities);
+    expect(after).toBe(["#2=IFCWALL('guid',$,'NewName',$,", '$,$,$,$,.NOTDEFINED.);'].join('\n'));
+  });
+
   it('collects every unreadable record into one error', () => {
     const before = [
       'DATA;',
@@ -512,6 +538,20 @@ describe('applyAttributeMutations', () => {
     expect(() =>
       applyAttributeMutations(before, [mutation(6, 'Name', 'X')], objectTypeEntities),
     ).toThrow(/#6=IFCWALL/);
+  });
+
+  it('rewrites a record whose trailing comment before ";" is longer than the truncation guard\'s lookahead window', () => {
+    // The truncation guard's tail lookahead used to be a fixed 256 bytes: a
+    // legal block comment between ')' and ';' longer than that made the
+    // regex-based trivia skip stop mid-comment, so `tail[afterTrivia]` landed
+    // on '/' rather than ';' and a genuine, readable record was false-refused.
+    // It failed safe (refused rather than corrupted), so not a correctness
+    // bug, but this pins that a long trailing comment no longer costs the
+    // rewrite.
+    const longComment = `/*${'x'.repeat(400)}*/`;
+    const before = `#1=IFCWALL('guid',$,'Old',$,$,$,$,$,$)${longComment};\n`;
+    const after = applyAttributeMutations(before, [mutation(1, 'Name', 'New')], objectTypeEntities);
+    expect(after).toBe(`#1=IFCWALL('guid',$,'New',$,$,$,$,$,$)${longComment};\n`);
   });
 
   it('rewrites a well-formed record with a # and a comma inside its Name, byte-for-byte elsewhere', () => {

--- a/packages/cli/src/commands/mutate.ts
+++ b/packages/cli/src/commands/mutate.ts
@@ -16,7 +16,11 @@ import { MutablePropertyView } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
 import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
 import { PropertyValueType, findAttribute, type IfcSchemaVersion } from '@ifc-lite/data';
-import { splitTopLevelStepArgs } from './step-args.js';
+import { ATTRIBUTE_INDEX, applyAttributeMutations } from './mutate-step-record.js';
+
+// Re-exported so `mutate.test.ts` keeps importing these straight from
+// `./mutate.js`; the implementation lives in the sibling module above.
+export { ATTRIBUTE_INDEX, applyAttributeMutations };
 
 /**
  * Parse a --where filter string.
@@ -266,17 +270,6 @@ export async function mutateCommand(args: string[]): Promise<void> {
 }
 
 /**
- * IFC entity attribute indices (0-based positions in STEP argument list).
- * Standard for all IfcRoot subtypes: GlobalId(0), OwnerHistory(1), Name(2), Description(3).
- * IfcObject subtypes add ObjectType(4). Tag varies by entity type.
- */
-const ATTRIBUTE_INDEX: Record<string, number> = {
-  name: 2,
-  description: 3,
-  objecttype: 4,
-};
-
-/**
  * IFC types that define an ObjectType attribute, read from the bundled
  * buildingSMART schema for the file's own version.
  *
@@ -300,101 +293,3 @@ export async function entitiesWithObjectType(schema: string): Promise<ReadonlySe
   return new Set([...(attr?.simpleValueEntities ?? []), ...(attr?.complexEntities ?? [])]);
 }
 
-/**
- * Apply attribute mutations to STEP content via text replacement.
- * For each target entity, finds its STEP line and replaces the attribute at the known index.
- *
- * THROWS rather than rewriting a record whose text this pass cannot read. The
- * write below is BY INDEX, so it is only correct if `args[2]` really is the
- * record's third attribute; when the scan lost its place `args` still has parts
- * and the write still lands somewhere, silently (#4125, #2470). What a mis-scan
- * looks like, and why `splitTopLevelStepArgs` refuses one, is in
- * `step-args.ts`'s header.
- *
- * Throwing, not skipping-and-reporting, because this command's whole output is
- * a FILE: a skip writes one that looks like what was asked for and is missing
- * the edit, under a `Mutated 1 entities` line. The throw reaches `main().catch`
- * in `index.ts`, which prints `Error [mutate]: ...` and exits 1 with no output
- * file, so exit code and filesystem agree. The `Warning: ... skipping` paths
- * below stay warnings, and they are not both about the request: one names an attribute
- * the SCHEMA does not give that entity, the other ALSO fires when the record has fewer
- * arguments than the attribute index. Both stay warnings because the record was read.
- */
-export function applyAttributeMutations(
-  content: string,
-  mutations: { entity: any; propName: string; value: string }[],
-  objectTypeEntities: ReadonlySet<string>,
-): string {
-  // Group mutations by expressId for efficient single-pass replacement
-  const mutationsByEntity = new Map<number, { propName: string; value: string }[]>();
-  for (const m of mutations) {
-    const id = m.entity.ref.expressId;
-    const list = mutationsByEntity.get(id) ?? [];
-    list.push({ propName: m.propName, value: m.value });
-    mutationsByEntity.set(id, list);
-  }
-
-  // Records this pass was asked to rewrite and could not read. Collected
-  // rather than thrown on first sight so one run names every one of them.
-  const unreadable: string[] = [];
-
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Match entity lines: #123=IFCTYPE(...);
-    const match = line.match(/^#(\d+)\s*=\s*(\w+)\s*\(/);
-    if (!match) continue;
-
-    const expressId = parseInt(match[1], 10);
-    const entityType = match[2].toUpperCase();
-    const entityMuts = mutationsByEntity.get(expressId);
-    if (!entityMuts) continue;
-
-    // Parse the STEP argument list (handle nested parens and quoted strings)
-    const argsStart = line.indexOf('(');
-    const argsEnd = line.lastIndexOf(')');
-    // A record wrapped across lines is caught rather than truncated: `argsEnd`
-    // is the LAST ')' on the line and the slice EXCLUDES it, so the nested list
-    // that ')' closed is left open and the split refuses. The exporter re-emits
-    // source lines verbatim, so a wrapped record from the input reaches here
-    // intact, and used to be skipped in silence while the run reported the
-    // mutation as done.
-    const args =
-      argsEnd > argsStart ? splitTopLevelStepArgs(line.slice(argsStart + 1, argsEnd)) : null;
-    if (args === null) {
-      unreadable.push(`#${expressId}=${entityType}`);
-      continue;
-    }
-
-    for (const mut of entityMuts) {
-      const attrIdx = ATTRIBUTE_INDEX[mut.propName.toLowerCase()];
-      if (attrIdx !== undefined && attrIdx < args.length) {
-        // Validate ObjectType is only written to entities that define it
-        if (mut.propName.toLowerCase() === 'objecttype' && !objectTypeEntities.has(entityType)) {
-          process.stderr.write(`Warning: attribute "ObjectType" not applicable to ${entityType} #${expressId}, skipping\n`);
-          continue;
-        }
-        // Escape for STEP format and wrap in quotes
-        const escaped = mut.value.replace(/\\/g, '\\\\').replace(/'/g, "''");
-        args[attrIdx] = `'${escaped}'`;
-      } else {
-        process.stderr.write(`Warning: attribute "${mut.propName}" not recognized for entity #${expressId}\n`);
-      }
-    }
-
-    lines[i] = line.slice(0, argsStart + 1) + args.join(',') + line.slice(argsEnd);
-  }
-
-  if (unreadable.length > 0) {
-    throw new Error(
-      `refusing to rewrite ${unreadable.length} record(s) whose STEP text could not be read as a ` +
-        `complete argument list: ${unreadable.join(', ')}. Attributes are written by index, so a ` +
-        `mis-scanned list would put the value on the wrong attribute and drop the ones it swallowed ` +
-        `(LTplus-AG/ifc-lite#4125). Usual causes: an undoubled apostrophe inside a quoted string, an ` +
-        `unbalanced parenthesis, a comment inside the argument list, or a record spanning several ` +
-        `lines. No output file was written.`,
-    );
-  }
-
-  return lines.join('\n');
-}

--- a/packages/cli/src/commands/step-args.test.ts
+++ b/packages/cli/src/commands/step-args.test.ts
@@ -51,6 +51,18 @@ describe('splitTopLevelStepArgs', () => {
         "'guid',$,'50% /* not a comment',$",
         ["'guid'", '$', "'50% /* not a comment'", '$'],
       ],
+      // #4163's multi-line work feeds this a raw, un-pre-split `argsText`, so a
+      // record wrapped across a line, with the comma correctly kept BEFORE the
+      // break, must still split into the right number of parts. This is the
+      // well-formed counterpart to the malformed `$\n$` case below: same shape,
+      // comma present, and it must be ACCEPTED with the correct count (9, not
+      // 8) rather than refused as collateral damage from widening the
+      // whitespace sets.
+      [
+        'a bare token list wrapped across a newline with the comma kept',
+        "'guid',$,'Old',$,\n$,$,$,$,.NOTDEFINED.",
+        ["'guid'", '$', "'Old'", '$', '\n$', '$', '$', '$', '.NOTDEFINED.'],
+      ],
     ])('splits %s', (_label, input, expected) => {
       expect(splitTopLevelStepArgs(input)).toEqual(expected);
     });
@@ -139,6 +151,20 @@ describe('splitTopLevelStepArgs', () => {
       // The OPENER is what breaks the run, so a comment that never closes is
       // refused for the same reason rather than by luck.
       ['an unterminated STEP block comment', "'guid',/*unclosed,$"],
+      // The #4163 defect this file's header names by name: two bare tokens
+      // (`$` and `$`) separated by a raw newline with NO comma between them.
+      // Before `\n`/`\r`/`\x0b`/`\x0c` joined `isTokenBreak` and
+      // `countWhitespace`, a bare run spanned the newline silently and this
+      // came back as 8 accepted parts for 9 attributes (measured against the
+      // pre-fix source: `["'guid'","$","'Old'","$\n$","$","$","$",".NOTDEFINED."]`,
+      // non-null, i.e. treated as READABLE) rather than refused — the same
+      // phantom-slot shift as the rest of #4125/#4163, just triggered by a line
+      // wrap instead of a phantom string. Every attribute past the merged pair
+      // then mutates into the wrong slot while the CLI reports success.
+      [
+        'a bare token split across a raw newline with the comma dropped',
+        "'guid',$,'Old',$\n$,$,$,$,.NOTDEFINED.",
+      ],
     ])('refuses %s', (_label, input) => {
       expect(splitTopLevelStepArgs(input)).toBeNull();
     });

--- a/packages/cli/src/commands/step-args.ts
+++ b/packages/cli/src/commands/step-args.ts
@@ -274,27 +274,38 @@ function isTokenBreak(char: string): boolean {
     char === ',' ||
     char === '/' ||
     char === ' ' ||
-    char === '\t'
+    char === '\t' ||
+    char === '\n' ||
+    char === '\r' ||
+    char === '\x0b' ||
+    char === '\x0c'
   );
 }
 
 /**
  * How many whitespace characters run from `from`.
  *
- * Space and tab only, where every NAMED STEP whitespace set in this repo
- * (`is_step_space`, `isSpaceByte`, `isAsciiSpace`, `STEP_TRIVIA`) is the six
- * characters ` \t\n\r\x0b\x0c`. That is safe here only because the caller
- * splits on newlines before this ever runs. `\n` and `\r` are in neither this
- * set nor {@link isTokenBreak}, so a bare run spans them silently and two tokens
- * separated by a newline come back as ONE part (measured: `'$\n$'` splits to
- * `["$\n$"]`, where `'$ $'` and `'$\t$'` are refused). That is the same
- * token-ending-where-it-cannot defect this module exists to catch, unreachable only
- * because the caller pre-splits on newlines. #4163's multi-line work would
- * start feeding real multi-line argument lists through here; widen both sets then
- * rather than relying on that accident.
+ * All six characters every NAMED STEP whitespace set in this repo agrees on
+ * (`is_step_space`, `isSpaceByte`, `isAsciiSpace`, `STEP_TRIVIA`): ` \t\n\r\x0b\x0c`.
+ * This used to be space and tab only, safe only because the caller split on
+ * newlines before this ever ran; #4163's multi-line work now feeds this a raw
+ * multi-line `argsText`, so `\n` and `\r` (and `\x0b`/`\x0c`, in the set for the
+ * same reason) had to join both this and {@link isTokenBreak} or a bare run
+ * spans a line break silently and two tokens separated by one come back as ONE
+ * part (measured, before this widening: `'$\n$'` split to `["$\n$"]`, where
+ * `'$ $'` and `'$\t$'` were already refused).
  */
 function countWhitespace(text: string, from: number): number {
   let n = 0;
-  while (from + n < text.length && (text[from + n] === ' ' || text[from + n] === '\t')) n++;
+  while (
+    from + n < text.length &&
+    (text[from + n] === ' ' ||
+      text[from + n] === '\t' ||
+      text[from + n] === '\n' ||
+      text[from + n] === '\r' ||
+      text[from + n] === '\x0b' ||
+      text[from + n] === '\x0c')
+  )
+    n++;
   return n;
 }


### PR DESCRIPTION
## What this now adds on top of #4174

#4174 (merged) fixed mutate's wrong-attribute silent-corruption class
(#4125/#2470: an undoubled apostrophe inside a string swallows top-level
commas; `splitTopLevelStepArgs` now refuses a mis-scanned argument split
instead of writing into it). Its own body explicitly filed **this** issue,
#4163, as out of scope: mutate's record *location* is a per-line regex,
narrower than the parser's, and disagrees with it on a record wrapped
across lines or with a comment between the class keyword and `(`.

That gap is still live on current `main`. Verified against
`applyAttributeMutations` as shipped:

```
#1=IFCWALL/* edited */('guid',$,'Old','D',$,$,$,$,.NOTDEFINED.);
```

`/^#(\d+)\s*=\s*(\w+)\s*\(/` does not match this line at all (the comment
sits between the keyword and `(`), so the line is skipped in total silence
-- no throw, no warning -- while `mutateCommand` still prints
`Mutated 1 entities` and exits 0 over a file that carries none of the edit.

This PR is a rebase onto current `main`, resolved deliberately rather than
mechanically: it keeps `main`'s (== #4174's) validating `splitTopLevelStepArgs`
as the argument-list splitter, unchanged, and layers only the record
**location** fix on top -- `StepTokenizer.scanEntities()` (the parser's own
balanced-parenthesis, string- and comment-aware scan) finds each target
record's exact byte span, wherever it falls relative to line breaks or a
comment before `(`. A record this pass cannot split safely is still refused,
exactly as it is on `main` today, because the splitter itself is untouched.

**Why not just merge the original diff**: it shipped with its own
`splitStepArgs`, a pre-#4125, non-validating splitter, which reintroduced the
exact corruption #4174 had just closed. Verified against #4174's own
`apos.ifc` reproduction run through the original `applyAttributeMutations`:

```
#2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED.);
--set Name=NewName  ->  #2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'NewName',.NOTDEFINED.);
```

Nine attributes silently down to four, exit 0 -- the same shape #4174 exists
to prevent. That splitter is gone from this version; `mutate-step-record.ts`
imports `splitTopLevelStepArgs` from `step-args.ts` instead of carrying its
own.

**A further hazard, found while combining the two designs and closed here**:
`scanEntities()`'s own balanced-paren scan can itself be fooled. A stray,
unmatched `)` inside a malformed record's argument list (not inside a string
or comment) brings the scan's depth back to 0 early, so it reports the
record as ending there -- silently TRUNCATED, well short of the record's
real extent. That truncated span is internally well-formed (it is exactly
as long as it is balanced), so a validating splitter given only that span
cannot see the cut either. Verified against the original diff:

```
#6=IFCWALL('a',$,B),$,$,$,$,$,$);
--set Name=X  ->  #6=IFCWALL('a',$,'X'),$,$,$,$,$,$);
```

silently written, leaving `,$,$,$,$,$,$);` dangling as corrupted bytes right
after the rewritten record. This version adds a structural guard: a located
record's `)` must be followed (modulo STEP trivia) by `;`, the record
terminator. A genuine record always has one there; a truncated one does not
(the bytes that would carry it are still unconsumed argument text), so it is
refused instead of partially rewritten.

## Test plan
- Every retained behaviour has a test that fails on unmodified `main` and
  passes here (`mutate.test.ts`): a record wrapped across lines, a record
  wrapped mid-nested-list, a record with a comment before `(`, and the
  truncated-span guard above.
- Mutation-tested by hand, each confirmed to turn exactly the tests it
  covers RED and nothing else: disabling the truncation guard, swapping the
  validating splitter for a naive comma-split, and removing the trivia-skip
  before a record's `(`.
- Full `packages/cli` vitest suite: 868 passed, 8 skipped, 71 files.
- `node scripts/check-module-size.mjs`: OK (`mutate.ts` 295 lines,
  `mutate-step-record.ts` 298 lines, both well under budget).
- `node scripts/check-changesets.mjs`, `check-test-wiring.mjs`,
  `check-source-text-assertions.mjs`: all pass.

Closes #4163

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

