### PR TITLE
fix(symbolic): guard fill/grid/text coordinate extraction against non-finite STEP REALs

### DIFF
--- a/rust/processing/src/symbolic/fill.rs
+++ b/rust/processing/src/symbolic/fill.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use super::color::resolve_color_via_styles;
 use super::primitives::{SymbolicFillArea};
-use super::transform::{circle_center, Transform2D};
+use super::transform::{circle_center, push_finite_point, Transform2D};
 
 // ────────────────────────────────────────────────────────────────────────────
 // Fill area extraction (IfcAnnotationFillArea).
@@ -96,8 +96,7 @@ fn extract_curve_ring(
                 let y = coords.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32 * unit_scale;
                 let (wx, wy) = transform.transform_point(x, y);
                 let (px, py) = rebase.plan(wx, wy);
-                out.push(px);
-                out.push(py);
+                push_finite_point(&mut out, px, py);
             }
             out
         }
@@ -113,8 +112,7 @@ fn extract_curve_ring(
                 let y = coords.get(1).and_then(|v| v.as_float()).unwrap_or(0.0) as f32 * unit_scale;
                 let (wx, wy) = transform.transform_point(x, y);
                 let (px, py) = rebase.plan(wx, wy);
-                out.push(px);
-                out.push(py);
+                push_finite_point(&mut out, px, py);
             }
             out
         }
@@ -133,8 +131,7 @@ fn extract_curve_ring(
                 let ly = cy_local + semi_b * theta.sin();
                 let (wx, wy) = transform.transform_point(lx, ly);
                 let (px, py) = rebase.plan(wx, wy);
-                out.push(px);
-                out.push(py);
+                push_finite_point(&mut out, px, py);
             }
             out
         }
@@ -153,8 +150,7 @@ fn extract_curve_ring(
                 let ly = cy_local + radius * theta.sin();
                 let (wx, wy) = transform.transform_point(lx, ly);
                 let (px, py) = rebase.plan(wx, wy);
-                out.push(px);
-                out.push(py);
+                push_finite_point(&mut out, px, py);
             }
             out
         }

