### PR TITLE
fix(symbolic): guard push_circle against a non-finite post-transform center

### DIFF
--- a/.changeset/fix-symbolic-finiteness-followup.md
+++ b/.changeset/fix-symbolic-finiteness-followup.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix five gaps where a malformed STEP REAL (e.g. `1.E400`, which parses to `f32::INFINITY`) could survive as non-finite coordinates into the symbolic 2D extraction paths used for drawing/section views, rather than being dropped as unrenderable: `IfcAnnotationFillArea` boundary-ring extraction (`fill.rs`), `IfcGridAxis` endpoint sampling (`grid.rs`, drops the whole axis rather than a single point), `IfcTextLiteral` placement (`text.rs`, drops the whole text item), a circle push after ambient-placement transform (`push_circle` in `output_cap.rs`, which re-checks finiteness post-transform even though `items.rs` already validates the local center) and an `IfcTrimmedCurve` near-collinear-chord fallback (`trimmed_curve.rs`, guarded the same way its sibling arc-tessellation branch already was). All five now route through the same finite-or-drop convention as the already-guarded `items.rs` polyline/curve paths, so a malformed file can no longer push `Infinity`/`NaN` through the WASM boundary into `Drawing2DState`.

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -10,7 +10,8 @@
 //! allowed to do; nothing here knows about any IFC type.
 
 use super::items::extract_symbolic_item_inner;
-use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
+use super::output_cap::SymbolicAccumulator;
+use super::output_cap_types::SymbolicTruncationReason;
 use super::rebase::RenderFrameRebase;
 use super::transform::Transform2D;
 use ifc_lite_core::{DecodedEntity, EntityDecoder};

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
+use super::output_cap::SymbolicAccumulator;
+use super::output_cap_types::SymbolicTruncationReason;
 use super::rebase::RenderFrameRebase;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -14,7 +14,8 @@
 //! infrastructure instead of a failed assertion.
 
 use super::item_walk::{extract_symbolic_item, MAX_ITEM_DEPTH, MAX_ITEM_REVISITS};
-use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
+use super::output_cap::SymbolicAccumulator;
+use super::output_cap_types::SymbolicTruncationReason;
 use super::primitives::SymbolicData;
 use super::rebase::RenderFrameRebase;
 use super::transform::Transform2D;

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -73,6 +73,7 @@ mod grid;
 mod item_walk;
 mod items;
 mod output_cap;
+mod output_cap_types;
 mod output_cap_validate;
 #[cfg(test)]
 mod items_cycle_tests;
@@ -84,7 +85,7 @@ mod text;
 mod transform;
 mod trimmed_curve;
 
-pub use output_cap::{SymbolicTruncation, SymbolicTruncationReason};
+pub use output_cap_types::{SymbolicTruncation, SymbolicTruncationReason};
 pub use primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,
 };

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -73,6 +73,7 @@ mod grid;
 mod item_walk;
 mod items;
 mod output_cap;
+mod output_cap_validate;
 #[cfg(test)]
 mod items_cycle_tests;
 #[cfg(test)]

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -11,12 +11,12 @@
 //! to find it, and a reader adding a primitive should not have to step around
 //! the bound.
 
+use super::output_cap_types::{SymbolicTruncation, SymbolicTruncationReason};
 use super::output_cap_validate::all_finite;
 use super::primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline,
     SymbolicText,
 };
-use serde::{Deserialize, Serialize};
 
 /// Upper bound on the total number of symbolic primitives one extraction may
 /// emit, across every product in the file.
@@ -82,91 +82,6 @@ pub const MAX_SYMBOLIC_BYTES: usize = 256 * 1024 * 1024;
 const PRIMITIVE_OVERHEAD_BYTES: usize = 64;
 /// Charged per `f32` coordinate or per byte of text.
 const BYTES_PER_COORD: usize = 8;
-
-/// Which bound stopped an extraction early.
-///
-/// `SymbolicData` had no diagnostics channel at all (#2938), so a drawing that
-/// lost 60% of its curves was indistinguishable, in the response, from one that
-/// legitimately had nothing more to emit.
-///
-/// The reason matters as much as the fact. #2938's own lead case is a
-/// well-formed nested block import losing content to the PER-ITEM revisit
-/// budget while the whole-file totals sit far below the extraction bounds --
-/// so a diagnostic that only reported the extraction bounds would have reported
-/// nothing on the exact scenario the issue is about.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum SymbolicTruncationReason {
-    /// [`MAX_SYMBOLIC_ELEMENTS`] reached.
-    ElementCount,
-    /// [`MAX_SYMBOLIC_BYTES`] reached.
-    OutputBytes,
-    /// One representation item nested deeper than the walk follows.
-    ItemDepth,
-    /// The EXTRACTION exhausted its revisit budget: a large acyclic fan-out,
-    /// or a legitimate deeply-nested block import.
-    ///
-    /// Shared across the whole file since #3114, not per item -- a per-item
-    /// budget reset on every top-level item, so nothing bounded a fan-out
-    /// spread across many items. The name is kept for wire compatibility.
-    /// Note the budget is extraction-wide while `ItemWalk::seen` stays per
-    /// item, so re-placing one library block is not charged as a revisit.
-    ItemRevisits,
-    /// The walk's path guard (`ItemWalk::enter_node`) refused to re-enter a
-    /// node already on the current path -- a genuine cycle in the
-    /// representation graph, not merely a large fan-out. Distinct from
-    /// [`Self::ItemRevisits`], whose budget can also be exhausted by an
-    /// acyclic file (#2938's lead case); this reason is a cycle and nothing
-    /// else (#3108).
-    ItemCycle,
-}
-
-impl SymbolicTruncationReason {
-    /// The wire spelling, identical to what `Serialize` emits.
-    ///
-    /// The WASM boundary cannot hand a serde enum to JavaScript, so it needs a
-    /// plain string; having it here rather than a `match` in wasm-bindings keeps
-    /// one vocabulary for both surfaces. `the_wire_spellings_match_serde` pins
-    /// them together, because two hand-kept lists is how they drift.
-    pub fn as_wire_str(self) -> &'static str {
-        match self {
-            Self::ElementCount => "element-count",
-            Self::OutputBytes => "output-bytes",
-            Self::ItemDepth => "item-depth",
-            Self::ItemRevisits => "item-revisits",
-            Self::ItemCycle => "item-cycle",
-        }
-    }
-}
-
-/// What stopped an extraction early, when something did.
-///
-/// Present only on a truncated result.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SymbolicTruncation {
-    /// The MOST SEVERE bound that fired, not the first: an extraction bound
-    /// outranks a per-item one whatever the scan order. See
-    /// `SymbolicAccumulator::record`.
-    pub reason: SymbolicTruncationReason,
-    /// Primitives emitted in total. NOT necessarily equal to any limit: a
-    /// traversal bound stops content from being produced while the file-level
-    /// totals stay far below the extraction bounds.
-    pub emitted: usize,
-    /// The bound's value, when the reason has a single numeric one. `None` for
-    /// the traversal reasons, whose bounds count a DIFFERENT UNIT from
-    /// `emitted` -- revisits and nesting depth, not primitives -- so there is
-    /// no meaningful "{emitted} of {limit}" to render.
-    ///
-    /// Note this is no longer because those bounds are per item: since #3114
-    /// the revisit budget is extraction-wide. It is the units that do not
-    /// line up, and that is what keeps `limit` absent.
-    ///
-    /// Skipped rather than serialized as `null`: the TypeScript mirror declares
-    /// `limit?: number`, which means the key is ABSENT. Emitting `null` satisfies
-    /// Rust and breaks the consumer's `'limit' in truncated` check.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub limit: Option<usize>,
-}
 
 /// The extraction's accumulator: a `SymbolicData` under construction, plus the
 /// bound it is being built under.
