### PR TITLE
feat(viewer): add cancellable PDF page appearance sources

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install monorepo deps

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -90,6 +90,7 @@
     "lucide-react": "^1.40.0",
     "maplibre-gl": "^6.7.0",
     "parquet-wasm": "^0.7.2",
+    "pdfjs-dist": "6.3.289",
     "postcss": "^8.5.28",
     "posthog-js": "^1.426.3",
     "proj4": "^2.22.0",

--- a/apps/viewer/src/lib/appearance/pdf/README.md
+++ b/apps/viewer/src/lib/appearance/pdf/README.md
@@ -1,0 +1,79 @@
+# PDF appearance source (F2 / #4260)
+
+This browser service turns one selected PDF page/crop into a PNG in the existing
+AppearanceAssetInventory. It does not create IFC annotations, reference planes,
+semantic objects, or calibrated IFC projections. Those consume the returned
+source metadata through the existing authoring workflow.
+
+Development requires Node 22.13 or newer within Node 22, or Node 24, matching
+the PDF.js engine requirement and the repository's supported Node versions.
+
+## Integration
+
+Lazy-import `PdfAppearanceSource` when the user chooses a PDF. Call
+`PdfAppearanceSource.open(file, inventory, {signal,password})`, then `page(n)` or
+`rasterize({pageNumber,rotation,cropPoints,dpi},{signal})`. Additional rotation is
+clockwise relative to the PDF page's intrinsic rotation. Crop coordinates are
+`[left,top,width,height]` in the rotated visible page, measured in physical PDF
+points (1/72 inch). `paperSizeMetres` describes paper only; a drawing's printed
+1:100 label is not applied automatically. User calibration remains a distinct
+model-space operation.
+
+The raster recipe includes native CropBox/UserUnit/rotation, PDF→page and
+pixel→PDF transforms, requested/effective DPI, crop, and pixel dimensions. Budget
+reduction changes raster resolution, not the calibrated physical page size.
+Do not infer physical size from the PNG header or stretch a page per IFC object.
+
+Each result has a session `sourceId`, a content-derived `documentId`, and its
+complete page/crop recipe, separately from `asset.id`. Image deduplication may
+reuse identical PNG bytes for unrelated pages or documents. A future source UI
+must keep `sourceId` and that lineage; using the image digest as its source key
+would discard calibration and provenance.
+
+The source owns original PDF bytes/password only in this session. Its derived
+PNGs have independent source-owner leases in the shared image inventory. Retain
+the image under the normal draft/model/history owner before removing the source;
+`dispose()` cancels work, releases its source image leases, and drops PDF bytes.
+Only the derived PNG enters ordinary IFCZIP/model asset export. An IFCZIP is not
+a backup of the editable PDF document. Password-required and password-incorrect
+errors are typed; retain the selected File in the UI while prompting for retry.
+
+## Decoder and limits
+
+Pinned PDF.js `pdfjs-dist` 6.3.289, Apache-2.0. Parsing/rasterization is lazy and
+runs inside a dedicated cancellable worker; cancellation terminates the job,
+including stalled decoding. Only a selected page is rendered. File size, page
+count, output/intermediate pixels, dimensions and runtime have limits; these do
+not constitute a hard VM memory limit on arbitrary compressed PDF streams.
+
+PDF.js receives `stopAtErrors`, XFA disabled, bounded image size, and bundled
+CMaps/standard fonts/image-decoder resources. No document JavaScript actions are
+invoked. No PyMuPDF dependency is used. The
+worker uses OffscreenCanvas with font outlines. Pages requiring DOM SVG color,
+alpha, luminosity or knockout filters reject explicitly rather than silently
+producing a different appearance. Complex documents need real-page comparison;
+PDF rasterization does not imply editable vector/font/annotation support.
+
+Primary references checked 2026-09-09:
+
+- https://mozilla.github.io/pdf.js/examples/
+- https://mozilla.github.io/pdf.js/api/draft/api.js.html
+- https://www.npmjs.com/package/pdfjs-dist
+- https://github.com/mozilla/pdf.js/blob/master/LICENSE
+
+## Evidence
+
+Actual PDF.js tests generate an original CC0 two-page PDF with CropBox,
+90-degree intrinsic rotation and UserUnit=2; verify page selection, paper scale
+independent of DPI, extra rotation/crop, bounded raster output, encrypted PDF
+password diagnostics, malformed input and cancellation. Worker orchestration
+and source/image ownership tests exercise stale results and teardown.
+
+A fresh actual Chromium tab on the viewer dev server rendered that document
+through the production worker to a 144×200 PNG at 72 DPI. The earlier controlled
+PDF with font outlines and vector labels also rendered to 612×396 pixels.
+The production source-document→inventory path also verified exact red/green
+orientation markers, PNG-only export resources, retention after PDF removal
+while a model owner remains, and final release after that model owner leaves.
+This is service-level browser evidence; the integrated F2 calibration and
+projection journey is not yet established by these runs.