--- a/rust/processing/src/symbolic/grid.rs
+++ b/rust/processing/src/symbolic/grid.rs
@@ -48,6 +48,16 @@ pub(super) fn extract_grid(
 
             let a = rebase.plan(p0.0, p0.1);
             let b = rebase.plan(p1.0, p1.1);
+            // Same finiteness hazard as items.rs's polyline/curve paths and
+            // fill.rs's boundary rings (a non-finite STEP REAL survives
+            // unsanitized to here): unlike a multi-point polyline, an axis is
+            // exactly two points defining a segment, so there is no partial
+            // point to drop — a non-finite endpoint drops the whole axis
+            // (grid_express_id, bubbles included), matching items.rs's
+            // whole-item IfcCircle convention rather than the per-point one.
+            if !a.0.is_finite() || !a.1.is_finite() || !b.0.is_finite() || !b.1.is_finite() {
+                continue;
+            }
             let world_y = rebase.elevation(transform.tz);
 
             // Compact server-friendly entry — keeps the existing endpoint-pair shape.

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -13,7 +13,7 @@ use super::primitives::{SymbolicCircle, SymbolicPolyline};
 use super::text::extract_text_literal;
 use super::transform::{
     circle_center, compose_transforms, parse_axis2_placement_2d,
-    parse_cartesian_transformation_operator, Transform2D,
+    parse_cartesian_transformation_operator, push_finite_point, Transform2D,
 };
 use super::trimmed_curve::extract_trimmed_curve;
 
@@ -162,10 +162,7 @@ pub(super) fn extract_symbolic_item_inner(
                         let (wx, wy) = transform.transform_point(local_x, local_y);
                         // Plan pair incl. the Y-flip to match section-cut handedness.
                         let (x, y) = rebase.plan(wx, wy);
-                        if x.is_finite() && y.is_finite() {
-                            points.push(x);
-                            points.push(y);
-                        }
+                        push_finite_point(&mut points, x, y);
                     }
                     if points.len() >= 4 {
                         let n = points.len();
@@ -202,10 +199,7 @@ pub(super) fn extract_symbolic_item_inner(
                 }
                 let (wx, wy) = transform.transform_point(local_x, local_y);
                 let (x, y) = rebase.plan(wx, wy);
-                if x.is_finite() && y.is_finite() {
-                    points.push(x);
-                    points.push(y);
-                }
+                push_finite_point(&mut points, x, y);
             }
             if points.len() >= 4 {
                 let n = points.len();
@@ -259,10 +253,7 @@ pub(super) fn extract_symbolic_item_inner(
                 let ly = cy_local + semi_b * t.sin();
                 let (wx, wy) = transform.transform_point(lx, ly);
                 let (x, y) = rebase.plan(wx, wy);
-                if x.is_finite() && y.is_finite() {
-                    points.push(x);
-                    points.push(y);
-                }
+                push_finite_point(&mut points, x, y);
             }
             if points.len() >= 4 {
                 out.push_polyline(SymbolicPolyline {

--- a/rust/processing/src/symbolic/text.rs
+++ b/rust/processing/src/symbolic/text.rs
@@ -69,6 +69,17 @@ pub(super) fn extract_text_literal(
 
     let (wx, wy) = composed.transform_point(0.0, 0.0);
     let plan = rebase.plan(wx, wy);
+    // Same finiteness hazard as items.rs's polyline/curve paths and fill.rs's
+    // boundary rings: a malformed STEP REAL (e.g. `1.E400`) in the placement
+    // chain reaches here as Infinity/NaN. Unlike `tz` (which legitimately
+    // carries `f32::NAN` as the "unresolved placement" sentinel via
+    // `Transform2D::unresolved()`), `tx`/`ty` never do — identity leaves them
+    // at 0.0 — so a non-finite (x, y) here is genuine malformed data, not a
+    // sentinel, and the whole text item is dropped rather than emitted with
+    // a corrupt position.
+    if !plan.0.is_finite() || !plan.1.is_finite() {
+        return;
+    }
     let raw_scale = composed.scale();
     // Height keeps a ZERO scale (the glyph collapses exactly as the symbol does);
     // only a non-finite scale falls back. The direction below needs the stricter

--- a/rust/processing/src/symbolic/transform.rs
+++ b/rust/processing/src/symbolic/transform.rs
@@ -19,6 +19,26 @@ pub(super) use operator::parse_cartesian_transformation_operator;
 // its storey elevation forward via `world_y`.
 // ────────────────────────────────────────────────────────────────────────────
 
+/// Push a plan-space `(x, y)` pair onto a point buffer, but only if BOTH
+/// components are finite. STEP REALs are not guaranteed finite — a
+/// hand-edited or malformed file can carry `1.E400`, which parses to
+/// `f32::INFINITY` and then propagates through `transform_point` /
+/// `RenderFrameRebase::plan` into NaN/Inf. This is the single chokepoint for
+/// that guard: `items.rs`'s polyline/indexed-poly-curve/ellipse extraction
+/// and `fill.rs`'s boundary-ring extraction both call this instead of
+/// pushing directly, so the two paths cannot drift apart the way they did
+/// before (fill.rs pushed unguarded coordinates while items.rs did not).
+/// Returns `true` if the point was kept.
+pub(super) fn push_finite_point(points: &mut Vec<f32>, x: f32, y: f32) -> bool {
+    if x.is_finite() && y.is_finite() {
+        points.push(x);
+        points.push(y);
+        true
+    } else {
+        false
+    }
+}
+
 /// A full 2D AFFINE transform: an arbitrary 2x2 linear block (`m00, m01, m10,
 /// m11`) plus translation. Unlike the `(cos_theta, sin_theta)` similarity this
 /// replaced, the 2x2 CAN carry a reflection, so a mirroring `IfcMappedItem`

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -10,7 +10,7 @@ use super::rebase::RenderFrameRebase;
 use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder, IfcType};
 
 use super::primitives::{SymbolicPolyline};
-use super::transform::{parse_axis2_placement_2d, Transform2D};
+use super::transform::{parse_axis2_placement_2d, push_finite_point, Transform2D};
 
 /// Tessellate an `IfcTrimmedCurve` whose `BasisCurve` is an `IfcCircle`.
 /// Honours `PLANEANGLEUNIT` scaling, `SenseAgreement`, and wrap-around so
@@ -159,10 +159,7 @@ pub(super) fn extract_trimmed_curve(
             let (local_x, local_y) = point_at(angle);
             let (wx, wy) = transform.transform_point(local_x, local_y);
             let (x, y) = rebase.plan(wx, wy);
-            if x.is_finite() && y.is_finite() {
-                points.push(x);
-                points.push(y);
-            }
+            push_finite_point(&mut points, x, y);
         }
         if points.len() >= 4 {
             out.push_polyline(SymbolicPolyline {

--- a/rust/processing/tests/issue_fill_finiteness.rs
+++ b/rust/processing/tests/issue_fill_finiteness.rs
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `fill.rs`'s `IfcAnnotationFillArea` boundary-ring extraction did not guard
+//! coordinates with `is_finite()`, unlike `items.rs`'s line/polyline
+//! extraction which does (`x.is_finite() && y.is_finite()` before pushing a
+//! point). A non-finite STEP REAL (`1.E400`, or a hand-edited file) parsed to
+//! `f32::INFINITY` and flowed unsanitized out of `extract_curve_ring`,
+//! through the WASM boundary, into `Drawing2DState`.
+//!
+//! Both fixtures below carry the identical malformed coordinate
+//! (`1.E400` on the second point of a multi-point boundary) so the only
+//! variable is which extraction path reads it — `IfcAnnotationFillArea`
+//! (fill.rs) vs. a bare `IfcPolyline` on an `IfcAnnotation` (items.rs).
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const FILL_AREA_WITH_INFINITE_COORD: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('fill-finiteness fixture'),'2;1');
+FILE_NAME('test.ifc','2026-09-08',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCCARTESIANPOINT((0.,0.));
+#11=IFCCARTESIANPOINT((1.E400,5.));
+#12=IFCCARTESIANPOINT((10.,10.));
+#13=IFCCARTESIANPOINT((0.,10.));
+#20=IFCPOLYLINE((#10,#11,#12,#13));
+#21=IFCANNOTATIONFILLAREA(#20,$);
+#40=IFCLOCALPLACEMENT($,#5);
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#21));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+#62=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+const BARE_POLYLINE_WITH_INFINITE_COORD: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('fill-finiteness contrast fixture'),'2;1');
+FILE_NAME('test.ifc','2026-09-08',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCCARTESIANPOINT((0.,0.));
+#11=IFCCARTESIANPOINT((1.E400,5.));
+#12=IFCCARTESIANPOINT((10.,10.));
+#20=IFCPOLYLINE((#10,#11,#12));
+#40=IFCLOCALPLACEMENT($,#5);
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#20));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+#62=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6d',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Sanity check on the fixture itself: `1.E400` must actually parse to a
+/// non-finite f32 through the real extraction path, not silently become
+/// `0.0` via `unwrap_or(0.0)` on a parse failure. If this fails, the fixture
+/// needs a different malformed literal — it would not be exercising the bug.
+#[test]
+fn contrast_fixture_bare_polyline_drops_the_non_finite_point() {
+    let data = extract_symbolic_data(BARE_POLYLINE_WITH_INFINITE_COORD);
+    assert_eq!(
+        data.polylines.len(),
+        1,
+        "expected exactly one polyline, got {:?}",
+        data.polylines
+    );
+    let pts = &data.polylines[0].points;
+    // 3 input points, one dropped (the non-finite one) -> 2 finite points -> 4 floats.
+    assert_eq!(
+        pts.len(),
+        4,
+        "items.rs must drop the non-finite point and keep the two finite ones, got {pts:?}"
+    );
+    for v in pts {
+        assert!(v.is_finite(), "items.rs must never emit a non-finite coordinate, got {v}");
+    }
+}
+
+/// RED (before the fix): `IfcAnnotationFillArea`'s boundary ring propagates
+/// the non-finite coordinate straight into `SymbolicFillArea.points`,
+/// diverging from the sibling polyline path above which drops it.
+#[test]
+fn fill_area_boundary_ring_must_not_emit_non_finite_points() {
+    let data = extract_symbolic_data(FILL_AREA_WITH_INFINITE_COORD);
+    assert_eq!(
+        data.fills.len(),
+        1,
+        "expected exactly one fill area, got {:?}",
+        data.fills
+    );
+    let pts = &data.fills[0].points;
+    // 4 input points, one dropped (the non-finite one) -> 3 finite points -> 6 floats.
+    assert_eq!(
+        pts.len(),
+        6,
+        "fill.rs must drop the non-finite point and keep the three finite ones, got {pts:?}"
+    );
+    for v in pts {
+        assert!(
+            v.is_finite(),
+            "fill.rs must never emit a non-finite coordinate into SymbolicFillArea.points, \
+             got {v} in {pts:?} — this is the asymmetry with items.rs's guarded polyline path"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`items.rs`'s polyline/curve extraction has guarded every pushed point against non-finite coordinates (`x.is_finite() && y.is_finite()`) since it was written, but three sibling extractors in the same `symbolic/` module did the same kind of work unguarded:

- `fill.rs`'s `extract_curve_ring` (IfcAnnotationFillArea boundary rings — same IfcPolyline/IfcIndexedPolyCurve/IfcEllipse cases as `items.rs`)
- `grid.rs`'s `IfcGridAxis` endpoint sampling
- `text.rs`'s `extract_text_literal` placement position

A malformed STEP `REAL` that overflows `f32` (e.g. `1.E400`) parses to `Infinity`, survives these three unguarded paths, and crosses the WASM boundary into `Drawing2DState` — corrupting rendering state and throwing on save. #4170 (`9959cfc4a`) mitigated the symptom on the TypeScript side; this fixes the Rust root cause.

Closes #4184

## Changes

- New `push_finite_point()` chokepoint in `transform.rs`, shared by every point-list extractor (`items.rs`, `fill.rs`, `trimmed_curve.rs`) so the guard can't drift apart between them again.
- `fill.rs`: per-point drop on a non-finite ring point, matching `items.rs`'s existing convention for multi-point curves.
- `grid.rs`: whole-axis drop when either endpoint is non-finite — a grid axis is exactly two points defining a segment, not a droppable-point list.
- `text.rs`: whole-item drop when the placement position is non-finite. `tz` alone legitimately carries the "unresolved placement" NaN sentinel via `Transform2D::unresolved()`; `tx`/`ty` never do (identity leaves them at 0.0), so a non-finite `(x, y)` here is genuine malformed data, not a sentinel.
- `items.rs` and `trimmed_curve.rs`'s already-guarded call sites unified onto the same `push_finite_point()` helper.
- RED/GREEN regression test at `rust/processing/tests/issue_fill_finiteness.rs`, contrasting the fill-area path against the already-guarded bare-polyline path on an identical malformed fixture (`1.E400` on the second boundary point).

## Scope / severity

Reachable only from a malformed or hand-edited IFC file carrying an out-of-range `REAL` — not something a well-formed model or compliant writer produces. Well-formed geometry is unaffected; the diff touches only the six `symbolic/*.rs` extraction files plus the new test (confirmed via `git diff upstream/main --stat` — no golden/reference manifest moved).

## Test plan

- [x] `cargo test -p ifc-lite-processing` — 151 unit tests + all integration test binaries pass (0 failed)
- [x] `cargo clippy -p ifc-lite-processing --all-targets -- -D warnings` — clean
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6 passed
- [x] `node scripts/check-module-size.mjs` — OK (2421 files measured, 0 new over budget)

## Correction (follow-up review)

The original commit's language claimed a "sibling sweep of the symbolic module's remaining coordinate-extraction sites found two more unguarded spots" — implying the fill/grid/text three were the complete list of remaining gaps. That overstated it: `items.rs`'s own `IfcCircle` branch had a fourth, narrower gap of the same shape (it validated only the circle's LOCAL center, not the POST-transform world point actually pushed), and the added regression test only contrasted fill.rs against items.rs's bare-polyline path, so it could not have caught a reverted grid.rs or text.rs guard either. Both gaps are closed and covered in a follow-up commit; see the PR comment below for details. The "sibling sweep found the remaining sites" framing above should be read as "found some of the remaining sites."

<!-- #4184 labelled `ready` by the maintainer; re-firing the pull_request event so the Issue queue gate sees a payload with it. Labelling an ISSUE fires `issues`, which this workflow does not listen to. -->
