### PR TITLE
feat(geometry): preserve canonical triangle provenance for appearance

### DIFF
--- a/.changeset/quiet-turtles-draw.md
+++ b/.changeset/quiet-turtles-draw.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/geometry": minor
+---
+
+Preserve canonical triangle provenance on item-identified meshes extracted from WASM, allowing appearance tools to validate UV mapping against the actual source topology without copying geometry buffers.

--- a/docs/guide/geometry.md
+++ b/docs/guide/geometry.md
@@ -241,6 +241,23 @@ A material-layer slice is a fourth kind of absence with a different reading: it
 carries `materialId` instead, so the identity is present but is a material's,
 not an item's.
 
+### Canonical triangle provenance
+
+Item-identified meshes extracted from WASM carry optional `appearanceSource`
+metadata. Its `indices` reference identifies the current topology, while
+`sourceIndices` identifies the canonical unsplit triangle order. At extraction,
+both reference the existing mesh index array; no geometry buffer is copied.
+Those shared references survive worker structured clone and buffer transfer.
+
+Consumers that split triangles must carry a `cornerIndices` mapping from each
+current triangle corner to its canonical triangle corner. A consumer that
+rebuilds topology without such a mapping must discard the metadata. This is
+provenance for matching authored UVs to actual geometry, not a claim that every
+item is eligible for editing. Transports and caches must explicitly preserve
+the array identities before a downstream authoring tool can rely on them.
+Keeping a fragment may retain its original unsplit index array; callers that
+release CPU geometry must release this metadata too.
+
 ## Streaming Geometry
 
 Process geometry incrementally for large files:

--- a/packages/geometry/src/canonical-mesh-metadata.ts
+++ b/packages/geometry/src/canonical-mesh-metadata.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { MeshData } from './types.js';
+import type { EntityGeometryFingerprint } from './geometry-fingerprints.js';
+
+/** The worker and collection fallback stamp identical canonical source metadata
+ * before any renderer streaming split. Repeated array references survive clone. */
+export function attachCanonicalMeshMetadata(
+  mesh: MeshData,
+  fingerprint?: EntityGeometryFingerprint,
+): void {
+  if (mesh.geometryItemId !== undefined) {
+    mesh.appearanceSource = {
+      kind: 'canonical-item',
+      indices: mesh.indices,
+      sourceIndices: mesh.indices,
+    };
+  }
+  if (fingerprint) {
+    mesh.geometryHash = fingerprint.hash;
+    if (fingerprint.aabb) mesh.geometryAabb = fingerprint.aabb;
+    if (fingerprint.volume !== undefined) mesh.geometryVolume = fingerprint.volume;
+  }
+}