--- a/apps/viewer/src/lib/appearance/pdf/browser-backend.ts
+++ b/apps/viewer/src/lib/appearance/pdf/browser-backend.ts
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { getDocument, GlobalWorkerOptions } from 'pdfjs-dist';
+import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
+import { PDF_LIMITS, PdfAppearanceError } from './types.js';
+import type { PdfEngineBackend } from './engine.js';
+const resources = import.meta.glob(
+  [
+    '/node_modules/pdfjs-dist/{cmaps,standard_fonts,wasm}/*.{bcmap,pfb,ttf,wasm,js}',
+    '/node_modules/pdfjs-dist/{LICENSE,cmaps/LICENSE*,standard_fonts/LICENSE*,wasm/LICENSE*}',
+  ],
+  { eager: true, query: '?url', import: 'default' },
+) as Record<string, string>;
+class BinaryDataFactory {
+  async fetch({
+    kind,
+    filename,
+  }: {
+    kind: string;
+    filename: string;
+  }): Promise<Uint8Array> {
+    const folders: Record<string, string> = {
+      cMapUrl: 'cmaps',
+      standardFontDataUrl: 'standard_fonts',
+      wasmUrl: 'wasm',
+    };
+    const folder = folders[kind];
+    const url = resources[`/node_modules/pdfjs-dist/${folder}/${filename}`];
+    if (!url)
+      throw new PdfAppearanceError(
+        'unsupported',
+        `The PDF decoder resource ${filename} is unavailable.`,
+      );
+    const response = await fetch(url);
+    if (!response.ok)
+      throw new PdfAppearanceError(
+        'render',
+        `Could not load PDF decoder resource ${filename}.`,
+      );
+    return new Uint8Array(await response.arrayBuffer());
+  }
+}
+function validateCanvasExtent(width: number, height: number): void {
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width < 1 ||
+    height < 1 ||
+    width > PDF_LIMITS.maxDimension ||
+    height > PDF_LIMITS.maxDimension ||
+    width * height > PDF_LIMITS.maxPixels
+  ) {
+    throw new PdfAppearanceError(
+      'budget',
+      'A PDF intermediate image exceeds the pixel budget.',
+    );
+  }
+}
+class CanvasFactory {
+  create(width: number, height: number) {
+    validateCanvasExtent(width, height);
+    const canvas = new OffscreenCanvas(width, height),
+      context = canvas.getContext('2d');
+    if (!context)
+      throw new PdfAppearanceError(
+        'unsupported',
+        'PDF page rendering needs OffscreenCanvas support.',
+      );
+    return { canvas, context };
+  }
+  reset(target: { canvas: OffscreenCanvas }, width: number, height: number) {
+    validateCanvasExtent(width, height);
+    target.canvas.width = width;
+    target.canvas.height = height;
+  }
+  destroy(target: {
+    canvas: OffscreenCanvas | null;
+    context: OffscreenCanvasRenderingContext2D | null;
+  }) {
+    if (target.canvas) target.canvas.width = target.canvas.height = 0;
+    target.canvas = null;
+    target.context = null;
+  }
+}
+/** SVG URL filters require a DOM. Reject their use instead of silently altering appearance. */
+class FilterFactory {
+  addFilter(maps?: number[][] | null) {
+    if (
+      !maps ||
+      maps.every((map) => map.every((value, index) => value === index))
+    )
+      return 'none';
+    throw new PdfAppearanceError(
+      'unsupported',
+      'This page uses PDF color-transfer filters unavailable in worker rendering. Export this page as a PNG.',
+    );
+  }
+  addAlphaFilter() {
+    throw new PdfAppearanceError(
+      'unsupported',
+      'This page uses an unsupported PDF alpha filter. Export this page as a PNG.',
+    );
+  }
+  addLuminosityFilter() {
+    throw new PdfAppearanceError(
+      'unsupported',
+      'This page uses an unsupported PDF luminosity filter. Export this page as a PNG.',
+    );
+  }
+  addKnockoutFilter() {
+    throw new PdfAppearanceError(
+      'unsupported',
+      'This page uses an unsupported PDF knockout filter. Export this page as a PNG.',
+    );
+  }
+  destroy() {}
+}
+export function browserPdfBackend(): PdfEngineBackend {
+  if (typeof OffscreenCanvas === 'undefined')
+    throw new PdfAppearanceError(
+      'unsupported',
+      'PDF page rendering needs a browser with OffscreenCanvas support.',
+    );
+  GlobalWorkerOptions.workerSrc = workerUrl;
+  return {
+    getDocument,
+    options: {
+      CanvasFactory,
+      BinaryDataFactory,
+      FilterFactory,
+      useWorkerFetch: false,
+      disableFontFace: true,
+      useSystemFonts: false,
+    },
+    surface(width, height) {
+      const factory = new CanvasFactory(),
+        target = factory.create(width, height);
+      return {
+        // PDF.js types expose DOM canvas only; its CanvasGraphics consumes the shared 2D API.
+        canvas: target.canvas as unknown as HTMLCanvasElement,
+        context: target.context as unknown as CanvasRenderingContext2D,
+        async png() {
+          return new Uint8Array(
+            await (
+              await target.canvas.convertToBlob({ type: 'image/png' })
+            ).arrayBuffer(),
+          );
+        },
+        dispose() {
+          factory.destroy(target);
+        },
+      };
+    },
+  };
+}

--- a/apps/viewer/src/lib/appearance/pdf/engine.test.ts
+++ b/apps/viewer/src/lib/appearance/pdf/engine.test.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { jsPDF } from 'jspdf';
+import {
+  runPdfJob,
+  type PdfEngineBackend,
+  type PdfRasterSurface,
+} from './engine.js';
+import { controlledPdf } from './fixtures.js';
+import { inspectImage } from '../asset-format.js';
+import { PdfAppearanceError } from './types.js';
+async function backend(): Promise<PdfEngineBackend> {
+  const pdf = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  type NativeCanvas = HTMLCanvasElement & {
+    toBuffer(type: string): Uint8Array;
+  };
+  type Target = { canvas: NativeCanvas; context: CanvasRenderingContext2D };
+  let factory: {
+    create(width: number, height: number): Target;
+    destroy(target: Target): void;
+  };
+  return {
+    getDocument(options) {
+      const task = pdf.getDocument(options);
+      // The engine awaits/reports this same loading rejection; this observer only captures its canvas factory.
+      void task.promise.then(
+        (document) => {
+          factory = document.canvasFactory as typeof factory;
+        },
+        () => {},
+      );
+      return task;
+    },
+    options: { disableFontFace: true, useSystemFonts: false },
+    surface(width, height): PdfRasterSurface {
+      const target = factory.create(width, height);
+      return {
+        ...target,
+        async png() {
+          return new Uint8Array(target.canvas.toBuffer('image/png'));
+        },
+        dispose() {
+          factory.destroy(target);
+        },
+      };
+    },
+  };
+}
+test('PDF native CropBox/UserUnit/rotation and page selection survive actual decoding (#4260)', async () => {
+  const source = controlledPdf(),
+    length = source.length,
+    engine = await backend();
+  const result = await runPdfJob(engine, source, { kind: 'inspect' });
+  assert.equal(
+    source.length,
+    length,
+    'PDF.js must not detach original document bytes',
+  );
+  assert.equal(result.kind, 'inspect');
+  if (result.kind !== 'inspect') return;
+  assert.equal(result.pageCount, 2);
+  assert.deepEqual(result.page.viewBox, [10, 20, 110, 92]);
+  assert.equal(result.page.userUnit, 2);
+  assert.equal(result.page.intrinsicRotation, 90);
+  assert.equal(result.page.widthPoints, 144);
+  assert.equal(result.page.heightPoints, 200);
+  const second = await runPdfJob(engine, source, {
+    kind: 'inspect',
+    pageNumber: 2,
+  });
+  assert.equal(second.kind, 'inspect');
+  if (second.kind === 'inspect') assert.equal(second.page.widthPoints, 72);
+});
+test('actual PDF raster respects rotated crop, paper size independent of DPI, and pixel budgets (#4260)', async () => {
+  const engine = await backend(),
+    source = controlledPdf();
+  const results = [];
+  for (const dpi of [72, 144]) {
+    const result = await runPdfJob(engine, source, {
+      kind: 'raster',
+      request: {
+        pageNumber: 1,
+        rotation: 90,
+        cropPoints: [20, 10, 72, 36],
+        dpi,
+      },
+    });
+    assert.equal(result.kind, 'raster');
+    if (result.kind !== 'raster') return;
+    results.push(result);
+    assert.deepEqual(result.recipe.paperSizeMetres, [0.0254, 0.0127]);
+    assert.deepEqual(inspectImage(result.png), {
+      mimeType: 'image/png',
+      width: dpi,
+      height: dpi / 2,
+    });
+  }
+  assert.equal(
+    results[0].recipe.pixelToPdf[0],
+    results[1].recipe.pixelToPdf[0] * 2,
+  );
+  const fractional = await runPdfJob(engine, source, {
+    kind: 'raster',
+    request: {
+      pageNumber: 1,
+      rotation: 90,
+      cropPoints: [20.1, 10.2, 71.3, 35.7],
+      dpi: 73,
+    },
+  });
+  assert.equal(fractional.kind, 'raster');
+  if (fractional.kind === 'raster') {
+    const recipe = fractional.recipe,
+      [a, b, c, d, e, f] = recipe.pixelToPdf;
+    const corners = [
+      [e, f],
+      [
+        a * recipe.pixelWidth + c * recipe.pixelHeight + e,
+        b * recipe.pixelWidth + d * recipe.pixelHeight + f,
+      ],
+    ];
+    for (const [index, expected] of [
+      [99.95, 25.1],
+      [64.3, 42.95],
+    ].entries()) {
+      assert.ok(Math.abs(corners[index][0] - expected[0]) < 1e-9);
+      assert.ok(Math.abs(corners[index][1] - expected[1]) < 1e-9);
+    }
+  }
+  const bounded = await runPdfJob(engine, source, {
+    kind: 'raster',
+    request: { pageNumber: 1, dpi: 600, maxPixels: 10000, maxDimension: 100 },
+  });
+  assert.equal(bounded.kind, 'raster');
+  if (bounded.kind === 'raster') {
+    assert.ok(bounded.recipe.pixelWidth * bounded.recipe.pixelHeight <= 10000);
+    assert.ok(
+      bounded.recipe.pixelWidth <= 100 && bounded.recipe.pixelHeight <= 100,
+    );
+    assert.ok(bounded.recipe.effectiveDpi < 600);
+  }
+});
+test('actual encrypted PDFs provide password-required and incorrect-password diagnostics (#4260)', async () => {
+  const document = new jsPDF({
+    encryption: { userPassword: 'drawing', ownerPassword: 'owner-secret' },
+  });
+  document.text('Controlled encrypted drawing', 10, 10);
+  const source = new Uint8Array(document.output('arraybuffer')),
+    engine = await backend();
+  for (const [password, code] of [
+    [undefined, 'password-required'],
+    ['wrong', 'password-incorrect'],
+  ] as const) {
+    await assert.rejects(
+      runPdfJob(engine, source, { kind: 'inspect' }, { password }),
+      (error) => error instanceof PdfAppearanceError && error.code === code,
+    );
+  }
+  assert.equal(
+    (
+      await runPdfJob(
+        engine,
+        source,
+        { kind: 'inspect' },
+        { password: 'drawing' },
+      )
+    ).kind,
+    'inspect',
+  );
+});
+test('cancelled, invalid and out-of-page PDF requests never produce an image (#4260)', async () => {
+  const engine = await backend(),
+    controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    runPdfJob(
+      engine,
+      controlledPdf(),
+      { kind: 'inspect' },
+      { signal: controller.signal },
+    ),
+    (error) =>
+      error instanceof PdfAppearanceError && error.code === 'cancelled',
+  );
+  await assert.rejects(
+    runPdfJob(engine, new TextEncoder().encode('invalid'), { kind: 'inspect' }),
+    (error) =>
+      error instanceof PdfAppearanceError && error.code === 'invalid-pdf',
+  );
+  await assert.rejects(
+    runPdfJob(engine, controlledPdf(), {
+      kind: 'raster',
+      request: { pageNumber: 1, cropPoints: [-1, 0, 10, 10] },
+    }),
+    /crop/,
+  );
+});

