### PR TITLE
feat(viewer): retain original IFCZIP appearance assets

### DIFF
--- a/.changeset/fine-pandas-fold.md
+++ b/.changeset/fine-pandas-fold.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": minor
+---
+
+Expose original IFCZIP resource paths and model entry paths alongside the existing basename lookup, and report when image extraction limits omit archive resources.

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -2222,7 +2222,7 @@ export function useIfcLoader() {
       // and a `dispose()` placed after the last statement would miss all of
       // them. The free itself still waits on the parse chain; see
       // createGeometryProcessorDisposer.
-      try { appearanceLoad?.finish(useViewerStore.getState().models.has(modelId) && (target.kind === 'federated' || (useViewerStore.getState().geometryResult?.meshes.length ?? 0) > 0)); }
+      try { appearanceLoad?.finishForModel(useViewerStore.getState().models.get(modelId)); }
       finally { geometryHandle?.release(); }
     }
   }, [setLoading, setGeometryStreamingActive, setError, setProgress, setIfcDataStore, setGeometryResult, appendGeometryBatch, appendInstancedShards, updateMeshColors, updateCoordinateInfo, loadFromCache, saveToCache, loadFromServer, revalidateSourceDecoupledHit]);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -1376,15 +1376,14 @@ export function useIfcLoader() {
       // Default path: parser runs in a Web Worker via WorkerParser, both
       // workers + main share the same SharedArrayBuffer source, and the
       // main thread never blocks on parse.
-      // Fallback: in-process IfcParser.parseColumnar (the previous default)
-      // — used when cross-origin isolation is missing or the worker spawn
-      // fails (auto-fallback inside the catch).
+      // Fall back to main-thread parsing when isolation or worker startup fails.
       let resolveDataStore: (dataStore: IfcDataStore) => void;
       let rejectDataStore: (err: unknown) => void;
       const dataStorePromise = new Promise<IfcDataStore>((resolve, reject) => {
         resolveDataStore = resolve;
         rejectDataStore = reject;
       });
+      if (target.kind === 'primary') void appearanceLoad?.finishAfter(dataStorePromise, () => useViewerStore.getState().models.get(modelId));
 
       const onPartialDataStore = (partialStore: IfcDataStore) => {
         if (loadSessionRef.current !== currentSession) return;
@@ -2050,6 +2049,7 @@ export function useIfcLoader() {
                   });
                 }
               });
+              if (target.kind === 'federated') void appearanceLoad?.finishAfter(finalizePromise, () => useViewerStore.getState().models.get(modelId));
               break;
           }
         }

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -20,7 +20,8 @@ import { buildModelLoadReportPatch, type ModelLoadReportFields } from '../lib/lo
 import { computeSourceFingerprint } from './sourceFingerprint.js';
 import { computeFullSourceHash } from '../utils/sourceContentHash.js';
 import { IfcParser, detectFormat, unwrapIfcZipWithResources, type IfcDataStore } from '@ifc-lite/parser';
