### PR TITLE
fix(viewer): reject degenerate polygon-area and cloud 2D markup

### DIFF
--- a/.changeset/degenerate-2d-markup-guards.md
+++ b/.changeset/degenerate-2d-markup-guards.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+2D drawing markup's polygon-area and revision-cloud tools no longer accept a degenerate zero-size shape, matching the guard the measure tool already had. A polygon is rejected when its (shoelace) area is under `MIN_MEASUREMENT_DISTANCE ** 2` (1e-6 m²) — this also catches three collinear points, which widen to a zero-area polygon despite being distinct clicks. A cloud is rejected only when its bounding box is smaller than `MIN_MEASUREMENT_DISTANCE` on both axes — a cloud that is thin on only one axis (e.g. 5m x 0m) is still accepted, since it genuinely renders. `MIN_MEASUREMENT_DISTANCE` is 1mm.

--- a/apps/viewer/src/store/slices/drawing2DDegenerateGuards.ts
+++ b/apps/viewer/src/store/slices/drawing2DDegenerateGuards.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Degenerate-annotation guards for the 2D measure, polygon-area, and cloud
+ * tools (issue #4197).
+ *
+ * completeMeasure2D already rejected a click-without-drag measurement via a
+ * minimum-distance check; completePolygonArea2D and completeCloudAnnotation2D
+ * only checked point *count*, not size, so three coincident/collinear clicks
+ * could store a zero-area polygon (a permanent "0.0 cm2" label), and a
+ * zero-size cloud could be stored but render as nothing -- cloudPathGenerator.ts
+ * already skips edges below MIN_MEASUREMENT_DISTANCE -- while still being
+ * selectable and (since #4159) persisted to localStorage.
+ *
+ * The three guards share one length threshold (1mm, the smallest drag a
+ * user's click can plausibly register as intentional) so they agree on what
+ * "degenerate" means:
+ *  - a measurement is degenerate below that LENGTH;
+ *  - a polygon is degenerate below the AREA of a square with that side
+ *    (1e-6 m^2) -- this also catches three collinear points, which shoelace
+ *    to exactly zero area despite being three distinct clicks;
+ *  - a cloud is degenerate when its bounding box's larger DIMENSION is
+ *    below that same length, matching the threshold cloudPathGenerator.ts
+ *    uses to decide whether an edge is visible at all.
+ */
+
+interface Point2D {
+  x: number;
+  y: number;
+}
+
+/** Minimum meaningful length in drawing units (meters): 1mm. */
+export const MIN_MEASUREMENT_DISTANCE = 0.001;
+
+/** Minimum meaningful polygon area in drawing units squared (m^2): a 1mm x 1mm square. */
+const MIN_POLYGON_AREA = MIN_MEASUREMENT_DISTANCE ** 2;
+
+/** A measurement shorter than a user's smallest plausible drag. */
+export const isDegenerateMeasurement = (distance: number): boolean =>
+  distance < MIN_MEASUREMENT_DISTANCE;
+
+/** A polygon whose (possibly negative, pre-abs) shoelace area is ~0 -- coincident or collinear points. */
+export const isDegenerateArea = (area: number): boolean =>
+  Math.abs(area) < MIN_POLYGON_AREA;
+
+/** A cloud whose bounding box is smaller, in both dimensions, than a renderable edge. */
+export const isDegenerateCloud = (points: Point2D[]): boolean => {
+  const xs = points.map((p) => p.x);
+  const ys = points.map((p) => p.y);
+  const width = Math.max(...xs) - Math.min(...xs);
+  const height = Math.max(...ys) - Math.min(...ys);
+  return Math.max(width, height) < MIN_MEASUREMENT_DISTANCE;
+};

--- a/apps/viewer/src/store/slices/drawing2DSlice.test.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.test.ts
@@ -7,6 +7,7 @@ import assert from 'node:assert';
 import { createStore } from 'zustand/vanilla';
 import type { DxfUnderlay } from '@ifc-lite/drawing-2d';
 import { createDrawing2DSlice, type Drawing2DSlice } from './drawing2DSlice.js';
+import { generateCloudArcs } from '../../components/viewer/tools/cloudPathGenerator.js';
 
 const makeStore = () => createStore<Drawing2DSlice>(createDrawing2DSlice);
 
@@ -212,5 +213,30 @@ describe('drawing2DSlice: degenerate polygon/cloud rejection (issue #4197)', () 
     addCloudAnnotation2DPoint({ x: 0.05, y: 0.05 });
     completeCloudAnnotation2D('detail');
     assert.strictEqual(s.getState().cloudAnnotations2D.length, 1, 'a real small cloud must still be accepted');
+  });
+
+  // isDegenerateCloud rejects only when BOTH bounding-box dimensions are
+  // below threshold (Math.max of width/height). A 5m x 0m cloud has one
+  // zero dimension but one very real 5m dimension: cloudPathGenerator only
+  // skips the two zero-length edges, the two 5m edges still produce arcs,
+  // so this cloud is visible and must be accepted. Using Math.min instead
+  // of Math.max would falsely reject it -- nothing else in this file
+  // exercises the asymmetric (one-flat-dimension) case, so a future
+  // max-to-min edit would pass every other test here.
+  it('completeCloudAnnotation2D accepts a cloud with one zero dimension and one real dimension (5m x 0m), and it renders', () => {
+    const s = makeStore();
+    const { addCloudAnnotation2DPoint, completeCloudAnnotation2D } = s.getState();
+    addCloudAnnotation2DPoint({ x: 0, y: 0 });
+    addCloudAnnotation2DPoint({ x: 5, y: 0 });
+    completeCloudAnnotation2D('flat-edge');
+    assert.strictEqual(
+      s.getState().cloudAnnotations2D.length,
+      1,
+      'a 5m x 0m cloud has a real 5m dimension and must be accepted, not treated as degenerate'
+    );
+
+    const [p1, p2] = s.getState().cloudAnnotations2D[0]!.points;
+    const arcs = generateCloudArcs(p1!, p2!, 0.2);
+    assert.ok(arcs.length > 0, 'the two 5m edges must still produce renderable arcs even though the other two edges are zero-length');
   });
 });