--- a/apps/viewer/src/lib/appearance/pdf/engine.ts
+++ b/apps/viewer/src/lib/appearance/pdf/engine.ts
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { getDocument, RenderTask } from 'pdfjs-dist';
+import type { DocumentInitParameters } from 'pdfjs-dist/types/src/display/api.js';
+import { pageInfo, rasterRecipe } from './raster-recipe.js';
+import {
+  PDF_LIMITS,
+  PdfAppearanceError,
+  type PdfJob,
+  type PdfJobResult,
+} from './types.js';
+export interface PdfRasterSurface {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  png(): Promise<Uint8Array>;
+  dispose(): void;
+}
+export interface PdfEngineBackend {
+  getDocument: typeof getDocument;
+  options?: Partial<DocumentInitParameters>;
+  surface(width: number, height: number): PdfRasterSurface;
+}
+export function pdfError(error: unknown): PdfAppearanceError {
+  if (error instanceof PdfAppearanceError) return error;
+  if (error instanceof Error && error.name === 'PasswordException') {
+    const incorrect = 'code' in error && error.code === 2;
+    return new PdfAppearanceError(
+      incorrect ? 'password-incorrect' : 'password-required',
+      incorrect
+        ? 'That PDF password is incorrect. Try again.'
+        : 'This PDF needs a password before pages can be imported.',
+    );
+  }
+  if (
+    error instanceof Error &&
+    ['AbortError', 'RenderingCancelledException'].includes(error.name)
+  )
+    return new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+  return new PdfAppearanceError(
+    error instanceof Error && error.name === 'InvalidPDFException'
+      ? 'invalid-pdf'
+      : 'render',
+    `Cannot read this PDF page. ${error instanceof Error ? error.message : String(error)}`,
+  );
+}
+/** Decode/render only. IFC placement and drawing calibration belong to the shared authoring layer. */
+export async function runPdfJob(
+  backend: PdfEngineBackend,
+  source: Uint8Array,
+  job: PdfJob,
+  options: { password?: string; signal?: AbortSignal } = {},
+): Promise<PdfJobResult> {
+  if (source.byteLength === 0 || source.byteLength > PDF_LIMITS.maxBytes)
+    throw new PdfAppearanceError(
+      'budget',
+      'Choose a PDF no larger than 64 MiB.',
+    );
+  if (options.signal?.aborted)
+    throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+  // PDF.js may transfer data to its parsing worker. Never detach a source owner's bytes.
+  const loading = backend.getDocument({
+    ...backend.options,
+    data: new Uint8Array(source),
+    password: options.password,
+    enableXfa: false,
+    stopAtErrors: true,
+    maxImageSize: PDF_LIMITS.maxPixels,
+    canvasMaxAreaInBytes: PDF_LIMITS.maxPixels * 4,
+  });
+  let render: RenderTask | undefined;
+  const abort = () => {
+    render?.cancel();
+    void loading
+      .destroy()
+      .catch((error) =>
+        console.warn('[PDF] cancellation cleanup failed', error),
+      );
+  };
+  options.signal?.addEventListener('abort', abort, { once: true });
+  try {
+    const document = await loading.promise;
+    if (document.numPages > PDF_LIMITS.maxPages)
+      throw new PdfAppearanceError(
+        'budget',
+        `Choose a PDF with at most ${PDF_LIMITS.maxPages} pages.`,
+      );
+    const pageNumber =
+      job.kind === 'inspect' ? (job.pageNumber ?? 1) : job.request.pageNumber;
+    if (
+      !Number.isSafeInteger(pageNumber) ||
+      pageNumber < 1 ||
+      pageNumber > document.numPages
+    )
+      throw new PdfAppearanceError('invalid-pdf', 'Choose a page in this PDF.');
+    const page = await document.getPage(pageNumber);
+    try {
+      if (options.signal?.aborted)
+        throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+      if (job.kind === 'inspect')
+        return {
+          kind: 'inspect',
+          pageCount: document.numPages,
+          page: pageInfo(page),
+        };
+      const recipe = rasterRecipe(page, job.request),
+        scale = recipe.effectiveDpi / 72;
+      const scaleX = recipe.pixelWidth / recipe.cropPoints[2],
+        scaleY = recipe.pixelHeight / recipe.cropPoints[3];
+      const surface = backend.surface(recipe.pixelWidth, recipe.pixelHeight);
+      try {
+        render = page.render({
+          canvas: surface.canvas,
+          canvasContext: surface.context,
+          viewport: page.getViewport({
+            scale,
+            rotation: (page.rotate + recipe.rotation) % 360,
+          }),
+          transform: [
+            scaleX / scale,
+            0,
+            0,
+            scaleY / scale,
+            -recipe.cropPoints[0] * scaleX,
+            -recipe.cropPoints[1] * scaleY,
+          ],
+          background: 'rgb(255,255,255)',
+        });
+        await render.promise;
+        const png = await surface.png();
+        if (options.signal?.aborted)
+          throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+        return { kind: 'raster', png, recipe };
+      } finally {
+        surface.dispose();
+      }
+    } finally {
+      page.cleanup();
+    }
+  } catch (error) {
+    if (options.signal?.aborted)
+      throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+    throw pdfError(error);
+  } finally {
+    options.signal?.removeEventListener('abort', abort);
+    await loading.destroy();
+  }
+}

