### PR TITLE
fix(cli): close over a dropped relation's blockers only when they all resolve (#4150)

### DIFF
--- a/.changeset/fix-4150-blockedon-ownerhistory.md
+++ b/.changeset/fix-4150-blockedon-ownerhistory.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+extract-entities: only force-keep a dropped spatial relation's blockers when every one of them is a defined `IfcOwnerHistory` (#4150).
+
+`planSpatialRelations` reported the unkept non-SET references of a relation it dropped for that reason alone, and `buildSubset` closed over all of them. On schema-invalid input that over-extracted in two ways: a relation blocked on both a real private `IfcOwnerHistory` and a phantom id still dropped in the replan, but the owner subtree was kept and emitted as records nothing references; and a bare product reference in a `Name` or `Description` slot pulled that product's whole closure in, which could resurrect an unrelated containment whose member intersection had been empty. Blockers are now grouped per relation, and a group is closed over only when it resolves entirely, so the relation it belongs to actually survives the replan. Valid input is unaffected, and the private-`IfcOwnerHistory` rescue from #4126 still works, including alongside a relation whose blockers do not resolve.

--- a/packages/cli/src/commands/extract-entities.test.ts
+++ b/packages/cli/src/commands/extract-entities.test.ts
@@ -555,6 +555,89 @@ describe('buildSubset: a relation whose OwnerHistory is never defined', () => {
   });
 });
 