-import { decodeTextureResources, attachTextureBitmaps, type TextureBitmapStore } from '../utils/textureResources.js';
+import { attachTextureBitmaps, type TextureBitmapStore } from '../utils/textureResources.js';
+import { modelAppearanceAssets } from '../lib/appearance/model-assets.js';
 import { WorkerParser } from '@ifc-lite/parser/browser';
 import { memoryAccounting } from '../lib/perf/memoryAccounting.js';
 import {
@@ -411,6 +412,7 @@ export function useIfcLoader() {
      * stays null for those.
      */
     let geometryHandle: GeometryProcessorDisposer | null = null;
+    let appearanceLoad: ReturnType<typeof modelAppearanceAssets.begin> | undefined;
 
     /**
      * Resource-limit recovery, shared by BOTH failure paths.
@@ -776,13 +778,9 @@ export function useIfcLoader() {
       if (!pointCloudFormat) {
         const zipContents = await unwrapIfcZipWithResources(buffer);
         buffer = zipContents.model;
-        // #1781: decode sibling texture images (IfcImageTexture targets) once,
-        // up front — mesh batches attach the shared bitmaps synchronously as
-        // they arrive. Empty/no-zip loads resolve to null and pay nothing.
-        textureBitmaps = await decodeTextureResources(zipContents.resources);
-        if (textureBitmaps) {
-          console.log(`[useIfc] Decoded ${textureBitmaps.size} .ifcZIP texture image(s)`);
-        }
+        // Retain original archive paths/encoded bytes alongside shared bitmaps.
+        appearanceLoad = modelAppearanceAssets.begin(modelId);
+        textureBitmaps = await appearanceLoad.decode(zipContents);
       }
 
       const sourceKeyFingerprint = computeSourceFingerprint(buffer);
@@ -2224,7 +2222,8 @@ export function useIfcLoader() {
       // and a `dispose()` placed after the last statement would miss all of
       // them. The free itself still waits on the parse chain; see
       // createGeometryProcessorDisposer.
-      geometryHandle?.release();
+      try { appearanceLoad?.finish(useViewerStore.getState().models.has(modelId) && (target.kind === 'federated' || (useViewerStore.getState().geometryResult?.meshes.length ?? 0) > 0)); }
+      finally { geometryHandle?.release(); }
     }
   }, [setLoading, setGeometryStreamingActive, setError, setProgress, setIfcDataStore, setGeometryResult, appendGeometryBatch, appendInstancedShards, updateMeshColors, updateCoordinateInfo, loadFromCache, saveToCache, loadFromServer, revalidateSourceDecoupledHit]);
 

--- a/apps/viewer/src/lib/appearance/asset-format.ts
+++ b/apps/viewer/src/lib/appearance/asset-format.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export type AppearanceImageMime = 'image/png' | 'image/jpeg';
+
+export interface AppearanceAssetLimits {
+  maxImageBytes: number;
+  maxDimension: number;
+  maxPixels: number;
+  maxEncodedBytes: number;
+  maxDecodedBytes: number;
+}
+
+export const DEFAULT_APPEARANCE_ASSET_LIMITS: Readonly<AppearanceAssetLimits> = Object.freeze({
+  maxImageBytes: 32 * 1024 * 1024,
+  maxDimension: 8192,
+  maxPixels: 16 * 1024 * 1024,
+  maxEncodedBytes: 128 * 1024 * 1024,
+  // Convento carries six 4096² textures (384 MiB); retain room for authoring previews.
+  maxDecodedBytes: 512 * 1024 * 1024,
+});
+
+export class AppearanceAssetError extends Error {
+  constructor(public readonly code: 'format' | 'size' | 'budget' | 'missing' | 'owner' | 'decode', message: string) {
+    super(message);
+    this.name = 'AppearanceAssetError';
+  }
+}
+
+export function inspectImage(bytes: Uint8Array, claimedMime?: string): { mimeType: AppearanceImageMime; width: number; height: number } {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let result: { mimeType: AppearanceImageMime; width: number; height: number } | undefined;
+  if (bytes.length >= 33 && [137, 80, 78, 71, 13, 10, 26, 10].every((b, i) => bytes[i] === b)) {
+    if (view.getUint32(8) !== 13 || view.getUint32(12) !== 0x49484452) {
+      throw new AppearanceAssetError('format', 'The PNG header is damaged. Export the image again as PNG or JPEG.');
+    }
+    let offset = 8;
+    let hasData = false;
+    let ended = false;
+    while (offset + 12 <= bytes.length) {
+      const length = view.getUint32(offset);
+      if (length > bytes.length - offset - 12) break;
+      const type = view.getUint32(offset + 4);
+      if (type === 0x49444154) hasData = true;
+      offset += length + 12;
+      if (type === 0x49454e44) { ended = length === 0 && offset === bytes.length; break; }
+    }
+    if (!hasData || !ended) throw new AppearanceAssetError('format', 'The PNG is truncated or has invalid chunks. Export the image again.');
+    result = { mimeType: 'image/png', width: view.getUint32(16), height: view.getUint32(20) };
+  } else if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    if (bytes[bytes.length - 2] !== 0xff || bytes[bytes.length - 1] !== 0xd9) throw new AppearanceAssetError('format', 'The JPEG is truncated. Export the image again.');
+    let offset = 2;
+    let hasScan = false;
+    while (offset < bytes.length) {
+      if (bytes[offset++] !== 0xff) break;
+      while (offset < bytes.length && bytes[offset] === 0xff) offset++;
+      const marker = bytes[offset++];
+      if (marker === 0xd9) break;
+      if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+      if (offset + 2 > bytes.length) break;
+      const length = view.getUint16(offset);
+      if (length < 2 || offset + length > bytes.length) break;
+      if (marker === 0xda) {
+        const components = bytes[offset + 2];
+        hasScan = !!result && components > 0 && length === 6 + 2 * components;
+        break;
+      }
+      if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker)) {
+        if (length < 8 || bytes[offset + 7] === 0 || length !== 8 + 3 * bytes[offset + 7] || result) break;
+        result = { mimeType: 'image/jpeg', width: view.getUint16(offset + 5), height: view.getUint16(offset + 3) };
+      }
+      offset += length;
+    }
+    if (!hasScan) result = undefined;
+  }
+  if (!result) throw new AppearanceAssetError('format', 'Choose a valid PNG or JPEG image; this file has no supported image header.');
+  const mime = claimedMime?.split(';')[0].trim().toLowerCase();
+  if (mime && mime !== 'application/octet-stream' && mime !== result.mimeType) {
+    throw new AppearanceAssetError('format', `The file contents are ${result.mimeType}, but its declared type is ${mime}. Export it again with the matching image format.`);
+  }
+  return result;
+}
+
+export function validateDimensions(width: number, height: number, limits: AppearanceAssetLimits): void {
+  if (!Number.isSafeInteger(width) || !Number.isSafeInteger(height) || width <= 0 || height <= 0) {
+    throw new AppearanceAssetError('size', 'The image dimensions are invalid. Export the image again.');
+  }
+  if (width > limits.maxDimension || height > limits.maxDimension || width * height > limits.maxPixels) {
+    throw new AppearanceAssetError('size', `Resize this image: maximum edge ${limits.maxDimension}px and maximum ${limits.maxPixels} pixels.`);
+  }
+}

--- a/apps/viewer/src/lib/appearance/assets.test.ts
+++ b/apps/viewer/src/lib/appearance/assets.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { AppearanceAssetInventory, AppearanceAssetError, type AppearanceAssetOwner } from './assets.js';
+
+// Real encoded one-pixel PNG; tests inspect byte/resource ownership, not mocked return values.
+const png = () => new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=', 'base64'));
+const source: AppearanceAssetOwner = { kind: 'source', id: 'upload' };
+const draft: AppearanceAssetOwner = { kind: 'draft', id: 'panel' };
+const history: AppearanceAssetOwner = { kind: 'history', id: 'apply-1' };
+function bitmap(width = 1, height = 1) { return { width, height, closes: 0, close() { this.closes++; } }; }
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+// #4243: assets must survive all render/export/history consumers and close exactly once.
+it('deduplicates concurrent imports, preserves original bytes and decodes only on demand', async () => {
+  let calls = 0;
+  const image = bitmap();
+  const assets = new AppearanceAssetInventory({ decode: async () => { calls++; return image; } });
+  const input = png();
+  const [a, b] = await Promise.all([assets.add(input, { owner: source }), assets.add(input, { owner: draft })]);
+  assert.equal(a, b);
+  assert.equal(calls, 0);
+  assert.match(a.exportName, /^textures\/[0-9a-f]{64}\.png$/);
+  input.fill(0);
+  const copy = assets.encoded(a.id);
+  assert.deepEqual(copy, png());
+  copy.fill(0);
+  assert.deepEqual(assets.encoded(a.id), png());
+  const resources = assets.exportResources([a.id, b.id]);
+  assert.equal(resources.size, 1);
+  assert.deepEqual(resources.get(a.exportName), png());
+  await Promise.all([assets.decode(a.id, source), assets.decode(a.id, draft)]);
+  assert.equal(calls, 1);
+  assets.retain(a.id, history);
+  assets.release(a.id, source);
+  assets.releaseOwner(draft);
+  assert.equal(image.closes, 0);
+  assert.deepEqual(assets.encoded(a.id), png(), 'undo history retains encoded resources');
+  assets.releaseOwner(history);
+  assert.equal(image.closes, 1);
+  assert.equal(assets.get(a.id), undefined);
+  assets.clear();
+  assert.equal(image.closes, 1);
+});
+
+it('content names distinguish different complete hashes and disregard user filenames', async () => {
+  const assets = new AppearanceAssetInventory({ decode: async () => bitmap() });
+  const one = png(), two = png();
+  two[45] ^= 1; // Different encoded image payload; its signature/header prefix is identical.
+  const a = await assets.add(one, { owner: source });
+  const b = await assets.add(two, { owner: source });
+  assert.notEqual(a.id, b.id);
+  assert.notEqual(a.exportName, b.exportName);
+  assert.equal(assets.exportResources([a.id, b.id]).size, 2);
+  assets.clear();
+});
+
+it('one cancelled waiter leaves another owner’s shared decode intact', async () => {
+  const work = deferred<ReturnType<typeof bitmap>>();
+  const assets = new AppearanceAssetInventory({ decode: () => work.promise });
+  const a = await assets.add(png(), { owner: source });
+  assets.retain(a.id, draft);
+  const controller = new AbortController();
+  const first = assets.decode(a.id, draft, controller.signal);
+  const second = assets.decode(a.id, source);
+  controller.abort();
+  await assert.rejects(first, { name: 'AbortError' });
+  assets.releaseOwner(draft);
+  const image = bitmap();
+  work.resolve(image);
+  await second;
+  assert.equal(image.closes, 0);
+  assets.releaseOwner(source);
+  assert.equal(image.closes, 1);
+});
+
+it('final release closes late decoded results and prevents stale replacement of reimported content', async () => {
+  const work = deferred<ReturnType<typeof bitmap>>();
+  const assets = new AppearanceAssetInventory({ decode: () => work.promise });
+  const a = await assets.add(png(), { owner: source });
+  const pending = assets.decode(a.id, source);
+  assets.releaseOwner(source);
+  const replacement = await assets.add(png(), { owner: draft });
+  const image = bitmap();
+  work.resolve(image);
+  await assert.rejects(pending, { name: 'AbortError' });
+  assert.equal(image.closes, 1);
+  assert.equal(assets.get(replacement.id), replacement);
+  assets.clear();
+});
+
+it('decoder failure is retryable and releases its budget, including synchronous throws', async () => {
+  let calls = 0;
+  const assets = new AppearanceAssetInventory({ decode: () => {
+    if (++calls === 1) throw new Error('bad decoder');
+    return Promise.resolve(bitmap());
+  }, limits: { maxDecodedBytes: 4 } });
+  const a = await assets.add(png(), { owner: source });
+  await assert.rejects(assets.decode(a.id, source), /Cannot decode this image/);
+  await assets.decode(a.id, source);
+  assert.equal(calls, 2);
+  assets.clear();
+});
+
+it('mismatched decoded dimensions close the rejected bitmap and retain encoded source for recovery', async () => {
+  const image = bitmap(2, 1);
+  const assets = new AppearanceAssetInventory({ decode: async () => image });
+  const a = await assets.add(png(), { owner: source });
+  await assert.rejects(assets.decode(a.id, source), /dimensions do not match/);
+  assert.equal(image.closes, 1);
+  assert.deepEqual(assets.encoded(a.id), png());
+  assets.clear();
+  assert.equal(image.closes, 1);
+});
+
+it('rejects malformed headers, MIME mismatch and oversized dimensions before decoding', async () => {
+  let calls = 0;
+  const assets = new AppearanceAssetInventory({ decode: async () => { calls++; return bitmap(); } });
+  await assert.rejects(assets.add(png(), { owner: source, mimeType: 'image/svg+xml' }), AppearanceAssetError);
+  await assert.rejects(assets.add(png().slice(0, 24), { owner: source }), /supported image header/);
+  await assert.rejects(assets.add(png().slice(0, -3), { owner: source }), /truncated/);
+  const huge = png();
+  new DataView(huge.buffer).setUint32(16, 0x7fffffff);
+  await assert.rejects(assets.add(huge, { owner: source }), /Resize this image/);
+  const invalidJpeg = new Uint8Array([0xff, 0xd8, 0xff, 0xe1, 0, 0, 0xff, 0xd9]);
+  await assert.rejects(assets.add(invalidJpeg, { owner: source }), /supported image header/);
+  assert.equal(calls, 0);
+});
+
+it('enforces inventory and in-flight decoded budgets, reclaiming them after final completion', async () => {
+  const work = deferred<ReturnType<typeof bitmap>>();
+  const bytes = png();
+  const assets = new AppearanceAssetInventory({ decode: () => work.promise, limits: { maxEncodedBytes: bytes.length, maxDecodedBytes: 4 } });
+  const a = await assets.add(bytes, { owner: source });
+  const other = png(); other[45] ^= 1;
+  await assert.rejects(assets.add(other, { owner: draft }), /storage budget/);
+  const pending = assets.decode(a.id, source);
+  assets.releaseOwner(source);
+  const b = await assets.add(other, { owner: draft });
+  await assert.rejects(assets.decode(b.id, draft), /Decoded image budget/);
+  work.resolve(bitmap());
+  await assert.rejects(pending, { name: 'AbortError' });
+  assets.clear();
+});
+
+it('clear invalidates imports in flight and decode requires a live caller lease', async () => {
+  const assets = new AppearanceAssetInventory({ decode: async () => bitmap() });
+  const pending = assets.add(png(), { owner: source });
+  assets.clear();
+  await assert.rejects(pending, { name: 'AbortError' });
+  const a = await assets.add(png(), { owner: source });
+  await assert.rejects(assets.decode(a.id, draft), /Retain this image/);
+  const controller = new AbortController(); controller.abort();
+  await assert.rejects(assets.add(png(), { owner: draft, signal: controller.signal }), { name: 'AbortError' });
+  assets.clear();
+});
+
+it('reads real JPEG dimensions lazily and rejects a truncated scan header before decode', async () => {
+  const bytes = new Uint8Array(Buffer.from('/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDx/9k=', 'base64'));
+  let calls = 0;
+  const assets = new AppearanceAssetInventory({ decode: async () => { calls++; return bitmap(2, 1); } });
+  const asset = await assets.add(bytes, { owner: source, mimeType: 'image/jpeg' });
+  assert.equal(asset.width, 2);
+  assert.equal(asset.height, 1);
+  assert.equal(calls, 0);
+  assert.match(asset.exportName, /\.jpg$/);
+  const sof = bytes.findIndex((value, index) => value === 0xff && bytes[index + 1] === 0xc0);
+  const end = sof + 2 + ((bytes[sof + 2] << 8) | bytes[sof + 3]);
+  const truncated = new Uint8Array(end + 2);
+  truncated.set(bytes.subarray(0, end)); truncated.set([0xff, 0xd9], end);
+  await assert.rejects(assets.add(truncated, { owner: source }), /supported image header/);
+  assert.equal(calls, 0);
+  const decoded = await assets.decode(asset.id, source);
+  assets.releaseOwner(source);
+  assert.equal(decoded.closes, 1);
+});

--- a/apps/viewer/src/lib/appearance/assets.ts
+++ b/apps/viewer/src/lib/appearance/assets.ts
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  AppearanceAssetError, DEFAULT_APPEARANCE_ASSET_LIMITS, inspectImage, validateDimensions,
+  type AppearanceAssetLimits, type AppearanceImageMime,
+} from './asset-format.js';
+export { AppearanceAssetError, type AppearanceAssetLimits } from './asset-format.js';
+
+export interface AppearanceAssetOwner {
+  kind: 'source' | 'draft' | 'model' | 'history';
+  id: string;
+}
+export interface AppearanceBitmap { readonly width: number; readonly height: number; close(): void }
+export interface AppearanceAsset {
+  readonly id: string;
+  readonly mimeType: AppearanceImageMime;
+  readonly byteLength: number;
+  readonly width: number;
+  readonly height: number;
+  /** Full content digest basename avoids ambiguous IFCZIP basename resolution. */
+  readonly exportName: string;
+}
+interface Entry<B extends AppearanceBitmap> {
+  asset: Readonly<AppearanceAsset>;
+  bytes: Uint8Array;
+  owners: Set<string>;
+  decoded?: B;
+  pending?: Promise<B>;
+  reservedBytes: number;
+}
+export type AppearanceImageDecoder<B extends AppearanceBitmap> = (bytes: Uint8Array, mimeType: AppearanceImageMime) => Promise<B>;
+
+function ownerKey(owner: AppearanceAssetOwner): string {
+  if (!owner.id) throw new AppearanceAssetError('owner', 'An appearance asset needs an owner identifier.');
+  return JSON.stringify([owner.kind, owner.id]);
+}
+function cancelled(): Error {
+  const error = new Error('Image operation cancelled.');
+  error.name = 'AbortError';
+  return error;
+}
+function checkSignal(signal?: AbortSignal): void { if (signal?.aborted) throw cancelled(); }
+
+/** Cancellation belongs to each caller; it must not cancel another owner's shared decode. */
+function waitFor<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(cancelled());
+  return new Promise((resolve, reject) => {
+    const abort = () => { signal.removeEventListener('abort', abort); reject(cancelled()); };
+    signal.addEventListener('abort', abort, { once: true });
+    promise.then(
+      value => { signal.removeEventListener('abort', abort); resolve(value); },
+      error => { signal.removeEventListener('abort', abort); reject(error); },
+    );
+  });
+}
+
+async function browserDecode(bytes: Uint8Array, mimeType: AppearanceImageMime): Promise<ImageBitmap> {
+  if (typeof createImageBitmap !== 'function') {
+    throw new AppearanceAssetError('decode', 'Image decoding is unavailable. Try a browser with image bitmap support.');
+  }
+  // Copy detaches Blob ownership from inventory storage; preserve source UV/image orientation.
+  return createImageBitmap(new Blob([new Uint8Array(bytes)], { type: mimeType }), { imageOrientation: 'none' });
+}
+
+/**
+ * Session inventory for original encoded images. Own bytes here, never in Zustand.
+ * Owners are idempotent leases; each independent consumer needs a distinct owner id.
+ * Hold an owner until renderer/history/export use has finished. Final release closes
+ * its bitmap, including one returned after release; callers never close shared bitmaps.
+ * This is in-memory ownership, not a claim of durable project persistence.
+ */
+export class AppearanceAssetInventory<B extends AppearanceBitmap = ImageBitmap> {
+  private readonly entries = new Map<string, Entry<B>>();
+  private readonly limits: AppearanceAssetLimits;
+  private readonly decoder: AppearanceImageDecoder<B>;
+  private encodedBytes = 0;
+  private decodedBytes = 0;
+  private generation = 0;
+
+  constructor(options: { decode: AppearanceImageDecoder<B>; limits?: Partial<AppearanceAssetLimits> });
+  constructor(options?: B extends ImageBitmap ? { limits?: Partial<AppearanceAssetLimits> } : never);
+  constructor(options: { decode?: AppearanceImageDecoder<B>; limits?: Partial<AppearanceAssetLimits> } = {}) {
+    this.limits = { ...DEFAULT_APPEARANCE_ASSET_LIMITS, ...options.limits };
+    for (const value of Object.values(this.limits)) {
+      if (!Number.isSafeInteger(value) || value <= 0) throw new AppearanceAssetError('budget', 'Image budgets must be positive whole numbers.');
+    }
+    // The default constructor is available only for ImageBitmap; injected decoders
+    // use the explicit generic constructor overload above.
+    this.decoder = options.decode ?? (browserDecode as AppearanceImageDecoder<B>);
+  }
+
+  async add(input: Uint8Array | Blob, options: { owner: AppearanceAssetOwner; mimeType?: string; signal?: AbortSignal }): Promise<Readonly<AppearanceAsset>> {
+    const key = ownerKey(options.owner);
+    const generation = this.generation;
+    checkSignal(options.signal);
+    const size = input instanceof Uint8Array ? input.byteLength : input.size;
+    if (size === 0 || size > this.limits.maxImageBytes) {
+      throw new AppearanceAssetError('size', `Choose an image between 1 and ${this.limits.maxImageBytes} encoded bytes, or resize this image.`);
+    }
+    const bytes = input instanceof Uint8Array ? new Uint8Array(input) : new Uint8Array(await input.arrayBuffer());
+    checkSignal(options.signal);
+    const dimensions = inspectImage(bytes, options.mimeType ?? (input instanceof Uint8Array ? undefined : input.type));
+    validateDimensions(dimensions.width, dimensions.height, this.limits);
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    checkSignal(options.signal);
+    if (generation !== this.generation) throw cancelled();
+    const id = Array.from(new Uint8Array(digest), b => b.toString(16).padStart(2, '0')).join('');
+    const existing = this.entries.get(id);
+    if (existing) {
+      existing.owners.add(key);
+      return existing.asset;
+    }
+    if (this.encodedBytes + bytes.byteLength > this.limits.maxEncodedBytes) {
+      throw new AppearanceAssetError('budget', 'Image storage budget exceeded. Remove unused sources or use smaller images.');
+    }
+    const asset = Object.freeze({ id, ...dimensions, byteLength: bytes.byteLength, exportName: `textures/${id}.${dimensions.mimeType === 'image/png' ? 'png' : 'jpg'}` });
+    this.entries.set(id, { asset, bytes, owners: new Set([key]), reservedBytes: 0 });
+    this.encodedBytes += bytes.byteLength;
+    return asset;
+  }
+
+  get(id: string): Readonly<AppearanceAsset> | undefined { return this.entries.get(id)?.asset; }
+  retain(id: string, owner: AppearanceAssetOwner): void { this.entry(id).owners.add(ownerKey(owner)); }
+  release(id: string, owner: AppearanceAssetOwner): void {
+    const entry = this.entries.get(id);
+    if (!entry) return;
+    entry.owners.delete(ownerKey(owner));
+    if (entry.owners.size === 0) this.drop(id, entry);
+  }
+  releaseOwner(owner: AppearanceAssetOwner): void {
+    const key = ownerKey(owner);
+    for (const [id, entry] of this.entries) {
+      entry.owners.delete(key);
+      if (entry.owners.size === 0) this.drop(id, entry);
+    }
+  }
+
+  async decode(id: string, owner: AppearanceAssetOwner, signal?: AbortSignal): Promise<B> {
+    checkSignal(signal);
+    const entry = this.entry(id);
+    const key = ownerKey(owner);
+    if (!entry.owners.has(key)) throw new AppearanceAssetError('owner', 'Retain this image for the requesting owner before decoding it.');
+    if (!entry.pending && !entry.decoded) {
+      const cost = entry.asset.width * entry.asset.height * 4;
+      if (this.decodedBytes + cost > this.limits.maxDecodedBytes) {
+        throw new AppearanceAssetError('budget', 'Decoded image budget exceeded. Close unused models or previews, or choose smaller images.');
+      }
+      entry.reservedBytes = cost;
+      this.decodedBytes += cost;
+      entry.pending = this.decodeEntry(id, entry);
+    }
+    const bitmap = await waitFor(entry.decoded ? Promise.resolve(entry.decoded) : entry.pending!, signal);
+    checkSignal(signal);
+    if (this.entries.get(id) !== entry || !entry.owners.has(key)) throw cancelled();
+    return bitmap;
+  }
+
+  /** Defensive copies keep source bytes immutable while exporters build archives. */
+  encoded(id: string): Uint8Array<ArrayBuffer> { return new Uint8Array(this.entry(id).bytes); }
+  exportResources(ids: Iterable<string>): Map<string, Uint8Array> {
+    const resources = new Map<string, Uint8Array>();
+    for (const id of ids) {
+      const entry = this.entry(id);
+      if (!resources.has(entry.asset.exportName)) resources.set(entry.asset.exportName, new Uint8Array(entry.bytes));
+    }
+    return resources;
+  }
+  clear(): void {
+    this.generation++;
+    for (const [id, entry] of this.entries) this.drop(id, entry);
+  }
+
+  private entry(id: string): Entry<B> {
+    const entry = this.entries.get(id);
+    if (!entry) throw new AppearanceAssetError('missing', 'This appearance image was released. Reimport it or restore its source before continuing.');
+    return entry;
+  }
+  private unreserve(entry: Entry<B>): void {
+    this.decodedBytes -= entry.reservedBytes;
+    entry.reservedBytes = 0;
+  }
+  private drop(id: string, entry: Entry<B>): void {
+    this.entries.delete(id);
+    this.encodedBytes -= entry.bytes.byteLength;
+    // In-flight decodes still consume their reservation until they settle.
+    if (!entry.pending) this.unreserve(entry);
+    entry.decoded?.close();
+    entry.decoded = undefined;
+  }
+  private async decodeEntry(id: string, entry: Entry<B>): Promise<B> {
+    let bitmap: B | undefined;
+    try {
+      const decoded = await Promise.resolve().then(() => this.decoder(new Uint8Array(entry.bytes), entry.asset.mimeType));
+      bitmap = decoded;
+      if (this.entries.get(id) !== entry) throw cancelled();
+      validateDimensions(decoded.width, decoded.height, this.limits);
+      if (decoded.width !== entry.asset.width || decoded.height !== entry.asset.height) {
+        throw new AppearanceAssetError('decode', 'Decoded dimensions do not match the image header. Export the image again without orientation metadata.');
+      }
+      entry.decoded = decoded;
+      return decoded;
+    } catch (error) {
+      bitmap?.close();
+      this.unreserve(entry);
+      if (error instanceof AppearanceAssetError || (error instanceof Error && error.name === 'AbortError')) throw error;
+      throw new AppearanceAssetError('decode', `Cannot decode this image. Export it again as PNG or JPEG. ${error instanceof Error ? error.message : String(error)}`);
+    } finally {
+      entry.pending = undefined;
+    }
+  }
+}

