### PR TITLE
fix(ci): run the MPL license-header gate, and make it right first (#4087)

### DIFF
--- a/.changeset/fix-4087-license-header-gate.md
+++ b/.changeset/fix-4087-license-header-gate.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/renderer': patch
+'@ifc-lite/geometry': patch
+'@ifc-lite/parser': patch
+---
+
+Add the missing MPL-2.0 file headers these packages ship without (#4087).
+
+`packages/renderer/src/{bvh,raycaster,snap-detector}.ts`, `packages/geometry/src/huge-file-error.ts` and three test files carried no license notice at all. `scripts/add-license-headers.mjs --check` now runs in CI, so the omission cannot recur. No behaviour, API surface or output changes: every edit is a four-line comment at the top of a file.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,6 @@ jobs:
               - 'docs/**'
               - 'examples/**'
               - 'packages/**'
-              - 'playwright.config.ts'
               - 'rust/**'
               - 'server/**'
               - 'tests/**'
@@ -190,6 +189,23 @@ jobs:
               # The gate's own source and its scanned `scripts/` tree, one
               # glob covering both.
               - 'scripts/**'
+              # The REPO ROOT, scanned non-recursively by extension (it used to
+              # be one named file, `playwright.config.ts`, which is still the
+              # only root-level file any of these match today). A gate that
+              # reads a path no glob can trigger it on is a gate that does not
+              # run on the PR introducing the mistake, so these have to widen
+              # with the scan. `*` does not cross `/`, so each of these matches
+              # root-level files ONLY and costs nothing on a subtree edit.
+              - '*.ts'
+              - '*.tsx'
+              - '*.js'
+              - '*.mjs'
+              - '*.cjs'
+              - '*.mts'
+              - '*.cts'
+              - '*.css'
+              - '*.rs'
+              - '*.py'
             frontend:
               # A changeset naming a package that does not exist fails the
               # RELEASE workflow, which only runs on main - so the Lint job has

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,7 @@ jobs:
       plato: ${{ steps.filter.outputs.plato }}
       docs: ${{ steps.filter.outputs.docs }}
       agents_md: ${{ steps.filter.outputs.agents_md }}
+      license_headers: ${{ steps.filter.outputs.license_headers }}
       # `true` when the WASM source is byte-identical to the published release
       # tag, so `build` can fetch the prebuilt bundle instead of compiling
       # wasm32. See the `build` job and scripts/ci-wasm-prebuilt-eligible.sh.
@@ -156,6 +157,38 @@ jobs:
               # tree: over-triggering is the safe direction for a reachability
               # check (that allowlist's own header says so), and the cost is one
               # 5-minute free-runner job with no install and no build artifact.
+              - 'scripts/**'
+            # The MPL-2.0 header gate (`add-license-headers.mjs --check`). Its
+            # own job for the same reasons agents_md has one: it needs no build
+            # artifact, no pnpm install and no Depot runner, and its INPUT is
+            # every first-party source tree in the repo -- `docs/**` (its
+            # stylesheets), `tools/**` (its `.mjs` and `.py` harnesses) and
+            # `apps/landing/**` among them, none of which is in `frontend` and
+            # none of which should drag a PR through the nine-job frontend
+            # lane just to check a comment at the top of a file. Each of those
+            # three was confirmed to hold scanned files, not assumed to: a
+            # trigger justified by a tree the gate reads nothing from is the
+            # same false comfort as the gate itself was before #4087. A gate
+            # whose trigger is narrower than its input cannot fire on the PR
+            # that introduces the very thing it guards against
+            # (scripts/check-ci-path-coverage.mjs), so this filter is the whole
+            # scanned population, deliberately over-triggering.
+            license_headers:
+              # test.yml DEFINES the license-headers job, so an edit that
+              # breaks, renames or deletes its steps must be able to run it.
+              - '.github/workflows/test.yml'
+              - 'api/**'
+              - 'apps/**'
+              - 'docs/**'
+              - 'examples/**'
+              - 'packages/**'
+              - 'playwright.config.ts'
+              - 'rust/**'
+              - 'server/**'
+              - 'tests/**'
+              - 'tools/**'
+              # The gate's own source and its scanned `scripts/` tree, one
+              # glob covering both.
               - 'scripts/**'
             frontend:
               # A changeset naming a package that does not exist fails the
@@ -1984,9 +2017,47 @@ jobs:
       - name: Check AGENTS.md ratchet regressions
         run: node --test scripts/check-agents-md-size.test.mjs
 
+  # AGENTS.md: "MPL-2.0 header on every new file". `add-license-headers.mjs`
+  # has had a `--check` mode that says whether that held, and NOTHING RAN IT
+  # (#4087) — a gate that exists and never executes is the same absence as no
+  # gate at all, and it had drifted accordingly: it exited 1 with 128 files
+  # flagged, 85 of them correctly-licensed SPDX files it could not recognise.
+  #
+  # Its own job rather than a step in node-tests, for the reason the
+  # `license_headers` filter block above states: the gate READS every
+  # first-party source tree, including `docs/**`, `tools/**` (whose `.mjs` and
+  # `.py` harnesses it scans) and `apps/landing/**`, which `frontend`
+  # deliberately does not carry. Wiring it into node-tests would either leave
+  # it unable to fire on three of the trees it scans, or drag doc-only PRs
+  # through the whole frontend lane. Here it is
+  # one checkout plus node on a free runner: no pnpm install, no build
+  # artifact, no Depot runner.
+  #
+  # The detector's own tests run FIRST, the same order the node-tests gate
+  # pairs use: this gate's entire value is in not passing over a tree it
+  # misread, so a broken detector must fail here rather than report agreement.
+  license-headers:
+    name: MPL license headers
+    needs: changes
+    if: needs.changes.outputs.license_headers == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Check the license-header classifier's own regressions
+        run: node --test scripts/lib/license-header.test.mjs
+      - name: Check every source file declares MPL-2.0
+        run: node scripts/add-license-headers.mjs --check
+
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md]
+    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md, license-headers]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ubuntu-latest
@@ -2007,6 +2078,7 @@ jobs:
             [plato-check]="${{ needs.plato-check.result }}"
             [docs-checks]="${{ needs.docs-checks.result }}"
             [agents-md]="${{ needs.agents-md.result }}"
+            [license-headers]="${{ needs.license-headers.result }}"
           )
           fail=0
           for j in "${!results[@]}"; do

--- a/LICENSE_HEADER.md
+++ b/LICENSE_HEADER.md
@@ -2,7 +2,10 @@
 
 All new source files must include the Mozilla Public License 2.0 header at the top.
 
-### TypeScript / JavaScript / CSS (`.ts`, `.tsx`, `.js`, `.css`)
+Two spellings count as a declaration: the prose notice below, and the SPDX
+one-liner. Either one alone is complete. Never put both on the same file.
+
+### TypeScript / JavaScript / CSS (`.ts`, `.tsx`, `.js`, `.mjs`, `.cjs`, `.mts`, `.cts`, `.css`)
 ```text
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,3 +18,48 @@ All new source files must include the Mozilla Public License 2.0 header at the t
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 ```
+
+### Python (`.py`)
+```text
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+```
+
+### The SPDX one-liner
+
+```text
+// SPDX-License-Identifier: MPL-2.0
+```
+
+`rust/export` uses this form throughout, and the gate accepts it there and
+anywhere else. It is a complete MPL-2.0 declaration on its own, so a file
+carrying it must not also get the prose notice stacked on top.
+
+For a new file, write the prose notice for its file type unless the tree you
+are adding to already uses SPDX, in which case match its neighbours.
+
+### Where the notice goes
+
+First line of the file, except when the file opens with a shebang. Then the
+notice goes directly after it: `#!` is only a shebang when it is the first two
+bytes, and a header pushed above it turns an `.mjs` file into a syntax error
+and a `.py` file into a non-executable one.
+
+A shebang is a leading `#!` in a `.js`/`.mjs`/`.cjs`/`.ts`/`.tsx`/`.mts`/`.cts`
+or `.py` file. In Rust a leading `#![...]` is an INNER ATTRIBUTE, not a
+shebang, and the notice goes ABOVE it on line 1 —
+`rust/core/fuzz/fuzz_targets/parse_entity.rs` is the one file in the repo where
+this comes up.
+
+### Enforcement
+
+```sh
+node scripts/add-license-headers.mjs --check   # reports what is missing
+node scripts/add-license-headers.mjs           # writes the missing headers
+```
+
+CI runs the `--check` mode as the `license-headers` job in
+`.github/workflows/test.yml`. The file types in scope, the two accepted
+spellings, and the generated trees that are exempt are all defined in
+`scripts/lib/license-header.mjs`, which is where to change them.

--- a/apps/viewer-embed/src/vite-env.d.ts
+++ b/apps/viewer-embed/src/vite-env.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string;

--- a/apps/viewer-embed/vite.config.ts
+++ b/apps/viewer-embed/vite.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import wasm from 'vite-plugin-wasm';

