### PR TITLE
feat(viewer): implement selector type= as a relating-type-Name filter rule

### DIFF
--- a/.changeset/selector-type-name.md
+++ b/.changeset/selector-type-name.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": minor
+---
+
+`type=WT01` (IfcOpenShell selector syntax) now becomes a filter rule instead of being reported back as unsupported (#4094, follow-up to #4091/#4106): it matches the Name of the element's RELATING TYPE via `IfcRelDefinesByType` — a different dimension from a bare class term like `IfcWall`, which still matches the element's own IFC class. Supports `=`, `!=`, `*=`, `!*=` and a `/regex/` value, like `Name=`; `>`, `>=`, `<`, `<=` are not supported (a type Name is compared as text, not ordered). An element with no `IfcRelDefinesByType` relation never matches.
+
+Still reported rather than applied: `parent=`, `query:` value queries, `+` group unions, material `Category`, and reading quantity rows from a property term. The CLI, MCP and SDK adapters do not accept selector text yet — only the viewer's Filter tab does.

--- a/apps/viewer/src/components/viewer/FilterRuleControls.tsx
+++ b/apps/viewer/src/components/viewer/FilterRuleControls.tsx
@@ -103,5 +103,6 @@ export function blankRuleOfKind(kind: FilterRule['kind']): FilterRule {
     case 'material':       return Rule.material('contains', '');
     case 'classification': return Rule.classification('', 'contains', '');
     case 'elevation':      return Rule.elevation('gt', 0);
+    case 'type':           return Rule.typeName('contains', '');
   }
 }

--- a/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
@@ -151,6 +151,14 @@ export function RuleRow({ rule, modelOptions, ifcTypeOptions, storeyOptions, pse
         />
       )}
 
+      {rule.kind === 'type' && (
+        <NameEditor
+          op={rule.op}
+          value={rule.value}
+          onChange={(op, value) => onChange(Rule.typeName(op, value))}
+        />
+      )}
+
       <button
         type="button"
         onClick={onRemove}

