### PR TITLE
fix(export): validate the split before writing a STEP attribute by index (#4125)

### DIFF
--- a/.changeset/fix-4125-by-index-writers-validating-split.md
+++ b/.changeset/fix-4125-by-index-writers-validating-split.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/export": patch
+---
+
+Refuse a STEP attribute edit rather than land it on the wrong attribute, in the three writers that set a slot by index (#4125).
+
+`step-attribute-mutations.ts` (named and positional edits) and `retype.ts` split a record's argument list with the PERMISSIVE `splitTopLevelArgs` and then wrote `args[index]`. A permissive split still produces parts when the scan went wrong, and those parts are not the record's slots. On a record with two undoubled apostrophes, which is what an authoring tool emits when it forgets to double one, quote parity stays even and paren depth returns to zero, so nothing structural notices: `#1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);` split into seven parts for a nine-attribute class. Editing `Description` then overwrote `ObjectPlacement`, deleting the `#5` reference that was there, and reported `attributed: true`; retyping it to `IfcWallStandardCase` emitted eleven top-level arguments for a nine-attribute class.
+
+All three now use `splitTopLevelStepArguments`, which carries a per-slot grammar check, and drop the edit when it refuses. The refusal is reported rather than left to look like a no-op: `SourceLineMutations` gains `unreadable`, and both passes that write a source line push a warning naming the entity.
+
+Measured on 122 real IFC files (19,461,436 records): zero records change verdict, so no file that previously mutated stops mutating. That sweep found no argument list carrying a `/* ... */` comment, which is why it did not catch the Rust splitter refusing one; that was caught in review and fixed afterwards, and the fix only widens what is accepted, so the conclusion is unaffected.
+
+The Rust exporter had the same shape (`step_text.rs`'s `apply_attr_mutations_counted`). Its splitter now validates too and lives in `step_slot.rs`, and each refusal is counted into `StepStats::attribute_edits_refused`, which callers of `export_step_with_stats` can read. The wasm JSON path does not surface that count today: `export_step` discards the stats, so nothing reaches `export_step_json`. Wiring it through is a separate change. The inputs both languages must refuse are pinned to one shared fixture, `rust/export/tests/fixtures/step_refuse_vectors.json`, following the `step_escape_vectors.json` precedent.

--- a/packages/cli/src/commands/step-args.ts
+++ b/packages/cli/src/commands/step-args.ts
@@ -87,13 +87,39 @@
  * deliberately its near-twin rather than an import: `@ifc-lite/export`'s
  * `exports` map exposes only `.`, so reaching it would mean adding a published
  * export (and an `api-surface` entry) to a v4.0.0 package to fix a CLI bug.
- * #4125 tracks consolidating them (`derive-variants.mts` and
- * `placement-datum.test.ts` are two the issue does not name), and that is a real merge rather
- * than a no-op swap: its `splitTopLevelStepArguments` has the three structural
- * checks and NO per-part check at all, which is exactly the top-level-only
- * version the two paragraphs above show is insufficient. Measured, it splits
- * `$,/* renamed *\/ $` into two parts and `'guid',$,'Name',/* c *\/,$` into five.
- * The three structural checks are the contract the two DO share.
+ * #4125 declined consolidating them, with its own measurement of why: the
+ * splitters in this repo have different CONTRACTS, so a shared function needs a
+ * mode flag or a richer return type, which is a new abstraction rather than a
+ * de-duplication. What they could share is the REFUSE side, and for TWO of the
+ * three it is pinned rather than described: the export twin and the Rust
+ * `split_top_level_args` are both held to the vectors in
+ * `rust/export/tests/fixtures/step_refuse_vectors.json`, by
+ * `packages/export/src/step-refuse.parity.test.ts` and by
+ * `rust/export/src/step_slot_tests.rs`'s
+ * `refuses_every_shared_cross_language_vector`.
+ *
+ * THIS splitter is NOT held to those vectors, and would not pass them today. `"`
+ * is absent from `isTokenBreak` below, so a binary literal is consumed as a bare
+ * run and two of the shared vectors are ACCEPTED here: `'g',"0F` splits as two
+ * parts with the unterminated literal intact, and `'g',"01,23"` splits into
+ * THREE parts for two attributes, because the comma inside the literal is read
+ * as a separator. The consumer is a live by-index writer — `mutate-step-record.ts`
+ * does `args[attrIdx] = …` and then `args.join(',')` — so that is the #4125
+ * failure still open in this file, not a hypothetical one. Adding the character
+ * is a behaviour change that would also refuse legitimate binary literals such
+ * as `"0F"`, which needs corpus verification rather than a one-character edit;
+ * LTplus-AG/ifc-lite#4200 tracks both the fix and the parity test that would
+ * have caught it.
+ *
+ * They diverge on the ACCEPT side, deliberately: this one refuses any slot
+ * carrying a `/* ... *\/` comment, while the export twin keeps the comment's
+ * bytes inside the slot and accepts it. That divergence is each caller's
+ * choice, so no fixture pins it.
+ *
+ * The export twin's `splitTopLevelStepArguments` used to have the three
+ * structural checks and no per-part check at all; #4173 gave it one
+ * (`isWellFormedStepSlot`), so the two now agree that a part must be one
+ * well-formed value.
  */
 
 /**
@@ -159,12 +185,12 @@ export function splitTopLevelStepArgs(input: string): string[] | null {
   if (inString || depth !== 0) return null;
   parts.push(current);
   // These three are the contract this shares with
-  // `packages/export/src/step-argument-parser.ts`, which has exactly them and no
-  // per-part check. That parity, not speed, is why they are kept: they add no
-  // coverage at all, and deleting any one of them, or all three, fails no test
-  // (measured). Only the `depth < 0` check above is an early exit; these two run
-  // after the whole scan and save only a walk over the parts. Kept as
-  // the shared spelling until #4125 merges the copies.
+  // `packages/export/src/step-argument-parser.ts`, which has them too (plus its
+  // own per-part check since #4173). That parity, not speed, is why they are
+  // kept: they add no coverage at all, and deleting any one of them, or all
+  // three, fails no test (measured). Only the `depth < 0` check above is an
+  // early exit; these two run after the whole scan and save only a walk over
+  // the parts.
   return parts.every(isLoneStepToken) ? parts : null;
 }
 

--- a/packages/export/src/by-index-writers-refuse.test.ts
+++ b/packages/export/src/by-index-writers-refuse.test.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #4125: the two source-line writers in this package that set a STEP attribute
+ * BY INDEX must refuse a record whose argument list does not scan into slots,
+ * and must SAY they refused.
+ *
+ * The record below is what an authoring tool emits when it forgets to double an
+ * apostrophe, twice. Two undoubled apostrophes leave quote parity even and
+ * paren depth at zero, so nothing structural notices: the permissive splitter
+ * returns seven parts for a nine-attribute class, with `IFCLABEL('a's'),$,
+ * IFCLABEL('b's')` folded into one. Every case here is paired with the SAME
+ * record with its apostrophes doubled, so a green result cannot come from the
+ * writers having stopped writing.
+ */
+import { describe, it, expect } from 'vitest';
+import { ENTITIES_IFC4 } from '@ifc-lite/data';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import { applySourceLineMutations } from './step-attribute-mutations.js';
+import { retypeStepLine } from './retype.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
+
+/** Nine attributes, two of them carrying an undoubled apostrophe. */
+const PHANTOM = "#1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);";
+/** The same record, apostrophes doubled: the control. */
+const CONTROL = "#1=IFCWALL('g',$,IFCLABEL('a''s'),$,IFCLABEL('b''s'),#5,#6,'T',.SOLIDWALL.);";
+
+/**
+ * The two overlay lookups `applySourceLineMutations` makes, and nothing else.
+ *
+ * A `Pick` of the real class rather than a hand-written shape, so both
+ * signatures stay checked against it; the widening back to
+ * `MutablePropertyView` is the only unchecked step, and it is sound here
+ * because the function under test guards each call with `typeof … ===
+ * 'function'` and reaches no other member.
+ */
+type OverlayStub = Pick<
+  MutablePropertyView,
+  'getEntityTypeMutation' | 'getPositionalMutationsForEntity'
+>;
+
+function viewWith(
+  typeMutation: ReturnType<MutablePropertyView['getEntityTypeMutation']>,
+  positionals: ReturnType<MutablePropertyView['getPositionalMutationsForEntity']>,
+): MutablePropertyView {
+  const stub: OverlayStub = {
+    getEntityTypeMutation: () => typeMutation,
+    getPositionalMutationsForEntity: () => positionals,
+  };
+  return stub as MutablePropertyView;
+}
+
+/**
+ * Run the pipeline over one record with only the edits a case actually asks
+ * for.
+ *
+ * `overlayActive` is DERIVED from the view rather than passed beside it. In the
+ * exporter the two are one fact -- there is a view exactly when the overlay is
+ * active -- so a case that set them apart by hand would be exercising a state
+ * the exporter cannot produce, and the seventh positional argument is the easy
+ * one to get wrong.
+ */
+function runPipeline(args: {
+  record: string;
+  attributes?: Map<string, string>;
+  typeMutation?: ReturnType<MutablePropertyView['getEntityTypeMutation']>;
+  positionals?: ReturnType<MutablePropertyView['getPositionalMutationsForEntity']>;
+}) {
+  const typeMutation = args.typeMutation ?? null;
+  const positionals = args.positionals ?? null;
+  const view =
+    typeMutation === null && positionals === null ? null : viewWith(typeMutation, positionals);
+  return applySourceLineMutations(
+    view,
+    1,
+    args.record,
+    'IFCWALL',
+    args.attributes,
+    'IFC4',
+    view !== null,
+  );
+}
+
+describe('applySourceLineMutations refuses a record whose slots do not scan', () => {
+  it('a named attribute edit does not land on a different attribute', () => {
+    // `Description` is slot 3. On the permissive split, slot 3 of the SEVEN
+    // parts is `#5` -- the record's real `ObjectPlacement` -- so the edit
+    // overwrote a placement reference with a string and reported success.
+    const result = runPipeline({
+      record: PHANTOM,
+      attributes: new Map([['Description', 'NEWDESC']]),
+    });
+    expect(result.text).toBe(PHANTOM);
+    expect(result.attributed).toBe(false);
+    expect(result.unreadable).toBe(true);
+    expect(result.text).not.toContain('NEWDESC');
+    expect(result.text).toContain('#5');
+  });
+
+  it('the control record with doubled apostrophes still takes the edit', () => {
+    const result = runPipeline({
+      record: CONTROL,
+      attributes: new Map([['Description', 'NEWDESC']]),
+    });
+    expect(result.attributed).toBe(true);
+    expect(result.unreadable).toBe(false);
+    expect(result.text).toBe(
+      "#1=IFCWALL('g',$,IFCLABEL('a''s'),'NEWDESC',IFCLABEL('b''s'),#5,#6,'T',.SOLIDWALL.);",
+    );
+  });
+
+  it('a positional edit does not land on a different slot', () => {
+    const result = runPipeline({ record: PHANTOM, positionals: new Map([[3, 'NEWDESC']]) });
+    expect(result.text).toBe(PHANTOM);
+    expect(result.positional).toBe(false);
+    expect(result.unreadable).toBe(true);
+  });
+
+  it('the control record still takes the positional edit', () => {
+    const result = runPipeline({ record: CONTROL, positionals: new Map([[3, 'NEWDESC']]) });
+    expect(result.positional).toBe(true);
+    expect(result.unreadable).toBe(false);
+  });
+
+  it('a record nobody edited is not reported as a refusal', () => {
+    // `unreadable` is a claim about an edit that was asked for and dropped. A
+    // malformed record this export merely copies has refused nothing, and
+    // warning about it would be noise in every file that has one.
+    const result = runPipeline({ record: PHANTOM });
+    expect(result.text).toBe(PHANTOM);
+    expect(result.unreadable).toBe(false);
+  });
+});
+
+describe('retypeStepLine refuses a record whose slots do not scan', () => {
+  it('does not emit more attributes than the target class declares', () => {
+    // Before the fix this returned
+    // `#1=IFCWALLSTANDARDCASE('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.,$,$);`
+    // -- ELEVEN top-level arguments for a nine-attribute class, because one of
+    // the seven parts it re-laid-out still carried two commas of its own.
+    const out = retypeStepLine(PHANTOM, 'IFCWALL', 'IFCWALLSTANDARDCASE', null, 'IFC4');
+    expect(out).toBe(PHANTOM);
+  });
+
+  it('the control record still retypes, to the target class\'s own attribute count', () => {
+    const out = retypeStepLine(CONTROL, 'IFCWALL', 'IFCWALLSTANDARDCASE', null, 'IFC4');
+    expect(out.startsWith('#1=IFCWALLSTANDARDCASE(')).toBe(true);
+    expect(out).not.toBe(CONTROL);
+    // The count is read off the schema rather than typed in, so this cannot
+    // outlive a registry change while still claiming to check it.
+    const slots = splitTopLevelStepArguments(out.slice(out.indexOf('(') + 1, out.lastIndexOf(');')));
+    expect(slots).not.toBeNull();
+    expect(slots).toHaveLength(
+      ENTITIES_IFC4.find((e) => e.name.toUpperCase() === 'IFCWALLSTANDARDCASE')!.attributes.length,
+    );
+  });
+
+  it('the pipeline reports the refused retype rather than a silent no-op', () => {
+    const result = runPipeline({
+      record: PHANTOM,
+      typeMutation: { newType: 'IFCWALLSTANDARDCASE', predefinedType: null },
+    });
+    expect(result.text).toBe(PHANTOM);
+    expect(result.retyped).toBe(false);
+    expect(result.unreadable).toBe(true);
+  });
+});

--- a/packages/export/src/retype.ts
+++ b/packages/export/src/retype.ts
@@ -28,7 +28,7 @@
 
 import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3 } from '@ifc-lite/data';
 import { escapeStepString } from './step-serialization.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 import type { IfcSchemaVersion } from './schema-converter.js';
 
 interface RetypeEntityInfo {
@@ -91,7 +91,7 @@ export interface RetypeArgsResult {
  * Re-lay-out an entity's STEP argument tokens for a new class.
  *
  * `argTokens` are already-serialized STEP fragments (as produced by
- * {@link splitTopLevelArgs}). Returns a fresh token array in the target
+ * {@link splitTopLevelStepArguments}). Returns a fresh token array in the target
  * class's attribute order. When source or target layout can't be resolved
  * from the schema (vendor extension, malformed), `resolved` is false and the
  * caller should fall back to a keyword-only swap.
@@ -183,7 +183,16 @@ export function retypeStepLine(
   }
 
   const idPrefix = entityText.slice(0, eq + 1); // "#123="
-  const argTokens = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
+  // Validating, not permissive: the re-layout below maps source slot i to the
+  // attribute NAME at position i, so a mis-scanned list renames every slot
+  // after the first swallowed comma. On the #4125 record — two undoubled
+  // apostrophes, which leave quote parity even and paren depth at zero — the
+  // permissive split returned seven parts for a nine-attribute class, and the
+  // rewrite emitted ELEVEN top-level arguments because one part still carried
+  // two commas of its own. A `null` here means the line is left exactly as the
+  // source wrote it, which the caller reads as `retyped: false`.
+  const argTokens = splitTopLevelStepArguments(entityText.slice(openParen + 1, closeParen));
+  if (argTokens === null) return entityText;
   const { tokens, resolved } = retypeArgTokens(argTokens, sourceType, newType, predefinedType, schema);
 
   if (!resolved) {

--- a/packages/export/src/step-attribute-mutations.ts
+++ b/packages/export/src/step-attribute-mutations.ts
@@ -16,7 +16,7 @@
  * serializers are `step-attribute-serializers.ts`.
  */
 
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 import { getRealTypedSlots } from './attribute-real-slots.js';
 import { retypeStepLine } from './retype.js';
 import { attrIndex, stepSourceSchema } from './subset-entity-reader.js';
@@ -24,6 +24,7 @@ import type { IfcAttributeValue } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { IfcSchemaVersion } from './schema-converter.js';
 import { serializeNamedAttribute, serializePositionalOverride } from './step-attribute-serializers.js';
+import { unreadableRecordEditsDroppedWarning } from './step-export-types.js';
 import type { SourceLineMutations } from './step-exporter.js';
 
 /**
@@ -54,8 +55,8 @@ import type { SourceLineMutations } from './step-exporter.js';
  * The expressId is unchanged by all of this, so geometry / placement /
  * representation and every IfcRel* reference (keyed by #id) carry over.
  *
- * All three flags report EFFECT, not intent — each is the answer to "did this
- * operation change the line", measured across that operation alone. The count
+ * The three delivery flags report EFFECT, not intent — each is the answer to
+ * "did this operation change the line", measured across that operation alone. The count
  * and the ledger are claims about the FILE, so an edit that resolves to the
  * text already there has delivered nothing and must not be reported: retyping
  * an entity to the class it already is, or writing a positional slot the token
@@ -69,6 +70,13 @@ import type { SourceLineMutations } from './step-exporter.js';
  * two are nominated (their edits have no earlier nomination site); named
  * attribute edits are nominated by the collection pass and `attributed` only
  * settles their delivery.
+ *
+ * `unreadable` is the fourth field and answers a different question: not what
+ * this line carries, but whether the pipeline could read it at all. Every edit
+ * kind above writes a slot BY INDEX, so all of them refuse together on a record
+ * whose argument list does not scan — and three false delivery flags cannot say
+ * that, because a discarded edit sets them too. Both call sites turn it into a
+ * warning naming the entity (#4125).
  */
 export function applySourceLineMutations(
   mutationView: MutablePropertyView | null,
@@ -129,7 +137,103 @@ export function applySourceLineMutations(
     positional = text !== beforePositionals;
   }
 
-  return { text, attributed, retyped, positional };
+  // All three edit kinds above address this line's arguments BY INDEX, so all
+  // three refuse together when the argument list does not scan into slots —
+  // and all three then look exactly like an edit that resolved to the text
+  // already there. That is the failure this whole family is about, so the
+  // refusal is stated rather than left to be inferred from three false flags
+  // (#4125). Only ever set when an edit was actually asked for: a malformed
+  // record nobody edited has refused nothing.
+  //
+  // The three delivery flags are tested FIRST because any one of them being
+  // true already answers the question, without splitting the record a second
+  // time. Each of `retypeStepLine`, `applyAttributeMutations` and
+  // `applyPositionalMutations` returns its input UNCHANGED when it refuses, so
+  // a flag that is true means that writer replaced a slot, which means it
+  // scanned the argument list — over the same substring, between the same
+  // `indexOf('(')` and `lastIndexOf(');')` bounds `argumentListScans` uses. So
+  // the added conjuncts only ever skip a call that would have returned true;
+  // they cannot turn a refusal into a readable record.
+  const requested = typeMutation !== null
+    || (attributeMutations?.size ?? 0) > 0
+    || (positionals?.size ?? 0) > 0;
+  const unreadable = requested
+    && !attributed
+    && !retyped
+    && !positional
+    && !argumentListScans(entityText);
+
+  return { text, attributed, retyped, positional, unreadable };
+}
+
+/**
+ * The pipeline as a writing pass is handed it: {@link applySourceLineMutations}
+ * with the export's `MutablePropertyView` already bound
+ * (`step-export-contexts.ts`). Derived from the function rather than restated,
+ * so the injected form cannot drift from the real one.
+ */
+type BoundSourceLineMutations = (
+  ...args: WithoutView<Parameters<typeof applySourceLineMutations>>
+) => SourceLineMutations;
+type WithoutView<T extends unknown[]> = T extends [MutablePropertyView | null, ...infer Rest]
+  ? Rest
+  : never;
+
+/**
+ * Run the pipeline for a writing pass and report BOTH ways it can decline to
+ * write, into that pass's warnings.
+ *
+ * Two passes emit a source entity's defining line — the source-iteration pass
+ * and the type-object `HasPropertySets` rewrite that REPLACES it — and each
+ * needs the same pair: the per-attribute rejection (a REAL-typed slot handed a
+ * non-number) and the whole-record refusal ({@link SourceLineMutations.unreadable}).
+ * They were two identical blocks at the two call sites, which is one block per
+ * pass too many: a third pass copying one of them gets a report that is right
+ * about one channel and silent about the other, and silence is what #4125 is
+ * about. So the call and both reports are one thing here.
+ */
+export function applySourceLineMutationsReported(
+  apply: BoundSourceLineMutations,
+  warnings: string[],
+  expressId: number,
+  entityText: string,
+  recordType: string,
+  attributeMutations: Map<string, string> | undefined,
+  sourceSchema: IfcSchemaVersion,
+  overlayActive: boolean,
+): SourceLineMutations {
+  const mutated = apply(
+    expressId,
+    entityText,
+    recordType,
+    attributeMutations,
+    sourceSchema,
+    overlayActive,
+    (attr, value) =>
+      warnings.push(
+        `entity #${expressId}: attribute ${attr} not written - ` +
+          `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
+      ),
+  );
+  if (mutated.unreadable) {
+    warnings.push(unreadableRecordEditsDroppedWarning(expressId, recordType));
+  }
+  return mutated;
+}
+
+/**
+ * Does this line's own argument list scan into slots?
+ *
+ * Scoped to the arguments deliberately. Text that is not a `#N=CLASS(...);`
+ * record at all is a different fact, and one every writer here already returns
+ * untouched without claiming anything; this answers only the question the
+ * by-index writers below actually ask.
+ */
+function argumentListScans(entityText: string): boolean {
+  const openParen = entityText.indexOf('(');
+  const closeParen = entityText.lastIndexOf(');');
+  if (openParen < 0 || closeParen < openParen) return true;
+  return splitTopLevelStepArguments(entityText.slice(openParen + 1, closeParen)) !== null;
 }
 
 /**
@@ -148,7 +252,14 @@ function applyAttributeMutations(
     return entityText;
   }
 
-  const args = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
+  // Validating, not permissive. Every write below is BY INDEX into these
+  // parts, so parts that are not the record's slots put the value on another
+  // attribute and delete whatever was there, while `changed` still says the
+  // edit landed (#2470, #4125). A `null` refuses the whole line's named edits
+  // rather than handing back a success that did not happen; the caller reports
+  // it (see {@link applySourceLineMutations}).
+  const args = splitTopLevelStepArguments(entityText.slice(openParen + 1, closeParen));
+  if (args === null) return entityText;
   // A source line NEVER pads (unlike the overlay-created path): a short
   // argument list here means the file speaks a different schema, and growing
   // a record we did not author would corrupt it.
@@ -213,7 +324,10 @@ function applyPositionalMutations(
   const closeParen = entityText.lastIndexOf(');');
   if (openParen < 0 || closeParen < openParen) return entityText;
 
-  const args = splitTopLevelArgs(entityText.slice(openParen + 1, closeParen));
+  // Validating for the same reason as the named path above: `args[index] = …`
+  // is only an edit to attribute `index` when the parts ARE the record's slots.
+  const args = splitTopLevelStepArguments(entityText.slice(openParen + 1, closeParen));
+  if (args === null) return entityText;
   const realSlots = getRealTypedSlots(entityType, schemaVersion);
   let changed = false;
   for (const [index, value] of positionals) {

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -228,13 +228,44 @@ export const styleEntityWithheldWarning = (expressId: number, type: string): str
   `Entity #${expressId} (${type}) was withheld from the export: it names at least one entity that has no line in this export, in a slot with no spelling for an omitted reference (a single-valued attribute, or a set whose every member is omitted).`;
 
 /**
+ * The edits queued for a source record were dropped because its own argument
+ * list could not be read as a list of slots.
+ *
+ * Said out loud, because the alternative was worse in both directions. Writing
+ * by index into parts a mis-scan produced lands the value on a different
+ * attribute and deletes what was there, while reporting success; refusing
+ * without saying so leaves an export that looks like it carried the edit. The
+ * usual cause is an undoubled apostrophe inside a string-typed attribute, which
+ * an authoring tool emits when it forgets to double one — two of those leave
+ * quote parity even and paren depth at zero, so nothing structural notices
+ * (#4125).
+ */
+export const unreadableRecordEditsDroppedWarning = (expressId: number, type: string): string =>
+  `Entity #${expressId} (${type}) was written exactly as the source file has it: its argument list could not be read as a list of attributes, so every edit queued for it (attribute, retype and positional alike) was dropped rather than applied to a slot that may not be the one meant. The usual cause is an apostrophe inside a string attribute that was not doubled.`;
+
+/**
  * What `step-attribute-mutations.ts`'s `applySourceLineMutations` produced: the rewritten
  * line, plus which edit kinds that rewrite actually delivered. The delivery
  * half is {@link SourceLineDelivery} rather than three loose booleans so that
  * the pipeline and the ledger cannot disagree about what a source line carries
  * — an added kind has one place to be added.
  */
-export type SourceLineMutations = SourceLineDelivery & { text: string };
+export type SourceLineMutations = SourceLineDelivery & {
+  text: string;
+  /**
+   * The line's argument list did not scan into slots, so NONE of the edits
+   * queued for it was applied and `text` is the source's own bytes.
+   *
+   * Separate from the three delivery flags because it answers a different
+   * question. Those say what this line carries; this says the pipeline refused
+   * to write it at all. Without it a refusal is indistinguishable from an edit
+   * that resolved to the text already there — three false flags either way —
+   * and writing by index into an argument list this scanner could not read is
+   * exactly how an edit lands on the wrong attribute while reporting success
+   * (#2470, #4125).
+   */
+  unreadable: boolean;
+};
 
 /**
  * The state one `export()` call shares across its seven phases.

--- a/packages/export/src/step-property-sets.ts
+++ b/packages/export/src/step-property-sets.ts
@@ -31,6 +31,7 @@ import {
   typeOwnedPsetRewriteWarning,
 } from './type-owned-psets.js';
 import { recordSourceLineDelivery } from './delta-modification-ledger.js';
+import { applySourceLineMutationsReported } from './step-attribute-mutations.js';
 import { nominateDeliveredInPlaceEdits } from './in-place-nomination.js';
 import { type PropertySetContext, getPropertySetName } from './step-property-set-readers.js';
 import { generatePropertySetEntities, generateQuantitySetEntities } from './step-property-set-generators.js';
@@ -128,18 +129,21 @@ export function generatePropertyAndQuantitySetEntities(
       );
       // The RECORD's class is the from-type: the bytes are still the source
       // class, whatever `typeOf` now says the entity effectively is.
-      mutated = ctx.applySourceLineMutations(
+      //
+      // The reporting travels with the call (`applySourceLineMutationsReported`)
+      // because this rewrite REPLACES the source-iteration pass's line for these
+      // ids (`rewrittenEntityIds`) — a refusal reported only there would be
+      // silent for exactly the entities this branch owns, and a pass that
+      // remembered one of the two warnings would be silent about the other.
+      mutated = applySourceLineMutationsReported(
+        ctx.applySourceLineMutations,
+        pass.warnings,
         entityId,
         sourceLine,
         record.type,
         pass.modifiedAttributes.get(entityId),
         pass.sourceSchema,
         pass.overlayActive,
-        (attr, value) =>
-          pass.warnings.push(
-            `entity #${entityId}: attribute ${attr} not written - ` +
-              `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
-          ),
       );
     }
     if (mutated === null) {

--- a/packages/export/src/step-refuse.parity.test.ts
+++ b/packages/export/src/step-refuse.parity.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * TypeScript half of the STEP argument-list REFUSE parity pin (#4125).
+ *
+ * The Rust splitter (`rust/export/src/step_slot.rs`, `split_top_level_args`,
+ * exercised by `rust/export/src/step_slot_tests.rs`) is held to the SAME
+ * fixture, so the two implementations cannot drift apart silently. Mirrors
+ * `step-escape.parity.test.ts`, which does the same for the STEP string
+ * escaper — and exists for the same reason that one does: #4173 hardened this
+ * splitter while the Rust one stayed permissive, and nothing said so, because
+ * each side described the other in prose.
+ *
+ * Only the REFUSE side is pinned. What each splitter ACCEPTS is its caller's
+ * choice and the two diverge on purpose; the fixture's own header says why.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
+
+interface Vector {
+  name: string;
+  why: string;
+  input: string;
+}
+
+interface Fixture {
+  cases: Vector[];
+}
+
+// The fixture lives in the Rust crate so `include_str!` can reach it; this
+// side resolves it relative to the source file. NOT guarded by `existsSync`:
+// a missing fixture means the pin is not being enforced, which must fail
+// loudly.
+const fixturePath = fileURLToPath(
+  new URL('../../../rust/export/tests/fixtures/step_refuse_vectors.json', import.meta.url),
+);
+const fixture: Fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+describe('splitTopLevelStepArguments refuses the shared cross-language vectors', () => {
+  it('the fixture actually carries cases (an empty sweep proves nothing)', () => {
+    expect(fixture.cases.length).toBeGreaterThanOrEqual(8);
+  });
+
+  for (const v of fixture.cases) {
+    it(`refuses: ${v.name}`, () => {
+      expect(splitTopLevelStepArguments(v.input)).toBeNull();
+    });
+  }
+});

--- a/packages/export/src/step-source-iteration.ts
+++ b/packages/export/src/step-source-iteration.ts
@@ -56,6 +56,7 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { filterHiddenRefsFromRelationshipLine } from './reference-collector.js';
 import { STYLE_RESCUE_TYPES } from './style-closure.js';
 import { styleEntityWithheldWarning } from './step-export-types.js';
+import { applySourceLineMutationsReported } from './step-attribute-mutations.js';
 import { convertStepLine, type IfcSchemaVersion } from './schema-converter.js';
 import { nominateDeliveredInPlaceEdits } from './in-place-nomination.js';
 import { decodeRange } from './source-ref-bounds.js';
@@ -226,18 +227,29 @@ export function writeSourceEntityLines(
       // Shared verbatim with the type-object `HasPropertySets` rewrite in
       // `step-property-sets.ts`, which writes the line this pass would
       // otherwise have written — hence injected rather than moved here.
-      const mutated = ctx.applySourceLineMutations(
+      // Through `applySourceLineMutationsReported` rather than the injected
+      // pipeline directly, so this pass and the type-object rewrite cannot end
+      // up reporting different halves of the same refusal.
+      //
+      // Into a per-entity buffer, NOT straight into `pass.warnings`: both
+      // reports the pipeline makes are about the line this iteration is about
+      // to write, and the `IFCREL*` and style-rescue branches below can still
+      // `continue` — withholding that line entirely and pushing their own
+      // warning for it. Reported here, the unreadable-record warning would say
+      // the entity "was written exactly as the source file has it" beside a
+      // warning saying it was not written at all: two warnings, one of them
+      // false, for one outcome. So the buffer is flushed once the withholding
+      // branches have had their say and this line is going out.
+      const mutationWarnings: string[] = [];
+      const mutated = applySourceLineMutationsReported(
+        ctx.applySourceLineMutations,
+        mutationWarnings,
         expressId,
         entityText,
         entityRef.type,
         pass.modifiedAttributes.get(expressId),
         pass.sourceSchema,
         pass.overlayActive,
-        (attr, value) =>
-          pass.warnings.push(
-            `entity #${expressId}: attribute ${attr} not written - ` +
-              `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
-          ),
       );
       let nextEntityText = mutated.text;
 
@@ -284,6 +296,10 @@ export function writeSourceEntityLines(
         }
         nextEntityText = filtered;
       }
+
+      // Past every branch that can withhold this line, so the pipeline's own
+      // reports are now true statements about a record this pass is writing.
+      pass.warnings.push(...mutationWarnings);
 
       // A retype or a positional edit that CHANGED the line is what makes
       // this entity count; a named attribute edit was already nominated by

--- a/packages/export/src/unreadable-record-warning.test.ts
+++ b/packages/export/src/unreadable-record-warning.test.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The REPORTING half of #4125, at the export's own surface.
+ *
+ * `by-index-writers-refuse.test.ts` pins that the writers refuse and that
+ * `SourceLineMutations.unreadable` says so. That flag is internal: nothing there
+ * fails if the export never turns it into something a caller can see. Deleting
+ * the `unreadableRecordEditsDroppedWarning` push left the whole suite green,
+ * which is the same "silent discard" shape #4125 is about, surviving inside the
+ * change that prevents it. So each of the two passes that write a source entity
+ * line gets a case here asserting the warning reaches `result.stats.warnings` —
+ * the collection an exporter's caller actually reads.
+ *
+ * The last case is the other direction, and the reason the report is not simply
+ * pushed where it is produced: a record whose line the export WITHHOLDS must not
+ * also be reported as "written exactly as the source file has it". Two warnings
+ * for one outcome, one of them false.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+/**
+ * Two undoubled apostrophes in adjacent string attributes, which is what an
+ * authoring tool emits when it forgets to double one. The scan closes the string
+ * at the first stray apostrophe and reopens at the next, swallowing the comma
+ * between them: quote parity stays even and paren depth returns to zero, so the
+ * split produces parts that are not the record's slots. Every phantom below has
+ * the same shape.
+ *
+ * `#10` (the wall) and `#20` (the containment relationship) carry one each;
+ * `#5`'s is placed AFTER `HasPropertySets` so the parser still resolves the
+ * type-owned pset list and the rewrite pass this file is about still runs.
+ */
+const BASE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition[DesignTransferView]'),'2;1');
+FILE_NAME('base.ifc','2026-09-09T10:00:00+01:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0OSuGGYUFyIf0LtE29OSuG',$,'My Project',$,$,$,$,$,$);
+#5=IFCWALLTYPE('0OSuGGYUFyIf0LtE29OSuT',$,'WT1',$,$,(#30),$,'a's','b's',.STANDARD.);
+#10=IFCWALL('0OSuGGYUFyIf0LtE29OSuW',$,'W1',$,$,$,$,'a's','b's');
+#20=IFCRELCONTAINEDINSPATIALSTRUCTURE('0OSuGGYUFyIf0LtE29OSuR',$,'a's','b's',(#10),#40);
+#30=IFCPROPERTYSET('0OSuGGYUFyIf0LtE29OSuP',$,'Pset_TypeOwned',$,(#31));
+#31=IFCPROPERTYSINGLEVALUE('Foo',$,IFCTEXT('old'),$);
+#40=IFCBUILDINGSTOREY('0OSuGGYUFyIf0LtE29OSuS',$,'Level 0',$,$,$,$,$,$,0.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+/** The same three records with their apostrophes doubled: the control file. */
+const CONTROL_IFC = BASE_IFC.replace(/'a's','b's'/g, "'a''s','b''s'");
+
+const WALL_ID = 10;
+const WALL_TYPE_ID = 5;
+const REL_ID = 20;
+
+async function parse(text: string): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(toArrayBuffer(new TextEncoder().encode(text)));
+}
+
+function newSession(store: IfcDataStore) {
+  const view = new MutablePropertyView(null, 'test-model');
+  return { view, editor: new StoreEditor(store, view) };
+}
+
+/**
+ * The refusal report, matched on the sentence that makes the claim rather than
+ * on the whole string: a reworded warning should not fail this, but a warning
+ * that stopped being pushed must.
+ */
+function refusalReportsFor(warnings: string[], expressId: number): string[] {
+  return warnings.filter(
+    (w) => w.includes(`#${expressId}`) && w.includes('was written exactly as the source file has it'),
+  );
+}
+
+describe('an unreadable record whose edits were dropped is reported to the caller', () => {
+  it('the source-iteration pass says so, in the export result', async () => {
+    const store = await parse(BASE_IFC);
+    const { view, editor } = newSession(store);
+    editor.setAttribute(WALL_ID, 'Description', 'NEWDESC');
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    // The edit was genuinely dropped: the record still reads as the file had it.
+    expect(text).not.toContain('NEWDESC');
+    // ...and the caller can see that it was, without inferring it from absence.
+    expect(refusalReportsFor(result.stats.warnings, WALL_ID)).toHaveLength(1);
+  });
+
+  it('the type-object HasPropertySets rewrite says so too', async () => {
+    // This pass REPLACES the source-iteration pass's line for these ids
+    // (`rewrittenEntityIds` makes that pass skip them), so a report made only
+    // there would be silent for exactly the entities this branch owns.
+    const store = await parse(BASE_IFC);
+    const { view, editor } = newSession(store);
+    editor.setAttribute(WALL_TYPE_ID, 'Name', 'RENAMED-TYPE');
+    editor.addPropertySet(WALL_TYPE_ID, 'Pset_TypeOwned', [
+      { name: 'Foo', value: 'new', type: 'TEXT' },
+    ]);
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).not.toContain('RENAMED-TYPE');
+    expect(refusalReportsFor(result.stats.warnings, WALL_TYPE_ID)).toHaveLength(1);
+  });
+
+  it('control: a readable record takes the edit and is not reported', async () => {
+    // Without this, a green result above could come from the writers having
+    // stopped writing rather than from them refusing the record they should.
+    const store = await parse(CONTROL_IFC);
+    const { view, editor } = newSession(store);
+    editor.setAttribute(WALL_ID, 'Description', 'NEWDESC');
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).toContain('NEWDESC');
+    expect(refusalReportsFor(result.stats.warnings, WALL_ID)).toHaveLength(0);
+  });
+
+  it('a record the export WITHHELD is not also reported as written as the source has it', async () => {
+    // #20 is unreadable AND names an entity this session deleted, in a list that
+    // has no other member — so `filterHiddenRefsFromRelationshipLine` withholds
+    // the whole line and pushes its own warning. The refusal report is about a
+    // line that is going out; this one is not, so only the withheld warning is
+    // true of this entity.
+    const store = await parse(BASE_IFC);
+    const { view, editor } = newSession(store);
+    editor.setAttribute(REL_ID, 'Description', 'NEWDESC');
+    editor.removeEntity(WALL_ID);
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    // The line really is withheld.
+    expect(text).not.toMatch(new RegExp(`^#${REL_ID}\\s*=`, 'm'));
+    // The withholding is reported...
+    expect(result.stats.warnings.some((w) => w.includes(`#${REL_ID}`))).toBe(true);
+    // ...and NOT by a second warning claiming the entity was written.
+    expect(refusalReportsFor(result.stats.warnings, REL_ID)).toHaveLength(0);
+  });
+});

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -47,9 +47,11 @@ pub use schema_pad::padded_type_universe;
 mod shades;
 pub mod source_header;
 mod step;
+mod step_api;
 mod step_cow;
 mod step_header;
 mod step_json;
+mod step_slot;
 mod step_text;
 mod usd;
 

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -12,114 +12,13 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ifc_lite_core::EntityScanner;
 
-/// A single root-attribute edit: replace the top-level attribute at `index` of entity
-/// `express_id` with `value` (already STEP-serialized, e.g. `'New Name'` or `$`).
-/// This is the wasm-bridge form of a `MutablePropertyView` UPDATE_ATTRIBUTE mutation.
-pub struct AttrMutation {
-    pub express_id: u32,
-    pub index: usize,
-    pub value: String,
-}
-
-/// A property create/update: attach (or overwrite) `prop_name` in `pset_name` on
-/// `express_id` with `value` — the STEP-serialized nominal value, e.g. `IFCLABEL('2HR')`
-/// or `IFCREAL(42.)`. The wasm-bridge form of a `MutablePropertyView` CREATE/UPDATE_PROPERTY.
-/// Synthesizes fresh `IfcPropertySingleValue` / `IfcPropertySet` / `IfcRelDefinesByProperties`
-/// entities appended to DATA (new psets; merge-into-existing is a follow-on).
-pub struct PropMutation {
-    pub express_id: u32,
-    pub pset_name: String,
-    pub prop_name: String,
-    pub value: String,
-}
-
-/// Replace one attribute of a record that other records share, by copying the
-/// record and repointing a single referrer at the copy.
-///
-/// The reason this is a writer job rather than a caller one is the id. A copy
-/// needs a number no record holds, and the writer is what knows `max_id`; a
-/// caller that allocates its own has to agree with `PropMutation`'s synthesis
-/// about which numbers are free, and two allocators sharing one space is a
-/// collision waiting for the first export that uses both.
-///
-/// Doing it here also keeps the copy inside the emit path, so it is counted in
-/// [`StepStats::written`] and converted when the export targets another schema.
-/// A record spliced into the output afterwards is neither.
-///
-/// Property sets are the case this exists for. IFC exporters routinely give
-/// each element its own `IfcPropertySet` and point them all at one
-/// `IfcPropertySingleValue` per distinct value, so editing that value in place
-/// changes it for every element sharing it. Copying first changes one.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CopyOnWriteMutation {
-    /// The record to copy.
-    pub express_id: u32,
-    /// Which attribute of the copy to replace, zero-based.
-    pub index: usize,
-    /// The replacement, STEP-serialized, e.g. `IFCLABEL('2HR')`.
-    pub value: String,
-    /// The record that should point at the copy instead of the original.
-    pub referrer_id: u32,
-    /// Which attribute of the referrer holds that reference. A list attribute
-    /// is rewritten with the one reference substituted and the rest untouched.
-    pub referrer_index: usize,
-}
-
-/// Options for STEP export.
-#[derive(Default)]
-pub struct StepOptions {
-    /// FILE_SCHEMA label to write (e.g. `IFC4`). `None` ⇒ preserve the source schema.
-    /// When `Some` and the target differs, entity types/attributes are converted (P2).
-    pub schema: Option<String>,
-    /// Express ids to include. `None` ⇒ the whole model. When set, the forward
-    /// reference closure is added so every emitted `#ref` resolves.
-    pub included: Option<Vec<u32>>,
-    /// Root-attribute edits to apply during serialization (P3 mutation bridge).
-    pub attribute_mutations: Vec<AttrMutation>,
-    /// Property create/update edits — synthesized as new pset entities appended to DATA.
-    pub property_mutations: Vec<PropMutation>,
-    /// Copy-then-edit mutations for records other records share.
-    pub copy_on_write: Vec<CopyOnWriteMutation>,
-    /// `FILE_DESCRIPTION` item. `None` ⇒ keep the source file's items, and
-    /// fall back to the generic view-definition default only when the source
-    /// carried none.
-    pub description: Option<String>,
-    /// `FILE_NAME` author. `None` ⇒ keep the source file's.
-    pub author: Option<String>,
-    /// `FILE_NAME` organization. `None` ⇒ keep the source file's.
-    pub organization: Option<String>,
-    /// `FILE_NAME` preprocessor_version — the tool writing this file.
-    /// `None` ⇒ `ifc-lite`.
-    pub application: Option<String>,
-    /// `FILE_NAME` name. `None` ⇒ `export.ifc`.
-    pub filename: Option<String>,
-    /// `FILE_NAME` time_stamp. `None` ⇒ the source file's stamp. There is no
-    /// clock fallback: `SystemTime::now` is unavailable on the
-    /// `wasm32-unknown-unknown` target this exporter ships to, so a caller that
-    /// wants "now" states it.
-    pub time_stamp: Option<String>,
-}
-
-/// Coverage stats for a STEP export.
-pub struct StepStats {
-    /// Entities in the source model.
-    pub total: usize,
-    /// Entities written (after filtering + reference closure).
-    pub written: usize,
-    /// Copy-on-write mutations the file could not express, so none was made.
-    /// Non-zero means an edit the caller asked for is not in the output, and
-    /// the caller is the only one who can say what to do about it.
-    pub copies_refused: usize,
-    /// `#<digits>` references above `u32::MAX` refused (issue #3421) while
-    /// resolving a filtered export's reference closure. The referenced record
-    /// could never itself be a real entity, so this excludes nothing
-    /// reachable — it only says the source has an id ifc-lite can't hold (#3752).
-    pub refused_refs: usize,
-}
+pub use crate::step_api::{
+    AttrMutation, CopyOnWriteMutation, PropMutation, StepOptions, StepStats,
+};
 
 use crate::schema_detect::detect_schema;
 use crate::step_text::{
-    apply_attr_mutations, escape, merge_edits, refs_in_line_counted, renumber,
+    apply_attr_mutations_counted, escape, merge_edits, refs_in_line_counted, renumber,
 };
 
 /// Export the parsed model in `content` as a STEP/IFC string.
@@ -194,6 +93,7 @@ fn emit<W: std::io::Write>(
 
     // 2. Resolve the included set + forward reference closure.
     let mut refused_refs = 0usize;
+    let mut attribute_edits_refused = 0usize;
     let included: HashSet<u32> = match &opts.included {
         None => order.iter().copied().collect(),
         Some(roots) => {
@@ -262,7 +162,9 @@ fn emit<W: std::io::Write>(
                 let raw = String::from_utf8_lossy(&content[s..e]);
                 // Apply root-attribute edits first (original-schema positions), then convert.
                 let edited = match merge_edits(muts_by_id.get(id), repointed.get(id)) {
-                    Some(edits) => apply_attr_mutations(&raw, &edits),
+                    Some(edits) => {
+                        apply_attr_mutations_counted(&raw, &edits, &mut attribute_edits_refused)
+                    }
                     None => raw.into_owned(),
                 };
                 if converting {
@@ -295,7 +197,7 @@ fn emit<W: std::io::Write>(
             // why they are resolved into their own map.
             let mut muts = muts_by_id.get(source_id).cloned().unwrap_or_default();
             muts.extend(edits.iter().map(|(i, v)| (*i, v.clone())));
-            let edited = apply_attr_mutations(&raw, &muts);
+            let edited = apply_attr_mutations_counted(&raw, &muts, &mut attribute_edits_refused);
             let renumbered = renumber(&edited, *copy_id);
             if converting {
                 out.write_all(
@@ -337,7 +239,13 @@ fn emit<W: std::io::Write>(
         // duplicate real records.
         let Some(mut next) = next_id else {
             out.write_all(b"ENDSEC;\nEND-ISO-10303-21;\n")?;
-            return Ok(StepStats { total: order.len(), written, copies_refused, refused_refs });
+            return Ok(StepStats {
+                total: order.len(),
+                written,
+                copies_refused,
+                refused_refs,
+                attribute_edits_refused,
+            });
         };
         for ((express_id, pset_name), props) in &groups {
             // One property set costs one id per property plus one for the set
@@ -387,7 +295,13 @@ fn emit<W: std::io::Write>(
 
     out.write_all(b"ENDSEC;\nEND-ISO-10303-21;\n")?;
 
-    Ok(StepStats { total: order.len(), written, copies_refused, refused_refs })
+    Ok(StepStats {
+        total: order.len(),
+        written,
+        copies_refused,
+        refused_refs,
+        attribute_edits_refused,
+    })
 }
 
 #[cfg(test)]

--- a/rust/export/src/step_api.rs
+++ b/rust/export/src/step_api.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The STEP exporter's public vocabulary: what a caller asks for
+//! ([`StepOptions`] and the three mutation kinds) and what it gets told
+//! afterwards ([`StepStats`]).
+//!
+//! Split out of `step.rs` for the module-size ratchet
+//! (`rust/processing/tests/module_size_ratchet.rs`), the same way the text
+//! primitives went to `step_text.rs` and the copy-on-write pass to
+//! `step_cow.rs`. `step.rs` was 399 lines against a 400-line limit, so the next
+//! change to it had to move something out, and these five declaration-only
+//! types were the coherent thing to move: no behaviour, no dependency on the
+//! export loop, and one theme between them.
+//!
+//! No CALLER can see the split, and the header does not claim otherwise:
+//! `step.rs` re-exports all five (so `crate::step::StepOptions` and every other
+//! existing path still resolves) and `lib.rs` already exported them from the
+//! crate root. The benefit is to the ratchet and to whoever next reads
+//! `step.rs`, not to the interface.
+
+/// A single root-attribute edit: replace the top-level attribute at `index` of entity
+/// `express_id` with `value` (already STEP-serialized, e.g. `'New Name'` or `$`).
+/// This is the wasm-bridge form of a `MutablePropertyView` UPDATE_ATTRIBUTE mutation.
+pub struct AttrMutation {
+    pub express_id: u32,
+    pub index: usize,
+    pub value: String,
+}
+
+/// A property create/update: attach (or overwrite) `prop_name` in `pset_name` on
+/// `express_id` with `value` — the STEP-serialized nominal value, e.g. `IFCLABEL('2HR')`
+/// or `IFCREAL(42.)`. The wasm-bridge form of a `MutablePropertyView` CREATE/UPDATE_PROPERTY.
+/// Synthesizes fresh `IfcPropertySingleValue` / `IfcPropertySet` / `IfcRelDefinesByProperties`
+/// entities appended to DATA (new psets; merge-into-existing is a follow-on).
+pub struct PropMutation {
+    pub express_id: u32,
+    pub pset_name: String,
+    pub prop_name: String,
+    pub value: String,
+}
+
+/// Replace one attribute of a record that other records share, by copying the
+/// record and repointing a single referrer at the copy.
+///
+/// The reason this is a writer job rather than a caller one is the id. A copy
+/// needs a number no record holds, and the writer is what knows `max_id`; a
+/// caller that allocates its own has to agree with `PropMutation`'s synthesis
+/// about which numbers are free, and two allocators sharing one space is a
+/// collision waiting for the first export that uses both.
+///
+/// Doing it here also keeps the copy inside the emit path, so it is counted in
+/// [`StepStats::written`] and converted when the export targets another schema.
+/// A record spliced into the output afterwards is neither.
+///
+/// Property sets are the case this exists for. IFC exporters routinely give
+/// each element its own `IfcPropertySet` and point them all at one
+/// `IfcPropertySingleValue` per distinct value, so editing that value in place
+/// changes it for every element sharing it. Copying first changes one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyOnWriteMutation {
+    /// The record to copy.
+    pub express_id: u32,
+    /// Which attribute of the copy to replace, zero-based.
+    pub index: usize,
+    /// The replacement, STEP-serialized, e.g. `IFCLABEL('2HR')`.
+    pub value: String,
+    /// The record that should point at the copy instead of the original.
+    pub referrer_id: u32,
+    /// Which attribute of the referrer holds that reference. A list attribute
+    /// is rewritten with the one reference substituted and the rest untouched.
+    pub referrer_index: usize,
+}
+
+/// Options for STEP export.
+#[derive(Default)]
+pub struct StepOptions {
+    /// FILE_SCHEMA label to write (e.g. `IFC4`). `None` ⇒ preserve the source schema.
+    /// When `Some` and the target differs, entity types/attributes are converted (P2).
+    pub schema: Option<String>,
+    /// Express ids to include. `None` ⇒ the whole model. When set, the forward
+    /// reference closure is added so every emitted `#ref` resolves.
+    pub included: Option<Vec<u32>>,
+    /// Root-attribute edits to apply during serialization (P3 mutation bridge).
+    pub attribute_mutations: Vec<AttrMutation>,
+    /// Property create/update edits — synthesized as new pset entities appended to DATA.
+    pub property_mutations: Vec<PropMutation>,
+    /// Copy-then-edit mutations for records other records share.
+    pub copy_on_write: Vec<CopyOnWriteMutation>,
+    /// `FILE_DESCRIPTION` item. `None` ⇒ keep the source file's items, and
+    /// fall back to the generic view-definition default only when the source
+    /// carried none.
+    pub description: Option<String>,
+    /// `FILE_NAME` author. `None` ⇒ keep the source file's.
+    pub author: Option<String>,
+    /// `FILE_NAME` organization. `None` ⇒ keep the source file's.
+    pub organization: Option<String>,
+    /// `FILE_NAME` preprocessor_version — the tool writing this file.
+    /// `None` ⇒ `ifc-lite`.
+    pub application: Option<String>,
+    /// `FILE_NAME` name. `None` ⇒ `export.ifc`.
+    pub filename: Option<String>,
+    /// `FILE_NAME` time_stamp. `None` ⇒ the source file's stamp. There is no
+    /// clock fallback: `SystemTime::now` is unavailable on the
+    /// `wasm32-unknown-unknown` target this exporter ships to, so a caller that
+    /// wants "now" states it.
+    pub time_stamp: Option<String>,
+}
+
+/// Coverage stats for a STEP export.
+pub struct StepStats {
+    /// Entities in the source model.
+    pub total: usize,
+    /// Entities written (after filtering + reference closure).
+    pub written: usize,
+    /// Copy-on-write mutations the file could not express, so none was made.
+    /// Non-zero means an edit the caller asked for is not in the output, and
+    /// the caller is the only one who can say what to do about it.
+    pub copies_refused: usize,
+    /// `#<digits>` references above `u32::MAX` refused (issue #3421) while
+    /// resolving a filtered export's reference closure. The referenced record
+    /// could never itself be a real entity, so this excludes nothing
+    /// reachable — it only says the source has an id ifc-lite can't hold (#3752).
+    pub refused_refs: usize,
+    /// Records whose root-attribute edits could not be applied because the
+    /// record's own argument list did not scan into slots, so the line was
+    /// emitted as the source wrote it (issue #4125). Non-zero means an edit the
+    /// caller asked for is not in the output. Counted rather than left as an
+    /// unchanged line, because a refusal that looks like a successful no-op is
+    /// the failure this whole family is about: writing by index into a
+    /// mis-scanned list lands on the wrong attribute and reports success.
+    pub attribute_edits_refused: usize,
+}

--- a/rust/export/src/step_cow.rs
+++ b/rust/export/src/step_cow.rs
@@ -57,7 +57,7 @@ fn candidate<'a>(
         return None;
     }
     // The attribute has to exist before an id is spent on the copy.
-    // `apply_attr_mutations` ignores an index past the end, so without this the
+    // `apply_attr_mutations_counted` ignores an index past the end, so without this the
     // copy comes out identical to the record it copied and the referrer is
     // repointed at a duplicate that changed nothing.
     let source_line = String::from_utf8_lossy(&content[source_start..source_end]);

--- a/rust/export/src/step_slot.rs
+++ b/rust/export/src/step_slot.rs
@@ -1,0 +1,347 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Reading a STEP record's top-level argument list out of its text, for a
+//! caller that then reads or writes one slot BY INDEX.
+//!
+//! The failure this module exists to prevent is silent. A scanner that loses
+//! track of quote state or paren depth still produces parts; they are just not
+//! the record's arguments any more, because the commas it swallowed took every
+//! following slot with them. A write by index then lands on whatever the
+//! mis-scan accumulated and the caller reports a success that did not happen
+//! (LTplus-AG/ifc-lite#2470, #4125). So the split returns `None` rather than
+//! parts it does not believe in, and both call sites in
+//! [`crate::step_text`] treat `None` as "this edit cannot be made".
+//!
+//! This module deliberately grows no permissive variant. Both its callers
+//! ([`crate::step_text::apply_attr_mutations_counted`] and
+//! [`crate::step_text::attribute_of`]) index into the parts, and text that
+//! reaches them comes from the user's file, so a permissive sibling here would
+//! be a footgun with no consumer.
+//!
+//! The crate still HAS one, though, and this module does not replace it:
+//! `schema_convert.rs`'s `split_top_level` (`schema_convert.rs:203`) is the same
+//! quote/depth/comma state machine in its older `bytes[i] as char` form, and its
+//! callers `trim_attributes` and `remap_attrs_by_name` both rewrite records by
+//! pairing values with slots by POSITION — the failure above, in another file.
+//! Out of scope for #4125, which is the three by-index writers; tracked in
+//! LTplus-AG/ifc-lite#4200.
+//!
+//! The TypeScript twin is `packages/export/src/step-argument-parser.ts`'s
+//! `splitTopLevelStepArguments`. The two cannot share code, so the inputs both
+//! must refuse are pinned to one shared fixture,
+//! `tests/fixtures/step_refuse_vectors.json` (see `step_slot_tests.rs`'s
+//! `refuses_every_shared_cross_language_vector`
+//! and `packages/export/src/step-refuse.parity.test.ts`) — the same arrangement
+//! `step_escape_vectors.json` gives the two escapers (#3300). Only the REFUSE
+//! side is shared, because the splitters in this repo diverge on what they
+//! ACCEPT: this module and the export twin both keep a `/* ... */` comment's
+//! bytes inside the slot that carries them, while the CLI's
+//! `splitTopLevelStepArgs` refuses any slot carrying one — each contract is its
+//! own caller's choice, and pinning an accept would freeze a divergence as if it
+//! were agreement.
+//!
+//! One accept-side divergence from the export twin is NOT a chosen contract, and
+//! is recorded here so the next reader does not have to measure it again: an
+//! empty element INSIDE a nested list. `'g',(1,,2),'b'` is accepted by this
+//! module as three slots and refused (`null`) by `splitTopLevelStepArguments`,
+//! because this module extends the empty-slot rule below into nested lists and
+//! the twin does not. Both measured directly, 2026-09-09. Changing either moves
+//! one language's grammar with nothing pinning the other, so it is out of scope
+//! for #4125 and tracked in LTplus-AG/ifc-lite#4200 with the rest of the
+//! splitter unification.
+
+/// Split a STEP attribute list into its top-level arguments, or `None` when
+/// the text is not an argument list this can scan.
+///
+/// `attrs` is the text BETWEEN a record's outermost parentheses. Nothing is
+/// trimmed, so for accepted input `parts.join(",")` reproduces `attrs` byte for
+/// byte and a caller that replaces one part leaves every other byte alone —
+/// with ONE exception, the whitespace-only early return below. `"   "` splits to
+/// `[]`, so `join(",")` is `""` and
+/// [`crate::step_text::apply_attr_mutations_counted`] rewrites `#1=IFCFOO(   );`
+/// to `#1=IFCFOO();`. That is deliberate: the TypeScript twin returns `[]` for
+/// any input whose `trim()` is empty (measured directly, 2026-09-09), and a
+/// record with no arguments has no slot for a by-index caller to write, so the
+/// only bytes the exception can drop are padding that carries no value. Every
+/// OTHER accepted input rejoins byte for byte, which
+/// `accepted_parts_rejoin_to_the_input` pins.
+///
+/// Rejected:
+///   - a quote still open at the end (unterminated string);
+///   - a paren depth that does not return to zero, or that ever goes below it
+///     (both ends matter: a depth that dips negative and climbs back looks
+///     balanced at the end while every comma in between was read as nested);
+///   - a part that is not one well-formed STEP value (see
+///     [`is_well_formed_step_slot`]), which is what catches the mis-scans the
+///     three checks above cannot see.
+///
+/// An EMPTY top-level slot (`a,,b`, or a trailing comma) is NOT rejected. It is
+/// invalid STEP that costs no alignment: an empty argument is ONE part, exactly
+/// as the entity parser counts it, so every index still names the attribute it
+/// is meant to. An empty INPUT is not an empty slot: `#1=IFCFOO();` is a record
+/// with no arguments, so it splits to `[]` and any slot request then fails the
+/// caller's own bounds check.
+///
+/// A `/* ... */` COMMENT is KEPT, not refused: its bytes stay inside whichever
+/// slot they sit in, and the scan steps over the whole region as one unit so a
+/// comma, paren or apostrophe inside it cannot be read as structure. Comments
+/// are valid ISO 10303-21 and this repo has met them in real files (#3789,
+/// #4162); refusing a slot that carries one made every by-index write on such a
+/// record drop, and made [`crate::step_text::attribute_of`] return `None` so
+/// `step_cow`'s copy-on-write refused the whole copy when the REFERRER line
+/// carried a comment. The export twin does the same thing with the same bytes.
+/// A slot that is ONLY a comment is still refused — a comment is not a value, so
+/// counting it as one more empty slot shifts every index after it, which is what
+/// the third and fourth shared refuse vectors pin.
+pub(crate) fn split_top_level_args(attrs: &str) -> Option<Vec<String>> {
+    if attrs.trim().is_empty() {
+        return Some(Vec::new());
+    }
+
+    // Over chars, not bytes. `bytes[i] as char` reads a UTF-8 continuation byte
+    // as a Latin-1 character and re-encodes it, so a property name like
+    // `Größe` came back as `GrÃ¶ÃŸe` in any record this rewrote. Every
+    // delimiter STEP cares about is ASCII, so indexing chars costs nothing and
+    // leaves the rest of the text alone.
+    let text: Vec<char> = attrs.chars().collect();
+    let n = text.len();
+    let mut out: Vec<String> = Vec::new();
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut current = String::new();
+    let mut i = 0usize;
+    while i < n {
+        let ch = text[i];
+
+        // A comment's content is unrestricted ISO 10303-21 text — a comma, an
+        // unbalanced paren, or an odd number of `'` inside one would otherwise
+        // corrupt this scan's comma/paren/quote state even though the comment is
+        // not an argument boundary. Copy the whole region (open marker through
+        // the matching `*/`, or to the end when unterminated) into the current
+        // slot as one atomic unit; the per-slot grammar check below still gets
+        // the last word on whether that slot is a value.
+        if !in_string && ch == '/' && i + 1 < n && text[i + 1] == '*' {
+            let stop = comment_end(&text, i).unwrap_or(n);
+            current.extend(text[i..stop].iter());
+            i = stop;
+            continue;
+        }
+
+        if ch == '\'' {
+            current.push(ch);
+            if in_string && i + 1 < n && text[i + 1] == '\'' {
+                current.push('\'');
+                i += 2;
+                continue;
+            }
+            in_string = !in_string;
+            i += 1;
+            continue;
+        }
+
+        if !in_string {
+            if ch == '(' {
+                depth += 1;
+            } else if ch == ')' {
+                depth -= 1;
+                if depth < 0 {
+                    // Already past the record's own closing paren: every comma
+                    // from here would be read as nested and the split is
+                    // meaningless.
+                    return None;
+                }
+            } else if ch == ',' && depth == 0 {
+                out.push(std::mem::take(&mut current));
+                i += 1;
+                continue;
+            }
+        }
+        current.push(ch);
+        i += 1;
+    }
+    if in_string || depth != 0 {
+        return None;
+    }
+    out.push(current);
+
+    // The three checks above track SCAN state, not slot CONTENT. A phantom
+    // string can swallow a real boundary — an undoubled `'` inside two
+    // different string-typed arguments reads as one string spanning both, so
+    // the text between them gets folded into a single part while quote parity
+    // and paren depth both stay clean. Every check above is satisfied on a slot
+    // list that is not the record's arguments.
+    if out.iter().any(|part| !is_well_formed_step_slot(part)) {
+        return None;
+    }
+    Some(out)
+}
+
+/// Whether `part` — one slot [`split_top_level_args`] already separated on a
+/// top-level comma, raw text including any surrounding whitespace or comments —
+/// is a single well-formed STEP value, or is empty.
+///
+/// The forms, per ISO 10303-21: a string literal (`'...'`, `''` escaping an
+/// apostrophe), a binary literal (`"..."`, which has no doubled-quote escape),
+/// `$`, `*`, a bare token (keyword, enumeration, number, `#`-reference), or a
+/// typed value / list (`NAME(...)` or `(...)`). Empty is accepted, matching the
+/// empty-slot rule above.
+///
+/// A `/* ... */` comment is TRIVIA here, skipped wherever whitespace is skipped,
+/// so a slot that carries one around its value is accepted with the comment's
+/// bytes still in it. A slot that is ONLY a comment is not: `skip_trivia` runs
+/// it out and the value the scan then expects is missing, so the part fails —
+/// which is the point, since a comment is not a value and counting it as one
+/// more empty slot would shift every index after it.
+///
+/// A `/` that is NOT opening a comment cannot be swallowed into a bare token: it
+/// is outside [`is_bare_token_char`]'s set, so the run stops there and the
+/// "consumed to the end" check at the bottom fails the part.
+fn is_well_formed_step_slot(part: &str) -> bool {
+    let text: Vec<char> = part.chars().collect();
+    let n = text.len();
+    let mut i = 0usize;
+    let mut depth = 0usize;
+    let mut expect_value = true;
+
+    // Whitespace AND comments, so `IFCLABEL /* c */ ('x')` reads as one typed
+    // value. An UNTERMINATED comment runs to the end rather than failing here:
+    // in a value position that leaves nothing to read and the part is refused a
+    // line later, and in a trailing position the twin accepts it too (measured,
+    // 2026-09-09) — matching it is what keeps the two grammars comparable.
+    let skip_trivia = |i: &mut usize| loop {
+        while *i < n && text[*i].is_whitespace() {
+            *i += 1;
+        }
+        if *i + 1 < n && text[*i] == '/' && text[*i + 1] == '*' {
+            match comment_end(&text, *i) {
+                Some(end) => *i = end,
+                None => {
+                    *i = n;
+                    return;
+                }
+            }
+            continue;
+        }
+        return;
+    };
+
+    // Whitespace only, deliberately NOT trivia: an all-comment part must not
+    // take this early accept, or a comment-only slot becomes an empty slot and
+    // every index after it shifts.
+    if text.iter().all(|c| c.is_whitespace()) {
+        return true; // empty (or whitespace-only) slot
+    }
+
+    loop {
+        skip_trivia(&mut i);
+        if expect_value {
+            // A list element may be empty (`(1,,2)`), as a top-level slot may be.
+            if depth > 0 && i < n && (text[i] == ',' || text[i] == ')') {
+                expect_value = false;
+                continue;
+            }
+            if i >= n {
+                return false;
+            }
+            match text[i] {
+                '\'' => {
+                    i += 1;
+                    loop {
+                        if i >= n {
+                            return false; // unterminated string
+                        }
+                        if text[i] == '\'' {
+                            if i + 1 < n && text[i + 1] == '\'' {
+                                i += 2;
+                                continue;
+                            }
+                            i += 1;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                '"' => {
+                    // No doubled-quote escape inside a binary literal: the first
+                    // following `"` ends it, matching ifcopenshell's tokenizer.
+                    i += 1;
+                    while i < n && text[i] != '"' {
+                        i += 1;
+                    }
+                    if i >= n {
+                        return false; // unterminated binary literal
+                    }
+                    i += 1;
+                }
+                '(' => {
+                    depth += 1;
+                    i += 1;
+                    continue; // the list's first element is still a value to read
+                }
+                '$' | '*' => i += 1,
+                _ => {
+                    let start = i;
+                    while i < n && is_bare_token_char(text[i]) {
+                        i += 1;
+                    }
+                    if i == start {
+                        return false;
+                    }
+                    // A typed value: `NAME(...)`, trivia tolerated before the `(`.
+                    let mut after = i;
+                    skip_trivia(&mut after);
+                    if after < n && text[after] == '(' {
+                        depth += 1;
+                        i = after + 1;
+                        continue;
+                    }
+                }
+            }
+            expect_value = false;
+            continue;
+        }
+
+        // A value just closed, so only `,` or `)` may follow. At depth zero the
+        // value was the whole slot, and nothing but whitespace may remain.
+        if depth == 0 {
+            return i == n;
+        }
+        if i >= n {
+            return false;
+        }
+        if text[i] == ')' {
+            depth -= 1;
+            i += 1;
+            continue;
+        }
+        if text[i] != ',' {
+            return false;
+        }
+        i += 1;
+        expect_value = true;
+    }
+}
+
+/// Characters a bare STEP token (keyword, enumeration, number, `#`-reference)
+/// is made of — the same set as the export twin's `/[A-Za-z0-9_.+\-#]/`. `/` is
+/// absent, so a `/` the trivia skipper did not consume (one not opening a
+/// comment) breaks the run short of the slot's end and the slot is refused.
+fn is_bare_token_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '+' | '-' | '#')
+}
+
+/// Index just past the `*/` closing the comment that opens at `open` (which
+/// points at its `/`), or `None` when the comment is never closed.
+fn comment_end(text: &[char], open: usize) -> Option<usize> {
+    let mut i = open + 2;
+    while i + 1 < text.len() {
+        if text[i] == '*' && text[i + 1] == '/' {
+            return Some(i + 2);
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "step_slot_tests.rs"]
+mod tests;

--- a/rust/export/src/step_slot_tests.rs
+++ b/rust/export/src/step_slot_tests.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for `step_slot.rs`, split out under the house pattern (AGENTS.md) so
+//! the production module stays under the module-size ratchet.
+
+use super::*;
+
+#[test]
+fn split_top_level_args_respects_nesting() {
+    let args = "'a',$,(#1,#2,#3),IFCBOOLEAN(.T.),#9";
+    let parts = split_top_level_args(args).expect("a well-formed argument list");
+    assert_eq!(parts.len(), 5);
+    assert_eq!(parts[2], "(#1,#2,#3)");
+    assert_eq!(parts[3], "IFCBOOLEAN(.T.)");
+}
+
+/// Accepted input must be reassemblable byte for byte, or a caller replacing
+/// one slot silently rewrites the ones it did not touch.
+#[test]
+fn accepted_parts_rejoin_to_the_input() {
+    for input in [
+        "'a',$,(#1,#2,#3),IFCBOOLEAN(.T.),#9",
+        "'g', $ ,'Name',*",
+        "'g',,$",
+        "\"0F3A\",$",
+        "'it''s',$",
+        "IFCLABEL ( 'x' ),$",
+        "'g',/* c */$,'b'",
+        "'g',$ /* trailing */,'b'",
+        "'g',IFCLABEL /* c */ ('x'),'b'",
+        "'g',/* has , and ( and ' */$,'b'",
+    ] {
+        let parts = split_top_level_args(input)
+            .unwrap_or_else(|| panic!("expected {input:?} to be accepted"));
+        assert_eq!(parts.join(","), input, "round-trip for {input:?}");
+    }
+}
+
+/// The empty argument list of a record with no attributes, which is not the
+/// same thing as one empty slot.
+#[test]
+fn an_empty_input_is_no_slots_at_all() {
+    assert_eq!(split_top_level_args(""), Some(Vec::new()));
+    assert_eq!(split_top_level_args("   "), Some(Vec::new()));
+}
+
+/// A `/* ... */` comment is legal ISO 10303-21 and this repo has met it in real
+/// files (#3789, #4162). Refusing a slot that carries one is not a tightening,
+/// it is a refusal to read a legal record: every by-index write on it drops, and
+/// `attribute_of` returning `None` makes `step_cow::candidate` refuse the whole
+/// copy-on-write when the REFERRER line carries the comment.
+///
+/// The exact expected parts are written out, not just `is_some()`: the comment's
+/// bytes must stay INSIDE the slot they were written in, which is what the
+/// export twin does (`splitTopLevelStepArguments`, measured 2026-09-09) and what
+/// keeps a caller's replacement of one slot from moving another slot's bytes.
+///
+/// These live here rather than in the shared fixture because that fixture is
+/// refuse-only by design — the splitters in this repo accept different things on
+/// purpose, and pinning an accept would freeze a divergence as agreement.
+#[test]
+fn accepts_a_slot_carrying_a_comment() {
+    assert_eq!(
+        split_top_level_args("'g',/* c */$,'b'"),
+        Some(vec![
+            "'g'".to_string(),
+            "/* c */$".to_string(),
+            "'b'".to_string(),
+        ]),
+    );
+    assert_eq!(
+        split_top_level_args("'g',$ /* trailing */,'b'"),
+        Some(vec![
+            "'g'".to_string(),
+            "$ /* trailing */".to_string(),
+            "'b'".to_string(),
+        ]),
+    );
+}
+
+/// A comment's content is unrestricted text, so the delimiters STEP cares about
+/// can appear inside one. The scan must step over the region atomically rather
+/// than read those bytes as structure — otherwise the comma below splits one
+/// slot into two and the apostrophe opens a phantom string that swallows the
+/// rest of the record.
+#[test]
+fn a_comment_does_not_supply_structure() {
+    assert_eq!(
+        split_top_level_args("'g',/* a, b ( c ' d */$,'b'"),
+        Some(vec![
+            "'g'".to_string(),
+            "/* a, b ( c ' d */$".to_string(),
+            "'b'".to_string(),
+        ]),
+    );
+}
+
+/// The other half of the comment rule, and the reason it is not simply
+/// "comments are ignored": a comment is not a VALUE. A slot holding nothing else
+/// is one more part than the record has attributes, so every index after it
+/// names the wrong one. Also the third and fourth shared refuse vectors; kept
+/// here beside the accepts because the pair is the whole contract.
+#[test]
+fn refuses_a_slot_that_is_only_a_comment() {
+    assert_eq!(split_top_level_args("'guid',$,'Name',/* c */,$"), None);
+    assert_eq!(split_top_level_args("$,/* renamed */,$"), None);
+}
+
+/// #4125: two undoubled apostrophes leave quote parity EVEN and paren depth at
+/// ZERO, so every scan-state check passes on a split that is not the record's
+/// slots. Only the per-part grammar rule sees it.
+///
+/// Also the first case in the shared fixture below, and kept here anyway: it is
+/// the record the issue is about, and a named test says which refusal is the
+/// point of the module. The other hand-written refusal cases were deleted once
+/// the fixture covered them, since a sweep that fails names the vector.
+#[test]
+fn refuses_the_two_apostrophe_phantom() {
+    let attrs = "'g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.";
+    assert_eq!(split_top_level_args(attrs), None);
+}
+
+/// The Rust half of the cross-language REFUSE parity pin (#4125).
+///
+/// The TypeScript twin (`packages/export/src/step-argument-parser.ts`'s
+/// `splitTopLevelStepArguments`, via
+/// `packages/export/src/step-refuse.parity.test.ts`) is held to the SAME file,
+/// so the two cannot drift apart silently — the arrangement
+/// `step_escape_vectors.json` gives the two STEP escapers (#3300), for the same
+/// reason: two implementations that cannot share code were held together only
+/// by each describing the other in prose.
+///
+/// The fixture lives in `tests/fixtures/` because that is where this repo's
+/// other shared vector files live; `include_str!` resolves it relative to this
+/// source file. NOT guarded by an existence check: a missing fixture means the
+/// pin is not being enforced, and that must fail loudly.
+#[test]
+fn refuses_every_shared_cross_language_vector() {
+    let raw = include_str!("../tests/fixtures/step_refuse_vectors.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid JSON");
+    let cases = doc["cases"].as_array().expect("cases is an array");
+    assert!(
+        cases.len() >= 8,
+        "an empty or near-empty vector list proves nothing; got {}",
+        cases.len()
+    );
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let input = case["input"].as_str().expect("input is a string");
+        assert_eq!(
+            split_top_level_args(input),
+            None,
+            "vector `{name}`: {input:?} must be refused"
+        );
+    }
+}
+

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -462,7 +462,7 @@ fn an_exhausted_id_space_emits_no_copy() {
     assert_eq!(ids.len(), before, "an id was handed out twice");
 }
 
-/// An attribute index past the end of the record. `apply_attr_mutations`
+/// An attribute index past the end of the record. `apply_attr_mutations_counted`
 /// ignores it, so the copy would be a byte-identical twin and the referrer
 /// would be repointed at a record that changed nothing.
 #[test]
@@ -735,7 +735,7 @@ fn a_caller_edit_at_a_missing_index_does_not_buy_a_copy() {
     let (out, stats) = export_step_with_stats(
         src.as_bytes(),
         &StepOptions {
-            // Index 9 is past the end of #9, and apply_attr_mutations ignores
+            // Index 9 is past the end of #9, and apply_attr_mutations_counted ignores
             // it, so the repointing computed from it never reaches the file.
             attribute_mutations: vec![AttrMutation {
                 express_id: 9,

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 //! STEP text-level primitives shared by the STEP exporter (`step.rs`): string
-//! escaping, `#ref` scanning, and the attribute-list splitting used to apply
-//! root-attribute mutations.
+//! escaping, `#ref` scanning, and the by-index reads and writes of a record's
+//! root attributes.
 //!
 //! Header `FILE_SCHEMA` detection used to live here and is now `schema_detect`.
 //! It left because it is not a text EDIT: it reads one fact out of raw bytes
 //! before anything is parsed, and unlike everything here it runs on whole
 //! uncapped attacker-supplied files.
+//!
+//! The argument-list SPLIT left too, to `step_slot.rs`, when it grew a grammar
+//! check per slot (#4125). It is what the by-index writers here stand on rather
+//! than another line utility beside them, and its own header carries the rule
+//! that makes them safe.
 //!
 //! Split out of `step.rs` to keep that file under the module-size ratchet
 //! (`rust/processing/tests/module_size_ratchet.rs`). These are self-contained
@@ -17,6 +22,8 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use ifc_lite_core::express_id::parse_express_id;
+
+use crate::step_slot::split_top_level_args;
 
 /// The edits that apply to one record, where a caller's attribute mutation and
 /// a copy-on-write repointing can both land on it. The repointing wins: it was
@@ -136,75 +143,50 @@ pub(crate) fn refs_in_line_counted(line: &[u8], out: &mut Vec<u32>, refused: &mu
     }
 }
 
-/// Split a STEP attribute list into its top-level arguments (parens/strings aware).
-fn split_top_level_args(attrs: &str) -> Vec<String> {
-    let mut out: Vec<String> = Vec::new();
-    let mut depth = 0i32;
-    let mut in_string = false;
-    let mut current = String::new();
-    // Over chars, not bytes. `bytes[i] as char` reads a UTF-8 continuation byte
-    // as a Latin-1 character and re-encodes it, so a property name like
-    // `Größe` came back as `GrÃ¶ÃŸe` in any record this rewrote. Every
-    // delimiter STEP cares about is ASCII, so iterating chars costs nothing and
-    // leaves the rest of the text alone.
-    let mut chars = attrs.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\'' && !in_string {
-            in_string = true;
-            current.push(ch);
-        } else if ch == '\'' && in_string {
-            if chars.peek() == Some(&'\'') {
-                current.push_str("''");
-                chars.next();
-                continue;
-            }
-            in_string = false;
-            current.push(ch);
-        } else if in_string {
-            current.push(ch);
-        } else if ch == '(' {
-            depth += 1;
-            current.push(ch);
-        } else if ch == ')' {
-            depth -= 1;
-            current.push(ch);
-        } else if ch == ',' && depth == 0 {
-            out.push(std::mem::take(&mut current));
-        } else {
-            current.push(ch);
-        }
-    }
-    out.push(current);
-    out
-}
-
-/// Apply root-attribute edits to a `#id=TYPE(attrs);` line. Returns the line unchanged
-/// when it cannot be parsed.
-pub(crate) fn apply_attr_mutations(line: &str, muts: &BTreeMap<usize, String>) -> String {
+/// Apply root-attribute edits to a `#id=TYPE(attrs);` line, keeping the source
+/// line and COUNTING the refusal when they cannot be applied.
+///
+/// The edits are refused when the text is not a `#id=TYPE(...)` record at all,
+/// or when its argument list could not be scanned into slots
+/// ([`split_top_level_args`] refused it). Either way it is a refusal, not a
+/// no-op — the caller asked for an edit that is not in the output. Writing the
+/// edit anyway is the #2470 shape one level up: an undoubled apostrophe makes a
+/// nine-attribute record scan as seven slots, so writing `Description` by index
+/// lands on `ObjectPlacement`, deletes the reference that was there, and reports
+/// success (#4125).
+///
+/// One function, and `refused` rather than an `Option` the caller interprets,
+/// because both emit sites need the same PAIR — leave the record as its author
+/// wrote it, and say that an edit is missing — and a site that did the first
+/// without the second would ship a file that looks like it carried the edit.
+pub(crate) fn apply_attr_mutations_counted(
+    line: &str,
+    muts: &BTreeMap<usize, String>,
+    refused: &mut usize,
+) -> String {
     let trimmed = line.trim_end();
     let body = trimmed.strip_suffix(';').unwrap_or(trimmed);
-    let eq = match body.find('=') {
-        Some(e) => e,
-        None => return line.to_string(),
-    };
-    let after = &body[eq + 1..];
-    let popen = match after.find('(') {
-        Some(p) => p,
-        None => return line.to_string(),
-    };
-    let aclose = match after.rfind(')') {
-        Some(c) if c > popen => c,
-        _ => return line.to_string(),
-    };
-    let prefix = &body[..=eq];
-    let type_name = &after[..popen];
-    let mut args = split_top_level_args(&after[popen + 1..aclose]);
-    for (idx, val) in muts {
-        if *idx < args.len() {
-            args[*idx] = val.clone();
+    let edited = body.find('=').and_then(|eq| {
+        let after = &body[eq + 1..];
+        let popen = after.find('(')?;
+        let aclose = after.rfind(')').filter(|c| *c > popen)?;
+        let prefix = &body[..=eq];
+        let type_name = &after[..popen];
+        let mut args = split_top_level_args(&after[popen + 1..aclose])?;
+        for (idx, val) in muts {
+            if *idx < args.len() {
+                args[*idx] = val.clone();
+            }
+        }
+        Some(format!("{prefix}{type_name}({});", args.join(",")))
+    });
+    match edited {
+        Some(text) => text,
+        None => {
+            *refused += 1;
+            line.to_string()
         }
     }
-    format!("{prefix}{type_name}({});", args.join(","))
 }
 
 #[cfg(test)]
@@ -228,6 +210,13 @@ pub(crate) fn renumber(line: &str, new_id: u32) -> String {
 /// Split from the substitution below so a caller applying two edits to the
 /// same attribute can feed the first result into the second, rather than
 /// computing both from the original and losing one.
+///
+/// `None` covers both "that slot is past the end" and "this record's argument
+/// list could not be scanned into slots at all". The caller
+/// (`step_cow::candidate`) already treats `None` as "this mutation cannot be
+/// made" and counts it into `StepStats::copies_refused`, which is the right
+/// answer for either: a slot read out of a mis-scanned list is some other
+/// attribute's text, and a copy built from it would carry the wrong value.
 pub(crate) fn attribute_of(line: &str, index: usize) -> Option<String> {
     let trimmed = line.trim_end();
     let body = trimmed.strip_suffix(';').unwrap_or(trimmed);
@@ -235,7 +224,7 @@ pub(crate) fn attribute_of(line: &str, index: usize) -> Option<String> {
     let after = &body[eq + 1..];
     let popen = after.find('(')?;
     let aclose = after.rfind(')').filter(|c| *c > popen)?;
-    split_top_level_args(&after[popen + 1..aclose])
+    split_top_level_args(&after[popen + 1..aclose])?
         .into_iter()
         .nth(index)
 }

--- a/rust/export/src/step_text_tests.rs
+++ b/rust/export/src/step_text_tests.rs
@@ -29,15 +29,6 @@ fn export_step_round_trips_a_backslash_carrying_schema_label_through_source_sche
     );
 }
 
-#[test]
-fn split_top_level_args_respects_nesting() {
-    let args = "'a',$,(#1,#2,#3),IFCBOOLEAN(.T.),#9";
-    let parts = split_top_level_args(args);
-    assert_eq!(parts.len(), 5);
-    assert_eq!(parts[2], "(#1,#2,#3)");
-    assert_eq!(parts[3], "IFCBOOLEAN(.T.)");
-}
-
 // The `escape()` literal-table tests that used to live here (backslash
 // doubling, apostrophe+backslash ordering, per-char control mapping, run
 // length, byte-identical plain text, non-ASCII directive encoding) are now
@@ -277,5 +268,69 @@ fn export_step_with_stats_reports_refused_refs_in_a_filtered_export() {
     assert_eq!(
         control_stats.refused_refs, 0,
         "an ordinary reference must not be counted as refused"
+    );
+}
+
+/// #4125: a record whose argument list does not scan into slots must NOT be
+/// edited by index. Before the validating splitter, writing `Description`
+/// (index 3) on this line landed on `ObjectPlacement`, deleted the `#5` that
+/// was there, and returned a `String` the caller read as a success.
+#[test]
+fn apply_attr_mutations_refuses_a_record_whose_slots_do_not_scan() {
+    let line = "#1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);";
+    let mut muts = BTreeMap::new();
+    muts.insert(3usize, "'NEWDESC'".to_string());
+    let mut refused = 0usize;
+    assert_eq!(
+        apply_attr_mutations_counted(line, &muts, &mut refused),
+        line,
+        "an edit by index into a mis-scanned list must refuse, not land on another attribute"
+    );
+    assert_eq!(refused, 1, "and the refusal must be counted, not silent");
+
+    // The control: the SAME record with its apostrophes doubled, where slot 3
+    // really is `Description`, still takes the edit.
+    let control = "#1=IFCWALL('g',$,IFCLABEL('a''s'),$,IFCLABEL('b''s'),#5,#6,'T',.SOLIDWALL.);";
+    assert_eq!(
+        apply_attr_mutations_counted(control, &muts, &mut refused),
+        "#1=IFCWALL('g',$,IFCLABEL('a''s'),'NEWDESC',IFCLABEL('b''s'),#5,#6,'T',.SOLIDWALL.);",
+        "a scannable record must still take the edit"
+    );
+    assert_eq!(refused, 1, "and must not be counted as a refusal");
+}
+
+/// The refusal above must be VISIBLE. An unchanged line is what a no-op edit
+/// also produces, so the export counts the refusal into its stats.
+#[test]
+fn export_step_counts_a_refused_attribute_edit() {
+    use crate::step::{export_step_with_stats, AttrMutation, StepOptions};
+
+    let source = b"ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);\nENDSEC;\nEND-ISO-10303-21;\n";
+    let opts = StepOptions {
+        attribute_mutations: vec![AttrMutation {
+            express_id: 1,
+            index: 3,
+            value: "'NEWDESC'".to_string(),
+        }],
+        ..Default::default()
+    };
+    let (step, stats) = export_step_with_stats(source, &opts);
+    assert_eq!(stats.attribute_edits_refused, 1);
+    assert!(
+        step.contains("#1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);"),
+        "the source line ships unedited rather than corrupted; got:\n{step}"
+    );
+    assert!(
+        !step.contains("NEWDESC"),
+        "the refused edit must not appear anywhere; got:\n{step}"
+    );
+
+    // The control, so a zero above is not merely "this export never edits".
+    let control_source = b"ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCWALL('g',$,IFCLABEL('a''s'),$,IFCLABEL('b''s'),#5,#6,'T',.SOLIDWALL.);\nENDSEC;\nEND-ISO-10303-21;\n";
+    let (control_step, control_stats) = export_step_with_stats(control_source, &opts);
+    assert_eq!(control_stats.attribute_edits_refused, 0);
+    assert!(
+        control_step.contains("'NEWDESC'"),
+        "the control edit must land; got:\n{control_step}"
     );
 }

--- a/rust/export/tests/fixtures/step_refuse_vectors.json
+++ b/rust/export/tests/fixtures/step_refuse_vectors.json
@@ -1,0 +1,56 @@
+{
+  "//": "Shared cross-language REFUSE vectors for the validating STEP argument-list splitters (issue #4125). Each `input` is the text BETWEEN a record's outermost parentheses, and every validating splitter pinned to this file must return null/None for it. Pinned here: the TypeScript `splitTopLevelStepArguments` (packages/export/src/step-argument-parser.ts, via packages/export/src/step-refuse.parity.test.ts) and the Rust `split_top_level_args` (rust/export/src/step_slot.rs, via rust/export/src/step_slot_tests.rs). The two cannot share code, and before this file each described the other's behaviour in prose -- the arrangement issue #3300 identifies as the cause of #3284, and the same one that let #4173 harden the TypeScript splitter while the Rust one stayed permissive for weeks. Follows rust/export/tests/fixtures/step_escape_vectors.json exactly, including living in the Rust crate so include_str! can reach it.",
+  "//accepts": "REFUSALS ONLY, on purpose. The splitters in this repo deliberately diverge on what they ACCEPT -- the export twin keeps a `/* ... */` comment's bytes inside a slot and accepts it, packages/cli/src/commands/step-args.ts refuses any slot carrying one -- because each contract is its caller's choice. Pinning an accept here would freeze a divergence as if it were agreement. What they must agree on is that none of them hands a by-index writer parts it cannot vouch for.",
+  "cases": [
+    {
+      "name": "two undoubled apostrophes across two typed values",
+      "why": "The #4125 record. The scan closes the string at the first stray apostrophe and reopens at the next, so the text between them -- including `),$,IFCLABEL(` -- folds into ONE part. Quote parity stays even and paren depth returns to zero, so every scan-state check passes on a nine-attribute record read as seven slots.",
+      "input": "'g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL."
+    },
+    {
+      "name": "two undoubled apostrophes across two plain string attributes",
+      "why": "The same phantom without the nested parens: nine attributes read as four, so writing slot 2 deletes attributes 3 to 7 (#4174).",
+      "input": "'guid',$,'John's wall',$,$,$,$,'A's',.NOTDEFINED."
+    },
+    {
+      "name": "a slot holding only a comment",
+      "why": "A comment is not a value, so counting it as one more empty slot shifts every index after it -- five parts for four attributes.",
+      "input": "'guid',$,'Name',/* c */,$"
+    },
+    {
+      "name": "a comment-only slot with no whitespace in it",
+      "why": "Whitespace is not what gives a phantom slot away: three parts for two attributes.",
+      "input": "$,/* renamed */,$"
+    },
+    {
+      "name": "unterminated binary literal",
+      "why": "ISO 10303-21's `\"...\"` binary literal has no doubled-quote escape, so the first following `\"` ends it and a missing one leaves the slot open.",
+      "input": "'g',\"0F"
+    },
+    {
+      "name": "unterminated binary literal swallowing a comma",
+      "why": "The comma inside the literal is read as a slot boundary, so one attribute becomes two.",
+      "input": "'g',\"01,23\""
+    },
+    {
+      "name": "reversed paren pair",
+      "why": "A depth that dips negative and climbs back looks balanced at the end, while every comma in between was read as nested.",
+      "input": "'g'),$,(#5"
+    },
+    {
+      "name": "reversed paren pair between two strings",
+      "why": "The same shape with no `$` between, so nothing but the negative-depth check catches it.",
+      "input": "'a'),(  'b'"
+    },
+    {
+      "name": "unterminated string",
+      "why": "The scan never leaves the string, so every comma after the opening quote was swallowed.",
+      "input": "'g',$,'oops"
+    },
+    {
+      "name": "unbalanced nested list",
+      "why": "The list never closes, so the commas after it were read as nested.",
+      "input": "'g',(#1,#2"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #4125.

Three writers set a STEP attribute by index after splitting the record's argument list with a permissive splitter. A permissive split still returns parts when the scan went wrong, and those parts are not the record's slots, so the edit lands on a different attribute and reports success.

All three reproduced with exact bytes on a record carrying two undoubled apostrophes, which is what an authoring tool emits when it forgets to double one. Quote parity stays even and paren depth returns to zero, so nothing structural notices:

```
before: #1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),#5,#6,'T',.SOLIDWALL.);
after : #1=IFCWALL('g',$,IFCLABEL('a's'),$,IFCLABEL('b's'),'NEWDESC',#6,'T',.SOLIDWALL.);
flags : {attributed: true, retyped: false, positional: false}
```

`NEWDESC` landed in `ObjectPlacement`'s slot and deleted the `#5` reference. Retyping the same record emitted eleven top-level arguments for a nine-attribute class. The Rust twin returned byte-identical output as a `String` the caller reads as success, and `attribute_of` returned the wrong attribute for two different indices.

## What changed

All three now use the validating splitter and drop the edit when it refuses. The refusal is reported rather than left looking like a no-op, because the three existing delivery flags cannot express it: a discarded edit sets them too.

The Rust half has one validating splitter and deliberately no permissive sibling, since both Rust callers index into the parts and both read the user's file. The inputs both languages must refuse are pinned to one shared fixture rather than described in prose, following the `step_escape_vectors.json` precedent that exists because prose-about-another-module caused #3284.

## What review changed

`/simplify` and `/code-review` both ran against this commit. Two findings were worth the round trip.

**A regression the corpus sweep could not see.** The new Rust splitter refused any slot carrying a legal `/* ... */` comment, because it was modelled on the CLI splitter's grammar rule instead of its real twin in `packages/export`. Measured before the fix: `'g',/* c */$,'b'` returned `None`. That is valid ISO 10303-21 and the permissive splitter it replaced handled it, so edits that used to land were being dropped, and `attribute_of` returning `None` refused the whole copy-on-write when the referrer line carried a comment. The 19,461,436-record sweep reported zero Rust refusals, which is consistent with the bug rather than evidence against it: real files rarely put comments inside an argument list, so a clean sweep over a population lacking the case says nothing about the case. Fixed by matching the twin, and the fix is proven load-bearing by reverting it and watching three tests fail.

**A documented invariant that was false.** `split_top_level_args("   ")` returns `Some([])`, so `parts.join(",")` does not reproduce the input, contradicting the module's stated byte-for-byte guarantee. The tempting fix would have created a new divergence: the TypeScript twin returns `[]` for any input whose `trim()` is empty, not only for `""`, so making Rust return one slot there would have split the two languages on the accept side. The exception is documented instead.

Four review findings were rejected or deferred on the record, each with its reason, in the issue and in the code comments. One is filed as #4200.

## Verification

- All three defects reproduced with exact bytes before the fix, and each fix mutation-checked by reverting it and confirming named tests fail.
- Ten shared refuse vectors still refuse in both languages after the comment fix.
- Corpus sweep over 122 real `.ifc` files, 19,461,436 records, with a positive control asserted first so a zero cannot come from an instrument that cannot report. Zero records change verdict, so no file that previously mutated stops mutating. That sweep predates the comment fix and contained no comment-carrying argument lists, which is stated in the changeset rather than papered over.
- `@ifc-lite/export` 1218 passed, `@ifc-lite/cli` 898 passed, typecheck, lint, `cargo test -p ifc-lite-export` 446 passed, `cargo clippy --workspace --all-targets -- -D warnings` clean, and the six repo gates green.

## Known and not fixed here

The CLI's own `splitTopLevelStepArgs` is a fourth by-index writer with the same defect class: `"` is absent from its `isTokenBreak`, so `'g',"01,23"` splits into three parts for two attributes and `mutate-step-record.ts` writes into the wrong one. The obvious one-character fix was measured and also refuses legitimate binary literals such as `"0F"`, so it needs the corpus treatment rather than a guess. Tracked in #4200 along with a second permissive scanner still in `rust/export` and two export paths that build an index-addressable array permissively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K
