### PR TITLE
fix(viewer): restore the persisted section cut alongside 2D markup

### DIFF
--- a/.changeset/restore-section-cut-with-markup.md
+++ b/.changeset/restore-section-cut-with-markup.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+A reload now regenerates the section cut that a restored `SectionConfig` describes, instead of loading it into a value nothing consumed. Previously the restored 2D drawing markup (measurements, annotations) came back floating over whichever plane the section slice already held; `useDrawingGeneration` now converts the restored `SectionConfig` back into the store's `sectionPlane` and lets the existing plane-changed path regenerate the drawing, so markup returns with its own cut.

--- a/apps/viewer/src/hooks/useDrawing2DPersistence.ts
+++ b/apps/viewer/src/hooks/useDrawing2DPersistence.ts
@@ -119,6 +119,36 @@ let lastSectionConfig: SectionConfig | null = null;
 let lastSectionConfigModelId: string | null = null;
 
 /**
+ * Set (to `activeModelId`) the instant `applyHash` restores an entry that
+ * actually carries a `sectionConfig` (issue #4153 gap: restore reached
+ * `lastSectionConfig` but was never fed to drawing generation, so the saved
+ * markup came back with no section cut to sit on). Consumed exactly once by
+ * {@link consumeRestoredSectionConfig} — `useDrawingGeneration.ts` reads it
+ * to re-derive the store's `sectionPlane` (percentage-of-bounds, semantic
+ * axis) from this hook's world-space `SectionConfig`, then lets the existing
+ * plane-changed auto-generate path do the rest. Reset to `null` everywhere
+ * `lastSectionConfig` itself is reset, so a model with nothing saved (or
+ * whose restore has not concluded yet) can never be "consumed" as if it had.
+ */
+let pendingSectionConfigModelId: string | null = null;
+
+/**
+ * Hand the generation bridge (`useDrawingGeneration.ts`) the `SectionConfig`
+ * this hook just restored for `modelId`, if any — one-shot: a second call for
+ * the same restore returns `null`, so a plane the user has since changed is
+ * never silently re-applied. Returns `null` for a model whose restore has not
+ * (yet) surfaced a saved plane, or for any model other than the one the
+ * pending config belongs to — the same per-model keying `restoringModelId`
+ * uses, so a caller cannot cross-apply model A's cut to model B by racing
+ * this against a switch.
+ */
+export function consumeRestoredSectionConfig(modelId: string): SectionConfig | null {
+  if (pendingSectionConfigModelId !== modelId) return null;
+  pendingSectionConfigModelId = null;
+  return lastSectionConfigModelId === modelId ? lastSectionConfig : null;
+}
+
+/**
  * Set the instant the restore effect below starts working on a model, and
  * cleared once its `applyHash` step concludes for that SAME model (#4159
  * review: cross-model `sectionConfig` contamination). `setActiveModel`'s
@@ -261,6 +291,7 @@ export function useDrawing2DPersistence(): void {
     if (!activeModelId) {
       lastSectionConfig = null;
       lastSectionConfigModelId = null;
+      pendingSectionConfigModelId = null;
       restoringModelId = null;
       return;
     }
@@ -283,6 +314,7 @@ export function useDrawing2DPersistence(): void {
     // call. Mark it again, immediately before the call that fires it.
     lastSectionConfig = null;
     lastSectionConfigModelId = null;
+    pendingSectionConfigModelId = null;
     // #4159 review (cross-model sectionConfig contamination): mark this
     // model as "restore in flight" for the SAME reason the clear above is
     // marked via `suppressNextSaveFor` — until `applyHash` runs below,
@@ -298,6 +330,7 @@ export function useDrawing2DPersistence(): void {
       if (!stillCurrent()) return;
       lastSectionConfig = null;
       lastSectionConfigModelId = null;
+      pendingSectionConfigModelId = null;
       if (restoringModelId === activeModelId) restoringModelId = null;
       if (!hash) return;
 
@@ -307,6 +340,11 @@ export function useDrawing2DPersistence(): void {
 
       lastSectionConfig = entry.sectionConfig;
       lastSectionConfigModelId = activeModelId;
+      // #4153 gap: only mark a config "pending" when there IS one to apply —
+      // an entry with markup but no saved cut (`sectionConfig: null`, e.g.
+      // saved before this fix shipped) must leave the section plane alone
+      // rather than have `useDrawingGeneration.ts` try to consume `null`.
+      if (entry.sectionConfig) pendingSectionConfigModelId = activeModelId;
       useViewerStore.setState({
         measure2DResults: entry.measure2DResults,
         polygonArea2DResults: entry.polygonArea2DResults,

--- a/apps/viewer/src/hooks/useDrawingGeneration.restoredSectionConfig.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.restoredSectionConfig.test.tsx
@@ -1,0 +1,262 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Closes the user-visible gap left in the merged drawing-persistence feature
+ * (issue #4153): markup (measurements, annotations) is restored on reload,
+ * but the section cut that produced it is not — `useDrawing2DPersistence.ts`
+ * loaded `entry.sectionConfig` only into its own module-local
+ * `lastSectionConfig` variable, used solely to re-save it, and never fed it
+ * to drawing generation. After a reload the restored markup floated over
+ * whichever cut `sectionPlane` already held (the slice default, or a
+ * PREVIOUS session's unrelated last-used cardinal mode), not the one it was
+ * actually drawn against.
+ *
+ * This mounts BOTH real hooks together (`useDrawing2DPersistence` +
+ * `useDrawingGeneration`), exactly as `Section2DPanel.tsx` does, wired
+ * through a `sectionPlane` prop that is read live from the store — so the
+ * fix under test (`useDrawingGeneration.ts` consuming
+ * `consumeRestoredSectionConfig` and writing the converted plane back into
+ * the store) is exercised end-to-end, not just at the module-level API.
+ *
+ * The fixture uses two disjoint boxes so the resulting `Drawing2D`'s
+ * entity ids alone prove WHICH plane the generator actually cut on:
+ *   - box A (id 100): x [0,10], y [6,10], z [0,10] — spans the full x range,
+ *     but its y range excludes 5, so the slice's DEFAULT cut (axis 'down',
+ *     50% of y => y=5) never touches it.
+ *   - box B (id 200): x [0,3],  y [0,10], z [0,10] — its y range includes 5
+ *     (the default cut hits it), but its x range excludes 8.
+ * The persisted `sectionConfig` cuts on x=8 (80% of the [0,10] x-bounds).
+ * That plane intersects ONLY box A. If restore is wired correctly, the
+ * generated drawing contains entity 100 and not 200; if the gap this test
+ * targets is still open, generation runs on the untouched default plane and
+ * produces entity 200 instead (or, once #4153 was reopened as a regression,
+ * neither/both — any outcome other than exactly {100} is a failure).
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Drawing2D } from '@ifc-lite/drawing-2d';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store';
+import { useDrawing2DPersistence } from './useDrawing2DPersistence.js';
+import { useDrawingGeneration } from './useDrawingGeneration.js';
+import {
+  saveDrawing2DEntry,
+  clearAllDrawing2DEntries,
+} from '@/store/slices/drawing2DSlice.persistence.js';
+import { computeFullSourceHashFromBlob } from '@/utils/sourceContentHash.js';
+
+// ─── Fixture ─────────────────────────────────────────────────────────────
+
+function box(
+  expressId: number,
+  min: [number, number, number],
+  max: [number, number, number],
+): MeshData {
+  const [x0, y0, z0] = min;
+  const [x1, y1, z1] = max;
+  const positions = new Float32Array([
+    x0, y0, z0,  x1, y0, z0,  x1, y1, z0,  x0, y1, z0,
+    x0, y0, z1,  x1, y0, z1,  x1, y1, z1,  x0, y1, z1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2,  0, 2, 3,
+    4, 6, 5,  4, 7, 6,
+    0, 4, 5,  0, 5, 1,
+    3, 2, 6,  3, 6, 7,
+    0, 3, 7,  0, 7, 4,
+    1, 5, 6,  1, 6, 2,
+  ]);
+  return {
+    expressId,
+    ifcType: 'IfcWall',
+    modelIndex: 0,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+    geometryClass: 0,
+  };
+}
+
+const BOX_A_ID = 100; // hit only by the persisted x=8 cut
+const BOX_B_ID = 200; // hit only by the default down/50% (y=5) cut
+
+const geometryResult: GeometryResult = {
+  meshes: [
+    box(BOX_A_ID, [0, 6, 0], [10, 10, 10]),
+    box(BOX_B_ID, [0, 0, 0], [3, 10, 10]),
+  ],
+  totalTriangles: 24,
+  totalVertices: 16,
+  coordinateInfo: {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } },
+    shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } },
+    hasLargeCoordinates: false,
+  },
+} as GeometryResult;
+
+function fileWithBytes(seed: number, name: string): File {
+  const bytes = new Uint8Array(256).map((_, i) => (i + seed) % 256);
+  return new File([bytes], name, { type: 'application/octet-stream' });
+}
+
+function stubModel(id: string, sourceFile: File): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: sourceFile.size,
+    sourceFile,
+    idOffset: 0,
+    maxExpressId: 0,
+  } as FederatedModel;
+}
+
+// ─── Harness — mirrors Section2DPanel.tsx's wiring ─────────────────────────
+
+let runGenerate: (() => Promise<void>) | null = null;
+let lastDrawing: Drawing2D | null = null;
+
+function Harness(): null {
+  useDrawing2DPersistence();
+  const sectionPlane = useViewerStore((s) => s.sectionPlane);
+  const displayOptions = useViewerStore((s) => s.drawing2DDisplayOptions);
+  const { generateDrawing } = useDrawingGeneration({
+    activeTool: 'select',
+    geometryResult,
+    ifcDataStore: null,
+    sectionPlane,
+    displayOptions: {
+      showHiddenLines: displayOptions.showHiddenLines,
+      useSymbolicRepresentations: false,
+      show3DOverlay: displayOptions.show3DOverlay,
+      scale: displayOptions.scale,
+      showConstructionProjection: false,
+    },
+    combinedHiddenIds: new Set<number>(),
+    combinedIsolatedIds: null,
+    computedIsolatedIds: null,
+    models: new Map([['model-a', { id: 'model-a', visible: true }]]),
+    // Closed, same as the real production gap this issue describes: restore
+    // runs unconditionally regardless of panel visibility.
+    panelVisible: false,
+    typeVisibility: {
+      spaces: true,
+      spatialZones: true,
+      openings: true,
+      virtualElements: true,
+      site: true,
+      ifcAnnotations: true,
+    },
+    drawing: null,
+    setDrawing: (d) => { lastDrawing = d; },
+    setDrawingStatus: () => {},
+    setDrawingProgress: () => {},
+    setDrawingError: () => {},
+  });
+  runGenerate = generateDrawing;
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function mount(): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Harness />);
+  });
+}
+
+async function flushDeep(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 40; i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  });
+}
+
+function entityIds(drawing: Drawing2D | null): Set<number> {
+  const out = new Set<number>();
+  for (const line of drawing?.lines ?? []) out.add(line.entityId);
+  for (const poly of drawing?.cutPolygons ?? []) out.add(poly.entityId);
+  return out;
+}
+
+beforeEach(() => {
+  clearAllDrawing2DEntries();
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels();
+  lastDrawing = null;
+  runGenerate = null;
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) { container.remove(); container = null; }
+  clearAllDrawing2DEntries();
+});
+
+describe('restore feeding generation — MUTATION TARGET: issue #4153 gap', () => {
+  it('regenerates the section cut from the restored SectionConfig, not the slice default', async () => {
+    const file = fileWithBytes(7, 'restored-cut.ifc');
+    const hash = (await computeFullSourceHashFromBlob(file))!;
+    const model = stubModel('model-a', file);
+
+    const defaults = useViewerStore.getState().drawing2DDisplayOptions;
+    saveDrawing2DEntry(hash, {
+      measure2DResults: [],
+      polygonArea2DResults: [],
+      textAnnotations2D: [],
+      cloudAnnotations2D: [],
+      drawing2DDisplayOptions: defaults,
+      // World-space x cut at 8 (80% of the fixture's [0,10] x-bounds) — hits
+      // box A (id 100) only, never box B (id 200).
+      sectionConfig: {
+        plane: { axis: 'x', position: 8, flipped: false },
+        projectionDepth: 10,
+        includeHiddenLines: false,
+        creaseAngle: 30,
+        scale: 100,
+      },
+    });
+
+    useViewerStore.setState({ models: new Map([['model-a', model]]) });
+    await mount();
+
+    await act(async () => { useViewerStore.getState().setActiveModel('model-a'); });
+    await flushDeep();
+
+    assert.ok(runGenerate, 'harness never rendered — useDrawingGeneration was not called');
+    await act(async () => { await runGenerate!(); });
+
+    const ids = entityIds(lastDrawing);
+    assert.ok(
+      ids.has(BOX_A_ID),
+      `restored cut (x=8) must intersect box A (id ${BOX_A_ID}) — got entity ids ${JSON.stringify([...ids])}. ` +
+      'Generation ran on the un-restored default plane instead of the persisted sectionConfig.',
+    );
+    assert.ok(
+      !ids.has(BOX_B_ID),
+      `restored cut (x=8) must NOT intersect box B (id ${BOX_B_ID}), which only the slice-default ` +
+      `down/50% cut (y=5) would hit — got entity ids ${JSON.stringify([...ids])}.`,
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -43,7 +43,7 @@ import {
 import type { SpatialHierarchy } from '@ifc-lite/data';
 import * as IfcWasm from '@ifc-lite/wasm';
 import { customPlaneCenter, useViewerStore } from '@/store';
-import { notifyDrawing2DSectionConfig } from './useDrawing2DPersistence.js';
+import { notifyDrawing2DSectionConfig, consumeRestoredSectionConfig } from './useDrawing2DPersistence.js';
 import { buildModelViewIdFilter, selectModelMeshes } from '@/lib/type-view-visibility';
 import { isTypeVisible, type TypeVisibilityGate } from '@/store/typeVisibilityFilter';
 
@@ -59,6 +59,15 @@ export const AXIS_MAP: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
   down: 'y',
   front: 'z',
   side: 'x',
+};
+
+/** Inverse of {@link AXIS_MAP} — restoring a persisted `SectionConfig`
+ * (world-space `x`/`y`/`z`) back into the store's semantic `sectionPlane`
+ * (issue #4153 gap) needs the reverse lookup. */
+const AXIS_MAP_REVERSE: Record<'x' | 'y' | 'z', 'down' | 'front' | 'side'> = {
+  y: 'down',
+  z: 'front',
+  x: 'side',
 };
 
 // Depth of the slab IN FRONT of the section plane (in shifted-world