--- a/apps/viewer/src/lib/appearance/model-assets.test.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.test.ts
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '@/test/setup-dom.js';
+import { it } from 'node:test';
+import assert from 'node:assert/strict';
+import { AppearanceAssetInventory } from './assets.js';
+import { ModelAppearanceAssets, modelAppearanceAssets } from './model-assets.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+const png = () => new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jRZkAAAAASUVORK5CYII=', 'base64'));
+function image() { return { width: 1, height: 1, closes: 0, close() { this.closes++; } }; }
+const archive = () => ({ originalResources: new Map([['nested/Textures/Wood.PNG', png()]]), modelPath: 'nested/model.ifc' });
+
+// #4243: loaded geometry and portable exports have separate lifetimes.
+it('keeps original paths/encoded bytes through import, model replacement and federation close', async () => {
+  const bitmap = image();
+  const inventory = new AppearanceAssetInventory({ decode: async () => bitmap });
+  const models = new ModelAppearanceAssets(inventory);
+  for (const model of ['a', 'b', 'a']) {
+    const load = models.begin(model);
+    assert.equal((await load.decode(archive()))?.get('wood.png'), bitmap);
+    load.finish(true);
+  }
+  models.remove('a');
+  assert.equal(bitmap.closes, 0);
+  const exported = models.exportOriginals('b');
+  assert.equal(exported.modelPath, 'nested/model.ifc');
+  assert.deepEqual(exported.resources.get('nested/Textures/Wood.PNG'), png());
+  models.clear();
+  assert.equal(bitmap.closes, 1);
+  assert.equal(models.exportOriginals('b').resources.size, 0);
+});
+
+it('failed load releases decoded images without publishing original resources', async () => {
+  const bitmap = image();
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => bitmap }));
+  const load = models.begin('failed');
+  assert.throws(() => models.exportOriginals('failed'), /still loading/);
+  await load.decode(archive());
+  load.finish(false);
+  assert.equal(bitmap.closes, 1);
+  assert.equal(models.exportOriginals('failed').resources.size, 0);
+});
+
+it('model close during decode closes the late bitmap and prevents stale load publication', async () => {
+  let resolve!: (value: ReturnType<typeof image>) => void;
+  let started!: () => void;
+  const begun = new Promise<void>(yes => { started = yes; });
+  const bitmap = image();
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: () => {
+    started();
+    return new Promise<ReturnType<typeof image>>(yes => { resolve = yes; });
+  } }));
+  const load = models.begin('closing');
+  const loading = load.decode(archive());
+  await begun;
+  models.remove('closing');
+  await assert.rejects(loading, { name: 'AbortError' });
+  resolve(bitmap);
+  await new Promise<void>(yes => setImmediate(yes));
+  load.finish(true);
+  assert.equal(bitmap.closes, 1);
+  assert.equal(models.exportOriginals('closing').resources.size, 0);
+});
+
+it('preserves distinct same-basename originals while existing viewer resolution stays first-wins', async () => {
+  const second = png(); second[second.length - 1] ^= 1;
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => image() }));
+  const load = models.begin('collisions');
+  const bitmaps = await load.decode({ originalResources: new Map([['a/wood.png', png()], ['b/wood.png', second]]) });
+  load.finish(true);
+  assert.equal(bitmaps?.size, 1);
+  const exported = models.exportOriginals('collisions');
+  assert.deepEqual(exported.resources.get('a/wood.png'), png());
+  assert.deepEqual(exported.resources.get('b/wood.png'), second);
+  models.clear();
+});
+
+// Exercise real teardown actions: a reset preserves models; close releases them.
+it('real model teardown keeps textures through view reset and releases on close/clear', async () => {
+  const previous = globalThis.createImageBitmap;
+  const bitmaps: ReturnType<typeof image>[] = [];
+  globalThis.createImageBitmap = async () => { const bitmap = image(); bitmaps.push(bitmap); return bitmap; };
+  try {
+    useViewerStore.setState(fixtureModels(fixtureModel('a'), fixtureModel('b')));
+    for (const id of ['a', 'b']) {
+      const load = modelAppearanceAssets.begin(id);
+      await load.decode(archive());
+      load.finish(true);
+    }
+    useViewerStore.getState().resetViewerState();
+    assert.equal(bitmaps[0].closes, 0);
+    assert.equal(modelAppearanceAssets.exportOriginals('a').resources.size, 1);
+    useViewerStore.getState().removeModel('a');
+    assert.equal(bitmaps[0].closes, 0);
+    assert.equal(modelAppearanceAssets.exportOriginals('a').resources.size, 0);
+    useViewerStore.getState().clearAllModels();
+    assert.equal(bitmaps[0].closes, 1);
+  } finally {
+    modelAppearanceAssets.clear();
+    globalThis.createImageBitmap = previous;
+  }
+});
+
+it('refuses incomplete portable export when an original image was rejected', async t => {
+  const warning = t.mock.method(console, 'warn', () => {});
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => image() }));
+  const load = models.begin('invalid');
+  const bitmaps = await load.decode({ originalResources: new Map([
+    ['a/wood.png', new Uint8Array([1, 2, 3])], ['b/wood.png', png()],
+  ]) });
+  load.finish(true);
+  // Preserve historical basename first-wins even when the first entry is invalid.
+  assert.equal(bitmaps, null);
+  assert.equal(warning.mock.callCount(), 1);
+  assert.throws(() => models.exportOriginals('invalid'), /a\/wood.png/);
+  models.clear();
+});
+
+it('does not claim a complete portable export when the parser omitted archive images', async () => {
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => image() }));
+  const load = models.begin('partial');
+  await load.decode({ ...archive(), resourcesIncomplete: true });
+  load.finish(true);
+  assert.throws(() => models.exportOriginals('partial'), /exceeded image extraction limits/);
+  models.clear();
+});
+
+it('registers authored uses only on Apply, preserves shared commands through undo and restores on redo', async () => {
+  const bitmap = image();
+  const inventory = new AppearanceAssetInventory({ decode: async () => bitmap });
+  const models = new ModelAppearanceAssets(inventory);
+  const owner = { kind: 'history' as const, id: 'history' };
+  const asset = await inventory.add(png(), { owner });
+  const uri = models.getAuthoredUri('model', asset.id);
+  assert.equal(models.exportResources('model').resources.size, 0);
+  models.registerAuthored('model', 'first', [asset.id]);
+  models.registerAuthored('model', 'second', [asset.id]);
+  models.unregisterAuthored('model', 'first');
+  assert.deepEqual(models.exportResources('model').resources.get(uri), png());
+  models.unregisterAuthored('model', 'second');
+  assert.equal(models.exportResources('model').resources.size, 0);
+  assert.ok(inventory.get(asset.id), 'history retains bytes for redo');
+  models.registerAuthored('model', 'first', [asset.id]);
+  inventory.releaseOwner(owner);
+  assert.deepEqual(models.exportResources('model').resources.get(uri), png());
+  models.clear();
+  assert.equal(inventory.get(asset.id), undefined);
+});
+
+it('rejects a forged imported digest basename and validates a whole registration before retaining', async () => {
+  const inventory = new AppearanceAssetInventory({ decode: async () => image() });
+  const models = new ModelAppearanceAssets(inventory);
+  const owner = { kind: 'source' as const, id: 'upload' };
+  const asset = await inventory.add(png(), { owner });
+  const other = png(); other[other.length - 1] ^= 1;
+  const load = models.begin('model');
+  await load.decode({ originalResources: new Map([[`another/${asset.exportName.split('/').pop()}`, other]]) });
+  load.finish(true);
+  assert.throws(() => models.getAuthoredUri('model', asset.id), /different content/);
+  assert.throws(() => models.registerAuthored('new-model', 'cmd', [asset.id, 'missing']), /released/);
+  inventory.releaseOwner(owner);
+  assert.equal(inventory.get(asset.id), undefined, 'failed registration did not retain the valid first asset');
+  models.clear();
+});
+
+// Allocation-footprint fixture: Convento's six 4096² JPEG images, without
+// allocating 384 MiB of pixel buffers in a unit test. Header dimensions match
+// the injected decoder's tracked bitmap footprint; real decoding is the viewer lab gate.
+it('retains all six Convento-sized JPEGs plus a new authoring source under default budgets', async () => {
+  const original = new Uint8Array(Buffer.from('/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDx/9k=', 'base64'));
+  const frame = original.findIndex((value, index) => value === 0xff && original[index + 1] === 0xc0);
+  const resources = new Map<string, Uint8Array>();
+  for (let i = 0; i < 6; i++) {
+    const bytes = new Uint8Array(original);
+    const header = new DataView(bytes.buffer);
+    header.setUint16(frame + 5, 4096); header.setUint16(frame + 7, 4096);
+    bytes[bytes.length - 3] = i; // Distinct encoded identities, one bitmap each.
+    resources.set(`texture${i}.jpg`, bytes);
+  }
+  const decoded: Array<{ width: number; height: number; closes: number; close(): void }> = [];
+  const inventory = new AppearanceAssetInventory({ decode: async bytes => {
+    const large = bytes[0] === 0xff;
+    const header = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const bitmap = { width: large ? 4096 : header.getUint32(16), height: large ? 4096 : header.getUint32(20), closes: 0, close() { this.closes++; } };
+    decoded.push(bitmap); return bitmap;
+  } });
+  const models = new ModelAppearanceAssets(inventory);
+  const load = models.begin('convento');
+  assert.equal((await load.decode({ originalResources: resources }))?.size, 6);
+  load.finish(true);
+  const owner = { kind: 'draft' as const, id: 'new-image' };
+  const uploaded = png();
+  const header = new DataView(uploaded.buffer); header.setUint32(16, 1024); header.setUint32(20, 1024);
+  const asset = await inventory.add(uploaded, { owner });
+  await inventory.decode(asset.id, owner);
+  assert.equal(decoded.length, 7);
+  assert.equal(decoded[6].width, 1024);
+  assert.equal(models.exportResources('convento').resources.size, 6);
+  inventory.releaseOwner(owner); models.clear();
+  assert.ok(decoded.every(bitmap => bitmap.closes === 1));
+});
+
+it('surfaces archive decode budget failures instead of publishing partially textured geometry', async () => {
+  const other = png(); other[other.length - 1] ^= 1;
+  const bitmap = image();
+  const inventory = new AppearanceAssetInventory({ decode: async () => bitmap, limits: { maxDecodedBytes: 4 } });
+  const models = new ModelAppearanceAssets(inventory);
+  const load = models.begin('over-budget');
+  await assert.rejects(load.decode({ originalResources: new Map([['one.png', png()], ['two.png', other]]) }), /Decoded image budget exceeded/);
+  load.finish(false);
+  assert.equal(bitmap.closes, 1);
+  assert.equal(models.exportResources('over-budget').resources.size, 0);
+});

