### PR TITLE
Support precise model and scan placement in the renderer

### DIFF
--- a/.changeset/early-rooms-press.md
+++ b/.changeset/early-rooms-press.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/renderer": minor
+"@ifc-lite/pointcloud": minor
+---
+
+Support absolute model and pointcloud translations without rewriting mesh or scan vertices. Keep model draw origins independent, compose scan alignment and manual offsets in double precision, and retain placement bounds after CPU geometry release. Streaming pointcloud callers can choose a nearby decode origin before narrowing coordinates to float32.

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -991,3 +991,30 @@ async function createViewer() {
 - [Server Guide](server.md) - Server-based rendering
 - [2D Drawing Guide](drawing-2d.md) - Generate 2D plans and elevations
 - [API Reference](../api/typescript.md) - Complete API docs
+
+
+## Model workspace translations
+
+`Renderer.setModelTranslation(modelIndex, [x, y, z])` sets an absolute manual
+translation in **renderer Y-up metres**. It applies to flat, textured, instanced
+and embedded pointcloud geometry assigned that model index, including later
+uploads. Pass `[0, 0, 0]` to reset. Keep each loaded model's index stable until
+it is removed; do not compact indices while its geometry remains on the GPU.
+`renderer.getScene().getModelTranslation(modelIndex)` reads the current offset
+in the same Y-up metre frame. It defaults to zero before a placement is set.
+The scene retains occurrence records and bounds after releasing CPU vertices,
+so whole-model movement remains available in GPU-resident mode.
+
+For a separately streamed scan, call
+`Renderer.setPointCloudTranslation(handle, [x, y, z])`. Its manual translation
+composes after the matrix passed to `setPointCloudTransform`, which accepts
+`Float64Array` as well as `Float32Array`. Pass coarse alignment matrices in
+float64 so cancellation with a manual correction happens before GPU rounding.
+`getPointCloudTransform(handle)` returns the final draw matrix for CPU spatial
+consumers. `getModelPlacementBounds(modelIndex, handle?)` returns placed bounds
+for framing a model and its streamed scan.
+
+These APIs move workspace geometry; they do not rewrite source IFC placements
+or point records. The web viewer supplies transactions, undo, persistence and
+engineering Z-up inputs on top of them. See [Repositioning models and
+pointclouds](federation.md#repositioning-models-and-pointclouds).

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -68,3 +68,18 @@ See the [docs site](https://ifclite.dev/docs/) for guides and the full API refer
 ## License
 
 [MPL-2.0](../../LICENSE)
+
+
+## Local origins for large-coordinate scans
+
+`streamPointCloud({ ..., autoOrigin: true })` chooses a nearby origin before
+emitting chunks when `originOffset` is absent. Header bounds choose the centre;
+formats without usable bounds probe one point and reopen the original bytes.
+The decoder subtracts that origin in float64 before writing float32 positions.
+`onOpen(info)` receives the chosen `info.originOffset` in native X/Y/Z source
+units, before the first `onChunk`. Compose that offset with your alignment and
+manual translation in double precision before sending a final matrix to the
+GPU. Explicit `originOffset` takes precedence; the default remains unchanged.
+Opening may perform an extra decode pass for formats without header bounds.
+A local origin preserves nearby detail but cannot repair a source whose
+coordinates were already quantized or an extremely large spatial extent.

--- a/packages/pointcloud/src/streaming/host.test.ts
+++ b/packages/pointcloud/src/streaming/host.test.ts
@@ -53,6 +53,34 @@ function buildLasFile(rows: Array<{ x: number; y: number; z: number; cls?: numbe
 }
 
 describe('streamPointCloud (in-process source)', () => {
+  it('preserves millimetre LAS samples loaded before an IFC provides an alignment (#4226)', async () => {
+    const bytes = await buildLasFile([{ x: 1, y: 0, z: 0 }, { x: 2, y: 0, z: 0 }]).arrayBuffer();
+    const view = new DataView(bytes);
+    view.setFloat64(131, 0.001, true);
+    view.setFloat64(155, 10_000_000, true);
+    view.setFloat64(179, 10_000_000.002, true);
+    view.setFloat64(187, 10_000_000.001, true);
+    let origin = 0;
+    const samples: number[] = [];
+    const handle = streamPointCloud({
+      format: 'las', blob: new Blob([bytes]), autoOrigin: true,
+      onOpen: (info) => { origin = info.originOffset?.[0] ?? 0; },
+      onChunk: (chunk) => {
+        for (let i = 0; i < chunk.pointCount; i++) samples.push(chunk.positions[i * 3]);
+      },
+      createSource: ({ blob, stride, originOffset }) => new LasStreamingSource(blob, {
+        downsample: { stride: stride ?? 1 }, originOffset,
+      }),
+    });
+    await handle.done;
+    expect(samples).toHaveLength(2);
+    // Coarse translation is evaluated in f64 before the final small coordinates
+    // reach the renderer; the decoder must not already have collapsed the pair.
+    expect(Math.abs((origin - 10_000_000) + samples[0] - 0.001)).toBeLessThan(1e-7);
+    expect(Math.abs((origin - 10_000_000) + samples[1] - 0.002)).toBeLessThan(1e-7);
+    expect(samples[1] - samples[0]).toBeGreaterThan(0.000999);
+  });
+
   it('streams chunks to the host callback and reports completion', async () => {
     const rows: Array<{ x: number; y: number; z: number }> = [];
     for (let i = 0; i < 12; i++) rows.push({ x: i, y: 0, z: 0 });
@@ -90,6 +118,13 @@ describe('streamPointCloud (in-process source)', () => {
     expect(opened).toBe(1);
     expect(completedTotal).toBe(12);
     expect(collected).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  it('rejects invalid point caps before opening a source (#4226)', () => {
+    for (const maxPointsInMemory of [0, -1, NaN, Infinity]) {
+      expect(() => streamPointCloud({ format: 'las', blob: buildLasFile([]), maxPointsInMemory,
+        onChunk: () => {}, createSource: () => { throw new Error('must not open'); } })).toThrow(/maxPointsInMemory/);
+    }
   });
 
   it('downsamples when total exceeds maxPointsInMemory', async () => {

--- a/packages/pointcloud/src/streaming/host.ts
+++ b/packages/pointcloud/src/streaming/host.ts
@@ -51,9 +51,11 @@ export interface StreamPointCloudOptions {
    * `computePointCloudAlignment().decodeOriginOffset`.
    */
   originOffset?: readonly [number, number, number];
+  /** Choose a local decode origin when no explicit alignment is supplied (#4226). */
+  autoOrigin?: boolean;
 
   /** Called once after the source's header parses. */
-  onOpen?: (info: PointSourceInfo & { stride: number }) => void;
+  onOpen?: (info: PointSourceInfo & { stride: number; originOffset?: readonly [number, number, number] }) => void;
   /** Called for each decoded chunk. */
   onChunk: (chunk: DecodedPointChunk) => void;
   /** Periodic progress signal in 0..1. */
@@ -89,6 +91,9 @@ export function streamPointCloud(opts: StreamPointCloudOptions): StreamHandle {
   const maxPoints = opts.maxPointsInMemory ?? DEFAULT_MAX_POINTS;
   const maxFile = opts.maxFileSize ?? DEFAULT_MAX_FILE;
   const chunkSize = opts.chunkSize ?? DEFAULT_CHUNK;
+  if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
+    throw new Error('streamPointCloud: maxPointsInMemory must be a positive finite number');
+  }
   // chunkSize <= 0 would let the source.next() loop emit empty chunks
   // forever without advancing its cursor. Fail loudly so callers can't
   // accidentally lock up the worker.
@@ -129,20 +134,31 @@ export function streamPointCloud(opts: StreamPointCloudOptions): StreamHandle {
       });
       info = await source.open(composed);
 
-      if (info.totalPointCount > maxPoints) {
-        stride = Math.ceil(info.totalPointCount / maxPoints);
+      stride = Math.max(1, Math.ceil(info.totalPointCount / maxPoints));
+      let originOffset = opts.originOffset;
+      let consumedProbe = false;
+      if (opts.autoOrigin && !originOffset && info.totalPointCount > 0) {
+        const { min, max } = info.bbox;
+        if ([...min, ...max].every(Number.isFinite) && [...min, ...max].some((v) => v !== 0)) {
+          originOffset = [min[0] / 2 + max[0] / 2, min[1] / 2 + max[1] / 2, min[2] / 2 + max[2] / 2];
+        } else {
+          // Formats without header bounds (notably E57) can probe one sample.
+          // Its rounded position only CHOOSES a nearby frame. Reopen and decode
+          // from the original bytes so this first sample loses no precision.
+          const probe = await source.next(1, composed);
+          consumedProbe = true;
+          if (probe && probe.pointCount > 0 && probe.positions.subarray(0, 3).every(Number.isFinite)) {
+            originOffset = [probe.positions[0], probe.positions[1], probe.positions[2]];
+          }
+        }
+      }
+      if (stride > 1 || consumedProbe || originOffset !== opts.originOffset) {
         source.close();
-        source = probeFactory({
-          format: opts.format,
-          blob: opts.blob,
-          label: opts.label,
-          stride,
-          originOffset: opts.originOffset,
-        });
+        source = probeFactory({ format: opts.format, blob: opts.blob, label: opts.label, stride, originOffset });
         info = await source.open(composed);
       }
 
-      opts.onOpen?.({ ...info, stride });
+      opts.onOpen?.({ ...info, stride, originOffset });
 
       while (true) {
         if (composed.aborted) break;

--- a/packages/renderer/src/deviation-computer.test.ts
+++ b/packages/renderer/src/deviation-computer.test.ts
@@ -249,3 +249,34 @@ describe('DeviationComputer.compute(): releaseTransientParams on the rejection p
     assert.strictEqual(paramsBuffer.destroyed, 1, 'the transient params buffer must be released on the happy path too');
   });
 });
+
+
+describe('DeviationComputer workspace placement (#4226)', () => {
+  it('rebuilds the uploaded BVH after a model move, but reuses it for unchanged positions', async () => {
+    const created: Array<GPUBuffer & { destroyed: number }> = [];
+    const device = makeFakeGpuDevice();
+    device.createBuffer = () => { const buffer = fakeBuffer(); created.push(buffer); return buffer; };
+    const uploads = new Map<GPUBuffer, Float32Array>();
+    device.queue.writeBuffer = (buffer, _offset, data) => {
+      if (data instanceof Float32Array) uploads.set(buffer, data.slice());
+    };
+    const computer = new DeviationComputer(); computer.init(device);
+    const mesh = { ...makeMesh(1), origin: [0, 0, 0] as [number, number, number] };
+    const ctx = makeCtx(device);
+    ctx.scene = { forEachMeshData: (visit: (value: typeof mesh) => void) => visit(mesh) } as unknown as DeviationComputeContext['scene'];
+    try {
+      await computer.compute({}, ctx);
+      const firstNodes = created[0], firstTriangles = created[1];
+      await computer.compute({}, ctx);
+      assert.equal(firstNodes.destroyed, 0); assert.equal(firstTriangles.destroyed, 0);
+      mesh.origin = [100, 0, 0];
+      await computer.compute({}, ctx);
+      assert.equal(firstNodes.destroyed, 1, 'the old spatial BVH is evicted after translation');
+      assert.equal(firstTriangles.destroyed, 1);
+      const rebuilt = created.find((buffer) => buffer !== firstTriangles && uploads.get(buffer)?.length === 12)!;
+      const triangle = uploads.get(rebuilt)!;
+      assert.equal(triangle[0], 100, 'rebuilt BVH triangle starts at the moved world position');
+      assert.equal(triangle[3], 101); assert.equal(triangle[6], 100);
+    } finally { computer.destroy(); }
+  });
+});

--- a/packages/renderer/src/deviation/deviation-computer.ts
+++ b/packages/renderer/src/deviation/deviation-computer.ts
@@ -38,7 +38,7 @@ function computeBvhFingerprint(meshes: ReadonlyArray<MeshData>): string {
         const mi = m.modelIndex ?? -1;
         const posLen = m.positions?.length ?? 0;
         const idxLen = m.indices?.length ?? 0;
-        parts.push(`${id}:${mi}:${posLen}:${idxLen}`);
+        parts.push(`${id}:${mi}:${posLen}:${idxLen}:${m.origin?.join(',') ?? ''}:${m.positions[0]},${m.positions[1]},${m.positions[2]}`);
     }
     return parts.join('|');
 }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1076,6 +1076,7 @@ export class Renderer {
 
     /** Absolute workspace translation in renderer Y-up metres (#4226). */
     setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
+        this.pointCloudRenderer?.validateModelTranslation(modelIndex, translation);
         this.scene.setModelTranslation(modelIndex, translation);
         this.pointCloudRenderer?.setModelTranslation(modelIndex, translation);
         this.clearCaches();

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -122,6 +122,7 @@ export type {
     PointCloudNodeMeta,
 } from './pointcloud/point-cloud-node.js';
 
+import { modelPlacementBounds, sceneMeshBounds } from './model-placement-bounds.js';
 import { WebGPUDevice, type AdapterInfoSnapshot } from './device.js';
 import { RenderPipeline } from './pipeline.js';
 import { Camera } from './camera.js';
@@ -973,14 +974,9 @@ export class Renderer {
         if (!this.pointCloudRenderer) {
             throw new Error('Renderer not initialized. Call init() first.');
         }
+        for (const asset of assets) this.pointCloudRenderer.setModelTranslation(asset.modelIndex ?? 0, this.scene.getModelTranslation(asset.modelIndex ?? 0));
         this.pointCloudRenderer.setAssets(assets);
-        // Replace, not append — bounds may have shrunk (e.g. an IFCx
-        // reload with a smaller scan). `expandForPointClouds`
-        // alone only grows; recompute from scratch to keep
-        // fit-to-view + section-plane sliders accurate.
-        this.modelBoundsTracker.recompute();
-        this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.refreshPlacementBounds();
     }
 
     /** Append additional point clouds without clearing existing ones. */
@@ -989,6 +985,7 @@ export class Renderer {
             throw new Error('Renderer not initialized. Call init() first.');
         }
         for (const asset of assets) {
+            this.pointCloudRenderer.setModelTranslation(asset.modelIndex ?? 0, this.scene.getModelTranslation(asset.modelIndex ?? 0));
             this.pointCloudRenderer.addAsset(asset);
         }
         this.modelBoundsTracker.expandForPointClouds();
@@ -1009,9 +1006,7 @@ export class Renderer {
     /** Drop all point cloud GPU resources. */
     clearPointClouds(): void {
         this.pointCloudRenderer?.clear();
-        this.modelBoundsTracker.recompute();
-        this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.refreshPlacementBounds();
     }
 
     /**
@@ -1046,9 +1041,7 @@ export class Renderer {
         this.pointCloudRenderer?.removeAsset(handle);
         // Bounds may have shrunk — recompute from scratch so fit-to-view
         // and section-plane sliders see fresh extents.
-        this.modelBoundsTracker.recompute();
-        this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.refreshPlacementBounds();
     }
 
     /**
@@ -1066,30 +1059,44 @@ export class Renderer {
         this.requestRender();
     }
 
-    /** Aggregate bounds across all batched + individual meshes. Returns
-     *  null if the scene has no mesh geometry. */
-    private computeMeshBounds(): { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } } | null {
-        let minX = Infinity, minY = Infinity, minZ = Infinity;
-        let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
-        let any = false;
-        for (const batch of this.scene.getBatchedMeshes()) {
-            if (!batch.bounds) continue;
-            any = true;
-            if (batch.bounds.min[0] < minX) minX = batch.bounds.min[0];
-            if (batch.bounds.min[1] < minY) minY = batch.bounds.min[1];
-            if (batch.bounds.min[2] < minZ) minZ = batch.bounds.min[2];
-            if (batch.bounds.max[0] > maxX) maxX = batch.bounds.max[0];
-            if (batch.bounds.max[1] > maxY) maxY = batch.bounds.max[1];
-            if (batch.bounds.max[2] > maxZ) maxZ = batch.bounds.max[2];
-        }
-        if (!any) return null;
-        return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+    /** Bounds across flat draw batches. */
+    private computeMeshBounds() {
+        return sceneMeshBounds(this.scene);
     }
 
     /** Apply rendering options (color mode, fixed override, point size). */
     setPointCloudOptions(opts: import('./pointcloud/point-cloud-renderer.js').PointCloudRenderOptions): void {
         this.pointCloudRenderer?.setOptions(opts);
         this.requestRender();
+    }
+
+    getModelPlacementBounds(modelIndex: number, pointCloudHandle?: { id: number }) {
+        return modelPlacementBounds(this.scene, this.pointCloudRenderer, modelIndex, pointCloudHandle);
+    }
+
+    /** Absolute workspace translation in renderer Y-up metres (#4226). */
+    setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
+        this.scene.setModelTranslation(modelIndex, translation);
+        this.pointCloudRenderer?.setModelTranslation(modelIndex, translation);
+        this.clearCaches();
+        this.refreshPlacementBounds();
+    }
+
+    /** Streamed clouds are addressed by durable asset handle. */
+    setPointCloudTranslation(handle: { id: number }, translation: readonly [number, number, number]): void {
+        this.pointCloudRenderer?.setAssetTranslation(handle, translation);
+        this.clearCaches();
+        this.refreshPlacementBounds();
+    }
+
+    private refreshPlacementBounds(): void {
+        this.modelBoundsTracker.recompute();
+        this.camera.setSceneBounds(this.modelBounds);
+        this.requestRender();
+    }
+
+    getPointCloudTransform(handle: { id: number }): Float32Array | undefined {
+        return this.pointCloudRenderer?.getAssetTransform(handle);
     }
 
     /**
@@ -1100,17 +1107,10 @@ export class Renderer {
      */
     setPointCloudTransform(
         handle: import('./pointcloud/point-cloud-renderer.js').PointCloudAssetHandle,
-        matrix: Float32Array | null,
+        matrix: Float32Array | Float64Array | null,
     ): void {
         this.pointCloudRenderer?.setAssetTransform(handle, matrix);
-        // The asset's world-space extents just moved: re-fold the (now
-        // matrix-aware) point-cloud bounds into the scene bounds and push
-        // them to the camera (matching every other bounds-mutating
-        // point-cloud method) so framing / zoom-to-fit targets where the
-        // points actually render.
-        this.modelBoundsTracker.recompute();
-        this.camera.setSceneBounds(this.modelBounds);
-        this.requestRender();
+        this.refreshPlacementBounds();
     }
 
     /**
@@ -1168,7 +1168,7 @@ export class Renderer {
         this.scene.appendToBatches(meshes, device, this.pipeline, false);
 
         // Calculate and store model bounds for fitToView
-        this.modelBoundsTracker.updateFromMeshes(meshes);
+        this.modelBoundsTracker.updateFromMeshes(meshes, (index) => this.scene.getModelTranslation(index));
 
         console.log(`[Renderer] Loaded ${meshes.length} meshes`);
 
@@ -1193,7 +1193,7 @@ export class Renderer {
         this.scene.appendToBatches(meshes, device, this.pipeline, isStreaming);
 
         // Update model bounds incrementally
-        this.modelBoundsTracker.updateFromMeshes(meshes);
+        this.modelBoundsTracker.updateFromMeshes(meshes, (index) => this.scene.getModelTranslation(index));
 
         // Update camera scene bounds for tight orthographic near/far planes
         this.camera.setSceneBounds(this.modelBounds);
@@ -1410,7 +1410,7 @@ export class Renderer {
         // We compute the same `world` here. When there's no shared origin yet
         // (legacy / pre-batch), fall back to a plain f64 fold (local + origin).
         const o = meshData.origin;
-        const so = this.scene.getSharedFrameOrigin();
+        const so = this.scene.getSharedFrameOrigin(meshData.modelIndex);
         const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
         const fr = Math.fround;
         const sox = so ? fr(so[0]) : null, soy = so ? fr(so[1]) : 0, soz = so ? fr(so[2]) : 0;

--- a/packages/renderer/src/model-bounds-tracker.ts
+++ b/packages/renderer/src/model-bounds-tracker.ts
@@ -121,7 +121,7 @@ export class ModelBoundsTracker {
     }
 
     /** Fold newly loaded mesh geometry into the tracked AABB. */
-    updateFromMeshes(meshes: import('@ifc-lite/geometry').MeshData[]): void {
+    updateFromMeshes(meshes: import('@ifc-lite/geometry').MeshData[], translationForModel?: (modelIndex: number) => readonly [number, number, number]): void {
         if (!this.bounds) {
             this.bounds = {
                 min: { x: Infinity, y: Infinity, z: Infinity },
@@ -135,7 +135,8 @@ export class ModelBoundsTracker {
             // Model bounds are world-space, so fold the per-mesh origin. No-op when
             // origin is absent/[0,0,0]. Mirrors coordinate-handler.ts.
             const o = mesh.origin;
-            const ox = o ? o[0] : 0, oy = o ? o[1] : 0, oz = o ? o[2] : 0;
+            const delta = translationForModel?.(mesh.modelIndex ?? 0);
+            const ox = (o?.[0] ?? 0) + (delta?.[0] ?? 0), oy = (o?.[1] ?? 0) + (delta?.[1] ?? 0), oz = (o?.[2] ?? 0) + (delta?.[2] ?? 0);
             for (let i = 0; i < positions.length; i += 3) {
                 const x = positions[i] + ox;
                 const y = positions[i + 1] + oy;

--- a/packages/renderer/src/model-placement-bounds.ts
+++ b/packages/renderer/src/model-placement-bounds.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { Scene } from './scene.js';
+import type { PointCloudRenderer } from './pointcloud/point-cloud-renderer.js';
+
+export function modelPlacementBounds(scene: Scene, points: PointCloudRenderer | null, modelIndex: number, handle?: { id: number }) {
+  const min = { x: Infinity, y: Infinity, z: Infinity }, max = { x: -Infinity, y: -Infinity, z: -Infinity };
+  const include = (bounds: { min: readonly number[]; max: readonly number[] } | null | undefined) => {
+    if (!bounds || !bounds.min.every(Number.isFinite) || !bounds.max.every(Number.isFinite)) return;
+    min.x = Math.min(min.x, bounds.min[0]); min.y = Math.min(min.y, bounds.min[1]); min.z = Math.min(min.z, bounds.min[2]);
+    max.x = Math.max(max.x, bounds.max[0]); max.y = Math.max(max.y, bounds.max[1]); max.z = Math.max(max.z, bounds.max[2]);
+  };
+  for (const batch of scene.getBatchedMeshes()) if ((batch.modelIndices?.[0] ?? 0) === modelIndex) include(batch.bounds);
+  for (const mesh of scene.getMeshes()) if (!mesh.hydrated && (mesh.modelIndex ?? 0) === modelIndex) include(mesh.bounds);
+  for (const template of scene.getInstancedTemplates()) if (template.modelIndex === modelIndex) include(template.bounds);
+  for (const mesh of scene.getTexturedMeshes()) {
+    if ((mesh.modelIndex ?? 0) !== modelIndex) continue;
+    include(mesh.bounds);
+  }
+  include(points?.getPlacementBounds(modelIndex, handle));
+  return Number.isFinite(min.x) ? { min, max } : null;
+}
+
+export function sceneMeshBounds(scene: Scene) {
+
+  let minX = Infinity, minY = Infinity, minZ = Infinity;
+  let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+  let any = false;
+  for (const batch of [...scene.getBatchedMeshes(), ...scene.getTexturedMeshes(), ...scene.getInstancedTemplates(), ...scene.getMeshes().filter((mesh) => !mesh.hydrated)]) {
+      if (!batch.bounds || !batch.bounds.min.every(Number.isFinite) || !batch.bounds.max.every(Number.isFinite)) continue;
+      any = true;
+      if (batch.bounds.min[0] < minX) minX = batch.bounds.min[0];
+      if (batch.bounds.min[1] < minY) minY = batch.bounds.min[1];
+      if (batch.bounds.min[2] < minZ) minZ = batch.bounds.min[2];
+      if (batch.bounds.max[0] > maxX) maxX = batch.bounds.max[0];
+      if (batch.bounds.max[1] > maxY) maxY = batch.bounds.max[1];
+      if (batch.bounds.max[2] > maxZ) maxZ = batch.bounds.max[2];
+  }
+  if (!any) return null;
+  return { min: { x: minX, y: minY, z: minZ }, max: { x: maxX, y: maxY, z: maxZ } };
+}

--- a/packages/renderer/src/model-translation.test.ts
+++ b/packages/renderer/src/model-translation.test.ts
@@ -291,3 +291,15 @@ it('retains replaced, edited and removed authored bounds across model moves (#42
   placements.set(7, [0, 0, 0]); placements.placeAuthoredMesh(mesh);
   assert.deepEqual(mesh.bounds, { min: [2, -2, 4], max: [5, 6, 7] });
 });
+
+it('does not resurrect removed released geometry after a flat-scene reshape (#4226)', () => {
+  const scene = new Scene(), { device, pipeline } = recordingGpu();
+  scene.appendToBatches([triangle(1, 7), triangle(2, 7, 10)], device, pipeline);
+  scene.releaseGeometryData(); scene.clearFlatGeometry();
+  scene.appendToBatches([triangle(2, 7, 10)], device, pipeline);
+  scene.releaseGeometryData(); scene.setModelTranslation(7, [100, 0, 0]);
+  assert.equal(scene.getEntityBoundingBox(1), null);
+  assert.equal(scene.raycast({ x: 100.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 }), null);
+  assert.deepEqual(scene.getBounds(), { min: { x: 110, y: 0, z: 0 }, max: { x: 111, y: 1, z: 0 } });
+  assert.equal(scene.raycast({ x: 110.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 })?.expressId, 2);
+});

--- a/packages/renderer/src/model-translation.test.ts
+++ b/packages/renderer/src/model-translation.test.ts
@@ -292,11 +292,13 @@ it('retains replaced, edited and removed authored bounds across model moves (#42
   assert.deepEqual(mesh.bounds, { min: [2, -2, 4], max: [5, 6, 7] });
 });
 
-it('does not resurrect removed released geometry after a flat-scene reshape (#4226)', () => {
+for (const reshape of [false, true]) it(`does not resurrect removed released geometry (reshape: ${reshape}, #4226)`, () => {
   const scene = new Scene(), { device, pipeline } = recordingGpu();
   scene.appendToBatches([triangle(1, 7), triangle(2, 7, 10)], device, pipeline);
-  scene.releaseGeometryData(); scene.clearFlatGeometry();
-  scene.appendToBatches([triangle(2, 7, 10)], device, pipeline);
+  scene.releaseGeometryData();
+  if (reshape) {
+    scene.clearFlatGeometry(); scene.appendToBatches([triangle(2, 7, 10)], device, pipeline);
+  } else scene.removeMeshesForEntity(1);
   scene.releaseGeometryData(); scene.setModelTranslation(7, [100, 0, 0]);
   assert.equal(scene.getEntityBoundingBox(1), null);
   assert.equal(scene.raycast({ x: 100.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 }), null);

--- a/packages/renderer/src/model-translation.test.ts
+++ b/packages/renderer/src/model-translation.test.ts
@@ -1,0 +1,256 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MeshData } from '@ifc-lite/geometry';
+import { Scene } from './scene.js';
+import { Renderer } from './index.js';
+import { ModelTranslations } from './model-translation.js';
+import { MathUtils } from './math.js';
+import type { Mesh } from './types.js';
+import { modelPlacementBounds } from './model-placement-bounds.js';
+import type { RenderPipeline } from './pipeline.js';
+import { buildGeometryCache } from './snap-geometry-cache.js';
+
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  COPY_SRC: 4, COPY_DST: 8, INDEX: 16, VERTEX: 32, UNIFORM: 64, STORAGE: 128,
+};
+
+function triangle(expressId: number, modelIndex: number, x = 0): MeshData {
+  return { expressId, modelIndex, origin: [x, 0, 0], color: [1, 1, 1, 1],
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]) };
+}
+
+function recordingGpu() {
+  const buffers: Array<{ data: ArrayBuffer; writes: number }> = [];
+  const device = {
+    limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 },
+    createBuffer({ size }: GPUBufferDescriptor) {
+      const buffer = { size, data: new ArrayBuffer(size), writes: 0,
+        getMappedRange() { return this.data; }, unmap() {}, destroy() {} };
+      buffers.push(buffer);
+      return buffer;
+    },
+    createBindGroup() { return {}; },
+    queue: { writeBuffer() { throw new Error('Flat translation must not upload vertices.'); } },
+  } as unknown as GPUDevice;
+  const pipeline = { getUniformBufferSize: () => 512, getBindGroupLayout: () => ({}) } as unknown as RenderPipeline;
+  return { device, pipeline, buffers };
+}
+
+describe('whole-model renderer placement (#4226)', () => {
+  for (const streaming of [false, true]) it(`frames later uploads in their pre-existing placement (streaming: ${streaming}, #4226)`, () => {
+    const { device, pipeline } = recordingGpu();
+    const canvas = { width: 256, height: 256, getBoundingClientRect: () => ({ width: 256, height: 256 }) } as unknown as HTMLCanvasElement;
+    const renderer = new Renderer(canvas);
+    // Only the GPU boundary is replaced; Renderer, Scene, batching and the
+    // camera's bounds tracker execute their actual upload paths.
+    const internals = renderer as unknown as Record<string, unknown>;
+    internals.device = { isInitialized: () => true, getDevice: () => device };
+    internals.pipeline = pipeline;
+    renderer.setModelTranslation(7, [10_000, 0, 0]);
+    const first = triangle(1, 7);
+    if (streaming) renderer.addMeshes([first], true); else renderer.loadGeometry([first]);
+    assert.deepEqual(renderer.getModelBounds(), { min: { x: 10_000, y: 0, z: 0 }, max: { x: 10_001, y: 1, z: 0 } });
+    renderer.addMeshes([triangle(2, 7, 5)], streaming);
+    assert.deepEqual(renderer.getModelBounds(), { min: { x: 10_000, y: 0, z: 0 }, max: { x: 10_006, y: 1, z: 0 } });
+    renderer.fitToView();
+    assert.deepEqual(renderer.getCamera().getTarget(), { x: 10_003, y: 0.5, z: 0 });
+    assert.deepEqual(first.origin, [0, 0, 0], 'incremental bounds do not mutate source coordinates');
+  });
+  it('moves picking and snap vertices with the model while preserving source geometry', () => {
+    const scene = new Scene(), source = triangle(1, 0);
+    scene.addMeshData(source);
+    const direction = { x: 0, y: 0, z: -1 };
+    assert.equal(scene.raycast({ x: 0.2, y: 0.2, z: 2 }, direction)?.expressId, 1);
+    scene.setModelTranslation(0, [10, 0, 0]);
+    assert.equal(scene.raycast({ x: 0.2, y: 0.2, z: 2 }, direction), null);
+    assert.equal(scene.raycast({ x: 10.2, y: 0.2, z: 2 }, direction)?.expressId, 1);
+    const placed = scene.getMeshDataPieces(1)![0];
+    assert.ok(buildGeometryCache(placed).vertices.some((point) => point.x === 10));
+    assert.strictEqual(placed.positions, source.positions, 'no vertex copy');
+    assert.deepEqual(source.origin, [0, 0, 0], 'source export frame unchanged');
+    scene.setModelTranslation(0, [0, 0, 0]);
+    assert.equal(scene.raycast({ x: 0.2, y: 0.2, z: 2 }, direction)?.expressId, 1);
+  });
+
+  it('separates same-colour models and moves batch origins without rebuilding GPU buffers', () => {
+    const scene = new Scene(), { device, pipeline, buffers } = recordingGpu();
+    scene.appendToBatches([triangle(1, 0), triangle(2, 1, 3)], device, pipeline);
+    const before = scene.getBatchedMeshes().map((batch) => ({ batch, vertexBuffer: batch.vertexBuffer,
+      origin: [...batch.origin!], bounds: structuredClone(batch.bounds!) }));
+    assert.equal(before.length, 2);
+    const bufferCount = buffers.length;
+    scene.setModelTranslation(1, [10, 0, 0]);
+    for (const item of before) {
+      assert.strictEqual(item.batch.vertexBuffer, item.vertexBuffer);
+      const expectedModel = item.batch.expressIds.includes(2) ? 1 : 0;
+      assert.ok([...item.batch.modelIndices!].every((index) => index === expectedModel));
+      const delta = expectedModel === 1 ? 10 : 0;
+      assert.equal(item.batch.origin![0], item.origin[0] + delta);
+      assert.equal(item.batch.bounds!.min[0], item.bounds.min[0] + delta);
+    }
+    assert.equal(buffers.length, bufferCount, 'preview allocates no GPU geometry');
+    assert.equal(scene.getEntityBoundingBox(2)?.min.x, 13);
+  });
+
+  it('keeps same-colour overrides attached to their own federated model', () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    scene.appendToBatches([triangle(1, 0), triangle(2, 1, 3)], device, pipeline);
+    scene.setColorOverrides(new Map([[1, [1, 0, 0, 1]], [2, [1, 0, 0, 1]]]), device, pipeline);
+    const overlays = scene.getOverrideBatches();
+    assert.equal(overlays.length, 2);
+    const before = overlays.map((batch) => ({ batch, origin: batch.origin![0], buffer: batch.vertexBuffer }));
+    scene.setModelTranslation(1, [10, 0, 0]);
+    for (const { batch, origin, buffer } of before) {
+      const expectedModel = batch.expressIds.includes(2) ? 1 : 0;
+      assert.ok([...batch.modelIndices!].every((index) => index === expectedModel));
+      assert.equal(batch.origin![0], origin + (expectedModel === 1 ? 10 : 0));
+      assert.equal(batch.vertexBuffer, buffer, 'overlay movement does not rebuild its geometry');
+    }
+  });
+
+  it('moves authored non-batched meshes without evicting them, and places later uploads', () => {
+    const scene = new Scene(), { device } = recordingGpu();
+    const authored = (id: number, modelIndex: number, x: number): Mesh => {
+      const transform = MathUtils.identity(); transform.m[12] = x;
+      return { expressId: id, modelIndex, transform, color: [1, 1, 1, 1], indexCount: 3,
+        vertexBuffer: device.createBuffer({ size: 36, usage: GPUBufferUsage.VERTEX }),
+        indexBuffer: device.createBuffer({ size: 12, usage: GPUBufferUsage.INDEX }),
+        bounds: { min: [x, 0, 0], max: [x + 1, 1, 0] } };
+    };
+    const moving = authored(1, 7, 3), fixed = authored(2, 8, 5);
+    scene.addMeshData(triangle(1, 7, 3)); scene.addMesh(moving); scene.addMesh(fixed);
+    const highlight = { ...authored(1, 7, 3), hydrated: true }; scene.addMesh(highlight);
+    const vertexBuffer = moving.vertexBuffer;
+    scene.setModelTranslation(7, [10, 20, 30]);
+    assert.deepEqual(scene.getMeshes(), [moving, fixed], 'only the hydrated highlight is discarded');
+    assert.equal(moving.vertexBuffer, vertexBuffer);
+    assert.deepEqual(Array.from(moving.transform.m.slice(12, 15)), [13, 20, 30]);
+    assert.deepEqual(Array.from(fixed.transform.m.slice(12, 15)), [5, 0, 0]);
+    assert.deepEqual(modelPlacementBounds(scene, null, 7), { min: { x: 13, y: 20, z: 30 }, max: { x: 14, y: 21, z: 30 } });
+    assert.equal(scene.raycast({ x: 13.2, y: 20.2, z: 32 }, { x: 0, y: 0, z: -1 })?.expressId, 1);
+    scene.releaseGeometryData();
+    scene.setModelTranslation(7, [20, 0, 0]);
+    assert.equal(scene.getEntityBoundingBox(1)!.min.x, 23, 'released CPU pick bounds follow the authored mesh');
+    scene.setModelTranslation(7, [10, 20, 30]);
+    const late = authored(3, 7, 8); scene.addMesh(late);
+    assert.deepEqual(Array.from(late.transform.m.slice(12, 15)), [18, 20, 30]);
+    scene.setModelTranslation(7, [0, 0, 0]);
+    assert.equal(moving.transform.m[12], 3); assert.equal(late.transform.m[12], 8);
+  });
+
+  it('moves both completed and pending batches during asynchronous finalization', async () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    const a = triangle(1, 1), b = { ...triangle(2, 1, 3), color: [1, 0, 0, 1] as [number, number, number, number] };
+    scene.appendToBatches([a, b], device, pipeline, true);
+    // budget=0 builds one replacement synchronously, then yields before the
+    // second; both old drawables and the unexposed replacement must move.
+    const finalizing = scene.finalizeStreamingAsync(device, pipeline, 0);
+    scene.setModelTranslation(1, [100, 0, 0]);
+    await finalizing;
+    for (const batch of scene.getBatchedMeshes()) {
+      assert.equal(batch.bounds!.min[0], batch.expressIds.includes(2) ? 103 : 100);
+    }
+    assert.equal(scene.raycast({ x: 103.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 })?.expressId, 2);
+  });
+
+  it('restores cold geometry through source bounds and uploads its current placement', async () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu(), source = triangle(1, 1, 3);
+    scene.appendToBatches([source], device, pipeline);
+    scene.setColdGeometryProvider({ loadMeshesInBounds: async (min, max) => {
+      assert.deepEqual(min, [3, 0, 0]); assert.deepEqual(max, [4, 1, 0]);
+      return [source];
+    } });
+    scene.setGpuResidencyBudget(1); scene.setHostResidencyBudget(1);
+    for (let i = 0; i < 1000; i++) scene.beginResidencyFrame();
+    for (let i = 0; i < 240; i++) scene.enforceGpuBudget();
+    assert.equal(scene.getMeshDataPieces(1), undefined, 'CPU geometry was evicted to the real cold tier');
+    scene.setModelTranslation(1, [1000, 0, 0]);
+    await scene.drainColdTier();
+    assert.equal(scene.restoreAllEvicted(device, pipeline), 1);
+    assert.equal(scene.getBatchedMeshes()[0].bounds!.min[0], 1003, 'GPU restoration uses the placed bucket mesh');
+    assert.equal(scene.raycast({ x: 1003.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 })?.expressId, 1);
+    assert.deepEqual(source.origin, [3, 0, 0]);
+  });
+
+  it('preserves each released contribution when models temporarily share an entity id', () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    scene.appendToBatches([triangle(1, 0), triangle(1, 1, 3)], device, pipeline);
+    scene.releaseGeometryData();
+    scene.setModelTranslation(1, [100, 0, 0]);
+    assert.equal(scene.getEntityBoundingBox(1)!.min.x, 0);
+    assert.equal(scene.getEntityBoundingBox(1)!.max.x, 104);
+    assert.equal(scene.raycast({ x: 0.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 })?.expressId, 1);
+    scene.setModelTranslation(0, [-10, 0, 0]);
+    assert.equal(scene.getEntityBoundingBox(1)!.min.x, -10);
+    assert.equal(scene.getEntityBoundingBox(1)!.max.x, 104);
+  });
+
+  it('moves GPU-resident geometry and cached pick bounds after CPU release', () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    scene.appendToBatches([triangle(1, 0, 0.125), triangle(2, 1, 5)], device, pipeline);
+    scene.releaseGeometryData();
+    assert.equal(scene.isGeometryDataReleased(), true);
+    for (let i = 0; i < 100; i++) {
+      scene.setModelTranslation(0, [10_000_000, 0, 0]);
+      scene.setModelTranslation(0, [0.001, 0, 0]);
+      assert.ok(Math.abs(scene.getEntityBoundingBox(1)!.min.x - 0.126) < 1e-10);
+      assert.equal(scene.getEntityBoundingBox(2)!.min.x, 5);
+    }
+    scene.setModelTranslation(0, [0, 0, 0]);
+    assert.equal(scene.getEntityBoundingBox(1)!.min.x, 0.125);
+    assert.equal(scene.raycast({ x: 0.2, y: 0.2, z: 2 }, { x: 0, y: 0, z: -1 })?.expressId, 1);
+  });
+
+  it('gives distant models separate local GPU frames', () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    scene.appendToBatches([triangle(1, 0), triangle(2, 1, 10_000_000.001)], device, pipeline);
+    const batches = scene.getBatchedMeshes();
+    assert.ok(Math.abs(batches[1].origin![0] - batches[0].origin![0]) > 9_000_000);
+    scene.setModelTranslation(1, [-10_000_000, 0, 0]);
+    assert.ok(Math.abs(scene.getEntityBoundingBox(2)!.min.x - 0.001) < 1e-7);
+    assert.equal(scene.getEntityBoundingBox(1)!.min.x, 0);
+  });
+
+  it('retains fine residuals when moving a georeferenced model near zero and rebuilding', () => {
+    const scene = new Scene(), { device, pipeline } = recordingGpu();
+    const source = triangle(1, 0, 10_000_000);
+    scene.appendToBatches([source], device, pipeline);
+    scene.setModelTranslation(0, [-10_000_000 + 0.001, 0, 0]);
+    assert.ok(Math.abs(scene.getBatchedMeshes()[0].bounds!.min[0] - 0.001) < 0.0001);
+    scene.clearFlatGeometry();
+    scene.appendToBatches([source], device, pipeline);
+    assert.ok(Math.abs(scene.getBatchedMeshes()[0].bounds!.min[0] - 0.001) < 0.0001);
+    assert.equal(source.origin![0], 10_000_000);
+  });
+
+  it('applies current placement to newly arriving geometry and resets at full teardown', () => {
+    const scene = new Scene();
+    scene.setModelTranslation(1, [4, 5, 6]);
+    scene.addMeshData(triangle(1, 1));
+    assert.deepEqual(scene.getEntityBoundingBox(1)?.min, { x: 4, y: 5, z: 6 });
+    scene.clear();
+    scene.addMeshData(triangle(1, 1));
+    assert.deepEqual(scene.getEntityBoundingBox(1)?.min, { x: 0, y: 0, z: 0 });
+  });
+
+  it('reconstructs instance translation from a double baseline after coarse previews', () => {
+    const translations = new ModelTranslations(), data = new ArrayBuffer(88), view = new DataView(data);
+    view.setFloat32(48, 0.125, true);
+    translations.placeInstances(data, 0, 88);
+    for (let i = 0; i < 100; i++) {
+      translations.set(0, [10_000_000, 0, 0]);
+      translations.placeInstances(data, 0, 88);
+      translations.set(0, [0.001, 0, 0]);
+      translations.placeInstances(data, 0, 88);
+      assert.ok(Math.abs(view.getFloat32(48, true) - 0.126) < 1e-7);
+    }
+    translations.set(0, [0, 0, 0]);
+    translations.placeInstances(data, 0, 88);
+    assert.equal(view.getFloat32(48, true), 0.125);
+  });
+});

--- a/packages/renderer/src/model-translation.test.ts
+++ b/packages/renderer/src/model-translation.test.ts
@@ -254,3 +254,40 @@ describe('whole-model renderer placement (#4226)', () => {
     assert.equal(view.getFloat32(48, true), 0.125);
   });
 });
+
+it('moves every released color-merged entity, not only its wrapper id (#4226)', () => {
+  const scene = new Scene(), { device, pipeline } = recordingGpu();
+  const merged = triangle(100, 7);
+  merged.entityIds = new Uint32Array([11, 12, 13]);
+  scene.appendToBatches([merged], device, pipeline);
+  const before = [11, 12, 13].map((id) => scene.getEntityBoundingBox(id));
+  assert.ok(before.every(Boolean));
+  scene.releaseGeometryData();
+  scene.setModelTranslation(7, [100, 200, 300]);
+  for (const [index, id] of [11, 12, 13].entries()) {
+    const box = scene.getEntityBoundingBox(id)!;
+    assert.equal(box.min.x, before[index]!.min.x + 100);
+    assert.equal(box.min.y, before[index]!.min.y + 200);
+    assert.equal(box.min.z, before[index]!.min.z + 300);
+  }
+  scene.setModelTranslation(7, [0, 0, 0]);
+  assert.deepEqual([11, 12, 13].map((id) => scene.getEntityBoundingBox(id)), before);
+});
+
+it('retains replaced, edited and removed authored bounds across model moves (#4226)', () => {
+  const placements = new ModelTranslations();
+  const mesh = { modelIndex: 7, transform: MathUtils.identity(), bounds: { min: [0, 0, 0], max: [1, 1, 1] } } as Mesh;
+  placements.placeAuthoredMesh(mesh);
+  mesh.bounds = { min: [2, 3, 4], max: [5, 6, 7] };
+  placements.set(7, [10, 0, 0]); placements.placeAuthoredMesh(mesh);
+  assert.deepEqual(mesh.bounds, { min: [12, 3, 4], max: [15, 6, 7] });
+  mesh.bounds!.min[1] = -2;
+  placements.set(7, [20, 0, 0]); placements.placeAuthoredMesh(mesh);
+  assert.deepEqual(mesh.bounds, { min: [22, -2, 4], max: [25, 6, 7] });
+  mesh.bounds = undefined;
+  placements.set(7, [30, 0, 0]); placements.placeAuthoredMesh(mesh);
+  assert.equal(mesh.bounds, undefined);
+  mesh.bounds = { min: [32, -2, 4], max: [35, 6, 7] };
+  placements.set(7, [0, 0, 0]); placements.placeAuthoredMesh(mesh);
+  assert.deepEqual(mesh.bounds, { min: [2, -2, 4], max: [5, 6, 7] });
+});

--- a/packages/renderer/src/model-translation.ts
+++ b/packages/renderer/src/model-translation.ts
@@ -112,6 +112,8 @@ export class ModelTranslations {
 
   sourceMesh(mesh: MeshData): MeshData { return this.meshes.get(mesh)?.source ?? mesh; }
 
+  forgetEntityBounds(id: number): void { this.releasedEntities.delete(id); }
+
   clearFlatBounds(): void {
     this.releasedEntities.clear();
     this.releasedBounds = new WeakMap();

--- a/packages/renderer/src/model-translation.ts
+++ b/packages/renderer/src/model-translation.ts
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { Mesh } from './types.js';
+import type { MeshData } from '@ifc-lite/geometry';
+import type { BoundingBox } from './scene-raycaster.js';
+import { worldAabbFromPieces } from './scene-geometry.js';
+
+type Offset = readonly [number, number, number];
+type Drawable = { origin?: [number, number, number]; bounds?: Bounds };
+type Bounds = { min: [number, number, number]; max: [number, number, number] };
+const ZERO: Offset = [0, 0, 0];
+
+/** Validate before storing an offset, including when no drawables exist yet. */
+export function assertModelTranslation(modelIndex: number, offset: Offset): void {
+  if (!Number.isSafeInteger(modelIndex) || modelIndex < 0 || offset.length !== 3 || !offset.every((value) => Number.isFinite(value) && Number.isFinite(Math.fround(value)))) {
+    throw new Error('Model translation requires a model index and three finite coordinates.');
+  }
+}
+
+function sum(a: Offset, b: Offset): [number, number, number] {
+  return [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+}
+
+function difference(a: Offset, b: Offset): [number, number, number] {
+  return [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+}
+
+function moveBounds(bounds: Bounds, delta: Offset): Bounds {
+  return { min: sum(bounds.min, delta), max: sum(bounds.max, delta) };
+}
+
+interface MeshPlacement {
+  source: MeshData;
+  placed: MeshData;
+}
+
+interface BatchPlacement {
+  modelIndex: number;
+  origin: Offset;
+  bounds: Bounds | undefined;
+}
+
+/** Scene-owned translations in renderer Y-up metres. Mesh vertices remain shared
+ * and immutable: only double-precision local origins and batch draw origins move.
+ * Every preview is evaluated against the baseline, never the previous preview. */
+export class ModelTranslations {
+  private authored = new WeakMap<Mesh, { base: number[]; written: number[]; offset: Offset; bounds?: Bounds }>();
+  private offsets = new Map<number, Offset>();
+  private meshes = new WeakMap<MeshData, MeshPlacement>();
+  private batches = new WeakMap<Drawable, BatchPlacement>();
+  private instances = new WeakMap<ArrayBuffer, { base: Float64Array; written: Float32Array; offset: Offset }>();
+  private releasedBounds = new WeakMap<BoundingBox, Bounds>();
+  private releasedEntities = new Map<number, Map<number, BoundingBox>>();
+
+  get(modelIndex = 0): Offset { return this.offsets.get(modelIndex) ?? ZERO; }
+
+  set(modelIndex: number, offset: Offset): boolean {
+    assertModelTranslation(modelIndex, offset);
+    if (this.get(modelIndex).every((value, i) => value === offset[i])) return false;
+    this.offsets.set(modelIndex, [...offset]);
+    return true;
+  }
+
+  /** Preserve source identity and source coordinates for export and re-alignment. */
+  placeMesh(source: MeshData): MeshData {
+    let entry = this.meshes.get(source);
+    if (!entry) {
+      entry = { source, placed: { ...source } };
+      this.meshes.set(source, entry);
+      this.meshes.set(entry.placed, entry);
+    }
+    const delta = this.get(entry.source.modelIndex);
+    entry.placed.origin = sum(entry.source.origin ?? ZERO, delta);
+    if (entry.source.localToWorld) {
+      entry.placed.localToWorld = entry.source.localToWorld.map((value, index) =>
+        index === 3 ? value + delta[0] : index === 7 ? value + delta[1] : index === 11 ? value + delta[2] : value);
+    }
+    const box = entry.source.geometryAabb;
+    if (box) entry.placed.geometryAabb = { ...box,
+      min: sum(box.min, delta), max: sum(box.max, delta) };
+    return entry.placed;
+  }
+
+  /** Public non-batched meshes carry placement in their draw/pick matrix.
+   * Hydrated highlights already contain placed vertices and are rebuilt instead. */
+  placeAuthoredMesh(mesh: Mesh): void {
+    if (mesh.hydrated) return;
+    const delta = this.get(mesh.modelIndex), matrix = mesh.transform.m;
+    let entry = this.authored.get(mesh);
+    if (!entry) {
+      const base = [matrix[12], matrix[13], matrix[14]];
+      entry = { base, written: [...base], offset: ZERO, bounds: mesh.bounds };
+      this.authored.set(mesh, entry);
+    }
+    if (entry.offset.every((value, index) => value === delta[index])) return;
+    for (let axis = 0; axis < 3; axis++) {
+      entry.base[axis] += matrix[12 + axis] - entry.written[axis];
+      matrix[12 + axis] = entry.base[axis] + delta[axis];
+      entry.written[axis] = matrix[12 + axis];
+    }
+    if (entry.bounds) mesh.bounds = moveBounds(entry.bounds, delta);
+    entry.offset = delta;
+  }
+
+  sourceMesh(mesh: MeshData): MeshData { return this.meshes.get(mesh)?.source ?? mesh; }
+
+  retainEntityBounds(pieces: ReadonlyMap<number, MeshData[]>): void {
+    for (const [id, meshes] of pieces) {
+      const groups = new Map<number, MeshData[]>();
+      for (const mesh of meshes) {
+        const source = this.sourceMesh(mesh), index = source.modelIndex ?? 0;
+        const group = groups.get(index) ?? []; group.push(source); groups.set(index, group);
+      }
+      const bounds = new Map<number, BoundingBox>();
+      for (const [index, group] of groups) { const box = worldAabbFromPieces(group); if (box) bounds.set(index, box); }
+      this.releasedEntities.set(id, bounds);
+    }
+  }
+
+  releasedEntityBounds(id: number): BoundingBox | undefined {
+    const result: BoundingBox = { min: { x: Infinity, y: Infinity, z: Infinity }, max: { x: -Infinity, y: -Infinity, z: -Infinity } };
+    for (const [index, box] of this.releasedEntities.get(id) ?? []) {
+      const delta = this.get(index);
+      for (const [axis, i] of [['x', 0], ['y', 1], ['z', 2]] as const) {
+        result.min[axis] = Math.min(result.min[axis], box.min[axis] + delta[i]);
+        result.max[axis] = Math.max(result.max[axis], box.max[axis] + delta[i]);
+      }
+    }
+    return Number.isFinite(result.min.x) ? result : undefined;
+  }
+
+  sourceDrawableBounds(batch: Drawable): Bounds | undefined { return this.batches.get(batch)?.bounds ?? batch.bounds; }
+
+  /** Released geometry retains only entity bounds. Keep their unrounded baseline
+   * too, so repeated coarse previews do not accumulate coordinate cancellation. */
+  placeReleasedBounds(box: BoundingBox, previous: Offset, modelIndex: number): BoundingBox {
+    const base = this.releasedBounds.get(box) ?? {
+      min: difference([box.min.x, box.min.y, box.min.z], previous),
+      max: difference([box.max.x, box.max.y, box.max.z], previous),
+    };
+    const moved = moveBounds(base, this.get(modelIndex));
+    const result = { min: { x: moved.min[0], y: moved.min[1], z: moved.min[2] },
+      max: { x: moved.max[0], y: moved.max[1], z: moved.max[2] } };
+    this.releasedBounds.set(result, base);
+    return result;
+  }
+
+  /** Used when (re)building batches so a coarse translation cancels in f64 before
+   * the residual vertex coordinates narrow to f32. All colours in a model share
+   * the same frame, retaining bit-coincident highlights and overlay surfaces. */
+  frameOrigin(base: Offset | null, modelIndex = 0): [number, number, number] | undefined {
+    return base ? sum(base, this.get(modelIndex)) : undefined;
+  }
+
+  registerDrawable<T extends Drawable>(batch: T, modelIndex: number): T {
+    const delta = this.get(modelIndex);
+    this.batches.set(batch, { modelIndex,
+      origin: difference(batch.origin ?? ZERO, delta),
+      bounds: batch.bounds ? moveBounds(batch.bounds, [-delta[0], -delta[1], -delta[2]]) : undefined,
+    });
+    return batch;
+  }
+
+  moveDrawable(batch: Drawable): void {
+    const base = this.batches.get(batch);
+    if (!base) return;
+    const delta = this.get(base.modelIndex);
+    batch.origin = sum(base.origin, delta);
+    if (base.bounds) batch.bounds = moveBounds(base.bounds, delta);
+  }
+
+  /** Only occurrence transforms change; template vertex/index buffers never do.
+   * Keep a double baseline so undo never subtracts a rounded GPU translation. */
+  placeInstances(data: ArrayBuffer, modelIndex: number, stride: number): boolean {
+    const delta = this.get(modelIndex), count = data.byteLength / stride;
+    const view = new DataView(data);
+    let entry = this.instances.get(data);
+    if (!entry) {
+      const base = new Float64Array(count * 3), written = new Float32Array(count * 3);
+      for (let i = 0; i < count; i++) for (let axis = 0; axis < 3; axis++) {
+        base[i * 3 + axis] = written[i * 3 + axis] = view.getFloat32(i * stride + 48 + axis * 4, true);
+      }
+      entry = { base, written, offset: ZERO };
+      this.instances.set(data, entry);
+    }
+    if (entry.offset.every((value, i) => value === delta[i])) return false;
+    for (let i = 0; i < count; i++) for (let axis = 0; axis < 3; axis++) {
+      const j = i * 3 + axis, byte = i * stride + 48 + axis * 4;
+      // Preserve intervening element edits / exploded-storey offsets.
+      entry.base[j] += view.getFloat32(byte, true) - entry.written[j];
+      const value = entry.base[j] + delta[axis];
+      view.setFloat32(byte, value, true);
+      entry.written[j] = value;
+    }
+    entry.offset = delta;
+    return true;
+  }
+
+  clear(): void {
+    this.offsets.clear();
+    this.authored = new WeakMap();
+    this.meshes = new WeakMap();
+    this.batches = new WeakMap();
+    this.instances = new WeakMap();
+    this.releasedBounds = new WeakMap();
+    this.releasedEntities.clear();
+  }
+}

--- a/packages/renderer/src/model-translation.ts
+++ b/packages/renderer/src/model-translation.ts
@@ -112,6 +112,11 @@ export class ModelTranslations {
 
   sourceMesh(mesh: MeshData): MeshData { return this.meshes.get(mesh)?.source ?? mesh; }
 
+  clearFlatBounds(): void {
+    this.releasedEntities.clear();
+    this.releasedBounds = new WeakMap();
+  }
+
   retainEntityBounds(pieces: ReadonlyMap<number, MeshData[]>): void {
     for (const [id, meshes] of pieces) {
       const groups = new Map<number, MeshData[]>();

--- a/packages/renderer/src/model-translation.ts
+++ b/packages/renderer/src/model-translation.ts
@@ -46,7 +46,7 @@ interface BatchPlacement {
  * and immutable: only double-precision local origins and batch draw origins move.
  * Every preview is evaluated against the baseline, never the previous preview. */
 export class ModelTranslations {
-  private authored = new WeakMap<Mesh, { base: number[]; written: number[]; offset: Offset; bounds?: Bounds }>();
+  private authored = new WeakMap<Mesh, { base: number[]; written: number[]; offset: Offset; bounds?: Bounds; writtenBounds?: Bounds }>();
   private offsets = new Map<number, Offset>();
   private meshes = new WeakMap<MeshData, MeshPlacement>();
   private batches = new WeakMap<Drawable, BatchPlacement>();
@@ -91,7 +91,7 @@ export class ModelTranslations {
     let entry = this.authored.get(mesh);
     if (!entry) {
       const base = [matrix[12], matrix[13], matrix[14]];
-      entry = { base, written: [...base], offset: ZERO, bounds: mesh.bounds };
+      entry = { base, written: [...base], offset: ZERO, bounds: mesh.bounds ? moveBounds(mesh.bounds, ZERO) : undefined, writtenBounds: mesh.bounds ? moveBounds(mesh.bounds, ZERO) : undefined };
       this.authored.set(mesh, entry);
     }
     if (entry.offset.every((value, index) => value === delta[index])) return;
@@ -100,7 +100,13 @@ export class ModelTranslations {
       matrix[12 + axis] = entry.base[axis] + delta[axis];
       entry.written[axis] = matrix[12 + axis];
     }
+    if (!mesh.bounds) entry.bounds = undefined;
+    else if (!entry.bounds || !entry.writtenBounds) entry.bounds = moveBounds(mesh.bounds, entry.offset.map((v) => -v) as [number, number, number]);
+    else for (const edge of ['min', 'max'] as const) for (let axis = 0; axis < 3; axis++) {
+      entry.bounds[edge][axis] += mesh.bounds[edge][axis] - entry.writtenBounds[edge][axis];
+    }
     if (entry.bounds) mesh.bounds = moveBounds(entry.bounds, delta);
+    entry.writtenBounds = mesh.bounds ? moveBounds(mesh.bounds, ZERO) : undefined;
     entry.offset = delta;
   }
 
@@ -117,6 +123,10 @@ export class ModelTranslations {
       for (const [index, group] of groups) { const box = worldAabbFromPieces(group); if (box) bounds.set(index, box); }
       this.releasedEntities.set(id, bounds);
     }
+  }
+
+  releasedEntityIds(modelIndex: number): number[] {
+    return [...this.releasedEntities].filter(([, groups]) => groups.has(modelIndex)).map(([id]) => id);
   }
 
   releasedEntityBounds(id: number): BoundingBox | undefined {

--- a/packages/renderer/src/point-cloud-placement.test.ts
+++ b/packages/renderer/src/point-cloud-placement.test.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Renderer } from './index.js';
+import { PointCloudRenderer } from './pointcloud/point-cloud-renderer.js';
+import { PointCloudPlacements } from './pointcloud/point-cloud-placement.js';
+import { transformAabb, type PointCloudNode } from './pointcloud/point-cloud-node.js';
+
+describe('pointcloud import/manual transform composition (#4226)', () => {
+  it('cancels a large decode origin before narrowing and retains correction across realignment', () => {
+    const node = { model: undefined } as unknown as PointCloudNode;
+    const placements = new PointCloudPlacements();
+    const baseline = new Float64Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10_000_000.001, 0, 0, 1]);
+    placements.align(node, baseline);
+    placements.translate(node, [-10_000_000, 0, 0]);
+    const bounds = transformAabb({ min: [0, 0, 0], max: [1, 1, 1] }, node.model);
+    assert.ok(Math.abs(bounds.min[0] - 0.001) < 1e-7);
+    baseline[12] = 10_000_002;
+    placements.align(node, baseline);
+    assert.equal(transformAabb({ min: [0, 0, 0], max: [1, 1, 1] }, node.model).min[0], 2);
+    placements.translate(node, [0, 0, 0]);
+    assert.equal(node.model![12], 10_000_002);
+  });
+
+  it('does not share placement between assets or accept non-finite input', () => {
+    const a = {} as PointCloudNode, b = {} as PointCloudNode, placements = new PointCloudPlacements();
+    placements.translate(a, [5, 2, 3]);
+    placements.translate(b, [-3, 0, 0]);
+    assert.equal(a.model![12], 5);
+    assert.equal(b.model![12], -3);
+    assert.throws(() => placements.translate(a, [NaN, 0, 0]), /finite/);
+    assert.equal(a.model![12], 5);
+    assert.throws(() => placements.translate(a, [1e100, 0, 0]), /range/);
+    placements.align(a, null);
+    assert.equal(a.model![12], 5, 'rejected translation cannot poison subsequent alignment');
+    const overflow = new Float64Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1e100, 0, 0, 1]);
+    assert.throws(() => placements.align(a, overflow), /range/);
+    placements.translate(a, [6, 0, 0]);
+    assert.equal(a.model![12], 6, 'rejected alignment cannot poison subsequent translation');
+  });
+});
+
+it('keeps inline scan placement after resource-only clearing (#4226)', () => {
+  (globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2 };
+  (globalThis as Record<string, unknown>).GPUBufferUsage = { VERTEX: 32, COPY_DST: 8, UNIFORM: 64, STORAGE: 128 };
+  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
+    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
+    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
+  } as unknown as GPUDevice;
+  const renderer = new PointCloudRenderer(device, 'rgba8unorm', 'depth32float', 1);
+  renderer.setModelTranslation(7, [10, 20, 30]);
+  renderer.clear();
+  const handle = renderer.addAsset({ expressId: 1, modelIndex: 7, chunk: { pointCount: 1,
+    positions: new Float32Array([1, 2, 3]), bbox: { min: [1, 2, 3], max: [1, 2, 3] } } });
+  assert.deepEqual(renderer.getPlacementBounds(7, handle), { min: [11, 22, 33], max: [11, 22, 33] });
+  renderer.clear();
+});
+
+for (const replace of [false, true]) it(`retains a pre-init model offset for embedded clouds (replace: ${replace}, #4226)`, () => {
+  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
+    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
+    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
+  } as unknown as GPUDevice;
+  const renderer = new Renderer({ width: 256, height: 256, getBoundingClientRect: () => ({ width: 256, height: 256 }) } as unknown as HTMLCanvasElement);
+  renderer.setModelTranslation(7, [100, 200, 300]);
+  // Device creation boundary: the actual point renderer is created after the
+  // public placement call, just as it is after Renderer.init's device await.
+  const points = new PointCloudRenderer(device, 'rgba8unorm', 'depth32float', 1);
+  (renderer as unknown as { pointCloudRenderer: PointCloudRenderer }).pointCloudRenderer = points;
+  const assets = [{ expressId: 1, modelIndex: 7, chunk: { pointCount: 1,
+    positions: new Float32Array([1, 2, 3]), bbox: { min: [1, 2, 3] as [number, number, number], max: [1, 2, 3] as [number, number, number] } } }];
+  if (replace) renderer.setPointClouds(assets); else renderer.addPointClouds(assets);
+  assert.deepEqual(renderer.getModelPlacementBounds(7), { min: { x: 101, y: 202, z: 303 }, max: { x: 101, y: 202, z: 303 } });
+  points.clear();
+});
+
+it('rejects invalid deferred cloud offsets before a later upload can inherit them (#4226)', () => {
+  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
+    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
+    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
+  } as unknown as GPUDevice;
+  const renderer = new PointCloudRenderer(device, 'rgba8unorm', 'depth32float', 1);
+  renderer.setModelTranslation(7, [5, 6, 7]);
+  for (const invalid of [NaN, Infinity, 1e100]) assert.throws(() => renderer.setModelTranslation(7, [invalid, 0, 0]), /finite/);
+  for (const index of [-1, 0.5, Infinity, NaN]) assert.throws(() => renderer.setModelTranslation(index, [0, 0, 0]), /model index/);
+  assert.equal(renderer.getNodeCount(), 0);
+  const handle = renderer.addAsset({ expressId: 1, modelIndex: 7, chunk: { pointCount: 1,
+    positions: new Float32Array([1, 2, 3]), bbox: { min: [1, 2, 3], max: [1, 2, 3] } } });
+  assert.deepEqual(renderer.getPlacementBounds(7, handle), { min: [6, 8, 10], max: [6, 8, 10] });
+  assert.throws(() => renderer.setModelTranslation(7, [NaN, 0, 0]), /finite/);
+  assert.deepEqual(renderer.getPlacementBounds(7, handle), { min: [6, 8, 10], max: [6, 8, 10] });
+  assert.equal(renderer.getNodeCount(), 1); renderer.clear();
+});

--- a/packages/renderer/src/point-cloud-placement.test.ts
+++ b/packages/renderer/src/point-cloud-placement.test.ts
@@ -8,6 +8,15 @@ import { PointCloudRenderer } from './pointcloud/point-cloud-renderer.js';
 import { PointCloudPlacements } from './pointcloud/point-cloud-placement.js';
 import { transformAabb, type PointCloudNode } from './pointcloud/point-cloud-node.js';
 
+  (globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2 };
+  (globalThis as Record<string, unknown>).GPUBufferUsage = { VERTEX: 32, COPY_DST: 8, UNIFORM: 64, STORAGE: 128 };
+function pointDevice(): GPUDevice {
+  return { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
+    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
+    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
+  } as unknown as GPUDevice;
+}
+
 describe('pointcloud import/manual transform composition (#4226)', () => {
   it('cancels a large decode origin before narrowing and retains correction across realignment', () => {
     const node = { model: undefined } as unknown as PointCloudNode;
@@ -43,13 +52,7 @@ describe('pointcloud import/manual transform composition (#4226)', () => {
 });
 
 it('keeps inline scan placement after resource-only clearing (#4226)', () => {
-  (globalThis as Record<string, unknown>).GPUShaderStage = { VERTEX: 1, FRAGMENT: 2 };
-  (globalThis as Record<string, unknown>).GPUBufferUsage = { VERTEX: 32, COPY_DST: 8, UNIFORM: 64, STORAGE: 128 };
-  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
-    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
-    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
-  } as unknown as GPUDevice;
-  const renderer = new PointCloudRenderer(device, 'rgba8unorm', 'depth32float', 1);
+  const renderer = new PointCloudRenderer(pointDevice(), 'rgba8unorm', 'depth32float', 1);
   renderer.setModelTranslation(7, [10, 20, 30]);
   renderer.clear();
   const handle = renderer.addAsset({ expressId: 1, modelIndex: 7, chunk: { pointCount: 1,
@@ -59,10 +62,7 @@ it('keeps inline scan placement after resource-only clearing (#4226)', () => {
 });
 
 for (const replace of [false, true]) it(`retains a pre-init model offset for embedded clouds (replace: ${replace}, #4226)`, () => {
-  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
-    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
-    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
-  } as unknown as GPUDevice;
+  const device = pointDevice();
   const renderer = new Renderer({ width: 256, height: 256, getBoundingClientRect: () => ({ width: 256, height: 256 }) } as unknown as HTMLCanvasElement);
   renderer.setModelTranslation(7, [100, 200, 300]);
   // Device creation boundary: the actual point renderer is created after the
@@ -77,11 +77,7 @@ for (const replace of [false, true]) it(`retains a pre-init model offset for emb
 });
 
 it('rejects invalid deferred cloud offsets before a later upload can inherit them (#4226)', () => {
-  const device = { limits: { maxBufferSize: 1 << 28, maxStorageBufferBindingSize: 1 << 28 }, createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}),
-    createShaderModule: () => ({}), createRenderPipeline: () => ({}), createBindGroup: () => ({}),
-    createBuffer: ({ size }: GPUBufferDescriptor) => ({ size, destroy() {} }), queue: { writeBuffer() {} },
-  } as unknown as GPUDevice;
-  const renderer = new PointCloudRenderer(device, 'rgba8unorm', 'depth32float', 1);
+  const renderer = new PointCloudRenderer(pointDevice(), 'rgba8unorm', 'depth32float', 1);
   renderer.setModelTranslation(7, [5, 6, 7]);
   for (const invalid of [NaN, Infinity, 1e100]) assert.throws(() => renderer.setModelTranslation(7, [invalid, 0, 0]), /finite/);
   for (const index of [-1, 0.5, Infinity, NaN]) assert.throws(() => renderer.setModelTranslation(index, [0, 0, 0]), /model index/);
@@ -91,5 +87,30 @@ it('rejects invalid deferred cloud offsets before a later upload can inherit the
   assert.deepEqual(renderer.getPlacementBounds(7, handle), { min: [6, 8, 10], max: [6, 8, 10] });
   assert.throws(() => renderer.setModelTranslation(7, [NaN, 0, 0]), /finite/);
   assert.deepEqual(renderer.getPlacementBounds(7, handle), { min: [6, 8, 10], max: [6, 8, 10] });
-  assert.equal(renderer.getNodeCount(), 1); renderer.clear();
+  const later = renderer.addAsset({ expressId: 2, modelIndex: 7, chunk: { pointCount: 1,
+    positions: new Float32Array([0, 0, 0]), bbox: { min: [0, 0, 0], max: [0, 0, 0] } } });
+  assert.deepEqual(renderer.getPlacementBounds(7, later), { min: [5, 6, 7], max: [5, 6, 7] });
+  assert.equal(renderer.getNodeCount(), 2); renderer.clear();
+});
+
+it('preflights all composed cloud matrices before moving any scene geometry (#4226)', () => {
+  const renderer = new Renderer({ width: 256, height: 256, getBoundingClientRect: () => ({ width: 256, height: 256 }) } as unknown as HTMLCanvasElement);
+  const points = new PointCloudRenderer(pointDevice(), 'rgba8unorm', 'depth32float', 1);
+  (renderer as unknown as { pointCloudRenderer: PointCloudRenderer }).pointCloudRenderer = points;
+  const asset = (id: number) => ({ expressId: id, modelIndex: 7, chunk: { pointCount: 1,
+    positions: new Float32Array([0, 0, 0]), bbox: { min: [0, 0, 0] as [number, number, number], max: [0, 0, 0] as [number, number, number] } } });
+  const first = points.addAsset(asset(1)), second = points.addAsset(asset(2));
+  const alignment = new Float64Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 3e38, 0, 0, 1]);
+  points.setAssetTransform(second, alignment);
+  const before = renderer.getModelPlacementBounds(7);
+  assert.throws(() => renderer.setModelTranslation(7, [1e38, 0, 0]), /range/);
+  assert.deepEqual(renderer.getModelPlacementBounds(7), before);
+  assert.deepEqual(points.getPlacementBounds(7, first), { min: [0, 0, 0], max: [0, 0, 0] });
+  const third = points.addAsset(asset(3));
+  assert.deepEqual(points.getPlacementBounds(7, third), { min: [0, 0, 0], max: [0, 0, 0] });
+  const scene = (renderer as unknown as { scene: { getModelTranslation(index: number): readonly number[] } }).scene;
+  assert.deepEqual(scene.getModelTranslation(7), [0, 0, 0]);
+  renderer.setModelTranslation(7, [-1e38, 0, 0]);
+  assert.equal(points.getPickNodes()[0].model?.[12], Math.fround(-1e38), 'GPU picking receives the visible placement matrix');
+  points.clear();
 });

--- a/packages/renderer/src/point-picker-placement.test.ts
+++ b/packages/renderer/src/point-picker-placement.test.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { PointPicker } from './point-picker.js';
+import type { WebGPUDevice } from './device.js';
+
+it('keeps independent GPU pick uniforms for differently placed clouds in one pass (#4226)', () => {
+  Object.assign(globalThis, { GPUShaderStage: { VERTEX: 1, FRAGMENT: 2 }, GPUBufferUsage: { UNIFORM: 64, COPY_DST: 8 } });
+  const buffers: Array<{ data: ArrayBuffer; destroyed: boolean }> = [];
+  const device = {
+    createBindGroupLayout: () => ({}), createPipelineLayout: () => ({}), createShaderModule: () => ({}), createRenderPipeline: () => ({}),
+    createBuffer: ({ size }: GPUBufferDescriptor) => {
+      const b = { data: new ArrayBuffer(size), destroyed: false, destroy() { this.destroyed = true; } }; buffers.push(b); return b;
+    },
+    createBindGroup: (descriptor: GPUBindGroupDescriptor) => ({ buffer: (Array.from(descriptor.entries)[0].resource as GPUBufferBinding).buffer }),
+    queue: { writeBuffer(buffer: { data: ArrayBuffer }, offset: number, data: ArrayBuffer, start: number, length: number) {
+      new Uint8Array(buffer.data).set(new Uint8Array(data, start, length), offset);
+    } },
+  } as unknown as GPUDevice;
+  const picker = new PointPicker({ getDevice: () => device } as WebGPUDevice);
+  const draws: Array<{ data: ArrayBuffer }> = [];
+  let binding: { buffer: { data: ArrayBuffer } };
+  const pass = { setPipeline() {}, setVertexBuffer() {}, setBindGroup(_index: number, group: typeof binding) { binding = group; },
+    draw() { draws.push(binding.buffer); } } as unknown as GPURenderPassEncoder;
+  const identity = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+  const model = identity.slice(); model[12] = 100;
+  const nodes = [{ expressId: 7, model, chunks: [{ vertexBuffer: {} as GPUBuffer, pointCount: 1 }] },
+    { expressId: 8, chunks: [{ vertexBuffer: {} as GPUBuffer, pointCount: 1 }] }];
+  const draw = () => picker.drawIntoPass(pass, nodes, identity, { width: 256, height: 256 },
+    { sizeMode: 0, worldRadius: 1, pointSizePx: 4, clickTolerancePx: 2 }, { normal: [1, 0, 0], distance: 101, flipped: false });
+  draw();
+  // Inspect buffers at submission time, after ALL queue writes, not at write time.
+  assert.notEqual(draws[0], draws[1]);
+  assert.equal(new Uint32Array(draws[0].data)[24], 7); assert.equal(new Uint32Array(draws[1].data)[24], 8);
+  assert.equal(new Float32Array(draws[0].data)[44], 100); assert.equal(new Float32Array(draws[1].data)[44], 0);
+  assert.equal(new Float32Array(draws[0].data)[31], 101);
+  model[12] = -50; draw();
+  assert.equal(new Float32Array(draws[2].data)[44], -50); assert.equal(buffers.length, 2, 'picks reuse uniform buffers');
+  picker.destroy(); assert.ok(buffers.every((b) => b.destroyed));
+});

--- a/packages/renderer/src/point-picker.ts
+++ b/packages/renderer/src/point-picker.ts
@@ -23,6 +23,7 @@ import { POINT_QUAD_VERTS, POINT_VERTEX_BYTES } from './pointcloud/point-pipelin
 export interface PointPickNode {
   expressId: number;
   modelIndex?: number;
+  model?: Float32Array;
   chunks: ReadonlyArray<{ vertexBuffer: GPUBuffer; pointCount: number }>;
 }
 
@@ -70,15 +71,15 @@ export function decodePickSample(value: number): DecodedPickSample {
   return { meshIndexPlusOne: value, pointExpressId: 0, instanceExpressId: 0, kind: 'mesh' };
 }
 
-// mat4x4 (64) + vec4 viewport (16) + vec4 sizing (16) + vec4 entityIdOverride (16) + vec4 section (16)
-const UNIFORM_BYTES = 128;
+// View projection + viewport/sizing/id/section + per-asset model matrix.
+const UNIFORM_BYTES = 192;
+const IDENTITY = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
 
 export class PointPicker {
   private device: GPUDevice;
   private pipeline: GPURenderPipeline;
   private bindGroupLayout: GPUBindGroupLayout;
-  private uniformBuffer: GPUBuffer;
-  private bindGroup: GPUBindGroup;
+  private uniforms: Array<{ buffer: GPUBuffer; bindGroup: GPUBindGroup }> = [];
   private uniformScratch = new Float32Array(UNIFORM_BYTES / 4);
   private uniformU32 = new Uint32Array(this.uniformScratch.buffer);
   private destroyed = false;
@@ -96,16 +97,6 @@ export class PointPicker {
       ],
     });
 
-    this.uniformBuffer = this.device.createBuffer({
-      size: UNIFORM_BYTES,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-
-    this.bindGroup = this.device.createBindGroup({
-      layout: this.bindGroupLayout,
-      entries: [{ binding: 0, resource: { buffer: this.uniformBuffer } }],
-    });
-
     const shader = this.device.createShaderModule({
       code: `
 struct U {
@@ -118,6 +109,7 @@ struct U {
   // y = sectionEnabled (0/1), z = sectionFlipped (0/1).
   entityIdOverride: vec4<u32>,
   section: vec4<f32>,         // xyz = plane normal, w = plane distance
+  model: mat4x4<f32>,
 }
 @binding(0) @group(0) var<uniform> u: U;
 
@@ -145,7 +137,8 @@ fn vs_main(input: VIn, @builtin(vertex_index) vId: u32) -> VOut {
   );
   let corner = corners[vId];
 
-  var clip = u.viewProj * vec4<f32>(input.position, 1.0);
+  let world = u.model * vec4<f32>(input.position, 1.0);
+  var clip = u.viewProj * world;
 
   let sizeMode = u32(u.sizing.x);
   let worldRadius = u.sizing.y;
@@ -158,7 +151,7 @@ fn vs_main(input: VIn, @builtin(vertex_index) vId: u32) -> VOut {
   if (sizeMode == 0u) {
     halfPx = max(0.5, pointSizePx * 0.5);
   } else {
-    let edgePos = u.viewProj * vec4<f32>(input.position + vec3<f32>(worldRadius, 0.0, 0.0), 1.0);
+    let edgePos = u.viewProj * vec4<f32>(world.xyz + vec3<f32>(worldRadius, 0.0, 0.0), 1.0);
     let centerNdcX = clip.x / max(abs(clip.w), 1e-6);
     let edgeNdcX = edgePos.x / max(abs(edgePos.w), 1e-6);
     let projectedPx = abs(edgeNdcX - centerNdcX) * 0.5 * viewport.x;
@@ -179,7 +172,7 @@ fn vs_main(input: VIn, @builtin(vertex_index) vId: u32) -> VOut {
   o.pos = clip;
   o.entityId = input.entityId;
   o.quadUv = corner;
-  o.worldPos = input.position;
+  o.worldPos = world.xyz;
   return o;
 }
 
@@ -256,14 +249,24 @@ fn fs_main(input: VOut) -> @location(0) u32 {
   ): void {
     if (this.destroyed || nodes.length === 0) return;
     pass.setPipeline(this.pipeline);
-    pass.setBindGroup(0, this.bindGroup);
+
     // Per-node uniform write so federation-relabelled IDs surface in
     // the picker too. The per-vertex `entityId` attribute is baked at
     // upload time and goes stale once the FederationRegistry assigns
     // an idOffset to the model — the override forces the picker to
     // emit the asset's CURRENT expressId regardless.
-    for (const node of nodes) {
-      this.writeUniforms(viewProj, viewport, sizing, node.expressId >>> 0, section);
+    // Each draw needs a distinct buffer: queue writes execute before the pass,
+    // so reusing one buffer would give every asset the last asset's transform/id.
+    for (const [index, node] of nodes.entries()) {
+      let uniform = this.uniforms[index];
+      if (!uniform) {
+        const buffer = this.device.createBuffer({ size: UNIFORM_BYTES, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+        uniform = { buffer, bindGroup: this.device.createBindGroup({ layout: this.bindGroupLayout,
+          entries: [{ binding: 0, resource: { buffer } }] }) };
+        this.uniforms.push(uniform);
+      }
+      this.writeUniforms(uniform.buffer, node.model, viewProj, viewport, sizing, node.expressId >>> 0, section);
+      pass.setBindGroup(0, uniform.bindGroup);
       for (const chunk of node.chunks) {
         if (chunk.pointCount === 0) continue;
         pass.setVertexBuffer(0, chunk.vertexBuffer);
@@ -273,6 +276,8 @@ fn fs_main(input: VOut) -> @location(0) u32 {
   }
 
   private writeUniforms(
+    buffer: GPUBuffer,
+    model: Float32Array | undefined,
     viewProj: Float32Array,
     viewport: { width: number; height: number },
     sizing: { sizeMode: number; worldRadius: number; pointSizePx: number; clickTolerancePx: number },
@@ -301,12 +306,14 @@ fn fs_main(input: VOut) -> @location(0) u32 {
     u[29] = section ? section.normal[1] : 0;
     u[30] = section ? section.normal[2] : 0;
     u[31] = section ? section.distance : 0;
-    this.device.queue.writeBuffer(this.uniformBuffer, 0, u.buffer, u.byteOffset, UNIFORM_BYTES);
+    u.set(model ?? IDENTITY, 32);
+    this.device.queue.writeBuffer(buffer, 0, u.buffer, u.byteOffset, UNIFORM_BYTES);
   }
 
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
-    this.uniformBuffer.destroy();
+    for (const { buffer } of this.uniforms) buffer.destroy();
+    this.uniforms = [];
   }
 }

--- a/packages/renderer/src/pointcloud/point-cloud-node.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-node.ts
@@ -363,3 +363,16 @@ function growBounds(
 function clamp01(v: number): number {
   return v < 0 ? 0 : v > 1 ? 1 : v;
 }
+
+/** Destroy all nodes, or only assets belonging to one ingestion owner. */
+export function clearOwnedPointCloudNodes<Owner extends string>(
+  nodes: Map<number, PointCloudNode>, owners: Map<number, Owner>, owner?: Owner,
+): void {
+  for (const [id, node] of nodes) {
+    if (owner !== undefined && owners.get(id) !== owner) continue;
+    destroyNode(node);
+    nodes.delete(id);
+    owners.delete(id);
+  }
+  if (owner === undefined) owners.clear();
+}

--- a/packages/renderer/src/pointcloud/point-cloud-placement.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-placement.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { transformAabb, type PointCloudNode } from './point-cloud-node.js';
+
+type Translation = readonly [number, number, number];
+interface Placement { baseline: Float64Array; translation: Translation }
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Compose import alignment and manual placement through one writer. In particular
+ * toggling alignment must never erase a manual correction (#4226). */
+export class PointCloudPlacements {
+  private placements = new WeakMap<PointCloudNode, Placement>();
+
+  private entry(node: PointCloudNode): Placement {
+    let entry = this.placements.get(node);
+    if (!entry) {
+      entry = { baseline: new Float64Array(node.model ?? IDENTITY), translation: [0, 0, 0] };
+      this.placements.set(node, entry);
+    }
+    return entry;
+  }
+
+  align(node: PointCloudNode, matrix: Float32Array | Float64Array | null): void {
+    if (matrix && (matrix.length !== 16 || !matrix.every(Number.isFinite))) {
+      throw new Error('Pointcloud placement needs a finite 4×4 matrix.');
+    }
+    const entry = this.entry(node);
+    const next = { ...entry, baseline: new Float64Array(matrix ?? IDENTITY) };
+    this.apply(node, next);
+    this.placements.set(node, next);
+  }
+
+  translate(node: PointCloudNode, translation: Translation): void {
+    if (translation.length !== 3 || !translation.every(Number.isFinite)) {
+      throw new Error('Pointcloud translation needs three finite coordinates.');
+    }
+    const entry = this.entry(node);
+    const next = { ...entry, translation: [...translation] as Translation };
+    this.apply(node, next);
+    this.placements.set(node, next);
+  }
+
+  private apply(node: PointCloudNode, entry: Placement): void {
+    const matrix = new Float32Array(entry.baseline);
+    for (let axis = 0; axis < 3; axis++) {
+      // Sum in f64 FIRST. Narrowing the baseline at map magnitude would lose
+      // the millimetres before a coarse move can bring the cloud near zero.
+      matrix[12 + axis] = entry.baseline[12 + axis] + entry.translation[axis];
+    }
+    if (!matrix.every(Number.isFinite)) throw new Error('Pointcloud placement exceeds the renderable coordinate range.');
+    node.model = matrix;
+  }
+}
+
+/** Shared world-space bounds for whole-scene fitting and model-specific framing. */
+export function unionPointCloudBounds(nodes: Iterable<PointCloudNode | undefined>) {
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (const node of nodes) {
+    if (!node || node.pointCount === 0) continue;
+    const bounds = transformAabb(node.bounds, node.model);
+    if (![...bounds.min, ...bounds.max].every(Number.isFinite)) continue;
+    for (let axis = 0; axis < 3; axis++) {
+      min[axis] = Math.min(min[axis], bounds.min[axis]);
+      max[axis] = Math.max(max[axis], bounds.max[axis]);
+    }
+  }
+  return Number.isFinite(min[0]) ? { min, max } : null;
+}

--- a/packages/renderer/src/pointcloud/point-cloud-placement.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-placement.ts
@@ -41,7 +41,13 @@ export class PointCloudPlacements {
     this.placements.set(node, next);
   }
 
-  private apply(node: PointCloudNode, entry: Placement): void {
+  validateTranslation(node: PointCloudNode, translation: Translation): void {
+    this.matrix({ ...this.entry(node), translation });
+  }
+
+  private apply(node: PointCloudNode, entry: Placement): void { node.model = this.matrix(entry); }
+
+  private matrix(entry: Placement): Float32Array {
     const matrix = new Float32Array(entry.baseline);
     for (let axis = 0; axis < 3; axis++) {
       // Sum in f64 FIRST. Narrowing the baseline at map magnitude would lose
@@ -49,7 +55,7 @@ export class PointCloudPlacements {
       matrix[12 + axis] = entry.baseline[12 + axis] + entry.translation[axis];
     }
     if (!matrix.every(Number.isFinite)) throw new Error('Pointcloud placement exceeds the renderable coordinate range.');
-    node.model = matrix;
+    return matrix;
   }
 }
 

--- a/packages/renderer/src/pointcloud/point-cloud-renderer.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-renderer.ts
@@ -263,13 +263,7 @@ export class PointCloudRenderer {
     node.meta.expressId = newExpressId >>> 0;
   }
 
-  /**
-   * Set (or clear) a streamed asset's per-vertex GPU model matrix
-   * (issue #1804: point-cloud ↔ `IfcMapConversion` alignment). Pass
-   * `null` to reset to identity. Takes effect on the next frame's
-   * uniform write — no GPU buffer rewrite needed, so toggling alignment
-   * on/off is cheap.
-   */
+  /** Import alignment composes with manual placement without reuploading points. */
   setAssetTransform(handle: PointCloudAssetHandle, matrix: Float32Array | Float64Array | null): void {
     const node = this.nodes.get(handle.id);
     if (!node) return;
@@ -281,8 +275,15 @@ export class PointCloudRenderer {
     if (node) this.placements.translate(node, translation);
   }
 
-  setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
+  validateModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
     assertModelTranslation(modelIndex, translation);
+    for (const [id, node] of this.nodes) if (this.nodeOwners.get(id) === 'ifcx' && (node.meta.modelIndex ?? 0) === modelIndex) {
+      this.placements.validateTranslation(node, translation);
+    }
+  }
+
+  setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
+    this.validateModelTranslation(modelIndex, translation);
     this.modelTranslations.set(modelIndex, [...translation]);
     for (const [id, node] of this.nodes) {
       if (this.nodeOwners.get(id) === 'ifcx' && (node.meta.modelIndex ?? 0) === modelIndex) {
@@ -432,23 +433,20 @@ export class PointCloudRenderer {
     return null;
   }
 
-  /**
-   * Snapshot of nodes shaped for the picker — only the data the GPU
-   * picking pass actually needs (expressId, modelIndex, chunk vertex
-   * buffers + counts). Returns a fresh array; callers may iterate
-   * freely without worrying about mutation during a pick.
-   */
+  /** Picker snapshot includes the exact model matrix used by visible splats. */
   getPickNodes(): Array<{
     expressId: number;
     modelIndex?: number;
+    model?: Float32Array;
     chunks: Array<{ vertexBuffer: GPUBuffer; pointCount: number }>;
   }> {
-    const out: Array<{ expressId: number; modelIndex?: number; chunks: Array<{ vertexBuffer: GPUBuffer; pointCount: number }> }> = [];
+    const out: Array<{ expressId: number; modelIndex?: number; model?: Float32Array; chunks: Array<{ vertexBuffer: GPUBuffer; pointCount: number }> }> = [];
     for (const node of this.nodes.values()) {
       if (node.pointCount === 0) continue;
       out.push({
         expressId: node.meta.expressId,
         modelIndex: node.meta.modelIndex,
+        model: node.model,
         chunks: node.chunks.map((c) => ({ vertexBuffer: c.vertexBuffer, pointCount: c.pointCount })),
       });
     }

--- a/packages/renderer/src/pointcloud/point-cloud-renderer.ts
+++ b/packages/renderer/src/pointcloud/point-cloud-renderer.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { assertModelTranslation } from '../model-translation.js';
 
 /**
  * Manages point cloud assets in the renderer.
@@ -16,12 +17,12 @@
  */
 
 import type { PointCloudAsset } from '@ifc-lite/geometry';
+import { PointCloudPlacements, unionPointCloudBounds } from './point-cloud-placement.js';
 import { PointRenderPipeline, POINT_QUAD_VERTS, POINT_UNIFORM_SIZE } from './point-pipeline.js';
 import {
   appendChunkToNode,
   createNode,
-  destroyNode,
-  transformAabb,
+  destroyNode, clearOwnedPointCloudNodes,
   uploadAssetToGpu,
   type PointCloudChunkInput,
   type PointCloudNode,
@@ -132,6 +133,8 @@ type NodeOwner = 'ifcx' | 'streamed';
 export class PointCloudRenderer {
   private device: GPUDevice;
   private pipeline: PointRenderPipeline;
+  private placements = new PointCloudPlacements();
+  private modelTranslations = new Map<number, readonly [number, number, number]>();
   private nodes = new Map<number, PointCloudNode>();
   private nodeOwners = new Map<number, NodeOwner>();
   private nextHandleId = 1;
@@ -186,9 +189,7 @@ export class PointCloudRenderer {
   }
 
   getOptions(): Readonly<ResolvedPointCloudRenderOptions> {
-    // Snapshot the mask — handing out the live Uint32Array would let
-    // callers mutate renderer visibility without going through
-    // setOptions.
+    // Snapshot the mask so callers cannot mutate visibility outside setOptions.
     return { ...this.options, classMask: this.options.classMask.slice() };
   }
 
@@ -201,6 +202,7 @@ export class PointCloudRenderer {
   setAssets(assets: ReadonlyArray<PointCloudAsset>): void {
     this.clearOwner('ifcx');
     for (const asset of assets) {
+      if (asset.chunk.pointCount === 0) continue; // streamed identity descriptors carry no geometry
       this.addAsset(asset);
     }
   }
@@ -210,6 +212,7 @@ export class PointCloudRenderer {
     const id = this.nextHandleId++;
     this.nodes.set(id, node);
     this.nodeOwners.set(id, 'ifcx');
+    this.placements.translate(node, this.modelTranslations.get(asset.modelIndex ?? 0) ?? [0, 0, 0]);
     return { id };
   }
 
@@ -267,30 +270,48 @@ export class PointCloudRenderer {
    * uniform write — no GPU buffer rewrite needed, so toggling alignment
    * on/off is cheap.
    */
-  setAssetTransform(handle: PointCloudAssetHandle, matrix: Float32Array | null): void {
+  setAssetTransform(handle: PointCloudAssetHandle, matrix: Float32Array | Float64Array | null): void {
     const node = this.nodes.get(handle.id);
     if (!node) return;
-    node.model = matrix ?? undefined;
+    this.placements.align(node, matrix);
+  }
+
+  setAssetTranslation(handle: PointCloudAssetHandle, translation: readonly [number, number, number]): void {
+    const node = this.nodes.get(handle.id);
+    if (node) this.placements.translate(node, translation);
+  }
+
+  setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): void {
+    assertModelTranslation(modelIndex, translation);
+    this.modelTranslations.set(modelIndex, [...translation]);
+    for (const [id, node] of this.nodes) {
+      if (this.nodeOwners.get(id) === 'ifcx' && (node.meta.modelIndex ?? 0) === modelIndex) {
+        this.placements.translate(node, translation);
+      }
+    }
+  }
+
+  getAssetTransform(handle: PointCloudAssetHandle): Float32Array | undefined {
+    const matrix = this.nodes.get(handle.id)?.model;
+    return matrix ? new Float32Array(matrix) : undefined;
+  }
+
+  getPlacementBounds(modelIndex: number, handle?: PointCloudAssetHandle) {
+    const nodes = handle ? [this.nodes.get(handle.id)] : [...this.nodes].filter(([id, node]) =>
+      this.nodeOwners.get(id) === 'ifcx' && (node.meta.modelIndex ?? 0) === modelIndex).map(([, node]) => node);
+    return unionPointCloudBounds(nodes);
   }
 
   // ─── lifecycle / queries ─────────────────────────────────────────────────
 
   clear(): void {
-    for (const node of this.nodes.values()) {
-      destroyNode(node);
-    }
-    this.nodes.clear();
-    this.nodeOwners.clear();
+    // Clearing assets is independent of model placement. Full renderer teardown
+    // discards this renderer instance and its offset map together.
+    clearOwnedPointCloudNodes(this.nodes, this.nodeOwners);
   }
 
   private clearOwner(owner: NodeOwner): void {
-    for (const [id, ownerKind] of this.nodeOwners.entries()) {
-      if (ownerKind !== owner) continue;
-      const node = this.nodes.get(id);
-      if (node) destroyNode(node);
-      this.nodes.delete(id);
-      this.nodeOwners.delete(id);
-    }
+    clearOwnedPointCloudNodes(this.nodes, this.nodeOwners, owner);
   }
 
   hasAssets(): boolean {
@@ -320,28 +341,7 @@ export class PointCloudRenderer {
   }
 
   getBounds(): { min: [number, number, number]; max: [number, number, number] } | null {
-    if (this.nodes.size === 0) return null;
-    let minX = Infinity, minY = Infinity, minZ = Infinity;
-    let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
-    let any = false;
-    for (const node of this.nodes.values()) {
-      if (!Number.isFinite(node.bounds.min[0])) continue;
-      any = true;
-      // Report WORLD-space extents: fold the per-asset model matrix
-      // (issue #1804 IfcMapConversion alignment) into the chunk-space
-      // bounds, so the height-ramp min/max and the viewer's scene
-      // bounds/framing agree with where the vertex shader actually
-      // places the points. Identity/no-matrix nodes pass through as-is.
-      const b = transformAabb(node.bounds, node.model);
-      if (b.min[0] < minX) minX = b.min[0];
-      if (b.min[1] < minY) minY = b.min[1];
-      if (b.min[2] < minZ) minZ = b.min[2];
-      if (b.max[0] > maxX) maxX = b.max[0];
-      if (b.max[1] > maxY) maxY = b.max[1];
-      if (b.max[2] > maxZ) maxZ = b.max[2];
-    }
-    if (!any) return null;
-    return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+    return unionPointCloudBounds(this.nodes.values());
   }
 
   /**

--- a/packages/renderer/src/scene-geometry.ts
+++ b/packages/renderer/src/scene-geometry.ts
@@ -317,3 +317,14 @@ export function splitMeshDataForBufferLimit(meshDataArray: MeshData[], maxBuffer
 
   return chunks;
 }
+
+/** Never cache an empty sentinel: a later streaming fragment may add vertices. */
+export function cachedWorldAabb(
+  id: number, pieces: readonly AabbPiece[] | undefined, cache: Map<number, BoundingBox>,
+): BoundingBox | null {
+  const cached = cache.get(id);
+  if (cached) return cached;
+  const box = worldAabbFromPieces(pieces);
+  if (box) cache.set(id, box);
+  return box;
+}

--- a/packages/renderer/src/scene-instanced-model-scope.test.ts
+++ b/packages/renderer/src/scene-instanced-model-scope.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import { sceneMeshBounds } from './model-placement-bounds.js';
 import { Scene } from './scene.js';
 import type { DecodedInstancedShard } from '@ifc-lite/geometry';
 
@@ -218,9 +219,9 @@ describe('Scene.removeInstancedTemplatesForModel — index stability', () => {
     assert.deepStrictEqual([cpu[2]?.indices.length, cpu[3]?.indices.length, cpu[4]?.indices.length], [3, 6, 9]);
   });
 
-  it('keeps CPU templates slot-aligned after releaseGeometryData() drops them', () => {
-    // releaseGeometryData() empties the CPU template array while the GPU slots
-    // live on. A shard uploaded afterwards must land on its GPU slot, not at
+  it('keeps occurrence slots and placement after releasing template vertices (#4226)', () => {
+    // releaseGeometryData() drops template vertices while occurrence records
+    // and GPU slots live on. A shard uploaded afterwards must land on its GPU slot, not at
     // CPU index 0 — otherwise every CPU consumer (raycast / measure / section /
     // export) reads a different template's triangles than the occurrence names.
     const { scene, device } = twoModelScene();
@@ -229,7 +230,13 @@ describe('Scene.removeInstancedTemplatesForModel — index stability', () => {
 
     assert.deepStrictEqual(occSlots(scene, 30), [5]);
     const cpu = scene['instancedTemplateCpu'] as ReadonlyArray<{ indices: Uint32Array } | undefined>;
-    assert.strictEqual(cpu[0], undefined, 'the new template must not squat on a released slot');
+    assert.strictEqual(cpu[0]?.indices.length, 0, 'the new template must not squat on a released slot');
+    const before = scene.getEntityBoundingBox(10)!.min.x;
+    const other = scene.getEntityBoundingBox(20)!.min.x;
+    scene.setModelTranslation(3, [5, 0, 0]);
+    assert.strictEqual(scene.getEntityBoundingBox(10)!.min.x, before + 5);
+    assert.strictEqual(scene.getEntityBoundingBox(20)!.min.x, other);
+    assert.strictEqual(scene.getInstancedMeshDataPieces(10), undefined, 'release still drops exact triangle geometry');
     assert.strictEqual(cpu[5]?.indices.length, 3);
     assert.strictEqual(scene.getInstancedMeshDataPieces(30)?.length, 1);
   });
@@ -478,5 +485,15 @@ describe('Scene.removeInstancedTemplatesForModel — bounding-box teardown (#207
 
     const after = scene.raycast({ x: 0.3, y: 5, z: -0.3 }, { x: 0, y: -1, z: 0 });
     assert.strictEqual(after, null, 'id 10 had geometry only in the removed model; no box should remain to hit');
+  });
+});
+
+it('refreshes camera bounds for a moved instance-only model (#4226)', () => {
+  const scene = new Scene(), { device } = fakeDevice();
+  scene.addInstancedShard(device, shard(1, [1]), 3);
+  scene.setModelTranslation(3, [100, 200, 300]);
+  assert.deepStrictEqual(sceneMeshBounds(scene), {
+    // The shard is IFC Z-up: its unit Y edge becomes renderer negative Z.
+    min: { x: 100, y: 200, z: 299 }, max: { x: 101, y: 200, z: 300 },
   });
 });

--- a/packages/renderer/src/scene-model-translation.ts
+++ b/packages/renderer/src/scene-model-translation.ts
@@ -33,7 +33,7 @@ interface TranslationScene {
 export function translateSceneModel(scene: TranslationScene, modelIndex: number, translation: readonly [number, number, number]): boolean {
   const previous = scene.translations.get(modelIndex);
   if (!scene.translations.set(modelIndex, translation)) return false;
-  const releasedIds = new Set<number>();
+  const releasedIds = new Set(scene.translations.releasedEntityIds(modelIndex));
   for (const batch of scene.batches) {
     if ((batch.modelIndices?.[0] ?? 0) === modelIndex) for (const id of batch.expressIds) releasedIds.add(id);
   }

--- a/packages/renderer/src/scene-model-translation.ts
+++ b/packages/renderer/src/scene-model-translation.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { MeshData } from '@ifc-lite/geometry';
+import type { BatchedMesh, Mesh } from './types.js';
+import type { InstancedTemplateGPU, TexturedMesh } from './scene.js';
+import type { ModelTranslations } from './model-translation.js';
+import type { BoundingBox } from './scene-raycaster.js';
+import { foldOccurrenceWorldBox, INSTANCE_STRIDE_BYTES } from './instanced-render.js';
+import { worldAabbFromPieces } from './scene-geometry.js';
+
+type Triple = [number, number, number];
+interface CpuTemplate { instanceData: ArrayBuffer; localMin: Triple; localMax: Triple }
+interface TranslationScene {
+  translations: ModelTranslations;
+  pieces: Map<number, MeshData[]>;
+  bounds: Map<number, BoundingBox>;
+  batches: BatchedMesh[];
+  meshes: Mesh[];
+  overrides: BatchedMesh[];
+  textured: TexturedMesh[];
+  templates: (InstancedTemplateGPU | undefined)[];
+  cpu: (CpuTemplate | undefined)[];
+  occurrences: Map<number, { templateIndex: number; byteOffset: number }[]>;
+  device: GPUDevice | undefined;
+  evictHighlight: (id: number) => void;
+  clearPartial: () => void;
+  unionBounds: (id: number, view: DataView, offset: number, min: Triple, max: Triple) => {
+    minX: number; minY: number; minZ: number; maxX: number; maxY: number; maxZ: number;
+  };
+}
+
+export function translateSceneModel(scene: TranslationScene, modelIndex: number, translation: readonly [number, number, number]): boolean {
+  const previous = scene.translations.get(modelIndex);
+  if (!scene.translations.set(modelIndex, translation)) return false;
+  const releasedIds = new Set<number>();
+  for (const batch of scene.batches) {
+    if ((batch.modelIndices?.[0] ?? 0) === modelIndex) for (const id of batch.expressIds) releasedIds.add(id);
+  }
+  for (const mesh of [...scene.textured, ...scene.meshes]) if ((mesh.modelIndex ?? 0) === modelIndex) releasedIds.add(mesh.expressId);
+  for (const id of releasedIds) {
+    if (scene.pieces.has(id)) continue;
+    const box = scene.bounds.get(id);
+    const released = scene.translations.releasedEntityBounds(id);
+    if (released) scene.bounds.set(id, released);
+    else if (box) scene.bounds.set(id, scene.translations.placeReleasedBounds(box, previous, modelIndex));
+    scene.evictHighlight(id);
+  }
+  const seen = new Set<MeshData>();
+  for (const [id, pieces] of scene.pieces) {
+    if (!pieces.some((piece) => (piece.modelIndex ?? 0) === modelIndex)) continue;
+    scene.bounds.delete(id);
+    scene.evictHighlight(id);
+    for (const piece of pieces) {
+      if (seen.has(piece)) continue;
+      seen.add(piece);
+      scene.translations.placeMesh(piece);
+    }
+    const flat = worldAabbFromPieces(pieces);
+    if (flat) scene.bounds.set(id, flat);
+  }
+  for (const mesh of scene.meshes) scene.translations.placeAuthoredMesh(mesh);
+  for (const mesh of scene.textured) scene.translations.moveDrawable(mesh);
+  for (const batch of scene.batches) scene.translations.moveDrawable(batch);
+  for (const batch of scene.overrides) scene.translations.moveDrawable(batch);
+  scene.clearPartial();
+  for (let i = 0; i < scene.templates.length; i++) {
+    const gpu = scene.templates[i], cpu = scene.cpu[i];
+    if (!gpu || !cpu || gpu.modelIndex !== modelIndex) continue;
+    if (scene.translations.placeInstances(cpu.instanceData, modelIndex, INSTANCE_STRIDE_BYTES)) {
+      scene.device?.queue.writeBuffer(gpu.instanceBuffer, 0, cpu.instanceData);
+    }
+    gpu.bounds = null;
+  }
+  // Visit occurrences once, not once per template. Rebuild the full entity union
+  // only after all its matrices have moved (a multi-template entity must not lose pieces).
+  for (const [id, occurrences] of scene.occurrences) {
+    if (!occurrences.some((occ) => scene.templates[occ.templateIndex]?.modelIndex === modelIndex)) continue;
+    const flat = scene.pieces.has(id) ? worldAabbFromPieces(scene.pieces.get(id)!) : scene.translations.releasedEntityBounds(id);
+    if (flat) scene.bounds.set(id, flat); else scene.bounds.delete(id);
+    scene.evictHighlight(id);
+    for (const occ of occurrences) {
+      const gpu = scene.templates[occ.templateIndex], cpu = scene.cpu[occ.templateIndex];
+      if (!gpu || !cpu) continue;
+      const world = scene.unionBounds(id, new DataView(cpu.instanceData), occ.byteOffset, cpu.localMin, cpu.localMax);
+      if (gpu.modelIndex === modelIndex) foldOccurrenceWorldBox(gpu, world);
+    }
+  }
+  return true;
+}
+
+/** Release template vertices while retaining the occurrence records required for
+ * model placement, visibility and bounds in GPU-resident mode. */
+export function releaseInstanceVertices(templates: readonly ({ positions: Float32Array; normals: Float32Array; indices: Uint32Array } | undefined)[]): void {
+  for (const template of templates) {
+    if (!template) continue;
+    template.positions = new Float32Array();
+    template.normals = new Float32Array();
+    template.indices = new Uint32Array();
+  }
+}
+
+/** Entity edits rewrite textured vertices independently of model origins. */
+export function refreshTexturedBounds(translations: ModelTranslations, drawable: TexturedMesh, mesh: MeshData): void {
+  const box = worldAabbFromPieces([mesh]);
+  drawable.bounds = box ? { min: [box.min.x, box.min.y, box.min.z], max: [box.max.x, box.max.y, box.max.z] } : undefined;
+  translations.registerDrawable(drawable, drawable.modelIndex ?? 0);
+}

--- a/packages/renderer/src/scene-textured-origin.test.ts
+++ b/packages/renderer/src/scene-textured-origin.test.ts
@@ -20,6 +20,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import { modelPlacementBounds, sceneMeshBounds } from './model-placement-bounds.js';
 import { Scene } from './scene.js';
 import { mergeGeometry } from './scene-geometry.js';
 import type { MeshData } from '@ifc-lite/geometry';
@@ -153,4 +154,51 @@ describe('textured meshes carry their per-element origin (#1973)', () => {
 
     assert.deepStrictEqual([...scene.getTexturedMeshes()[0].origin], [0, 0, 0]);
   });
+});
+
+
+it('moves only the owning textured model and keeps texture uploads stable (#4226)', () => {
+  const scene = new Scene(), { device, writes } = fakeDevice();
+  const moving = { ...meshData(1, ORIGIN, true), modelIndex: 7 };
+  const fixed = { ...meshData(2, [0, 0, 0], true), modelIndex: 0 };
+  scene.appendToBatches([moving, fixed], device, fakePipeline);
+  const uploads = writes.length;
+  scene.setModelTranslation(7, [100, 200, 300]);
+  const meshes = scene.getTexturedMeshes();
+  assert.deepStrictEqual(meshes.find((m) => m.expressId === 1)!.origin, [112.5, 210.5, 296.75]);
+  assert.deepStrictEqual(meshes.find((m) => m.expressId === 2)!.origin, [0, 0, 0]);
+  assert.strictEqual(writes.length, uploads, 'moving a textured model does not re-upload its vertices or texture');
+  assert.deepStrictEqual(moving.origin, ORIGIN, 'the source placement remains unchanged');
+  scene.setModelTranslation(7, [0, 0, 0]);
+  assert.deepStrictEqual(meshes.find((m) => m.expressId === 1)!.origin, ORIGIN);
+  scene.clear();
+});
+
+it('frames textured pieces by model even when entity ids coincide (#4226)', () => {
+  const scene = new Scene(), { device } = fakeDevice();
+  scene.appendToBatches([{ ...meshData(1, ORIGIN, true), modelIndex: 7 },
+    { ...meshData(1, [0, 0, 0], true), modelIndex: 0 }], device, fakePipeline);
+  scene.releaseGeometryData(); scene.setModelTranslation(7, [100, 0, 0]);
+  assert.deepStrictEqual(modelPlacementBounds(scene, null, 0), { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 0 } });
+  assert.strictEqual(modelPlacementBounds(scene, null, 7)!.min.x, 112.5);
+  assert.deepStrictEqual(sceneMeshBounds(scene), { min: { x: 0, y: 0, z: -3.25 }, max: { x: 113.5, y: 11.5, z: 0 } });
+  scene.clear();
+});
+
+for (const edit of ['translate', 'rotate'] as const) it(`refreshes textured bounds after ${edit} and subsequent model placement (#4226)`, () => {
+  const scene = new Scene(), { device, writes } = fakeDevice();
+  scene.appendToBatches([{ ...meshData(1, [0, 0, 0], true), modelIndex: 7 }], device, fakePipeline);
+  scene.setModelTranslation(7, [100, 0, 0]);
+  if (edit === 'translate') scene.translateMeshesForEntity(1, [2, 3, 4]);
+  else scene.rotateMeshesForEntity(1, Math.PI / 2, [100, 0, 0]);
+  const drawable = scene.getTexturedMeshes()[0];
+  const expected = worldBounds(texturedPositions(writes.at(-1)!, 3), [...drawable.origin]);
+  assert.deepStrictEqual(drawable.bounds, expected, 'bounds enclose the actual uploaded vertices');
+  scene.setModelTranslation(7, [110, 0, 0]);
+  const moved = { min: [...expected.min], max: [...expected.max] };
+  moved.min[0] += 10; moved.max[0] += 10;
+  assert.deepStrictEqual(drawable.bounds, moved, 'the next preview retains the geometry edit');
+  scene.setModelTranslation(7, [0, 0, 0]);
+  assert.strictEqual(drawable.bounds!.min[0], expected.min[0] - 100);
+  scene.clear();
 });

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3985,11 +3985,9 @@ export class Scene {
     this.buckets.clear();
     this.meshDataBucket = new Map();
     this.meshDataMap.clear();
-    for (const eid of [...this.boundingBoxes.keys()]) {
-      if (!this.instancedEntityMap.has(eid)) {
-        this.boundingBoxes.delete(eid);
-      }
-    }
+    this.modelTranslations.clearFlatBounds();
+    this.boundingBoxes.clear();
+    for (const eid of this.instancedEntityMap.keys()) this.recomputeInstancedBounds(eid);
     this.activeBucketKey.clear();
     this.lastDrawnFrame.clear();
     this.residencyRestoreQueue.clear();

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -1273,6 +1273,7 @@ export class Scene {
    *     the IFC tombstone just means we ignore it for queries.
    */
   removeMeshesForEntity(expressId: number): boolean {
+    this.modelTranslations.forgetEntityBounds(expressId);
     const meshDataList = this.meshDataMap.get(expressId);
     if (!meshDataList || meshDataList.length === 0) {
       this.boundingBoxes.delete(expressId);

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -21,7 +21,7 @@ import {
   rayIntersectsBox,
 } from './scene-raycaster.js';
 import { selectBoundingBoxesInRect } from './scene-rect-select.js';
-import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane, worldAabbFromPieces, destroyGpuResources } from './scene-geometry.js';
+import { mergeGeometry, splitMeshDataForBufferLimit, colorSaltByte, packEntityLane, cachedWorldAabb, worldAabbFromPieces, destroyGpuResources } from './scene-geometry.js';
 import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
 import { composeInstancedOverrideColor } from './instanced-override-color.js';
 import { simplifyIndicesByClustering, lodCellSizeForBounds, LOD_MIN_TRIANGLES } from './lod-simplify.js';
@@ -32,6 +32,8 @@ import { isEntityVisible } from './entity-visibility.js';
 import { planInstancedGhosting } from './instanced-ghost-plan.js';
 import { selectEvictions, type ResidencyShell, type ColdGeometryProvider } from './residency.js';
 import { OPAQUE_ALPHA_CUTOFF } from './overlay-routing.js';
+import { translateSceneModel, releaseInstanceVertices, refreshTexturedBounds } from './scene-model-translation.js';
+import { ModelTranslations } from './model-translation.js';
 import { extractEntityFromMergedMesh } from './merged-mesh-extract.js';
 import {
   dropAllPartialCaches as dropAllPartialCachesIn,
@@ -74,6 +76,8 @@ interface BatchBucket {
  *  bindGroup wiring all three. Drawn per-mesh in a dedicated sub-pass. */
 export interface TexturedMesh {
   expressId: number;
+  modelIndex?: number;
+  bounds?: { min: [number, number, number]; max: [number, number, number] };
   vertexBuffer: GPUBuffer;
   indexBuffer: GPUBuffer;
   indexCount: number;
@@ -228,6 +232,7 @@ export class Scene {
   private batchedMeshes: BatchedMesh[] = [];                        // flat render array (rebuilt from buckets)
   private buckets: Map<string, BatchBucket> = new Map();            // bucketKey -> consolidated bucket state
   private meshDataBucket: Map<MeshData, BatchBucket> = new Map();   // reverse lookup: MeshData -> owning bucket
+  private modelTranslations = new ModelTranslations();
   private meshDataMap: Map<number, MeshData[]> = new Map();         // Map expressId -> MeshData[] (for lazy buffer creation, accumulates multiple pieces)
   private boundingBoxes: Map<number, BoundingBox> = new Map();      // Map expressId -> bounding box (computed lazily)
   private texturedMeshes: TexturedMesh[] = [];                      // #961: IFC surface-textured meshes (own buffers/texture/bindGroup)
@@ -320,11 +325,9 @@ export class Scene {
   private finalizeInProgress = false;
   private nextSplitId: number = 0; // Monotonic counter for sub-bucket keys
   private nextBatchId: number = 0; // Monotonic counter for unique batch identifiers
-  // Shared local-frame origin for ALL batches (set from the first batch's world
-  // bbox centre). Every batch stores positions relative to it and draws with
-  // model = translate(sharedFrameOrigin), so coincident faces across batches
-  // stay bit-coincident (no seam z-fight) while f32 vertex coords stay small.
-  private sharedFrameOrigin: [number, number, number] | null = null;
+  // Per-model shared origins keep all colours and highlights bit-coincident
+  // without narrowing the distance between federated models into f32 vertices.
+  private sharedFrameOrigins = new Map<number, [number, number, number]>();
   private cachedMaxBufferSize: number = 0; // device.limits.maxBufferSize * safety factor (set on first use)
   private static readonly STREAMING_FRAGMENT_MAX_INDICES = 180_000;
   private static readonly STREAMING_FRAGMENT_MAX_VERTEX_BYTES = 8 * 1024 * 1024;
@@ -385,6 +388,7 @@ export class Scene {
    * Add mesh to scene
    */
   addMesh(mesh: Mesh): void {
+    this.modelTranslations.placeAuthoredMesh(mesh);
     this.meshes.push(mesh);
   }
 
@@ -405,8 +409,8 @@ export class Scene {
   /** The shared local-frame origin all batches relativize against (null until
    *  the first batch is built). Per-mesh highlight/picker VBOs replicate the
    *  batch's exact f32 path against this so they render bit-coincident. */
-  getSharedFrameOrigin(): [number, number, number] | null {
-    return this.sharedFrameOrigin;
+  getSharedFrameOrigin(modelIndex = 0): [number, number, number] | null {
+    return this.modelTranslations.frameOrigin(this.sharedFrameOrigins.get(modelIndex) ?? null, modelIndex) ?? null;
   }
 
   /**
@@ -695,8 +699,9 @@ export class Scene {
     const provider = this.coldProvider;
     if (!bucket || !shell || !shell.bounds || !provider) return;
 
+    const sourceBounds = this.modelTranslations.sourceDrawableBounds(shell)!;
     const promise = provider
-      .loadMeshesInBounds(shell.bounds.min, shell.bounds.max)
+      .loadMeshesInBounds(sourceBounds.min, sourceBounds.max)
       .then((meshes) => {
         // Re-validate: a clear()/finalize may have replaced the world.
         const current = this.buckets.get(key);
@@ -706,7 +711,8 @@ export class Scene {
         const members = meshes.filter(
           (m) => idSet.has(m.expressId) && this.bucketBaseKey(m) === baseKey
         );
-        for (const m of members) {
+        for (const source of members) {
+          const m = this.modelTranslations.placeMesh(source);
           bucket.meshData.push(m);
           bucket.vertexBytes += (m.positions.length / 3) * BATCH_CONSTANTS.BYTES_PER_VERTEX;
           this.meshDataBucket.set(m, bucket);
@@ -876,7 +882,9 @@ export class Scene {
    * recolour routing.
    */
   private bucketBaseKey(meshData: MeshData, color?: [number, number, number, number]): string {
-    return bucketBaseKeyFor(meshData, this.colorKey(color ?? meshData.color), this.spatialChunking);
+    const source = this.modelTranslations.sourceMesh(meshData);
+    const key = bucketBaseKeyFor(source, this.colorKey(color ?? meshData.color), this.spatialChunking);
+    return source.modelIndex ? `model${source.modelIndex}~${key}` : key;
   }
 
   /**
@@ -885,6 +893,7 @@ export class Scene {
    * Accumulates multiple mesh pieces per expressId (elements can have multiple geometry pieces)
    */
   addMeshData(meshData: MeshData): void {
+    meshData = this.modelTranslations.placeMesh(meshData);
     // For color-merged batches with per-vertex entityIds, register the mesh
     // under EVERY unique entity so picking/visibility/selection can find it.
     if (meshData.entityIds && meshData.entityIds.length > 0) {
@@ -1117,6 +1126,7 @@ export class Scene {
    * when streaming completes to do one O(N) full merge.
    */
   appendToBatches(meshDataArray: MeshData[], device: GPUDevice, pipeline: RenderPipeline, isStreaming: boolean = false): void {
+    meshDataArray = meshDataArray.map((mesh) => this.modelTranslations.placeMesh(mesh));
     // Cache max buffer size on first call
     if (this.cachedMaxBufferSize === 0) {
       this.cachedMaxBufferSize = this.getMaxBufferSize(device);
@@ -1424,10 +1434,6 @@ export class Scene {
   }
 
   /**
-   * Translate every flat (non-instanced) mesh for `expressId` by `delta`. See
-   * {@link translateMeshesForEntity} for the full contract; this is the flat half.
-   */
-  /**
    * Mark a mesh's bucket for rebuild after its positions were mutated in
    * place (move/rotate), migrating it to a new bucket when spatial chunking
    * is on and the mesh crossed a grid-cell boundary. Without the migration
@@ -1515,6 +1521,7 @@ export class Scene {
           const interleaved = this.interleaveTexturedVertices(texturedData[i]);
           if (interleaved) {
             this.texturedDevice.queue.writeBuffer(entries[i].vertexBuffer, 0, interleaved);
+            refreshTexturedBounds(this.modelTranslations, entries[i], texturedData[i]);
           }
         }
       }
@@ -1622,14 +1629,28 @@ export class Scene {
    *  rebuilt from the entity's current geometry on the next render. Used after a
    *  translate or removal, which mutate the underlying geometry but don't touch
    *  these standalone highlight meshes. */
-  private evictHighlightMeshes(expressId: number): void {
+  private evictHighlightMeshes(expressId: number, hydratedOnly = false): void {
     if (this.meshes.length === 0) return;
     const kept: Mesh[] = [];
     for (const mesh of this.meshes) {
-      if (mesh.expressId === expressId) destroyGpuResources(mesh);
+      if (mesh.expressId === expressId && (!hydratedOnly || mesh.hydrated)) destroyGpuResources(mesh);
       else kept.push(mesh);
     }
     this.meshes = kept;
+  }
+
+  /** Absolute workspace translation, renderer Y-up metres (#4226). */
+  getModelTranslation(modelIndex: number) { return this.modelTranslations.get(modelIndex); }
+  setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): boolean {
+    const batches = this.finalizeInProgress ? [...new Set([...this.batchedMeshes,
+      ...[...this.buckets.values()].flatMap((bucket) => bucket.batchedMesh ? [bucket.batchedMesh] : [])])] : this.batchedMeshes;
+    return translateSceneModel({ translations: this.modelTranslations, pieces: this.meshDataMap,
+      bounds: this.boundingBoxes, batches, meshes: this.meshes, overrides: this.overrideBatches, textured: this.texturedMeshes,
+      templates: this.instancedTemplates, cpu: this.instancedTemplateCpu, occurrences: this.instancedEntityMap,
+      device: this.instancedDevice, evictHighlight: (id) => this.evictHighlightMeshes(id, true),
+      clearPartial: () => this.dropAllPartialCaches(),
+      unionBounds: (id, view, offset, min, max) => this.unionInstancedWorldAabb(id, view, offset, ...min, ...max),
+    }, modelIndex, translation);
   }
 
   /** Bulk variant of `translateMeshesForEntity`. */
@@ -1708,6 +1729,7 @@ export class Scene {
           const interleaved = this.interleaveTexturedVertices(texturedData[i]);
           if (interleaved) {
             this.texturedDevice.queue.writeBuffer(entries[i].vertexBuffer, 0, interleaved);
+            refreshTexturedBounds(this.modelTranslations, entries[i], texturedData[i]);
           }
         }
       }
@@ -2224,18 +2246,16 @@ export class Scene {
     // so caching the inverted-empty sentinel here would publish a geometry-less
     // entity to every CPU consumer with a garbage box (#2480).
     for (const [expressId, pieces] of this.meshDataMap) {
-      if (this.boundingBoxes.has(expressId)) continue;
-      const bbox = worldAabbFromPieces(pieces);
-      if (bbox) this.boundingBoxes.set(expressId, bbox);
+      cachedWorldAabb(expressId, pieces, this.boundingBoxes);
     }
 
+    this.modelTranslations.retainEntityBounds(this.meshDataMap);
     this.streamingFragments = [];
     this.buckets.clear();
     this.meshDataBucket = new Map();
     this.meshDataMap.clear();
-    // Free the compact instanced template geometry too; the per-occurrence world
-    // AABBs already live in boundingBoxes, so bbox-raycast still finds instanced ids.
-    this.instancedTemplateCpu = [];
+    // Keep occurrence transforms for placement; release heavy template vertices.
+    releaseInstanceVertices(this.instancedTemplateCpu);
     this.activeBucketKey.clear();
     this.lastDrawnFrame.clear();
     this.residencyRestoreQueue.clear();
@@ -2279,18 +2299,14 @@ export class Scene {
     // Same rule as `finishEphemeralStreaming`: an entity with no usable vertex
     // gets no entry rather than the inverted-empty sentinel (#2480).
     for (const [expressId, pieces] of this.meshDataMap) {
-      if (this.boundingBoxes.has(expressId)) continue;
-      const bbox = worldAabbFromPieces(pieces);
-      if (bbox) this.boundingBoxes.set(expressId, bbox);
+      cachedWorldAabb(expressId, pieces, this.boundingBoxes);
     }
 
+    this.modelTranslations.retainEntityBounds(this.meshDataMap);
     // 2. Clear the heavy data structures — typed arrays become GC-eligible
     this.meshDataMap.clear();
-    // Free the compact instanced template geometry; per-occurrence world AABBs are
-    // already cached in boundingBoxes, so the released-path bbox-raycast still
-    // resolves instanced ids (exact-triangle measure/section is unavailable post-
-    // release, same as the flat path).
-    this.instancedTemplateCpu = [];
+    // Keep occurrence transforms for placement; release heavy template vertices.
+    releaseInstanceVertices(this.instancedTemplateCpu);
     // Clear meshData arrays in each bucket (typed arrays become GC-eligible)
     // but keep the bucket shells so batchedMesh references remain valid
     for (const bucket of this.buckets.values()) {
@@ -2450,21 +2466,16 @@ export class Scene {
     pipeline: RenderPipeline,
     bucketKey?: string
   ): BatchedMesh {
-    // Use ONE shared scene origin for every batch (set from the first batch's
-    // world bbox centre). A per-batch origin would make abutting elements in
-    // different colour batches diverge by a few f32 ULP at building-scale world
-    // coords → seam/end-cap z-fighting. A shared origin makes every coincident
-    // world point relativize identically → no seam z-fight, and the model
-    // sits at most ±(model extent) from it (f32-precise at building scale).
-    const merged = this.mergeGeometry(meshDataArray, this.sharedFrameOrigin ?? undefined);
-    if (!this.sharedFrameOrigin && (merged.origin[0] || merged.origin[1] || merged.origin[2])) {
-      this.sharedFrameOrigin = merged.origin;
+    // Partition by model so a translation updates only draw origins. Relativize
+    // all colours against the same model frame before any f32 narrowing (#4226).
+    const modelIndex = meshDataArray[0]?.modelIndex ?? 0;
+    const offset = this.modelTranslations.get(modelIndex);
+    const merged = this.mergeGeometry(meshDataArray,
+      this.modelTranslations.frameOrigin(this.sharedFrameOrigins.get(modelIndex) ?? null, modelIndex));
+    if (!this.sharedFrameOrigins.has(modelIndex)) {
+      this.sharedFrameOrigins.set(modelIndex, [merged.origin[0] - offset[0], merged.origin[1] - offset[1], merged.origin[2] - offset[2]]);
     }
     const expressIds = meshDataArray.map(m => m.expressId);
-    // Parallel to `expressIds` (same index = same source piece) so picking
-    // can scope each batch ENTRY to its own model — batches group by colour,
-    // not by model, so distinct models sharing an expressId+colour can be
-    // co-batched (see BatchedMesh.modelIndices doc).
     const modelIndices = meshDataArray.map(m => m.modelIndex);
 
     // Create vertex buffer (interleaved positions + normals)
@@ -2589,7 +2600,7 @@ export class Scene {
       }
     }
 
-    return {
+    return this.modelTranslations.registerDrawable({
       id: this.nextBatchId++,
       colorKey: bucketKey ?? this.colorKey(color),
       vertexBuffer,
@@ -2606,7 +2617,7 @@ export class Scene {
       origin: merged.origin,
       ...(lod1IndexBuffer ? { lod1IndexBuffer, lod1IndexCount } : {}),
       ...(quantized ? { quantized } : {}),
-    };
+    }, modelIndex);
   }
 
 
@@ -2889,21 +2900,15 @@ export class Scene {
     // override colour directly). No-op when no instanced data is loaded.
     this.setInstancedColorOverrides(overrides);
 
-    // Group expressIds by override color
+    // An overlay batch must belong to one model so placement cannot move a
+    // different model's highlighted geometry along with its first mesh.
     const colorGroups = new Map<string, { color: [number, number, number, number]; meshData: MeshData[] }>();
-
     for (const [expressId, color] of overrides) {
-      const key = this.colorKey(color);
-      let group = colorGroups.get(key);
-      if (!group) {
-        group = { color, meshData: [] };
-        colorGroups.set(key, group);
-      }
-      const pieces = this.meshDataMap.get(expressId);
-      if (pieces) {
-        for (const piece of pieces) {
-          group.meshData.push(piece);
-        }
+      for (const piece of this.meshDataMap.get(expressId) ?? []) {
+        const key = `${piece.modelIndex ?? 0}:${this.colorKey(color)}`;
+        let group = colorGroups.get(key);
+        if (!group) { group = { color, meshData: [] }; colorGroups.set(key, group); }
+        group.meshData.push(piece);
       }
     }
 
@@ -3214,6 +3219,7 @@ export class Scene {
 
       // instanceBuffer is already the interleaved mat4 + entityId + rgba block
       // (INSTANCE_STRIDE_BYTES per occurrence) from prepareInstancedRender.
+      this.modelTranslations.placeInstances(t.instanceBuffer, modelIndex, INSTANCE_STRIDE_BYTES);
       const instSize = t.instanceCount * INSTANCE_STRIDE_BYTES;
       const instanceBuffer = device.createBuffer({
         size: instSize,
@@ -3843,8 +3849,10 @@ export class Scene {
       });
       const bindGroup = pipeline.createTexturedBindGroup(uniformBuffer, texture.createView(), sampler);
 
-      this.texturedMeshes.push({
-        expressId: meshData.expressId,
+      const box = worldAabbFromPieces([meshData]);
+      this.texturedMeshes.push(this.modelTranslations.registerDrawable({
+        expressId: meshData.expressId, modelIndex: meshData.modelIndex,
+        bounds: box ? { min: [box.min.x, box.min.y, box.min.z], max: [box.max.x, box.max.y, box.max.z] } : undefined,
         vertexBuffer,
         indexBuffer,
         indexCount: meshData.indices.length,
@@ -3859,7 +3867,7 @@ export class Scene {
           ? [meshData.origin[0], meshData.origin[1], meshData.origin[2]]
           : [0, 0, 0],
         ...(sharedTextureKey !== undefined ? { sharedTextureKey } : {}),
-      });
+      }, meshData.modelIndex ?? 0));
     } catch (error) {
       vertexBuffer?.destroy();
       indexBuffer?.destroy();
@@ -3919,6 +3927,7 @@ export class Scene {
   }
 
   clear(): void {
+    this.modelTranslations.clear();
     // GPU-instancing templates own their vertex/index/instance buffers.
     // (Freed slots are holes whose buffers are already destroyed — skip them so
     // a per-model removal followed by clear() can't double-destroy.)
@@ -3970,7 +3979,7 @@ export class Scene {
     // instanced templates are unaffected — their per-occurrence transforms are
     // already baked to absolute world coordinates at upload time, not relative
     // to this origin.
-    this.sharedFrameOrigin = null;
+    this.sharedFrameOrigins.clear();
     this.meshes = [];
     this.batchedMeshes = [];
     this.buckets.clear();
@@ -4084,19 +4093,7 @@ export class Scene {
    * @returns Bounding box with min/max corners, or null if no mesh data exists
    */
   getEntityBoundingBox(expressId: number): BoundingBox | null {
-    // Check cache first
-    const cached = this.boundingBoxes.get(expressId);
-    if (cached) return cached;
-
-    // Compute from mesh data. `null` covers both "no pieces at all" and
-    // "pieces with no vertex a box can be built from" — and, critically, is
-    // NOT cached (#2480): a transient empty piece must not poison the entry
-    // for an entity that later gains real geometry, and this cache has no
-    // invalidation tied to that.
-    const bbox = worldAabbFromPieces(this.meshDataMap.get(expressId));
-    if (!bbox) return null;
-    this.boundingBoxes.set(expressId, bbox);
-    return bbox;
+    return cachedWorldAabb(expressId, this.meshDataMap.get(expressId), this.boundingBoxes);
   }
 
   /**


### PR DESCRIPTION
Refs #4226

Moving a model or scan now keeps its rendering, picking and bounds in the same position without rewriting vertex buffers. Per-model draw origins and double-precision scan alignment preserve fine residuals after large shifts; later uploads inherit the placement, and GPU-resident scenes retain per-entity bounds after CPU geometry is released.

Stack 1/4. Followed by #4256 (workspace state), #4257 (interaction and integration), and #4270 (sections).

Adversarial regressions cover color-merged released entities, authored bounds edits, independent per-cloud GPU pick uniforms, invalid deferred offsets, and atomic rejection of overflowing composed scan transforms. Existing coverage includes instances, textures, cold restoration, realignment and streaming finalization. Published renderer/pointcloud changes include a changeset and guide updates. Vertex buffers remain shared; no decode speedup is claimed.

Local validation of the combined implementation: root typecheck passes (1,809 test files covered); renderer tests pass 1,411 with one skip; the strict production-browser run passes all three scenarios, including real IFC sectioning, both scan/IFC load orders, magnetic snapping and normal GPU selection of the translated scan. The full viewer suite is being rerun after the latest fixes. Required current-head CI and independent review are still pending. Nothing has been merged.