--- a/apps/viewer/src/lib/appearance/pdf/fixtures.ts
+++ b/apps/viewer/src/lib/appearance/pdf/fixtures.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/** Original controlled PDF content, dedicated to CC0. No real-project/private data. */
+export function controlledPdf(): Uint8Array<ArrayBuffer> {
+  const contents = '1 0 0 rg 10 20 30 30 re f\n0 1 0 rg 90 60 20 30 re f\n';
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 5 0 R] /Count 2 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 144 144] /CropBox [10 20 110 92] /Rotate 90 /UserUnit 2 /Resources << >> /Contents 4 0 R >>',
+    `<< /Length ${contents.length} >>\nstream\n${contents}endstream`,
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 72 144] /Resources << >> /Contents 4 0 R >>',
+  ];
+  let pdf = '%PDF-1.7\n';
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(pdf.length);
+    pdf += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xref = pdf.length;
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets.slice(1))
+    pdf += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  return new TextEncoder().encode(pdf);
+}

--- a/apps/viewer/src/lib/appearance/pdf/pdf.worker.ts
+++ b/apps/viewer/src/lib/appearance/pdf/pdf.worker.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { runPdfJob, pdfError } from './engine.js';
+import type { PdfWorkerRequest, PdfWorkerResponse } from './types.js';
+self.onmessage = async (event: MessageEvent<PdfWorkerRequest>) => {
+  const { id, source, password, job } = event.data;
+  let response: PdfWorkerResponse;
+  try {
+    const { browserPdfBackend } = await import('./browser-backend.js');
+    response = {
+      id,
+      result: await runPdfJob(browserPdfBackend(), source, job, { password }),
+    };
+  } catch (error) {
+    const failure = pdfError(error);
+    response = { id, error: { code: failure.code, message: failure.message } };
+  }
+  if ('result' in response && response.result.kind === 'raster')
+    self.postMessage(response, { transfer: [response.result.png.buffer] });
+  else self.postMessage(response);
+};

--- a/apps/viewer/src/lib/appearance/pdf/pdfjs-legacy.d.ts
+++ b/apps/viewer/src/lib/appearance/pdf/pdfjs-legacy.d.ts
@@ -1,0 +1,4 @@
+/** PDF.js ships the legacy runtime with the same declared public API as its modern build. */
+declare module 'pdfjs-dist/legacy/build/pdf.mjs' {
+  export * from 'pdfjs-dist';
+}

--- a/apps/viewer/src/lib/appearance/pdf/raster-recipe.ts
+++ b/apps/viewer/src/lib/appearance/pdf/raster-recipe.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { PDFPageProxy } from 'pdfjs-dist';
+import {
+  PDF_LIMITS,
+  PdfAppearanceError,
+  type PdfPageInfo,
+  type PdfRasterRecipe,
+  type PdfRasterRequest,
+} from './types.js';
+export function pageInfo(page: PDFPageProxy, rotation = 0): PdfPageInfo {
+  const viewport = page.getViewport({
+    scale: 1,
+    rotation: (page.rotate + rotation) % 360,
+  });
+  if (
+    ![viewport.width, viewport.height, page.userUnit].every(
+      (value) => Number.isFinite(value) && value > 0,
+    )
+  ) {
+    throw new PdfAppearanceError(
+      'invalid-pdf',
+      'This PDF page has invalid physical dimensions.',
+    );
+  }
+  return {
+    pageNumber: page.pageNumber,
+    viewBox: [...page.view] as [number, number, number, number],
+    userUnit: page.userUnit,
+    intrinsicRotation: page.rotate,
+    widthPoints: viewport.width,
+    heightPoints: viewport.height,
+    pdfToPage: [...viewport.transform],
+  };
+}
+export function rasterRecipe(
+  page: PDFPageProxy,
+  request: PdfRasterRequest,
+): PdfRasterRecipe {
+  const rotation = request.rotation ?? 0;
+  if (![0, 90, 180, 270].includes(rotation))
+    throw new PdfAppearanceError(
+      'invalid-pdf',
+      'Choose a quarter-turn page rotation.',
+    );
+  const info = pageInfo(page, rotation);
+  const crop = request.cropPoints ?? [
+    0,
+    0,
+    info.widthPoints,
+    info.heightPoints,
+  ];
+  if (
+    crop.length !== 4 ||
+    !crop.every(Number.isFinite) ||
+    crop[0] < 0 ||
+    crop[1] < 0 ||
+    crop[2] <= 0 ||
+    crop[3] <= 0 ||
+    crop[0] + crop[2] > info.widthPoints ||
+    crop[1] + crop[3] > info.heightPoints
+  ) {
+    throw new PdfAppearanceError(
+      'invalid-pdf',
+      'The crop must be a positive rectangle inside the rotated page.',
+    );
+  }
+  const dpi = request.dpi ?? 144,
+    maxPixels = request.maxPixels ?? PDF_LIMITS.maxPixels;
+  const maxDimension = request.maxDimension ?? PDF_LIMITS.maxDimension;
+  if (
+    !Number.isFinite(dpi) ||
+    dpi <= 0 ||
+    dpi > 600 ||
+    !Number.isSafeInteger(maxPixels) ||
+    maxPixels < 1 ||
+    maxPixels > PDF_LIMITS.maxPixels ||
+    !Number.isSafeInteger(maxDimension) ||
+    maxDimension < 1 ||
+    maxDimension > PDF_LIMITS.maxDimension
+  ) {
+    throw new PdfAppearanceError(
+      'budget',
+      'Choose at most 600 DPI within the page image pixel budget.',
+    );
+  }
+  let scale = Math.min(
+    dpi / 72,
+    maxDimension / crop[2],
+    maxDimension / crop[3],
+    Math.sqrt(maxPixels / (crop[2] * crop[3])),
+  );
+  let width = Math.max(1, Math.ceil(crop[2] * scale)),
+    height = Math.max(1, Math.ceil(crop[3] * scale));
+  for (
+    let iteration = 0;
+    iteration < 8 &&
+    (width * height > maxPixels ||
+      width > maxDimension ||
+      height > maxDimension);
+    iteration++
+  ) {
+    scale *=
+      Math.min(
+        Math.sqrt(maxPixels / (width * height)),
+        maxDimension / width,
+        maxDimension / height,
+      ) * 0.99;
+    width = Math.max(1, Math.ceil(crop[2] * scale));
+    height = Math.max(1, Math.ceil(crop[3] * scale));
+  }
+  if (
+    width * height > maxPixels ||
+    width > maxDimension ||
+    height > maxDimension
+  )
+    throw new PdfAppearanceError(
+      'budget',
+      'This crop cannot fit the image budget.',
+    );
+  // Integer raster dimensions can round differently on each axis. Map the exact
+  // crop to the full PNG extent, so its corners retain their physical position.
+  const scaleX = width / crop[2],
+    scaleY = height / crop[3];
+  const [pa, pb, pc, pd, pe, pf] = info.pdfToPage;
+  const [a, b, c, d, e, f] = [
+    pa * scaleX,
+    pb * scaleY,
+    pc * scaleX,
+    pd * scaleY,
+    (pe - crop[0]) * scaleX,
+    (pf - crop[1]) * scaleY,
+  ];
+  const determinant = a * d - b * c;
+  if (!Number.isFinite(determinant) || determinant === 0)
+    throw new PdfAppearanceError(
+      'invalid-pdf',
+      'The page transform is singular.',
+    );
+  return {
+    page: info,
+    rotation,
+    cropPoints: [...crop],
+    requestedDpi: dpi,
+    effectiveDpi: Math.min(scaleX, scaleY) * 72,
+    pixelWidth: width,
+    pixelHeight: height,
+    paperSizeMetres: [(crop[2] / 72) * 0.0254, (crop[3] / 72) * 0.0254],
+    pixelToPdf: [
+      d / determinant,
+      -b / determinant,
+      -c / determinant,
+      a / determinant,
+      (c * f - d * e) / determinant,
+      (b * e - a * f) / determinant,
+    ],
+  };
+}