@@ -332,15 +247,18 @@ impl SymbolicAccumulator {
         // file-bounded so it has no fan-out amplifier, but an uncharged
         // heap field is the same class of hole as `alignment` was.
         let payload = axis.tag.len();
-        self.try_push(payload, all_finite(&axis.endpoints), |data| data.grid_axes.push(axis));
+        self.try_push(payload, all_finite(&axis.endpoints), |data| {
+            data.grid_axes.push(axis)
+        });
     }
 
     /// Append a polyline unless the extraction has hit its cap.
     pub(super) fn push_polyline(&mut self, polyline: SymbolicPolyline) {
-        let payload = polyline.points.len()
-            + polyline.ifc_type.len()
-            + polyline.representation.len();
-        self.try_push(payload, all_finite(&polyline.points), |data| data.polylines.push(polyline));
+        let payload =
+            polyline.points.len() + polyline.ifc_type.len() + polyline.representation.len();
+        self.try_push(payload, all_finite(&polyline.points), |data| {
+            data.polylines.push(polyline)
+        });
     }
 
     /// Append a circle unless the extraction has hit its cap.
@@ -367,7 +285,9 @@ impl SymbolicAccumulator {
             + text.alignment.len()
             + text.ifc_type.len()
             + text.representation.len();
-        self.try_push(payload, all_finite(&[text.x, text.y]), |data| data.texts.push(text));
+        self.try_push(payload, all_finite(&[text.x, text.y]), |data| {
+            data.texts.push(text)
+        });
     }
 
     /// Append a filled region unless the extraction has hit its cap.
@@ -376,7 +296,9 @@ impl SymbolicAccumulator {
             + fill.holes_offsets.len()
             + fill.ifc_type.len()
             + fill.representation.len();
-        self.try_push(payload, all_finite(&fill.points), |data| data.fills.push(fill));
+        self.try_push(payload, all_finite(&fill.points), |data| {
+            data.fills.push(fill)
+        });
     }
 
     /// Finish, stamping the diagnostics field iff an append was ever refused.
@@ -393,7 +315,11 @@ impl SymbolicAccumulator {
                 | SymbolicTruncationReason::ItemRevisits
                 | SymbolicTruncationReason::ItemCycle => None,
             };