--- a/apps/viewer/postcss.config.js
+++ b/apps/viewer/postcss.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export default {
   plugins: {
     '@tailwindcss/postcss': {},

--- a/apps/viewer/src/components/ui/table.tsx
+++ b/apps/viewer/src/components/ui/table.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/apps/viewer/src/components/viewer/GLBExportDialog.placement.test.tsx
+++ b/apps/viewer/src/components/viewer/GLBExportDialog.placement.test.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/components/viewer/appearance/AppearancePanel.controller.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearancePanel.controller.test.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/components/viewer/dragOverlayState.test.ts
+++ b/apps/viewer/src/components/viewer/dragOverlayState.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {

--- a/apps/viewer/src/components/viewer/dragOverlayState.ts
+++ b/apps/viewer/src/components/viewer/dragOverlayState.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Pure state machine for the file drop-zone overlay.
  *

--- a/apps/viewer/src/lib/appearance/apply-plan.ts
+++ b/apps/viewer/src/lib/appearance/apply-plan.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/command.test.ts
+++ b/apps/viewer/src/lib/appearance/command.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/cooperative-corpus.test.ts
+++ b/apps/viewer/src/lib/appearance/cooperative-corpus.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/dependencies-corpus.test.ts
+++ b/apps/viewer/src/lib/appearance/dependencies-corpus.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/history.test.ts
+++ b/apps/viewer/src/lib/appearance/history.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/history.ts
+++ b/apps/viewer/src/lib/appearance/history.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/pdf/pdfjs-legacy.d.ts
+++ b/apps/viewer/src/lib/appearance/pdf/pdfjs-legacy.d.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /** PDF.js ships the legacy runtime with the same declared public API as its modern build. */
 declare module 'pdfjs-dist/legacy/build/pdf.mjs' {
   export * from 'pdfjs-dist';

--- a/apps/viewer/src/lib/appearance/serialization-corpus.test.ts
+++ b/apps/viewer/src/lib/appearance/serialization-corpus.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/appearance/validate-plan.ts
+++ b/apps/viewer/src/lib/appearance/validate-plan.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/src/lib/scripts/templates/data-quality-audit.ts
+++ b/apps/viewer/src/lib/scripts/templates/data-quality-audit.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Data Quality Audit ──────────────────────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/envelope-check.ts
+++ b/apps/viewer/src/lib/scripts/templates/envelope-check.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Building Envelope & Thermal Check ───────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/federation-compare.ts
+++ b/apps/viewer/src/lib/scripts/templates/federation-compare.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Multi-Model Federation Comparison ───────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/fire-safety-check.ts
+++ b/apps/viewer/src/lib/scripts/templates/fire-safety-check.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Fire Safety Compliance Check ────────────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/mep-equipment-schedule.ts
+++ b/apps/viewer/src/lib/scripts/templates/mep-equipment-schedule.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── MEP Equipment Schedule ──────────────────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/quantity-takeoff.ts
+++ b/apps/viewer/src/lib/scripts/templates/quantity-takeoff.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Quantity Takeoff ────────────────────────────────────────────────────

--- a/apps/viewer/src/lib/scripts/templates/reset-view.ts
+++ b/apps/viewer/src/lib/scripts/templates/reset-view.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // Reset colors and visibility

--- a/apps/viewer/src/lib/scripts/templates/space-validation.ts
+++ b/apps/viewer/src/lib/scripts/templates/space-validation.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export {} // module boundary (stripped by transpiler)
 
 // ── Space & Room Validation ─────────────────────────────────────────────

--- a/apps/viewer/src/test/appearance-controller.harness.tsx
+++ b/apps/viewer/src/test/appearance-controller.harness.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/apps/viewer/tailwind.config.js
+++ b/apps/viewer/tailwind.config.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ['class'],

--- a/apps/viewer/vite-plugins/cesium-assets.ts
+++ b/apps/viewer/vite-plugins/cesium-assets.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import path from 'node:path';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import Icons from 'unplugin-icons/vite';

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* ══════════════════════════════════════════════════════════════════════
    IFC-Lite Documentation — "PLANKOPF"
    Swiss engineering plan-sheet theme, matching ifclite.dev. Two neutrals +

--- a/examples/collab-demo/stubs/y-webrtc.js
+++ b/examples/collab-demo/stubs/y-webrtc.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export const WebrtcProvider = class {
   constructor() {
     throw new Error('y-webrtc stub: WebRTC provider unused in demo (websocket only)');

--- a/examples/collab-demo/vite.config.ts
+++ b/examples/collab-demo/vite.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { defineConfig } from 'vite';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';

--- a/examples/threejs-collab/stubs/y-webrtc.js
+++ b/examples/threejs-collab/stubs/y-webrtc.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 export const WebrtcProvider = class {
   constructor() {
     throw new Error('y-webrtc stub: WebRTC provider unused in 3D demo (websocket only)');

--- a/examples/threejs-collab/vite.config.ts
+++ b/examples/threejs-collab/vite.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { defineConfig } from 'vite';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';

--- a/packages/export/src/appearance-dependencies.test.ts
+++ b/packages/export/src/appearance-dependencies.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/packages/export/src/appearance-dependencies.ts
+++ b/packages/export/src/appearance-dependencies.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/packages/export/src/texture-map-closure.test.ts
+++ b/packages/export/src/texture-map-closure.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/packages/geometry/src/adversarial-skew.test.ts
+++ b/packages/geometry/src/adversarial-skew.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* Adversarial probes for PR #1680 (worker-script skew recovery).
  * Originally written to break the feature; they CONFIRMED the dispatched
  * event died in the viewer's message re-validation (the synthetic

--- a/packages/geometry/src/huge-file-error.test.ts
+++ b/packages/geometry/src/huge-file-error.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { describe, expect, it } from 'vitest';
 import { largeFilePrepassError } from './huge-file-error.js';
 

--- a/packages/geometry/src/huge-file-error.ts
+++ b/packages/geometry/src/huge-file-error.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Turn the bare wasm trap a huge model triggers in the streaming prepass into an
  * actionable, human-readable error.

--- a/packages/ifcx/test-federated.mjs
+++ b/packages/ifcx/test-federated.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Test script for Federated IFCX parsing
  * Run with: node test-federated.mjs

--- a/packages/ifcx/test-parse.mjs
+++ b/packages/ifcx/test-parse.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Test script for IFCX parsing
  * Run with: node test-parse.mjs <ifcx-file>

--- a/packages/parser/src/adversarial-gate.test.ts
+++ b/packages/parser/src/adversarial-gate.test.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* Adversarial probes for PR #1680 parser gate (wasmBytesScanAllowed).
  * Written to break the feature; safe to delete. */
 

--- a/packages/renderer/src/bvh.ts
+++ b/packages/renderer/src/bvh.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import type { MeshData } from '@ifc-lite/geometry';
 import type { Ray, Vec3 } from './raycaster.js';
 

--- a/packages/renderer/src/raycaster.ts
+++ b/packages/renderer/src/raycaster.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import type { MeshData } from '@ifc-lite/geometry';
 
 export interface Ray {

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import type { MeshData } from '@ifc-lite/geometry';
 import type { Ray, Vec3, Intersection } from './raycaster.js';
 import { Raycaster } from './raycaster.js';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({

--- a/rust/core/fuzz/fuzz_targets/parse_entity.rs
+++ b/rust/core/fuzz/fuzz_targets/parse_entity.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;

--- a/rust/core/src/step_codepages.rs
+++ b/rust/core/src/step_codepages.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! ISO 8859 code-page tables for the STEP `\S\` escape (ISO 10303-21 6.4.3).
 //!
 //! Split out of `step_encoding.rs` purely to keep that file under the repo's

--- a/rust/core/src/step_encoding.rs
+++ b/rust/core/src/step_encoding.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! STEP string escape decoding/encoding (ISO 10303-21 / IFC).
 //!
 //! IFC string attribute values encode non-ASCII characters with backslash

--- a/rust/core/tests/ifc_string_parity.rs
+++ b/rust/core/tests/ifc_string_parity.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Pins the Rust STEP string decoder to the shared cross-language test vectors
 //! in `tests/fixtures/ifc_string_vectors.json`. The TypeScript decoder in
 //! `@ifc-lite/encoding` is held to the same fixture, so the two cannot drift.

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Smoke tests for the FFI boundary itself — pointer validation, error codes,
 //! the parse→serialize→free round trip, and the `opening_filter_mode` mapping.
 //! Geometry correctness is covered by the `geometry`/`processing` crates; here

--- a/rust/geometry/tests/census_rtc/mod.rs
+++ b/rust/geometry/tests/census_rtc/mod.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Match the loader's coordinate-frame choice before producing f32 meshes.
 //! Survey coordinates must not become geometry-loss goldens (#3925).
 //!

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery_tests.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery_tests.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! Tests for `prepass_discovery`, split out of it for the module-size ratchet.
 //!
 //! The rule there is shrink or split by default -- a raise is possible on both

--- a/rust/wasm-bindings/src/api/styling/prepass_issue_1910_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass_issue_1910_tests.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! #1910 — `combined_pre_pass` must schedule a spatial container that
 //! exceptionally carries a non-null Representation.
 //!

--- a/rust/wasm-bindings/src/api/styling/prepass_issue_3187_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass_issue_3187_tests.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 //! #3187 — geometry jobs must be labelled legacy-aware.
 //!
 //! Split into its own file rather than grown inline: `prepass.rs` is on the

--- a/scripts/add-license-headers.mjs
+++ b/scripts/add-license-headers.mjs
@@ -24,18 +24,17 @@
  * reporting.
  */
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
 
 import {
     licenseHeaderFor,
     hasLicenseHeader,
     withLicenseHeader,
     LICENSE_HEADERS,
-    EXCLUDED_DIRS,
 } from './lib/license-header.mjs';
+import { REPO_ROOT, findFiles } from './lib/license-scan.mjs';
 import { isMainEntry } from './lib/is-main-entry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -93,60 +92,6 @@ function addLicenseHeader(filePath) {
         console.error(`Error writing ${filePath}:`, error.message);
         return FAILED;
     }
-}
-
-// The scan-root entry that means "the repository root itself". `findFiles`
-// scans it non-recursively; see the comment on the `find` command below.
-const REPO_ROOT = '.';
-
-// Returns { files, missingRoots }. A missing scan root used to be a
-// console.warn that the caller could scroll past — the scan would silently
-// continue over whatever roots DID exist, "Found 0 files to process"
-// would print same as a real clean scan, and --check would exit 0 having
-// verified nothing. Callers now decide what to do with missingRoots; both
-// the --check and default paths below treat it as fatal (see the "loudly"
-// comment further down).
-function findFiles(scanRoots, extensions) {
-    const files = [];
-    const missingRoots = [];
-
-    for (const dir of scanRoots) {
-        const fullPath = join(rootDir, dir);
-        if (!existsSync(fullPath)) {
-            missingRoots.push(fullPath);
-            continue;
-        }
-
-        // Use find command to get all files with specified extensions.
-        // The directory exclusions are `EXCLUDED_DIRS`, not a second spelling
-        // of it: `licenseHeaderFor` re-checks them downstream, so a divergence
-        // here would not be a correctness bug — it would be a silent cost,
-        // `find` walking a tree whose every hit is then discarded.
-        //
-        // The repo root is the one root scanned NON-recursively. Every other
-        // root is a subtree of it, so a recursive walk here would re-walk all
-        // of them, double-count every file, and drag in `node_modules`,
-        // `target` and every other build directory besides. `-maxdepth 1` is
-        // placed before `-type f` because BSD `find` (macOS) rejects it as an
-        // option after a primary, while GNU `find` accepts either.
-        const depthLimit = dir === REPO_ROOT ? '-maxdepth 1 ' : '';
-        const extPattern = extensions.map(ext => `-name "*.${ext}"`).join(' -o ');
-        const prunePattern = EXCLUDED_DIRS.map(dir => `! -path "*/${dir}/*"`).join(' ');
-        const findCmd = `find "${fullPath}" ${depthLimit}-type f \\( ${extPattern} \\) ${prunePattern}`;
-
-        try {
-            const output = execSync(findCmd, { encoding: 'utf-8', cwd: rootDir });
-            const foundFiles = output.trim().split('\n').filter(f => f);
-            files.push(...foundFiles);
-        } catch (error) {
-            // find command may return non-zero if no files found, which is okay
-            if (error.status !== 1) {
-                console.error(`Error finding files in ${dir}:`, error.message);
-            }
-        }
-    }
-
-    return { files, missingRoots };
 }
 
 // Everything below runs only when this file is what node was asked to run.
@@ -245,7 +190,7 @@ function main() {
     const extensions = Object.keys(LICENSE_HEADERS);
 
     console.log('Finding source files...');
-    const { files, missingRoots } = findFiles(scanRoots, extensions);
+    const { files, missingRoots, scanErrors } = findFiles(rootDir, scanRoots, extensions);
 
     // A missing scan root means this script's assumptions about the repo
     // layout are stale (wrong cwd, a renamed/moved directory, a restructured
@@ -266,6 +211,25 @@ function main() {
             `\nThis script resolves its scan roots relative to its own location (${rootDir}).\n` +
             'Run it from within the repo, or update the `scanRoots` list above if the repo layout\n' +
             'changed. Refusing to run against a partial/wrong set of roots.'
+        );
+        process.exitCode = 2;
+        return;
+    }
+
+    // A root that EXISTS but could not be enumerated is the same false pass as
+    // one that is missing, and quieter: `find` failing (ENOBUFS on an oversized
+    // result, a permission error, a broken mount) used to be logged and skipped,
+    // so that root contributed zero files and the run still printed a clean
+    // result. Same exit code as a missing root, for the same reason.
+    if (scanErrors.length > 0) {
+        console.error(`\n❌ Could not enumerate scan root${scanErrors.length === 1 ? '' : 's'}:`);
+        for (const { root, message } of scanErrors) {
+            console.error(`  ${root}: ${message}`);
+        }
+        console.error(
+            '\nA root that could not be listed is a root nothing checked. Refusing to report a\n' +
+            'result for the roots that did enumerate, which would announce coverage this run\n' +
+            'does not have.'
         );
         process.exitCode = 2;
         return;

--- a/scripts/add-license-headers.mjs
+++ b/scripts/add-license-headers.mjs
@@ -95,6 +95,10 @@ function addLicenseHeader(filePath) {
     }
 }
 
+// The scan-root entry that means "the repository root itself". `findFiles`
+// scans it non-recursively; see the comment on the `find` command below.
+const REPO_ROOT = '.';
+
 // Returns { files, missingRoots }. A missing scan root used to be a
 // console.warn that the caller could scroll past — the scan would silently
 // continue over whatever roots DID exist, "Found 0 files to process"
@@ -118,9 +122,17 @@ function findFiles(scanRoots, extensions) {
         // of it: `licenseHeaderFor` re-checks them downstream, so a divergence
         // here would not be a correctness bug — it would be a silent cost,
         // `find` walking a tree whose every hit is then discarded.
+        //
+        // The repo root is the one root scanned NON-recursively. Every other
+        // root is a subtree of it, so a recursive walk here would re-walk all
+        // of them, double-count every file, and drag in `node_modules`,
+        // `target` and every other build directory besides. `-maxdepth 1` is
+        // placed before `-type f` because BSD `find` (macOS) rejects it as an
+        // option after a primary, while GNU `find` accepts either.
+        const depthLimit = dir === REPO_ROOT ? '-maxdepth 1 ' : '';
         const extPattern = extensions.map(ext => `-name "*.${ext}"`).join(' -o ');
         const prunePattern = EXCLUDED_DIRS.map(dir => `! -path "*/${dir}/*"`).join(' ');
-        const findCmd = `find "${fullPath}" -type f \\( ${extPattern} \\) ${prunePattern}`;
+        const findCmd = `find "${fullPath}" ${depthLimit}-type f \\( ${extPattern} \\) ${prunePattern}`;
 
         try {
             const output = execSync(findCmd, { encoding: 'utf-8', cwd: rootDir });
@@ -145,7 +157,15 @@ function findFiles(scanRoots, extensions) {
 // `scripts/` — so this file uses it rather than relying on nobody importing
 // it. The classification lib next door is a module boundary, not a substitute
 // for this guard.
-if (isMainEntry(import.meta.url)) {
+//
+// The CLI is a FUNCTION and every branch `return`s after setting
+// `process.exitCode`, never `process.exit()`. `process.exit()` tears the
+// process down without draining stdout, and stdout is a PIPE in CI: writes
+// there are asynchronous, so a long "missing the MPL license header" list can
+// be cut off mid-path while the status still says 1. That list IS this gate's
+// output. Setting `exitCode` and returning lets node flush both streams and
+// leave with the same status.
+function main() {
     // --- CLI flags ---------------------------------------------------------
     // Unknown flags are a hard error, not a silent no-op: this script used to
     // ignore any flag it didn't recognize and fall straight through to the
@@ -158,7 +178,8 @@ if (isMainEntry(import.meta.url)) {
         if (!KNOWN_FLAGS.has(arg)) {
             console.error(`Unknown flag: ${arg}`);
             console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')} (or no flags at all)`);
-            process.exit(1);
+            process.exitCode = 1;
+            return;
         }
     }
     const checkMode = argv.includes('--check');
@@ -179,28 +200,34 @@ if (isMainEntry(import.meta.url)) {
     // `scripts` and `tools` unscanned — 12 headerless files at the time this
     // list was widened, and no signal at all that they were out of scope. The
     // derivation is "every top-level directory that holds first-party source of
-    // a type in `LICENSE_HEADERS`, plus the root-level configs". Re-derived
+    // a type in `LICENSE_HEADERS`, plus the repo root itself". Re-derived
     // when `.mjs`/`.cjs`/`.mts`/`.cts`/`.py` joined that table, because a root
     // list and an extension list are only right TOGETHER: `demo/` (one shell
     // script) and `patches/` (patch files) still hold nothing of any scanned
-    // type and stay out rather than being listed as no-ops, and
-    // `playwright.config.ts` is still the only scanned file at the repo root.
+    // type and stay out rather than being listed as no-ops.
+    //
+    // `REPO_ROOT` replaced a single NAMED root-level file. Naming one file made
+    // the root a list of one nobody would think to extend: a PR adding a second
+    // root-level config of a scanned type got no header check at all, which is
+    // the requirement this gate exists for. The root is scanned by EXTENSION
+    // like every other root, non-recursively so it does not re-walk the ten
+    // below it. It matches exactly the one file the named entry matched, so it
+    // widens what the gate catches tomorrow and moves nothing today.
+    //
     // `.changeset/changelog-resilient.cjs` is the one file of a scanned type
-    // that no root reaches; adding `.changeset` here would put release
-    // machinery inside a source-header gate for one file, so it is left alone
-    // knowingly rather than by omission. An entry may name a FILE as well as a
-    // directory — `find` accepts either — which is how a root-level config is
-    // covered without scanning the repo root and every build directory under it.
+    // that no root reaches (`-maxdepth 1` does not descend into it); adding
+    // `.changeset` here would put release machinery inside a source-header gate
+    // for one file, so it is left alone knowingly rather than by omission.
     //
     // Adding a root that does not exist is a hard exit 2, below, so entries here
     // are checked rather than assumed.
     const scanRoots = [
+        REPO_ROOT,
         'api',
         'apps',
         'docs',
         'examples',
         'packages',
-        'playwright.config.ts',
         'rust',
         'scripts',
         'server',
@@ -240,7 +267,8 @@ if (isMainEntry(import.meta.url)) {
             'Run it from within the repo, or update the `scanRoots` list above if the repo layout\n' +
             'changed. Refusing to run against a partial/wrong set of roots.'
         );
-        process.exit(2);
+        process.exitCode = 2;
+        return;
     }
 
     console.log(`Found ${files.length} files to process`);
@@ -258,7 +286,8 @@ if (isMainEntry(import.meta.url)) {
                 '\n❌ --check scanned 0 files. That is a failed check, not a clean repo — ' +
                 'refusing to report success for a check that verified nothing.'
             );
-            process.exit(2);
+            process.exitCode = 2;
+            return;
         }
 
         // Dry run: report files missing the header, write nothing, and fail CI
@@ -307,7 +336,8 @@ if (isMainEntry(import.meta.url)) {
                 'verified. That is a failed check, not a clean repo — refusing to report success for a check ' +
                 `that did not actually look at ${readErrors.length === 1 ? 'this file' : 'these files'}.`
             );
-            process.exit(2);
+            process.exitCode = 2;
+            return;
         }
 
         if (missing.length > 0) {
@@ -316,11 +346,13 @@ if (isMainEntry(import.meta.url)) {
                 console.log(`  ${file}`);
             }
             console.log(`\n❌ ${missing.length} file(s) missing the license header. Run without --check to add them.`);
-            process.exit(1);
+            process.exitCode = 1;
+            return;
         }
 
         console.log(`\n✅ All files have the license header.`);
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
 
     let added = 0;
@@ -353,8 +385,13 @@ if (isMainEntry(import.meta.url)) {
         for (const file of failures) {
             console.error(`  ${file}`);
         }
-        process.exit(2);
+        process.exitCode = 2;
+        return;
     }
 
     console.log(`\nDone!`);
+}
+
+if (isMainEntry(import.meta.url)) {
+    main();
 }

--- a/scripts/add-license-headers.mjs
+++ b/scripts/add-license-headers.mjs
@@ -3,96 +3,74 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+/**
+ * MPL-2.0 header on every source file (AGENTS.md, "New source files").
+ *
+ * Two modes over the same population:
+ *   node scripts/add-license-headers.mjs           writes the missing headers
+ *   node scripts/add-license-headers.mjs --check   reports them, writes nothing
+ *
+ * `--check` is the gate, and until #4087 NOTHING RAN IT. A mode nobody
+ * invokes cannot be wrong loudly, so it drifted: it exited 1 with 128 files
+ * flagged, 85 of which were correctly licensed under an SPDX identifier it
+ * did not recognise, 16 were generated output that wants exclusion rather
+ * than a header, and its scan list covered four trees out of eleven. It now
+ * runs in the `license-headers` job of .github/workflows/test.yml, whose
+ * `license_headers` path filter is the whole scanned population so the gate
+ * can fire on every tree it reads.
+ *
+ * Classification (which files are in scope, what counts as a declaration) is
+ * `scripts/lib/license-header.mjs`; this file owns the scan, the CLI and the
+ * reporting.
+ */
+
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, relative } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
+
+import {
+    licenseHeaderFor,
+    hasLicenseHeader,
+    withLicenseHeader,
+    LICENSE_HEADERS,
+    EXCLUDED_DIRS,
+} from './lib/license-header.mjs';
+import { isMainEntry } from './lib/is-main-entry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
 
-// License headers by file type
-const LICENSE_HEADERS = {
-    ts: `/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-`,
-    tsx: `/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-`,
-    js: `/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-`,
-    css: `/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-`,
-    rs: `// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-`,
-};
+// Which files must carry a header, which spellings count as one, and which
+// generated trees are exempt all live in `scripts/lib/license-header.mjs`.
+// The split is a module boundary, not a workaround: the lib is a pure
+// classifier over a path and a string, and this file is the I/O around it —
+// the scan, the CLI, the report, the writes. Everything below the
+// `isMainEntry` guard is that outer half, so the two can be read, changed and
+// tested without each other. `scripts/lib/license-header.test.mjs` exercises
+// the classifier directly; the CLI's behaviour is exercised by running it.
 
-// Files to exclude (generated files)
-const EXCLUDED_FILES = [
-    'packages/wasm/ifc_lite_wasm.js',
-    'packages/wasm/ifc_lite_wasm.d.ts',
-    'packages/wasm/ifc_lite_wasm_bg.wasm.d.ts',
-];
-
-// Directories to exclude
-const EXCLUDED_DIRS = ['node_modules', 'dist', 'target'];
-
-function getFileExtension(filePath) {
-    const parts = filePath.split('.');
-    return parts.length > 1 ? parts[parts.length - 1] : null;
+// Repo-relative path, which is the form the classification lib speaks.
+function repoRelative(filePath) {
+    return relative(rootDir, filePath);
 }
 
-function shouldExclude(filePath) {
-    // Check if file is in excluded directories
-    for (const dir of EXCLUDED_DIRS) {
-        if (filePath.includes(`/${dir}/`) || filePath.includes(`\\${dir}\\`)) {
-            return true;
-        }
-    }
-
-    // Check if file is in excluded files list
-    const relativePath = filePath.replace(rootDir + '/', '').replace(rootDir + '\\', '');
-    if (EXCLUDED_FILES.some(excluded => relativePath.includes(excluded))) {
-        return true;
-    }
-
-    return false;
-}
-
-function hasLicenseHeader(content) {
-    // Check if file already has the MPL license header
-    const mplPattern = /This Source Code Form is subject to the terms of the Mozilla Public/i;
-    return mplPattern.test(content);
-}
-
-// Shared by both the write path (addLicenseHeader) and the --check loop
-// below, so the two can't drift on what counts as "a file this script cares
-// about" — duplicating this in --check was itself the same class of bug as
-// the flag-parsing footgun: two copies that quietly stop agreeing.
-function isEligibleFile(filePath) {
-    const ext = getFileExtension(filePath);
-    if (!ext || !LICENSE_HEADERS[ext]) {
-        return null; // Not a file type we handle
-    }
-    if (shouldExclude(filePath)) {
-        return null; // File is excluded
-    }
-    return ext;
-}
+// THREE outcomes, not two. A boolean folded "I wrote a header", "nothing to
+// do here" and "I could not read/write this file" into false-or-true, so the
+// write loop counted an I/O failure as a skip: the run printed `Error writing
+// ...` on stderr, then `Errors: 0`, then exited 0. That is the same false-pass
+// shape --check spends a distinct exit code 2 avoiding, on the mode that
+// actually mutates files. Callers must be able to tell the third case apart,
+// so it is in the return type.
+const ADDED = 'added';
+const SKIPPED = 'skipped';
+const FAILED = 'failed';
 
 function addLicenseHeader(filePath) {
-    const ext = isEligibleFile(filePath);
-    if (!ext) {
-        return false;
+    const rel = repoRelative(filePath);
+    if (licenseHeaderFor(rel) === null) {
+        return SKIPPED;
     }
 
     let content;
@@ -100,49 +78,49 @@ function addLicenseHeader(filePath) {
         content = readFileSync(filePath, 'utf-8');
     } catch (error) {
         console.error(`Error reading ${filePath}:`, error.message);
-        return false;
+        return FAILED;
     }
 
-    // Skip if already has license header
-    if (hasLicenseHeader(content)) {
-        return false;
+    const updated = withLicenseHeader(rel, content);
+    if (updated === null) {
+        return SKIPPED; // already declares MPL-2.0
     }
-
-    const header = LICENSE_HEADERS[ext];
-
-    // Add header with a blank line after it
-    const newContent = header + '\n' + content;
 
     try {
-        writeFileSync(filePath, newContent, 'utf-8');
-        return true;
+        writeFileSync(filePath, updated, 'utf-8');
+        return ADDED;
     } catch (error) {
         console.error(`Error writing ${filePath}:`, error.message);
-        return false;
+        return FAILED;
     }
 }
 
-// Returns { files, missingDirs }. A missing directory used to be a
+// Returns { files, missingRoots }. A missing scan root used to be a
 // console.warn that the caller could scroll past — the scan would silently
-// continue over whatever directories DID exist, "Found 0 files to process"
+// continue over whatever roots DID exist, "Found 0 files to process"
 // would print same as a real clean scan, and --check would exit 0 having
-// verified nothing. Callers now decide what to do with missingDirs; both
+// verified nothing. Callers now decide what to do with missingRoots; both
 // the --check and default paths below treat it as fatal (see the "loudly"
 // comment further down).
-function findFiles(directories, extensions) {
+function findFiles(scanRoots, extensions) {
     const files = [];
-    const missingDirs = [];
+    const missingRoots = [];
 
-    for (const dir of directories) {
+    for (const dir of scanRoots) {
         const fullPath = join(rootDir, dir);
         if (!existsSync(fullPath)) {
-            missingDirs.push(fullPath);
+            missingRoots.push(fullPath);
             continue;
         }
 
-        // Use find command to get all files with specified extensions
+        // Use find command to get all files with specified extensions.
+        // The directory exclusions are `EXCLUDED_DIRS`, not a second spelling
+        // of it: `licenseHeaderFor` re-checks them downstream, so a divergence
+        // here would not be a correctness bug — it would be a silent cost,
+        // `find` walking a tree whose every hit is then discarded.
         const extPattern = extensions.map(ext => `-name "*.${ext}"`).join(' -o ');
-        const findCmd = `find "${fullPath}" -type f \\( ${extPattern} \\) ! -path "*/node_modules/*" ! -path "*/dist/*" ! -path "*/target/*"`;
+        const prunePattern = EXCLUDED_DIRS.map(dir => `! -path "*/${dir}/*"`).join(' ');
+        const findCmd = `find "${fullPath}" -type f \\( ${extPattern} \\) ${prunePattern}`;
 
         try {
             const output = execSync(findCmd, { encoding: 'utf-8', cwd: rootDir });
@@ -156,164 +134,227 @@ function findFiles(directories, extensions) {
         }
     }
 
-    return { files, missingDirs };
+    return { files, missingRoots };
 }
 
-// --- CLI flags -------------------------------------------------------------
-// Unknown flags are a hard error, not a silent no-op: this script used to
-// ignore any flag it didn't recognize and fall straight through to the
-// default (write) behavior below, so a typo'd or not-yet-implemented flag
-// (e.g. `--check` before this mode existed) would silently rewrite every
-// source file in the repo instead of doing what the caller asked.
-const KNOWN_FLAGS = new Set(['--check']);
-const argv = process.argv.slice(2);
-for (const arg of argv) {
-    if (!KNOWN_FLAGS.has(arg)) {
-        console.error(`Unknown flag: ${arg}`);
-        console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')} (or no flags at all)`);
-        process.exit(1);
+// Everything below runs only when this file is what node was asked to run.
+// Without the guard, importing this module — a test, a tool, an editor's
+// module graph — would scan the repo and, in the default mode, WRITE to every
+// file missing a header. `scripts/lib/is-main-entry.mjs` is the repo's
+// standard answer to that — it has its own test and callers throughout
+// `scripts/` — so this file uses it rather than relying on nobody importing
+// it. The classification lib next door is a module boundary, not a substitute
+// for this guard.
+if (isMainEntry(import.meta.url)) {
+    // --- CLI flags ---------------------------------------------------------
+    // Unknown flags are a hard error, not a silent no-op: this script used to
+    // ignore any flag it didn't recognize and fall straight through to the
+    // default (write) behavior below, so a typo'd or not-yet-implemented flag
+    // (e.g. `--check` before this mode existed) would silently rewrite every
+    // source file in the repo instead of doing what the caller asked.
+    const KNOWN_FLAGS = new Set(['--check']);
+    const argv = process.argv.slice(2);
+    for (const arg of argv) {
+        if (!KNOWN_FLAGS.has(arg)) {
+            console.error(`Unknown flag: ${arg}`);
+            console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')} (or no flags at all)`);
+            process.exit(1);
+        }
     }
-}
-const checkMode = argv.includes('--check');
+    const checkMode = argv.includes('--check');
 
-// Main execution
-//
-// `prototype/src` was removed here (not in the `directories` list below): it
-// hasn't existed in the repo since the initial-structure commit, but the
-// missing-directory check used to be a console.warn the write path quietly
-// continued past, so this went unnoticed until the check above started
-// treating it as fatal — exactly the kind of drift the missing-directory
-// check exists to catch.
-const directories = [
-    'apps/viewer/src',
-    'packages',
-    'rust',
-    'tests',
-];
+    // Main execution
+    //
+    // `prototype/src` was removed here (not in the `scanRoots` list below): it
+    // hasn't existed in the repo since the initial-structure commit, but the
+    // missing-root check used to be a console.warn the write path quietly
+    // continued past, so this went unnoticed until the check above started
+    // treating it as fatal — exactly the kind of drift the missing-root check
+    // exists to catch.
+    //
+    // EVERY first-party source tree, not a subset (#4087). The old list was
+    // `apps/viewer/src`, `packages`, `rust`, `tests`, which left `apps/server`,
+    // `apps/viewer-embed`, `apps/landing`, everything in `apps/viewer` outside
+    // `src/` (its vite config and plugins), `examples`, `docs`, `api`, `server`,
+    // `scripts` and `tools` unscanned — 12 headerless files at the time this
+    // list was widened, and no signal at all that they were out of scope. The
+    // derivation is "every top-level directory that holds first-party source of
+    // a type in `LICENSE_HEADERS`, plus the root-level configs". Re-derived
+    // when `.mjs`/`.cjs`/`.mts`/`.cts`/`.py` joined that table, because a root
+    // list and an extension list are only right TOGETHER: `demo/` (one shell
+    // script) and `patches/` (patch files) still hold nothing of any scanned
+    // type and stay out rather than being listed as no-ops, and
+    // `playwright.config.ts` is still the only scanned file at the repo root.
+    // `.changeset/changelog-resilient.cjs` is the one file of a scanned type
+    // that no root reaches; adding `.changeset` here would put release
+    // machinery inside a source-header gate for one file, so it is left alone
+    // knowingly rather than by omission. An entry may name a FILE as well as a
+    // directory — `find` accepts either — which is how a root-level config is
+    // covered without scanning the repo root and every build directory under it.
+    //
+    // Adding a root that does not exist is a hard exit 2, below, so entries here
+    // are checked rather than assumed.
+    const scanRoots = [
+        'api',
+        'apps',
+        'docs',
+        'examples',
+        'packages',
+        'playwright.config.ts',
+        'rust',
+        'scripts',
+        'server',
+        'tests',
+        'tools',
+    ];
 
-const extensions = ['ts', 'tsx', 'js', 'css', 'rs'];
+    // DERIVED from the classifier, never restated. `findFiles` only hands
+    // `licenseHeaderFor` the files whose extension is in this list, so a second
+    // copy drifts in the direction that says nothing: add a key to
+    // `LICENSE_HEADERS` without editing the copy and those files are never
+    // surfaced, the classifier never runs on them, and `--check` reports a clean
+    // repo it did not look at. Deriving it makes that impossible rather than
+    // merely unlikely.
+    const extensions = Object.keys(LICENSE_HEADERS);
 
-console.log('Finding source files...');
-const { files, missingDirs } = findFiles(directories, extensions);
+    console.log('Finding source files...');
+    const { files, missingRoots } = findFiles(scanRoots, extensions);
 
-// A missing target directory means this script's assumptions about the repo
-// layout are stale (wrong cwd, a renamed/moved directory, a restructured
-// `packages/`, ...). Silently scanning whatever subset of directories DID
-// exist — possibly zero of them — and reporting that as a normal result is
-// exactly the false-pass failure mode this script must not have: --check
-// exiting 0 having verified nothing, or the default path "adding headers"
-// to nothing while believing it covered the repo. Fatal in BOTH modes,
-// deliberately, not just --check: a partial write is just as misleading as
-// a partial check, it's only less visible because nothing consumes its
-// exit code today.
-if (missingDirs.length > 0) {
-    console.error(`\n❌ Expected director${missingDirs.length === 1 ? 'y' : 'ies'} not found:`);
-    for (const dir of missingDirs) {
-        console.error(`  ${dir}`);
-    }
-    console.error(
-        `\nThis script resolves its target directories relative to its own location (${rootDir}).\n` +
-        'Run it from within the repo, or update the `directories` list above if the repo layout\n' +
-        'changed. Refusing to run against a partial/wrong set of directories.'
-    );
-    process.exit(2);
-}
-
-console.log(`Found ${files.length} files to process`);
-
-if (checkMode) {
-    // Zero files scanned is not a clean repo — it's a check that verified
-    // nothing, and reporting success for it would be the same false-pass
-    // bug as the missing-directory case above, just triggered a different
-    // way (e.g. the extensions list stops matching anything). Distinct exit
-    // code AND distinct wording from "files are missing headers" below:
-    // this is "the check could not run", not "the check ran and found a
-    // problem to fix".
-    if (files.length === 0) {
+    // A missing scan root means this script's assumptions about the repo
+    // layout are stale (wrong cwd, a renamed/moved directory, a restructured
+    // `packages/`, ...). Silently scanning whatever subset of roots DID
+    // exist — possibly zero of them — and reporting that as a normal result is
+    // exactly the false-pass failure mode this script must not have: --check
+    // exiting 0 having verified nothing, or the default path "adding headers"
+    // to nothing while believing it covered the repo. Fatal in BOTH modes,
+    // deliberately, not just --check: a partial write is just as misleading as
+    // a partial check, it's only less visible because nothing consumes its
+    // exit code today.
+    if (missingRoots.length > 0) {
+        console.error(`\n❌ Expected scan root${missingRoots.length === 1 ? '' : 's'} not found:`);
+        for (const dir of missingRoots) {
+            console.error(`  ${dir}`);
+        }
         console.error(
-            '\n❌ --check scanned 0 files. That is a failed check, not a clean repo — ' +
-            'refusing to report success for a check that verified nothing.'
+            `\nThis script resolves its scan roots relative to its own location (${rootDir}).\n` +
+            'Run it from within the repo, or update the `scanRoots` list above if the repo layout\n' +
+            'changed. Refusing to run against a partial/wrong set of roots.'
         );
         process.exit(2);
     }
 
-    // Dry run: report files missing the header, write nothing, and fail CI
-    // if any are found.
-    const missing = [];
-    // A file that fails to read (permissions, a race with a deleting process,
-    // a broken symlink, ...) was previously `continue`d past silently: not
-    // added to `missing`, not counted in `excluded` either, so it still
-    // landed in the `files.length - excluded` "Checked" total below and the
-    // run could print "All files have the license header" having actually
-    // never looked at that file's content — the same false-pass class as the
-    // zero-files-scanned case above, just one file at a time instead of the
-    // whole scan. Track it separately and fail loudly instead.
-    const readErrors = [];
-    let excluded = 0;
+    console.log(`Found ${files.length} files to process`);
+
+    if (checkMode) {
+        // Zero files scanned is not a clean repo — it's a check that verified
+        // nothing, and reporting success for it would be the same false-pass
+        // bug as the missing-root case above, just triggered a different
+        // way (e.g. the extensions list stops matching anything). Distinct exit
+        // code AND distinct wording from "files are missing headers" below:
+        // this is "the check could not run", not "the check ran and found a
+        // problem to fix".
+        if (files.length === 0) {
+            console.error(
+                '\n❌ --check scanned 0 files. That is a failed check, not a clean repo — ' +
+                'refusing to report success for a check that verified nothing.'
+            );
+            process.exit(2);
+        }
+
+        // Dry run: report files missing the header, write nothing, and fail CI
+        // if any are found.
+        const missing = [];
+        // A file that fails to read (permissions, a race with a deleting process,
+        // a broken symlink, ...) was previously `continue`d past silently: not
+        // added to `missing`, not counted in `excluded` either, so it still
+        // landed in the `files.length - excluded` "Checked" total below and the
+        // run could print "All files have the license header" having actually
+        // never looked at that file's content — the same false-pass class as the
+        // zero-files-scanned case above, just one file at a time instead of the
+        // whole scan. Track it separately and fail loudly instead.
+        const readErrors = [];
+        let excluded = 0;
+
+        for (const file of files) {
+            if (licenseHeaderFor(repoRelative(file)) === null) {
+                excluded++;
+                continue;
+            }
+
+            let content;
+            try {
+                content = readFileSync(file, 'utf-8');
+            } catch (error) {
+                console.error(`Error reading ${file}:`, error.message);
+                readErrors.push(file);
+                continue;
+            }
+
+            if (!hasLicenseHeader(content)) {
+                missing.push(file);
+            }
+        }
+
+        console.log(`\nResults:`);
+        console.log(`  Checked: ${files.length - excluded - readErrors.length}`);
+        console.log(`  Excluded: ${excluded}`);
+        console.log(`  Unreadable: ${readErrors.length}`);
+        console.log(`  Missing header: ${missing.length}`);
+
+        if (readErrors.length > 0) {
+            console.error(
+                `\n❌ ${readErrors.length} file(s) could not be read, so their license header could not be ` +
+                'verified. That is a failed check, not a clean repo — refusing to report success for a check ' +
+                `that did not actually look at ${readErrors.length === 1 ? 'this file' : 'these files'}.`
+            );
+            process.exit(2);
+        }
+
+        if (missing.length > 0) {
+            console.log(`\nFiles missing the MPL license header:`);
+            for (const file of missing) {
+                console.log(`  ${file}`);
+            }
+            console.log(`\n❌ ${missing.length} file(s) missing the license header. Run without --check to add them.`);
+            process.exit(1);
+        }
+
+        console.log(`\n✅ All files have the license header.`);
+        process.exit(0);
+    }
+
+    let added = 0;
+    let skipped = 0;
+    const failures = [];
 
     for (const file of files) {
-        const ext = isEligibleFile(file);
-        if (!ext) {
-            excluded++;
-            continue;
-        }
-
-        let content;
-        try {
-            content = readFileSync(file, 'utf-8');
-        } catch (error) {
-            console.error(`Error reading ${file}:`, error.message);
-            readErrors.push(file);
-            continue;
-        }
-
-        if (!hasLicenseHeader(content)) {
-            missing.push(file);
-        }
+        const outcome = addLicenseHeader(file);
+        if (outcome === ADDED) added++;
+        else if (outcome === SKIPPED) skipped++;
+        else failures.push(file);
     }
 
     console.log(`\nResults:`);
-    console.log(`  Checked: ${files.length - excluded - readErrors.length}`);
-    console.log(`  Excluded: ${excluded}`);
-    console.log(`  Unreadable: ${readErrors.length}`);
-    console.log(`  Missing header: ${missing.length}`);
+    console.log(`  Added headers: ${added}`);
+    console.log(`  Skipped (already have header or excluded): ${skipped}`);
+    console.log(`  Errors: ${failures.length}`);
 
-    if (readErrors.length > 0) {
+    // Same verdict --check gives an unreadable file, on the mode that writes:
+    // a file this run could not read or could not write does NOT have a
+    // header, and reporting `Errors: 0` and exiting 0 over it would be the
+    // false pass this script exists to stop. `errors` used to be a `let` that
+    // nothing ever incremented, so that is exactly what it did.
+    if (failures.length > 0) {
         console.error(
-            `\n❌ ${readErrors.length} file(s) could not be read, so their license header could not be ` +
-            'verified. That is a failed check, not a clean repo — refusing to report success for a check ' +
-            `that did not actually look at ${readErrors.length === 1 ? 'this file' : 'these files'}.`
+            `\n❌ ${failures.length} file(s) could not be read or written, so their license header ` +
+            'was not added. That is a failed run, not a clean repo — refusing to report success for ' +
+            `${failures.length === 1 ? 'a file' : 'files'} this run did not actually header.`
         );
+        for (const file of failures) {
+            console.error(`  ${file}`);
+        }
         process.exit(2);
     }
 
-    if (missing.length > 0) {
-        console.log(`\nFiles missing the MPL license header:`);
-        for (const file of missing) {
-            console.log(`  ${file}`);
-        }
-        console.log(`\n❌ ${missing.length} file(s) missing the license header. Run without --check to add them.`);
-        process.exit(1);
-    }
-
-    console.log(`\n✅ All files have the license header.`);
-    process.exit(0);
+    console.log(`\nDone!`);
 }
-
-let added = 0;
-let skipped = 0;
-let errors = 0;
-
-for (const file of files) {
-    if (addLicenseHeader(file)) {
-        added++;
-    } else {
-        skipped++;
-    }
-}
-
-console.log(`\nResults:`);
-console.log(`  Added headers: ${added}`);
-console.log(`  Skipped (already have header or excluded): ${skipped}`);
-console.log(`  Errors: ${errors}`);
-console.log(`\nDone!`);

--- a/scripts/check-ci-path-coverage.mjs
+++ b/scripts/check-ci-path-coverage.mjs
@@ -109,6 +109,9 @@ const REQUIRED_COVERAGE = [
   ['scripts/docs/generate-docs-sections.mjs', 'tests/benchmark/baseline.json'],
   ['scripts/docs/generate-docs-sections.mjs', 'apps/landing/app.jsx'],
   ['scripts/docs/generate-docs-sections.mjs', 'apps/landing/bench-data.json'],
+  // The license-header gate scans the repo ROOT by extension, and the
+  // derivation cannot see that: the root literal '.' is NOT_AN_INPUT.
+  ['scripts/add-license-headers.mjs', 'playwright.config.ts'],
 ];
 
 const failures = [];

--- a/scripts/fixtures/build-manifest.mjs
+++ b/scripts/fixtures/build-manifest.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 // Build tests/models/manifest.json by walking the working tree under
 // tests/models/. Recognised fixture types: .ifc, .IFC, .ifcx.
 //

--- a/scripts/fixtures/fetch-fixtures.mjs
+++ b/scripts/fixtures/fetch-fixtures.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 // Fetch test fixtures listed in tests/models/manifest.json.
 //
 // Usage:

--- a/scripts/fixtures/upload-fixtures.mjs
+++ b/scripts/fixtures/upload-fixtures.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 // One-time / on-demand uploader for fixture assets.
 //
 // Usage:

--- a/scripts/lib/license-header.mjs
+++ b/scripts/lib/license-header.mjs
@@ -144,13 +144,13 @@ const MPL_SPDX_RE = /SPDX-License-Identifier:\s*MPL-2\.0/i;
 /**
  * How many leading lines count as "the header".
  *
- * MEASURED, not picked: across the 5318 in-scope files, the deepest a real
+ * MEASURED, not picked: across the 5323 in-scope files, the deepest a real
  * header starts is line 8 (`scripts/test-geometry-regression.mjs` and
- * `-reference.mjs`, whose notice sits at the end of a leading doc comment),
- * while the shallowest occurrence that is EMITTED DATA rather than a header is
- * line 18 (`packages/codegen/src/type-ids-generator.ts`, inside a template
- * literal). 10 is between the two: every file accepted today is still
- * accepted, and the nearest false accept is 8 lines out of reach.
+ * `-reference.mjs`, whose notice sits at the end of a leading doc comment).
+ * 10 leaves two lines of slack over that and is the SECOND of the two
+ * conditions below, not the only one — `leadingCommentText` already rejects
+ * emitted data at any depth, so this bound is what stops a long banner comment
+ * from being read as a header hundreds of lines into a file.
  */
 const HEADER_SCAN_LINES = 10;
 
@@ -166,23 +166,92 @@ function leadingLines(content) {
 }
 
 /**
- * Does this file already declare MPL-2.0, in either accepted spelling, AT THE
- * TOP?
+ * The COMMENT text of the leading comment block, with everything else dropped.
  *
- * Scoped to the leading lines rather than the whole text, because the whole
- * text says yes to a file whose only occurrence of the notice is emitted DATA
- * — a template literal, a fixture string, a docstring. `packages/codegen/src`
- * holds 4 such files today (`generator.ts:118`, `serialization-generator.ts:22`,
- * `type-ids-generator.ts:18`, `rust-generator.ts:40`), and every one of them
- * also carries a real header on line 1, so nothing in the repo relies on the
- * late match. A NEW sibling generator without a top header would have been
- * waved through by the gate meant to catch exactly that.
+ * The leading block is what you get after an optional shebang and before the
+ * first non-comment, non-blank line. Blank lines do not end it (a shebang, a
+ * blank, then the notice is a real header); the first line of actual code
+ * does.
+ *
+ * Three comment forms are recognised, which is every form the headered file
+ * types use: `/* … *\/`, `//`, and `#`. `#` is what makes the Python form a
+ * comment, and it also covers a shebang line, so there is no separate case for
+ * one. That `#` is NOT a comment marker in the JS/TS family, and opens an
+ * attribute rather than a comment in Rust, only ever widens what counts as a
+ * comment — the safe direction for a detector whose false REJECTS demand a
+ * second header on a correctly-licensed file. Measured over the whole repo:
+ * widening it this way flips nothing.
+ *
+ * @param {string} head the leading lines of a file
+ * @returns {string} the comment text of the leading block, `''` when there is none
+ */
+function leadingCommentText(head) {
+    const lines = head.split('\n');
+    const comment = [];
+    let inBlock = false;
+
+    for (const line of lines) {
+        let rest = line;
+        for (;;) {
+            if (inBlock) {
+                const close = rest.indexOf('*/');
+                if (close === -1) {
+                    comment.push(rest);
+                    break;
+                }
+                comment.push(rest.slice(0, close));
+                rest = rest.slice(close + 2);
+                inBlock = false;
+                continue;
+            }
+
+            const trimmed = rest.trim();
+            if (trimmed === '') break;               // blank line: the block continues
+            if (trimmed.startsWith('//') || trimmed.startsWith('#')) {
+                comment.push(trimmed);
+                break;
+            }
+            if (trimmed.startsWith('/*')) {
+                inBlock = true;
+                rest = trimmed.slice(2);
+                continue;
+            }
+            return comment.join('\n');              // first line of real code
+        }
+    }
+
+    return comment.join('\n');
+}
+
+/**
+ * Does this file already declare MPL-2.0, in either accepted spelling, in its
+ * LEADING COMMENT?
+ *
+ * TWO conditions, and the first is the one that matters: the notice has to sit
+ * inside the leading comment block, not merely somewhere near the top. Reading
+ * the leading lines as unparsed TEXT says yes to a file whose only occurrence
+ * of the notice is DATA — a fixture string, a template literal, a docstring —
+ * and a header gate that a string literal satisfies is not enforcing anything.
+ * Both of these were accepted by the text-only form:
+ *
+ *   export const fixture = "SPDX-License-Identifier: MPL-2.0";
+ *   const s = "This Source Code Form is subject to the terms of the Mozilla Public";
+ *
+ * ...and the same shape one line further in is what `packages/codegen/src`
+ * already holds four times over (`generator.ts:118`,
+ * `serialization-generator.ts:22`, `type-ids-generator.ts:18`,
+ * `rust-generator.ts:40`). Every one of those files also carries a real header
+ * on line 1, so nothing in the repo relies on the data match: measured over
+ * the whole scanned population, requiring a real comment flips no file's
+ * verdict.
+ *
+ * The second condition is `HEADER_SCAN_LINES`, above.
  *
  * @param {string} content the file's text; only its first 10 lines are read
  * @returns {boolean}
  */
 export function hasLicenseHeader(content) {
-    const head = leadingLines(content);
+    const head = leadingCommentText(leadingLines(content));
     return MPL_PROSE_RE.test(head) || MPL_SPDX_RE.test(head);
 }
 
@@ -248,8 +317,13 @@ export function licenseHeaderFor(relativePath) {
  * the same reason `.rs` is — `#!` is not a shebang there either. A type added
  * to `LICENSE_HEADERS` and not considered here gets the safe answer, a header
  * on line 1, which is what every non-shebang file in the repo already has.
+ *
+ * A deliberate SUBSET of `LICENSE_HEADERS`, so it cannot be derived from it
+ * the way the scan's extension list is. `license-header.test.mjs` asserts the
+ * subset instead: an entry here that is not a key there is a typo or an
+ * orphan, and it would mean "never shebang-aware" in silence.
  */
-const SHEBANG_EXTENSIONS = new Set(['js', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts', 'py']);
+export const SHEBANG_EXTENSIONS = new Set(['js', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts', 'py']);
 
 /**
  * The file's contents with a header inserted, or `null` when nothing should

--- a/scripts/lib/license-header.mjs
+++ b/scripts/lib/license-header.mjs
@@ -1,0 +1,287 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What counts as an MPL-2.0 declaration, and which files have to carry one.
+ *
+ * This is the classification half of `scripts/add-license-headers.mjs`. The
+ * split is a module boundary: everything here is a pure function of a path
+ * and a string, while the script next door owns the scan, the CLI, the report
+ * and the writes. Nothing here touches the filesystem — callers hand it a
+ * repo-relative path and, where relevant, the file's contents — which is what
+ * lets `license-header.test.mjs` exercise the rules themselves at unit speed,
+ * with no repo to walk and nothing to undo afterwards.
+ *
+ * The rule the whole gate turns on (#4087): TWO spellings declare MPL-2.0 and
+ * both are in this tree — the prose notice `add-license-headers.mjs` writes,
+ * and the one-line SPDX identifier that `rust/export` uses throughout.
+ * Matching only the prose form is what kept `--check` unusable: it reported
+ * 85 correctly-licensed SPDX files as missing a header, and the write path
+ * would have stacked a prose header on top of a valid SPDX line in every one
+ * of them. Keep the two spellings together HERE; a second copy of either
+ * regex elsewhere is how they silently diverge again.
+ */
+
+/**
+ * The notice itself, once. Every accepted header is this text in one comment
+ * syntax or another, so it lives here as data rather than as one transcription
+ * per extension. Ten copies of the same three lines can drift a word apart
+ * while every one of them still looks right in isolation, and the gate's whole
+ * job is that this wording is the same everywhere.
+ */
+const NOTICE = [
+    'This Source Code Form is subject to the terms of the Mozilla Public',
+    'License, v. 2.0. If a copy of the MPL was not distributed with this',
+    'file, You can obtain one at https://mozilla.org/MPL/2.0/.',
+];
+
+/** C-family block comment: `/* … *\/`. */
+function blockComment(notice) {
+    return `/* ${notice.join('\n * ')} */\n`;
+}
+
+/** One comment line per notice line, behind `marker`. */
+function lineComment(marker, notice) {
+    return notice.map(line => `${marker} ${line}`).join('\n') + '\n';
+}
+
+const BLOCK = blockComment(NOTICE);
+const SLASH_LINES = lineComment('//', NOTICE);
+const HASH_LINES = lineComment('#', NOTICE);
+
+/**
+ * License headers by file extension. The KEYS are the scan population:
+ * `scripts/add-license-headers.mjs` derives its `find` extension list from
+ * them, so a type added here is scanned from that moment, and a type absent
+ * here is a type this repo does not header.
+ *
+ * `.mjs`/`.cjs`/`.mts`/`.cts` and `.py` are here because leaving them out was
+ * the same defect as the four-tree scan list this gate already fixed, one
+ * level down: the roots said `scripts/` and `tools/` while the extensions said
+ * `.ts`, so the gate read 13 of `scripts/`'s 312 code files, `tools/` was a
+ * scan root that matched nothing at all, and `scripts/lib/license-header.mjs`
+ * — this file, where the gate's own classification lives — was not checked by
+ * the gate. The convention was never in doubt, only the enforcement: 334 of
+ * the repo's 343 `.mjs`/`.cjs`/`.mts`/`.cts` files and all 13 of its `.py`
+ * files already carried a header, so widening the table cost 8 prepends and
+ * zero argument.
+ */
+export const LICENSE_HEADERS = {
+    ts: BLOCK,
+    tsx: BLOCK,
+    js: BLOCK,
+    mjs: BLOCK,
+    cjs: BLOCK,
+    mts: BLOCK,
+    cts: BLOCK,
+    css: BLOCK,
+    rs: SLASH_LINES,
+    // Derived from what the 13 tracked `.py` files already use, byte for
+    // byte, not invented here: all 13 agree on this exact `#` form.
+    py: HASH_LINES,
+};
+
+/** Directory NAMES excluded wherever they appear in a path. */
+export const EXCLUDED_DIRS = ['node_modules', 'dist', 'target'];
+
+/**
+ * Generated output: never headered, because a header here is either discarded
+ * by the next regeneration or actively breaks a freshness gate. A trailing
+ * `/` makes an entry a directory prefix; anything else is an exact
+ * repo-relative path.
+ *
+ * (The three entries this replaced — `packages/wasm/ifc_lite_wasm.js`,
+ * `.d.ts`, `_bg.wasm.d.ts` — named a layout wasm-pack stopped producing, so
+ * they had excluded nothing for as long as the current `pkg/` layout has
+ * existed. Directory prefixes are used here so the list cannot go stale one
+ * filename at a time the same way.)
+ */
+export const EXCLUDED_PATHS = [
+    // wasm-pack output. Only `pkg/ifc-lite.d.ts` is committed (force-added
+    // past wasm-pack's own `pkg/.gitignore`); the rest is gitignored build
+    // product that `scripts/build-wasm.sh` leaves on disk, and `find` walks
+    // it anyway because it is neither `dist/` nor `target/`.
+    //
+    // ALL FIVE wasm-pack out-dirs under a scan root, not the two that happen
+    // to be built by default. CI builds none of them, so a partial list is
+    // invisible there and only bites a developer who ran the build: `--check`
+    // then lists generated files as missing a header, and the write path
+    // stamps MPL notices into wasm-pack's output. Each path is the `--out-dir`
+    // its build script passes, read off the script rather than guessed —
+    // `scripts/build-wasm.sh:84` (`pkg`), `:140` (`pkg-threaded`), `:208`
+    // (`pkg-wide`, behind `BUILD_WIDE=1`), and `rust/csg-thread-bench/build.sh`
+    // `:20`/`:21`, whose `web/pkg-plain` and `web/pkg-threaded` are relative to
+    // the script's own directory (it `cd`s there on line 19).
+    'packages/wasm/pkg/',
+    'packages/wasm/pkg-threaded/',
+    'packages/wasm/pkg-wide/',
+    'rust/csg-thread-bench/web/pkg-plain/',
+    'rust/csg-thread-bench/web/pkg-threaded/',
+    // EXPRESS-schema codegen output. `scripts/check-codegen-sync.mjs`
+    // BYTE-COMPARES these against a fresh run of the real generator, so a
+    // header prepended here is not merely pointless — it fails that gate.
+    // The generators are `packages/codegen`'s `generate:ifc4` /
+    // `generate:ifc4x3`, plus the parser's committed mirror of the IFC4 half
+    // (`packages/codegen/INTEGRATION.md`). Measured while excluding these:
+    // those templates emit the MPL header on 4 of their 9 outputs each
+    // (index, serializers, test-compile, type-ids) and omit it on the other
+    // 5 (entities, enums, schema-registry, selects, types). Excluding the
+    // tree freezes that inconsistency rather than fixing it — the fix is in
+    // the codegen TEMPLATES plus a regeneration, which is a different change
+    // from this one and is not attempted here.
+    'packages/codegen/generated/',
+    'packages/parser/src/generated/',
+    // NOT excluded, deliberately: `packages/data/src/ifc-schema/generated/`
+    // is byte-compared by that same gate, but ITS generator writes the MPL
+    // header into every file it emits, so those files already pass and need
+    // no exemption. An exemption would only hide it if that ever stopped.
+];
+
+const MPL_PROSE_RE = /This Source Code Form is subject to the terms of the Mozilla Public/i;
+const MPL_SPDX_RE = /SPDX-License-Identifier:\s*MPL-2\.0/i;
+
+/**
+ * How many leading lines count as "the header".
+ *
+ * MEASURED, not picked: across the 5318 in-scope files, the deepest a real
+ * header starts is line 8 (`scripts/test-geometry-regression.mjs` and
+ * `-reference.mjs`, whose notice sits at the end of a leading doc comment),
+ * while the shallowest occurrence that is EMITTED DATA rather than a header is
+ * line 18 (`packages/codegen/src/type-ids-generator.ts`, inside a template
+ * literal). 10 is between the two: every file accepted today is still
+ * accepted, and the nearest false accept is 8 lines out of reach.
+ */
+const HEADER_SCAN_LINES = 10;
+
+/** The first `HEADER_SCAN_LINES` lines of `content`, or all of it if shorter. */
+function leadingLines(content) {
+    let end = 0;
+    for (let n = 0; n < HEADER_SCAN_LINES; n++) {
+        const next = content.indexOf('\n', end);
+        if (next === -1) return content;
+        end = next + 1;
+    }
+    return content.slice(0, end);
+}
+
+/**
+ * Does this file already declare MPL-2.0, in either accepted spelling, AT THE
+ * TOP?
+ *
+ * Scoped to the leading lines rather than the whole text, because the whole
+ * text says yes to a file whose only occurrence of the notice is emitted DATA
+ * — a template literal, a fixture string, a docstring. `packages/codegen/src`
+ * holds 4 such files today (`generator.ts:118`, `serialization-generator.ts:22`,
+ * `type-ids-generator.ts:18`, `rust-generator.ts:40`), and every one of them
+ * also carries a real header on line 1, so nothing in the repo relies on the
+ * late match. A NEW sibling generator without a top header would have been
+ * waved through by the gate meant to catch exactly that.
+ *
+ * @param {string} content the file's text; only its first 10 lines are read
+ * @returns {boolean}
+ */
+export function hasLicenseHeader(content) {
+    const head = leadingLines(content);
+    return MPL_PROSE_RE.test(head) || MPL_SPDX_RE.test(head);
+}
+
+function extensionOf(relativePath) {
+    const base = relativePath.slice(relativePath.lastIndexOf('/') + 1);
+    const dot = base.lastIndexOf('.');
+    return dot > -1 ? base.slice(dot + 1) : null;
+}
+
+/**
+ * The header this file would have to carry, or `null` when the file is out of
+ * scope — a type this repo does not header, or generated/vendored output.
+ *
+ * Both the `--check` loop and the write path go through this one function, so
+ * they cannot drift on what counts as "a file this script cares about".
+ *
+ * @param {string} relativePath repo-relative, `/`-separated (or Windows `\`)
+ * @returns {string | null}
+ */
+export function licenseHeaderFor(relativePath) {
+    const normalized = relativePath.replace(/\\/g, '/');
+
+    const ext = extensionOf(normalized);
+    if (!ext || !Object.hasOwn(LICENSE_HEADERS, ext)) return null;
+
+    // Match whole path SEGMENTS, so a directory called `distribution` is not
+    // swallowed by the `dist` entry.
+    const segments = normalized.split('/');
+    if (segments.some(segment => EXCLUDED_DIRS.includes(segment))) return null;
+
+    // Anchored (prefix for a directory entry, equality for a file) rather
+    // than a substring test: a substring test would also exclude
+    // `vendor/packages/wasm/pkg/x.ts`, and an exclusion that matches more
+    // than it names is how a header gate goes quiet without saying so.
+    const excluded = EXCLUDED_PATHS.some(entry =>
+        entry.endsWith('/') ? normalized.startsWith(entry) : normalized === entry);
+    if (excluded) return null;
+
+    return LICENSE_HEADERS[ext];
+}
+
+/**
+ * File types where a leading `#!` is a shebang, so the header goes UNDER it.
+ *
+ * The gate is the EXTENSION, not the two bytes, because `#!` at the start of a
+ * file means two different things in this repo. In the JS/TS family and in
+ * Python it can only be a hashbang (or, in Python, an ordinary comment — which
+ * is harmless to push down); in Rust `#![...]` is an INNER ATTRIBUTE, and
+ * `rust/core/fuzz/fuzz_targets/parse_entity.rs` opens with `#![no_main]`.
+ * Keying on `content.startsWith('#!')` therefore wrote that file's header on
+ * line 2, contradicting both `LICENSE_HEADER.md` ("first line of the file")
+ * and the copy this very change commits, so stripping the header and re-running
+ * write mode produced a DIFFERENT file. On a multi-line attribute
+ * (`#![cfg_attr(\n  feature = "nightly",\n  ...)]`) it spliced the three
+ * comment lines between `#![cfg_attr(` and the rest of the token tree; that
+ * still compiles, since Rust comments are trivia, but it is not the header
+ * anyone asked for and it is not on line 1.
+ *
+ * Chosen over sharpening the test to `#!/`: the question "is `#!` a shebang
+ * here" is a property of the LANGUAGE, so the file type is what should answer
+ * it, and phrasing it that way keeps working for the shebang spellings a `#!/`
+ * test would miss (`#! /usr/bin/env node`, `#!python3`). `.css` is absent for
+ * the same reason `.rs` is — `#!` is not a shebang there either. A type added
+ * to `LICENSE_HEADERS` and not considered here gets the safe answer, a header
+ * on line 1, which is what every non-shebang file in the repo already has.
+ */
+const SHEBANG_EXTENSIONS = new Set(['js', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts', 'py']);
+
+/**
+ * The file's contents with a header inserted, or `null` when nothing should
+ * be written — the file is out of scope, or it already declares MPL-2.0.
+ *
+ * A shebang line stays FIRST. `#!` is only a comment when it is the first two
+ * bytes of the file: push it down and an `.mjs` file stops parsing at all
+ * (`SyntaxError`), a `.py` one stops being executable, and the header that
+ * was supposed to be a no-op edit has broken the program. Every in-scope file
+ * in this repo that carries both already orders them this way — shebang, then
+ * notice — so this is the existing convention, expressed once.
+ *
+ * This mattered the moment `.mjs`/`.cjs`/`.py` joined `LICENSE_HEADERS`: of
+ * the 8 files the widened gate found headerless, 5 begin with a shebang.
+ * Before that, the write path had never met one, which is the only reason a
+ * plain prepend had been correct.
+ *
+ * @param {string} relativePath repo-relative path
+ * @param {string} content the file's current text
+ * @returns {string | null}
+ */
+export function withLicenseHeader(relativePath, content) {
+    const header = licenseHeaderFor(relativePath);
+    if (header === null) return null;
+    if (hasLicenseHeader(content)) return null;
+
+    const ext = extensionOf(relativePath.replace(/\\/g, '/'));
+    const shebangLine = SHEBANG_EXTENSIONS.has(ext) && content.startsWith('#!');
+    if (!shebangLine) return header + '\n' + content;
+
+    const lineEnd = content.indexOf('\n');
+    const shebang = lineEnd === -1 ? content + '\n' : content.slice(0, lineEnd + 1);
+    const rest = lineEnd === -1 ? '' : content.slice(lineEnd + 1);
+    return shebang + header + '\n' + rest;
+}

--- a/scripts/lib/license-header.test.mjs
+++ b/scripts/lib/license-header.test.mjs
@@ -36,6 +36,7 @@ import {
   licenseHeaderFor,
   withLicenseHeader,
   LICENSE_HEADERS,
+  SHEBANG_EXTENSIONS,
 } from './license-header.mjs';
 
 const scratch = mkdtempSync(join(tmpdir(), 'license-header-test-'));
@@ -233,20 +234,15 @@ test('`tools/` is not a scan root that scans nothing (#4087)', () => {
 });
 
 test('Python gets the `#` comment form the repo already uses', () => {
-  const header = licenseHeaderFor('rust/python/tests/test_bindings.py');
-  assert.equal(header, LICENSE_HEADERS.py);
-  // Byte-for-byte what all 13 tracked `.py` files carry today. A `//` or `/*`
-  // header in a Python file is a syntax error, so the wrong wrapper here does
-  // not merely look wrong, it breaks the file the write path touches.
-  assert.equal(
-    header,
-    '# This Source Code Form is subject to the terms of the Mozilla Public\n' +
-    '# License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
-    '# file, You can obtain one at https://mozilla.org/MPL/2.0/.\n',
-  );
+  // A `//` or `/*` header in a Python file is a syntax error, so the wrong
+  // wrapper here does not merely look wrong, it breaks the file the write path
+  // touches. The exact bytes of that form are pinned against
+  // `LICENSE_HEADER.md` by the literal oracles at the bottom of this file.
+  assert.equal(licenseHeaderFor('rust/python/tests/test_bindings.py'), LICENSE_HEADERS.py);
+  assert.ok(LICENSE_HEADERS.py.startsWith('# '));
 });
 
-test('every extension uses exactly one of the two comment forms', () => {
+test('every extension uses exactly one of the three comment forms', () => {
   // One notice, wrapped; nothing in the table is a fifth transcription that
   // could drift a word away from the others.
   const block = LICENSE_HEADERS.ts;
@@ -330,4 +326,106 @@ test('the write path prepends to each new type and a re-check accepts it', () =>
     assert.equal(updated, LICENSE_HEADERS[ext] + '\n' + UNLICENSED_FILE, `${ext}: wrong header or mangled body`);
     assert.equal(withLicenseHeader(path, updated), null, `${ext} must be idempotent`);
   }
+});
+
+// --- A HEADER IS A COMMENT, not merely early text ---------------------------
+//
+// Scoping the search to the leading lines was half the fix. It still read
+// those lines as unparsed TEXT, so the embedded-data case it was meant to stop
+// simply moved from line 18 to line 1: a fixture string or a generator's
+// template literal at the top of a file satisfied the detector, and the gate
+// waved the file through. The notice now has to sit inside the leading comment
+// block — everything after an optional shebang and before the first
+// non-comment, non-blank line.
+
+test('a notice inside a STRING LITERAL is not a header', () => {
+  const fixture = 'export const fixture = "SPDX-License-Identifier: MPL-2.0";\n';
+  const prose = 'const s = "This Source Code Form is subject to the terms of the Mozilla Public";\n';
+  assert.equal(hasLicenseHeader(fixture), false);
+  assert.equal(hasLicenseHeader(prose), false);
+  // ...so the write path gives such a file a real header, above the data.
+  assert.equal(
+    withLicenseHeader('packages/codegen/src/spdx-fixture.ts', fixture),
+    LICENSE_HEADERS.ts + '\n' + fixture,
+  );
+});
+
+test('the same SPDX text in a real leading comment IS a header', () => {
+  // The control. This must not regress: it is how all 84 `rust/export` files
+  // and every SPDX-declared file in the repo are licensed.
+  assert.equal(hasLicenseHeader('// SPDX-License-Identifier: MPL-2.0\n\nexport const x = 1;\n'), true);
+  // A blank line does not end the leading block; a line of code does.
+  assert.equal(hasLicenseHeader('#!/usr/bin/env node\n\n// SPDX-License-Identifier: MPL-2.0\n'), true);
+  assert.equal(hasLicenseHeader('export const x = 1;\n// SPDX-License-Identifier: MPL-2.0\n'), false);
+});
+
+test('the 10-line window still bounds the leading comment block', () => {
+  // The comment rule and the window are TWO conditions; this is the second one
+  // on its own — a real leading comment, with the notice 12 lines down. The
+  // deepest header measured in this repo starts on line 8, so a banner this
+  // long is not one, and without the window a long attribution preamble that
+  // quotes the notice would read as a header.
+  const banner = '/*\n' + ' * filler\n'.repeat(10) +
+    ' * This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    ' * License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    ' * file, You can obtain one at https://mozilla.org/MPL/2.0/.\n */\n';
+  assert.equal(banner.split('\n').findIndex(line => /This Source Code Form/.test(line)) + 1, 12);
+  assert.equal(hasLicenseHeader(banner), false);
+});
+
+// --- LITERAL ORACLES for the notice itself ---------------------------------
+//
+// Every other assertion in this file reads `LICENSE_HEADERS` to decide what
+// `LICENSE_HEADERS` should be, so the whole file stays green while the table
+// drifts a word away from `LICENSE_HEADER.md` — which is the AUTHORITY for
+// what the notice says, and what a contributor copies from. These three are
+// transcribed from that document and from nothing else, so a changed word in
+// the table is a failing test rather than a silent divergence.
+
+test('the block form is exactly the text LICENSE_HEADER.md documents', () => {
+  assert.equal(
+    LICENSE_HEADERS.ts,
+    '/* This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    ' * License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    ' * file, You can obtain one at https://mozilla.org/MPL/2.0/. */\n',
+  );
+});
+
+test('the `//` form is exactly the text LICENSE_HEADER.md documents', () => {
+  assert.equal(
+    LICENSE_HEADERS.rs,
+    '// This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    '// License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    '// file, You can obtain one at https://mozilla.org/MPL/2.0/.\n',
+  );
+});
+
+test('the `#` form is exactly the text LICENSE_HEADER.md documents', () => {
+  assert.equal(
+    LICENSE_HEADERS.py,
+    '# This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    '# License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    '# file, You can obtain one at https://mozilla.org/MPL/2.0/.\n',
+  );
+});
+
+test('every shebang-aware extension is a type this repo actually headers', () => {
+  // `SHEBANG_EXTENSIONS` is a SECOND hardcoded extension list. The scan's list
+  // is derived from `LICENSE_HEADERS` precisely so it cannot drift; this one
+  // cannot be, because it is a deliberate subset — `.rs` and `.css` belong in
+  // the table and NOT here, since `#!` opens an inner attribute in Rust and
+  // nothing in CSS. So assert the relationship that does hold. An entry here
+  // that is not a key there is a typo or an orphan from a renamed extension,
+  // and its only effect would be silence: the branch it guards can never run,
+  // so the type would quietly stop being shebang-aware while the write path
+  // went on prepending headers above shebangs.
+  for (const ext of SHEBANG_EXTENSIONS) {
+    assert.ok(
+      Object.hasOwn(LICENSE_HEADERS, ext),
+      `SHEBANG_EXTENSIONS has '${ext}', which LICENSE_HEADERS does not header`,
+    );
+  }
+  // Both halves of the subset are load-bearing, so pin the exclusions too.
+  assert.equal(SHEBANG_EXTENSIONS.has('rs'), false, '`#![...]` is an inner attribute, not a shebang');
+  assert.equal(SHEBANG_EXTENSIONS.has('css'), false, 'CSS has no shebang');
 });

--- a/scripts/lib/license-header.test.mjs
+++ b/scripts/lib/license-header.test.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The two accepted spellings of an MPL-2.0 declaration, and the exclusions
+ * that keep generated output out of the gate's population.
+ *
+ * THE DEFECT PINNED HERE (#4087). `hasLicenseHeader` matched only the PROSE
+ * notice, so 85 files carrying `// SPDX-License-Identifier: MPL-2.0` — a
+ * valid MPL-2.0 declaration, 84 of them in `rust/export` — read as
+ * unlicensed. `--check` therefore exited 1 on a correctly-licensed tree and
+ * could never be turned on, and the write path would have stacked a prose
+ * header on top of a valid SPDX line in every one of those files. The two
+ * forms are asserted here in BOTH directions so they cannot silently
+ * diverge again: each is accepted, and a file with neither is still
+ * rejected — a detector that answered `true` unconditionally would satisfy
+ * half of this file and fail the other half.
+ *
+ * The header-form cases read real files off disk rather than inline strings:
+ * the bug was about what is in the repo's files, and a test that only ever
+ * sees a literal cannot notice a reader that mangles them.
+ *
+ * Run: node --test scripts/lib/license-header.test.mjs
+ */
+
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  hasLicenseHeader,
+  licenseHeaderFor,
+  withLicenseHeader,
+  LICENSE_HEADERS,
+} from './license-header.mjs';
+
+const scratch = mkdtempSync(join(tmpdir(), 'license-header-test-'));
+after(() => rmSync(scratch, { recursive: true, force: true }));
+
+/** Write `content` to a throwaway file and hand back what a reader sees. */
+function fileWith(name, content) {
+  const path = join(scratch, name);
+  writeFileSync(path, content, 'utf-8');
+  return readFileSync(path, 'utf-8');
+}
+
+const PROSE_FILE = `/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export const answer = 42;
+`;
+
+const SPDX_FILE = `// SPDX-License-Identifier: MPL-2.0
+
+pub fn answer() -> u32 {
+    42
+}
+`;
+
+const UNLICENSED_FILE = `export const answer = 42;
+`;
+
+test('the prose notice counts as an MPL-2.0 declaration', () => {
+  assert.equal(hasLicenseHeader(fileWith('prose.ts', PROSE_FILE)), true);
+});
+
+test('the SPDX identifier counts as an MPL-2.0 declaration (#4087)', () => {
+  assert.equal(hasLicenseHeader(fileWith('spdx.rs', SPDX_FILE)), true);
+});
+
+test('a file with neither form is still reported as missing a header', () => {
+  assert.equal(hasLicenseHeader(fileWith('bare.ts', UNLICENSED_FILE)), false);
+});
+
+test('an SPDX identifier for a DIFFERENT license is not an MPL-2.0 declaration', () => {
+  assert.equal(hasLicenseHeader('// SPDX-License-Identifier: Apache-2.0\n'), false);
+});
+
+test('the notice buried DEEP in a file is not a header (#4087)', () => {
+  // A generator that emits the notice as DATA — a template literal, a fixture
+  // string, a docstring — used to satisfy the detector on the strength of that
+  // occurrence alone, so a headerless new generator would be waved through by
+  // the gate meant to catch it. `packages/codegen/src` has 4 files that embed
+  // the notice this way (the shallowest at line 18); all 4 also carry a real
+  // header on line 1, so this is a tightening with nothing behind it today.
+  const generator = 'export function emit() {\n' +
+    '  return `/* This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    ' * License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    ' * file, You can obtain one at https://mozilla.org/MPL/2.0/. */`;\n' +
+    '}\n';
+  const buried = '// line 1\n'.repeat(10) + generator;
+  assert.equal(hasLicenseHeader(buried), false);
+  // ...and the write path therefore gives it a real header.
+  assert.equal(
+    withLicenseHeader('packages/codegen/src/new-generator.ts', buried),
+    LICENSE_HEADERS.ts + '\n' + buried,
+  );
+
+  // A file that both EMITS the notice and carries a real header is still fine.
+  assert.equal(hasLicenseHeader(LICENSE_HEADERS.ts + '\n' + buried), true);
+});
+
+test('a header at the bottom of the leading comment block still counts', () => {
+  // The deepest real header measured in this repo starts on line 8, at the end
+  // of a leading doc comment (`scripts/test-geometry-regression.mjs`). Shrink
+  // the window past that and the gate starts demanding a second header on
+  // correctly-licensed files.
+  const late = '#!/usr/bin/env node\n/**\n * Title\n *\n * Prose.\n *\n * More prose.\n' +
+    ' * This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    ' * License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    ' * file, You can obtain one at https://mozilla.org/MPL/2.0/.\n */\n';
+  assert.equal(late.split('\n').findIndex(l => /This Source Code Form/.test(l)) + 1, 8);
+  assert.equal(hasLicenseHeader(late), true);
+  assert.equal(withLicenseHeader('scripts/test-geometry-regression.mjs', late), null);
+});
+
+test('the write path leaves an SPDX-declared file untouched (#4087)', () => {
+  // The 85-file regression in one assertion: before the fix this returned a
+  // prose header stacked on top of the SPDX line.
+  assert.equal(withLicenseHeader('rust/export/src/lib.rs', SPDX_FILE), null);
+});
+
+test('the write path prepends a header a re-check then accepts', () => {
+  const updated = withLicenseHeader('packages/renderer/src/bvh.ts', UNLICENSED_FILE);
+  assert.notEqual(updated, null);
+  assert.equal(hasLicenseHeader(updated), true);
+  assert.ok(updated.endsWith(UNLICENSED_FILE), 'original content must survive verbatim');
+  assert.equal(withLicenseHeader('packages/renderer/src/bvh.ts', updated), null);
+});
+
+test('the comment syntax follows the file type', () => {
+  assert.equal(licenseHeaderFor('packages/renderer/src/bvh.ts'), LICENSE_HEADERS.ts);
+  assert.equal(licenseHeaderFor('rust/core/src/lib.rs'), LICENSE_HEADERS.rs);
+  assert.ok(licenseHeaderFor('rust/core/src/lib.rs').startsWith('//'));
+  assert.ok(licenseHeaderFor('packages/renderer/src/bvh.ts').startsWith('/*'));
+});
+
+test('a file type this repo does not header is out of scope', () => {
+  assert.equal(licenseHeaderFor('docs/index.md'), null);
+  assert.equal(licenseHeaderFor('Makefile'), null);
+  assert.equal(licenseHeaderFor('docs/mkdocs.yml'), null);
+  assert.equal(licenseHeaderFor('tools/ifcopenshell_reference/Dockerfile'), null);
+});
+
+test('generated output is excluded, and only where it actually lives', () => {
+  assert.equal(licenseHeaderFor('packages/codegen/generated/ifc4/enums.ts'), null);
+  assert.equal(licenseHeaderFor('packages/parser/src/generated/enums.ts'), null);
+  assert.equal(licenseHeaderFor('packages/wasm/pkg/ifc-lite.d.ts'), null);
+
+  // Hand-written siblings of each excluded tree stay in scope; an exclusion
+  // that swallowed these would silence the gate over real source.
+  assert.notEqual(licenseHeaderFor('packages/codegen/src/cli.ts'), null);
+  assert.notEqual(licenseHeaderFor('packages/parser/src/columnar-parser.ts'), null);
+  assert.notEqual(licenseHeaderFor('packages/wasm/src/index.ts'), null);
+  // packages/data's generator emits the header itself, so its output is NOT
+  // exempt here — see the note in license-header.mjs.
+  assert.notEqual(licenseHeaderFor('packages/data/src/ifc-schema/generated/attributes.ts'), null);
+});
+
+test('exclusions are anchored, not substring matches', () => {
+  // A substring test would have excluded both of these.
+  assert.notEqual(licenseHeaderFor('vendor/packages/codegen/generated/x.ts'), null);
+  assert.notEqual(licenseHeaderFor('packages/wasm/pkg-notes/x.ts'), null);
+});
+
+test('EVERY wasm-pack out-dir under a scan root is excluded, not just the default two', () => {
+  // CI builds none of these, so a missing entry is invisible there and only
+  // bites a developer who ran the build: `--check` lists generated files as
+  // missing a header, and write mode stamps MPL notices into wasm-pack output.
+  // Each path is the `--out-dir` its build script passes.
+  // scripts/build-wasm.sh:208, behind BUILD_WIDE=1.
+  assert.equal(licenseHeaderFor('packages/wasm/pkg-wide/ifc-lite.d.ts'), null);
+  // rust/csg-thread-bench/build.sh:20-21, relative to the script's own dir.
+  assert.equal(licenseHeaderFor('rust/csg-thread-bench/web/pkg-plain/csgbench.js'), null);
+  assert.equal(licenseHeaderFor('rust/csg-thread-bench/web/pkg-threaded/csgbench.js'), null);
+
+  // Hand-written siblings of the bench's generated trees stay in scope.
+  assert.notEqual(licenseHeaderFor('rust/csg-thread-bench/web/serve.mjs'), null);
+  assert.notEqual(licenseHeaderFor('rust/csg-thread-bench/src/lib.rs'), null);
+});
+
+test('excluded directory names match whole path segments', () => {
+  assert.equal(licenseHeaderFor('packages/x/dist/index.js'), null);
+  assert.equal(licenseHeaderFor('packages/x/node_modules/dep/index.js'), null);
+  // `distribution` is not `dist`.
+  assert.notEqual(licenseHeaderFor('packages/x/src/distribution/index.ts'), null);
+});
+
+test('Windows-style separators classify the same as POSIX ones', () => {
+  assert.equal(licenseHeaderFor('packages\\codegen\\generated\\ifc4\\enums.ts'), null);
+  assert.equal(licenseHeaderFor('packages\\renderer\\src\\bvh.ts'), LICENSE_HEADERS.ts);
+});
+
+// --- The extensions the gate actually reads (#4087 follow-up) --------------
+//
+// The roots said `scripts/` and `tools/` while the extensions said `.ts`, so
+// the gate read 9 of `scripts/`'s ~306 code files, `tools/` was a scan root
+// that matched nothing at all, and `license-header.mjs` itself was not
+// checked. These cases pin the population by NAMING real files in the trees
+// that were dark, so narrowing the table again reds a test instead of
+// quietly shrinking what the gate looks at.
+
+test('the script trees the gate reads are `.mjs`, not just `.ts` (#4087)', () => {
+  assert.equal(licenseHeaderFor('scripts/check-module-size.mjs'), LICENSE_HEADERS.mjs);
+  // The classifier this whole gate turns on has to be inside its own scope.
+  assert.equal(licenseHeaderFor('scripts/lib/license-header.mjs'), LICENSE_HEADERS.mjs);
+  assert.equal(licenseHeaderFor('tools/demo-kit/derive-variants.mts'), LICENSE_HEADERS.mts);
+  assert.equal(licenseHeaderFor('packages/x/legacy.cjs'), LICENSE_HEADERS.cjs);
+  assert.equal(licenseHeaderFor('packages/x/legacy.cts'), LICENSE_HEADERS.cts);
+});
+
+// CLASSIFICATION IS NOT COVERAGE, and this file can only test the first half.
+// One headerless `.cjs` in the repo stays out of reach after the extensions
+// widened: `.changeset/changelog-resilient.cjs`. The classifier says it would
+// need a header; `add-license-headers.mjs`'s scan roots never walk
+// `.changeset/`, so nothing ever asks. Left alone deliberately rather than
+// fixed by adding a root, which would put changeset machinery inside a
+// source-header gate and fire the job on nearly every PR. Not asserted here
+// either: naming that path in this file makes it a derived INPUT of the
+// license-headers job, and `check-ci-path-coverage.mjs` correctly reports
+// that the job's trigger cannot reach it.
+
+test('`tools/` is not a scan root that scans nothing (#4087)', () => {
+  // Both file types that make `tools/` a non-empty root.
+  assert.notEqual(licenseHeaderFor('tools/world-gym/oracle_validate.py'), null);
+  assert.notEqual(licenseHeaderFor('tools/ifcopenshell_reference/compare.py'), null);
+  assert.notEqual(licenseHeaderFor('tools/demo-kit/derive-variants.mts'), null);
+});
+
+test('Python gets the `#` comment form the repo already uses', () => {
+  const header = licenseHeaderFor('rust/python/tests/test_bindings.py');
+  assert.equal(header, LICENSE_HEADERS.py);
+  // Byte-for-byte what all 13 tracked `.py` files carry today. A `//` or `/*`
+  // header in a Python file is a syntax error, so the wrong wrapper here does
+  // not merely look wrong, it breaks the file the write path touches.
+  assert.equal(
+    header,
+    '# This Source Code Form is subject to the terms of the Mozilla Public\n' +
+    '# License, v. 2.0. If a copy of the MPL was not distributed with this\n' +
+    '# file, You can obtain one at https://mozilla.org/MPL/2.0/.\n',
+  );
+});
+
+test('every extension uses exactly one of the two comment forms', () => {
+  // One notice, wrapped; nothing in the table is a fifth transcription that
+  // could drift a word away from the others.
+  const block = LICENSE_HEADERS.ts;
+  const slash = LICENSE_HEADERS.rs;
+  const hash = LICENSE_HEADERS.py;
+  assert.ok(block.startsWith('/*') && block.trimEnd().endsWith('*/'));
+  assert.ok(slash.startsWith('//'));
+  assert.ok(hash.startsWith('#'));
+  for (const [ext, header] of Object.entries(LICENSE_HEADERS)) {
+    assert.ok(
+      header === block || header === slash || header === hash,
+      `${ext} is neither the block, the // nor the # form`,
+    );
+    // The notice text itself, identical in all of them.
+    assert.ok(hasLicenseHeader(header), `${ext}'s header must satisfy the detector`);
+    assert.equal(header.split('\n').filter(Boolean).length, 3, `${ext} must be a 3-line notice`);
+  }
+});
+
+test('a `#!` line stays first when the header goes in', () => {
+  // `#!` is a shebang only as the first two bytes of the file. 5 of the 8
+  // files the widened gate found headerless begin with one, and a header
+  // prepended above it makes an `.mjs` file a SyntaxError.
+  const script = '#!/usr/bin/env node\nconsole.log(1);\n';
+  const updated = withLicenseHeader('scripts/fixtures/fetch-fixtures.mjs', script);
+  assert.equal(updated, '#!/usr/bin/env node\n' + LICENSE_HEADERS.mjs + '\nconsole.log(1);\n');
+  assert.equal(updated.split('\n')[0], '#!/usr/bin/env node', 'shebang must stay on line 1');
+  assert.equal(hasLicenseHeader(updated), true);
+  // Idempotent, same as the no-shebang path.
+  assert.equal(withLicenseHeader('scripts/fixtures/fetch-fixtures.mjs', updated), null);
+});
+
+test('a `#!` line stays first in Python too', () => {
+  const script = '#!/usr/bin/env python3\nprint(1)\n';
+  const updated = withLicenseHeader('tools/world-gym/oracle_validate.py', script);
+  assert.equal(updated, '#!/usr/bin/env python3\n' + LICENSE_HEADERS.py + '\nprint(1)\n');
+});
+
+test('a Rust INNER ATTRIBUTE is not a shebang, so the header still lands on line 1', () => {
+  // `#!` opens a shebang in the JS/TS family and in Python, and an inner
+  // attribute in Rust. Keying the branch on the two bytes wrote the header on
+  // line 2 of `rust/core/fuzz/fuzz_targets/parse_entity.rs`, which this repo
+  // commits with the header on line 1 — so stripping that file's header and
+  // re-running write mode produced a DIFFERENT file, and `LICENSE_HEADER.md`
+  // says "first line of the file".
+  const attr = '#![no_main]\n\nuse libfuzzer_sys::fuzz_target;\n';
+  const updated = withLicenseHeader('rust/core/fuzz/fuzz_targets/parse_entity.rs', attr);
+  assert.equal(updated, LICENSE_HEADERS.rs + '\n' + attr);
+  assert.equal(
+    updated.split('\n')[0],
+    '// This Source Code Form is subject to the terms of the Mozilla Public',
+    'the header must start on line 1, above the inner attribute',
+  );
+});
+
+test('a MULTI-LINE Rust inner attribute is not split open by the header', () => {
+  // The two-byte test spliced the three comment lines between `#![cfg_attr(`
+  // and the rest of the token tree. Rust treats comments as trivia so that
+  // still compiled (verified with rustc), which is precisely why nothing
+  // would have caught it.
+  const attr = '#![cfg_attr(\n    feature = "nightly",\n    feature(portable_simd)\n)]\n\nuse core::simd;\n';
+  const updated = withLicenseHeader('rust/core/src/lib.rs', attr);
+  assert.equal(updated, LICENSE_HEADERS.rs + '\n' + attr);
+  assert.ok(updated.includes(attr), 'the attribute must survive as one unbroken token tree');
+});
+
+test('a `#` that is not a shebang is not treated as one', () => {
+  // A Python file opening with an ordinary comment gets the header FIRST,
+  // the same as any other headerless file.
+  const script = '# a plain comment\nprint(1)\n';
+  const updated = withLicenseHeader('tools/world-gym/oracle_validate.py', script);
+  assert.equal(updated, LICENSE_HEADERS.py + '\n# a plain comment\nprint(1)\n');
+});
+
+test('the write path prepends to each new type and a re-check accepts it', () => {
+  for (const ext of ['mjs', 'cjs', 'mts', 'cts', 'py']) {
+    const path = `tools/sample.${ext}`;
+    const updated = withLicenseHeader(path, UNLICENSED_FILE);
+    assert.notEqual(updated, null, `${ext} must be in scope`);
+    assert.equal(hasLicenseHeader(updated), true, `${ext}'s written header must re-check clean`);
+    assert.equal(updated, LICENSE_HEADERS[ext] + '\n' + UNLICENSED_FILE, `${ext}: wrong header or mangled body`);
+    assert.equal(withLicenseHeader(path, updated), null, `${ext} must be idempotent`);
+  }
+});

--- a/scripts/lib/license-scan.mjs
+++ b/scripts/lib/license-scan.mjs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Enumerating the files the license gate is responsible for.
+ *
+ * Split from `scripts/add-license-headers.mjs` because deciding WHICH files a
+ * run covers is a different job from deciding what to do with them, and the
+ * two fail differently: this module's failures are all "the run covered less
+ * than it claims", which the CLI must turn into a refusal rather than a
+ * result. Keeping it separate is also what lets the coverage rules be tested
+ * without importing a CLI that scans and writes.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { EXCLUDED_DIRS } from './license-header.mjs';
+
+// The scan-root entry that means "the repository root itself". `findFiles`
+// scans it non-recursively; see the comment on the `find` command below.
+export const REPO_ROOT = '.';
+
+// Returns { files, missingRoots, scanErrors }. A missing scan root used to be a
+// console.warn that the caller could scroll past — the scan would silently
+// continue over whatever roots DID exist, "Found 0 files to process"
+// would print same as a real clean scan, and --check would exit 0 having
+// verified nothing. Callers now decide what to do with missingRoots; both
+// the --check and default paths below treat it as fatal (see the "loudly"
+// comment further down).
+export function findFiles(rootDir, scanRoots, extensions) {
+    const files = [];
+    const missingRoots = [];
+    const scanErrors = [];
+
+    for (const dir of scanRoots) {
+        const fullPath = join(rootDir, dir);
+        if (!existsSync(fullPath)) {
+            missingRoots.push(fullPath);
+            continue;
+        }
+
+        // Use find command to get all files with specified extensions.
+        // The directory exclusions are `EXCLUDED_DIRS`, not a second spelling
+        // of it: `licenseHeaderFor` re-checks them downstream, so a divergence
+        // here would not be a correctness bug — it would be a silent cost,
+        // `find` walking a tree whose every hit is then discarded.
+        //
+        // The repo root is the one root scanned NON-recursively. Every other
+        // root is a subtree of it, so a recursive walk here would re-walk all
+        // of them, double-count every file, and drag in `node_modules`,
+        // `target` and every other build directory besides. `-maxdepth 1` is
+        // placed before `-type f` because BSD `find` (macOS) rejects it as an
+        // option after a primary, while GNU `find` accepts either.
+        const depthLimit = dir === REPO_ROOT ? '-maxdepth 1 ' : '';
+        const extPattern = extensions.map(ext => `-name "*.${ext}"`).join(' -o ');
+        const prunePattern = EXCLUDED_DIRS.map(dir => `! -path "*/${dir}/*"`).join(' ');
+        const findCmd = `find "${fullPath}" ${depthLimit}-type f \\( ${extPattern} \\) ${prunePattern}`;
+
+        try {
+            // An explicit maxBuffer, because Node's default is 1 MiB and a root
+            // that outgrows it raises ENOBUFS. That lands in the catch below,
+            // which used to log and continue, so the root contributed ZERO files
+            // and the scan reported success having never looked at it. Under-
+            // scanning that announces itself as a clean result is the exact
+            // failure this gate exists to prevent, so the size is raised AND the
+            // failure is recorded.
+            const output = execSync(findCmd, {
+                encoding: 'utf-8',
+                cwd: rootDir,
+                maxBuffer: 64 * 1024 * 1024,
+            });
+            const foundFiles = output.trim().split('\n').filter(f => f);
+            files.push(...foundFiles);
+        } catch (error) {
+            // Exit 1 from `find` means "matched nothing", which is a real answer
+            // for a root that legitimately holds no scanned extension. Anything
+            // else means the enumeration did not happen, and a root nobody
+            // enumerated is not a root anybody checked: record it so the caller
+            // can refuse rather than quietly scanning the remainder.
+            if (error.status !== 1) {
+                scanErrors.push({ root: dir, message: error.message });
+            }
+        }
+    }
+
+    return { files, missingRoots, scanErrors };
+}

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -83,7 +83,11 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
   // `AGENTS.md ratchet`, added when check-agents-md-size.mjs got its own job
   // rather than riding in `Node tests` (it needs no build artifact and no
   // install, and routing it through `frontend` fanned one gate out to nine
-  // jobs). The count is a TRIPWIRE for a lane appearing or vanishing unnoticed,
+  // jobs), plus `MPL license headers` (#4087), which got its own job for the
+  // same two reasons and one more: it scans `docs/`, `tools/` and
+  // `apps/landing/`, which `frontend` deliberately does not carry, so a
+  // node-tests step could not have fired on three of the trees it reads.
+  // The count is a TRIPWIRE for a lane appearing or vanishing unnoticed,
   // so bumping it is a deliberate act: add the new name to the list below as
   // well, or the count alone would pass while asserting nothing about identity.
   const names = expandJobNames(readFileSync(join(REPO_ROOT, '.github/workflows/test.yml'), 'utf8'));
@@ -101,13 +105,14 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
     'Viewer tests (shard 3)',
     'Docs checks (docs-only PRs)',
     'AGENTS.md ratchet',
+    'MPL license headers',
     'Build + WASM + Rust + Node',
     // #3878: the two CSG accept gates are feature builds nothing else compiles.
     'CSG accept gates (feature builds)',
   ]) {
     assert.ok(names.includes(observed), `derived set is missing the observed lane "${observed}"`);
   }
-  assert.equal(names.length, 19);
+  assert.equal(names.length, 20);
 });
 
 test('FAIL CLOSED: an empty workflow file is NO_WORKFLOW_TEXT, not an empty lane set', () => {

--- a/scripts/lib/revert-oracle-cargo.mjs
+++ b/scripts/lib/revert-oracle-cargo.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 

--- a/scripts/lib/revert-oracle-cargo.test.mjs
+++ b/scripts/lib/revert-oracle-cargo.test.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';

--- a/scripts/lib/revert-oracle-python.test.mjs
+++ b/scripts/lib/revert-oracle-python.test.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -330,7 +330,7 @@
   1486 packages/viewer/src/viewer-html.ts
    500 scripts/check-agents-md-size.mjs
    680 scripts/check-changeset-bump.mjs
-   523 scripts/check-ci-path-coverage.mjs
+   526 scripts/check-ci-path-coverage.mjs
    574 scripts/check-collab-room-model-target.mjs
    529 scripts/check-generated.mjs
    430 scripts/check-git-lfs.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -179,7 +179,7 @@
    457 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
-   413 apps/viewer/vite.config.ts
+   417 apps/viewer/vite.config.ts
    788 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
    801 packages/bcf/src/reader.ts
@@ -311,7 +311,7 @@
    514 packages/renderer/src/section-plane.ts
    639 packages/renderer/src/shaders/main.wgsl.ts
    454 packages/renderer/src/shadow-pass.ts
-   764 packages/renderer/src/snap-detector.ts
+   768 packages/renderer/src/snap-detector.ts
    765 packages/renderer/src/symbolic-overlay-pipelines.ts
    587 packages/sandbox/src/bridge-create.ts
    421 packages/sandbox/src/bridge-query.ts


### PR DESCRIPTION
Closes #4087.

`scripts/add-license-headers.mjs --check` was invoked nowhere and carried no `@unwired-by-design` marker. Wiring it as-is would have been worse than leaving it off.

## What was actually wrong

Measured on `origin/main` before any change: `--check` exited 1 with 128 files flagged.

**85 of the 128 were false positives.** They carry `// SPDX-License-Identifier: MPL-2.0`, a valid MPL-2.0 declaration, and `hasLicenseHeader` matched only the prose form. Its printed remedy, "Run without --check to add them", would have prepended a prose header on top of a valid SPDX line in 85 correct files, 84 of them in `rust/export`. So the reachable branch was wrong, not merely unreached, and the gate's first run would have been 85 findings about the codebase rather than about any PR.

Of the remaining 43: 16 were generated output wanting exclusion, 27 genuinely needed a header. `apps/server/src`, the omission the issue predicted would matter, was already clean.

## What changed

Classification moved to `scripts/lib/license-header.mjs`, a pure module with its own tests, and it now accepts both spellings. Three generated trees are excluded by prefix, confirmed generated rather than assumed: `scripts/check-codegen-sync.mjs` byte-compares two of them against a fresh generator run, so a header there would fail that gate. `packages/data/src/ifc-schema/generated/` is deliberately not excluded, because its generator emits the header itself.

The gate is wired as its own `license-headers` job. Not a `node-tests` step: it reads `docs/`, `tools/` and `apps/landing/`, none of which the `frontend` filter carries, and `check-ci-path-coverage.mjs` refuses a gate that reads a path which cannot trigger it.

`LICENSE_HEADER.md` now records that SPDX is a second accepted spelling, because this change decided a policy question and the authority `AGENTS.md` points at still described one form.

## What review changed, and it was most of the work

**The gate examined less than a reader would assume.** The first version widened the scan roots from 4 to 11 and left the extension list at 5. Measured: `tools/` contributed **zero** files, a scan root that scanned nothing; `scripts/` was 13 of 312 code files, because it holds 297 `.mjs`; and `scripts/lib/license-header.mjs`, the module this PR adds, was not checked by the gate this PR turns on. Adding `mjs`, `cjs`, `mts`, `cts` and `py` closed it: 4993 files scanned to 5353, `tools/` from 0 to 35.

The mutation that shows why it mattered: revert the extension list to the old five with a headerless `.mjs` in the tree, and `--check` prints **"All files have the license header" and exits 0** over 4993 files.

**Two writer bugs, each caught by the round after the one that introduced it.** Five of the eight files needing headers open with `#!/usr/bin/env node`, and prepending at byte 0 would have made them SyntaxErrors. The fix for that then matched Rust inner attributes too, because `#![no_main]` also starts with `#!`, which put the notice on line 2 of a file this PR commits with it on line 1. The writer was not idempotent with its own committed convention. Now gated on the extensions that can carry a shebang, and pinned by a round-trip test: strip the header, run write mode, `git diff` must be empty.

**The detector read whole files.** A file whose only occurrence of the notice was deep inside it, in a template literal, passed the check and was skipped by the writer. Zero files were affected today, but four files under `packages/codegen/src` already embed the notice as emitted data, so a new sibling generator without a top header would have been silently exempted by the gate meant to catch it. Now scoped to the leading 10 lines, a window measured rather than picked: the deepest real header in the repo starts at line 8 and the shallowest embedded-as-data occurrence at line 18. Verified as a pure tightening, 5318 accepted before and after, zero verdict flips.

**Write mode reported success on I/O failure.** `errors` was never incremented, so an unreadable file printed to stderr and then reported `Errors: 0` and exited 0. Verified against both versions with `chmod 000`: was exit 0, now exit 2.

## Verification

- `--check` exit 0: 5353 scanned, 30 excluded, 0 missing.
- Mutations, each restored and the tree byte-compared afterwards: strip a `.mjs` header, exit 1 naming it; strip a `.py` header, exit 1, and write mode restores it with an **empty diff**, which is the proof the derived `#` form matches the repo's existing bytes; revert the extension widening, the false pass above; revert the shebang gate, two tests red; revert the leading-window scope, one test red.
- `check-module-size`, `check-test-wiring`, `check-ci-path-coverage`, `check-source-text-assertions`, `check-changesets`, `pnpm lint`, `pnpm typecheck` all exit 0. `license-header.test.mjs` 25/25, `pr-review-signal.test.mjs` 81/81.
- Two module-size budgets raised by exactly the header's 4 lines, via `--update --allow-raise`, with no other row moved.

Two gates went red during development and were fixed at the source rather than allowlisted: `check-source-text-assertions` was correctly flagging a `readFileSync` wrapper that tainted a whole file, and `check-ci-path-coverage` was correctly refusing a test that named paths the new job cannot be triggered by.

## Not verified

Three of the new exclusions are wasm-pack out-dirs (`packages/wasm/pkg-wide/`, `rust/csg-thread-bench/web/pkg-plain/`, `.../pkg-threaded/`) that do not exist in a fresh checkout. They are verified against the build scripts that write them and by unit test, not by a live scan over real wasm-pack output.

## Deferred

The codegen templates emit the MPL header on 4 of their 9 outputs and omit it on the other 5, so excluding those trees freezes an inconsistency rather than fixing it. Filed separately rather than left in a comment, because this PR's own evidence is that a stale exclusion list goes unnoticed: the three `EXCLUDED_FILES` entries it replaced named a wasm-pack layout that no longer exists and had been excluding nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfAavu3wBCfAPxEsv9BJ4K


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for applying Mozilla Public License 2.0 notices across supported source files and languages.

- **Chores**
  - Standardized MPL-2.0 notices across source code, examples, scripts, tests, and configuration files.
  - Improved license-header validation and reporting.

- **Tests**
  - Added automated coverage for license detection, insertion, exclusions, and validation.
  - Integrated license-header checks into the required test workflow.

- **Compatibility**
  - No changes to application behavior, public APIs, generated output, or runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->