--- a/apps/viewer/src/lib/appearance/pdf/source-document.test.ts
+++ b/apps/viewer/src/lib/appearance/pdf/source-document.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AppearanceAssetInventory } from '../assets.js';
+import { PdfAppearanceSource } from './source-document.js';
+import { controlledPdf } from './fixtures.js';
+import type { PdfWorkerClient } from './worker-client.js';
+import type { PdfJobResult, PdfRasterRecipe } from './types.js';
+const png = new Uint8Array(
+  Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
+    'base64',
+  ),
+);
+const page = {
+  pageNumber: 1,
+  viewBox: [0, 0, 72, 72] as [number, number, number, number],
+  userUnit: 1,
+  intrinsicRotation: 0,
+  widthPoints: 72,
+  heightPoints: 72,
+  pdfToPage: [1, 0, 0, -1, 0, 72],
+};
+const recipe: PdfRasterRecipe = {
+  page,
+  rotation: 0,
+  cropPoints: [0, 0, 72, 72],
+  requestedDpi: 1,
+  effectiveDpi: 1,
+  pixelWidth: 1,
+  pixelHeight: 1,
+  paperSizeMetres: [0.0254, 0.0254],
+  pixelToPdf: [72, 0, 0, -72, 0, 72],
+};
+function worker(): PdfWorkerClient {
+  return {
+    async run(_source, job): Promise<PdfJobResult> {
+      return job.kind === 'inspect'
+        ? { kind: 'inspect', pageCount: 1, page }
+        : { kind: 'raster', png, recipe };
+    },
+    cancel() {},
+    dispose() {},
+  };
+}
+function inventory() {
+  return new AppearanceAssetInventory({
+    decode: async () => ({ width: 1, height: 1, close() {} }),
+  });
+}
+test('PDF originals stay outside image export; independent source instances cannot release each other (#4260)', async () => {
+  const images = inventory(),
+    file = new File([controlledPdf()], 'drawing.pdf', {
+      type: 'application/pdf',
+    });
+  const first = await PdfAppearanceSource.open(file, images, {
+    worker: worker(),
+  });
+  const second = await PdfAppearanceSource.open(file, images, {
+    worker: worker(),
+  });
+  assert.equal(first.id, second.id, 'document identity is content-derived');
+  const a = await first.rasterize({ pageNumber: 1 }),
+    b = await second.rasterize({ pageNumber: 1 });
+  assert.equal(a.asset.id, b.asset.id);
+  assert.notEqual(
+    a.sourceId,
+    b.sourceId,
+    'deduplicating PNG bytes preserves independent source lineage',
+  );
+  assert.equal(a.documentId, first.id);
+  assert.equal(b.documentId, second.id);
+  assert.deepEqual(
+    [...images.exportResources([a.asset.id]).keys()],
+    [a.asset.exportName],
+  );
+  assert.match(a.asset.exportName, /\.png$/);
+  first.dispose();
+  assert.ok(images.get(b.asset.id), 'other source still owns the derived page');
+  images.retain(b.asset.id, { kind: 'model', id: 'model' });
+  second.dispose();
+  assert.ok(
+    images.get(b.asset.id),
+    'committed image survives PDF source removal',
+  );
+  images.release(b.asset.id, { kind: 'model', id: 'model' });
+  assert.equal(images.get(b.asset.id), undefined);
+});
+test('late PDF rasterization cannot publish or leak a source image after document removal (#4260)', async () => {
+  const images = inventory(),
+    client = worker();
+  let finish: ((result: PdfJobResult) => void) | undefined;
+  const run = client.run;
+  client.run = (source, job, options) =>
+    job.kind === 'inspect'
+      ? run(source, job, options)
+      : new Promise((resolve) => {
+          finish = resolve;
+        });
+  const document = await PdfAppearanceSource.open(
+    new File([controlledPdf()], 'drawing.pdf'),
+    images,
+    { worker: client },
+  );
+  const pending = document.rasterize({ pageNumber: 1 });
+  document.dispose();
+  finish!({ kind: 'raster', png, recipe });
+  await assert.rejects(pending, /removed/);
+  const owner = { kind: 'source' as const, id: 'probe' },
+    asset = await images.add(png, { owner });
+  images.release(asset.id, owner);
+  assert.equal(
+    images.get(asset.id),
+    undefined,
+    'late rasterization retained no hidden lease',
+  );
+});