-            self.data.truncated = Some(SymbolicTruncation { reason, emitted, limit });
+            self.data.truncated = Some(SymbolicTruncation {
+                reason,
+                emitted,
+                limit,
+            });
         }
         self.data
     }

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -347,8 +347,8 @@ impl SymbolicAccumulator {
     /// only the LOCAL center before transforming it, so a malformed ambient
     /// placement can still turn a finite local point into a non-finite one.
     pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
-        if !(circle.center_x.is_finite() && circle.center_y.is_finite() && circle.radius.is_finite())
-        {
+        let finite = circle.center_x.is_finite() && circle.center_y.is_finite();
+        if !finite || !circle.radius.is_finite() {
             return;
         }
         let payload = 8 + circle.ifc_type.len() + circle.representation.len();

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -11,6 +11,7 @@
 //! to find it, and a reader adding a primitive should not have to step around
 //! the bound.
 
+use super::output_cap_validate::all_finite;
 use super::primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline,
     SymbolicText,
@@ -306,20 +307,22 @@ impl SymbolicAccumulator {
     /// identical. Keeping it in five copies is how `push_text` came to omit
     /// `alignment` from its payload and under-count the byte bound by 13.5x, so
     /// a sixth primitive must not have to re-derive the block to get it right.
-    fn try_push<F>(&mut self, payload: usize, push: F)
+    fn try_push<F>(&mut self, payload: usize, valid: bool, push: F)
     where
         F: FnOnce(&mut SymbolicData),
     {
-        if let Some(reason) = self.exceeded_by(payload) {
-            self.record(reason);
-            self.exhausted = true;
-            #[cfg(test)]
-            {
-                self.refusals += 1;
+        if valid {
+            if let Some(reason) = self.exceeded_by(payload) {
+                self.record(reason);
+                self.exhausted = true;
+                #[cfg(test)]
+                {
+                    self.refusals += 1;
+                }
+            } else {
+                self.charge(payload);
+                push(&mut self.data);
             }
-        } else {
-            self.charge(payload);
-            push(&mut self.data);
         }
     }
 
@@ -329,7 +332,7 @@ impl SymbolicAccumulator {
         // file-bounded so it has no fan-out amplifier, but an uncharged
         // heap field is the same class of hole as `alignment` was.
         let payload = axis.tag.len();
-        self.try_push(payload, |data| data.grid_axes.push(axis));
+        self.try_push(payload, all_finite(&axis.endpoints), |data| data.grid_axes.push(axis));
     }
 
     /// Append a polyline unless the extraction has hit its cap.
@@ -337,7 +340,7 @@ impl SymbolicAccumulator {
         let payload = polyline.points.len()
             + polyline.ifc_type.len()
             + polyline.representation.len();
-        self.try_push(payload, |data| data.polylines.push(polyline));
+        self.try_push(payload, all_finite(&polyline.points), |data| data.polylines.push(polyline));
     }
 
     /// Append a circle unless the extraction has hit its cap.
@@ -347,12 +350,9 @@ impl SymbolicAccumulator {
     /// only the LOCAL center before transforming it, so a malformed ambient
     /// placement can still turn a finite local point into a non-finite one.
     pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
-        let finite = circle.center_x.is_finite() && circle.center_y.is_finite();
-        if !finite || !circle.radius.is_finite() {
-            return;
-        }
+        let valid = all_finite(&[circle.center_x, circle.center_y, circle.radius]);
         let payload = 8 + circle.ifc_type.len() + circle.representation.len();
-        self.try_push(payload, |data| data.circles.push(circle));
+        self.try_push(payload, valid, |data| data.circles.push(circle));
     }
 
     /// Append a text annotation unless the extraction has hit its cap.
@@ -367,7 +367,7 @@ impl SymbolicAccumulator {
             + text.alignment.len()
             + text.ifc_type.len()
             + text.representation.len();
-        self.try_push(payload, |data| data.texts.push(text));
+        self.try_push(payload, all_finite(&[text.x, text.y]), |data| data.texts.push(text));
     }
 
     /// Append a filled region unless the extraction has hit its cap.
@@ -376,7 +376,7 @@ impl SymbolicAccumulator {
             + fill.holes_offsets.len()
             + fill.ifc_type.len()
             + fill.representation.len();
-        self.try_push(payload, |data| data.fills.push(fill));
+        self.try_push(payload, all_finite(&fill.points), |data| data.fills.push(fill));
     }
 
     /// Finish, stamping the diagnostics field iff an append was ever refused.

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -341,7 +341,16 @@ impl SymbolicAccumulator {
     }
 
     /// Append a circle unless the extraction has hit its cap.
+    ///
+    /// Re-checks finiteness here — the single chokepoint every circle push
+    /// feeds through — rather than trusting the caller: `items.rs` validates
+    /// only the LOCAL center before transforming it, so a malformed ambient
+    /// placement can still turn a finite local point into a non-finite one.
     pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
+        if !(circle.center_x.is_finite() && circle.center_y.is_finite() && circle.radius.is_finite())
+        {
+            return;
+        }
         let payload = 8 + circle.ifc_type.len() + circle.representation.len();
         self.try_push(payload, |data| data.circles.push(circle));
     }

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -51,7 +51,9 @@
 //! field that says the cap was hit. Both halves are pinned here.
 //!
 use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
-use super::primitives::SymbolicData;
+use super::primitives::{
+    SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,
+};
 
 /// Test-only constructors and the refusal counter, kept HERE rather than in
 /// `output_cap.rs`.
@@ -837,4 +839,154 @@ fn the_wire_spellings_match_serde() {
             "as_wire_str disagrees with Serialize for {reason:?}"
         );
     }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// `push_*` finiteness guards (follow-up to #4189/#4190).
+//
+// `parse_axis2_placement_2d` and `parse_cartesian_transformation_operator`
+// deliberately do not refuse a non-finite ambient placement, so every
+// CONSUMER of a resolved placement must guard itself. Only `push_circle` did.
+// The four tests below call `push_grid_axis`/`push_polyline`/`push_text`/
+// `push_fill` DIRECTLY, with no caller in between, to prove the refusal lives
+// at the accumulator's own chokepoint and not merely in whichever caller
+// happened to check first. Each was run against the pre-fix accumulator (the
+// `valid` check reverted to `true`) and confirmed to fail before the fix
+// landed -- see the PR comment for the mutation diff and its RED output.
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn push_grid_axis_refuses_a_non_finite_endpoint_directly_at_the_push() {
+    let mut acc = SymbolicAccumulator::with_limits(500, 1_000_000);
+    acc.push_grid_axis(SymbolicGridAxis {
+        express_id: 1,
+        grid_express_id: 1,
+        tag: "A".to_string(),
+        endpoints: [0.0, 0.0, f32::NAN, 1.0],
+        world_y: f32::NAN,
+    });
+    acc.push_grid_axis(SymbolicGridAxis {
+        express_id: 2,
+        grid_express_id: 1,
+        tag: "B".to_string(),
+        endpoints: [0.0, 0.0, 1.0, 1.0],
+        world_y: f32::NAN,
+    });
+    let out = acc.into_data();
+    assert_eq!(
+        out.grid_axes.len(),
+        1,
+        "a non-finite endpoint must be refused at push_grid_axis while a \
+         finite one beside it is kept"
+    );
+}
+
+#[test]
+fn push_polyline_refuses_a_non_finite_point_directly_at_the_push() {
+    let mut acc = SymbolicAccumulator::with_limits(500, 1_000_000);
+    acc.push_polyline(SymbolicPolyline {
+        express_id: 1,
+        ifc_type: "IfcPolyline".to_string(),
+        points: vec![0.0, 0.0, f32::INFINITY, 1.0],
+        closed: false,
+        world_y: f32::NAN,
+        representation: "Plan".to_string(),
+    });
+    acc.push_polyline(SymbolicPolyline {
+        express_id: 2,
+        ifc_type: "IfcPolyline".to_string(),
+        points: vec![0.0, 0.0, 1.0, 1.0],
+        closed: false,
+        world_y: f32::NAN,
+        representation: "Plan".to_string(),
+    });
+    let out = acc.into_data();
+    assert_eq!(
+        out.polylines.len(),
+        1,
+        "a non-finite point must be refused at push_polyline while a finite \
+         polyline beside it is kept"
+    );
+}
+
+#[test]
+fn push_text_refuses_a_non_finite_anchor_directly_at_the_push() {
+    let mut acc = SymbolicAccumulator::with_limits(500, 1_000_000);
+    acc.push_text(SymbolicText {
+        express_id: 1,
+        ifc_type: "IfcTextLiteral".to_string(),
+        x: f32::NAN,
+        y: 0.0,
+        dir_x: 1.0,
+        dir_y: 0.0,
+        height: 1.0,
+        content: "a".to_string(),
+        alignment: String::new(),
+        world_y: f32::NAN,
+        color: [0.0, 0.0, 0.0, 1.0],
+        target_px: 0.0,
+        representation: "Plan".to_string(),
+    });
+    acc.push_text(SymbolicText {
+        express_id: 2,
+        ifc_type: "IfcTextLiteral".to_string(),
+        x: 0.0,
+        y: 0.0,
+        dir_x: 1.0,
+        dir_y: 0.0,
+        height: 1.0,
+        content: "b".to_string(),
+        alignment: String::new(),
+        world_y: f32::NAN,
+        color: [0.0, 0.0, 0.0, 1.0],
+        target_px: 0.0,
+        representation: "Plan".to_string(),
+    });
+    let out = acc.into_data();
+    assert_eq!(
+        out.texts.len(),
+        1,
+        "a non-finite x/y anchor must be refused at push_text while a finite \
+         text beside it is kept"
+    );
+}
+
+#[test]
+fn push_fill_refuses_a_non_finite_point_directly_at_the_push() {
+    let mut acc = SymbolicAccumulator::with_limits(500, 1_000_000);
+    acc.push_fill(SymbolicFillArea {
+        express_id: 1,
+        ifc_type: "IfcAnnotationFillArea".to_string(),
+        points: vec![0.0, 0.0, f32::NAN, 1.0, 1.0, 1.0],
+        holes_offsets: vec![],
+        fill_color: [0.0, 0.0, 0.0, 1.0],
+        has_hatching: false,
+        hatch_spacing: 0.0,
+        hatch_angle: 0.0,
+        hatch_angle_secondary: f32::NAN,
+        hatch_line_width: 0.0,
+        world_y: f32::NAN,
+        representation: "Plan".to_string(),
+    });
+    acc.push_fill(SymbolicFillArea {
+        express_id: 2,
+        ifc_type: "IfcAnnotationFillArea".to_string(),
+        points: vec![0.0, 0.0, 1.0, 1.0, 1.0, 1.0],
+        holes_offsets: vec![],
+        fill_color: [0.0, 0.0, 0.0, 1.0],
+        has_hatching: false,
+        hatch_spacing: 0.0,
+        hatch_angle: 0.0,
+        hatch_angle_secondary: f32::NAN,
+        hatch_line_width: 0.0,
+        world_y: f32::NAN,
+        representation: "Plan".to_string(),
+    });
+    let out = acc.into_data();
+    assert_eq!(
+        out.fills.len(),
+        1,
+        "a non-finite point must be refused at push_fill while a finite fill \
+         beside it is kept"
+    );
 }

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -50,7 +50,8 @@
 //! they are fixed by one instrument: a cap on the OUTPUT, plus a diagnostics
 //! field that says the cap was hit. Both halves are pinned here.
 //!
-use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
+use super::output_cap::SymbolicAccumulator;
+use super::output_cap_types::SymbolicTruncationReason;
 use super::primitives::{
     SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,
 };

--- a/rust/processing/src/symbolic/output_cap_types.rs
+++ b/rust/processing/src/symbolic/output_cap_types.rs
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Diagnostics wire types for [`super::output_cap::SymbolicAccumulator`].
+//!
+//! Split out of `output_cap.rs` rather than kept inline: that file sits at
+//! its 400-line ratchet ceiling, and these types are self-contained wire
+//! shapes with no dependency on the accumulator's push/charge logic, so they
+//! move without disturbing the policy they describe.
+
+use serde::{Deserialize, Serialize};
+
+/// Which bound stopped an extraction early.
+///
+/// `SymbolicData` had no diagnostics channel at all (#2938), so a drawing that
+/// lost 60% of its curves was indistinguishable, in the response, from one that
+/// legitimately had nothing more to emit.
+///
+/// The reason matters as much as the fact. #2938's own lead case is a
+/// well-formed nested block import losing content to the PER-ITEM revisit
+/// budget while the whole-file totals sit far below the extraction bounds --
+/// so a diagnostic that only reported the extraction bounds would have reported
+/// nothing on the exact scenario the issue is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SymbolicTruncationReason {
+    /// [`super::output_cap::MAX_SYMBOLIC_ELEMENTS`] reached.
+    ElementCount,
+    /// [`super::output_cap::MAX_SYMBOLIC_BYTES`] reached.
+    OutputBytes,
+    /// One representation item nested deeper than the walk follows.
+    ItemDepth,
+    /// The EXTRACTION exhausted its revisit budget: a large acyclic fan-out,
+    /// or a legitimate deeply-nested block import.
+    ///
+    /// Shared across the whole file since #3114, not per item -- a per-item
+    /// budget reset on every top-level item, so nothing bounded a fan-out
+    /// spread across many items. The name is kept for wire compatibility.
+    /// Note the budget is extraction-wide while `ItemWalk::seen` stays per
+    /// item, so re-placing one library block is not charged as a revisit.
+    ItemRevisits,
+    /// The walk's path guard (`ItemWalk::enter_node`) refused to re-enter a
+    /// node already on the current path -- a genuine cycle in the
+    /// representation graph, not merely a large fan-out. Distinct from
+    /// [`Self::ItemRevisits`], whose budget can also be exhausted by an
+    /// acyclic file (#2938's lead case); this reason is a cycle and nothing
+    /// else (#3108).
+    ItemCycle,
+}
+
+impl SymbolicTruncationReason {
+    /// The wire spelling, identical to what `Serialize` emits.
+    ///
+    /// The WASM boundary cannot hand a serde enum to JavaScript, so it needs a
+    /// plain string; having it here rather than a `match` in wasm-bindings keeps
+    /// one vocabulary for both surfaces. `the_wire_spellings_match_serde` pins
+    /// them together, because two hand-kept lists is how they drift.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::ElementCount => "element-count",
+            Self::OutputBytes => "output-bytes",
+            Self::ItemDepth => "item-depth",
+            Self::ItemRevisits => "item-revisits",
+            Self::ItemCycle => "item-cycle",
+        }
+    }
+}
+
+/// What stopped an extraction early, when something did.
+///
+/// Present only on a truncated result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicTruncation {
+    /// The MOST SEVERE bound that fired, not the first: an extraction bound
+    /// outranks a per-item one whatever the scan order. See
+    /// `SymbolicAccumulator::record`.
+    pub reason: SymbolicTruncationReason,
+    /// Primitives emitted in total. NOT necessarily equal to any limit: a
+    /// traversal bound stops content from being produced while the file-level
+    /// totals stay far below the extraction bounds.
+    pub emitted: usize,
+    /// The bound's value, when the reason has a single numeric one. `None` for
+    /// the traversal reasons, whose bounds count a DIFFERENT UNIT from
+    /// `emitted` -- revisits and nesting depth, not primitives -- so there is
+    /// no meaningful "{emitted} of {limit}" to render.
+    ///
+    /// Note this is no longer because those bounds are per item: since #3114
+    /// the revisit budget is extraction-wide. It is the units that do not
+    /// line up, and that is what keeps `limit` absent.
+    ///
+    /// Skipped rather than serialized as `null`: the TypeScript mirror declares
+    /// `limit?: number`, which means the key is ABSENT. Emitting `null` satisfies
+    /// Rust and breaks the consumer's `'limit' in truncated` check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}