+// #80 is blocked on TWO ids: a real private IfcOwnerHistory #6 (owning a
+// four-record subtree) and a phantom #999 in its Description slot. #81 is
+// blocked on a clean private IfcOwnerHistory #7 and nothing else. The replan
+// can only rescue #81, so #6's subtree must stay out: force-keeping it emits
+// five records nothing in the file references (#4150).
+const STOREY_MODEL_MIXED_BLOCKERS = STOREY_MODEL.replace(
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#5,'L01 contents',$,",
+  "#6= IFCOWNERHISTORY(#16,#17,$,.ADDED.,$,$,$,0);\n" +
+    '#16= IFCPERSONANDORGANIZATION(#18,#19,$);\n' +
+    "#18= IFCPERSON($,'p',$,$,$,$,$,$);\n" +
+    "#19= IFCORGANIZATION($,'o',$,$,$);\n" +
+    "#17= IFCAPPLICATION(#19,'1','app','app');\n" +
+    "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#6,'L01 contents',#999,",
+).replace(
+  "#81= IFCRELREFERENCEDINSPATIALSTRUCTURE('RREF000000000000000001',#5,",
+  "#7= IFCOWNERHISTORY($,$,$,.ADDED.,$,$,$,0);\n" +
+    "#81= IFCRELREFERENCEDINSPATIALSTRUCTURE('RREF000000000000000001',#7,",
+);
+
+describe('buildSubset: a relation blocked on a private OwnerHistory AND a phantom (#4150)', () => {
+  const p = parseStep(STOREY_MODEL_MIXED_BLOCKERS);
+  const { keep, rewritten } = buildSubset(new Set([70, 72]), p);
+
+  it('leaves the OwnerHistory subtree out when the replan still drops the relation', () => {
+    // The phantom #999 blocks #80 in round two exactly as it did in round one,
+    // so keeping #6 buys nothing and costs five orphaned records.
+    expect(keep.has(80)).toBe(false);
+    for (const id of [6, 16, 17, 18, 19]) expect(keep.has(id)).toBe(false);
+  });
+
+  it('still rescues a relation whose blockers are ALL a defined OwnerHistory (#4126)', () => {
+    // The blockers are grouped per relation for this: #80's unresolvable group
+    // must not suppress #81's resolvable one.
+    expect(keep.has(81)).toBe(true);
+    expect(keep.has(7)).toBe(true);
+    expect(rewritten.get(81)).toContain('(#70)');
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset({ keep, rewritten }, p);
+    expectNoDanglingRefs(out);
+    expect(out).not.toContain('#6=');
+    expect(out).toContain('#81=');
+  });
+});
+
+// #80's Description slot holds a bare `#74`, an L02 chair that no selector
+// picked. Unlike the `'Chair pairs with #71'` case above it is a bare argument,
+// not text, so it IS a reference and the plan reports it as blocking #80. But it
+// is a PRODUCT, and closing over it drags a second storey's contents into a
+// first-storey selection (#4150).
+const STOREY_MODEL_PRODUCT_BLOCKER = STOREY_MODEL.replace(
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#5,'L01 contents',$,",
+  "#80= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000001',#5,'L01 contents',#74,",
+);
+
+describe('buildSubset: a blocker that is a product, not an OwnerHistory (#4150)', () => {
+  const p = parseStep(STOREY_MODEL_PRODUCT_BLOCKER);
+  const { keep, rewritten } = buildSubset(new Set([70, 72]), p);
+
+  it('does not extract the unselected product the blocker names', () => {
+    expect(keep.has(74)).toBe(false);
+  });
+
+  it('does not resurrect the other storey containment on the second round', () => {
+    // #82's member intersection with the selection is empty, so round one drops
+    // it. Keeping #74 makes it non-empty, and #82 comes back rewritten to
+    // `(#74)`: one selected pair of chairs, two extra records in the output.
+    expect(keep.has(82)).toBe(false);
+    expect(rewritten.has(82)).toBe(false);
+  });
+
+  it('drops the relation the unresolvable blocker belongs to', () => {
+    expect(keep.has(80)).toBe(false);
+  });
+
+  it('serializes with zero dangling references', () => {
+    const out = serializeSubset({ keep, rewritten }, p);
+    expectNoDanglingRefs(out);
+    expect(out).not.toContain('#74=');
+  });
+});
+
 describe('planSpatialRelations: a record it cannot scan, or cannot read as six attributes', () => {
   const record = (body: string) => ({
     id: 80,

--- a/packages/cli/src/commands/extract-entities.ts
+++ b/packages/cli/src/commands/extract-entities.ts
@@ -209,26 +209,18 @@ export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Subs
     grew = false;
     for (const inst of parsed.instances.values()) {
       if (keep.has(inst.id)) continue;
-      const refs = [...inst.body.matchAll(REF_RE)].map((m) => parseInt(m[1], 10));
-      if (inst.type === 'IFCRELVOIDSELEMENT') {
-        // refs: [OwnerHistory, RelatingBuildingElement, RelatedOpeningElement].
-        const host = refs[refs.length - 2];
-        const opening = refs[refs.length - 1];
-        if (host !== undefined && opening !== undefined && keep.has(host)) {
-          // Close over the relation itself, not just the opening: the rel's own
-          // OwnerHistory must be kept too or the subset emits a dangling ref.
-          forwardClosure([inst.id], parsed, keep);
-          grew = true;
-        }
-      } else if (inst.type === 'IFCRELFILLSELEMENT') {
-        // refs: [OwnerHistory, RelatingOpeningElement, RelatedBuildingElement(filler)].
-        const opening = refs[refs.length - 2];
-        const filler = refs[refs.length - 1];
-        if (opening !== undefined && filler !== undefined && keep.has(opening)) {
-          forwardClosure([inst.id], parsed, keep);
-          grew = true;
-        }
-      }
+      if (inst.type !== 'IFCRELVOIDSELEMENT' && inst.type !== 'IFCRELFILLSELEMENT') continue;
+      // Different meanings, one shape. `Relating` (attribute 5, the second-to-last
+      // reference) is the ANCHOR that must be kept already: the host wall for voids, the
+      // opening for fills. `Related` (attribute 6) is what the relation drags in, the
+      // opening or the filling window/door, and it is not read here because the closure
+      // below reaches it anyway.
+      const anchor = [...inst.body.matchAll(REF_RE)].map((m) => parseInt(m[1], 10)).at(-2);
+      if (anchor === undefined || !keep.has(anchor)) continue;
+      // Close over the relation itself, not just what it drags in: the rel's own
+      // OwnerHistory must be kept too or the subset emits a dangling ref.
+      forwardClosure([inst.id], parsed, keep);
+      grew = true;
     }
   }
 
@@ -238,14 +230,22 @@ export function buildSubset(seedProducts: Set<number>, parsed: ParsedStep): Subs
   // no-dangling-reference invariant it preserves.
   let spatial = planSpatialRelations(parsed.instances.values(), keep);
   // A relation-private IfcOwnerHistory is reachable from nothing else, so the
-  // plan drops the relation and reports what blocked it. Keep those and replan
-  // (#4126). ONE replan suffices for a SCHEMA-VALID record: an IfcOwnerHistory
-  // subtree names no product, container or relation. On invalid input a second
-  // round is discarded and the relation stays dropped (pre-#4126 behaviour,
-  // never a dangling id). A `while` does NOT terminate here: a phantom blocker
-  // closes over nothing and is reported every round.
-  if (spatial.blockedOn.length > 0) {
-    forwardClosure(spatial.blockedOn, parsed, keep);
+  // plan drops the relation and reports what blocked it. Close over a dropped
+  // relation's blocker group and replan (#4126), but only when EVERY id in the
+  // group is a defined IfcOwnerHistory: then the closure keeps all of them and
+  // that relation survives round two. A group holding anything else (a phantom
+  // id, or a product named in a Name or Description slot, both schema-invalid)
+  // leaves its relation dropped whatever is kept, so closing over it would only
+  // emit records nothing references and drag unselected products in (#4150).
+  // ONE replan, not a `while`: for a SCHEMA-VALID record an IfcOwnerHistory
+  // subtree names no product, container or relation, so it blocks nothing new;
+  // on invalid input a second round is discarded and the relation stays dropped
+  // (never a dangling id).
+  const owners = spatial.blockedOn
+    .filter((ids) => ids.every((id) => parsed.instances.get(id)?.type === 'IFCOWNERHISTORY'))
+    .flat();
+  if (owners.length > 0) {
+    forwardClosure(owners, parsed, keep);
     spatial = planSpatialRelations(parsed.instances.values(), keep);
   }
   for (const id of spatial.add) keep.add(id);

--- a/packages/cli/src/commands/subset-relations.ts
+++ b/packages/cli/src/commands/subset-relations.ts
@@ -41,8 +41,8 @@
  *     and dropping there was the orphaned-storey symptom again (#4126). This
  *     function still takes no `parsed`, so it cannot close over such a
  *     reference; it REPORTS it in {@link SpatialRelationPlan.blockedOn} and the
- *     caller, which does have `parsed`, keeps it and replans. Purity is intact:
- *     `blockedOn` is a finding, not a mutation.
+ *     caller, which does have `parsed`, decides whether to keep it and replan.
+ *     Purity is intact: `blockedOn` is a finding, not a mutation.
  *
  * A KNOWN gap: {@link keepWhole}, the fallback for a record this module could
  * not read as its six attributes, still drops on the same private
@@ -111,14 +111,14 @@ export interface SpatialRelationPlan {
   /** Relation id → rewritten record text, for the ones that lost a member. */
   rewritten: Map<number, string>;
   /**
-   * Unkept non-SET references, in practice a relation-private `OwnerHistory`,
-   * of the relations that this plan dropped for THAT reason alone: their
-   * relating parent is kept and their member intersection is non-empty, so
-   * keeping these ids is all that stands between them and surviving. A caller
-   * holding the parsed model can close over them and replan (#4126). Every
-   * other drop is final and reports nothing here.
+   * One entry per relation this plan dropped for ONE reason alone: unkept non-SET references,
+   * in practice a relation-private `OwnerHistory`. Its relating parent is kept and its member
+   * intersection is non-empty, so keeping EVERY id in the entry is all that stands between it
+   * and surviving. Grouped per relation, because keeping only SOME of one relation's blockers
+   * leaves it dropped and those ids orphaned (#4150). A caller with the parsed model closes
+   * over a group and replans (#4126). Every other drop is final and reports nothing here.
    */
-  blockedOn: number[];
+  blockedOn: number[][];
 }
 
 /**
@@ -174,7 +174,7 @@ export function planSpatialRelations(
 ): SpatialRelationPlan {
   const add: number[] = [];
   const rewritten = new Map<number, string>();
-  const blockedOn: number[] = [];
+  const blockedOn: number[][] = [];
   for (const inst of instances) {
     const slots = STRUCTURE_RELATIONS[inst.type];
     if (slots === undefined) continue;
@@ -188,15 +188,15 @@ export function planSpatialRelations(
 
 /**
  * The record text this relation contributes to the subset, or null to drop it.
- * Returns `inst.full` unchanged when nothing was filtered out. Appends to
- * `blocked` when the ONLY thing standing in the way is an unkept non-SET
- * reference; see {@link SpatialRelationPlan.blockedOn}.
+ * Returns `inst.full` unchanged when nothing was filtered out. Appends ONE entry
+ * to `blocked` when the ONLY thing standing in the way is unkept non-SET
+ * references; see {@link SpatialRelationPlan.blockedOn}.
  */
 function relationLine(
   inst: StepRecord,
   [relatingIdx, relatedIdx]: [number, number],
   keep: ReadonlySet<number>,
-  blocked: number[],
+  blocked: number[][],
 ): string | null {
   // A null is a REJECTED scan, not an empty list: its parts are wherever the
   // scanner happened to be, so reading `args[relatingIdx]` or writing
@@ -238,7 +238,7 @@ function relationLine(
     }
   }
   if (unkept.length > 0) {
-    blocked.push(...unkept);
+    blocked.push(unkept);
     return null;
   }
 


### PR DESCRIPTION
Closes #4150.

`buildSubset` force-kept every id a dropped relation reported as blocking it. Two
consequences, both reproduced before fixing, both on schema-invalid input:

1. **Blockers were kept even when the replan still dropped the relation.** `#80` blocked
   on a private `#6= IFCOWNERHISTORY(#16,#17,...)` plus a phantom `#999`: round two
   correctly still drops `#80`, but `#6` and its whole subtree stay in `keep`, are
   emitted as records nothing references, and are counted in the CLI's `-> N instances`
   line. `keep.size` 32 where it should be 27.
2. **A non-OwnerHistory blocker dragged unrelated products in.** `#80`'s `Description`
   holding a bare `#74` (an L02 chair) pulled `#74` and its closure in, and round two
   resurrected `#82`, the OTHER storey's containment, whose intersection had been empty:

       #82= IFCRELCONTAINEDINSPATIALSTRUCTURE('RCON000000000000000002',#5,'L02 contents',$,(#74),#45);

   Two chairs selected, a third plus a relation extracted.

Neither dangles. This is over-extraction, not invalid output, and neither fires on valid
IFC.

## The fix this issue proposed does not work

I wrote it. Applied exactly as filed and measured:

    const owners = spatial.blockedOn.filter((id) => parsed.instances.get(id)?.type === 'IFCOWNERHISTORY');

    defect 2   FIXED
    defect 1   UNCHANGED, keep.size still 32

In defect 1 the blocker `#6` **is** an `IfcOwnerHistory`. It passes the type filter, its
subtree is still force-kept, and the relation still drops. The other blocker, the phantom
`#999`, was never kept anyway, since `forwardClosure` has skipped undefined ids since
#4128. On that shape the filter is a no-op for the defect it was proposed against.

A global all-or-nothing gate fixes both and breaks something else: one relation's
unresolvable group then suppresses another relation's resolvable one, killing the #4126
rescue.

## What works

Group the blockers PER RELATION, and close over a group only when it resolves entirely.

    subset-relations.ts   blockedOn: number[] -> number[][],  blocked.push(unkept)
    extract-entities.ts   .filter((ids) => ids.every(isOwnerHistory)).flat()

That condition is exactly the one under which the closure pays for itself: it keeps all
of that relation's blockers, so the relation survives round two. No group is kept whose
relation still drops. `planSpatialRelations` stays pure and still takes no `parsed`.

Round two runs with a `keep` that only grew, so the relating parent is still kept and the
member intersection can only widen. A group that passes the filter always survives.

## Mutation table, separating the three candidate shapes

| shape | result |
|---|---|
| no filter (pre-fix behaviour) | 6 tests fail |
| the flat OwnerHistory filter this issue proposed | 2 fail, defect 1 survives |
| global all-or-nothing gate | 2 fail, kills the #4126 rescue |
| per-relation grouping (this PR) | all pass |
| ungroup in `subset-relations.ts` (`push([id])` each) | 2 fail, degrades to the flat filter |
| collapsed anchor `.at(-2)` -> `.at(-1)` | 4 fail across both relation kinds and the real model |

Each of the three candidate fixes is separated by a test the other two fail.

## The voids/fills collapse

The issue proposed this as the funding mechanism for the budget. Verified before applying:
`host`/`opening` (VOIDS) and `opening`/`filler` (FILLS) are both `refs[len-2]` /
`refs[len-1]`, and the last-ref local existed only for a `!== undefined` guard implied by
the anchor's own. Both conditions reduce to `keep.has(refs.at(-2))`.

`.at(-2)` rather than `refs[refs.length - 2]` because this repo has no
`noUncheckedIndexedAccess`, so the index form types as `number` and the guard would be a
dead comparison; `at()` is declared `T | undefined`. A comment carries what the variable
names carried: attribute 5 is the anchor that must already be kept, the host wall for
voids and the opening for fills.

## The budget premise in the issue is gone

#4166 restructured `extract-entities.ts` (moving `productsUnderPlacement` and friends into
`storey-selection.ts`), so it is now 457 lines against its 518 budget with 61 lines of
headroom, not one. The collapse was kept because it is a real de-duplication, but it freed
8 lines rather than the estimated 11 and is no longer load-bearing.

New constraint on the current base: `subset-relations.ts` is exactly **400 lines with no
allowlist row**, so changes there must be net-zero. They are. Neither file grew.

## Verification

    pnpm --filter @ifc-lite/cli test    885 passed, 8 skipped, 71 files  (+7)
    pnpm typecheck                      clean
    pnpm lint                           0 errors
    node scripts/check-module-size.mjs  OK, 0 new over 400

`blockedOn` has one consumer and is not in the package's published surface, so widening it
to `number[][]` breaks no caller.

## Deferred, recorded on the issue

The gate checks a blocker's own type but not its CLOSURE, so an `IfcOwnerHistory` that
itself names a product still drags that product in. Reproduced. Schema-invalid input by
construction, since no `IfcOwnerHistory` slot can hold a product, and the termination
comment already scopes itself to a schema-valid record. Closing it means checking each
group's forward closure for products, which is wider than the grouping this PR is about.

## Not verified

Both defects require schema-invalid input by construction, so the fixtures are synthetic
and there is no real-model demonstration. The claim is bounded to what the fixtures show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K