--- a/apps/viewer/src/lib/appearance/pdf/source-document.ts
+++ b/apps/viewer/src/lib/appearance/pdf/source-document.ts
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type {
+  AppearanceAssetInventory,
+  AppearanceBitmap,
+  AppearanceAsset,
+} from '../assets.js';
+import {
+  createPdfWorkerClient,
+  type PdfWorkerClient,
+} from './worker-client.js';
+import {
+  PDF_LIMITS,
+  PdfAppearanceError,
+  type PdfPageInfo,
+  type PdfRasterRecipe,
+  type PdfRasterRequest,
+} from './types.js';
+const documentBytes = new WeakMap<object, number>();
+const maxDocumentBytes = 128 * 1024 * 1024;
+export interface PdfDerivedAppearance {
+  /** Session source identity, independent of deduplicated raster content. */
+  sourceId: string;
+  asset: Readonly<AppearanceAsset>;
+  recipe: PdfRasterRecipe;
+  documentId: string;
+}
+/** PDF bytes/password have session ownership only. Model/export paths receive PNG assets. */
+export class PdfAppearanceSource<B extends AppearanceBitmap = ImageBitmap> {
+  readonly kind = 'pdf';
+  private readonly ownerId = `pdf:${crypto.randomUUID()}`;
+  private readonly derived = new Set<string>();
+  private disposed = false;
+  private revision = 0;
+  private constructor(
+    readonly id: string,
+    readonly name: string,
+    readonly pageCount: number,
+    private bytes: Uint8Array,
+    private password: string | undefined,
+    private readonly inventory: AppearanceAssetInventory<B>,
+    private readonly worker: PdfWorkerClient,
+  ) {}
+  static async open<B extends AppearanceBitmap>(
+    file: File,
+    inventory: AppearanceAssetInventory<B>,
+    options: {
+      signal?: AbortSignal;
+      password?: string;
+      worker?: PdfWorkerClient;
+    } = {},
+  ): Promise<PdfAppearanceSource<B>> {
+    if (!file.size || file.size > PDF_LIMITS.maxBytes)
+      throw new PdfAppearanceError(
+        'budget',
+        'Choose a PDF no larger than 64 MiB.',
+      );
+    if (options.signal?.aborted)
+      throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+    const reserved = documentBytes.get(inventory) ?? 0;
+    if (reserved + file.size > maxDocumentBytes)
+      throw new PdfAppearanceError(
+        'budget',
+        'PDF source storage is full. Remove unused documents before importing another.',
+      );
+    documentBytes.set(inventory, reserved + file.size);
+    let worker: PdfWorkerClient | undefined;
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      worker = options.worker ?? createPdfWorkerClient();
+      const result = await worker.run(
+        bytes,
+        { kind: 'inspect' },
+        { signal: options.signal, password: options.password },
+      );
+      if (result.kind !== 'inspect')
+        throw new PdfAppearanceError(
+          'render',
+          'PDF inspection returned no page information.',
+        );
+      const digest = await crypto.subtle.digest(
+        'SHA-256',
+        new Uint8Array(bytes),
+      );
+      if (options.signal?.aborted)
+        throw new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+      const id = Array.from(new Uint8Array(digest), (b) =>
+        b.toString(16).padStart(2, '0'),
+      ).join('');
+      return new PdfAppearanceSource(
+        id,
+        file.name,
+        result.pageCount,
+        bytes,
+        options.password,
+        inventory,
+        worker,
+      );
+    } catch (error) {
+      worker?.dispose();
+      documentBytes.set(
+        inventory,
+        (documentBytes.get(inventory) ?? file.size) - file.size,
+      );
+      throw error;
+    }
+  }
+  async page(
+    pageNumber: number,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<PdfPageInfo> {
+    this.check();
+    const revision = ++this.revision;
+    const result = await this.worker.run(
+      this.bytes,
+      { kind: 'inspect', pageNumber },
+      { ...options, password: this.password },
+    );
+    if (result.kind !== 'inspect')
+      throw new PdfAppearanceError(
+        'render',
+        'PDF inspection returned no page information.',
+      );
+    this.check();
+    if (revision !== this.revision)
+      throw new PdfAppearanceError('cancelled', 'PDF page selection changed.');
+    return result.page;
+  }
+  async rasterize(
+    request: PdfRasterRequest,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<PdfDerivedAppearance> {
+    this.check();
+    const revision = ++this.revision;
+    const result = await this.worker.run(
+      this.bytes,
+      { kind: 'raster', request },
+      { ...options, password: this.password },
+    );
+    if (result.kind !== 'raster')
+      throw new PdfAppearanceError(
+        'render',
+        'PDF rendering returned no image.',
+      );
+    this.check();
+    const owner = {
+      kind: 'source' as const,
+      id: `${this.ownerId}:job:${revision}`,
+    };
+    const asset = await this.inventory.add(result.png, {
+      owner,
+      mimeType: 'image/png',
+      signal: options.signal,
+    });
+    try {
+      if (this.disposed || revision !== this.revision)
+        throw new PdfAppearanceError(
+          'cancelled',
+          'PDF page selection changed.',
+        );
+      this.inventory.retain(asset.id, { kind: 'source', id: this.ownerId });
+      this.derived.add(asset.id);
+      return {
+        sourceId: `${this.ownerId}:page:${revision}`,
+        asset,
+        recipe: result.recipe,
+        documentId: this.id,
+      };
+    } finally {
+      this.inventory.release(asset.id, owner);
+    }
+  }
+  cancel(): void {
+    this.revision++;
+    this.worker.cancel();
+  }
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.revision++;
+    this.worker.dispose();
+    documentBytes.set(
+      this.inventory,
+      (documentBytes.get(this.inventory) ?? this.bytes.length) -
+        this.bytes.length,
+    );
+    this.bytes = new Uint8Array();
+    this.password = undefined;
+    for (const id of this.derived)
+      this.inventory.release(id, { kind: 'source', id: this.ownerId });
+    this.derived.clear();
+  }
+  private check(): void {
+    if (this.disposed)
+      throw new PdfAppearanceError(
+        'cancelled',
+        'The PDF source was removed. Import it again.',
+      );
+  }
+}

--- a/apps/viewer/src/lib/appearance/pdf/types.ts
+++ b/apps/viewer/src/lib/appearance/pdf/types.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export type PdfQuarterTurn = 0 | 90 | 180 | 270;
+export type PdfRect = [number, number, number, number];
+export interface PdfPageInfo {
+  pageNumber: number;
+  /** PDF user-space box [xMin,yMin,xMax,yMax], before UserUnit and rotation. */
+  viewBox: PdfRect;
+  userUnit: number;
+  intrinsicRotation: number;
+  /** Rotated visible page extent in physical points (1/72 inch). */
+  widthPoints: number;
+  heightPoints: number;
+  pdfToPage: number[];
+}
+export interface PdfRasterRequest {
+  pageNumber: number;
+  /** Additional clockwise rotation relative to the document page. */
+  rotation?: PdfQuarterTurn;
+  /** [left,top,width,height] in the rotated page's physical points. */
+  cropPoints?: PdfRect;
+  dpi?: number;
+  maxPixels?: number;
+  maxDimension?: number;
+}
+export interface PdfRasterRecipe {
+  page: PdfPageInfo;
+  rotation: PdfQuarterTurn;
+  cropPoints: PdfRect;
+  requestedDpi: number;
+  effectiveDpi: number;
+  pixelWidth: number;
+  pixelHeight: number;
+  /** Physical PAPER crop size only. Drawing/model calibration is separate. */
+  paperSizeMetres: [number, number];
+  /** Affine [a,b,c,d,e,f], raster pixels → unrotated native PDF user space. */
+  pixelToPdf: number[];
+}
+export type PdfErrorCode =
+  | 'password-required'
+  | 'password-incorrect'
+  | 'invalid-pdf'
+  | 'budget'
+  | 'unsupported'
+  | 'cancelled'
+  | 'render';
+export class PdfAppearanceError extends Error {
+  constructor(
+    readonly code: PdfErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = code === 'cancelled' ? 'AbortError' : 'PdfAppearanceError';
+  }
+}
+export type PdfJob =
+  | { kind: 'inspect'; pageNumber?: number }
+  | { kind: 'raster'; request: PdfRasterRequest };
+export type PdfJobResult =
+  | { kind: 'inspect'; pageCount: number; page: PdfPageInfo }
+  | { kind: 'raster'; png: Uint8Array; recipe: PdfRasterRecipe };
+export interface PdfWorkerRequest {
+  id: number;
+  source: Uint8Array;
+  password?: string;
+  job: PdfJob;
+}
+export type PdfWorkerResponse =
+  | { id: number; result: PdfJobResult }
+  | { id: number; error: { code: PdfErrorCode; message: string } };
+export const PDF_LIMITS = Object.freeze({
+  maxBytes: 64 * 1024 * 1024,
+  maxPages: 2000,
+  maxPixels: 16 * 1024 * 1024,
+  maxDimension: 8192,
+  timeoutMs: 60000,
+});