--- a/rust/processing/src/symbolic/output_cap_validate.rs
+++ b/rust/processing/src/symbolic/output_cap_validate.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Finiteness guard for [`super::output_cap::SymbolicAccumulator`]'s
+//! `push_*` methods.
+//!
+//! Split out of `output_cap.rs` rather than added inline: that file sits at
+//! its 400-line ratchet ceiling, and four new guards push it over.
+//!
+//! `parse_axis2_placement_2d` and `parse_cartesian_transformation_operator`
+//! deliberately do NOT refuse a non-finite ambient placement themselves --
+//! routing to `Transform2D::unresolved()` would set `tx = ty = 0.0`, which is
+//! finite, and would stop every `tx`/`ty`-keyed guard downstream from firing.
+//! So the design is that every CONSUMER of a resolved placement guards
+//! itself. `push_circle` already did; the other four `push_*` methods on
+//! `SymbolicAccumulator` trusted their caller to have done so already.
+//! Because the accumulator's `data` field is private and reachable only
+//! through `push_*`, putting the guard here makes it impossible to bypass
+//! rather than merely conventional.
+//!
+//! ONLY tx/ty-derived coordinate fields are checked: `points`, `x`/`y`,
+//! `center_x`/`center_y`, `endpoints`. `push_circle` already checked its own
+//! `center_x`/`center_y`/`radius` before this change; it now goes through
+//! this same helper. The NaN-sentinel fields in `primitives.rs` -- every
+//! field marked `#[serde(with = "nan_as_null")]` (`world_y` on `SymbolicPolyline`,
+//! `SymbolicCircle`, `SymbolicText`, `SymbolicFillArea`, `SymbolicGridAxis`,
+//! plus `SymbolicFillArea::hatch_angle_secondary`) -- mean "unresolved" ON
+//! PURPOSE via `f32::NAN` and must NOT be rejected here: doing so would
+//! destroy the "unresolved elevation" convention `nan_as_null` exists to
+//! carry.
+
+/// True if every coordinate in `coords` is finite.
+///
+/// One shared chokepoint rather than four near-duplicates, for the same
+/// reason `SymbolicAccumulator::try_push` gives all five `push_*` one shared
+/// accept/refuse decision: `try_push`'s own doc notes that keeping a check in
+/// five copies is how `push_text` once came to omit a field from its byte
+/// charge, and a validity check invites the identical drift.
+pub(super) fn all_finite(coords: &[f32]) -> bool {
+    coords.iter().all(|c| c.is_finite())
+}