--- a/apps/viewer/src/lib/appearance/model-assets.test.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.test.ts
@@ -243,3 +243,29 @@ it('keeps metadata-only and instanced-only IFC originals, but releases failed pl
   assert.equal(bitmap.closes, 1, 'failed placeholders and removed models must not leak a pending source owner');
   useViewerStore.getState().clearAllModels();
 });
+
+// #4261: geometry completes before primary metadata, which finalizes in background.
+it('holds images until delayed metadata finalization and releases rejected or removed loads', async () => {
+  for (const outcome of ['success', 'partial', 'reject', 'remove'] as const) {
+    const bitmap = image();
+    const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => bitmap }));
+    const load = models.begin(outcome);
+    await load.decode(archive());
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const finalization = new Promise<void>((yes, no) => { resolve = yes; reject = no; });
+    let model = { ...fixtureModel(outcome), ifcDataStore: null as ReturnType<typeof fixtureModel>['ifcDataStore'] };
+    const settled = load.finishAfter(finalization, () => model);
+    assert.equal(load.finishAfter(Promise.resolve(), () => model), settled, 'completion registration is once-only');
+    load.finishForModel(model); // The canonical loader's early finally.
+    assert.equal(bitmap.closes, 0, 'geometry completion cannot close an image still used by the viewport');
+    assert.throws(() => models.exportOriginals(outcome), /still loading/);
+    if (outcome === 'remove') { models.remove(outcome); assert.equal(bitmap.closes, 1); }
+    if (outcome !== 'reject') model = fixtureModel(outcome);
+    if (outcome === 'reject' || outcome === 'partial') reject(new Error('metadata failed')); else resolve();
+    await settled;
+    assert.equal(models.exportOriginals(outcome).resources.size, outcome === 'success' || outcome === 'partial' ? 1 : 0);
+    models.clear();
+    assert.equal(bitmap.closes, 1);
+  }
+});

