### PR TITLE
fix(codegen): expose the schema-hierarchy helpers as their own subpath

### DIFF
--- a/.changeset/codegen-schema-hierarchy-subpath.md
+++ b/.changeset/codegen-schema-hierarchy-subpath.md
@@ -1,0 +1,23 @@
+---
+"@ifc-lite/codegen": minor
+"@ifc-lite/export": patch
+"@ifc-lite/ids": patch
+---
+
+Expose the runtime hierarchy helpers as their own subpath,
+`@ifc-lite/codegen/schema-hierarchy`, and import them from there in the two
+runtime call sites (`lod0-generator`, the IDS classification bridge).
+
+The package root exports two things with different audiences: the generator,
+which imports `node:fs` and `node:path` because it reads `.exp` files and
+writes source, and the `isSubtypeOf` family, which is pure and is meant to be
+called at runtime against a generated `SCHEMA_REGISTRY`. Importing the second
+therefore dragged the first along. In a bundler that tree-shakes, the generator
+falls away and nothing is wrong. In a dev server that does not, it is fetched
+and evaluated, the `node:fs` stub throws at import, and the viewer never
+mounts — it cycles through boot-self-heal reloads on a blank page.
+
+`schema-hierarchy.ts` has no imports at all, so the subpath is browser-safe by
+construction rather than by convention, and the existing build already emits
+`dist/schema-hierarchy.js` and its declarations. The root entry keeps every
+export it had, so nothing that imports it today has to change.

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./schema-hierarchy": {
+      "types": "./dist/schema-hierarchy.d.ts",
+      "import": "./dist/schema-hierarchy.js",
+      "default": "./dist/schema-hierarchy.js"
+    },
     "./ifc4": {
       "types": "./dist/generated/ifc4/index.d.ts",
       "import": "./dist/generated/ifc4/index.js",

--- a/packages/export/src/lod0-generator.ts
+++ b/packages/export/src/lod0-generator.ts
@@ -8,7 +8,7 @@ import {
   getAttributeNamesAcrossSchemas,
   scanIfcEntities,
 } from '@ifc-lite/parser';
-import { isProperSubtypeOfAny, type HierarchyRegistry } from '@ifc-lite/codegen';
+import { isProperSubtypeOfAny, type HierarchyRegistry } from '@ifc-lite/codegen/schema-hierarchy';
 import * as IFC4_SCHEMA from '@ifc-lite/codegen/ifc4';
 import * as IFC4X3_SCHEMA from '@ifc-lite/codegen/ifc4x3';
 

--- a/packages/export/vitest.config.ts
+++ b/packages/export/vitest.config.ts
@@ -8,6 +8,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     alias: {
+      // Before the bare `@ifc-lite/codegen` below, as the two schema subpaths
+      // already are: these keys are matched as PREFIXES in declaration order,
+      // so the root entry would otherwise rewrite
+      // `@ifc-lite/codegen/schema-hierarchy` into the nonexistent
+      // `codegen/src/index.ts/schema-hierarchy`.
+      '@ifc-lite/codegen/schema-hierarchy': path.resolve(__dirname, '../codegen/src/schema-hierarchy.ts'),
       '@ifc-lite/codegen/ifc4': path.resolve(__dirname, '../codegen/generated/ifc4/index.ts'),
       '@ifc-lite/codegen/ifc4x3': path.resolve(__dirname, '../codegen/generated/ifc4x3/index.ts'),
       '@ifc-lite/codegen': path.resolve(__dirname, '../codegen/src/index.ts'),

--- a/packages/ids/src/bridge/classifications.ts
+++ b/packages/ids/src/bridge/classifications.ts
@@ -7,7 +7,7 @@ import {
   EntityExtractor,
   extractClassificationsOnDemand,
 } from '@ifc-lite/parser';
-import { isProperSubtypeOfAny, type HierarchyRegistry } from '@ifc-lite/codegen';
+import { isProperSubtypeOfAny, type HierarchyRegistry } from '@ifc-lite/codegen/schema-hierarchy';
 import * as IFC4_SCHEMA from '@ifc-lite/codegen/ifc4';
 import * as IFC4X3_SCHEMA from '@ifc-lite/codegen/ifc4x3';
 import type { ClassificationInfo } from '../types.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2868,6 +2868,14 @@
     "serializeValue: function",
     "toStepLine: function"
   ],
+  "@ifc-lite/codegen/schema-hierarchy": [
+    "HierarchyEntity: interface",
+    "HierarchyRegistry: interface",
+    "isProperSubtypeOf: function",
+    "isProperSubtypeOfAny: function",
+    "isSubtypeOf: function",
+    "isSubtypeOfAny: function"
+  ],
   "@ifc-lite/collab": [
     "AGENT_PALETTE: const",
     "AgentIdentity: interface",


### PR DESCRIPTION
Closes #4209.

## What this changes

`@ifc-lite/codegen` gains a `./schema-hierarchy` subpath export, and the two
runtime call sites import the helpers from there:

- `packages/export/src/lod0-generator.ts`
- `packages/ids/src/bridge/classifications.ts`

The root entry is untouched, so nothing that imports it today has to change.

## Why

The root entry exports two things with different audiences. `generator.ts`
imports `node:fs` and `node:path`, because it reads `.exp` files and writes
source. The `isSubtypeOf` family is pure, and #3999 made it the answer for
runtime type-membership questions. Both leave through `src/index.ts`, so
importing the second drags the first in.

`packages/export/src/index.ts:50` re-exports `generateLod0` eagerly, and the
viewer imports `@ifc-lite/export` statically in about twenty modules, for
example `apps/viewer/src/lib/lists/export/csv.ts:5` for `escapeCsvCell`. The
generator therefore reaches the browser module graph. A production build
tree-shakes it away, which is presumably why this has not surfaced there. A
dev server does not, so the module is evaluated, Vite's `node:fs` stub throws
at import, and the viewer never mounts. It cycles through
`[boot-self-heal] app failed to boot (mount-timeout)` instead.

`schema-hierarchy.ts` has no imports at all. That is what makes the subpath
browser-safe by construction rather than by convention, and it is the only
thing anything in this repository imports from the codegen root: a grep for
`from '@ifc-lite/codegen'` across `packages/` and `apps/` returns exactly the
two lines this PR changes, for exactly the two symbols it moves.

## Verification

The existing build already emits `dist/schema-hierarchy.js` and its
declarations, so no build change was needed. From `packages/export`, Node
resolves the new specifier to `dist/schema-hierarchy.js` and the module
carries `isProperSubtypeOfAny` and the rest as functions.

`scripts/api-surface.json` gains the one entry the updater generates for the
new subpath, and the changeset marks `@ifc-lite/codegen` minor with the two
consumers patch.

What I could not run: a full `pnpm install` in my checkout dies in
`applyPatchToDir` on Windows, so the complete build, typecheck and test suite
did not run locally. CI is the first full pass. Happy to adjust anything that
comes back red, or to take a different shape entirely if you would rather drop
the generator from the root entry instead of adding a subpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `schema-hierarchy` module export for accessing hierarchy types and utilities.
  * The export is browser-safe and includes type definitions.

* **Bug Fixes**
  * Preserved existing hierarchy behavior while enabling imports through the dedicated module path.

* **Documentation**
  * Updated the documented API surface to include hierarchy interfaces and subtype-checking utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->