--- a/rust/processing/src/symbolic/primitives.rs
+++ b/rust/processing/src/symbolic/primitives.rs
@@ -33,9 +33,10 @@ use serde::{Deserialize, Serialize};
 /// "unresolved" sentinel to and from JSON `null`.
 ///
 /// Read back, any `null` becomes `f32::NAN`. `serde_json` also writes `±inf`
-/// as `null`, so an infinity would return as NaN — no producer in this crate
-/// emits one, and NaN is the correct reading of "not a usable elevation"
-/// either way. Consumers must test `is_nan()`, not `!is_finite()`.
+/// as `null`, so an infinity round-trips as NaN — `operator.rs`'s unchecked
+/// `as_float().unwrap_or(0.0)` on a placement's Z can make `tz`, and so
+/// `world_y`, infinite, and NaN is the correct reading of "not a usable
+/// elevation" either way. Consumers must test `is_nan()`, not `!is_finite()`.
 pub(crate) mod nan_as_null {
     use serde::{Deserialize, Deserializer, Serializer};
 

--- a/rust/processing/src/symbolic/primitives.rs
+++ b/rust/processing/src/symbolic/primitives.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::output_cap::SymbolicTruncation;
+use super::output_cap_types::SymbolicTruncation;
 use serde::{Deserialize, Serialize};
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -140,6 +140,15 @@ pub(super) fn extract_trimmed_curve(
         let (wex, wey) = transform.transform_point(end_x, end_y);
         let (sx, sy) = rebase.plan(wsx, wsy);
         let (ex, ey) = rebase.plan(wex, wey);
+        // Same hazard as the arc-tessellation branch below (a poisoned
+        // AMBIENT `transform` — not `basis`, already checked above — makes
+        // an otherwise-finite local chord non-finite post-transform); that
+        // branch routes every point through `push_finite_point`, this one
+        // must reject the whole two-point chord the same way rather than
+        // push a partly-finite pair.
+        if !sx.is_finite() || !sy.is_finite() || !ex.is_finite() || !ey.is_finite() {
+            return;
+        }
         let points = vec![sx, sy, ex, ey];
         out.push_polyline(SymbolicPolyline {
             express_id,

--- a/rust/processing/tests/issue_symbolic_finiteness_followup.rs
+++ b/rust/processing/tests/issue_symbolic_finiteness_followup.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Follow-up coverage for the finiteness sweep in `issue_fill_finiteness.rs`.
+//!
+//! That test only contrasts `fill.rs` against `items.rs`'s bare-polyline
+//! path — it says nothing about `grid.rs`'s or `text.rs`'s guards, nor about
+//! a FOURTH gap an adversarial review of PR #4185 found: `items.rs`'s
+//! `IfcCircle` branch checks only its own LOCAL `center_x`/`center_y` before
+//! `return`ing early, then pushes the POST-transform `(px, py)` unchecked.
+//! An ambient placement with a malformed STEP REAL (`1.E400`) in its
+//! `Location` — read by `parse_axis2_placement_2d` with no finiteness check
+//! — turns a perfectly finite local center into a non-finite world point.
+//! Fixed by guarding inside `output_cap.rs`'s `push_circle`, the single
+//! chokepoint every circle-producing call site feeds through (mirroring how
+//! `push_finite_point` is the chokepoint for point-list pushes), rather than
+//! at the `items.rs` call site — a per-call-site guard is exactly what let
+//! this gap open despite the sibling polyline/ellipse paths already being
+//! guarded post-transform.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const BOILERPLATE_HEADER: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('symbolic finiteness follow-up fixture'),'2;1');
+FILE_NAME('test.ifc','2026-09-09',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6e',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+"#;
+
+/// Gap 1: an ambient `IfcLocalPlacement` whose `Location` carries `1.E400`
+/// (#7/#8/#40) makes `Transform2D.tx = Infinity`, while the `IfcCircle`
+/// itself (#70-#72) has a perfectly finite local center. `items.rs` only
+/// checks the local center, so the non-finite value must be caught
+/// POST-transform, at (or before) `push_circle`.
+const CIRCLE_WITH_INFINITE_AMBIENT_PLACEMENT: &str = r#"
+#7=IFCCARTESIANPOINT((1.E400,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#40=IFCLOCALPLACEMENT($,#8);
+#70=IFCCARTESIANPOINT((0.,0.));
+#71=IFCAXIS2PLACEMENT2D(#70,$);
+#72=IFCCIRCLE(#71,2.);
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Curve2D',(#72));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+#62=IFCANNOTATION('1xScRe4drECQ4DMSqUjd6e',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Gap 2a: `grid.rs`'s `IfcGridAxis` endpoint sampling. The axis curve's
+/// second point (#11) carries `1.E400` directly, so the endpoint is
+/// non-finite even under an identity ambient placement.
+const GRID_AXIS_WITH_INFINITE_ENDPOINT: &str = r#"
+#10=IFCCARTESIANPOINT((0.,0.));
+#11=IFCCARTESIANPOINT((1.E400,5.));
+#20=IFCPOLYLINE((#10,#11));
+#30=IFCGRIDAXIS('A1',#20,.T.);
+#40=IFCLOCALPLACEMENT($,#5);
+#50=IFCGRID('2xScRe4drECQ4DMSqUjd6e',$,'Grid',$,$,#40,$,(#30),(),());
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Gap 2b: `text.rs`'s `IfcTextLiteral` placement. Same ambient-placement
+/// shape as the circle fixture above (#7/#8/#40 carry `1.E400`), but through
+/// the text literal's own `Placement` composition instead of a bare item
+/// transform.
+const TEXT_LITERAL_WITH_INFINITE_AMBIENT_PLACEMENT: &str = r#"
+#7=IFCCARTESIANPOINT((1.E400,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#40=IFCLOCALPLACEMENT($,#8);
+#70=IFCCARTESIANPOINT((0.,0.,0.));
+#71=IFCAXIS2PLACEMENT3D(#70,$,$);
+#72=IFCTEXTLITERAL('Hello',#71,.LEFT.);
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Annotation2D',(#72));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+#62=IFCANNOTATION('3xScRe4drECQ4DMSqUjd6e',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn fixture(body: &str) -> String {
+    format!("{BOILERPLATE_HEADER}{body}")
+}
+
+/// RED (before the `push_circle` guard existed): the circle's non-finite
+/// world-space center survived into `SymbolicCircle`. GREEN: the circle is
+/// dropped entirely, matching `items.rs`'s existing whole-item convention
+/// for a degenerate `IfcCircle` (e.g. non-positive radius).
+#[test]
+fn circle_with_non_finite_ambient_placement_is_dropped() {
+    let data = extract_symbolic_data(&fixture(CIRCLE_WITH_INFINITE_AMBIENT_PLACEMENT));
+    assert!(
+        data.circles.is_empty(),
+        "a circle whose post-transform center is non-finite must be dropped by push_circle, \
+         got {:?}",
+        data.circles
+    );
+}
+
+/// RED (if grid.rs's post-transform finiteness check were reverted): the
+/// axis (and its bubble text/tag) would carry an Infinity endpoint. GREEN:
+/// the whole axis is dropped (an axis is two points defining a segment, not
+/// a droppable-point list).
+#[test]
+fn grid_axis_with_non_finite_endpoint_is_dropped() {
+    let data = extract_symbolic_data(&fixture(GRID_AXIS_WITH_INFINITE_ENDPOINT));
+    assert!(
+        data.grid_axes.is_empty(),
+        "a grid axis with a non-finite endpoint must be dropped, got {:?}",
+        data.grid_axes
+    );
+    assert!(
+        data.polylines.is_empty(),
+        "the axis's rendered polyline must not be emitted either, got {:?}",
+        data.polylines
+    );
+    assert!(
+        data.texts.is_empty(),
+        "the axis's bubble/tag text must not be emitted either, got {:?}",
+        data.texts
+    );
+}
+
+/// RED (if text.rs's finiteness check on the composed placement were
+/// reverted): the text literal would carry an Infinity (x, y). GREEN: the
+/// whole text item is dropped.
+#[test]
+fn text_literal_with_non_finite_placement_is_dropped() {
+    let data = extract_symbolic_data(&fixture(TEXT_LITERAL_WITH_INFINITE_AMBIENT_PLACEMENT));
+    assert!(
+        data.texts.is_empty(),
+        "a text literal whose composed placement is non-finite must be dropped, got {:?}",
+        data.texts
+    );
+}

--- a/rust/processing/tests/issue_trimmed_curve_finiteness.rs
+++ b/rust/processing/tests/issue_trimmed_curve_finiteness.rs
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Fifth leaf in the symbolic finiteness sweep (see
+//! `issue_symbolic_finiteness_followup.rs` for the first four):
+//! `trimmed_curve.rs`'s `is_near_collinear` branch builds its two-point
+//! chord from `transform.transform_point(...)` / `rebase.plan(...)` and
+//! calls `out.push_polyline` with no finiteness check, while its own
+//! sibling arc-tessellation branch a few lines below routes every point
+//! through `push_finite_point`. An ambient placement with a malformed STEP
+//! REAL (`1.E400`) in its `Location` — read by `parse_axis2_placement_2d`
+//! with no finiteness check — turns a perfectly finite local chord into a
+//! non-finite world one.
+
+use ifc_lite_processing::extract_symbolic_data;
+
+const BOILERPLATE_HEADER: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('trimmed curve finiteness fixture'),'2;1');
+FILE_NAME('test.ifc','2026-09-09',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6f',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#90=IFCCARTESIANPOINT((0.,0.));
+#91=IFCAXIS2PLACEMENT2D(#90,$);
+#92=IFCCIRCLE(#91,10.);
+#93=IFCTRIMMEDCURVE(#92,(0.),(0.001),.T.,.PARAMETER.);
+#60=IFCSHAPEREPRESENTATION(#2,'Annotation','Curve2D',(#93));
+#61=IFCPRODUCTDEFINITIONSHAPE($,$,(#60));
+"#;
+
+/// The trimmed curve's OWN basis (#91) is a perfectly finite, un-rotated
+/// placement at the origin — `trimmed_curve.rs`'s existing
+/// `!basis.tx.is_finite() || !basis.ty.is_finite()` guard (line ~59) does
+/// NOT fire here. The angle span (0 to 0.001 rad on a radius-10 circle) is
+/// tiny, so `is_near_collinear` is true and the buggy two-point chord
+/// branch runs. Only the AMBIENT `IfcLocalPlacement` (#40, composed in as
+/// `transform`, not `basis`) is poisoned.
+const POISONED_AMBIENT_PLACEMENT: &str = r#"
+#7=IFCCARTESIANPOINT((1.E400,0.,0.));
+#8=IFCAXIS2PLACEMENT3D(#7,$,$);
+#40=IFCLOCALPLACEMENT($,#8);
+#62=IFCANNOTATION('1xScRe4drECQ4DMSqUjd6f',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// Control fixture: identical geometry, but the ambient placement is
+/// well-formed (identity, via #5). Establishes that the near-collinear
+/// chord is emitted normally when nothing is malformed, so the fix does
+/// not silently swallow legitimate near-collinear trimmed arcs.
+const WELL_FORMED_AMBIENT_PLACEMENT: &str = r#"
+#40=IFCLOCALPLACEMENT($,#5);
+#62=IFCANNOTATION('2xScRe4drECQ4DMSqUjd6f',$,'Note',$,$,#40,#61);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn fixture(body: &str) -> String {
+    format!("{BOILERPLATE_HEADER}{body}")
+}
+
+/// RED (before the fix): the near-collinear chord's non-finite world-space
+/// endpoints survived into `SymbolicPolyline`. GREEN: the trimmed curve is
+/// dropped entirely, matching the sibling arc-tessellation branch's
+/// existing convention (and `items.rs`'s convention for other degenerate
+/// symbolic primitives).
+#[test]
+fn near_collinear_trimmed_curve_with_non_finite_ambient_placement_is_dropped() {
+    let data = extract_symbolic_data(&fixture(POISONED_AMBIENT_PLACEMENT));
+    assert!(
+        data.polylines.is_empty(),
+        "a near-collinear trimmed curve whose post-transform chord is non-finite must be \
+         dropped, got {:?}",
+        data.polylines
+    );
+}
+
+/// Sanity/no-regression check: the same near-collinear trimmed curve under
+/// a well-formed ambient placement must still be emitted as a two-point
+/// polyline with finite coordinates.
+#[test]
+fn near_collinear_trimmed_curve_with_well_formed_placement_is_emitted() {
+    let data = extract_symbolic_data(&fixture(WELL_FORMED_AMBIENT_PLACEMENT));
+    assert_eq!(
+        data.polylines.len(),
+        1,
+        "a well-formed near-collinear trimmed curve must still be emitted, got {:?}",
+        data.polylines
+    );
+    let polyline = &data.polylines[0];
+    assert_eq!(polyline.points.len(), 4, "expected a two-point chord, got {:?}", polyline.points);
+    assert!(
+        polyline.points.iter().all(|v| v.is_finite()),
+        "all emitted points must be finite, got {:?}",
+        polyline.points
+    );
+}


### PR DESCRIPTION
## Summary

- `push_circle` (`rust/processing/src/symbolic/output_cap.rs`) now re-checks `center_x`/`center_y`/`radius` finiteness on the circle it's about to push, closing the gap where `items.rs`'s `IfcCircle` branch guarded only the pre-transform local center and then pushed the post-transform world point unchecked. A malformed ambient `IfcLocalPlacement.Location` (e.g. `1.E400`) can set `Transform2D.tx = Infinity` even though the circle's own local center is finite; guarding at `push_circle` closes it at the chokepoint every circle push feeds through, rather than at the call site (which is exactly how this gap opened despite the sibling polyline/ellipse paths already guarding post-transform).
- `trimmed_curve.rs`'s `is_near_collinear` branch (a fifth, separate gap, found in a further adversarial pass over this PR) built its two-point chord from `transform.transform_point(...)`/`rebase.plan(...)` and called `out.push_polyline` with no finiteness check, while its own sibling arc-tessellation branch a few lines below already routes every point through `push_finite_point`. Guarded directly at that call site, matching the sibling branch's convention. See `rust/processing/tests/issue_trimmed_curve_finiteness.rs`.
- Added `rust/processing/tests/issue_symbolic_finiteness_followup.rs` with three tests, each mutation-proved RED-then-GREEN:
  - `circle_with_non_finite_ambient_placement_is_dropped` — the new `push_circle` guard.
  - `grid_axis_with_non_finite_endpoint_is_dropped` — `grid.rs`'s guard from #4185, which previously had no test.
  - `text_literal_with_non_finite_placement_is_dropped` — `text.rs`'s guard from #4185, which previously had no test.

**Follow-up: accumulator-enforced rather than per-caller-conventional.** After the above landed, `SymbolicAccumulator`'s five `push_*` methods were audited together: `push_circle` was the only one of five that re-validated its own tx/ty-derived coordinates; `push_grid_axis`, `push_polyline`, `push_text` and `push_fill` trusted their caller to have guarded upstream (true today, but only by convention — every caller happens to). Because `SymbolicAccumulator::data` is private and reachable only through `push_*`, the fix moves the check to that single seam instead of adding it to each caller:

- `try_push` (the one place every `push_*` accepts or refuses an append) now takes a `valid: bool` and refuses silently before either the byte or count counters move, mirroring how `push_circle` already dropped an invalid circle without touching the refusal counter.
- A new shared helper, `all_finite(coords: &[f32]) -> bool`, backs all five `push_*` calls (`push_circle` now goes through it too). It lives in a new sibling module, `rust/processing/src/symbolic/output_cap_validate.rs`. The four new `try_push(...)` call sites also needed rustfmt's multi-line closure form, which `rustfmt --check` flagged as landing `output_cap.rs` at ~408 lines against the 400-line `module_size_ratchet` ceiling with the committed single-line form counted; fixed by also moving `SymbolicTruncationReason`/`SymbolicTruncation` out into a new `output_cap_types.rs` (they are self-contained wire types with no dependency on the accumulator logic). All three files are fmt-stable and under budget: `output_cap.rs`: 326 lines, `output_cap_validate.rs`: 42 lines, `output_cap_types.rs`: 97 lines.
- Only tx/ty-derived coordinate fields are checked: `points` (polyline, fill), `x`/`y` (text), `center_x`/`center_y`/`radius` (circle), `endpoints` (grid axis). Every NaN-sentinel field in `primitives.rs` marked `#[serde(with = "nan_as_null")]` (`world_y` on all five primitive types, plus `SymbolicFillArea::hatch_angle_secondary`) is left untouched — those mean "unresolved" on purpose, and rejecting them would break that convention.
- No behaviour change on real data: every current caller already pre-validates before calling `push_*`, and the full `symbolic` test suite (43 tests) is unchanged, green before and after.
- One test added per newly-guarded method in `output_cap_tests.rs`, calling `push_grid_axis`/`push_polyline`/`push_text`/`push_fill` directly with a non-finite coordinate and no caller in between, so each pins the accumulator's own guard rather than whichever caller happened to check first. Each was mutation-tested: reverting its guard to `true` turns it RED, restoring it turns it GREEN.
- Also corrects `nan_as_null`'s doc comment in `primitives.rs`, which claimed no producer in the crate emits an infinity. `operator.rs`'s unchecked `as_float().unwrap_or(0.0)` on a placement's Z can make `tz`, and so `world_y`, infinite; it still round-trips correctly today because `serde_json` already writes `±inf` as `null`, but the comment overclaimed.

Closes #4189

## Context

Follow-up to #4185, found while adversarially reviewing that PR after it merged. #4184/#4185 fixed `fill.rs`/`grid.rs`/`text.rs` guarding non-finite coordinates from malformed STEP REALs; this PR closes a fourth vector (`IfcCircle`'s post-transform push in `push_circle`) and a fifth (`trimmed_curve.rs`'s near-collinear chord), backfills test coverage for two of #4185's guards that shipped untested, and then generalizes the pattern so the guarantee no longer depends on every future caller remembering to check.

**Not a single chokepoint, but now enforced at one.** An earlier version of this description framed `push_circle`'s guard as closing "the" gap; a review correctly called that too strong, since each of the original five fixes was a per-call-site guard. `transform.rs`'s `parse_axis2_placement_2d` and `operator.rs`'s `parse_cartesian_transformation_operator` still read a placement's coordinates with no `is_finite()` check at all, so a malformed STEP REAL becomes an `Infinity` transform at the source, and that stays deliberate: routing a non-finite decoded coordinate to the existing `Transform2D::unresolved()` sentinel there would set `tx = ty = 0.0` (only `tz` carries the `NaN` flag), which would make several existing `tx`/`ty`-keyed consumer guards — `trimmed_curve.rs`'s own `!basis.tx.is_finite() || !basis.ty.is_finite()` among them — stop detecting the problem, silently rendering a malformed primitive at the origin instead of correctly dropping it. What changed with this follow-up is narrower: within `SymbolicAccumulator`, the five `push_*` methods are the only paths into the wire type's private fields, so the finiteness guard for tx/ty-derived fields now lives at that one seam rather than being re-derived at each of the five call sites (and any future sixth). Every consumer upstream of the accumulator (`items.rs`, `grid.rs`, `text.rs`, `fill.rs`, `trimmed_curve.rs`) still needs its own guard against the *unresolved* source transform for the reason above; this closes the narrower gap of a caller that forgets.

## Reachability

Same caveat as #4184/#4185: this needs a malformed or hand-edited IFC file carrying an out-of-range `REAL` in an object's placement. Well-formed models are unaffected today.

## Changesets

`.changeset/fix-symbolic-finiteness-followup.md` covers this PR's `rust/processing` changes (this follow-up's `push_circle`/`trimmed_curve.rs` guards, plus #4185's `fill.rs`/`grid.rs`/`text.rs` guards, which shipped without one): `rust/processing` builds into the published `@ifc-lite/wasm` package via `rust/wasm-bindings`'s path dependency, so a Rust-only diff there still needs a changeset. The later accumulator-enforcement change (`push_grid_axis`/`push_polyline`/`push_text`/`push_fill`, `output_cap_validate.rs`) is a no-op on real data and rides the same changeset rather than adding a second one.

## Test plan

- [x] `cargo test -p ifc-lite-processing --test issue_symbolic_finiteness_followup` green (RED-then-GREEN, mutation-proved)
- [x] `cargo test -p ifc-lite-processing --test issue_trimmed_curve_finiteness` green (RED-then-GREEN, mutation-proved)
- [x] `cargo test -p ifc-lite-processing --lib symbolic::output_cap_tests::` green, 17 tests (13 pre-existing + 4 new per-method finiteness tests) -- `output_cap_tests.rs` is a flat module, so this filter cannot match tests in the other three `symbolic` test files (the 43 cited above is the whole-module total, not this filter's) (RED-then-GREEN, mutation-proved for each)
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` green
- [x] `output_cap.rs` is 326 lines, `output_cap_validate.rs` is 42 lines, `output_cap_types.rs` is 97 lines — all under the ratchet's 400-line budget with real headroom, no allowlist edit
- [x] `rustfmt --edition 2021 --check` clean on `output_cap.rs` and `output_cap_validate.rs` (rustfmt 1.8.0-nightly, rustc 1.93.0-nightly). Correction: the version originally committed here was NOT fmt-stable -- rustfmt disagreed on the four new `try_push(...)` call sites (each 87-99 columns, formatter wanted a 3-line closure) and reflowed a fifth pre-existing struct literal, which would have pushed `output_cap.rs` to ~408 lines against the ratchet if applied. Fixed by applying rustfmt's formatting and moving `SymbolicTruncationReason`/`SymbolicTruncation` into a new `output_cap_types.rs` for real headroom, rather than by an allowlist row.

Note: `Issue queue` will fail until @louistrue labels #4189 `ready` — not something this PR can work around.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid circles with non-finite centers or radii are now discarded safely.
  - Geometry, fills, and text with non-finite transformed coordinates are consistently omitted from output.
  - Grid axes with invalid endpoints no longer appear in generated results.
  - Near-collinear trimmed-curve chords with non-finite world positions are discarded safely.
  - Invalid primitives no longer consume output capacity.

- **Tests**
  - Added coverage for invalid circles, fills, grid axes, polylines, text placements, and trimmed-curve chords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- #4189 labelled `ready` by the maintainer; re-firing the pull_request event so the Issue queue gate reads a payload carrying it. Labelling an ISSUE fires `issues`, which that workflow does not listen to. -->