@@ -894,6 +903,79 @@ export function useDrawingGeneration({
     finally { setIsRegenerating(false); }
   }), [computeDrawing, queue]);
   const doRegenerate = useCallback(() => generateDrawing(true), [generateDrawing]);
+
+  // Restore the persisted section cut on reload (issue #4153 gap):
+  // `useDrawing2DPersistence.ts`'s restore path loaded a saved model's
+  // `SectionConfig` only into its own module-local variable, used solely to
+  // re-save it — never fed back into the store's `sectionPlane`, so the
+  // section that produced the restored markup was never regenerated; the
+  // measurements/annotations came back floating over whatever cut
+  // `sectionPlane` already held (the default, or the last cardinal mode from
+  // a PREVIOUS, unrelated session — see `sectionSlice.ts`'s
+  // `loadLastSectionMode`). `consumeRestoredSectionConfig` hands this effect
+  // that saved `SectionConfig` exactly once per restore; converting it back
+  // into `sectionPlane`'s semantic axis + 0-100 percent (the inverse of the
+  // `axis`/`position` math in `computeDrawing` above) and writing it to the
+  // store lets the existing plane-changed auto-generate effect below do the
+  // actual regeneration — no new generation path, no bypass of the
+  // `restoringModelId` guard (`consumeRestoredSectionConfig` only returns a
+  // hit for the model whose restore already concluded, matching that guard's
+  // own per-model keying).
+  //
+  // Depends on BOTH `geometryResult` (bounds must be ready to convert a
+  // world-space position to a percentage) and `displayOptions` (a proxy for
+  // "the restore just concluded" — `applyHash` always assigns a fresh
+  // `drawing2DDisplayOptions` object when it restores an entry, restored
+  // `sectionConfig` or not) so this fires regardless of which of the two
+  // becomes ready last: a cache-loaded model has bounds before the async
+  // content hash resolves; a fresh load can resolve the hash first and wait
+  // on WASM meshing for bounds. `consumeRestoredSectionConfig` is one-shot,
+  // so an extra, premature firing (bounds ready, restore not concluded yet)
+  // is a harmless no-op, not a second consumption.
+  useEffect(() => {
+    const bounds = geometryResult?.coordinateInfo?.shiftedBounds;
+    if (!bounds) return;
+    const modelId = useViewerStore.getState().activeModelId;
+    if (!modelId) return;
+    const restored = consumeRestoredSectionConfig(modelId);
+    if (!restored) return;
+
+    const axis = restored.plane.axis;
+    const axisMin = bounds.min[axis];
+    const axisMax = bounds.max[axis];
+    const span = axisMax - axisMin;
+    // A degenerate (zero-extent) bounding box has no meaningful percentage —
+    // fall back to the slider's own default centre rather than divide by ~0.
+    const position = span > 1e-9
+      ? Math.min(100, Math.max(0, ((restored.plane.position - axisMin) / span) * 100))
+      : 50;
+
+    const customPlane = restored.plane.customPlane;
+    useViewerStore.setState((state) => ({
+      sectionPlane: {
+        ...state.sectionPlane,
+        axis: AXIS_MAP_REVERSE[axis],
+        position,
+        flipped: restored.plane.flipped,
+        enabled: true,
+        custom: customPlane
+          ? {
+              normal: [customPlane.normal.x, customPlane.normal.y, customPlane.normal.z],
+              distance: customPlane.distance,
+              // `origin` is already the projected pick point ON the plane
+              // (`dot(origin, normal) === distance`), so using it as
+              // `pickedAt` satisfies `customPlaneCenter`'s round-trip
+              // invariant exactly (see that function's own doc in
+              // `sectionSlice.ts`) — no original pick point survives the
+              // world-space `SectionConfig` this was restored from.
+              pickedAt: [customPlane.origin.x, customPlane.origin.y, customPlane.origin.z],
+              tangent: [customPlane.tangent.x, customPlane.tangent.y, customPlane.tangent.z],
+              bitangent: [customPlane.bitangent.x, customPlane.bitangent.y, customPlane.bitangent.z],
+            }
+          : undefined,
+      },
+    }));
+  }, [geometryResult, displayOptions]);
 
   // Match useRenderUpdates: a saved overlay preference needs the section tool.
   // Compare actual inputs, not callback identities or the drawing we publish.