--- a/apps/viewer/src/lib/appearance/model-assets.test.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.test.ts
@@ -134,12 +134,15 @@ it('registers authored uses only on Apply, preserves shared commands through und
   const owner = { kind: 'history' as const, id: 'history' };
   const asset = await inventory.add(png(), { owner });
   const uri = models.getAuthoredUri('model', asset.id);
+  assert.equal(models.hasResources('model'), false);
   assert.equal(models.exportResources('model').resources.size, 0);
   models.registerAuthored('model', 'first', [asset.id]);
   models.registerAuthored('model', 'second', [asset.id]);
   models.unregisterAuthored('model', 'first');
+  assert.equal(models.hasResources('model'), true);
   assert.deepEqual(models.exportResources('model').resources.get(uri), png());
   models.unregisterAuthored('model', 'second');
+  assert.equal(models.hasResources('model'), false);
   assert.equal(models.exportResources('model').resources.size, 0);
   assert.ok(inventory.get(asset.id), 'history retains bytes for redo');
   models.registerAuthored('model', 'first', [asset.id]);
@@ -212,4 +215,31 @@ it('surfaces archive decode budget failures instead of publishing partially text
   load.finish(false);
   assert.equal(bitmap.closes, 1);
   assert.equal(models.exportResources('over-budget').resources.size, 0);
+});
+
+// #4243 independent review: source ownership must not depend on flat geometry.
+it('keeps metadata-only and instanced-only IFC originals, but releases failed placeholders', async () => {
+  const bitmap = image();
+  const models = new ModelAppearanceAssets(new AppearanceAssetInventory({ decode: async () => bitmap }));
+  const metadata = { ...fixtureModel('metadata'), geometryResult: null };
+  const point = { x: 0, y: 0, z: 0 };
+  const bounds = { min: point, max: point };
+  const instanced = { ...fixtureModel('instanced'), geometryResult: {
+    meshes: [], totalVertices: 3, totalTriangles: 1, instancedGeometryHashes: new Map([[1, 1n]]),
+    coordinateInfo: { originShift: point, originalBounds: bounds, shiftedBounds: bounds, hasLargeCoordinates: false },
+  } };
+  const failed = { ...fixtureModel('failed'), ifcDataStore: null, geometryResult: null };
+  useViewerStore.setState(fixtureModels(metadata, instanced, failed));
+  // Global geometry belongs to another active model; finalization must resolve its own.
+  useViewerStore.setState({ activeModelId: 'failed', geometryResult: null });
+  for (const id of ['metadata', 'instanced', 'failed', 'removed']) {
+    const load = models.begin(id);
+    await load.decode(archive());
+    load.finishForModel(useViewerStore.getState().models.get(id));
+    assert.equal(models.hasResources(id), id === 'metadata' || id === 'instanced');
+    assert.equal(models.exportOriginals(id).resources.size, id === 'metadata' || id === 'instanced' ? 1 : 0);
+  }
+  models.clear();
+  assert.equal(bitmap.closes, 1, 'failed placeholders and removed models must not leak a pending source owner');
+  useViewerStore.getState().clearAllModels();
 });