--- a/apps/viewer/src/lib/appearance/pdf/worker-client.test.ts
+++ b/apps/viewer/src/lib/appearance/pdf/worker-client.test.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createPdfWorkerClient, type PdfWorker } from './worker-client.js';
+import {
+  PdfAppearanceError,
+  type PdfWorkerRequest,
+  type PdfWorkerResponse,
+} from './types.js';
+class Worker implements PdfWorker {
+  onmessage: PdfWorker['onmessage'] = null;
+  onerror: PdfWorker['onerror'] = null;
+  onmessageerror: PdfWorker['onmessageerror'] = null;
+  message?: PdfWorkerRequest;
+  terminated = 0;
+  failPost = false;
+  postMessage(message: PdfWorkerRequest) {
+    if (this.failPost) throw new Error('clone failed');
+    this.message = message;
+  }
+  terminate() {
+    this.terminated++;
+  }
+  fail(code: 'password-required' | 'password-incorrect' = 'password-required') {
+    this.onmessage?.({
+      data: {
+        id: this.message!.id,
+        error: { code, message: 'Password needed' },
+      },
+    } as MessageEvent<PdfWorkerResponse>);
+  }
+}
+test('PDF latest request cancels old worker; stale delivery cannot settle current request (#4260)', async () => {
+  const workers: Worker[] = [];
+  const client = createPdfWorkerClient({
+    workerFactory: () => {
+      const worker = new Worker();
+      workers.push(worker);
+      return worker;
+    },
+  });
+  const source = new Uint8Array([1, 2, 3]);
+  const first = client.run(source, { kind: 'inspect' }),
+    rejected = assert.rejects(
+      first,
+      (error) =>
+        error instanceof PdfAppearanceError && error.code === 'cancelled',
+    );
+  const oldCallback = workers[0].onmessage;
+  const second = client.run(source, { kind: 'inspect', pageNumber: 2 });
+  await rejected;
+  assert.equal(workers[0].terminated, 1);
+  oldCallback?.({
+    data: { id: 1, error: { code: 'invalid-pdf', message: 'stale' } },
+  } as MessageEvent<PdfWorkerResponse>);
+  workers[1].fail('password-incorrect');
+  await assert.rejects(
+    second,
+    (error) =>
+      error instanceof PdfAppearanceError &&
+      error.code === 'password-incorrect',
+  );
+  assert.equal(workers[1].terminated, 1);
+  assert.equal(workers[1].onmessage, null);
+  client.dispose();
+  assert.equal(workers[1].terminated, 1);
+});
+test('PDF abort, timeout and clone failure terminate jobs and reject without hanging (#4260)', async () => {
+  for (const mode of ['abort', 'timeout', 'post'] as const) {
+    const worker = new Worker();
+    worker.failPost = mode === 'post';
+    const client = createPdfWorkerClient({
+        workerFactory: () => worker,
+        timeoutMs: 5,
+      }),
+      abort = new AbortController();
+    const pending = client.run(
+      new Uint8Array([1]),
+      { kind: 'inspect' },
+      { signal: abort.signal },
+    );
+    if (mode === 'abort') abort.abort();
+    await assert.rejects(pending);
+    assert.equal(worker.terminated, 1);
+    assert.equal(worker.onerror, null);
+    client.dispose();
+  }
+});

