### PR TITLE
feat(mutations): atomic overlay publication for appearance commands

### DIFF
--- a/.changeset/fair-clocks-rule.md
+++ b/.changeset/fair-clocks-rule.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/mutations": minor
+---
+
+Add synchronous atomic overlay transactions with guarded publication and rollback, plus live entity lookup on StoreEditor.

--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -294,6 +294,29 @@ editor.removeEntity(unwantedExpressId);
 
 Edits accumulate in the same overlay used by `setProperty` / `setAttribute`. They land in the exported file the next time you call `exportToStep(store, { applyMutations: true })` from `@ifc-lite/export`.
 
+### Atomic overlay edits
+
+Use `StoreEditor.runAtomic` to create or modify a related set of IFC entities together. The callback receives a detached editor; a thrown error leaves the live overlay, mutation history and express-ID allocator unchanged. `MutablePropertyView.runAtomic` provides the same operation with a draft view for property and quantity edits.
+
+```typescript
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+
+const view = new MutablePropertyView(propertyTable, modelId);
+const editor = new StoreEditor(dataStore, view);
+const colour = editor.runAtomic(draft => {
+  const entity = draft.addEntity('IfcColourRgb', [null, 0.2, 0.4, 0.8]);
+  if (!draft.hasEntity(entity.expressId)) throw new Error('Missing created colour');
+  return entity;
+});
+console.log(editor.hasEntity(colour.expressId)); // true after publication
+```
+
+`hasEntity` recognizes live source, deferred-index and newly created entities, and rejects removed entities and invalid IDs. Atomic callbacks must be synchronous: prepare images, network requests and other asynchronous resources beforehand. Source tables and extractors remain shared read-only. Escaped draft editors and nested values cannot modify the published overlay. Reentering the original view is detected and preserves that independent edit rather than overwriting it.
+
+For commands coordinating IFC with another synchronous subsystem, `view.prepareAtomic(callback)` returns `{ result, validate, commit, rollback }`. Preparation runs the callback without publishing. Validate all external resources before calling `commit`; it rejects intervening overlay edits, including edits that skip history. Repeated successful commits are harmless and never replay an old snapshot over newer edits. After a successful commit, `rollback` restores the original overlay, history and allocator only if no subsequent edit occurred; otherwise it throws and preserves those newer edits. Repeated rollback is harmless, and a rolled-back transaction cannot be committed again. Rollback before commit is a no-op.
+
+These transactions publish IFC overlay state only. They do not group application undo stacks or roll back renderer, file or network effects. The caller must coordinate those effects and handle rollback refusal explicitly. Preparation copies the existing overlay and checks it for changes, so batch related edits in one transaction rather than opening a transaction for every entity.
+
 #### STEP value conventions
 
 `addEntity` and `setPositionalAttribute` accept the same value shape that `EntityExtractor.extractEntity().attributes` produces — keeping the read/write round-trip predictable:

--- a/packages/mutations/src/atomic-overlay.test.ts
+++ b/packages/mutations/src/atomic-overlay.test.ts
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, expect, it } from 'vitest';
+import { PropertyValueType, QuantityType } from '@ifc-lite/data';
+import { MutablePropertyView } from './mutable-property-view.js';
+import { StoreEditor } from './store-editor.js';
+
+function fixture() {
+  const view = new MutablePropertyView(null, 'model');
+  const editor = new StoreEditor({ entityIndex: { byId: new Map() } }, view);
+  const item = editor.addEntity('IfcTriangulatedFaceSet', ['#9', null, false, [[1, 2, 3]], null]);
+  view.setProperty(item.expressId, 'Existing', 'Note', 'keep', PropertyValueType.String);
+  view.setQuantity(item.expressId, 'Existing', 'Area', 12, QuantityType.Area);
+  return { view, editor, item: item.expressId };
+}
+
+describe('atomic overlay editing #4243', () => {
+  it('prepares without changing live exports/history/allocator and publishes once', () => {
+    const { view, editor } = fixture();
+    const next = view.peekNextExpressId();
+    const count = view.getMutations().length;
+    const prepared = view.prepareAtomic(draft => new StoreEditor({ entityIndex: { byId: new Map() } }, draft)
+      .addEntity('IfcImageTexture', [true, true, null, null, null, 'new.png']));
+    expect(editor.getNewEntity(next)).toBeNull();
+    expect(view.peekNextExpressId()).toBe(next);
+    expect(view.getMutations()).toHaveLength(count);
+    prepared.validate();
+    prepared.commit();
+    expect(editor.getNewEntity(next)?.attributes[5]).toBe('new.png');
+    expect(view.getMutations()).toHaveLength(count + 1);
+    editor.addEntity('IfcColourRgb', [null, 0, 1, 0]);
+    prepared.commit(); // Does not re-adopt an old snapshot over the later edit.
+    expect(editor.getNewEntity(next + 1)).not.toBeNull();
+  });
+
+  it('refuses a stale prepared draft after ordinary, skip-history and nested edits', () => {
+    for (const editKind of ['ordinary', 'skip-history', 'nested'] as const) {
+      const { view, editor, item } = fixture();
+      const prepared = view.prepareAtomic(draft => draft.setPositionalAttribute(item, 2, true));
+      if (editKind === 'ordinary') editor.addEntity('IfcColourRgb', [null, 1, 0, 0]);
+      else if (editKind === 'skip-history') view.setPositionalAttribute(item, 2, false, true);
+      else editor.getNewEntity(item)!.attributes[2] = true;
+      const actual = structuredClone({ entities: editor.getNewEntities(), history: view.getMutations(),
+        positional: view.getPositionalMutationsForEntity(item), next: view.peekNextExpressId() });
+      expect(() => prepared.validate()).toThrow('overlay changed');
+      expect(() => prepared.commit()).toThrow('overlay changed');
+      expect({ entities: editor.getNewEntities(), history: view.getMutations(),
+        positional: view.getPositionalMutationsForEntity(item), next: view.peekNextExpressId() }).toEqual(actual);
+    }
+  });
+
+  it('does not erase a reentrant edit made directly to the original view', () => {
+    const { view, editor, item } = fixture();
+    expect(() => view.prepareAtomic(draft => {
+      draft.setPositionalAttribute(item, 2, true);
+      editor.addEntity('IfcColourRgb', [null, 1, 0, 0]);
+    })).toThrow('overlay changed');
+    expect(editor.getNewEntities()).toHaveLength(2);
+    expect(view.getPositionalMutationsForEntity(item)).toBeNull();
+  });
+
+  it('rolls back a failed external publication including history/allocator, but never erases later edits', () => {
+    const { view, editor, item } = fixture();
+    const before = structuredClone({ entities: editor.getNewEntities(), history: view.getMutations(), next: view.peekNextExpressId() });
+    const transaction = view.prepareAtomic(draft => {
+      draft.deleteEntity(item);
+      new StoreEditor({ entityIndex: { byId: new Map() } }, draft).addEntity('IfcColourRgb', [null, 0, 0, 1]);
+    });
+    transaction.commit();
+    transaction.rollback();
+    transaction.rollback();
+    expect({ entities: editor.getNewEntities(), history: view.getMutations(), next: view.peekNextExpressId() }).toEqual(before);
+    const newer = view.prepareAtomic(draft => draft.setPositionalAttribute(item, 2, true));
+    newer.commit();
+    editor.addEntity('IfcColourRgb', [null, 0, 1, 0]);
+    expect(() => newer.rollback()).toThrow('changed after');
+    expect(editor.getNewEntities()).toHaveLength(2);
+    expect(view.getPositionalMutationsForEntity(item)?.get(2)).toBe(true);
+  });
+
+  it('rejects rollback after nested or skip-history edits to published maps', () => {
+    for (const nested of [true, false]) {
+      const { view, editor, item } = fixture();
+      const transaction = view.prepareAtomic(draft => draft.setPositionalAttribute(item, 2, true));
+      transaction.commit();
+      if (nested) editor.getNewEntity(item)!.attributes[2] = true;
+      else view.setPositionalAttribute(item, 2, false, true);
+      const changed = structuredClone({ entities: editor.getNewEntities(), positional: view.getPositionalMutationsForEntity(item) });
+      expect(() => transaction.rollback()).toThrow('changed after');
+      expect({ entities: editor.getNewEntities(), positional: view.getPositionalMutationsForEntity(item) }).toEqual(changed);
+    }
+  });
+
+  it('cannot recommit a rolled-back transaction', () => {
+    const { view, item } = fixture();
+    const transaction = view.prepareAtomic(draft => draft.setPositionalAttribute(item, 2, true));
+    transaction.commit();
+    transaction.rollback();
+    expect(() => transaction.commit()).toThrow('rolled back');
+    expect(view.getPositionalMutationsForEntity(item)).toBeNull();
+  });
+
+  it('resolves live source/deferred/created IDs and refuses removed or invalid IDs', () => {
+    const view = new MutablePropertyView(null, 'model');
+    const editor = new StoreEditor({ entityIndex: { byId: new Map([[10, { expressId: 10, byteOffset: 0, byteLength: 1, lineNumber: 1, type: 'IFCWALL' }]]) },
+      deferredEntityIndex: new Map([[20, { expressId: 20, byteOffset: 1, byteLength: 1, lineNumber: 2, type: 'IFCWALL' }]]) }, view);
+    expect(editor.hasEntity(10)).toBe(true);
+    expect(editor.hasEntity(20)).toBe(true);
+    const created = editor.addEntity('IfcColourRgb', [null, 1, 0, 0]);
+    expect(editor.hasEntity(created.expressId)).toBe(true);
+    editor.removeEntity(created.expressId);
+    editor.removeEntity(10);
+    expect(editor.hasEntity(created.expressId)).toBe(false);
+    expect(editor.hasEntity(10)).toBe(false);
+    for (const id of [0, -1, 1.5, NaN, Infinity, 999]) expect(editor.hasEntity(id)).toBe(false);
+  });
+
+  it('publishes a texture entity graph and its item edit together, never intermediate records', () => {
+    const { view, editor, item } = fixture();
+    const created = editor.runAtomic(draft => {
+      const texture = draft.addEntity('IfcImageTexture', [true, true, '.DIFFUSE.', null, null, 'textures/image.png']);
+      const uv = draft.addEntity('IfcTextureVertexList', [[[0, 0], [1, 0], [0, 1]]]);
+      const map = draft.addEntity('IfcIndexedTriangleTextureMap', [[`#${texture.expressId}`], `#${item}`, `#${uv.expressId}`, [[1, 2, 3]]]);
+      draft.setPositionalAttribute(item, 2, true);
+      expect(editor.getNewEntities()).toHaveLength(1);
+      expect(view.getPositionalMutationsForEntity(item)).toBeNull();
+      return { texture, uv, map };
+    });
+    expect(editor.getNewEntities()).toHaveLength(4);
+    expect(editor.getNewEntity(created.map.expressId)?.attributes).toEqual([
+      [`#${created.texture.expressId}`], `#${item}`, `#${created.uv.expressId}`, [[1, 2, 3]],
+    ]);
+    expect(view.getPositionalMutationsForEntity(item)?.get(2)).toBe(true);
+  });
+
+  it('preserves entities, dependent properties/quantities, history and allocator after failure', () => {
+    const { view, editor, item } = fixture();
+    const before = structuredClone({ entities: editor.getNewEntities(), history: view.getMutations(),
+      properties: view.getForEntity(item), quantities: view.getQuantitiesForEntity(item) });
+    const next = view.peekNextExpressId();
+    expect(() => editor.runAtomic(draft => {
+      draft.removeEntity(item);
+      draft.addEntity('IfcImageTexture', [true, true, null, null, null, 'new.png']);
+      throw new Error('failed prepared edit');
+    })).toThrow('failed prepared edit');
+    expect({ entities: editor.getNewEntities(), history: view.getMutations(),
+      properties: view.getForEntity(item), quantities: view.getQuantitiesForEntity(item) }).toEqual(before);
+    expect(view.peekNextExpressId()).toBe(next);
+    expect(editor.addEntity('IfcColourRgb', [null, 1, 0, 0]).expressId).toBe(next);
+  });
+
+  it('detaches escaped draft editors and nested attribute arrays after success', () => {
+    const { editor, item } = fixture();
+    let escaped: StoreEditor | undefined;
+    const attributes = [[0, 0], [1, 0], [0, 1]];
+    const uv = editor.runAtomic(draft => {
+      escaped = draft;
+      return draft.addEntity('IfcTextureVertexList', [attributes]);
+    });
+    attributes[0][0] = 99;
+    escaped?.removeEntity(item);
+    escaped?.setPositionalAttribute(uv.expressId, 0, [[88, 88]]);
+    expect(editor.getNewEntity(item)).not.toBeNull();
+    expect(editor.getNewEntity(uv.expressId)?.attributes).toEqual([[[0, 0], [1, 0], [0, 1]]]);
+  });
+
+  it('discards asynchronous drafts including writes occurring after rejection', async () => {
+    const { editor } = fixture();
+    let finish: (() => void) | undefined;
+    const gate = new Promise<void>(resolve => { finish = resolve; });
+    let operation: Promise<void> | undefined;
+    expect(() => editor.runAtomic(draft => {
+      operation = (async () => {
+        draft.addEntity('IfcColourRgb', [null, 1, 0, 0]);
+        await gate;
+        draft.addEntity('IfcColourRgb', [null, 0, 1, 0]);
+      })();
+      return operation;
+    })).toThrow('must be synchronous');
+    finish?.();
+    await operation;
+    expect(editor.getNewEntities()).toHaveLength(1);
+  });
+});

