### PR TITLE
fix(cli): refuse to rewrite a STEP record mutate cannot split cleanly (#4125)

### DIFF
--- a/.changeset/mutate-validating-step-split.md
+++ b/.changeset/mutate-validating-step-split.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`mutate` now refuses to rewrite a STEP record whose argument list it cannot read, instead of writing the attribute into whatever a mis-scan accumulated and reporting success (#4125).
+
+Attribute writes are by index, so a record split into the wrong parts puts the value on the wrong attribute and drops the ones the mis-scan swallowed. Measured on an IFC4 wall carrying two undoubled apostrophes, `--set Name=NewName` took a 9-attribute record down to 4 and exited 0; a record wrapped across two lines was skipped in silence while the run still reported the mutation. Both now fail with an error naming the record, and no output file is written. One legal shape is refused as a side effect: a record whose trailing comment contains a `)` (as in `#1=IFCWALL(...); /* note (x) */`) is now rejected rather than rewritten, because the argument list is located with `lastIndexOf(')')`. That is tracked as #4163.
+
+The argument list is validated at every nesting depth, so the same corruption inside typed values or adjacent lists of strings is caught as well: `IFCLABEL('a's'),$,IFCLABEL('b's'),$` keeps the parens balanced and still reads four attributes as two, and `IfcPerson`'s MiddleNames and PrefixTitles have that shape.
+
+A STEP block comment in the argument list is refused too, whatever it contains. A comment carrying no whitespace read as a whole extra argument, so `--set Description=NEWDESC` on `#2=IFCWALL('1BBB...',/*edited*/,$,'MyName','MyDescription',...)` overwrote Name and exited 0. The scan now breaks a bare token run on `/`, so the comment can never be mistaken for one; a `/` inside a quoted string is untouched, and storey and family names carrying one still rewrite.

--- a/packages/cli/src/commands/mutate.test.ts
+++ b/packages/cli/src/commands/mutate.test.ts
@@ -8,10 +8,10 @@ import {
   parseSetArg,
   coerceValue,
   matchesFilter,
-  splitStepArgs,
   applyAttributeMutations,
   entitiesWithObjectType,
 } from './mutate.js';
+import { splitTopLevelStepArgs } from './step-args.js';
 import { PropertyValueType } from '@ifc-lite/data';
 
 describe('parseWhereFilter', () => {
@@ -247,54 +247,6 @@ describe('matchesFilter', () => {
   });
 });
 
-describe('splitStepArgs', () => {
-  it('splits simple comma-separated values', () => {
-    expect(splitStepArgs("'abc',123,$,.T.")).toEqual(["'abc'", '123', '$', '.T.']);
-  });
-
-  it('handles nested parentheses', () => {
-    expect(splitStepArgs("'hello',(1,2,3),$")).toEqual(["'hello'", '(1,2,3)', '$']);
-  });
-
-  it('handles quoted strings with commas', () => {
-    expect(splitStepArgs("'hello, world',42")).toEqual(["'hello, world'", '42']);
-  });
-
-  it('handles escaped quotes in strings (doubled single quotes)', () => {
-    expect(splitStepArgs("'it''s a test',99")).toEqual(["'it''s a test'", '99']);
-  });
-
-  it('handles empty input', () => {
-    expect(splitStepArgs('')).toEqual([]);
-  });
-
-  it('handles single value', () => {
-    expect(splitStepArgs('42')).toEqual(['42']);
-  });
-
-  it('handles deeply nested parens', () => {
-    expect(splitStepArgs('#1,IFCWALL((1,(2,3)),4),#5')).toEqual(['#1', 'IFCWALL((1,(2,3)),4)', '#5']);
-  });
-
-  it('handles STEP null ($) and derived (*) markers', () => {
-    expect(splitStepArgs('$,$,*')).toEqual(['$', '$', '*']);
-  });
-
-  it('handles entity references', () => {
-    expect(splitStepArgs('#1,#2,#3')).toEqual(['#1', '#2', '#3']);
-  });
-
-  it('handles mixed content typical of IFC STEP lines', () => {
-    const result = splitStepArgs("'2aG1gNarLHm9Qs6Q3z97P1',#2,'Wall-001','An external wall',$");
-    expect(result).toHaveLength(5);
-    expect(result[0]).toBe("'2aG1gNarLHm9Qs6Q3z97P1'");
-    expect(result[1]).toBe('#2');
-    expect(result[2]).toBe("'Wall-001'");
-    expect(result[3]).toBe("'An external wall'");
-    expect(result[4]).toBe('$');
-  });
-});
-
 describe('applyAttributeMutations', () => {
   /** A minimal STEP body with one entity line of the given type. */
   const stepFile = (expressId: number, type: string, args: string): string =>
@@ -309,7 +261,7 @@ describe('applyAttributeMutations', () => {
   /** The arguments of the single entity line, after mutation. */
   const argsOf = (content: string): string[] => {
     const line = content.split('\n').find((l) => l.startsWith('#'))!;
-    return splitStepArgs(line.slice(line.indexOf('(') + 1, line.lastIndexOf(')')));
+    return splitTopLevelStepArgs(line.slice(line.indexOf('(') + 1, line.lastIndexOf(')')))!;
   };
 
   // IfcRoot fixes GlobalId(0), OwnerHistory(1), Name(2), Description(3), and
@@ -378,6 +330,176 @@ describe('applyAttributeMutations', () => {
       applyAttributeMutations(before, [mutation(1, 'Name', "O'Brien\\x")], objectTypeEntities),
     );
     expect(args[2]).toBe("'O''Brien\\\\x'");
+  });
+
+  // ---- #4125: a record this pass cannot read is refused, not rewritten ----
+
+  it('refuses the record whose undoubled apostrophes made a 9-attribute wall into 4', () => {
+    // Reproduced against the real command before the fix: exit 0, "Mutated 1
+    // entities", and the output line was
+    //   #2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'NewName',.NOTDEFINED.);
+    // with Description, ObjectType, ObjectPlacement, Representation and Tag
+    // gone. `step-args.ts`'s header has the walk-through.
+    const before = stepFile(2, 'IFCWALL', "'1BBBBBBBBBBBBBBBBBBBBB',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED.");
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities),
+    ).toThrow(/could not be read as a complete argument list/);
+  });
+
+  it('refuses the same wall when the apostrophes sit inside typed values', () => {
+    // Reproduced against the real command built from the FIRST fix for #4125,
+    // which checked only the top level: exit 0, "Mutated 1 entities", and
+    //   #2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'NewName',$,$,'T',.NOTDEFINED.);
+    // Nine attributes down to seven. The phantom string swallows
+    // `),$,IFCLABEL(`, one `)` and one `(`, so the depth still balances and
+    // each part is a keyword applied to one list.
+    const before = stepFile(
+      2,
+      'IFCWALL',
+      "'1BBBBBBBBBBBBBBBBBBBBB',$,IFCLABEL('a's'),$,IFCLABEL('b's'),$,$,'T',.NOTDEFINED.",
+    );
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities),
+    ).toThrow(/#2=IFCWALL/);
+  });
+
+  it('refuses a record carrying a STEP block comment, the cause the error names', () => {
+    // Reproduced against the built CLI at the first fix for #4125: a comment
+    // with no whitespace in it broke no bare run, so it was accepted as a
+    // phantom slot and `--set Description` landed on Name.
+    //   $ ifc-lite mutate cmt2.ifc --id 2 --set Description=NEWDESC --out outE.ifc
+    //   Mutated 1 entities: Description = NEWDESC        # exit 0
+    //   #2=IFCWALL('1BBB...',/*edited*/,$,'NEWDESC','MyDescription',$,$,$,$,.NOTDEFINED.);
+    // Name overwritten, Description untouched. "a comment inside the argument
+    // list" is listed as a usual cause in the error below, so it is pinned.
+    const before = stepFile(
+      2,
+      'IFCWALL',
+      "'1BBBBBBBBBBBBBBBBBBBBB',/*edited*/,$,'MyName','MyDescription',$,$,$,$,.NOTDEFINED.",
+    );
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Description', 'NEWDESC')], objectTypeEntities),
+    ).toThrow(/a comment inside the argument list/);
+  });
+
+  it('still rewrites a record whose Name contains a slash', () => {
+    // The false-positive control for the test above. `/` is what refuses a
+    // comment, and storey and family names carry slashes constantly, so a
+    // scanner that refused these would break `mutate` on ordinary files.
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'Level 1/2',$,$,$,$,$,$");
+    const args = argsOf(applyAttributeMutations(before, [mutation(1, 'Name', 'A/B')], objectTypeEntities));
+    expect(args[2]).toBe("'A/B'");
+    expect(args[3]).toBe('$');
+  });
+
+  it('names the refused record, so the error says which one', () => {
+    const before = stepFile(2, 'IFCWALL', "'guid',$,'John's wall',$,$,$,$,'A's',$");
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Name', 'X')], objectTypeEntities),
+    ).toThrow(/#2=IFCWALL/);
+  });
+
+  it.each([
+    ['an unterminated string', "'guid',$,'never closed"],
+    ['a stray closing paren', "'guid',$,'N'),$,$,$,$,$"],
+    ['an unclosed nested list', "'guid',$,'N',(1,2,$,$,$,$"],
+    // IfcPerson declares MiddleNames and PrefixTitles as adjacent lists of
+    // strings, so one undoubled apostrophe in each reads eight attributes as
+    // seven with the parens still balanced.
+    ['undoubled apostrophes in two adjacent string lists', "'id','Smith','John',('D'Arcy'),('O'Neill'),$,$,$"],
+  ])('refuses a record with %s', (_label, args) => {
+    const before = stepFile(4, 'IFCWALL', args);
+    expect(() =>
+      applyAttributeMutations(before, [mutation(4, 'Name', 'X')], objectTypeEntities),
+    ).toThrow(/refusing to rewrite 1 record/);
+  });
+
+  it('refuses a record that does not close on its own line instead of reporting a mutation it never made', () => {
+    // The exporter re-emits source lines verbatim, so a wrapped record from the
+    // input file arrives here split across two array entries. Measured against
+    // the real command before the fix: exit 0, "Mutated 1 entities: Name =
+    // NewName", and the wall's Name still 'Old' in the output file.
+    const before = [
+      'ISO-10303-21;',
+      'DATA;',
+      "#2=IFCWALL('guid',$,'Old',$,$,",
+      '$,$,$,$);',
+      'ENDSEC;',
+    ].join('\n');
+    expect(() =>
+      applyAttributeMutations(before, [mutation(2, 'Name', 'NewName')], objectTypeEntities),
+    ).toThrow(/#2=IFCWALL/);
+  });
+
+  it('refuses a wrapped record whose first line happens to close a nested list', () => {
+    // `lastIndexOf(')')` finds the `)` of the (#3,#4) set, so this line looks
+    // complete to a scan that only hunts for a closing paren.
+    const before = [
+      'DATA;',
+      "#5=IFCRELDEFINESBYPROPERTIES('guid',$,'Old',$,(#3,#4),",
+      '#6);',
+    ].join('\n');
+    expect(() =>
+      applyAttributeMutations(before, [mutation(5, 'Name', 'NewName')], objectTypeEntities),
+    ).toThrow(/#5=IFCRELDEFINESBYPROPERTIES/);
+  });
+
+  it('collects every unreadable record into one error', () => {
+    const before = [
+      'DATA;',
+      "#2=IFCWALL('guid',$,'John's wall',$,$,$,$,'A's',$);",
+      "#3=IFCWALL('guid3',$,'N'),$,$,$,$,$,$);",
+      'ENDSEC;',
+    ].join('\n');
+    expect(() =>
+      applyAttributeMutations(
+        before,
+        [mutation(2, 'Name', 'X'), mutation(3, 'Name', 'X')],
+        objectTypeEntities,
+      ),
+    ).toThrow(/refusing to rewrite 2 record\(s\).*#2=IFCWALL, #3=IFCWALL/s);
+  });
+
+  it('leaves an unreadable record that was NOT targeted alone', () => {
+    // The refusal is scoped to records this run was asked to rewrite. A
+    // malformed line elsewhere in the file is not this command's business.
+    const before = [
+      'DATA;',
+      "#2=IFCWALL('guid',$,'Old',$,$,$,$,$,$);",
+      "#9=IFCWALL('other',$,'Bob's wall',$,$,$,$,'C's',$);",
+      'ENDSEC;',
+    ].join('\n');
+    const after = applyAttributeMutations(before, [mutation(2, 'Name', 'New')], objectTypeEntities);
+    expect(after.split('\n')[2]).toBe(before.split('\n')[2]);
+    expect(after.split('\n')[1]).toContain("'New'");
+  });
+
+  it('rewrites a well-formed record with a # and a comma inside its Name, byte-for-byte elsewhere', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',#2,'Wall #3, north','Desc',$,#4,$,'TAG',.NOTDEFINED.");
+    const after = applyAttributeMutations(before, [mutation(1, 'Name', 'Renamed')], objectTypeEntities);
+    expect(after).toBe(stepFile(1, 'IFCWALL', "'guid',#2,'Renamed','Desc',$,#4,$,'TAG',.NOTDEFINED."));
+  });
+
+  it('rewrites through doubled-quote escapes and a nested list without touching them', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'it''s',(1.,2.,3.),$,$,$,'T''AG',$");
+    const after = applyAttributeMutations(before, [mutation(1, 'Name', 'New')], objectTypeEntities);
+    expect(after).toBe(stepFile(1, 'IFCWALL', "'guid',$,'New',(1.,2.,3.),$,$,$,'T''AG',$"));
+  });
+
+  it('leaves a record it was not asked to change byte-identical', () => {
+    const before = [
+      'ISO-10303-21;',
+      'DATA;',
+      "#1=IFCWALL('guid',$,'Keep me',$,$,$,$,'TAG',.NOTDEFINED.);",
+      "#2=IFCWALL('guid2', $ , 'Rename me' ,$,$,$,$,$,$);",
+      'ENDSEC;',
+    ].join('\n');
+    const after = applyAttributeMutations(before, [mutation(2, 'Name', 'New')], objectTypeEntities);
+    const beforeLines = before.split('\n');
+    const afterLines = after.split('\n');
+    expect(afterLines[2]).toBe(beforeLines[2]);
+    // and the rewritten one keeps every byte of its other slots, padding included
+    expect(afterLines[3]).toBe("#2=IFCWALL('guid2', $ ,'New',$,$,$,$,$,$);");
   });
 });
 

