### PR TITLE
feat(cache): preserve canonical appearance provenance on reload

### DIFF
--- a/.changeset/wide-turtles-camp.md
+++ b/.changeset/wide-turtles-camp.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": minor
+---
+
+Preserve canonical appearance provenance in cache format v19, with shared source topology across chunks and validated restored index identities.

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -89,6 +89,10 @@ The cache keys models by the xxHash64 of the source IFC, and `reader.validate(ca
 
 The binary layout is versioned via the exported `FORMAT_VERSION` constant. Readers accept entries written by the current or an older format version (with backward-compatible decoding, e.g. the per-mesh geometry-class byte added in v5) and reject entries written by a newer one, so mixed-version deployments fail safely toward a cold parse.
 
+Version 19 preserves explicitly supplied canonical `MeshData.appearanceSource` provenance. Fresh canonical meshes store an identity marker; fragmented or expanded meshes reference a geometry-header source-index pool, shared across spatial chunks, plus their corner mapping. Restored metadata points to the restored mesh indices, preserving the topology identity fence required by appearance preview. Invalid identities, source lengths, pool references and corner ranges fail cache reading/writing instead of enabling an unsafe preview. Unmarked meshes remain unmarked; old records never acquire inferred canonical identity.
+
+The viewer includes `FORMAT_VERSION` in its cache key, so older entries reparse once and receive real provenance from the canonical geometry pipeline. Direct readers can still decode v13–v18 records for viewing, with appearance provenance absent. When reading an older geometry header directly, pass its version as the second argument to `readGeometryHeadV13(reader, version)`; it defaults to the current format. Keep the returned chunk metadata when calling `decodeGeometryChunk`, since it carries the shared source-index pool. This does not add UV/image caching: texture-carrying viewer models retain their existing cache bypass.
+
 ## Source-hash contract (and `omitSourceHash`)
 
 By default the header stores the full-file `xxhash64` of the source in `sourceHash`, and `reader.validate()` / `read({ sourceBuffer })` compare against it. Hashing a large source can be a multi-second main-thread cost, so a caller that validates the source **another way** (e.g. an application-layer content hash plus a file modified-time guard, as the viewer's source-decoupled cache tier does) can pass `omitSourceHash: true`:

--- a/packages/cache/src/sections/appearance-provenance.test.ts
+++ b/packages/cache/src/sections/appearance-provenance.test.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it, expect } from 'vitest';
+import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
+import { BufferReader, BufferWriter } from '../utils/buffer-utils.js';
+import { writeMeshRecord, readMeshRecord, meshRecordByteLength, writeCoordinateInfo } from './geometry.js';
+import { buildGeometrySectionV13, openGeometryChunksV13 } from './geometry-chunks.js';
+import { FORMAT_VERSION } from '../types.js';
+import { readSourcePool } from './appearance-provenance.js';
+const point = { x: 0, y: 0, z: 0 };
+const coordinateInfo: CoordinateInfo = { originShift: point, originalBounds: { min: point, max: point }, shiftedBounds: { min: point, max: point }, hasLargeCoordinates: false };
+function mesh(): MeshData {
+  const indices = new Uint32Array([0,1,2]);
+  return { expressId: 10, geometryItemId: 14, indices, positions: new Float32Array([0,0,0,1,0,0,0,1,0]), normals: new Float32Array([0,0,1,0,0,1,0,0,1]), color: [1,1,1,1],
+    appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
+}
+function record(value: MeshData): ArrayBuffer { const writer = new BufferWriter(); writeMeshRecord(writer, value); expect(writer.position).toBe(meshRecordByteLength(value)); return writer.build(); }
+describe('canonical cache provenance #4243', () => {
+  it('restores the live index identity fence and never invents it for unmarked/old records', () => {
+    const input = mesh(), bytes = record(input);
+    const output = readMeshRecord(new BufferReader(bytes), FORMAT_VERSION);
+    expect(output.appearanceSource?.indices).toBe(output.indices);
+    expect(output.appearanceSource?.sourceIndices).toBe(output.indices);
+    const plain = { ...input, appearanceSource: undefined };
+    expect(readMeshRecord(new BufferReader(record(plain)), FORMAT_VERSION).appearanceSource).toBeUndefined();
+    // v18 is the exact preceding record prefix; no provenance trailer exists.
+    const previous = record(plain).slice(0, -1);
+    const old = readMeshRecord(new BufferReader(previous), 18);
+    expect(old.geometryItemId).toBe(14);
+    expect(old.appearanceSource).toBeUndefined();
+    expect(old.indices).toEqual(input.indices);
+  });
+  it('decodes the preceding v18 geometry head without consuming a nonexistent source pool', async () => {
+    const input = { ...mesh(), appearanceSource: undefined };
+    const oldRecord = record(input).slice(0, -1);
+    const head = new BufferWriter();
+    head.writeUint32(1); head.writeUint32(3); head.writeUint32(1);
+    writeCoordinateInfo(head, coordinateInfo);
+    head.writeUint32(1); // v18 chunk count, no v19 source pool.
+    const headLength = head.position + 44;
+    const out = new BufferWriter();
+    out.writeUint32(headLength); out.writeBytes(new Uint8Array(head.build()));
+    for (let i = 0; i < 6; i++) out.writeFloat32(0);
+    for (const value of [headLength + 4, oldRecord.byteLength, oldRecord.byteLength, 1, 0]) out.writeUint32(value);
+    out.writeBytes(new Uint8Array(oldRecord));
+    const restored = (await openGeometryChunksV13(out.build(), 0, 18).readChunk(0))[0];
+    expect(restored.indices).toEqual(input.indices);
+    expect(restored.geometryItemId).toBe(14);
+    expect(restored.appearanceSource).toBeUndefined();
+  });
+  it('preserves expanded current indices separately from canonical target topology', () => {
+    const input = mesh();
+    input.appearanceSource!.sourceIndices = new Uint32Array([0,0,1]);
+    const output = readMeshRecord(new BufferReader(record(input)), FORMAT_VERSION);
+    expect(output.appearanceSource?.indices).toBe(output.indices);
+    expect(output.appearanceSource?.sourceIndices).toEqual(new Uint32Array([0,0,1]));
+    expect(output.appearanceSource?.sourceIndices).not.toBe(output.indices);
+  });
+  it('deduplicates canonical source arrays across separately decoded spatial chunks', async () => {
+    const sourceIndices = new Uint32Array([0,1,2,2,1,3]);
+    const a = mesh(), b = mesh(); b.origin = [1000,0,0];
+    a.appearanceSource = { kind: 'canonical-item', indices: a.indices, sourceIndices, cornerIndices: new Uint32Array([0,1,2]) };
+    b.appearanceSource = { kind: 'canonical-item', indices: b.indices, sourceIndices, cornerIndices: new Uint32Array([3,4,5]) };
+    const bytes = await buildGeometrySectionV13([a,b], coordinateInfo, { compress: false });
+    const chunks = openGeometryChunksV13(bytes, 0, FORMAT_VERSION);
+    expect(chunks.chunks).toHaveLength(2);
+    expect(chunks.chunks[0].appearanceSources).toHaveLength(1);
+    const first = (await chunks.readChunk(0))[0], second = (await chunks.readChunk(1))[0];
+    expect(first.appearanceSource?.sourceIndices).toBe(second.appearanceSource?.sourceIndices);
+    expect(second.appearanceSource?.cornerIndices).toEqual(new Uint32Array([3,4,5]));
+    const firstChunk = chunks.chunks[0];
+    // Pooled mode5 trailer: tag + source-pool id + three corner indices.
+    new DataView(bytes).setUint32(firstChunk.byteOffset + firstChunk.byteLength - 16, 999, true);
+    await expect(openGeometryChunksV13(bytes, 0, FORMAT_VERSION).readChunk(0)).rejects.toThrow(/provenance/);
+  });
+  it('rejects forged pool counts and lengths before allocating source arrays', () => {
+    const pool = (count: number, length: number) => {
+      const out = new BufferWriter(); out.writeUint32(count); out.writeUint32(length);
+      return out.build();
+    };
+    expect(() => readSourcePool(new BufferReader(pool(2, 3)), 1, 8)).toThrow(/provenance/);
+    expect(() => readSourcePool(new BufferReader(pool(1, 300_000_000)), 1, 8)).toThrow(/provenance/);
+    // A forged header end cannot bypass the reader's actual buffer bounds.
+    expect(() => readSourcePool(new BufferReader(pool(1, 300_000_000)), 1, 0xffffffff)).toThrow(/past end/);
+    expect(() => readSourcePool(new BufferReader(pool(1, 4)), 1, 64)).toThrow(/provenance/);
+  });
+  it('refuses stale index identity, invalid corners and corrupted/truncated provenance records', () => {
+    const stale = mesh(); stale.indices = stale.indices.slice();
+    expect(() => record(stale)).toThrow(/provenance/);
+    expect(() => record({ ...mesh(), geometryItemId: 2 ** 32 + 14 })).toThrow(/provenance/);
+    const invalid = mesh(); invalid.appearanceSource!.cornerIndices = new Uint32Array([0,1,3]);
+    expect(() => record(invalid)).toThrow(/provenance/);
+    const input = mesh(); input.appearanceSource!.cornerIndices = new Uint32Array([0,1,2]);
+    const bytes = record(input), tail = bytes.byteLength - 12;
+    new DataView(bytes).setUint32(tail, 999, true);
+    expect(() => readMeshRecord(new BufferReader(bytes), FORMAT_VERSION)).toThrow(/provenance/);
+    expect(() => readMeshRecord(new BufferReader(record(input).slice(0,-1)), FORMAT_VERSION)).toThrow(/past end/);
+    const length = record(input); new DataView(length).setUint32(length.byteLength - 24 - 4, 0xffffffff, true);
+    expect(() => readMeshRecord(new BufferReader(length), FORMAT_VERSION)).toThrow(/provenance/);
+  });
+});

--- a/packages/cache/src/sections/appearance-provenance.ts
+++ b/packages/cache/src/sections/appearance-provenance.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { MeshData } from '@ifc-lite/geometry';
+import { BufferReader, BufferWriter } from '../utils/buffer-utils.js';
+
+const MAX_INDICES = 300_000_000;
+const invalid = () => new Error('Invalid cache: malformed canonical appearance provenance; rebuild this cache.');
+export type AppearanceSourcePool = ReadonlyMap<Uint32Array, number>;
+function equal(a: Uint32Array, b: Uint32Array): boolean {
+  return a === b || (a.length === b.length && a.every((value, index) => value === b[index]));
+}
+function validate(mesh: MeshData): NonNullable<MeshData['appearanceSource']> | undefined {
+  const source = mesh.appearanceSource;
+  if (!source) return undefined;
+  if (source.kind !== 'canonical-item' || source.indices !== mesh.indices || mesh.entityIds ||
+      !Number.isSafeInteger(mesh.geometryItemId) || mesh.geometryItemId! <= 0 || mesh.geometryItemId! >= 0xffffffff ||
+      mesh.indices.length === 0 || mesh.indices.length % 3 !== 0 ||
+      !(source.sourceIndices instanceof Uint32Array) || source.sourceIndices.length === 0 ||
+      source.sourceIndices.length > MAX_INDICES || source.sourceIndices.length % 3 !== 0) throw invalid();
+  for (const vertex of mesh.indices) if (vertex >= mesh.positions.length / 3) throw invalid();
+  if (source.cornerIndices) {
+    if (!(source.cornerIndices instanceof Uint32Array) || source.cornerIndices.length !== mesh.indices.length) throw invalid();
+    for (const corner of source.cornerIndices) if (corner >= source.sourceIndices.length) throw invalid();
+  } else if (source.sourceIndices.length !== mesh.indices.length) throw invalid();
+  return source;
+}
+function tag(mesh: MeshData, pool?: AppearanceSourcePool): number {
+  const source = validate(mesh);
+  if (!source) return 0;
+  if (!source.cornerIndices && equal(source.sourceIndices, mesh.indices)) return 1;
+  if (pool?.has(source.sourceIndices)) return source.cornerIndices ? 5 : 4;
+  return source.cornerIndices ? 3 : 2;
+}
+export function provenanceByteLength(mesh: MeshData, pool?: AppearanceSourcePool): number {
+  const mode = tag(mesh, pool), source = mesh.appearanceSource;
+  return mode < 2 ? 1 : 5 + (mode < 4 ? source!.sourceIndices.byteLength : 0) +
+    (source!.cornerIndices ? source!.cornerIndices.byteLength : 0);
+}
+export function writeProvenance(writer: BufferWriter, mesh: MeshData, pool?: AppearanceSourcePool): void {
+  const mode = tag(mesh, pool), source = mesh.appearanceSource;
+  writer.writeUint8(mode);
+  if (mode < 2) return;
+  writer.writeUint32(mode >= 4 ? pool!.get(source!.sourceIndices)! : source!.sourceIndices.length);
+  if (mode < 4) writer.writeTypedArray(source!.sourceIndices);
+  if (source!.cornerIndices) writer.writeTypedArray(source!.cornerIndices);
+}
+export function readProvenance(reader: BufferReader, mesh: MeshData, pool: readonly Uint32Array[] = []): void {
+  const mode = reader.readUint8();
+  if (mode === 0) return; // Never infer canonical identity from geometryItemId alone.
+  if (mode > 5) throw invalid();
+  let sourceIndices = mesh.indices;
+  if (mode >= 2) {
+    const value = reader.readUint32();
+    if (mode >= 4) {
+      if (!pool[value]) throw invalid();
+      sourceIndices = pool[value];
+    } else {
+      if (value > MAX_INDICES || value === 0 || value % 3 !== 0) throw invalid();
+      sourceIndices = reader.readUint32Array(value);
+    }
+  }
+  const cornerIndices = mode === 3 || mode === 5 ? reader.readUint32Array(mesh.indices.length) : undefined;
+  mesh.appearanceSource = { kind: 'canonical-item', indices: mesh.indices, sourceIndices,
+    ...(cornerIndices ? { cornerIndices } : {}) };
+  validate(mesh);
+}
+/** Deduplicate by existing source-array identity across every spatial chunk. */
+export function collectSourcePool(meshes: readonly MeshData[]): Map<Uint32Array, number> {
+  const pool = new Map<Uint32Array, number>();
+  for (const mesh of meshes) {
+    if (tag(mesh) < 2) continue;
+    const source = mesh.appearanceSource!.sourceIndices;
+    if (!pool.has(source)) pool.set(source, pool.size);
+  }
+  return pool;
+}
+export function writeSourcePool(writer: BufferWriter, pool: AppearanceSourcePool): void {
+  writer.writeUint32(pool.size);
+  for (const source of pool.keys()) { writer.writeUint32(source.length); writer.writeTypedArray(source); }
+}
+export function readSourcePool(reader: BufferReader, meshCount: number, end: number): Uint32Array[] {
+  const count = reader.readUint32();
+  if (count > meshCount || count > Math.floor((end - reader.position) / 4)) throw invalid();
+  const pool: Uint32Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const length = reader.readUint32();
+    if (!length || length > MAX_INDICES || length % 3 !== 0 || length > Math.floor((end - reader.position) / 4)) throw invalid();
+    pool.push(reader.readUint32Array(length));
+  }
+  return pool;
+}

--- a/packages/cache/src/sections/geometry-chunks.ts
+++ b/packages/cache/src/sections/geometry-chunks.ts
@@ -12,6 +12,7 @@
  *   totalVertices: u32
  *   totalTriangles: u32
  *   coordinateInfo                       // unchanged, variable length
+ *   sourceIndexPool (v19+)              // count + length-prefixed u32 arrays
  *   chunkCount: u32
  *   directory: chunkCount × 44 bytes {
  *     aabbMin f32×3, aabbMax f32×3,      // world AABB of the chunk
@@ -24,13 +25,15 @@
  *   ...chunk records at their byteOffsets
  *
  * A chunk record is a plain concatenation of per-mesh records (identical
- * layout to v12 — see geometry.ts writeMeshRecord), optionally deflate-raw
+ * versioned layout — see geometry.ts writeMeshRecord), optionally deflate-raw
  * compressed. Chunks are spatially coherent (grid cell of origin + first
  * vertex, soft byte cap; a mesh never splits), so a streamed reader paints
  * coherent regions and a future evict-to-disk residency layer can re-read
  * one chunk without touching the rest.
  */
 
+import { FORMAT_VERSION } from '../types.js';
+import { collectSourcePool, writeSourcePool, readSourcePool, type AppearanceSourcePool } from './appearance-provenance.js';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
 import {
@@ -96,14 +99,15 @@ interface PendingChunk {
 /** Group meshes into spatially coherent, byte-capped chunks (order-stable). */
 export function groupMeshesIntoChunks(
   meshes: MeshData[],
-  softBytes: number = GEOMETRY_CHUNK_SOFT_BYTES
+  softBytes: number = GEOMETRY_CHUNK_SOFT_BYTES,
+  pool?: AppearanceSourcePool
 ): MeshData[][] {
   const open = new Map<string, PendingChunk>();
   const closed: MeshData[][] = [];
   for (const mesh of meshes) {
     const key = cellKeyOf(mesh);
     let chunk = open.get(key);
-    const bytes = meshRecordByteLength(mesh);
+    const bytes = meshRecordByteLength(mesh, pool);
     if (chunk && chunk.bytes > 0 && chunk.bytes + bytes > softBytes) {
       closed.push(chunk.meshes);
       chunk = undefined;
@@ -151,7 +155,8 @@ export async function buildGeometrySectionV13(
 ): Promise<ArrayBuffer> {
   const compress = options.compress ?? true;
   const { validMeshes, actualTotalVertices, actualTotalTriangles } = validateMeshes(meshes);
-  const groups = groupMeshesIntoChunks(validMeshes);
+  const pool = collectSourcePool(validMeshes);
+  const groups = groupMeshesIntoChunks(validMeshes, undefined, pool);
 
   // Serialize (and optionally compress) every chunk record. Concurrency is
   // BOUNDED: a large model produces hundreds of chunks, and an unbounded
@@ -169,7 +174,7 @@ export async function buildGeometrySectionV13(
   const session = options.compressInWorker ? new GeometryCompressionSession() : undefined;
   const buildRecord = async (group: MeshData[]): Promise<BuiltRecord> => {
     const w = new BufferWriter(64 * 1024);
-    for (const mesh of group) writeMeshRecord(w, mesh);
+    for (const mesh of group) writeMeshRecord(w, mesh, pool);
     const raw = new Uint8Array(w.build());
     // Worker compression transfers raw.buffer; save this before detachment.
     const uncompressedLength = raw.byteLength;
@@ -207,6 +212,7 @@ export async function buildGeometrySectionV13(
   headBody.writeUint32(actualTotalVertices);
   headBody.writeUint32(actualTotalTriangles);
   writeCoordinateInfo(headBody, coordinateInfo);
+  writeSourcePool(headBody, pool);
   headBody.writeUint32(records.length);
   const headLength = headBody.position + records.length * DIRECTORY_ENTRY_BYTES;
 
@@ -238,16 +244,19 @@ export async function buildGeometrySectionV13(
 
 /** Parse the v13 geometry head; `reader` must be positioned at the geometry
  *  section start. Cheap: never touches chunk records. */
-export function readGeometryHeadV13(reader: BufferReader): GeometryHead {
+export function readGeometryHeadV13(reader: BufferReader, version: number = FORMAT_VERSION): GeometryHead {
+  const start = reader.position;
   const headLength = reader.readUint32();
   const meshCount = reader.readUint32();
   const totalVertices = reader.readUint32();
   const totalTriangles = reader.readUint32();
   const coordinateInfo = readCoordinateInfo(reader, 13);
+  const appearanceSources = version >= 19 ? readSourcePool(reader, meshCount, start + 4 + headLength) : undefined;
   const chunkCount = reader.readUint32();
   const chunks: GeometryChunkInfo[] = [];
   for (let i = 0; i < chunkCount; i++) {
     chunks.push({
+      ...(appearanceSources ? { appearanceSources } : {}),
       aabbMin: [reader.readFloat32(), reader.readFloat32(), reader.readFloat32()],
       aabbMax: [reader.readFloat32(), reader.readFloat32(), reader.readFloat32()],
       byteOffset: reader.readUint32(),
@@ -277,7 +286,7 @@ export async function decodeGeometryChunk(
   const reader = new BufferReader(buffer as ArrayBuffer);
   const meshes: MeshData[] = [];
   for (let i = 0; i < info.meshCount; i++) {
-    meshes.push(readMeshRecord(reader, version, i));
+    meshes.push(readMeshRecord(reader, version, i, info.appearanceSources));
   }
   // `meshCount` and `uncompressedLength` are two independently-corruptible
   // directory fields; a lying pair (meshCount inflated, uncompressedLength
@@ -309,7 +318,7 @@ export function openGeometryChunksV13(
 ): GeometryHead & { readChunk(index: number): Promise<MeshData[]> } {
   const reader = new BufferReader(buffer);
   reader.position = sectionOffset;
-  const head = readGeometryHeadV13(reader);
+  const head = readGeometryHeadV13(reader, version);
   // `reader.position` here is a STRUCTURAL fact: it's where the parse of
   // meshCount/totalVertices/totalTriangles/coordinateInfo/chunkCount/
   // directory actually landed, none of which depend on `head.headLength`.

--- a/packages/cache/src/sections/geometry.ts
+++ b/packages/cache/src/sections/geometry.ts
@@ -8,6 +8,7 @@
 
 import type { MeshData, CoordinateInfo, Vec3, AABB } from '@ifc-lite/geometry';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { writeProvenance, readProvenance, provenanceByteLength, type AppearanceSourcePool } from './appearance-provenance.js';
 
 /**
  * Validate + filter meshes (detached buffers / size mismatches / absurd
@@ -49,10 +50,10 @@ export function validateMeshes(meshes: MeshData[]): {
 }
 
 /**
- * One per-mesh record inside a v13 chunk (layout unchanged since the
- * pre-v13 sequential format — v13 only changed how records are GROUPED).
+ * One current-version per-mesh record inside a v13+ chunk. Version 19
+ * appends optional canonical appearance provenance after geometry arrays.
  */
-export function writeMeshRecord(writer: BufferWriter, mesh: MeshData): void {
+export function writeMeshRecord(writer: BufferWriter, mesh: MeshData, pool?: AppearanceSourcePool): void {
   writer.writeUint32(mesh.expressId);
 
   const vertexCount = mesh.positions.length / 3;
@@ -106,10 +107,11 @@ export function writeMeshRecord(writer: BufferWriter, mesh: MeshData): void {
   writer.writeTypedArray(mesh.positions);
   writer.writeTypedArray(mesh.normals);
   writer.writeTypedArray(mesh.indices);
+  writeProvenance(writer, mesh, pool);
 }
 
 /** Exact serialized size of one per-mesh record, for chunk byte budgeting. */
-export function meshRecordByteLength(mesh: MeshData): number {
+export function meshRecordByteLength(mesh: MeshData, pool?: AppearanceSourcePool): number {
   const ifcTypeBytes = mesh.ifcType ? new TextEncoder().encode(mesh.ifcType).length : 0;
   return (
     4 + 4 + 4 +            // expressId, vertexCount, indexCount
@@ -118,7 +120,7 @@ export function meshRecordByteLength(mesh: MeshData): number {
     1 +                    // geometryClass
     8 +                    // geometryItemId + materialId u32x2 (v14+)
     24 +                   // origin f64x3
-    mesh.positions.byteLength + mesh.normals.byteLength + mesh.indices.byteLength
+    mesh.positions.byteLength + mesh.normals.byteLength + mesh.indices.byteLength + provenanceByteLength(mesh, pool)
   );
 }
 
@@ -213,7 +215,7 @@ function assertFiniteVertexData(
 }
 
 /** Read one per-mesh record (see writeMeshRecord for the layout). */
-export function readMeshRecord(reader: BufferReader, version: number, meshIndex: number = 0): MeshData {
+export function readMeshRecord(reader: BufferReader, version: number, meshIndex: number = 0, pool?: readonly Uint32Array[]): MeshData {
   const expressId = reader.readUint32();
   const vertexCount = reader.readUint32();
   const indexCount = reader.readUint32();
@@ -290,7 +292,7 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
   assertFiniteVertexData(positions, 'positions', meshIndex, expressId);
   assertFiniteVertexData(normals, 'normals', meshIndex, expressId);
 
-  return {
+  const mesh: MeshData = {
     expressId,
     positions,
     normals,
@@ -304,6 +306,8 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
     ...(materialId !== undefined ? { materialId } : {}),
     ...(origin ? { origin } : {}),
   };
+  if (version >= 19) readProvenance(reader, mesh, pool);
+  return mesh;
 }
 
 export function readCoordinateInfo(reader: BufferReader, version: number = 2): CoordinateInfo {

--- a/packages/cache/src/sections/header.test.ts
+++ b/packages/cache/src/sections/header.test.ts
@@ -76,7 +76,8 @@ describe('writeHeader', () => {
     // `qsetGlobalId` column, 17 -> 18 with the Relationships section's
     // shadowed-rel-ids trailer (#3782); update this literal only alongside a
     // types.ts ledger entry.
-    expect(view.getUint16(4, true)).toBe(18);
+    // v19 adds canonical appearance provenance and a shared source-index pool.
+    expect(view.getUint16(4, true)).toBe(19);
   });
 
   it('writes each section-table entry field at its documented byte offset within the 16-byte entry', () => {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -151,7 +151,10 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  *   either. Not the destructive kind of bump: no existing cache entry is
  *   wrong to read, only silent about a rare case until it is re-parsed.
  */
-export const FORMAT_VERSION = 18;
+/** v19: optional canonical appearance provenance per mesh and a shared source-index
+ * pool in the geometry head. Earlier records remain unmarked; viewer cache keys
+ * include the version, so old entries reparse once rather than invent provenance. */
+export const FORMAT_VERSION = 19;
 
 /** Geometry chunking parameters (v13+). Grouping is a WRITE-side layout
  *  policy: readers only trust the directory, so these can change without a
@@ -172,6 +175,8 @@ export enum GeometryChunkFlags {
 
 /** One entry of the v13 geometry chunk directory. */
 export interface GeometryChunkInfo {
+  /** v19 decoded header pool shared across chunks; not a directory wire field. */
+  appearanceSources?: readonly Uint32Array[];
   /** World AABB of the chunk's meshes (f32, for future priority/culling). */
   aabbMin: [number, number, number];
   aabbMax: [number, number, number];


### PR DESCRIPTION
Cached IFC geometry currently loses the canonical topology identity needed for appearance authoring. Format v19 preserves explicit canonical provenance, restores its live index identity, and stores shared source topology once across spatial chunks. Missing provenance stays missing; malformed markers, index aliases, source lengths, pool references, and corner ranges fail visibly.

Stacked on `feat/appearance-geometry-provenance-4243`, which defines the canonical geometry metadata. Refs #4243. This foundation does not close the overall authoring issue. The viewer’s existing versioned cache key causes old entries to reparse once; direct v13–v18 readers remain compatible for viewing. Texture/image caching is unchanged.

Validation:

- Root Turbo cache suite: 180 passed, 1 fixture-dependent skip, including actual v18 header compatibility, independent chunk decoding with shared source-array identity, and corrupt/truncated pool and record rejection.
- Full root typecheck: 90/90 tasks, 1,787 test sources.
- API surface matches the committed snapshot; module-size gate, touched-file oxlint, and whitespace checks pass.
- The actual IFC/WASM → binary cache → appearance planner → renderer expansion regression passed in the integrated feature tree. That test remains with the final UI bridge because its planner/renderer dependencies are outside this package stack.

Includes cache minor changeset and format/migration documentation. No normal-load geometry behavior changes and no performance improvement claim. Source-pool deduplication is verified across separately decoded spatial chunks; malformed claimed lengths cannot allocate beyond the supplied buffer.