--- a/apps/viewer/src/lib/appearance/model-assets.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.ts
@@ -32,6 +32,7 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
     const controller = new AbortController();
     const images: ModelImages = { paths: new Map(), refused: [], incomplete: false };
     let finished = false;
+    let finalizing: Promise<void> | undefined;
     const cancel = () => {
       if (finished) return;
       finished = true;
@@ -67,9 +68,25 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
         }
         return bitmaps.size ? bitmaps : null;
       },
+      /** The primary loader returns before its background metadata finalizer. */
+      finishAfter: (finalization: Promise<unknown>, getModel: () => { ifcDataStore: IfcDataStore | null } | undefined): Promise<void> => {
+        if (finalizing) return finalizing;
+        if (finished) return Promise.resolve();
+        const finishCurrentModel = () => {
+          if (!finished) lease.finish(getModel()?.ifcDataStore != null);
+        };
+        finalizing = finalization.then(finishCurrentModel, error => {
+          console.warn('[textures] Appearance load finalization failed:', error);
+          finishCurrentModel(); // A retained partial IFC source is still exportable.
+        }).catch(error => {
+          console.warn('[textures] Cannot retain finalized appearance resources:', error);
+          cancel();
+        });
+        return finalizing;
+      },
       /** Model-local parsed source remains exportable without any flat meshes. */
       finishForModel: (model: { ifcDataStore: IfcDataStore | null } | undefined) => {
-        lease.finish(model?.ifcDataStore != null);
+        if (!finalizing) lease.finish(model?.ifcDataStore != null);
       },
       /** Retain only while a loaded model owns it. */
       finish: (modelExists: boolean) => {

--- a/apps/viewer/src/lib/appearance/model-assets.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.ts
@@ -16,6 +16,8 @@ interface ModelImages {
   incomplete: boolean;
 }
 
+// File-controlled archive paths must not inject control characters into diagnostics.
+// eslint-disable-next-line no-control-regex -- This character class intentionally removes ASCII controls.
 function displayPath(path: string): string { return path.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 160); }
 
 /** Original bytes belong to the model, independently of uploaded GPU copies. */