--- a/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.promote.test.tsx
@@ -121,14 +121,18 @@ describe('Filter tab — promoting the search bar query', () => {
   });
 
   it('a selector the adapter can only partly carry applies the rest and says so', () => {
-    const container = mountWithQuery('IfcWall, type=WT01');
+    // `type=WT01` used to be this test's unsupported example; #4094 gave it
+    // a real rule kind (`Rule.typeName`, see filter-evaluate.ts's
+    // `relatingTypeNameOf`), so `parent=Foo` — still genuinely unsupported —
+    // takes over pinning "applies the rest, names what it dropped".
+    const container = mountWithQuery('IfcWall, parent=Foo');
     promote(container);
-    // The type rule is real and is applied; the `type=` term is named, not
-    // dropped and not turned into a Name-contains that matches nothing.
+    // The class rule is real and is applied; the `parent=` term is named,
+    // not dropped and not turned into a Name-contains that matches nothing.
     assert.deepEqual(rules(), [
       Rule.ifcType(['IfcWall', 'IfcWallElementedCase', 'IfcWallStandardCase'], 'in'),
     ]);
-    assert.match(latestToast(container), /type=WT01/);
+    assert.match(latestToast(container), /parent=Foo/);
   });
 
   it('a selector with no rule at all reports instead of adding a guaranteed miss', () => {

--- a/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.selector.test.tsx
@@ -84,12 +84,15 @@ describe('SearchModalFilterSelector', () => {
   });
 
   it('a selector with an unsupported part applies the rest AND names what it dropped', () => {
+    // `type=WT01` used to be this test's unsupported example; #4094 gave it
+    // a real rule kind (`Rule.typeName`), so `parent=Foo` — still genuinely
+    // unsupported — takes over here.
     const container = mount();
-    type(field(container), 'IfcWall, type=WT01');
+    type(field(container), 'IfcWall, parent=Foo');
     click(applyButton(container));
 
     assert.deepEqual(rulesInStore(), [Rule.ifcType(WALLS, 'in')]);
-    assert.match(alertText(container), /type=WT01/);
+    assert.match(alertText(container), /parent=Foo/);
   });
 
   it('a selector that maps to no rule at all applies nothing and explains', () => {
@@ -103,7 +106,7 @@ describe('SearchModalFilterSelector', () => {
 
   it('a successful apply clears a previous complaint', () => {
     const container = mount();
-    type(field(container), 'IfcWall, type=WT01');
+    type(field(container), 'IfcWall, parent=Foo');
     click(applyButton(container));
     assert.notEqual(alertText(container), '');
 

--- a/apps/viewer/src/components/viewer/filter-rule-labels.ts
+++ b/apps/viewer/src/components/viewer/filter-rule-labels.ts
@@ -17,4 +17,5 @@ export const RULE_KIND_LABEL: Record<FilterRule['kind'], string> = {
   material: 'Material',
   classification: 'Classification',
   elevation: 'Elevation',
+  type: 'Type Name',
 };

--- a/apps/viewer/src/lib/search/filter-evaluate-type-name.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate-type-name.test.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `type=WT01` (IfcOpenShell selector syntax, #4094) matches an element
+ * whose RELATING TYPE (via `IfcRelDefinesByType`) has that Name — not the
+ * element's own `IfcType.getTypeName()` (its IFC *class*, e.g. "IfcWall"),
+ * which is a completely different dimension already covered by the
+ * `ifcType` rule. Before this fix, `selector-to-rules.ts` reported every
+ * `type=` term as unsupported (see #4094's adapter comment
+ * `"matching an element's type by name is not supported yet (#4094)"`),
+ * so the Filter tab's Selector field silently dropped the term rather than
+ * narrowing by it.
+ *
+ * Reuses the exact fixture shape from `filter-evaluate-type-psets.test.ts`:
+ * Wall-A/Wall-B (#100/#110) are both typed to `IfcWallType` "WT-Std" (#200)
+ * via `IfcRelDefinesByType` #230; Door-C (#120) has no type relation at all.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { evaluateFilterRules } from './filter-evaluate.js';
+import { Rule } from './filter-rules.js';
+
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
+#100=IFCWALL('Wall00000000000000001A',$,'Wall-A',$,$,$,$,$,.SOLIDWALL.);
+#110=IFCWALL('Wall00000000000000001B',$,'Wall-B',$,$,$,$,$,.SOLIDWALL.);
+#120=IFCDOOR('Door000000000000000001C',$,'Door-C',$,$,$,$,$,$);
+#200=IFCWALLTYPE('Type00000000000000001A',$,'WT-Std',$,$,(#210),$,$,$,.STANDARD.);
+#210=IFCPROPERTYSET('Pset00000000000000001A',$,'Pset_WallCommon',$,(#211));
+#211=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#230=IFCRELDEFINESBYTYPE('Rdbt00000000000000001A',$,$,$,(#100,#110),#200);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function buildStore(): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(FIXTURE);
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true }) as unknown as Promise<IfcDataStore>;
+}
+
+describe('evaluateFilterRules — type= (relating type Name)', () => {
+  it('matches every element whose IfcRelDefinesByType-related type has the given Name', async () => {
+    const store = await buildStore();
+    const out = evaluateFilterRules('m1', store, [
+      Rule.typeName('eq', 'WT-Std'),
+    ], 'AND');
+    assert.deepStrictEqual(out.map((r) => r.expressId).sort((a, b) => a - b), [100, 110]);
+  });
+
+  it('an element with no IfcRelDefinesByType relation never matches', async () => {
+    const store = await buildStore();
+    const out = evaluateFilterRules('m1', store, [
+      Rule.typeName('eq', 'WT-Std'),
+    ], 'AND');
+    assert.ok(!out.some((r) => r.expressId === 120), 'Door-C has no type relation and must not match');
+  });
+
+  it('is a distinct dimension from ifcType (the element\'s own IFC class)', async () => {
+    const store = await buildStore();
+    // "IfcWall" is Wall-A/Wall-B's own class, not their type's Name — a
+    // type= rule must not fall back to matching the class name.
+    const out = evaluateFilterRules('m1', store, [
+      Rule.typeName('eq', 'IfcWall'),
+    ], 'AND');
+    assert.deepStrictEqual(out, []);
+  });
+});

--- a/apps/viewer/src/lib/search/filter-evaluate.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.ts
@@ -514,7 +514,26 @@ function evaluateRule(
       if (elev === null) return false;
       return numericOpMatches(rule.op, elev, rule.value);
     }
+    case 'type': {
+      const typeName = relatingTypeNameOf(ctx, expressId);
+      if (typeName === null) return false;
+      return stringOpMatches(rule.op, typeName, rule.value, rule.valueKind);
+    }
   }
+}
+
+/**
+ * The Name of `expressId`'s RELATING TYPE via `IfcRelDefinesByType` — the
+ * `type=` selector dimension (#4094), distinct from `ctx.table.getTypeName`
+ * (the element's own IFC class). `null` when the element carries no such
+ * relation, which a `type=` rule must never match (an absent relation is
+ * not the same as a type with an empty Name).
+ */
+function relatingTypeNameOf(ctx: EvalContext, expressId: number): string | null {
+  if (!ctx.store.relationships) return null;
+  const typeIds = ctx.store.relationships.getRelated(expressId, RelationshipType.DefinesByType, 'inverse');
+  if (typeIds.length === 0) return null;
+  return ctx.table.getName(typeIds[0]);
 }
 
 function buildResult(modelId: string, ctx: EvalContext, expressId: number): FilteredElement {

--- a/apps/viewer/src/lib/search/filter-iteration-source.ts
+++ b/apps/viewer/src/lib/search/filter-iteration-source.ts
@@ -113,6 +113,10 @@ const RULE_COST: Record<FilterRule['kind'], number> = {
   // Relationship-graph walk + on-demand resolve — as costly as a pset parse.
   material:       10,
   classification: 10,
+  // One reverse-relationship lookup (IfcRelDefinesByType) + a columnar
+  // Name read on the resolved type id — no source-buffer parse, so it's
+  // cheap like `storey`/`elevation`, not `material`/`classification`.
+  type:           1,
 };
 
 export function orderRulesByCost(rules: readonly FilterRule[]): FilterRule[] {

--- a/apps/viewer/src/lib/search/filter-rules.test.ts
+++ b/apps/viewer/src/lib/search/filter-rules.test.ts
@@ -200,6 +200,7 @@ describe('isFilterRule / parseFilterRules', () => {
     assert.strictEqual(isFilterRule(Rule.elevation('gt', 3)), true);
     assert.strictEqual(isFilterRule(Rule.globalId(['325Q7Fhnf67OZC$$r43uzK'])), true);
     assert.strictEqual(isFilterRule(Rule.attribute('Description', 'eq', 'Foo')), true);
+    assert.strictEqual(isFilterRule(Rule.typeName('eq', 'WT01')), true);
   });
   it('rejects unknown kinds and non-objects', () => {
     assert.strictEqual(isFilterRule({ kind: 'bogus' }), false);

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -229,6 +229,22 @@ export interface ElevationRule {
   value: number;
 }
 
+/**
+ * `type=WT01` (IfcOpenShell selector syntax) — match against the Name of
+ * the element's RELATING TYPE, reached via `IfcRelDefinesByType`. This is
+ * a different dimension from {@link IfcTypeRule}, which matches the
+ * element's own IFC *class* (`IfcWall`); `type=` instead matches the type
+ * OBJECT's `Name` attribute (e.g. `IfcWallType.Name`, "WT01"). An element
+ * with no `IfcRelDefinesByType` relation never matches. #4094.
+ */
+export interface TypeNameRule {
+  kind: 'type';
+  op: StringOp;
+  value: string;
+  /** How `value` reads. Only consulted by the `matches` / `notMatches` ops. */
+  valueKind?: TextKind;
+}
+
 export type FilterRule =
   | ModelRule
   | StoreyRule
@@ -241,7 +257,8 @@ export type FilterRule =
   | QuantityRule
   | MaterialRule
   | ClassificationRule
-  | ElevationRule;
+  | ElevationRule
+  | TypeNameRule;
 
 // ── Combinator helpers ────────────────────────────────────────────────────────
 
@@ -333,6 +350,8 @@ export const Rule = {
   ): ClassificationRule =>
     ({ kind: 'classification', system: system || undefined, op, value, ...(valueKind ? { valueKind } : {}) }),
   elevation: (op: NumericOp, value: number): ElevationRule => ({ kind: 'elevation', op, value }),
+  typeName: (op: StringOp, value: string, valueKind?: TextKind): TypeNameRule =>
+    ({ kind: 'type', op, value, ...(valueKind ? { valueKind } : {}) }),
 } as const;
 
 // ── JSON guards ──────────────────────────────────────────────────────────────
@@ -352,7 +371,8 @@ export function isFilterRule(value: unknown): value is FilterRule {
     kind === 'quantity' ||
     kind === 'material' ||
     kind === 'classification' ||
-    kind === 'elevation'
+    kind === 'elevation' ||
+    kind === 'type'
   );
 }
 

--- a/apps/viewer/src/lib/search/selector-to-rules.test.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.test.ts
@@ -173,11 +173,14 @@ describe('selectorToFilterRules — the documented examples', () => {
     );
   });
 
-  it('12. location becomes a storey rule; type= is reported', () => {
+  it('12. location becomes a storey rule; type= becomes a relating-type-Name rule (#4094)', () => {
     const out = adapt('IfcWall, type=WT01, location="Level 3"');
-    assert.deepEqual(out.rules, [Rule.ifcType(WALLS, 'in'), Rule.storey(['Level 3'], 'in')]);
-    assert.equal(out.unsupported.length, 1);
-    assert.ok(out.unsupported[0]?.includes('type=WT01'), out.unsupported[0]);
+    assert.deepEqual(out.rules, [
+      Rule.ifcType(WALLS, 'in'),
+      Rule.typeName('eq', 'WT01'),
+      Rule.storey(['Level 3'], 'in'),
+    ]);
+    assert.equal(out.unsupported.length, 0);
   });
 
   it('13. a classification matched by a regular expression', () => {
@@ -418,11 +421,11 @@ describe('selectorToFilterRules — nothing is dropped in silence', () => {
   });
 
   it('every unsupported entry quotes the text the user typed', () => {
-    // Only `type=WT01`, `parent=Foo` and the dropped "+ IfcDoor" group remain
-    // unsupported here — the GlobalId subtraction and Description=x now both
+    // Only `parent=Foo` and the dropped "+ IfcDoor" group remain unsupported
+    // here — the GlobalId subtraction, Description=x and type=WT01 now all
     // become rules (#4094).
     const out = adapt(`IfcWall, ! ${GUID}, type=WT01, parent=Foo, Description=x + IfcDoor`);
-    assert.equal(out.unsupported.length, 3);
+    assert.equal(out.unsupported.length, 2);
     for (const entry of out.unsupported) {
       assert.match(entry, /^"/, `entry does not start with the quoted source: ${entry}`);
     }

--- a/apps/viewer/src/lib/search/selector-to-rules.ts
+++ b/apps/viewer/src/lib/search/selector-to-rules.ts
@@ -207,7 +207,7 @@ function adaptFilter(filter: SelectorFilter): FilterRule | string {
     case 'location':
       return adaptLocation(filter.op, filter.value, filter.text);
     case 'type':
-      return `${quote(filter.text)}: matching an element's type by name is not supported yet (#4094)`;
+      return adaptTypeName(filter.op, filter.value, filter.text);
     case 'parent':
       return `${quote(filter.text)}: "parent=" is not supported`;
     case 'query':
@@ -363,5 +363,25 @@ function adaptLocation(op: SelectorOp, value: SelectorValue, text: string): Filt
   // inside a space on that storey does NOT match, which is where this differs
   // from IfcOpenShell's "directly or indirectly" (#4094).
   return Rule.storey([value.text], setOp);
+}
+
+/**
+ * `type=WT01` — matches the RELATING TYPE's Name via `IfcRelDefinesByType`
+ * (`Rule.typeName` / `filter-evaluate.ts`'s `relatingTypeNameOf`), not the
+ * element's own IFC class (that's `IfcTypeRule`, built from a bare class
+ * term like `IfcWall`). Mirrors `adaptMaterial`: NULL is rejected (a type
+ * name is either the string on the relating type or the term reports
+ * nothing, the same "cannot be compared to NULL" the material dimension
+ * uses, rather than reusing the property-rule NULL→isSet/isNotSet
+ * convention, since a bare `type=` filter — unlike a pset property — is
+ * about a single positive string, not an optional field).
+ */
+function adaptTypeName(op: SelectorOp, value: SelectorValue, text: string): FilterRule | string {
+  if (value.kind === 'null') return `${quote(text)}: "type=" cannot be compared to NULL`;
+  const stringOp = stringOpFor(op, value);
+  if (!stringOp) return unsupportedOp(text, op, value);
+  const invalid = regexProblem(value);
+  if (invalid) return `${quote(text)}: ${invalid}`;
+  return Rule.typeName(stringOp, literalOf(value), regexValueKind(value));
 }
 

--- a/docs/guide/selector-syntax.md
+++ b/docs/guide/selector-syntax.md
@@ -70,7 +70,7 @@ exists only as part of `*=`. Use a regular expression for wildcards.
 | `location="Level 3"` | ⚠️ | see below |
 | GlobalId terms, `! <GlobalId>` | ✅ | several terms union (add) or subtract, mirroring class terms |
 | `Description=`, `ObjectType=`, `Tag=`, any other schema attribute | ✅ | all eight operators, `= NULL` / `!= NULL` as presence — see below |
-| `type=WT01` | ✅ | matches the relating type's Name, all eight operators |
+| `type=WT01` | ✅ | matches the relating type's Name; `=`, `!=`, `*=`, `!*=` and `/regex/`, like `Name=` — no `>`, `>=`, `<`, `<=` |
 | `parent=`, `query:` | ❌ | reported, not applied |
 | `+` unions of groups | ❌ | the first group is applied, the rest reported |
 

--- a/docs/guide/selector-syntax.md
+++ b/docs/guide/selector-syntax.md
@@ -70,7 +70,7 @@ exists only as part of `*=`. Use a regular expression for wildcards.
 | `location="Level 3"` | ⚠️ | see below |
 | GlobalId terms, `! <GlobalId>` | ✅ | several terms union (add) or subtract, mirroring class terms |
 | `Description=`, `ObjectType=`, `Tag=`, any other schema attribute | ✅ | all eight operators, `= NULL` / `!= NULL` as presence — see below |
-| `type=WT01` | ❌ | reported, not applied |
+| `type=WT01` | ✅ | matches the relating type's Name, all eight operators |
 | `parent=`, `query:` | ❌ | reported, not applied |
 | `+` unions of groups | ❌ | the first group is applied, the rest reported |
 


### PR DESCRIPTION
## Summary

Refs #4094 (one item of this multi-item issue's leftover scope — see "Remaining scope" below).

`type=WT01` (IfcOpenShell selector grammar) parsed correctly but the viewer's selector-to-rules adapter reported every occurrence as unsupported — the Filter tab's Selector field silently dropped the term instead of narrowing by it.

Adds `TypeNameRule` (kind `'type'`) — a new filter dimension distinct from the existing `ifcType` rule:
- `ifcType` matches the element's own IFC **class** (`IfcWall`).
- `type=` matches the Name of the element's **relating type**, reached via `IfcRelDefinesByType` (e.g. `IfcWallType.Name`, `"WT01"`).

`relatingTypeNameOf` resolves the relating type with `store.relationships.getRelated(id, RelationshipType.DefinesByType, 'inverse')` — the same direction and `ids[0]`-takes-first convention already used by `lib/lists/adapter.ts`'s `definingTypeId` and `lib/compare/buildFingerprints.ts`. An element with no `IfcRelDefinesByType` relation never matches (returns `null`, not `false`-by-accident).

Wires the new kind into: the Add-rule menu (`filter-rule-labels.ts`, label `"Type Name"`, distinct from `"IFC Type"`), the chip editor (`SearchModal.filter.editors.tsx`, reusing `NameEditor`), the JSON round-trip guard (`isFilterRule`/`parseFilterRules`), and the cost table used to order rules cheapest-first (`filter-iteration-source.ts`).

Two pre-existing tests (`SearchModal.filter.promote.test.tsx`, `SearchModal.filter.selector.test.tsx`) used `type=WT01` as their "still unsupported" example; switched to `parent=Foo`, which remains genuinely unsupported (verified: `selector-to-rules.ts`'s `parent` case still routes to the unsupported-text branch, untouched by this PR).

### Found and fixed in review, before this went up
- **Doc claim didn't match behavior.** `docs/guide/selector-syntax.md` initially claimed `type=WT01` supports "all eight operators" (copied from the `Pset.Prop`/attribute rows, which use a 12-op `ValueOp`/8 selector-op-spelling set including `>`,`>=`,`<`,`<=`). `adaptTypeName` actually routes through `stringOpFor`, the same 4-operator set (`=`, `!=`, `*=`, `!*=`) plus `/regex/` that `Name=` uses — confirmed by exercising the adapter directly: `type>WT01` etc. all come back as `"..." is not supported`. Corrected the doc row.
- **Untested JSON guard.** `isFilterRule`'s `kind === 'type'` arm had zero test coverage — reverting it (dropping the arm) left all 339 search/filter tests green, including `saved-filters.test.ts`'s round-trip suite. A saved filter holding a `type=` rule would have silently lost that rule on next load with nothing to catch a future regression. Added it to `filter-rules.test.ts`'s "accepts every known kind" case; confirmed reverting the arm now reddens that test.
- **Added the changeset** (`apps/viewer` is `private: true`, but `privatePackages.version: true` in `.changeset/config.json` means it is still versioned — two prior selector-adapter PRs in this exact area, #4106 and the GlobalId/attribute follow-up, each shipped one).

### Verified, not changed
- `getRelated(..., 'inverse')` direction confirmed correct against two other call sites in the codebase (`lists/adapter.ts`, `compare/buildFingerprints.ts`) that resolve an element's relating type the same way.
- `"Type Name"` vs `"IFC Type"` labels are not adjacent in the Add-rule menu (many kinds between them) and the two rule kinds serialize under distinct `kind` strings (`'type'` vs `'ifcType'`), so there's no JSON collision risk even though the labels share the word "Type".
- Mutation-hunted the `'inverse'`→`'forward'` direction flip (turns the new test file red — direction is load-bearing) and the `RULE_COST['type']` value (turns nothing red; this cost table has no dedicated test for any newly-added kind's literal value, a pre-existing gap not introduced by this PR — flagging rather than expanding scope).

## Remaining scope of #4094

Still reported rather than applied: `parent=`, `query:` value queries, `+` group unions, material `Category`, and reading quantity rows from a property term. The CLI, MCP and SDK adapters do not accept selector text yet — only the viewer's Filter tab does.

## Test plan
- [x] `apps/viewer` targeted suites: `filter-evaluate-type-name.test.ts`, `selector-to-rules.test.ts`, `SearchModal.filter.promote.test.tsx`, `SearchModal.filter.selector.test.tsx` — 68/68 pass
- [x] Broader search/filter suites (`src/lib/search/*.test.ts` + `SearchModal.filter.*`/`ClashPanel.*filter*` in `src/components/viewer`) — 339/339 pass
- [x] `pnpm exec tsc --noEmit` (scoped to `apps/viewer`) — clean
- [x] `node scripts/check-module-size.mjs` — OK, 0 new files over budget
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] Mutation-hunt: `'inverse'`→`'forward'` direction flip turns the new RED test red again (confirmed applied via `git diff` before/after); `RULE_COST['type']` value mutation turns nothing red (pre-existing gap, noted above, not fixed here to stay in scope); JSON-guard mutation turned nothing red until this PR's added assertion (now fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436