--- a/apps/viewer/src/store/slices/drawing2DSlice.test.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.test.ts
@@ -126,3 +126,91 @@ describe('drawing2DSlice: independent 2D/3D DXF underlay visibility (issue #2043
     assert.strictEqual(entry?.visible3D, false, 'toggling 2D must not touch the already-off 3D flag');
   });
 });
+
+// Issue #4197: completeMeasure2D already rejects a degenerate (near-zero
+// length) measurement via MIN_MEASUREMENT_DISTANCE, but completePolygonArea2D
+// and completeCloudAnnotation2D only checked point *count*, not size. Three
+// coincident clicks passed the `points.length < 3` check and stored a
+// polygon with area 0 (rendered as a permanent "0.0 cm2" label); a
+// zero-size cloud passed `points.length < 2` and was stored but rendered as
+// nothing (cloudPathGenerator.ts skips edges under 0.001), leaving an
+// invisible-but-selectable, localStorage-persisted annotation.
+describe('drawing2DSlice: degenerate polygon/cloud rejection (issue #4197)', () => {
+  it('completePolygonArea2D discards a coincident-point polygon (area ~0) instead of storing it', () => {
+    const s = makeStore();
+    const { addPolygonArea2DPoint, completePolygonArea2D } = s.getState();
+    // Three clicks at (nearly) the same point -- a real user mis-click, not
+    // a synthetic zero.
+    addPolygonArea2DPoint({ x: 1, y: 1 });
+    addPolygonArea2DPoint({ x: 1, y: 1 });
+    addPolygonArea2DPoint({ x: 1, y: 1 });
+    completePolygonArea2D(0, 0);
+    assert.strictEqual(
+      s.getState().polygonArea2DResults.length,
+      0,
+      'a zero-area polygon must not be stored'
+    );
+    assert.deepStrictEqual(
+      s.getState().polygonArea2DPoints,
+      [],
+      'in-progress points must still be reset on rejection, mirroring completeMeasure2D'
+    );
+  });
+
+  it('completePolygonArea2D discards a collinear-point polygon (area ~0) the same way', () => {
+    const s = makeStore();
+    const { addPolygonArea2DPoint, completePolygonArea2D } = s.getState();
+    // Three collinear points: zero area despite being three *distinct* clicks.
+    addPolygonArea2DPoint({ x: 0, y: 0 });
+    addPolygonArea2DPoint({ x: 1, y: 0 });
+    addPolygonArea2DPoint({ x: 2, y: 0 });
+    completePolygonArea2D(0, 2);
+    assert.strictEqual(
+      s.getState().polygonArea2DResults.length,
+      0,
+      'a collinear (zero-area) polygon must not be stored'
+    );
+  });
+
+  it('completePolygonArea2D still accepts a legitimate small polygon a user could plausibly draw', () => {
+    const s = makeStore();
+    const { addPolygonArea2DPoint, completePolygonArea2D } = s.getState();
+    // A 0.1m x 0.1m square (10cm x 10cm) -- small but real, e.g. a stud or
+    // a detail callout. Area = 0.01 m^2, perimeter = 0.4 m.
+    addPolygonArea2DPoint({ x: 0, y: 0 });
+    addPolygonArea2DPoint({ x: 0.1, y: 0 });
+    addPolygonArea2DPoint({ x: 0.1, y: 0.1 });
+    addPolygonArea2DPoint({ x: 0, y: 0.1 });
+    completePolygonArea2D(0.01, 0.4);
+    assert.strictEqual(s.getState().polygonArea2DResults.length, 1, 'a real small polygon must still be accepted');
+    assert.strictEqual(s.getState().polygonArea2DResults[0]?.area, 0.01);
+  });
+
+  it('completeCloudAnnotation2D discards a zero-size cloud (both points identical) instead of storing it', () => {
+    const s = makeStore();
+    const { addCloudAnnotation2DPoint, completeCloudAnnotation2D } = s.getState();
+    addCloudAnnotation2DPoint({ x: 2, y: 2 });
+    addCloudAnnotation2DPoint({ x: 2, y: 2 });
+    completeCloudAnnotation2D('note');
+    assert.strictEqual(
+      s.getState().cloudAnnotations2D.length,
+      0,
+      'a zero-size (invisible) cloud must not be stored'
+    );
+    assert.deepStrictEqual(
+      s.getState().cloudAnnotation2DPoints,
+      [],
+      'in-progress points must still be reset on rejection, mirroring completeMeasure2D'
+    );
+  });
+
+  it('completeCloudAnnotation2D still accepts a legitimate small cloud a user could plausibly draw', () => {
+    const s = makeStore();
+    const { addCloudAnnotation2DPoint, completeCloudAnnotation2D } = s.getState();
+    // A 0.05m x 0.05m (5cm) cloud around a small detail -- small but real.
+    addCloudAnnotation2DPoint({ x: 0, y: 0 });
+    addCloudAnnotation2DPoint({ x: 0.05, y: 0.05 });
+    completeCloudAnnotation2D('detail');
+    assert.strictEqual(s.getState().cloudAnnotations2D.length, 1, 'a real small cloud must still be accepted');
+  });
+});

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -3,16 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * 2D Drawing generation state slice
- *
- * Manages state for generating and viewing 2D architectural drawings
- * (floor plans, sections, elevations) from the 3D model.
+ * 2D Drawing generation state slice: manages state for generating and
+ * viewing 2D architectural drawings (floor plans, sections, elevations) from the 3D model.
  */
 
 import type { StateCreator } from 'zustand';
 import type { Drawing2D, DxfPlacement, DxfUnderlay, GraphicOverrideRule, GraphicOverridePreset } from '@ifc-lite/drawing-2d';
 import { BUILT_IN_PRESETS, DEFAULT_DXF_PLACEMENT } from '@ifc-lite/drawing-2d';
 import { DEFAULT_SCAN_SECTION_THICKNESS } from '@/hooks/scanSectionMath';