--- a/apps/viewer/src/lib/appearance/model-assets.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.ts
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { AppearanceAssetInventory, AppearanceAssetError, type AppearanceBitmap } from './assets.js';
+
+interface ArchiveImages {
+  originalResources: Map<string, Uint8Array>;
+  modelPath?: string;
+  resourcesIncomplete?: boolean;
+}
+interface ModelImages {
+  paths: Map<string, string>;
+  modelPath?: string;
+  refused: string[];
+  incomplete: boolean;
+}
+
+function displayPath(path: string): string { return path.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 160); }
+
+/** Original bytes belong to the model, independently of uploaded GPU copies. */
+export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
+  private models = new Map<string, ModelImages>();
+  private authored = new Map<string, Map<string, Set<string>>>();
+  private pending = new Map<string, { cancel(): void }>();
+  constructor(readonly inventory: AppearanceAssetInventory<B>) {}
+
+  /** Begin before decode so model removal can cancel a late decoder. */
+  begin(modelId: string) {
+    this.pending.get(modelId)?.cancel();
+    const owner = { kind: 'source' as const, id: crypto.randomUUID() };
+    const controller = new AbortController();
+    const images: ModelImages = { paths: new Map(), refused: [], incomplete: false };
+    let finished = false;
+    const cancel = () => {
+      if (finished) return;
+      finished = true;
+      controller.abort();
+      this.inventory.releaseOwner(owner);
+      if (this.pending.get(modelId) === lease) this.pending.delete(modelId);
+    };
+    const lease = {
+      cancel,
+      decode: async (archive: ArchiveImages): Promise<Map<string, B> | null> => {
+        images.modelPath = archive.modelPath;
+        images.incomplete = archive.resourcesIncomplete === true;
+        const bitmaps = new Map<string, B>();
+        const seenBasenames = new Set<string>();
+        // Sequential decode bounds the number of pending browser allocations.
+        for (const [path, bytes] of archive.originalResources) {
+          if (controller.signal.aborted) throw controller.signal.reason;
+          const basename = path.split('/').pop()!.toLowerCase();
+          const useBitmap = !seenBasenames.has(basename);
+          seenBasenames.add(basename);
+          try {
+            const asset = await this.inventory.add(bytes, { owner, signal: controller.signal });
+            images.paths.set(path, asset.id);
+            if (useBitmap) {
+              bitmaps.set(basename, await this.inventory.decode(asset.id, owner, controller.signal));
+            }
+          } catch (error) {
+            if (controller.signal.aborted || (error instanceof AppearanceAssetError && error.code === 'budget')) throw error;
+            // Retained but undecodable originals are still exportable.
+            if (!images.paths.has(path)) images.refused.push(path);
+            console.warn(`[textures] Cannot use IFCZIP image "${displayPath(path)}"`, error);
+          }
+        }
+        return bitmaps.size ? bitmaps : null;
+      },
+      /** Retain only while a loaded model (including visible partial geometry) owns it. */
+      finish: (modelExists: boolean) => {
+        if (finished) return;
+        if (modelExists) {
+          const modelOwner = { kind: 'model' as const, id: modelId };
+          // A replacement source may share assets with the old source: retain
+          // first, then release only ids no longer referenced by this model.
+          const old = this.models.get(modelId);
+          for (const id of images.paths.values()) this.inventory.retain(id, modelOwner);
+          const retained = new Set(images.paths.values());
+          for (const id of old?.paths.values() ?? []) {
+            if (!retained.has(id) && ![...this.authored.get(modelId)?.values() ?? []].some(ids => ids.has(id))) this.inventory.release(id, modelOwner);
+          }
+          this.models.set(modelId, images);
+        }
+        cancel();
+      },
+    };
+    this.pending.set(modelId, lease);
+    return lease;
+  }
+
+  /** The IFC entry must keep modelPath so its relative URLReferences resolve. */
+  exportOriginals(modelId: string): { modelPath?: string; resources: Map<string, Uint8Array> } {
+    if (this.pending.has(modelId)) throw new AppearanceAssetError('missing', 'Texture images are still loading. Wait for model loading to finish before exporting.');
+    const images = this.models.get(modelId);
+    if (images?.incomplete) {
+      throw new AppearanceAssetError('missing', 'Cannot export all original textures: the archive exceeded image extraction limits. Reduce image count or size and reload the archive.');
+    }
+    if (images?.refused.length) {
+      throw new AppearanceAssetError('missing', `Cannot export all original textures: ${images.refused.slice(0, 8).map(displayPath).join(', ')}. Reload smaller supported PNG/JPEG images.`);
+    }
+    const resources = new Map<string, Uint8Array>();
+    for (const [path, id] of images?.paths ?? []) resources.set(path, this.inventory.encoded(id));
+    return { modelPath: images?.modelPath, resources };
+  }
+  /** Pure preparation: the IFC URL is relative to its entry directory. */
+  getAuthoredUri(modelId: string, assetId: string): string {
+    const asset = this.inventory.get(assetId);
+    if (!asset) throw new AppearanceAssetError('missing', 'This image was released. Choose the source image again.');
+    const basename = asset.exportName.split('/').pop()!;
+    for (const [path, id] of this.models.get(modelId)?.paths ?? []) {
+      if (path.split('/').pop()?.toLowerCase() === basename && id !== assetId) {
+        throw new AppearanceAssetError('format', 'An imported texture uses this image filename for different content. Rename that archive resource before applying appearance.');
+      }
+    }
+    return asset.exportName;
+  }
+
+  /** One lease per active appearance command; history owns its own redo lease. */
+  registerAuthored(modelId: string, commandId: string, assetIds: Iterable<string>): void {
+    if (!commandId) throw new AppearanceAssetError('owner', 'Appearance changes need a command identifier.');
+    const ids = new Set(assetIds);
+    for (const id of ids) this.getAuthoredUri(modelId, id);
+    const commands = this.authored.get(modelId) ?? new Map<string, Set<string>>();
+    const previous = commands.get(commandId) ?? new Set<string>();
+    for (const id of ids) this.inventory.retain(id, { kind: 'model', id: modelId });
+    commands.set(commandId, ids);
+    this.authored.set(modelId, commands);
+    for (const id of previous) this.releaseUnused(modelId, id);
+  }
+  unregisterAuthored(modelId: string, commandId: string): void {
+    const commands = this.authored.get(modelId);
+    const ids = commands?.get(commandId);
+    commands?.delete(commandId);
+    if (commands?.size === 0) this.authored.delete(modelId);
+    for (const id of ids ?? []) this.releaseUnused(modelId, id);
+  }
+  exportResources(modelId: string): { modelPath?: string; resources: Map<string, Uint8Array> } {
+    const result = this.exportOriginals(modelId);
+    const folder = result.modelPath?.slice(0, result.modelPath.lastIndexOf('/') + 1) ?? '';
+    for (const ids of this.authored.get(modelId)?.values() ?? []) {
+      for (const id of ids) {
+        const path = folder + this.getAuthoredUri(modelId, id);
+        if (!result.resources.has(path)) result.resources.set(path, this.inventory.encoded(id));
+      }
+    }
+    return result;
+  }
+  private releaseUnused(modelId: string, assetId: string): void {
+    if ([...this.models.get(modelId)?.paths.values() ?? []].includes(assetId)) return;
+    for (const ids of this.authored.get(modelId)?.values() ?? []) if (ids.has(assetId)) return;
+    this.inventory.release(assetId, { kind: 'model', id: modelId });
+  }
+  remove(modelId: string): void {
+    this.pending.get(modelId)?.cancel();
+    this.models.delete(modelId);
+    this.authored.delete(modelId);
+    this.inventory.releaseOwner({ kind: 'model', id: modelId });
+  }
+  clear(): void {
+    for (const pending of this.pending.values()) pending.cancel();
+    for (const modelId of new Set([...this.models.keys(), ...this.authored.keys()])) this.remove(modelId);
+  }
+}
+
+export const appearanceAssets = new AppearanceAssetInventory();
+export const modelAppearanceAssets = new ModelAppearanceAssets(appearanceAssets);

--- a/apps/viewer/src/lib/appearance/model-assets.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { IfcDataStore } from '@ifc-lite/parser';
 import { AppearanceAssetInventory, AppearanceAssetError, type AppearanceBitmap } from './assets.js';
 
 interface ArchiveImages {
@@ -66,7 +67,11 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
         }
         return bitmaps.size ? bitmaps : null;
       },
-      /** Retain only while a loaded model (including visible partial geometry) owns it. */
+      /** Model-local parsed source remains exportable without any flat meshes. */
+      finishForModel: (model: { ifcDataStore: IfcDataStore | null } | undefined) => {
+        lease.finish(model?.ifcDataStore != null);
+      },
+      /** Retain only while a loaded model owns it. */
       finish: (modelExists: boolean) => {
         if (finished) return;
         if (modelExists) {
@@ -86,6 +91,13 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
     };
     this.pending.set(modelId, lease);
     return lease;
+  }
+
+  /** Cheap output-label hint; exportResources still validates readiness/completeness. */
+  hasResources(modelId: string): boolean {
+    if (this.models.get(modelId)?.paths.size) return true;
+    for (const ids of this.authored.get(modelId)?.values() ?? []) if (ids.size) return true;
+    return false;
   }
 
   /** The IFC entry must keep modelPath so its relative URLReferences resolve. */

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -17,6 +17,7 @@ import { federationRegistry, type GlobalIdLookup } from '@ifc-lite/renderer';
 import type { ViewerState } from '../index.js';
 import { localIdInParseRange, localIdInOverlay } from '../globalId.js';
 import { viewerTeardown } from '../teardown-registry.js';