--- a/packages/mutations/src/mutable-overlay-state.ts
+++ b/packages/mutations/src/mutable-overlay-state.ts
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import type { IfcAttributeValue, PropertyMutation, QuantityMutation, AttributeMutation,
+  EntityTypeMutation, Mutation, NewEntity } from './types.js';
+
+/** Iterative comparison also catches skip-history edits and escaped nested values. */
+function sameOverlayValue(left: unknown, right: unknown): boolean {
+  const pending: Array<[unknown, unknown]> = [[left, right]];
+  const visited = new WeakMap<object, WeakSet<object>>();
+  while (pending.length) {
+    const [a, b] = pending.pop()!;
+    if (Object.is(a, b)) continue;
+    if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false;
+    let matches = visited.get(a);
+    if (matches?.has(b)) continue;
+    if (!matches) { matches = new WeakSet(); visited.set(a, matches); }
+    matches.add(b);
+    if (a instanceof Map && b instanceof Map) {
+      if (a.size !== b.size) return false;
+      for (const [key, value] of a) {
+        if (!b.has(key)) return false;
+        pending.push([value, b.get(key)]);
+      }
+    } else if (a instanceof Set && b instanceof Set) {
+      if (a.size !== b.size || [...a].some(value => !b.has(value))) return false;
+    } else {
+      if (Object.getPrototypeOf(a) !== Object.getPrototypeOf(b)) return false;
+      if (Array.isArray(a) && Array.isArray(b) && a.length !== b.length) return false;
+      const keys = Object.keys(a);
+      if (keys.length !== Object.keys(b).length) return false;
+      for (const key of keys) {
+        if (!Object.hasOwn(b, key)) return false;
+        pending.push([(a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]]);
+      }
+    }
+  }
+  return true;
+}
+
+/**
+ * Everything `deleteEntity` purges out of the live overlay maps for a
+ * forgotten-created entity, captured so `restoreNewEntity` can put it all
+ * back. See the field doc on `MutablePropertyView.forgottenEntityOverlay`.
+ */
+export interface ForgottenEntityOverlay {
+  propertyEntries: Array<[key: string, mutation: PropertyMutation]>;
+  quantityEntries: Array<[key: string, mutation: QuantityMutation]>;
+  attributeEntries: Array<[key: string, mutation: AttributeMutation]>;
+  positionalAttrs: Map<number, IfcAttributeValue> | null;
+  typeMutation: EntityTypeMutation | null;
+  newPsets: Map<string, PropertySet> | null;
+  newQsets: Map<string, QuantitySet> | null;
+  deletedPsetKeys: string[];
+  deletedQsetKeys: string[];
+  /** This entity's own records, removed from the append-only `mutationHistory`. */
+  historyEntries: Mutation[];
+}
+
+/** Internal mutable overlay state; source tables and extractors are never copied. */
+export class MutableOverlayState {
+  protected propertyMutations: Map<string, PropertyMutation> = new Map();
+  protected quantityMutations: Map<string, QuantityMutation> = new Map();
+  /**
+   * Secondary indices: entityId → mutation keys for that entity.
+   *
+   * `getForEntity` previously iterated the entire `propertyMutations` /
+   * `quantityMutations` map per pset to find newly-added properties — O(M·P)
+   * per call. These indices keep that step O(M_entity) instead.
+   */
+  protected propertyKeysByEntity: Map<number, Set<string>> = new Map();
+  protected quantityKeysByEntity: Map<number, Set<string>> = new Map();
+  protected attributeKeysByEntity: Map<number, Set<string>> = new Map();
+  protected deletedPsets: Set<string> = new Set(); // `${entityId}:${psetName}`
+  protected deletedQsets: Set<string> = new Set(); // `${entityId}:${qsetName}`
+  protected newPsets: Map<number, Map<string, PropertySet>> = new Map(); // entityId -> psetName -> PropertySet
+  protected newQsets: Map<number, Map<string, QuantitySet>> = new Map(); // entityId -> qsetName -> QuantitySet
+  protected attributeMutations: Map<string, AttributeMutation> = new Map(); // `${entityId}:attr:${attrName}`
+  protected positionalAttrMutations: Map<number, Map<number, IfcAttributeValue>> = new Map(); // entityId -> argIndex -> value
+  protected typeMutations: Map<number, EntityTypeMutation> = new Map(); // entityId -> retype intent
+  protected newEntities: Map<number, NewEntity> = new Map();
+  protected tombstones: Set<number> = new Set();
+  /**
+   * Ids `createEntity` allocated and `deleteEntity` then forgot (removed from
+   * `newEntities`, per that method's "existing entities are tombstoned; new
+   * entities are simply forgotten" contract). Tracked separately so
+   * `getEffectiveChanges()` / `collectEffectiveChanges` can tell "overlay-created
+   * then forgotten" apart from "an ordinary source-buffer entity" — both are
+   * otherwise indistinguishable, being simply absent from `newEntities`.
+   * `restoreNewEntity` (the undo-of-delete counterpart) clears the id back out.
+   */
+  protected forgottenCreatedEntities: Set<number> = new Set();
+  /**
+   * Snapshot of a forgotten-created entity's overlay rows, stashed by
+   * `deleteEntity` and restored by `restoreNewEntity`.
+   *
+   * `deleteEntity` on an overlay-created entity does more than drop it from
+   * `newEntities` — it also PURGES every other overlay entry the entity left
+   * behind (property/quantity/attribute/positional/type mutations, its
+   * `newPsets`/`newQsets` entries, and its own `mutationHistory` records).
+   * Without that purge, an entity that was created, edited, then deleted
+   * before export left a dangling reference: `StepExporter` derives its
+   * property/quantity work list from `getMutations()` (the append-only
+   * history) and reads `getForEntity()` / `getQuantitiesForEntity()` straight
+   * off `newPsets` / `newQsets` — neither of which the review-side
+   * `forgottenCreatedEntities` filter in `effective-changes.ts` touches. The
+   * review dialog looked clean while the exported file still contained an
+   * `IFCPROPERTYSET` + `IFCRELDEFINESBYPROPERTIES` pointing at an expressId
+   * that was never actually created (maintainer finding on #1967).
+   *
+   * The purged data is captured here, not discarded, because `restoreNewEntity`
+   * (undo of the delete) must bring it all back — rows AND count AND what the
+   * exporter would see — not just re-add the bare `NewEntity` record.
+   */
+  protected forgottenEntityOverlay: Map<number, ForgottenEntityOverlay> = new Map();
+  /**
+   * Overlay-entity → source-entity aliases for property/quantity reads.
+   *
+   * When the viewer duplicates an existing entity, the new entity has
+   * no row in the parsed property table — `getBasePropertiesForEntity`
+   * would return `[]` and the property panel would show "No property
+   * sets". Aliasing redirects the BASE read to the source entity so
+   * the duplicate inherits its psets / qsets visually, while overlay
+   * mutations (overrides, creates, deletes) stay scoped to the
+   * overlay-entity's own id — so editing a property on the duplicate
+   * doesn't bleed into the source.
+   *
+   * Aliases follow at most one hop (no chains). They never affect
+   * STEP export — the export overlay emits the duplicate exactly as
+   * the StoreEditor recorded it, with whatever new IfcRel*ByProperties
+   * the caller chose to add.
+   */
+  protected entityAliases: Map<number, number> = new Map();
+  protected nextAllocatedId: number = 0;
+  protected mutationHistory: Mutation[] = [];
+
+  protected copyOverlayState() {
+    return structuredClone({
+      propertyMutations: this.propertyMutations,
+      quantityMutations: this.quantityMutations,
+      propertyKeysByEntity: this.propertyKeysByEntity,
+      quantityKeysByEntity: this.quantityKeysByEntity,
+      attributeKeysByEntity: this.attributeKeysByEntity,
+      deletedPsets: this.deletedPsets,
+      deletedQsets: this.deletedQsets,
+      newPsets: this.newPsets,
+      newQsets: this.newQsets,
+      attributeMutations: this.attributeMutations,
+      positionalAttrMutations: this.positionalAttrMutations,
+      typeMutations: this.typeMutations,
+      newEntities: this.newEntities,
+      tombstones: this.tombstones,
+      forgottenCreatedEntities: this.forgottenCreatedEntities,
+      forgottenEntityOverlay: this.forgottenEntityOverlay,
+      entityAliases: this.entityAliases,
+      nextAllocatedId: this.nextAllocatedId,
+      mutationHistory: this.mutationHistory,
+    });
+  }
+
+  protected restoreOverlayState(state: ReturnType<MutableOverlayState['copyOverlayState']>): void {
+    Object.assign(this, state);
+  }
+
+  protected matchesOverlayState(state: ReturnType<MutableOverlayState['copyOverlayState']>): boolean {
+    return sameOverlayValue(this.copyOverlayState(), state);
+  }
+}

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -21,6 +21,7 @@ import type { IfcAttributeValue, PropertyValue, PropertyMutation, QuantityMutati
 import { propertyKey, quantityKey, attributeKey, generateMutationId } from './types.js';
 import { collectEffectiveChanges, type AttributeExtractor } from './effective-changes.js';
 import { applyMutationsBatch } from './apply-mutations.js';
+import { MutableOverlayState, type ForgottenEntityOverlay } from './mutable-overlay-state.js';
 
 export type { AttributeExtractor } from './effective-changes.js';
 
@@ -39,109 +40,73 @@ export type PropertyExtractor = (entityId: number) => Array<{
  */
 export type QuantityExtractor = (entityId: number) => QuantitySet[];
 
-/**
- * Everything `deleteEntity` purges out of the live overlay maps for a
- * forgotten-created entity, captured so `restoreNewEntity` can put it all
- * back. See the field doc on `MutablePropertyView.forgottenEntityOverlay`.
- */
-interface ForgottenEntityOverlay {
-  propertyEntries: Array<[key: string, mutation: PropertyMutation]>;
-  quantityEntries: Array<[key: string, mutation: QuantityMutation]>;
-  attributeEntries: Array<[key: string, mutation: AttributeMutation]>;
-  positionalAttrs: Map<number, IfcAttributeValue> | null;
-  typeMutation: EntityTypeMutation | null;
-  newPsets: Map<string, PropertySet> | null;
-  newQsets: Map<string, QuantitySet> | null;
-  deletedPsetKeys: string[];
-  deletedQsetKeys: string[];
-  /** This entity's own records, removed from the append-only `mutationHistory`. */
-  historyEntries: Mutation[];
-}
-
-export class MutablePropertyView {
+export class MutablePropertyView extends MutableOverlayState {
   private baseTable: PropertyTable | null;
   private onDemandExtractor: PropertyExtractor | null = null;
   private quantityExtractor: QuantityExtractor | null = null;
   private attributeExtractor: AttributeExtractor | null = null;
-  private propertyMutations: Map<string, PropertyMutation> = new Map();
-  private quantityMutations: Map<string, QuantityMutation> = new Map();
-  /**
-   * Secondary indices: entityId → mutation keys for that entity.
-   *
-   * `getForEntity` previously iterated the entire `propertyMutations` /
-   * `quantityMutations` map per pset to find newly-added properties — O(M·P)
-   * per call. These indices keep that step O(M_entity) instead.
-   */
-  private propertyKeysByEntity: Map<number, Set<string>> = new Map();
-  private quantityKeysByEntity: Map<number, Set<string>> = new Map();
-  private attributeKeysByEntity: Map<number, Set<string>> = new Map();
-  private deletedPsets: Set<string> = new Set(); // `${entityId}:${psetName}`
-  private deletedQsets: Set<string> = new Set(); // `${entityId}:${qsetName}`
-  private newPsets: Map<number, Map<string, PropertySet>> = new Map(); // entityId -> psetName -> PropertySet
-  private newQsets: Map<number, Map<string, QuantitySet>> = new Map(); // entityId -> qsetName -> QuantitySet
-  private attributeMutations: Map<string, AttributeMutation> = new Map(); // `${entityId}:attr:${attrName}`
-  private positionalAttrMutations: Map<number, Map<number, IfcAttributeValue>> = new Map(); // entityId -> argIndex -> value
-  private typeMutations: Map<number, EntityTypeMutation> = new Map(); // entityId -> retype intent
-  private newEntities: Map<number, NewEntity> = new Map();
-  private tombstones: Set<number> = new Set();
-  /**
-   * Ids `createEntity` allocated and `deleteEntity` then forgot (removed from
-   * `newEntities`, per that method's "existing entities are tombstoned; new
-   * entities are simply forgotten" contract). Tracked separately so
-   * `getEffectiveChanges()` / `collectEffectiveChanges` can tell "overlay-created
-   * then forgotten" apart from "an ordinary source-buffer entity" — both are
-   * otherwise indistinguishable, being simply absent from `newEntities`.
-   * `restoreNewEntity` (the undo-of-delete counterpart) clears the id back out.
-   */
-  private forgottenCreatedEntities: Set<number> = new Set();
-  /**
-   * Snapshot of a forgotten-created entity's overlay rows, stashed by
-   * `deleteEntity` and restored by `restoreNewEntity`.
-   *
-   * `deleteEntity` on an overlay-created entity does more than drop it from
-   * `newEntities` — it also PURGES every other overlay entry the entity left
-   * behind (property/quantity/attribute/positional/type mutations, its
-   * `newPsets`/`newQsets` entries, and its own `mutationHistory` records).
-   * Without that purge, an entity that was created, edited, then deleted
-   * before export left a dangling reference: `StepExporter` derives its
-   * property/quantity work list from `getMutations()` (the append-only
-   * history) and reads `getForEntity()` / `getQuantitiesForEntity()` straight
-   * off `newPsets` / `newQsets` — neither of which the review-side
-   * `forgottenCreatedEntities` filter in `effective-changes.ts` touches. The
-   * review dialog looked clean while the exported file still contained an
-   * `IFCPROPERTYSET` + `IFCRELDEFINESBYPROPERTIES` pointing at an expressId
-   * that was never actually created (maintainer finding on #1967).
-   *
-   * The purged data is captured here, not discarded, because `restoreNewEntity`
-   * (undo of the delete) must bring it all back — rows AND count AND what the
-   * exporter would see — not just re-add the bare `NewEntity` record.
-   */
-  private forgottenEntityOverlay: Map<number, ForgottenEntityOverlay> = new Map();
-  /**
-   * Overlay-entity → source-entity aliases for property/quantity reads.
-   *
-   * When the viewer duplicates an existing entity, the new entity has
-   * no row in the parsed property table — `getBasePropertiesForEntity`
-   * would return `[]` and the property panel would show "No property
-   * sets". Aliasing redirects the BASE read to the source entity so
-   * the duplicate inherits its psets / qsets visually, while overlay
-   * mutations (overrides, creates, deletes) stay scoped to the
-   * overlay-entity's own id — so editing a property on the duplicate
-   * doesn't bleed into the source.
-   *
-   * Aliases follow at most one hop (no chains). They never affect
-   * STEP export — the export overlay emits the duplicate exactly as
-   * the StoreEditor recorded it, with whatever new IfcRel*ByProperties
-   * the caller chose to add.
-   */
-  private entityAliases: Map<number, number> = new Map();
-  private nextAllocatedId: number = 0;
-  private mutationHistory: Mutation[] = [];
   private modelId: string;
 
   constructor(baseTable: PropertyTable | null, modelId: string) {
+    super();
     this.baseTable = baseTable;
     this.modelId = modelId;
+  }
+
+  /**
+   * Stage synchronous overlay edits and publish them together (#4243).
+   * Throws leave the original overlay, history and allocator untouched.
+   * Source tables/extractors are shared read-only; mutable state is detached
+   * both before editing and on commit, so an escaped draft cannot edit this view.
+   * External effects (files, renderer or network) belong outside this callback.
+   */
+  runAtomic<T>(edit: (draft: MutablePropertyView) => T): T {
+    const prepared = this.prepareAtomic(edit);
+    prepared.commit();
+    return prepared.result;
+  }
+
+  /**
+   * Prepare an overlay publication without changing live IFC state (#4243).
+   * Use for commands that must validate other synchronous resources first.
+   * `validate` and `commit` reject intervening edits, including skip-history
+   * edits. Commit is idempotent; the prepared draft is never published by reference.
+   */
+  prepareAtomic<T>(edit: (draft: MutablePropertyView) => T): { result: T; validate(): void; commit(): void; rollback(): void } {
+    const original = this.copyOverlayState();
+    const draft = new MutablePropertyView(this.baseTable, this.modelId);
+    draft.onDemandExtractor = this.onDemandExtractor;
+    draft.quantityExtractor = this.quantityExtractor;
+    draft.attributeExtractor = this.attributeExtractor;
+    draft.restoreOverlayState(structuredClone(original));
+    const result = edit(draft);
+    if (result !== null && (typeof result === 'object' || typeof result === 'function')
+      && 'then' in result && typeof result.then === 'function') {
+      void Promise.resolve(result).catch(error => console.error('Discarded asynchronous overlay transaction failed', error));
+      throw new TypeError('Overlay transactions must be synchronous; prepare asynchronous work before editing');
+    }
+    const prepared = draft.copyOverlayState();
+    // Keep the rollback checkpoint detached from maps published to live readers.
+    const publication = structuredClone(prepared);
+    let committed = false;
+    let rolledBack = false;
+    const validate = () => {
+      if (rolledBack) throw new Error('The prepared IFC transaction was rolled back.');
+      if (!committed && !this.matchesOverlayState(original)) throw new Error('The IFC overlay changed during a prepared transaction.');
+    };
+    validate(); // A callback that re-enters the original view cannot erase that edit.
+    return { result, validate, commit: () => {
+      if (rolledBack) throw new Error('The prepared IFC transaction was rolled back.');
+      if (committed) return;
+      validate();
+      this.restoreOverlayState(publication);
+      committed = true;
+    }, rollback: () => {
+      if (!committed || rolledBack) return;
+      if (!this.matchesOverlayState(prepared)) throw new Error('The IFC overlay changed after the prepared transaction committed.');
+      this.restoreOverlayState(original);
+      rolledBack = true;
+    } };
   }
 
   /**

--- a/packages/mutations/src/store-editor.ts
+++ b/packages/mutations/src/store-editor.ts
@@ -71,6 +71,13 @@ export class StoreEditor {
     this.view.setExpressIdWatermark(this.maxExistingId);
   }
 
+  /** Stage one synchronous IFC edit; failure publishes no partial overlay (#4243).
+   * Prepare image/worker resources before calling this. Returned entity IDs are
+   * valid after success; the draft editor is detached after this callback. */
+  runAtomic<T>(edit: (draft: StoreEditor) => T): T {
+    return this.view.runAtomic(draft => edit(new StoreEditor(this.store, draft)));
+  }
+
   /**
    * Re-scan the store and bump the express-id watermark if the store has
    * grown since construction (e.g. after lazy index hydration or
@@ -257,6 +264,13 @@ export class StoreEditor {
   /** Look up the overlay record for a freshly-added entity. */
   getNewEntity(expressId: number): NewEntity | null {
     return this.view.getNewEntity(expressId);
+  }
+
+  /** Whether an id resolves to a live source or overlay entity. */
+  hasEntity(expressId: number): boolean {
+    return Number.isSafeInteger(expressId) && expressId > 0 && !this.view.isDeleted(expressId)
+      && (this.view.getNewEntity(expressId) !== null || this.store.entityIndex.byId.has(expressId)
+        || this.store.deferredEntityIndex?.has(expressId) === true);
   }
 
   /** All overlay-created entities, in insertion order. */


### PR DESCRIPTION
Appearance authoring needs to create a texture/style/UV graph without leaving partial IFC edits when another resource fails. Add synchronous `runAtomic` operations on `MutablePropertyView` and `StoreEditor`, plus `prepareAtomic` for coordinated publication and guarded rollback. `StoreEditor.hasEntity` resolves live source, deferred-index and overlay entities.

Preparation detaches overlay maps, history and the allocator. Commit rejects intervening edits; rollback refuses to erase later edits, including nested mutations and changes that skip history. Published maps remain separate from the rollback checkpoint. Escaped drafts cannot mutate committed state, asynchronous callbacks are rejected, and completed transactions are idempotent.

This is the atomic mutation foundation for Refs #4243; the viewer command, preview and undo integration follow separately. It does not implement application undo grouping or external-resource rollback. Preparing a transaction copies and compares the existing overlay, so callers should batch related edits.

Validation: root Node22 `pnpm typecheck` passed 90/90 tasks (1787 test files); root `pnpm test --filter=@ifc-lite/mutations` passed 251 tests with 10 existing fixture skips, including 11 atomic/entity-resolution invariants; docs samples 381/381; changed-file oxlint, module-size guard and diff check passed. `pnpm api-surface:update` regenerated the snapshot without a diff: existing exported classes gain methods, with no new top-level export. CLI-generated mutations minor changeset included.