--- a/packages/cli/src/commands/mutate.ts
+++ b/packages/cli/src/commands/mutate.ts
@@ -16,6 +16,7 @@ import { MutablePropertyView } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
 import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
 import { PropertyValueType, findAttribute, type IfcSchemaVersion } from '@ifc-lite/data';
+import { splitTopLevelStepArgs } from './step-args.js';
 
 /**
  * Parse a --where filter string.
@@ -302,6 +303,22 @@ export async function entitiesWithObjectType(schema: string): Promise<ReadonlySe
 /**
  * Apply attribute mutations to STEP content via text replacement.
  * For each target entity, finds its STEP line and replaces the attribute at the known index.
+ *
+ * THROWS rather than rewriting a record whose text this pass cannot read. The
+ * write below is BY INDEX, so it is only correct if `args[2]` really is the
+ * record's third attribute; when the scan lost its place `args` still has parts
+ * and the write still lands somewhere, silently (#4125, #2470). What a mis-scan
+ * looks like, and why `splitTopLevelStepArgs` refuses one, is in
+ * `step-args.ts`'s header.
+ *
+ * Throwing, not skipping-and-reporting, because this command's whole output is
+ * a FILE: a skip writes one that looks like what was asked for and is missing
+ * the edit, under a `Mutated 1 entities` line. The throw reaches `main().catch`
+ * in `index.ts`, which prints `Error [mutate]: ...` and exits 1 with no output
+ * file, so exit code and filesystem agree. The `Warning: ... skipping` paths
+ * below stay warnings, and they are not both about the request: one names an attribute
+ * the SCHEMA does not give that entity, the other ALSO fires when the record has fewer
+ * arguments than the attribute index. Both stay warnings because the record was read.
  */
 export function applyAttributeMutations(
   content: string,
@@ -316,6 +333,10 @@ export function applyAttributeMutations(
     list.push({ propName: m.propName, value: m.value });
     mutationsByEntity.set(id, list);
   }
+
+  // Records this pass was asked to rewrite and could not read. Collected
+  // rather than thrown on first sight so one run names every one of them.
+  const unreadable: string[] = [];
 
   const lines = content.split('\n');
   for (let i = 0; i < lines.length; i++) {
@@ -332,9 +353,18 @@ export function applyAttributeMutations(
     // Parse the STEP argument list (handle nested parens and quoted strings)
     const argsStart = line.indexOf('(');
     const argsEnd = line.lastIndexOf(')');
-    if (argsStart === -1 || argsEnd === -1) continue;
-
-    const args = splitStepArgs(line.slice(argsStart + 1, argsEnd));
+    // A record wrapped across lines is caught rather than truncated: `argsEnd`
+    // is the LAST ')' on the line and the slice EXCLUDES it, so the nested list
+    // that ')' closed is left open and the split refuses. The exporter re-emits
+    // source lines verbatim, so a wrapped record from the input reaches here
+    // intact, and used to be skipped in silence while the run reported the
+    // mutation as done.
+    const args =
+      argsEnd > argsStart ? splitTopLevelStepArgs(line.slice(argsStart + 1, argsEnd)) : null;
+    if (args === null) {
+      unreadable.push(`#${expressId}=${entityType}`);
+      continue;
+    }
 
     for (const mut of entityMuts) {
       const attrIdx = ATTRIBUTE_INDEX[mut.propName.toLowerCase()];
@@ -355,44 +385,16 @@ export function applyAttributeMutations(
     lines[i] = line.slice(0, argsStart + 1) + args.join(',') + line.slice(argsEnd);
   }
 
-  return lines.join('\n');
-}
-
-/**
- * Split a STEP argument string by commas, respecting nested parens and quoted strings.
- */
-export function splitStepArgs(argsStr: string): string[] {
-  const result: string[] = [];
-  let current = '';
-  let depth = 0;
-  let inString = false;
-
-  for (let i = 0; i < argsStr.length; i++) {
-    const ch = argsStr[i];
-    if (inString) {
-      current += ch;
-      if (ch === "'" && argsStr[i + 1] === "'") {
-        current += "'";
-        i++; // skip escaped quote
-      } else if (ch === "'") {
-        inString = false;
-      }
-    } else if (ch === "'") {
-      inString = true;
-      current += ch;
-    } else if (ch === '(') {
-      depth++;
-      current += ch;
-    } else if (ch === ')') {
-      depth--;
-      current += ch;
-    } else if (ch === ',' && depth === 0) {
-      result.push(current);
-      current = '';
-    } else {
-      current += ch;
-    }
+  if (unreadable.length > 0) {
+    throw new Error(
+      `refusing to rewrite ${unreadable.length} record(s) whose STEP text could not be read as a ` +
+        `complete argument list: ${unreadable.join(', ')}. Attributes are written by index, so a ` +
+        `mis-scanned list would put the value on the wrong attribute and drop the ones it swallowed ` +
+        `(LTplus-AG/ifc-lite#4125). Usual causes: an undoubled apostrophe inside a quoted string, an ` +
+        `unbalanced parenthesis, a comment inside the argument list, or a record spanning several ` +
+        `lines. No output file was written.`,
+    );
   }
-  if (current) result.push(current);
-  return result;
+
+  return lines.join('\n');
 }

--- a/packages/cli/src/commands/step-args.test.ts
+++ b/packages/cli/src/commands/step-args.test.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { splitTopLevelStepArgs } from './step-args.js';
+
+describe('splitTopLevelStepArgs', () => {
+  describe('lists it accepts', () => {
+    it.each([
+      ['simple comma-separated values', "'abc',123,$,.T.", ["'abc'", '123', '$', '.T.']],
+      ['a nested list', "'hello',(1,2,3),$", ["'hello'", '(1,2,3)', '$']],
+      ['deeply nested lists', '#1,IFCWALL((1,(2,3)),4),#5', ['#1', 'IFCWALL((1,(2,3)),4)', '#5']],
+      ['a comma inside a string', "'hello, world',42", ["'hello, world'", '42']],
+      ['a paren inside a string', "'a (b) c',42", ["'a (b) c'", '42']],
+      ['a doubled-quote escape', "'it''s a test',99", ["'it''s a test'", '99']],
+      ['an escaped quote next to the terminator', "'ends with''',7", ["'ends with'''", '7']],
+      ['an empty string literal', "'',$", ["''", '$']],
+      ['STEP null and derived markers', '$,$,*', ['$', '$', '*']],
+      ['entity references', '#1,#2,#3', ['#1', '#2', '#3']],
+      ['a single value', '42', ['42']],
+      ['no arguments at all', '', []],
+      // Invalid STEP, deliberately accepted: an empty slot is ONE part, so
+      // every later index still names the attribute it is meant to. Refusing
+      // it would refuse a rewrite that would have been correct.
+      ['an empty interior slot', 'a,,b', ['a', '', 'b']],
+      // The positive controls for the refusals below: the same shapes, written
+      // correctly. A validator that refused these would break `mutate` on
+      // well-formed files, which is the more expensive failure.
+      [
+        'a typed value holding a string',
+        "'guid',$,IFCLABEL('a'),$",
+        ["'guid'", '$', "IFCLABEL('a')", '$'],
+      ],
+      [
+        'adjacent string lists with their apostrophes doubled',
+        "'id','Smith','John',('D''Arcy'),('O''Neill'),$,$,$",
+        ["'id'", "'Smith'", "'John'", "('D''Arcy')", "('O''Neill')", '$', '$', '$'],
+      ],
+      // The positive controls for the comment refusals. `/` breaks a bare run,
+      // so these pin that it does NOT reach inside a string: storey and family
+      // names carry slashes constantly ('Level 1/2', 'M_Wall/Basic'), and
+      // refusing them would break `mutate` on ordinary files.
+      [
+        'a slash inside a string',
+        "'guid',$,'Level 1/2',$",
+        ["'guid'", '$', "'Level 1/2'", '$'],
+      ],
+      [
+        'a comment opener inside a string',
+        "'guid',$,'50% /* not a comment',$",
+        ["'guid'", '$', "'50% /* not a comment'", '$'],
+      ],
+    ])('splits %s', (_label, input, expected) => {
+      expect(splitTopLevelStepArgs(input)).toEqual(expected);
+    });
+
+    it('keeps a `#` inside a string out of the reference syntax', () => {
+      // A Name of "Wall #3, north" is the shape that makes a naive splitter
+      // look right and be wrong: the comma is inside the string and the `#`
+      // is not a reference.
+      expect(splitTopLevelStepArgs("'guid',$,'Wall #3, north',$")).toEqual([
+        "'guid'",
+        '$',
+        "'Wall #3, north'",
+        '$',
+      ]);
+    });
+
+    it('is byte-exact under join, so an untouched record round-trips', () => {
+      // The whole point of not trimming. `applyAttributeMutations` rebuilds the
+      // line as `prefix + parts.join(',') + suffix`, so any normalisation here
+      // would rewrite records nobody asked to change.
+      for (const input of [
+        "'2aG1gNarLHm9Qs6Q3z97P1',#2,'Wall-001','An external wall',$,$,$,'TAG',.NOTDEFINED.",
+        "'guid', $ , 'padded' ,(1., 2., 3.)",
+        "'it''s',(#1,#2),$",
+        "'a (b) c','d,e'",
+        'a,,b',
+        '42',
+        '',
+      ]) {
+        expect(splitTopLevelStepArgs(input)!.join(',')).toBe(input);
+      }
+    });
+  });
+
+  describe('lists it refuses', () => {
+    it.each([
+      // The #4125 reproduction, reduced to its argument list. `step-args.ts`'s
+      // header has the walk-through of why this is 4 parts for 9 attributes.
+      ['an undoubled apostrophe that leaves the scan mid-string', "'guid',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED."],
+      ['an unterminated string', "'guid',$,'never closed"],
+      ['a quote opened by the last character', "'guid',$,'"],
+      // Both of these are refused by the per-part check as well as by the
+      // structural one their label names; see the paren-pair test below.
+      ['a stray closing paren', "'guid',$,'N'),$,$"],
+      ['a stray closing paren that climbs back to zero', "'guid'),(  $,$"],
+      ['an unclosed nested list', "'guid',(1,2,3"],
+      ['a truncated record prefix', "'guid',$,$,$,(#2,#3"],
+      // The same mis-scan one level down, which checking only the top level
+      // cannot see: the phantom string swallows `),$,IFCLABEL(` whole, so the
+      // parens still balance and every part is a keyword applied to one list.
+      // Nine attributes read as seven, with the wrong slots from index 2 on.
+      [
+        'a phantom string that swallows a paren pair, leaving the depth balanced',
+        "'1BBBBBBBBBBBBBBBBBBBBB',$,IFCLABEL('a's'),$,IFCLABEL('b's'),$,$,'T',.NOTDEFINED.",
+      ],
+      // The same shape on a real entity: IfcPerson declares MiddleNames and
+      // PrefixTitles as adjacent lists of strings, so eight attributes read as
+      // seven. IfcPropertyTableValue's DefiningValues/DefinedValues do it too.
+      [
+        'undoubled apostrophes in two adjacent string lists (the IfcPerson shape)',
+        "'id','Smith','John',('D'Arcy'),('O'Neill'),$,$,$",
+      ],
+      // Here the swallow eats the only top-level comma, so this arrives as ONE
+      // part and nothing about the part's outline is wrong. Only the inside of
+      // the list gives it away.
+      ['two typed values run together into a single part', "IFCLABEL('a's'),IFCLABEL('b's')"],
+      // A STEP block comment, named as a cause in the error `mutate` throws.
+      // It is refused rather than understood: no copy of this rule reads one,
+      // and a comment sits where a token or a separator belongs, so accepting
+      // it adds a phantom slot and shifts every attribute after it.
+      //
+      // All five shapes are pinned because the whitespace in the first is what
+      // used to do the refusing, and only the first has any. The rest were
+      // ACCEPTED, with the splits named below, until `/` broke a bare run.
+      ['a STEP block comment with spaces around it', '$,/* renamed */ $'],
+      // Was ['$', '/*renamed*/', '$']: three slots for two attributes, the
+      // same phantom-slot shift as the rest of #4125. Reproduced end to end
+      // against the built CLI; see `mutate.test.ts`.
+      ['a STEP block comment carrying no whitespace at all', '$,/*renamed*/,$'],
+      // Was one token, so a record ending in a commented-out attribute kept
+      // its slot count and passed.
+      ['a STEP block comment stuck to the end of a token', '$/*x*/'],
+      // Was ["'guid'", '/*a', 'b*/', "'Name'"]: the comma inside the comment
+      // splits it in two, so four slots for three attributes.
+      ['a STEP block comment holding a comma', "'guid',/*a,b*/,'Name'"],
+      // The OPENER is what breaks the run, so a comment that never closes is
+      // refused for the same reason rather than by luck.
+      ['an unterminated STEP block comment', "'guid',/*unclosed,$"],
+    ])('refuses %s', (_label, input) => {
+      expect(splitTopLevelStepArgs(input)).toBeNull();
+    });
+
+    it('refuses a paren pair in the wrong order, though the counts balance', () => {
+      // ')...(' has as many of each as '(...)', so a scanner that only checks
+      // the FINAL depth calls it well-formed and reads every comma between the
+      // two as nested. The negative-depth check fires first here, but it is not
+      // what makes this safe: with that check deleted the scan yields a part
+      // "a)" that is not one token, and the per-part check refuses it anyway.
+      const input = "a),b,(c";
+      expect(input.split('(').length).toBe(input.split(')').length);
+      expect(splitTopLevelStepArgs(input)).toBeNull();
+    });
+  });
+});

--- a/packages/cli/src/commands/step-args.ts
+++ b/packages/cli/src/commands/step-args.ts
@@ -1,0 +1,300 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reading a STEP record's top-level argument list out of its text, for a
+ * caller that then edits one slot BY INDEX.
+ *
+ * The failure this exists to prevent is silent. A scanner that loses track of
+ * quote state or paren depth still produces parts; they are just not the
+ * record's arguments any more, because the commas it swallowed took every
+ * following slot with them. The write lands on whatever the mis-scan
+ * accumulated and the caller reports a success that did not happen
+ * (LTplus-AG/ifc-lite#2470, #4125 for the `mutate` instance). So this returns
+ * null rather than parts it does not believe in.
+ *
+ * The mis-scan nothing structural notices is an undoubled apostrophe, what an
+ * authoring tool emits when it forgets to double one. The scan closes the
+ * string at it and reopens on the next quote, so the text between the two is
+ * read inside-out and every comma in it is swallowed. TWO of them leave quote
+ * parity EVEN and paren depth at ZERO, so the scan ends clean on text that
+ * split wrong: `'guid',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED.` is nine
+ * attributes read as four, and writing slot 2 deletes attributes 3 to 7.
+ *
+ * What always shows is a token ending where a token cannot end: the phantom
+ * terminator leaves the rest of the content where a separator belongs
+ * (`'John's wall'` closes after `John`, leaving a bare `s`). So this validates
+ * the list as a grammar rather than counting characters. An argument is ONE
+ * token, after a token only whitespace and then `,` or `)` may follow, and that
+ * (In the STEP examples below, `*\/` is a JavaScript escape so the example does not
+ * terminate this comment block. The backslash is not in the STEP text, and STEP
+ * gives `\` its own meaning, so strip it before copying an example into a test.)
+ *
+ * holds AT EVERY DEPTH. Applied to the top level alone it misses a phantom that
+ * swallows a `)`, a `(` and the comma between them, which leaves the depth
+ * balanced and each surviving part passing a token check on its own:
+ * `IFCLABEL('a's'),$,IFCLABEL('b's'),$` is four attributes read as two. Any
+ * two top-level slots that each hold a string inside parens can do it, and real
+ * entities have that shape (`IfcPerson`'s MiddleNames / PrefixTitles,
+ * `IfcPropertyTableValue`'s DefiningValues / DefinedValues).
+ *
+ * What the rule cannot see is a corruption whose bytes are themselves a valid
+ * argument list: a stray apostrophe at the END of a string's content emits a
+ * doubled quote by accident, so `''','''` is two arguments to its author and
+ * one to anyone reading the text. A generated sweep accepted 814 of 80,035 corruptions
+ * with a split other than the author's, down from 1,066 before the rule reached into
+ * lists, and every survivor it looked at had that shape; separating them needs the
+ * schema, not the text. That harness is NOT committed, so those figures record one run
+ * and cannot be reproduced from this tree.
+ *
+ * A STEP block comment is refused rather than understood, because `mutate` must
+ * not rewrite a record it cannot read: `/` breaks a bare run, so a part
+ * carrying a comment outside a string is never one token, whatever the comment
+ * CONTAINS. Whitespace in the comment is not what gives it away:
+ * `$,/*renamed*\/,$` has none and was read as three slots for two attributes,
+ * the same phantom-slot shift as the rest of #4125 (see {@link isTokenBreak}
+ * for why breaking on the OPENER is enough).
+ *
+ * Several readers in this repo DO skip comments; diverging from them is
+ * deliberate. The nearest is `validate.ts` in this very package, which skips
+ * `/* ... *\/` while counting top-level attribute indices; it returns indices
+ * rather than parts, so it never has to put the bytes back. `source-header.ts`'s
+ * `splitTopLevel` is closer still, since it returns PARTS, but it drops the
+ * comment bytes, so it cannot satisfy the round-trip contract below either.
+ * And `packages/parser`'s
+ * `entity-extractor.ts` reads comments at every depth through
+ * `StepTextScan.skipLexicalAt`, and says so as policy: one comment-skip rule for
+ * decoded STEP text rather than a fourth hand-rolled copy. The difference is what
+ * the two produce. That one extracts VALUES and collapses a comment to a space;
+ * this one must satisfy `parts.join(',') === input` byte for byte, because its
+ * caller rewrites the user's file. Skipping a comment under that contract would
+ * silently delete it from their file, and keeping it inside the part means the
+ * part is not one token. Doing both needs a richer return type than `string[]`,
+ * which is a different module. (`STEP_TRIVIA` itself is legal anywhere whitespace
+ * is. Its call sites are what place it, and they all put it immediately before a
+ * `\(`.)
+ *
+ * What this module does NOT cover, so its refusal is not read as more than it is:
+ * `mutate` finds records with a line regex that allows only whitespace before the
+ * `(`, so a comment after the class keyword is skipped BEFORE reaching this code,
+ * and the run reports success having changed nothing; and `lastIndexOf(')')` can
+ * slice into a legal trailing comment. Both are #4163, one on each SIDE of the
+ * argument list (before the `(`, after the `)`), and both are the same
+ * line-versus-record shape as the wrapped-record case #4163 also covers.
+ *
+ * `packages/export/src/step-argument-parser.ts` is the nearest copy, and this is
+ * deliberately its near-twin rather than an import: `@ifc-lite/export`'s
+ * `exports` map exposes only `.`, so reaching it would mean adding a published
+ * export (and an `api-surface` entry) to a v4.0.0 package to fix a CLI bug.
+ * #4125 tracks consolidating them (`derive-variants.mts` and
+ * `placement-datum.test.ts` are two the issue does not name), and that is a real merge rather
+ * than a no-op swap: its `splitTopLevelStepArguments` has the three structural
+ * checks and NO per-part check at all, which is exactly the top-level-only
+ * version the two paragraphs above show is insufficient. Measured, it splits
+ * `$,/* renamed *\/ $` into two parts and `'guid',$,'Name',/* c *\/,$` into five.
+ * The three structural checks are the contract the two DO share.
+ */
+
+/**
+ * Split a STEP argument list on top-level commas, or return null when the text
+ * cannot be scanned as one. `input` is the text BETWEEN a record's outermost
+ * parentheses; the module header says why null rather than parts.
+ *
+ * Nothing is trimmed and nothing is normalised, so for input this accepts
+ * `parts.join(',')` reproduces `input` byte for byte and a caller that replaces
+ * one part leaves every other byte of the record alone. Rejected: a quote still
+ * open at the end, a paren depth that does not return to zero, a depth that
+ * ever goes NEGATIVE (a stray closing paren balanced by a later opening one),
+ * and a part that is not one token at every depth (see {@link isLoneStepToken}).
+ *
+ * An EMPTY top-level slot (`a,,b`, or a trailing comma) is NOT rejected: it is
+ * invalid STEP that costs no alignment, since an empty argument is one part
+ * exactly as the entity parser counts it, so every index still names the
+ * attribute it is meant to. An empty INPUT is not an empty slot: `#1=IFCFOO();`
+ * has no arguments, so it splits to `[]` and any slot request then fails the
+ * caller's bounds check.
+ */
+export function splitTopLevelStepArgs(input: string): string[] | null {
+  if (input === '') return [];
+
+  const parts: string[] = [];
+  let current = '';
+  let depth = 0;
+  let inString = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === "'") {
+      current += char;
+      // A doubled quote INSIDE a string is an escaped apostrophe. Outside one
+      // the first quote opens a string and the second is read on its own next
+      // pass, so `''` there is the empty string rather than an escape.
+      if (inString && input[i + 1] === "'") {
+        current += input[i + 1];
+        i++;
+        continue;
+      }
+      inString = !inString;
+      continue;
+    }
+
+    if (!inString) {
+      if (char === '(') {
+        depth++;
+      } else if (char === ')') {
+        depth--;
+        if (depth < 0) return null;
+      } else if (char === ',' && depth === 0) {
+        parts.push(current);
+        current = '';
+        continue;
+      }
+    }
+
+    current += char;
+  }
+
+  if (inString || depth !== 0) return null;
+  parts.push(current);
+  // These three are the contract this shares with
+  // `packages/export/src/step-argument-parser.ts`, which has exactly them and no
+  // per-part check. That parity, not speed, is why they are kept: they add no
+  // coverage at all, and deleting any one of them, or all three, fails no test
+  // (measured). Only the `depth < 0` check above is an early exit; these two run
+  // after the whole scan and save only a walk over the parts. Kept as
+  // the shared spelling until #4125 merges the copies.
+  return parts.every(isLoneStepToken) ? parts : null;
+}
+
+/**
+ * Is `part` exactly ONE STEP argument, all the way down? Surrounding whitespace
+ * is ignored, because a record may carry it and this must not refuse a record
+ * it could rewrite. An empty part passes, as an empty slot is accepted above.
+ */
+function isLoneStepToken(part: string): boolean {
+  const text = part.trim();
+  return text === '' || skipToken(text, 0) === text.length;
+}
+
+/**
+ * Index just past the one token starting at `from`, or -1 when the text there
+ * is not one token. The forms, per ISO 10303-21: a string (`'...'`, `''`
+ * escaping an apostrophe), a list (`(...)`), or a bare run (`$`, `*`, `#123`, a
+ * number, an enumeration `.T.`, a binary `"0F"`) optionally applied to a list
+ * (`IFCINTEGER(3)`).
+ *
+ * Deliberately loose about what a bare run CONTAINS and strict only about where
+ * it may end: this is not a STEP validator and must not become one. A list's
+ * elements are held to the same rule, so a fragment left by a phantom string
+ * terminator is caught wherever it lands. Nesting is carried in `depth` rather
+ * than by recursing, so a pathologically nested record (this text comes from a
+ * file) refuses instead of overflowing the stack.
+ */
+function skipToken(text: string, from: number): number {
+  let i = from;
+  let depth = 0;
+  let expectToken = true;
+
+  for (;;) {
+    i += countWhitespace(text, i);
+    const char = text[i];
+
+    if (expectToken) {
+      // A list element may be empty (`(1,,2)`), as a top-level slot may be.
+      if (depth > 0 && (char === ',' || char === ')')) {
+        expectToken = false;
+        continue;
+      }
+      if (char === "'") {
+        i = skipString(text, i);
+        if (i < 0) return -1;
+      } else if (char === '(') {
+        depth++;
+        i++;
+        continue; // the list's first element is still a token to read
+      } else {
+        const start = i;
+        while (i < text.length && !isTokenBreak(text[i])) i++;
+        // Nothing consumed: the end of the text, or a separator where a token
+        // belongs.
+        if (i === start) return -1;
+        const afterKeyword = i + countWhitespace(text, i);
+        if (text[afterKeyword] === '(') {
+          depth++;
+          i = afterKeyword + 1;
+          continue;
+        }
+      }
+      expectToken = false;
+      continue;
+    }
+
+    // A token just closed, so only `,` or `)` may follow. At depth zero the
+    // token was the whole argument.
+    if (depth === 0) return i;
+    if (char === ')') {
+      depth--;
+      i++;
+      continue;
+    }
+    if (char !== ',') return -1;
+    i++;
+    expectToken = true;
+  }
+}
+
+/** Index just past the string starting at `from`, or -1 if it never closes. */
+function skipString(text: string, from: number): number {
+  for (let i = from + 1; i < text.length; i++) {
+    if (text[i] !== "'") continue;
+    if (text[i + 1] === "'") i++;
+    else return i + 1;
+  }
+  return -1;
+}
+
+/**
+ * Can this character only begin or separate another token?
+ *
+ * `/` is in the set for the STEP block comment, which opens with `/*`. Breaking
+ * on the OPENER is enough, and is why there is no comment state machine here: a
+ * comment can only sit where a token or a separator belongs, and either way the
+ * `/` ends the bare run short of the part's end, so `isLoneStepToken` refuses
+ * the part however the comment is written. `*` is deliberately NOT in the set,
+ * because it is the derived-attribute marker and a token in its own right, so
+ * breaking on it would refuse `$,$,*`.
+ */
+function isTokenBreak(char: string): boolean {
+  return (
+    char === "'" ||
+    char === '(' ||
+    char === ')' ||
+    char === ',' ||
+    char === '/' ||
+    char === ' ' ||
+    char === '\t'
+  );
+}
+
+/**
+ * How many whitespace characters run from `from`.
+ *
+ * Space and tab only, where every NAMED STEP whitespace set in this repo
+ * (`is_step_space`, `isSpaceByte`, `isAsciiSpace`, `STEP_TRIVIA`) is the six
+ * characters ` \t\n\r\x0b\x0c`. That is safe here only because the caller
+ * splits on newlines before this ever runs. `\n` and `\r` are in neither this
+ * set nor {@link isTokenBreak}, so a bare run spans them silently and two tokens
+ * separated by a newline come back as ONE part (measured: `'$\n$'` splits to
+ * `["$\n$"]`, where `'$ $'` and `'$\t$'` are refused). That is the same
+ * token-ending-where-it-cannot defect this module exists to catch, unreachable only
+ * because the caller pre-splits on newlines. #4163's multi-line work would
+ * start feeding real multi-line argument lists through here; widen both sets then
+ * rather than relying on that accident.
+ */
+function countWhitespace(text: string, from: number): number {
+  let n = 0;
+  while (from + n < text.length && (text[from + n] === ' ' || text[from + n] === '\t')) n++;
+  return n;
+}


### PR DESCRIPTION
Refs #4125. Does NOT close it: this fixes the one LIVE HAZARD that issue catalogues, and
leaves the consolidation of the other copies open.

## The defect

`packages/cli/src/commands/mutate.ts` wrote a STEP attribute BY INDEX into whatever a
non-validating splitter accumulated. A mis-scanned argument list still produces parts, so
the write lands on the wrong attribute and reports success. That is the #2470 shape.

Measured on the real CLI, not a unit test:

    IN : #2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED.);
    $ ifc-lite mutate apos.ifc --id 2 --set Name=NewName --out out.ifc
    Mutated 1 entities: Name = NewName
    Written to out.ifc (2 entities, 0 new)          exit 0
    OUT: #2=IFCWALL('1BBBBBBBBBBBBBBBBBBBBB',$,'NewName',.NOTDEFINED.);

Nine attributes down to four, five silently deleted, exit 0. Two undoubled apostrophes,
which is what an authoring tool emits when it forgets to double them.

## Why the obvious fix is not enough

The three structural checks (unterminated string, unbalanced depth, negative depth) do
NOT catch this. Two undoubled apostrophes leave quote parity even and depth at zero, so
the scan finishes clean on text that split wrong. That was a measured test failure, not
an argument.

So the rule is: every split part must be exactly one STEP token followed only by
whitespace and a separator, applied AT EVERY DEPTH. The depth part is load-bearing.
Applied to the top level alone it misses a phantom that swallows a `)`, a `(` and the
comma between:

    IFCLABEL('a's'),$,IFCLABEL('b's'),$      four attributes read as two

`IfcPerson` (MiddleNames / PrefixTitles) and `IfcPropertyTableValue` (DefiningValues /
DefinedValues) have exactly that shape.

A third round found a further hole: a comment with no whitespace, quote or paren was
consumed as one bare token, so `--set Description` wrote to `Name` and exited 0. `/` is
now a token break. `*` deliberately is NOT, because it is the derived-attribute marker
and a token in its own right.

## False-positive cost, measured before adopting

Differential sweep, old splitter vs new, over 434 distinct `.ifc` files and
**25,322,685 records**:

    newly refused by the change     0
    both accept, different split    0
    parts.join(',') mismatch        0

Records containing `/*` anywhere: **2 in 25.3M**, both inside a GlobalId string, both
accepted before and after.

## Refuse, not skip

The command's entire output is a file. A skip writes one that looks like what was asked
for and is missing the edit, under a `Mutated 1 entities` line. The throw reaches
`main().catch` before `writeFile`, so exit code and filesystem agree. An unreadable
record that was NOT targeted does not block a run that targets a readable one.

## The limit, stated rather than papered over

814 of 80,035 generated corruptions are still accepted with a split other than the
author's, down from 1,066. Every survivor has a stray apostrophe at the END of a string's
content, which emits a doubled quote by accident and makes the bytes a genuinely VALID
argument list, just a different one: `''','''` is two arguments to its author and one to
any reader of the text. Separating those needs the entity's declared attribute count,
which a text-level splitter does not have. That harness is not committed, so those
figures record one run and are not reproducible from this tree.

## One legal shape is now refused

A record whose trailing comment contains a `)`, as in `#1=IFCWALL(...); /* note (x) */`,
is rejected rather than rewritten, because the argument list is located with
`lastIndexOf(')')`. Before this PR that line happened to rewrite correctly. It is
disclosed in the changeset and tracked as #4163.

## Mutation-checked, not just green

| mutant | result |
|---|---|
| revert to the top-level-only splitter | exactly the 5 refusal tests fail |
| remove `/` from the token break | exactly the 4 comment refusals plus the end-to-end one |
| naive `part.includes('/')` (over-broad) | exactly the 3 false-positive controls, and NOTHING else in 867 tests catches it |
| delete the per-part check | 15 fail |
| delete all three structural checks | 0 fail |

That last row is why the three structural checks are documented as kept for parity with
`@ifc-lite/export`'s twin rather than for coverage: they are wholly subsumed by the
per-part check, and a separate reviewer confirmed observational identity across 441,370
inputs.

## Verification

    pnpm --filter @ifc-lite/cli test     866 passed, 8 skipped, 71 files
    pnpm typecheck                       90/90
    pnpm lint                            0 errors
    node scripts/check-module-size.mjs   OK
    node scripts/check-changesets.mjs    OK

## Out of scope, filed

- #4163: mutate's record regex is narrower than the parser's, so a comment after the
  class keyword is skipped and the run reports success having changed nothing; and the
  trailing-comment case above. Both are the record-framing side of the same
  line-versus-record shape, including wrapped records (100% of product records on
  `schependomlaan.ifc`).
- #4162: `@ifc-lite/export`'s `replaceStepArgument` does the same by-index write with the
  same insufficient validation, next door.
- #4125 remains open for the consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K