+import { modelAppearanceAssets } from '../../lib/appearance/model-assets.js';
 import { modelRemovedScope } from '../teardown-scope.js';
 import {
   endIdsRowFocusPresentation,
@@ -376,6 +377,7 @@ export const createModelSlice: StateCreator<ViewerState, [], [], ModelSlice> = (
     // through `withVisibilityOwnershipInvalidation`.
     const state = get();
     set(viewerTeardown(modelRemovedScope(state, modelId), state));
+    modelAppearanceAssets.remove(modelId);
   },
 
   clearAllModels: () => {
@@ -514,6 +516,7 @@ export const createModelSlice: StateCreator<ViewerState, [], [], ModelSlice> = (
     // stored global id is stale by definition AND the very next model loaded
     // can be handed those exact numbers back.
     set(viewerTeardown({ kind: 'all-models-cleared' }, get()));
+    modelAppearanceAssets.clear();
   },
 
   setActiveModel: (modelId) => set((state) => {

--- a/apps/viewer/src/utils/textureResources.ts
+++ b/apps/viewer/src/utils/textureResources.ts
@@ -19,33 +19,6 @@ import type { MeshData } from '@ifc-lite/geometry';
 export type TextureBitmapStore = Map<string, ImageBitmap>;
 
 /**
- * Decode every sibling raster image to an `ImageBitmap`. Failures are
- * per-image and non-fatal (a corrupt entry just renders that texture's meshes
- * with their style colour). Returns null when there is nothing to decode so
- * untextured loads pay nothing.
- */
-export async function decodeTextureResources(
-  resources: Map<string, Uint8Array>,
-): Promise<TextureBitmapStore | null> {
-  if (resources.size === 0) return null;
-  const store: TextureBitmapStore = new Map();
-  await Promise.all(
-    Array.from(resources, async ([name, bytes]) => {
-      try {
-        // Copy into a fresh ArrayBuffer-backed blob part: `bytes` may be a
-        // view over a larger (or Shared) buffer.
-        const copy = new Uint8Array(bytes);
-        const bitmap = await createImageBitmap(new Blob([copy]));
-        store.set(name, bitmap);
-      } catch (err) {
-        console.warn(`[textures] Failed to decode .ifcZIP image "${name}"`, err);
-      }
-    }),
-  );
-  return store.size > 0 ? store : null;
-}
-
-/**
  * Normalize an `IfcImageTexture.URLReference` to the sibling-store key:
  * strip any URI scheme/path, URL-decode, lowercase — so `Textures/Wood.JPG`,
  * `./wood.jpg` and `file:///x/wood.jpg` all resolve a `wood.jpg` entry.

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -296,9 +296,19 @@ const result = await parseAuto(zipBuffer);
 const ifcBuffer = await unwrapIfcZip(zipBuffer);
 ```
 
-Referenced resources inside the archive (textures, documents) are not
-extracted — only the model file's bytes. An archive with zero or more than
-one `.ifc`/`.ifcxml` entry throws rather than guessing which one to load.
+`unwrapIfcZip` returns only model bytes. For textured archives, call
+`unwrapIfcZipWithResources`: its `resources` map resolves PNG/JPEG images by
+lowercased basename (first entry wins), while `originalResources` preserves
+each archive path using the same byte arrays. `modelPath` identifies the IFC
+entry; keep that path and the original image paths when repackaging a model
+whose texture references are relative. Non-zip input returns empty resource
+maps and no `modelPath`. Image extraction applies per-entry and aggregate
+size/count limits. `resourcesIncomplete` is true when those budgets omit at
+least one image; a portable exporter must report this rather than claim all
+resources were preserved. Other resource formats are not extracted.
+
+An archive with zero or more than one `.ifc`/`.ifcxml` entry throws rather
+than guessing which one to load.
 
 ### Direct IFCX Parsing
 

--- a/packages/parser/src/ifczip.test.ts
+++ b/packages/parser/src/ifczip.test.ts
@@ -248,3 +248,28 @@ describe('unwrapIfcZipWithResources aggregate budgets (#1781)', () => {
     expect(resources.size).toBe(256);
   });
 });
+
+// #4243: basename resolution is compatibility, not archive identity.
+it('preserves exact IFC/image archive paths and colliding resources without byte copies', async () => {
+  const zip = await makeZip({
+    'nested/Model.IFC': STEP_HEADER,
+    'nested/a/Wood.PNG': 'first',
+    'nested/b/wood.png': 'second',
+  });
+  const result = await unwrapIfcZipWithResources(zip);
+  expect(result.modelPath).toBe('nested/Model.IFC');
+  expect([...result.originalResources.keys()]).toEqual(['nested/a/Wood.PNG', 'nested/b/wood.png']);
+  expect(result.resources.get('wood.png')).toBe(result.originalResources.get('nested/a/Wood.PNG'));
+  expect(new TextDecoder().decode(result.originalResources.get('nested/b/wood.png'))).toBe('second');
+});
+
+it('reports extraction omissions at the entry cap without reporting complete archives as partial (#4243)', async () => {
+  const entries: Record<string, string> = { 'model.ifc': STEP_HEADER };
+  for (let i = 0; i < 256; i++) entries[`image${i}.png`] = 'x';
+  expect((await unwrapIfcZipWithResources(await makeZip(entries))).resourcesIncomplete).toBe(false);
+  entries['omitted.png'] = 'x';
+  const partial = await unwrapIfcZipWithResources(await makeZip(entries));
+  expect(partial.originalResources.size).toBe(256);
+  expect(partial.resourcesIncomplete).toBe(true);
+  expect((await unwrapIfcZipWithResources(toArrayBuffer(STEP_HEADER))).resourcesIncomplete).toBe(false);
+});

--- a/packages/parser/src/ifczip.ts
+++ b/packages/parser/src/ifczip.ts
@@ -144,6 +144,12 @@ export interface IfcZipContents {
    * versa). Empty for non-zip input and archives without images.
    */
   resources: Map<string, Uint8Array>;
+  /** Original archive paths, sharing the same bytes as basename aliases. */
+  originalResources: Map<string, Uint8Array>;
+  /** Preserve this entry path when exporting relative texture references. */
+  modelPath?: string;
+  /** At least one raster entry was omitted by extraction budgets. */
+  resourcesIncomplete: boolean;
 }
 
 /**
@@ -156,31 +162,32 @@ export interface IfcZipContents {
 export async function unwrapIfcZipWithResources(
   buffer: ArrayBuffer,
 ): Promise<IfcZipContents> {
-  if (!isZipBuffer(buffer)) return { model: buffer, resources: new Map() };
+  if (!isZipBuffer(buffer)) return { model: buffer, resources: new Map(), originalResources: new Map(), resourcesIncomplete: false };
   const { zip, entry } = await openZipModelEntry(buffer, MAX_UNCOMPRESSED_BYTES);
 
   const resources = new Map<string, Uint8Array>();
+  const originalResources = new Map<string, Uint8Array>();
   let totalImageBytes = 0;
+  let resourcesIncomplete = false;
   for (const res of Object.values(zip.files)) {
     if (res.dir || !IMAGE_ENTRY_RE.test(res.name)) continue;
-    if (resources.size >= MAX_IMAGE_ENTRIES) break;
+    if (originalResources.size >= MAX_IMAGE_ENTRIES) { resourcesIncomplete = true; break; }
     const size = declaredUncompressedSize(res);
-    if (typeof size === 'number' && size > MAX_IMAGE_BYTES) continue;
+    if (typeof size === 'number' && size > MAX_IMAGE_BYTES) { resourcesIncomplete = true; continue; }
     const basename = res.name.split('/').pop()?.toLowerCase();
     if (!basename) continue;
-    // First entry wins on a (pathological) basename collision — matching the
-    // deterministic first-wins convention used across the style indexes.
-    if (resources.has(basename)) continue;
     const bytes = await res.async('uint8array');
     // Enforce the aggregate budget on REAL decompressed sizes (the central-
     // directory declaration is advisory and absent on some writers).
-    if (bytes.byteLength > MAX_IMAGE_BYTES) continue;
-    if (totalImageBytes + bytes.byteLength > MAX_TOTAL_IMAGE_BYTES) break;
+    if (bytes.byteLength > MAX_IMAGE_BYTES) { resourcesIncomplete = true; continue; }
+    if (totalImageBytes + bytes.byteLength > MAX_TOTAL_IMAGE_BYTES) { resourcesIncomplete = true; break; }
     totalImageBytes += bytes.byteLength;
-    resources.set(basename, bytes);
+    originalResources.set(res.name, bytes);
+    // Preserve basename first-wins compatibility, retaining every original.
+    if (!resources.has(basename)) resources.set(basename, bytes);
   }
 
-  return { model: await entry.async('arraybuffer'), resources };
+  return { model: await entry.async('arraybuffer'), resources, originalResources, modelPath: entry.name, resourcesIncomplete };
 }
 
 /** JSZip's central-directory uncompressed size — internal field, so read


### PR DESCRIPTION
Loading an IFCZIP currently discards its original encoded texture files and archive paths after decoding. This retains those resources with explicit source/model/history ownership, routes image decoding through the canonical model loader, and releases assets on failed loads or model removal. The parser now preserves original paths and reports extraction omissions, so subsequent portable export can refuse incomplete archives.

Refs #4243

This is the first foundation slice; #4243 stays open. Portable export integration follows in #4263; Appearance controls and transactional Apply/Undo follow in later stacked PRs. The existing lowercase-basename rendering lookup remains compatible; original archive entries retain their distinct paths. Decoded-image capacity covers Convento’s six 4096² textures plus authoring headroom, and budget exhaustion reports an error instead of silently publishing partially textured geometry.

Validation on this branch:

- Root `pnpm typecheck` passed.
- Root parser suite: 1,214 passed / 3 skipped. Focused viewer inventory: 10 passed; model ownership: 13 passed.
- Model ownership tests exercise actual viewer remove/clear/reset actions, cancellation during decoding, failed loading, federation reuse and final bitmap cleanup. Independent review found a primary-load finalization gap; model-local parsed-source ownership now preserves images for metadata-only and instanced-only IFCs and releases failed placeholders. A follow-up deferred-parser regression ties primary ownership to the existing parser promise and federated ownership to its registration promise, preserving nonblocking primary loading and cancellation fencing. The Convento budget regression uses six 4096² JPEG allocation footprints plus a 1024² draft with an injected decoder; it deliberately allocates no large pixel buffers and makes no browser rendering claim.
- Parser fixtures verify exact nested resource paths, duplicate basenames and a 257-image archive that reports its extraction limit. Original encoded bytes remain available independently of decoded bitmap lifetime.
- Module-size and whitespace checks passed. Parser changeset and parsing guide included; `pnpm api-surface:update` left the snapshot unchanged (no exported names changed).

No geometry algorithms or renderer behavior change. PDF/scans and textured model merging remain later work; this slice does not claim their implementation.