--- a/packages/geometry/src/geometry-coordinate.test.ts
+++ b/packages/geometry/src/geometry-coordinate.test.ts
@@ -311,6 +311,18 @@ describe('convertMeshCollectionToBatch', () => {
     );
 
     expect(batch[0].geometryItemId).toBe(4242);
+    // #4243: canonical extraction is the authority for vertex-order provenance.
+    expect(batch[0].appearanceSource?.kind).toBe('canonical-item');
+    expect(batch[0].appearanceSource?.indices).toBe(batch[0].indices);
+    const cloned = structuredClone(batch[0]);
+    expect(cloned.appearanceSource?.indices).toBe(cloned.indices);
+    expect(cloned.appearanceSource?.sourceIndices).toBe(cloned.indices);
+    const transferred = structuredClone(cloned, { transfer: [cloned.indices.buffer] });
+    expect(cloned.indices.byteLength).toBe(0);
+    expect(transferred.appearanceSource?.indices).toBe(transferred.indices);
+    expect(transferred.appearanceSource?.sourceIndices).toBe(transferred.indices);
+    expect(transferred.indices).toEqual(batch[0].indices);
+    expect(batch[1].appearanceSource).toBeUndefined();
     expect(batch[0].materialId).toBeUndefined();
     // Absent stays ABSENT rather than becoming a key with `undefined`: the
     // cache writer and the REST mirror both distinguish "no key" from a value,

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -10,6 +10,7 @@
  * building rotation into coordinate info.
  */
 
+import { attachCanonicalMeshMetadata } from './canonical-mesh-metadata.js';
 import type { MeshData, CoordinateInfo } from './types.js';
 import type { DynamicBatchConfig } from './index.js';
 import {
@@ -155,15 +156,7 @@ export function convertMeshCollectionToBatch(
           };
         }
 
-        // #924 / #1891: attach the per-entity geometry fingerprint — hash and,
-        // when the pass produced them, the absolute world box and the proved
-        // enclosed volume (empty Map → no-op unless geometry hashing was
-        // enabled).
-        if (fingerprint) {
-          meshData.geometryHash = fingerprint.hash;
-          if (fingerprint.aabb) meshData.geometryAabb = fingerprint.aabb;
-          if (fingerprint.volume !== undefined) meshData.geometryVolume = fingerprint.volume;
-        }
+        attachCanonicalMeshMetadata(meshData, fingerprint);
 
         batch.push(meshData);
       } finally {

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { attachCanonicalMeshMetadata } from './canonical-mesh-metadata.js';
 import { ownedWasmBuffer } from './wasm-owned-buffer.js';
 import { publishPrepassFingerprint, runPrepassWithFingerprint } from './prepass-source-fingerprint.js';
 import { canReuseWorkerSource, type SourcePrepassApi, type FinalizeStyleArgs } from './worker-prepass-source.js';
@@ -1030,15 +1031,8 @@ function collectMeshes(
           session.pendingTransfers.push(ownedWasmBuffer(uvs));
           session.cumulativeMeshBytes += uvs.byteLength;
         }
-        // #924 / #1891: attach the per-entity geometry fingerprint — hash and,
-        // when the pass produced them, the absolute world box and the proved
-        // enclosed volume. All three are plain values, so they ride structured
-        // clone, NOT pendingTransfers.
-        if (fingerprint) {
-          meshData.geometryHash = fingerprint.hash;
-          if (fingerprint.aabb) meshData.geometryAabb = fingerprint.aabb;
-          if (fingerprint.volume !== undefined) meshData.geometryVolume = fingerprint.volume;
-        }
+        attachCanonicalMeshMetadata(meshData, fingerprint);
+
         flatMeshedIds.add(mesh.expressId);
         session.pendingMeshes.push(meshData);
       } finally {

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -39,6 +39,18 @@ export interface MeshData {
    *  Do not use winding for front/back-face determination or normal-based
    *  culling. Use depth testing or `abs(dot(normal, viewDir))` for shading. */
   indices: Uint32Array;
+  /** Canonical item triangle order, stamped at WASM extraction before streaming.
+   * Rebuilt topology must discard this metadata. The repeated indices reference
+   * survives structured clone and detects replacement without hashing geometry. */
+  appearanceSource?: {
+    kind: 'canonical-item';
+    /** Identity fence for the current geometry topology. */
+    indices: Uint32Array;
+    /** Original canonical final geometry, before streaming fragments. */
+    sourceIndices: Uint32Array;
+    /** Current triangle corner -> canonical triangle corner. Absent means identity. */
+    cornerIndices?: Uint32Array;
+  };
   /** Apparent rendering colour: IfcSurfaceStyleRendering.DiffuseColour
    *  when authored, otherwise the SurfaceColour. Matches what most IFC
    *  viewers display and what the GLB exporter uses by default. */

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -27,6 +27,25 @@ scripts/perf/flame.sh tests/models/ara3d/schependomlaan.ifc
 
 Fetch a fixture first if missing: `pnpm fixtures ara3d/schependomlaan.ifc`.
 
+## Canonical appearance provenance (#4243)
+
+Item-identified geometry now retains its canonical triangle-order identity at
+WASM extraction. A production-browser worker-load A/B against the same Rust
+runtime found a small median increase within the baseline run spread on the
+public AC20-FZK-Haus fixture; this is not an optimization or a speedup claim.
+All measured geometry/color/UV fingerprints and mesh/triangle counts matched.
+The additional metadata reuses existing index arrays, with no extra geometry
+buffer or transfer at extraction. Streaming fragments can retain an unsplit
+source index array; that memory lifetime still requires explicit downstream
+ownership and large-model qualification.
+
+The measurement boundary was completed metadata plus geometry worker output,
+with fresh Chromium processes and empty model caches. It did not measure
+renderer readiness: the stock combined viewer-readiness experiment encountered
+a baseline first-load viewport initialization race. Those failed samples were
+retained and excluded, not treated as successful loads. The lesson is to name
+and qualify the measured boundary before interpreting small load-time deltas.
+
 ## The native probe (`perf_probe`)
 
 `rust/processing/examples/perf_probe.rs`, wrapped by `probe.sh`. It drains the


### PR DESCRIPTION
Meshes need their actual canonical triangle order to match authored UVs after streaming. Both WASM extraction paths now attach optional `appearanceSource` metadata to item-identified meshes, reusing the existing index array. Structured clone and buffer transfer preserve these aliases; geometry buffers are unchanged.

Refs #4243. This foundation supports the stacked renderer appearance preview and cache provenance work. It does not expose an appearance UI or establish authoring eligibility for every representation item.

Validation: root geometry tests 404/404; plain root typecheck 90/90 including all 1,786 test files. The extraction regression verifies the index identity before and after structured clone and actual transferable-buffer detachment, plus absence when no source item is known.

Performance qualification: actual production browser worker loads use frozen main/branch bundles with identical WASM bytes. The initial stock viewer-readiness experiment exposed a baseline startup race (model completion before viewport initialization), and an added post-timing capture initially encountered a harness serialization error; those samples are retained and excluded. The corrected experiment measures metadata + geometry worker completion, explicitly excluding renderer readiness. Final idle-machine A/B: five interleaved fresh Chromium processes per side on AC20-FZK-Haus. Metadata completion median 203 → 207 ms (+2.0%); geometry streaming 159 → 162 ms (+1.9%); observed metadata+worker-output readiness 220.0 → 228.6 ms (+3.9%). Base readiness ranged 204.3–228.0 ms, so this small shift is within its run spread; no speedup or zero-overhead claim. The app's rounded total is 200 ms on both sides and is too coarse for this comparison.

All ten runs preserve 275 meshes / 56,698 vertices / 31,986 triangles and identical sorted per-mesh FNV fingerprints for positions, normals, indices, UVs, color and origin. All 243 item-identified branch meshes preserve source/current index aliases after actual worker transport. Both served WASM files have SHA256 `05885c39543b70bf82d5d01cc91485ff13ae90ec9f79fed39058d4049ec0cde7`. Evidence: `/tmp/geometry-provenance-worker-ab-final/`, summary `/tmp/geometry-provenance-perf-summary.json`; initial failures remain in `/tmp/geometry-provenance-browser-ab/`. OS file-cache state was not controlled; renderer startup and large-model fragment retention remain outside this verdict.

Memory: one small metadata object per item-identified mesh; no new index buffer at extraction. Downstream streaming fragments can retain an unsplit source index array, so consumers must release provenance when releasing CPU geometry. Caches/transports must preserve the aliases before authoring can use restored meshes.