+import { isDegenerateMeasurement, isDegenerateArea, isDegenerateCloud } from './drawing2DDegenerateGuards';
 
 export type Drawing2DStatus = 'idle' | 'generating' | 'ready' | 'error';
 
@@ -559,8 +558,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
       const distance = Math.sqrt(dx * dx + dy * dy);
 
       // Ignore zero-length measurements (click without drag)
-      const MIN_MEASUREMENT_DISTANCE = 0.001; // 1mm minimum
-      if (distance < MIN_MEASUREMENT_DISTANCE) {
+      if (isDegenerateMeasurement(distance)) {
         // Reset state without saving the measurement
         set({
           measure2DStart: null,
@@ -635,6 +633,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
     const state = get();
     if (state.polygonArea2DPoints.length < 3) return;
 
+    if (isDegenerateArea(area)) { set({ polygonArea2DPoints: [], annotation2DCursorPos: null }); return; } // near-zero-area guard (#4197)
     const result: PolygonArea2DResult = {
       id: `poly-area-${Date.now()}`,
       points: [...state.polygonArea2DPoints],
@@ -692,6 +691,7 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
     const state = get();
     if (state.cloudAnnotation2DPoints.length < 2) return;
 
+    if (isDegenerateCloud(state.cloudAnnotation2DPoints)) { set({ cloudAnnotation2DPoints: [], annotation2DCursorPos: null }); return; } // near-zero-size guard (#4197)
     const result: CloudAnnotation2D = {
       id: `cloud-${Date.now()}`,
       points: [...state.cloudAnnotation2DPoints],


### PR DESCRIPTION
## Summary

The 2D measure tool already rejected a click-without-drag measurement via a minimum-distance check, but the polygon-area and revision-cloud tools only checked point *count*, not size. Three coincident or collinear clicks could store a zero-area polygon (a permanent "0.0 cm2" label), and a zero-size cloud could be stored while rendering as nothing, yet still be selectable and persisted to localStorage.

`apps/viewer/src/store/slices/drawing2DDegenerateGuards.ts` adds three guards sharing one length threshold, `MIN_MEASUREMENT_DISTANCE` (1mm, in metres):

- `isDegenerateMeasurement` — a measurement shorter than that length.
- `isDegenerateArea` — a polygon whose (shoelace) area is under `MIN_MEASUREMENT_DISTANCE ** 2` (1e-6 m²). This also catches three collinear points, which widen to a zero-area polygon despite being three distinct clicks.
- `isDegenerateCloud` — a cloud whose bounding box is smaller than `MIN_MEASUREMENT_DISTANCE` on both axes. A cloud that is thin on only one axis (e.g. 5m x 0m) is still accepted, since it genuinely renders — this asymmetric case is pinned by its own test.

`drawing2DSlice.ts`'s `completePolygonArea2D` and `completeCloudAnnotation2D` now call these guards before storing an annotation, discarding the degenerate cases instead of persisting them.

Closes #4197

## Test plan

- [x] `drawing2DSlice.test.ts`: 14/14 passing (includes the new `degenerate polygon/cloud rejection` suite plus the pre-existing suites in the file)
- [x] `node scripts/check-module-size.mjs` exits 0