--- a/apps/viewer/src/lib/appearance/pdf/worker-client.ts
+++ b/apps/viewer/src/lib/appearance/pdf/worker-client.ts
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import {
+  PDF_LIMITS,
+  PdfAppearanceError,
+  type PdfJob,
+  type PdfJobResult,
+  type PdfWorkerRequest,
+  type PdfWorkerResponse,
+} from './types.js';
+export interface PdfWorker {
+  onmessage: ((event: MessageEvent<PdfWorkerResponse>) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  onmessageerror: ((event: MessageEvent) => void) | null;
+  postMessage(message: PdfWorkerRequest): void;
+  terminate(): void;
+}
+export interface PdfWorkerClient {
+  run(
+    source: Uint8Array,
+    job: PdfJob,
+    options?: { signal?: AbortSignal; password?: string },
+  ): Promise<PdfJobResult>;
+  cancel(): void;
+  dispose(): void;
+}
+export function createPdfWorkerClient(
+  options: { workerFactory?: () => PdfWorker; timeoutMs?: number } = {},
+): PdfWorkerClient {
+  const timeout = options.timeoutMs ?? PDF_LIMITS.timeoutMs;
+  if (!Number.isFinite(timeout) || timeout <= 0)
+    throw new PdfAppearanceError('budget', 'Invalid PDF job timeout.');
+  const factory =
+    options.workerFactory ??
+    (() =>
+      new Worker(new URL('./pdf.worker.ts', import.meta.url), {
+        type: 'module',
+      }));
+  let sequence = 0,
+    disposed = false,
+    abortCurrent: (() => void) | undefined;
+  const cancelled = () =>
+    new PdfAppearanceError('cancelled', 'PDF import cancelled.');
+  return {
+    cancel() {
+      abortCurrent?.();
+    },
+    dispose() {
+      disposed = true;
+      abortCurrent?.();
+    },
+    run(source, job, { signal, password } = {}) {
+      abortCurrent?.();
+      if (disposed || signal?.aborted) return Promise.reject(cancelled());
+      if (!source.length || source.length > PDF_LIMITS.maxBytes)
+        return Promise.reject(
+          new PdfAppearanceError(
+            'budget',
+            'Choose a PDF no larger than 64 MiB.',
+          ),
+        );
+      const id = ++sequence;
+      return new Promise((resolve, reject) => {
+        let worker: PdfWorker;
+        try {
+          worker = factory();
+        } catch (error) {
+          reject(
+            new PdfAppearanceError(
+              'unsupported',
+              `Cannot start PDF worker: ${String(error)}`,
+            ),
+          );
+          return;
+        }
+        let settled = false,
+          timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = (error?: Error, result?: PdfJobResult) => {
+          if (settled) return;
+          settled = true;
+          if (timer !== undefined) clearTimeout(timer);
+          signal?.removeEventListener('abort', abort);
+          worker.onmessage = worker.onerror = worker.onmessageerror = null;
+          worker.terminate();
+          if (id === sequence) abortCurrent = undefined;
+          if (error) reject(error);
+          else resolve(result!);
+        };
+        const abort = () => finish(cancelled());
+        abortCurrent = abort;
+        signal?.addEventListener('abort', abort, { once: true });
+        timer = setTimeout(
+          () =>
+            finish(
+              new PdfAppearanceError(
+                'budget',
+                'PDF page processing timed out. Choose a smaller document or crop.',
+              ),
+            ),
+          timeout,
+        );
+        worker.onmessage = (event) => {
+          const response = event.data;
+          if (!response || response.id !== id || id !== sequence || settled)
+            return;
+          if ('error' in response) {
+            finish(
+              new PdfAppearanceError(
+                response.error.code,
+                response.error.message,
+              ),
+            );
+            return;
+          }
+          if (!response.result || response.result.kind !== job.kind) {
+            finish(
+              new PdfAppearanceError(
+                'render',
+                'The PDF worker returned an unexpected result.',
+              ),
+            );
+            return;
+          }
+          finish(undefined, response.result);
+        };
+        worker.onerror = (event) =>
+          finish(
+            new PdfAppearanceError(
+              'render',
+              event.message || 'The PDF worker stopped unexpectedly.',
+            ),
+          );
+        worker.onmessageerror = () =>
+          finish(
+            new PdfAppearanceError(
+              'render',
+              'The PDF worker returned unreadable page data.',
+            ),
+          );
+        try {
+          worker.postMessage({ id, source, job, password });
+        } catch (error) {
+          finish(new PdfAppearanceError('render', String(error)));
+        }
+        if (signal?.aborted) abort();
+      });
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "typescript": "^6.0.3"
   },
   "engines": {
-    "node": ">=22.11 <23 || 24.x",
+    "node": ">=22.13 <23 || 24.x",
     "pnpm": ">=10.0.0"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       parquet-wasm:
         specifier: ^0.7.2
         version: 0.7.2
+      pdfjs-dist:
+        specifier: 6.3.289
+        version: 6.3.289
       postcss:
         specifier: ^8.5.10
         version: 8.5.28
@@ -2154,6 +2157,70 @@ packages:
 
   '@marijn/find-cluster-break@1.0.4':
     resolution: {integrity: sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==}
+
+  '@napi-rs/canvas-android-arm64@1.0.9':
+    resolution: {integrity: sha512-4LGXk2/0HVzE29K8SzML5WubgCp++B1FH3qgl35XmSZE+lLdr6P9VRQEnZ0MCLZMTSuJP41yyhtoiVNEuvrTIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.9':
+    resolution: {integrity: sha512-YNdfLBzY0W/Pep9fo2L6RmoNlNksnn05LRnX66W63R3ij58S25QOTcjdtEt2v8+PnCESzqZsYzUo+QPeIR44NA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.9':
+    resolution: {integrity: sha512-ceZQSknTEcy3dOXoekv59LTCkXjvnLsq+VW5PeNNDHEPQbRS5Ervkm1EaDa7WLAjiYWMLuSQTRTHao1dEX4prg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.9':
+    resolution: {integrity: sha512-XhfI0Wwv4llhd6nnWDtY3kQKjq0r+y1i91PlJlJI24ag2U9WrnwbG1qS3+fDLEyouwEVFchiKkTEHozK+5iUNA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.9':
+    resolution: {integrity: sha512-012oiYtKaE7i9oxc8q7nraT7kDOpLcaCmFLzVe9Ty34RHDdoDzbWLrVh827CNxYh/EADX1eSikA3ymLjo/nNuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.9':
+    resolution: {integrity: sha512-Ls5UWYFFn63casTZEczbeyEg3vRDRkv9lscuGwfchtY5yLLQhgOB8SN4YGxmfJ5vTaBwZ2YUxBS3NtmjJmFXdA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.9':
+    resolution: {integrity: sha512-hLKEGxV7ZiRHqndePTokgDMdBlo/rDfzg7P4p4QIv9pUhuYobnu3R2NIFLCRghG0nwfo+s2sw+c1xZFeCmEAsw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.9':
+    resolution: {integrity: sha512-6kaz3w0QMy77PDWk6rJ1ksIihdad3qzEyX2o2oGT8GwCaypfT5mhjr8buOO5hstyLxcWXDScuz56RsINLtBPIQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.9':
+    resolution: {integrity: sha512-xrGvmS3v55hmZ86ls/kBLVNMUTYio3f6Ik0DireemG994VfPAwiA3ZXA0Uf1bByctkB3NQ1Sfb+H5bkdUnnzfQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.9':
+    resolution: {integrity: sha512-QlSYQdMQslB81nlABo9wNfQ6npFhE7/O+saCZdqVGueGanyRk4jCogD5EwQenfP3kIq9e+mm6GreQBjX5MrA8g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.9':
+    resolution: {integrity: sha512-QviPdJImDi/jMAvBfqaw+19BndMd/sizXVW3NnpMd3VJGz++QXkOHcP9kWR/smHG0hNjHeyuHFyrx/5lD0oNcQ==}
+    engines: {node: '>= 10'}
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -4913,6 +4980,10 @@ packages:
     resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
     hasBin: true
 
+  pdfjs-dist@6.3.289:
+    resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
+    engines: {node: '>=22.13.0 || >=24'}
+
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
@@ -6313,6 +6384,50 @@ snapshots:
       pbf: 5.1.2
 
   '@marijn/find-cluster-break@1.0.4': {}
+
+  '@napi-rs/canvas-android-arm64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas@1.0.9':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.9
+      '@napi-rs/canvas-darwin-arm64': 1.0.9
+      '@napi-rs/canvas-darwin-x64': 1.0.9
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.9
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.9
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-x64-musl': 1.0.9
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.9
+    optional: true
 
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
@@ -8973,6 +9088,10 @@ snapshots:
   pbf@5.1.2:
     dependencies:
       resolve-protobuf-schema: 2.1.0
+
+  pdfjs-dist@6.3.289:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.9
 
   performance-now@2.1.0:
     optional: true


### PR DESCRIPTION
A PDF page can become an appearance image while retaining its page coordinates, crop, rotation, physical paper size, and document lineage. This adds a lazy PDF.js service that renders the selected page/crop in a cancellable worker and places only the resulting PNG in the existing image inventory. Original PDF bytes and passwords remain session-owned; image leases survive document removal when a model or history still owns them.

Stacked on #4261. Refs #4260. This is the PDF source service foundation: the Appearance UI, user calibration, outside-page appearance preservation, reference planes, and vector annotations remain separate work. Identical PNGs may share storage without collapsing source identity or page recipes.

The decoder is pinned to Apache-2.0 PDF.js 6.3.289, with bundled fonts/CMaps/decoder resources and notices. Node development support becomes 22.13+ within Node 22, or Node 24; the template CI job now uses current Node 22. Input/page/pixel/time limits and typed password diagnostics bound common failures. Unsupported DOM-only color filters fail explicitly. These bounds are not a hard memory limit for arbitrary compressed PDF streams.

Validation:
- Isolated branch: plain `pnpm typecheck` passed 90/90 tasks, covering all 1,791 test files. Root turbo viewer production build passed; focused PDF engine 4/4, worker client 2/2, and source ownership/lineage 2/2 tests passed.
- Real PDF.js tests use a generated CC0 PDF with CropBox, UserUnit=2, rotated pages and colored orientation markers; they verify cropping, physical size independent of resolution, pixel budgets, encrypted PDF passwords, malformed input, and cancellation.
- Worker/source tests verify cancellation, stale results, buffer ownership, PNG-only exports, and independent source leases for deduplicated images.
- An actual Chromium viewer tab rendered through the production worker and source inventory: 144×200 PNG, correct red/green orientation pixels, PNG-only export, and retained model ownership after PDF removal. A controlled page with font outlines also rendered successfully. This is service-level evidence, not an integrated projection UI acceptance claim.

See `apps/viewer/src/lib/appearance/pdf/README.md` for the API, limits, sources, and reproducible fixture details.