### PR DESCRIPTION
Refs #4153

## The gap

On `upstream/main` (`dd7612a09`), the merged drawing-persistence feature restored a model's saved measurements and annotations on reload, but not the section cut that produced them: `useDrawing2DPersistence.ts`'s restore path (`applyHash`) loaded `entry.sectionConfig` only into a module-local `lastSectionConfig` variable, used solely to fold it back into the *next* save — it was never fed to drawing generation. `notifyDrawing2DSectionConfig`'s only production caller is `useDrawingGeneration.ts`, one-directional (generation → persistence), never persistence → generation.

User-visible consequence: after a reload, the restored markup reappeared floating over whichever section cut the store already held (the slice default, or a previous session's unrelated last-used cardinal mode), not the one it was actually drawn against — the user had to manually recreate the section view.

## The fix

- `useDrawing2DPersistence.ts` gains a one-shot bridge, `consumeRestoredSectionConfig(modelId)`, set when `applyHash` restores an entry that actually carries a `sectionConfig`, keyed and guarded per model exactly like the existing `restoringModelId` cross-model guard (#4159).
- `useDrawingGeneration.ts` consumes it once bounds are available, converts the restored world-space `SectionConfig` (axis `x`/`y`/`z`, position in world units) back into the store's semantic `sectionPlane` (axis `down`/`front`/`side`, 0-100% of bounds — the inverse of the existing forward conversion), and writes it to the store. The existing plane-changed auto-generate effect then does the actual regeneration — no new generation path, no bypass of the `restoringModelId` guard.

Verified safe for the three cases called out in the issue:
- **No persisted entry**: `consumeRestoredSectionConfig` returns `null` (nothing pending) — `sectionPlane` is left untouched.
- **A different model's restore**: the pending config is keyed by exact model id; a caller can't cross-apply model A's cut to model B.
- **2D panel closed**: `useDrawingGeneration`'s hooks (including the new sync effect) run unconditionally in `Section2DPanel.tsx`, before its `panelVisible` early return, so the plane still gets synced; `drawingActive` stays `false` while the panel is closed, so no drawing is actually generated until the user opens it — at which point it now uses the correct restored plane immediately.

## Testing

New integration test `useDrawingGeneration.restoredSectionConfig.test.tsx` mounts both real hooks together (mirroring `Section2DPanel.tsx`'s wiring) with two disjoint fixture boxes positioned so only the restored plane's cut, not the slice default's, intersects the expected entity — proving generation actually used the persisted config rather than merely converting a config on paper.

Mutation-tested: reverted the wiring, confirmed the new test fails with the expected wrong-entity-id output, reapplied, confirmed green.

No regressions in the existing persistence suite: `useDrawing2DPersistence.test.tsx` (6/6), `drawing2DSlice.persistence.test.ts` (16/16), `drawing2DSlice.markupTransition.test.ts` (6/6), `sourceFingerprint.test.ts` (14/14), `sourceContentHash.test.ts` (6/6).

`node scripts/check-module-size.mjs`: OK, 0 new files over budget. `useDrawingGeneration.ts` at 1026/1036 lines (10 lines headroom). `useDrawing2DPersistence.ts` at 383 lines (under the 400-line allowlist threshold). `Section2DPanel.tsx` untouched (1362/1367).

## What remains

This closes the generation side of the gap only. Per the issue, #4167 (read side) and #4170 (UI action) still own the rest of #4153's scope — not touched here.