### PR TITLE
fix(clash): fromPositions throws on an all-non-finite axis instead of returning an inverted AABB

### DIFF
--- a/.changeset/fix-clash-aabb-nan-invisible.md
+++ b/.changeset/fix-clash-aabb-nan-invisible.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/clash": patch
+---
+
+`fromPositions` (`packages/clash/src/math/aabb.ts`) — the single choke point both the STEP and IFCX clash adapters funnel through when building `ClashElement.bounds` — now throws `NonFiniteAxisError` when every vertex is non-finite on some axis, instead of returning the box inverted (`min > max`) on that axis. The inverted box looked like a safe sentinel (the function's own doc claimed it was "rejected by `boxesTouch`"), but `boxesTouch` is only reached from the duplicates pass, not from the BVH broad phase (`@ifc-lite/spatial`, via `engine-ts/broad.ts`) that hard/soft rule-based clash detection uses: there, an inverted box fails every `min <= queryMax && max >= queryMin` check, so the element silently dropped out of every spatial query it should have participated in — including the one that would have found a genuine hard clash (#4254).
+
+`elementsFromStep` (`adapters/step.ts`) and `elementsFromIfcx` (`adapters/ifcx.ts`) now catch `NonFiniteAxisError` per occurrence/entity, skip just that one (rather than aborting the whole clash run for one corrupt element among many), and emit a single `console.warn` naming the model and the count — the same shape as their existing `missingGlobalIds` warning — so a dropped element is loud and countable instead of silently invisible. Positions with only *some* non-finite coordinates are unaffected: the existing per-coordinate fold (the finite coordinate of a partly poisoned vertex still counts) is unchanged.

--- a/packages/clash/src/adapters/ifcx.test.ts
+++ b/packages/clash/src/adapters/ifcx.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { elementsFromIfcx } from './ifcx.js';
 import { createClashEngine } from '../engine.js';
 import type { ClashRule } from '../types.js';
@@ -376,5 +376,105 @@ describe('elementsFromIfcx - drops non-physical / container classes (parity with
     const keys = elements.map((e) => e.key).sort();
     expect(keys).toEqual(['Project/Storey/Wall']);
     expect(elements[0].tag).toBe('IfcWall');
+  });
+});
+
+// #4254: a mesh whose every vertex is non-finite on some axis used to produce
+// an inverted (`min > max`) AABB from `fromPositions` — sound-looking, but
+// invisible to the BVH broad phase (`engine-ts/broad.ts`), so the entity
+// silently never clashed with anything. `fromPositions` now throws
+// `NonFiniteAxisError` for that shape; this adapter catches it, drops just
+// that entity, and warns once with a count.
+function nonFiniteIfcxFile() {
+  const ifcClass = (code: string) => ({
+    code,
+    uri: `https://identifier.buildingsmart.org/uri/buildingsmart/ifc/5/class/${code}`,
+  });
+  return {
+    header: {
+      id: 'clash-ifcx-nonfinite-fixture',
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 'ifc-lite clash adapter test',
+      timestamp: '2025-01-01T00:00:00Z',
+    },
+    imports: [],
+    schemas: {
+      'bsi::ifc::class': { value: SCHEMA_VALUE },
+      'usd::usdgeom::mesh': { value: SCHEMA_VALUE },
+    },
+    data: [
+      {
+        path: 'Project',
+        attributes: { 'bsi::ifc::class': ifcClass('IfcProject') },
+        children: { WallBad: 'Project/WallBad' },
+      },
+      {
+        path: 'Project/WallBad',
+        attributes: { 'bsi::ifc::class': ifcClass('IfcWall') },
+        children: { Body: 'Project/WallBad/Body' },
+      },
+      {
+        path: 'Project/WallBad/Body',
+        attributes: {
+          'usd::usdgeom::mesh': {
+            // Every point has a non-finite x; y/z are fine — matches the
+            // #4254 repro (`fromPositions([NaN,1,1, NaN,2,2])`). Plain JSON
+            // cannot encode a literal NaN/Infinity token (`JSON.stringify`
+            // turns both into `null`), so `__INF__` below is substituted
+            // with the numeric literal `1e400` AFTER stringifying — that is
+            // syntactically an ordinary (very large) JSON number, and
+            // `JSON.parse` rounds it to `Infinity` per IEEE 754, which is
+            // just as non-finite as NaN for this guard.
+            points: [
+              ['__INF__', 0, 0], ['__INF__', 0, 0], ['__INF__', 1, 0],
+            ],
+            faceVertexIndices: [0, 1, 2],
+          },
+        },
+      },
+    ],
+  };
+}
+
+function nonFiniteIfcxBuffer(): ArrayBuffer {
+  const json = JSON.stringify(nonFiniteIfcxFile()).replaceAll('"__INF__"', '1e400');
+  return new TextEncoder().encode(json).buffer as ArrayBuffer;
+}
+
+describe('elementsFromIfcx - drops an entity with a non-finite axis (#4254)', () => {
+  it('excludes the corrupt entity and warns once, naming the model and the count', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = await elementsFromIfcx({
+        buffer: nonFiniteIfcxBuffer(),
+        modelId: 'ifcx-4254',
+      });
+      // The corrupt entity never becomes a ClashElement — never an inverted
+      // box that would silently vanish from every spatial query.
+      expect(elements).toHaveLength(0);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0].join(' ');
+      expect(msg).toContain('[clash/ifcx]');
+      expect(msg).toContain('ifcx-4254');
+      expect(msg).toContain('skipped 1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still returns a good entity elsewhere in the same file', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = await elementsFromIfcx({
+        buffer: ifcxBuffer(),
+        modelId: 'ifcx-mixed',
+      });
+      // The baseline fixture has no corrupt geometry: no warning, full set.
+      expect(elements.length).toBeGreaterThan(0);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/clash/src/adapters/ifcx.test.ts
+++ b/packages/clash/src/adapters/ifcx.test.ts
@@ -407,7 +407,10 @@ function nonFiniteIfcxFile() {
       {
         path: 'Project',
         attributes: { 'bsi::ifc::class': ifcClass('IfcProject') },
-        children: { WallBad: 'Project/WallBad' },
+        children: {
+          WallBad: 'Project/WallBad',
+          WallGood: 'Project/WallGood',
+        },
       },
       {
         path: 'Project/WallBad',
@@ -433,6 +436,15 @@ function nonFiniteIfcxFile() {
           },
         },
       },
+      {
+        path: 'Project/WallGood',
+        attributes: { 'bsi::ifc::class': ifcClass('IfcWall') },
+        children: { Body: 'Project/WallGood/Body' },
+      },
+      {
+        path: 'Project/WallGood/Body',
+        attributes: { 'usd::usdgeom::mesh': cubeMesh(10, 0, 0, 1) },
+      },
     ],
   };
 }
@@ -452,7 +464,9 @@ describe('elementsFromIfcx - drops an entity with a non-finite axis (#4254)', ()
       });
       // The corrupt entity never becomes a ClashElement — never an inverted
       // box that would silently vanish from every spatial query.
-      expect(elements).toHaveLength(0);
+      expect(elements).toHaveLength(1);
+      expect(elements[0].key).toBe('Project/WallGood');
+      expect(elements[0].tag).toBe('IfcWall');
       expect(warn).toHaveBeenCalledTimes(1);
       const msg = warn.mock.calls[0].join(' ');
       expect(msg).toContain('[clash/ifcx]');
@@ -463,18 +477,4 @@ describe('elementsFromIfcx - drops an entity with a non-finite axis (#4254)', ()
     }
   });
 
-  it('still returns a good entity elsewhere in the same file', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      const { elements } = await elementsFromIfcx({
-        buffer: ifcxBuffer(),
-        modelId: 'ifcx-mixed',
-      });
-      // The baseline fixture has no corrupt geometry: no warning, full set.
-      expect(elements.length).toBeGreaterThan(0);
-      expect(warn).not.toHaveBeenCalled();
-    } finally {
-      warn.mockRestore();
-    }
-  });
 });

--- a/packages/clash/src/adapters/ifcx.ts
+++ b/packages/clash/src/adapters/ifcx.ts
@@ -45,7 +45,7 @@
 
 import { parseIfcx, type MeshData } from '@ifc-lite/ifcx';
 import { makeExclusionSet, qualifiedKey } from '../exclude.js';
-import { fromPositions } from '../math/aabb.js';
+import { fromPositions, NonFiniteAxisError } from '../math/aabb.js';
 import type { ClashElement, ExclusionSet } from '../types.js';
 import { isNonClashableTag, mergeMeshes } from './shared.js';
 
@@ -115,6 +115,9 @@ export async function elementsFromIfcx(options: IfcxAdapterOptions): Promise<Ifc
 
   const elements: ClashElement[] = [];
   const byExpressId = new Map<number, ClashElement>();
+  /** Entities dropped because every vertex was non-finite on some axis — see
+   *  the warning below and {@link NonFiniteAxisError}'s doc (#4254). */
+  let nonFiniteBoundsSkipped = 0;
 
   for (const [expressId, group] of groups) {
     // The prim path is the durable USD identity; skip entities we cannot key.
@@ -132,19 +135,47 @@ export async function elementsFromIfcx(options: IfcxAdapterOptions): Promise<Ifc
 
     const merged = mergeMeshes(group);
 
+    // A corrupt mesh (every vertex non-finite on one axis) has no usable
+    // AABB — see `NonFiniteAxisError`. Skip just this entity rather than
+    // letting it in with an inverted box that would silently vanish from
+    // every later spatial query (#4254), and rather than aborting the whole
+    // clash run for one corrupt entity among many.
+    let bounds;
+    try {
+      bounds = fromPositions(merged.positions);
+    } catch (err) {
+      if (err instanceof NonFiniteAxisError) {
+        nonFiniteBoundsSkipped += 1;
+        continue;
+      }
+      throw err;
+    }
+
     const element: ClashElement = {
       key,
       ref: refFromPath(key),
       model: modelId,
       tag,
       name: resolveName(entities, expressId),
-      bounds: fromPositions(merged.positions),
+      bounds,
       positions: merged.positions,
       indices: merged.indices,
     };
 
     elements.push(element);
     byExpressId.set(expressId, element);
+  }
+
+  // Loud by construction: unlike the near-silent inverted box this replaces
+  // (#4254), a dropped entity is counted and named here rather than shipping
+  // in the result set invisible to every spatial query.
+  if (nonFiniteBoundsSkipped > 0) {
+    console.warn(
+      `[clash/ifcx] skipped ${nonFiniteBoundsSkipped} entity(ies) in model "${modelId}": every ` +
+        'vertex was non-finite on at least one axis, so no usable AABB could be computed. These ' +
+        'entities are excluded from clash detection entirely rather than participating with a ' +
+        'corrupt bound.',
+    );
   }
 
   const exclusions = buildExclusions

--- a/packages/clash/src/adapters/step-exclusions.ts
+++ b/packages/clash/src/adapters/step-exclusions.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Void/host/assembly pair exclusions from IFC relationships, precomputed by
+ * `elementsFromStep` (`./step.ts`) and re-exported from that module's
+ * `@ifc-lite/clash/step` subpath — split out here purely to keep `step.ts`
+ * under its module-size budget. `buildStepExclusions` only ever runs against
+ * the `byExpressId` map `elementsFromStep` builds, so it stays a sibling of
+ * that function rather than a general-purpose export.
+ */
+
+import { type IfcDataStore } from '@ifc-lite/parser';
+import { EntityNode } from '@ifc-lite/query';
+import { makeExclusionSet, qualifiedKey } from '../exclude.js';
+import type { ClashElement, ExclusionSet } from '../types.js';
+
+/**
+ * Pair-exclusions from IFC relationships. Only relationship getters
+ * (`voids`/`filledBy`/`decomposedBy`/`decomposes`) are used here; these read
+ * the relationship graph and never call `extractEntityAttributesOnDemand`, so
+ * the per-element loop stays off the AGENTS.md hot-loop anti-pattern:
+ * - host vs the filler of its opening (wall vs door/window)
+ * - element vs its own (meshed) opening
+ * - members of the same `IfcRelAggregates` assembly
+ */
+export function buildStepExclusions(
+  store: IfcDataStore,
+  byExpressId: Map<number, ClashElement[]>,
+): ExclusionSet {
+  const pairs: Array<[string, string]> = [];
+
+  for (const [expressId, elementsAtId] of byExpressId) {
+    const node = new EntityNode(store, expressId);
+
+    // A relationship is stated between EXPRESS ids, not occurrences: fan it
+    // out across every occurrence bucketed at each side (usually one element
+    // each; more than one only for a GPU-instanced expressId), so a host's
+    // void/assembly exclusions cover every physical placement of the
+    // filler/sibling, not just whichever occurrence happened to be built last.
+    const pairAll = (otherId: number): void => {
+      const others = byExpressId.get(otherId);
+      if (!others) return;
+      for (const a of elementsAtId) {
+        const ek = qualifiedKey(a.model, a.key);
+        for (const b of others) {
+          pairs.push([ek, qualifiedKey(b.model, b.key)]);
+        }
+      }
+    };
+
+    for (const opening of node.voids()) {
+      pairAll(opening.expressId);
+      for (const filler of opening.filledBy()) {
+        pairAll(filler.expressId);
+      }
+    }
+
+    const parent = node.decomposedBy();
+    if (parent) {
+      for (const sibling of parent.decomposes()) {
+        if (sibling.expressId === expressId) continue;
+        pairAll(sibling.expressId);
+      }
+    }
+  }
+
+  return makeExclusionSet(pairs);
+}

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -563,6 +563,75 @@ describe('elementsFromStep - total GlobalId miss warning', () => {
   });
 });
 
+// #4254: a mesh whose every vertex is non-finite on some axis used to produce
+// an inverted (`min > max`) AABB — sound-looking, but invisible to the BVH
+// broad phase (`engine-ts/broad.ts`), so the element silently never clashed
+// with anything. `fromPositions` now throws `NonFiniteAxisError` for that
+// shape; the adapter catches it, drops just that occurrence, and warns once
+// with a count — the same shape as the GlobalId-miss warning above.
+function nonFiniteAxisMesh(expressId: number): MeshData {
+  const positions = new Float32Array([
+    NaN, 1, 1, NaN, 2, 2, NaN, 2, 1,
+  ]);
+  return {
+    expressId,
+    ifcType: 'IfcWall',
+    positions,
+    normals: new Float32Array(positions.length),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0.5, 0.5, 0.5, 1],
+  };
+}
+
+describe('elementsFromStep - drops an occurrence with a non-finite axis (#4254)', () => {
+  it('excludes the corrupt occurrence and warns once, naming the model and the count', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(WALL_AND_SPACE_IFC).buffer as ArrayBuffer,
+    );
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = elementsFromStep({
+        store,
+        meshes: [nonFiniteAxisMesh(wallId)],
+        modelId: 'model-4254',
+      });
+      // The corrupt occurrence never becomes a ClashElement — never an
+      // inverted box that would silently vanish from every spatial query.
+      expect(elements).toHaveLength(0);
+      expect(warn).toHaveBeenCalledTimes(1);
+      const msg = warn.mock.calls[0].join(' ');
+      expect(msg).toContain('[clash/step]');
+      expect(msg).toContain('model-4254');
+      expect(msg).toContain('skipped 1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still returns the good occurrence when only one of several is corrupt', async () => {
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(STOREY_WITH_GEOMETRY_IFC).buffer as ArrayBuffer,
+    );
+    const slabId = (store.entityIndex.byType.get('IFCSLAB') ?? [])[0];
+    const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { elements } = elementsFromStep({
+        store,
+        meshes: [nonFiniteAxisMesh(slabId), solidBoxMesh(wallId, 0.5)],
+        modelId: 'model-4254-mixed',
+      });
+      expect(elements).toHaveLength(1);
+      expect(elements[0].tag).toBe('IfcWall');
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0].join(' ')).toContain('skipped 1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
 /**
  * The SYNTHETIC FALLBACK KEY has to be unique per model.
  *

--- a/packages/clash/src/adapters/step.test.ts
+++ b/packages/clash/src/adapters/step.test.ts
@@ -613,19 +613,25 @@ describe('elementsFromStep - drops an occurrence with a non-finite axis (#4254)'
     const store = await new IfcParser().parseColumnar(
       new TextEncoder().encode(STOREY_WITH_GEOMETRY_IFC).buffer as ArrayBuffer,
     );
-    const slabId = (store.entityIndex.byType.get('IFCSLAB') ?? [])[0];
     const wallId = (store.entityIndex.byType.get('IFCWALL') ?? [])[0];
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       const { elements } = elementsFromStep({
         store,
-        meshes: [nonFiniteAxisMesh(slabId), solidBoxMesh(wallId, 0.5)],
+        // The corrupt occurrence deliberately does not exist in the store and
+        // therefore has no GlobalId. It must not contribute to the accounting
+        // for the one valid element that is actually returned.
+        meshes: [nonFiniteAxisMesh(999_999), solidBoxMesh(wallId, 0.5)],
         modelId: 'model-4254-mixed',
       });
       expect(elements).toHaveLength(1);
       expect(elements[0].tag).toBe('IfcWall');
       expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn.mock.calls[0].join(' ')).toContain('skipped 1');
+      const msg = warn.mock.calls[0].join(' ');
+      expect(msg).toContain('[clash/step]');
+      expect(msg).toContain('model-4254-mixed');
+      expect(msg).toContain('skipped 1');
+      expect(msg).not.toContain('every element');
     } finally {
       warn.mockRestore();
     }

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -18,7 +18,7 @@ import { type IfcDataStore } from '@ifc-lite/parser';
 import { EntityNode } from '@ifc-lite/query';
 import type { MeshData } from '@ifc-lite/geometry';
 import { makeExclusionSet, qualifiedKey } from '../exclude.js';
-import { fromPositions } from '../math/aabb.js';
+import { fromPositions, NonFiniteAxisError } from '../math/aabb.js';
 import type { ClashElement, ExclusionSet, Mat4 } from '../types.js';
 import { isNonClashableTag, mergeMeshes } from './shared.js';
 
@@ -193,6 +193,9 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
   const byExpressId = new Map<number, ClashElement[]>();
   /** Elements whose GlobalId lookup came back empty — see the check below. */
   let missingGlobalIds = 0;
+  /** Occurrences dropped because every vertex was non-finite on some axis —
+   *  see the warning below and {@link NonFiniteAxisError}'s doc (#4254). */
+  let nonFiniteBoundsSkipped = 0;
 
   // Pass 1: group every mesh by its OWNING OCCURRENCE — `occurrenceKey` when
   // present (a GPU-instanced entity's individual placement), else the bare
@@ -290,6 +293,23 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     const key = occurrenceKey ? `${baseKey}:${occurrenceKey}` : baseKey;
     if (!storedGlobalId) missingGlobalIds += 1;
 
+    // A corrupt mesh (every vertex non-finite on one axis, e.g. a NaN'd
+    // transform or a malformed source file) has no usable AABB — see
+    // `NonFiniteAxisError`. Skip just this occurrence rather than letting it
+    // in with an inverted box that would silently vanish from every later
+    // spatial query (#4254), and rather than aborting the whole clash run
+    // for one corrupt element among many.
+    let bounds;
+    try {
+      bounds = fromPositions(merged.positions, worldTransform);
+    } catch (err) {
+      if (err instanceof NonFiniteAxisError) {
+        nonFiniteBoundsSkipped += 1;
+        continue;
+      }
+      throw err;
+    }
+
     const element: ClashElement = {
       key,
       // `expressId` is local here, so the offset is applied exactly ONCE and
@@ -305,7 +325,7 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
       tag,
       name: storedName || undefined,
       storey: node.storey()?.name || undefined,
-      bounds: fromPositions(merged.positions, worldTransform),
+      bounds,
       positions: merged.positions,
       indices: merged.indices,
       transform: worldTransform,
@@ -350,6 +370,18 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
         'match the shift the host applied to `mesh.expressId`, so the store is being addressed ' +
         'with ids it does not contain — element keys, names and the void/host exclusions are ' +
         'all degraded.',
+    );
+  }
+
+  // Loud by construction: unlike the near-silent inverted box this replaces
+  // (#4254), a dropped occurrence is counted and named here rather than
+  // shipping in the result set invisible to every spatial query.
+  if (nonFiniteBoundsSkipped > 0) {
+    console.warn(
+      `[clash/step] skipped ${nonFiniteBoundsSkipped} occurrence(s) in model "${modelId}": ` +
+        'every vertex was non-finite on at least one axis after the world transform, so no ' +
+        'usable AABB could be computed. These occurrences are excluded from clash detection ' +
+        'entirely rather than participating with a corrupt bound.',
     );
   }
 

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -17,10 +17,11 @@
 import { type IfcDataStore } from '@ifc-lite/parser';
 import { EntityNode } from '@ifc-lite/query';
 import type { MeshData } from '@ifc-lite/geometry';
-import { makeExclusionSet, qualifiedKey } from '../exclude.js';
+import { makeExclusionSet } from '../exclude.js';
 import { fromPositions, NonFiniteAxisError } from '../math/aabb.js';
 import type { ClashElement, ExclusionSet, Mat4 } from '../types.js';
 import { isNonClashableTag, mergeMeshes } from './shared.js';
+import { buildStepExclusions } from './step-exclusions.js';
 
 /** Minimal federation contract — pass an `@ifc-lite/renderer` `FederationRegistry`. */
 export interface FederationLike {
@@ -392,55 +393,7 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
   return { elements, exclusions };
 }
 
-/**
- * Pair-exclusions from IFC relationships. Only relationship getters
- * (`voids`/`filledBy`/`decomposedBy`/`decomposes`) are used here; these read
- * the relationship graph and never call `extractEntityAttributesOnDemand`, so
- * the per-element loop stays off the AGENTS.md hot-loop anti-pattern:
- * - host vs the filler of its opening (wall vs door/window)
- * - element vs its own (meshed) opening
- * - members of the same `IfcRelAggregates` assembly
- */
-export function buildStepExclusions(
-  store: IfcDataStore,
-  byExpressId: Map<number, ClashElement[]>,
-): ExclusionSet {
-  const pairs: Array<[string, string]> = [];
-
-  for (const [expressId, elementsAtId] of byExpressId) {
-    const node = new EntityNode(store, expressId);
-
-    // A relationship is stated between EXPRESS ids, not occurrences: fan it
-    // out across every occurrence bucketed at each side (usually one element
-    // each; more than one only for a GPU-instanced expressId), so a host's
-    // void/assembly exclusions cover every physical placement of the
-    // filler/sibling, not just whichever occurrence happened to be built last.
-    const pairAll = (otherId: number): void => {
-      const others = byExpressId.get(otherId);
-      if (!others) return;
-      for (const a of elementsAtId) {
-        const ek = qualifiedKey(a.model, a.key);
-        for (const b of others) {
-          pairs.push([ek, qualifiedKey(b.model, b.key)]);
-        }
-      }
-    };
-
-    for (const opening of node.voids()) {
-      pairAll(opening.expressId);
-      for (const filler of opening.filledBy()) {
-        pairAll(filler.expressId);
-      }
-    }
-
-    const parent = node.decomposedBy();
-    if (parent) {
-      for (const sibling of parent.decomposes()) {
-        if (sibling.expressId === expressId) continue;
-        pairAll(sibling.expressId);
-      }
-    }
-  }
-
-  return makeExclusionSet(pairs);
-}
+// Pair-exclusions from IFC relationships (voids/filledBy/decomposedBy/decomposes)
+// live in `./step-exclusions.js`, split out purely to keep this file under its
+// module-size budget; re-exported here so `@ifc-lite/clash/step` is unchanged.
+export { buildStepExclusions } from './step-exclusions.js';

--- a/packages/clash/src/adapters/step.ts
+++ b/packages/clash/src/adapters/step.ts
@@ -292,8 +292,6 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
     // onto one review/exclusion key. Flat meshes are unaffected (occurrenceKey
     // absent, one bucket per expressId as before).
     const key = occurrenceKey ? `${baseKey}:${occurrenceKey}` : baseKey;
-    if (!storedGlobalId) missingGlobalIds += 1;
-
     // A corrupt mesh (every vertex non-finite on one axis, e.g. a NaN'd
     // transform or a malformed source file) has no usable AABB — see
     // `NonFiniteAxisError`. Skip just this occurrence rather than letting it
@@ -310,6 +308,9 @@ export function elementsFromStep(options: StepAdapterOptions): StepAdapterResult
       }
       throw err;
     }
+
+    // Count only occurrences that survive bounds validation and are returned.
+    if (!storedGlobalId) missingGlobalIds += 1;
 
     const element: ClashElement = {
       key,

--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -7,7 +7,6 @@ import { findDuplicates } from './duplicates.js';
 import { groupClashes } from './grouping.js';
 import { groupDuplicateSets } from './duplicate-sets.js';
 import { makeExclusionSet, qualifiedKey } from './exclude.js';
-import { fromPositions } from './math/aabb.js';
 import type { ClashElement, Vec3 } from './types.js';
 
 let nextRef = 1;
@@ -585,14 +584,17 @@ describe('findDuplicates', () => {
     });
     expect(findDuplicates(withNaN).clashes).toHaveLength(pairs);
 
-    // The `fromPositions` guard does not make this unreachable. When no vertex
-    // is finite on an axis it returns the box INVERTED (min `+Infinity`, max
-    // `-Infinity`) so `boxesTouch` rejects it — a sound bound, but still a
-    // non-finite minimum, and `Infinity - Infinity` is NaN too. Two such
-    // elements are enough, and they come through the adapters, not the SDK.
+    // `fromPositions` itself can no longer produce this: an axis with no
+    // finite vertex now throws `NonFiniteAxisError` (#4254), and both
+    // adapters catch it and drop the element before it ever reaches here. An
+    // inverted (min `+Infinity`, max `-Infinity`) bound is still reachable
+    // the same way plain NaN bounds are above — an SDK caller building
+    // `ClashElement.bounds` by hand — so the sweep still has to tolerate it:
+    // still a non-finite minimum, and `Infinity - Infinity` is NaN too. Two
+    // such elements are enough.
     const inverted = (key: string): ClashElement => ({
       key, ref: nextRef++, model: 'm', tag: 'IfcWall',
-      bounds: fromPositions(new Float32Array([NaN, NaN, NaN, NaN, NaN, NaN])),
+      bounds: { min: [Infinity, Infinity, Infinity], max: [-Infinity, -Infinity, -Infinity] },
       positions: new Float32Array(0), indices: new Uint32Array(0),
     });
     expect(Number.isFinite(inverted('probe').bounds.min[0])).toBe(false);

--- a/packages/clash/src/duplicates.ts
+++ b/packages/clash/src/duplicates.ts
@@ -383,13 +383,10 @@ export function findDuplicates(elements: ClashElement[], options: DuplicateOptio
   }
 
   // The sweep key must be a TOTAL order, so it is compared, never subtracted.
-  // `a - b` returns NaN for any pair involving a non-finite minimum — e.g. NaN
-  // or an inverted (`min > max`) bound handed in directly by an SDK caller
-  // that built `ClashElement.bounds` itself rather than via `fromPositions`
-  // (which now throws `NonFiniteAxisError` instead of ever returning such a
-  // box — see its doc, #4254). This sweep still has to tolerate one arriving
-  // by hand: a comparator that answers NaN violates the contract `Array.
-  // prototype.sort` requires, and V8's
+  // `a - b` returns NaN for any pair involving a non-finite minimum — a NaN or inverted
+  // (`min > max`) bound, built by hand rather than via `fromPositions` (which now throws
+  // `NonFiniteAxisError` instead — see its doc, #4254), can still reach here. A comparator
+  // that answers NaN violates the contract `Array.prototype.sort` requires, and V8's
   // TimSort then merges runs against that answer and emits an arbitrary
   // permutation of the WHOLE array: the sweep's eviction sees minima going
   // backwards, drops boxes that are still live, and real duplicates elsewhere in

--- a/packages/clash/src/duplicates.ts
+++ b/packages/clash/src/duplicates.ts
@@ -383,10 +383,13 @@ export function findDuplicates(elements: ClashElement[], options: DuplicateOptio
   }
 
   // The sweep key must be a TOTAL order, so it is compared, never subtracted.
-  // `a - b` returns NaN for any pair involving a non-finite minimum — NaN bounds
-  // from a direct SDK caller, and `+Infinity` from `fromPositions` when no vertex
-  // on an axis was finite (it returns the box inverted). A comparator that
-  // answers NaN violates the contract `Array.prototype.sort` requires, and V8's
+  // `a - b` returns NaN for any pair involving a non-finite minimum — e.g. NaN
+  // or an inverted (`min > max`) bound handed in directly by an SDK caller
+  // that built `ClashElement.bounds` itself rather than via `fromPositions`
+  // (which now throws `NonFiniteAxisError` instead of ever returning such a
+  // box — see its doc, #4254). This sweep still has to tolerate one arriving
+  // by hand: a comparator that answers NaN violates the contract `Array.
+  // prototype.sort` requires, and V8's
   // TimSort then merges runs against that answer and emits an arbitrary
   // permutation of the WHOLE array: the sweep's eviction sees minima going
   // backwards, drops boxes that are still live, and real duplicates elsewhere in

--- a/packages/clash/src/math/aabb.test.ts
+++ b/packages/clash/src/math/aabb.test.ts
@@ -19,6 +19,7 @@ import {
   fromPositions,
   inflate,
   intersects,
+  NonFiniteAxisError,
   overlapBounds,
   signedGap,
 } from './aabb.js';
@@ -188,6 +189,30 @@ describe('fromPositions', () => {
     expect(r).toEqual(box(0, 0, 0, 1, 2, 1));
     expect(r.min.every(Number.isFinite)).toBe(true);
     expect(r.max.every(Number.isFinite)).toBe(true);
+  });
+
+  it('throws NonFiniteAxisError naming the axis when NO vertex is finite on it, instead of returning an inverted box', () => {
+    // #4254: every vertex NaN on x, y/z fine. The old behaviour returned the
+    // box inverted on x (min +Infinity, max -Infinity) — sound-looking, but
+    // invisible to `@ifc-lite/spatial`'s `BVH.build`/`queryAABB`, which has
+    // no `min <= max` check on the path `engine-ts/broad.ts` reaches.
+    const p = new Float32Array([NaN, 1, 1, NaN, 2, 2]);
+    expect(() => fromPositions(p)).toThrow(NonFiniteAxisError);
+    expect(() => fromPositions(p)).toThrow(/axis x/);
+    expect(() => fromPositions(p)).toThrow(/2 vertices scanned/);
+  });
+
+  it('names every bad axis when all three are non-finite on every vertex', () => {
+    const p = new Float32Array([NaN, NaN, NaN, NaN, NaN, NaN]);
+    expect(() => fromPositions(p)).toThrow(/axis x, y, z/);
+  });
+
+  it('does NOT throw when every axis still has at least one finite vertex (partial poisoning survives)', () => {
+    // Companion to "drops non-finite coordinates..." above: the throw is
+    // scoped to an axis with ZERO finite contributions, not triggered by any
+    // non-finite coordinate appearing anywhere in the buffer.
+    const p = new Float32Array([0, 0, 0, 1, 1, 1, -Infinity, 2, Infinity]);
+    expect(() => fromPositions(p)).not.toThrow();
   });
 
   it('drops a coordinate the transform sends to ±Infinity', () => {

--- a/packages/clash/src/math/aabb.ts
+++ b/packages/clash/src/math/aabb.ts
@@ -25,14 +25,54 @@ function applyMat4(m: Mat4, x: number, y: number, z: number): Vec3 {
 }
 
 /**
+ * Thrown by {@link fromPositions} when every vertex is non-finite on at least
+ * one axis, so the axis has nothing finite to bound. Returning the box
+ * inverted (`min > max`) on that axis — as older revisions of this function
+ * did — is not a safe fallback: `boxesTouch` (`duplicate-metric.ts`) is only
+ * reached from the duplicates pass, not from the BVH broad phase
+ * (`@ifc-lite/spatial`) that `engine-ts/broad.ts` builds from `ClashElement.
+ * bounds`. There, an inverted box fails `min <= queryMax && max >= queryMin`
+ * on every query, so the element silently drops out of every spatial query —
+ * including the ones that would have found a genuine hard clash (#4254).
+ * Callers own the recovery: {@link fromPositions} cannot skip-and-report on
+ * its own (it has no element identity), so `step.ts` / `ifcx.ts` catch this,
+ * skip the one occurrence, and count+warn — the same shape as their existing
+ * `missingGlobalIds` handling — rather than aborting the whole clash run for
+ * one corrupt element among many.
+ */
+export class NonFiniteAxisError extends Error {
+  readonly axes: readonly ('x' | 'y' | 'z')[];
+  readonly vertexCount: number;
+
+  constructor(axes: readonly ('x' | 'y' | 'z')[], vertexCount: number) {
+    super(
+      `fromPositions: every vertex is non-finite on axis ${axes.join(', ')} ` +
+        `(${vertexCount} vertices scanned) — refusing to return an inverted ` +
+        `(min > max) box, which would silently drop this geometry from every ` +
+        `spatial query`,
+    );
+    this.name = 'NonFiniteAxisError';
+    this.axes = axes;
+    this.vertexCount = vertexCount;
+  }
+}
+
+/**
  * Axis-aligned bounds of a packed `[x,y,z,...]` position buffer.
  *
  * Non-finite coordinates (NaN and ±Infinity, checked after `transform` is
  * applied) never become bounds: an infinite bound makes `boxDistance` return
- * NaN, and a NaN distance passes every comparison-shaped gate downstream. If
- * NO vertex contributes a finite coordinate on an axis, the box is returned
- * inverted (`min > max`) on that axis, which is rejected by `boxesTouch`
- * rather than silently paired.
+ * NaN, and a NaN distance passes every comparison-shaped gate downstream. The
+ * finite coordinates of a partly poisoned vertex still count — the rule is
+ * per coordinate, not per vertex.
+ *
+ * If NO vertex contributes a finite coordinate on some axis, there is no
+ * finite bound to report on that axis at all: this throws
+ * {@link NonFiniteAxisError} naming the axis rather than returning the box
+ * inverted (`min > max`) on it. An inverted box is not "rejected" anywhere on
+ * the path that matters — `@ifc-lite/spatial`'s `BVH.build`/`queryAABB`
+ * (reached via `engine-ts/broad.ts`) has no such check, so it would silently
+ * make the element invisible to every spatial query instead (#4254).
  */
 export function fromPositions(positions: Float32Array, transform?: Mat4): AABB {
   if (positions.length < 3) {
@@ -68,6 +108,17 @@ export function fromPositions(positions: Float32Array, transform?: Mat4): AABB {
       if (z < minZ) minZ = z;
       if (z > maxZ) maxZ = z;
     }
+  }
+  // minX/maxX (etc.) only ever move together: the first finite coordinate
+  // seen on an axis sets both `< minX` and `> maxX` against itself, so a
+  // sentinel still sitting at ±Infinity here means NOT ONE vertex contributed
+  // a finite value on that axis — checking `min` alone is exhaustive.
+  const badAxes: ('x' | 'y' | 'z')[] = [];
+  if (minX === Infinity) badAxes.push('x');
+  if (minY === Infinity) badAxes.push('y');
+  if (minZ === Infinity) badAxes.push('z');
+  if (badAxes.length > 0) {
+    throw new NonFiniteAxisError(badAxes, Math.floor(positions.length / 3));
   }
   return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
 }

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -48,32 +48,30 @@
    428 apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
    531 apps/viewer/src/components/viewer/BCFPanel.tsx
   1061 apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
-   430 apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
    487 apps/viewer/src/components/viewer/CesiumOverlay.tsx
   1098 apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
    418 apps/viewer/src/components/viewer/chat/ExecutableCodeBlock.tsx
   1802 apps/viewer/src/components/viewer/ChatPanel.tsx
-  1314 apps/viewer/src/components/viewer/ClashPanel.tsx
-   752 apps/viewer/src/components/viewer/CommandPalette.tsx
+  1312 apps/viewer/src/components/viewer/ClashPanel.tsx
+   751 apps/viewer/src/components/viewer/CommandPalette.tsx
    410 apps/viewer/src/components/viewer/ComparePanel.tsx
   1059 apps/viewer/src/components/viewer/DataConnector.tsx
-  1842 apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+  1752 apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
    536 apps/viewer/src/components/viewer/DrawingSettingsPanel.tsx
    426 apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
    583 apps/viewer/src/components/viewer/EntityContextMenu.tsx
-   863 apps/viewer/src/components/viewer/ExportDialog.tsx
+   859 apps/viewer/src/components/viewer/ExportDialog.tsx
    531 apps/viewer/src/components/viewer/GLBExportDialog.tsx
   1424 apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
    435 apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
   1155 apps/viewer/src/components/viewer/HierarchyPanel.tsx
-  1198 apps/viewer/src/components/viewer/IDSPanel.tsx
+  1119 apps/viewer/src/components/viewer/IDSPanel.tsx
    569 apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
    534 apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
-  1714 apps/viewer/src/components/viewer/LensPanel.tsx
+  1709 apps/viewer/src/components/viewer/LensPanel.tsx
   1465 apps/viewer/src/components/viewer/lists/ListBuilder.tsx
-   622 apps/viewer/src/components/viewer/lists/ListPanel.tsx
    548 apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
-  1165 apps/viewer/src/components/viewer/MainToolbar.tsx
+  1139 apps/viewer/src/components/viewer/MainToolbar.tsx
    715 apps/viewer/src/components/viewer/measureHandlers.ts
    407 apps/viewer/src/components/viewer/PdfViewExportDialog.tsx
    574 apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -83,7 +81,7 @@
    417 apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
    510 apps/viewer/src/components/viewer/properties/TaskEditCard.tsx
   2146 apps/viewer/src/components/viewer/PropertiesPanel.tsx
-  1731 apps/viewer/src/components/viewer/PropertyEditor.tsx
+  1729 apps/viewer/src/components/viewer/PropertyEditor.tsx
    542 apps/viewer/src/components/viewer/schedule/AnimationSettingsPopover.tsx
    426 apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx
    648 apps/viewer/src/components/viewer/schedule/generate-schedule.ts
@@ -91,48 +89,47 @@
    488 apps/viewer/src/components/viewer/schedule/schedule-animator.ts
    701 apps/viewer/src/components/viewer/ScriptPanel.tsx
    734 apps/viewer/src/components/viewer/SearchInline.tsx
-   534 apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
-   862 apps/viewer/src/components/viewer/SearchModal.filter.tsx
+   509 apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
+   859 apps/viewer/src/components/viewer/SearchModal.filter.tsx
    404 apps/viewer/src/components/viewer/SearchModal.text.tsx
-  1367 apps/viewer/src/components/viewer/Section2DPanel.tsx
+  1348 apps/viewer/src/components/viewer/Section2DPanel.tsx
   1094 apps/viewer/src/components/viewer/selectionHandlers.ts
    502 apps/viewer/src/components/viewer/SheetSetupPanel.tsx
    437 apps/viewer/src/components/viewer/TitleBlockEditor.tsx
    581 apps/viewer/src/components/viewer/tools/AddElementOverlay.tsx
    501 apps/viewer/src/components/viewer/tools/measure-modes/radius.ts
    869 apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
-   760 apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+   755 apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
    694 apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
    436 apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
   1510 apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
    406 apps/viewer/src/components/viewer/useAnimationLoop.ts
-   981 apps/viewer/src/components/viewer/useGeometryStreaming.ts
+   980 apps/viewer/src/components/viewer/useGeometryStreaming.ts
    946 apps/viewer/src/components/viewer/useMouseControls.ts
    782 apps/viewer/src/components/viewer/ViewerLayout.tsx
-  1843 apps/viewer/src/components/viewer/Viewport.tsx
-  1539 apps/viewer/src/components/viewer/ViewportContainer.tsx
+  1819 apps/viewer/src/components/viewer/Viewport.tsx
+  1382 apps/viewer/src/components/viewer/ViewportContainer.tsx
    511 apps/viewer/src/components/viewer/ZonesPanel.tsx
    862 apps/viewer/src/hooks/ids/idsExportService.ts
    598 apps/viewer/src/hooks/ingest/federationAlign.ts
-   458 apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
-   545 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
-   551 apps/viewer/src/hooks/useAnnotation2D.ts
+   525 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
+   461 apps/viewer/src/hooks/useAnnotation2D.ts
    690 apps/viewer/src/hooks/useBCF.ts
-  1374 apps/viewer/src/hooks/useClash.ts
+  1358 apps/viewer/src/hooks/useClash.ts
    482 apps/viewer/src/hooks/useCompare.ts
-  1359 apps/viewer/src/hooks/useDrawingExport.ts
-  1036 apps/viewer/src/hooks/useDrawingGeneration.ts
-  1416 apps/viewer/src/hooks/useIDS.ts
+  1353 apps/viewer/src/hooks/useDrawingExport.ts
+  1029 apps/viewer/src/hooks/useDrawingGeneration.ts
+  1226 apps/viewer/src/hooks/useIDS.ts
    586 apps/viewer/src/hooks/useIfcCache.ts
-   681 apps/viewer/src/hooks/useIfcFederation.ts
-  2240 apps/viewer/src/hooks/useIfcLoader.ts
+   667 apps/viewer/src/hooks/useIfcFederation.ts
+  2245 apps/viewer/src/hooks/useIfcLoader.ts
    436 apps/viewer/src/hooks/useIfcServer.ts
-   488 apps/viewer/src/hooks/useKeyboardShortcuts.ts
-   496 apps/viewer/src/hooks/useSymbolicAnnotations.ts
+   483 apps/viewer/src/hooks/useKeyboardShortcuts.ts
+   493 apps/viewer/src/hooks/useSymbolicAnnotations.ts
    633 apps/viewer/src/lib/analytics-scrub.ts
    627 apps/viewer/src/lib/clash/persistence.ts
-   427 apps/viewer/src/lib/collab/geometry-sync.ts
-   445 apps/viewer/src/lib/compare/buildFingerprints.ts
+   419 apps/viewer/src/lib/collab/geometry-sync.ts
+   441 apps/viewer/src/lib/compare/buildFingerprints.ts
    436 apps/viewer/src/lib/compare/worldPlacement.ts
    417 apps/viewer/src/lib/export/model-changes.ts
    501 apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -147,9 +144,8 @@
   1141 apps/viewer/src/lib/llm/script-preflight.ts
    410 apps/viewer/src/lib/llm/stream-client.ts
    809 apps/viewer/src/lib/llm/system-prompt.ts
-   403 apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
    491 apps/viewer/src/lib/scripts/templates/create-building.ts
-   663 apps/viewer/src/lib/search/filter-evaluate.ts
+   598 apps/viewer/src/lib/search/filter-evaluate.ts
    450 apps/viewer/src/lib/search/tier1-index.ts
    452 apps/viewer/src/lib/slab-edit.ts
    412 apps/viewer/src/lib/sources/persistence.ts
@@ -159,49 +155,48 @@
    561 apps/viewer/src/services/ifc-cache.ts
    581 apps/viewer/src/store/basketVisibleSet.ts
    485 apps/viewer/src/store/constants.ts
-   581 apps/viewer/src/store/index.ts
+   579 apps/viewer/src/store/index.ts
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    992 apps/viewer/src/store/slices/clashSlice.ts
-  1599 apps/viewer/src/store/slices/collabSlice.ts
+  1598 apps/viewer/src/store/slices/collabSlice.ts
    482 apps/viewer/src/store/slices/dataSlice.ts
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts
    820 apps/viewer/src/store/slices/measurementSlice.ts
-   657 apps/viewer/src/store/slices/modelSlice.ts
-  3283 apps/viewer/src/store/slices/mutationSlice.ts
+   651 apps/viewer/src/store/slices/modelSlice.ts
+  3277 apps/viewer/src/store/slices/mutationSlice.ts
    478 apps/viewer/src/store/slices/pinboardSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts
    536 apps/viewer/src/store/slices/scriptSlice.ts
    574 apps/viewer/src/store/slices/sectionSlice.ts
    571 apps/viewer/src/store/slices/sheetSlice.ts
-   414 apps/viewer/src/store/slices/uiSlice.ts
+   412 apps/viewer/src/store/slices/uiSlice.ts
    497 apps/viewer/src/store/slices/visibilitySlice.ts
    415 apps/viewer/src/store/teardown.ts
    696 apps/viewer/src/store/types.ts
-   470 apps/viewer/src/utils/serverDataModel.ts
+   457 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
-   413 apps/viewer/vite.config.ts
+   417 apps/viewer/vite.config.ts
    788 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
    801 packages/bcf/src/reader.ts
    595 packages/bcf/src/viewpoint.ts
    753 packages/bcf/src/writer.ts
-   605 packages/cache/src/glb.ts
    441 packages/clash/src/bcf-bridge.ts
    433 packages/clash/src/duplicates.ts
    547 packages/cli/src/commands/ask.ts
    495 packages/cli/src/commands/create.ts
-   518 packages/cli/src/commands/extract-entities.ts
-   609 packages/cli/src/commands/query.ts
+   458 packages/cli/src/commands/extract-entities.ts
+   485 packages/cli/src/commands/query.ts
    791 packages/cli/src/headless-backend.ts
    457 packages/codegen/src/express-parser.ts
-   674 packages/codegen/src/rust-generator.ts
+   660 packages/codegen/src/rust-generator.ts
    640 packages/codegen/src/typescript-generator.ts
    427 packages/collab-server/src/access-control.ts
    805 packages/collab-server/src/layer-registry-route.ts
-   727 packages/collab-server/src/room-manager.ts
+   691 packages/collab-server/src/room-manager.ts
    662 packages/collab-server/src/room-token.ts
    677 packages/collab-server/src/server.ts
    653 packages/collab/src/doc/entity.ts
@@ -212,13 +207,12 @@
    448 packages/create/src/in-store/apply-style.ts
    535 packages/create/src/in-store/auto-space-detect.ts
   1164 packages/create/src/in-store/extract-walls.ts
-   437 packages/create/src/in-store/generate-spaces.ts
    819 packages/create/src/types.ts
   1106 packages/data/scripts/generate-ifc-schema.ts
-   438 packages/data/src/property-table.ts
+   432 packages/data/src/property-table.ts
    459 packages/data/src/step-serializers.ts
    508 packages/data/src/types.ts
-   440 packages/diff/src/fingerprint.ts
+   439 packages/diff/src/fingerprint.ts
    550 packages/drawing-2d/src/drawing-generator.ts
    507 packages/drawing-2d/src/dxf/convert.ts
    898 packages/drawing-2d/src/dxf/parser.ts
@@ -226,7 +220,7 @@
    428 packages/drawing-2d/src/edge-extractor.ts
    565 packages/drawing-2d/src/gpu-section-cutter.ts
    470 packages/drawing-2d/src/graphic-overrides/presets.ts
-   523 packages/drawing-2d/src/graphic-overrides/rule-engine.ts
+   499 packages/drawing-2d/src/graphic-overrides/rule-engine.ts
    572 packages/drawing-2d/src/index.ts
    436 packages/drawing-2d/src/line-merger.ts
    417 packages/drawing-2d/src/object-styles.ts
@@ -239,109 +233,105 @@
    573 packages/drawing-2d/src/symbols/door-symbol.ts
    808 packages/drawing-2d/src/types.ts
    592 packages/export/src/effective-index.ts
-   888 packages/export/src/ifc5-exporter.ts
+   824 packages/export/src/ifc5-exporter.ts
   1585 packages/export/src/merged-exporter.ts
-   639 packages/export/src/parquet-exporter.ts
+   616 packages/export/src/parquet-exporter.ts
    976 packages/export/src/reference-collector.ts
-   524 packages/export/src/schema-converter.ts
+   523 packages/export/src/schema-converter.ts
    437 packages/extensions/src/testing/runner.ts
    625 packages/geometry/src/coordinate-handler.ts
-  1648 packages/geometry/src/geometry-parallel.ts
-  1763 packages/geometry/src/geometry.worker.ts
+  1560 packages/geometry/src/geometry-parallel.ts
+  1757 packages/geometry/src/geometry.worker.ts
    937 packages/geometry/src/ifc-lite-bridge.ts
-  1550 packages/geometry/src/index.ts
+  1537 packages/geometry/src/index.ts
    730 packages/geometry/src/native-bridge.ts
-   469 packages/ids/src/audit/coherence/index.ts
    904 packages/ids/src/audit/ifc-schema/index.ts
    566 packages/ids/src/audit/structural/index.ts
    467 packages/ids/src/facets/property-facet.ts
-   743 packages/ids/src/parser/xml-parser.ts
+   597 packages/ids/src/parser/xml-parser.ts
    624 packages/ids/src/translation/service.ts
    639 packages/ids/src/types.ts
    841 packages/ids/src/validation/validator.ts
    468 packages/ifcx/src/federated-composition.ts
-   412 packages/ifcx/src/geometry-extractor.ts
-   706 packages/ifcx/src/index.ts
+   704 packages/ifcx/src/index.ts
    415 packages/ifcx/src/writer.ts
    464 packages/lens/src/engine.ts
    426 packages/lens/src/matching.ts
-   417 packages/lens/src/types.ts
+   416 packages/lens/src/types.ts
    812 packages/lists/src/engine.ts
    423 packages/lists/src/types.ts
-   485 packages/mcp/src/backend-query.ts
+   467 packages/mcp/src/backend-query.ts
    420 packages/mcp/src/overlay.ts
    544 packages/mcp/src/server.ts
-   477 packages/mcp/src/tools/diff-fingerprints.ts
+   476 packages/mcp/src/tools/diff-fingerprints.ts
    470 packages/mcp/src/tools/layer-review.ts
    483 packages/mcp/src/tools/mutate.ts
    627 packages/mcp/src/tools/query.ts
-   696 packages/mcp/src/tools/viewer.ts
+   694 packages/mcp/src/tools/viewer.ts
    413 packages/mcp/src/transport/http.ts
    465 packages/merge/src/component-state.ts
    530 packages/merge/src/three-way.ts
    493 packages/mutations/src/bulk-query-engine.ts
-   573 packages/mutations/src/csv-connector.ts
-  2121 packages/mutations/src/mutable-property-view.ts
+   558 packages/mutations/src/csv-connector.ts
+  1914 packages/mutations/src/mutable-property-view.ts
    422 packages/oauth-pkce/src/token-manager.ts
    920 packages/parser/src/columnar-parser.ts
-   474 packages/parser/src/compact-entity-index.ts
+   467 packages/parser/src/compact-entity-index.ts
    530 packages/parser/src/data-store-transport.ts
    827 packages/parser/src/material-resolver.ts
-  1004 packages/parser/src/on-demand-extractors.ts
-   523 packages/parser/src/project-units.ts
+   796 packages/parser/src/on-demand-extractors.ts
    594 packages/parser/src/schedule-extractor.ts
    494 packages/parser/src/source-bytes.ts
-   487 packages/parser/src/spatial-hierarchy-builder.ts
    513 packages/plugin-api/src/types.ts
    678 packages/pointcloud/src/formats/e57-decode.ts
    424 packages/pointcloud/src/formats/pcd.ts
    529 packages/pointcloud/src/streaming/e57-source.ts
    423 packages/provenance/src/certificate.ts
-   412 packages/provenance/src/commutation.ts
-   432 packages/provenance/src/dag-engine.ts
-  1211 packages/provenance/src/merge-battery.ts
-  1033 packages/provenance/src/merge-model.ts
+   410 packages/provenance/src/commutation.ts
+   429 packages/provenance/src/dag-engine.ts
+  1209 packages/provenance/src/merge-battery.ts
+  1032 packages/provenance/src/merge-model.ts
    609 packages/provenance/src/node-hash.ts
-   535 packages/query/src/duckdb-integration.ts
+   529 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
    684 packages/renderer/src/camera.ts
-  3709 packages/renderer/src/index.ts
+  3722 packages/renderer/src/index.ts
    756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts
-   477 packages/renderer/src/pointcloud/point-cloud-renderer.ts
+   475 packages/renderer/src/pointcloud/point-cloud-renderer.ts
    758 packages/renderer/src/pointcloud/point-cloud-spatial-index.ts
    474 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
    462 packages/renderer/src/scene-raycaster.ts
-  4353 packages/renderer/src/scene.ts
+  4214 packages/renderer/src/scene.ts
    639 packages/renderer/src/section-2d-overlay.ts
    514 packages/renderer/src/section-plane.ts
    639 packages/renderer/src/shaders/main.wgsl.ts
    454 packages/renderer/src/shadow-pass.ts
-   764 packages/renderer/src/snap-detector.ts
-   766 packages/renderer/src/symbolic-overlay-pipelines.ts
+   768 packages/renderer/src/snap-detector.ts
+   765 packages/renderer/src/symbolic-overlay-pipelines.ts
    587 packages/sandbox/src/bridge-create.ts
    421 packages/sandbox/src/bridge-query.ts
    498 packages/sandbox/src/bridge-schema.ts
    673 packages/sandbox/src/sandbox.ts
    458 packages/sdk/src/namespaces/bsdd.ts
    875 packages/sdk/src/types.ts
-  1082 packages/server-client/src/client.ts
+  1011 packages/server-client/src/client.ts
    784 packages/server-client/src/data-model-decoder.ts
-   466 packages/server-client/src/parquet-tables.ts
-   596 packages/server-client/src/types.ts
+   444 packages/server-client/src/parquet-tables.ts
+   595 packages/server-client/src/types.ts
    411 packages/source-dalux/src/http-client.ts
    406 packages/source-dalux/src/provider.ts
    432 packages/source-dropbox/src/provider.ts
    415 packages/viewer/src/server.ts
   1486 packages/viewer/src/viewer-html.ts
-   501 scripts/check-agents-md-size.mjs
+   500 scripts/check-agents-md-size.mjs
    680 scripts/check-changeset-bump.mjs
-   523 scripts/check-ci-path-coverage.mjs
+   526 scripts/check-ci-path-coverage.mjs
    574 scripts/check-collab-room-model-target.mjs
    529 scripts/check-generated.mjs
    430 scripts/check-git-lfs.mjs
-   598 scripts/check-isolate-expansion-routing.mjs
+   560 scripts/check-isolate-expansion-routing.mjs
    957 scripts/check-issue-queue.mjs
    448 scripts/check-legacy-entity-coverage.mjs
   1145 scripts/check-loader-hook-specifier-match.mjs
@@ -350,18 +340,18 @@
    855 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
-   621 scripts/check-test-revert-oracle.mjs
+   607 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
    499 scripts/docs/check-doc-samples.mjs
    506 scripts/generate-bim-globals.mjs
    423 scripts/generate-epsg-index.ts
    403 scripts/lib/ci-path-coverage.mjs
-   472 scripts/lib/pr-green-sweep.mjs
+   460 scripts/lib/pr-green-sweep.mjs
   1113 scripts/lib/pr-review-signal.mjs
    443 scripts/lib/prepass-class-boundary.mjs
    734 scripts/lib/refwalk-classify.mjs
-   528 scripts/lib/revert-oracle.mjs
+   523 scripts/lib/revert-oracle.mjs
    494 scripts/lib/rust-source-text-detect.mjs
   1165 scripts/lib/vitest-timeout-audit.mjs
    691 scripts/review/build-context-pack.mjs
@@ -369,6 +359,6 @@
    591 scripts/review/run-reviewer.mjs
    688 scripts/source-text-assertion-detect.mjs
    504 scripts/test-geometry-regression.mjs
-  2196 scripts/test-wasm-contract.mjs
+  2180 scripts/test-wasm-contract.mjs
    678 scripts/typecheck-tests.mjs
    467 scripts/xmatch/score.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -48,30 +48,32 @@
    428 apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
    531 apps/viewer/src/components/viewer/BCFPanel.tsx
   1061 apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+   430 apps/viewer/src/components/viewer/cesium/useCesiumModel.ts
    487 apps/viewer/src/components/viewer/CesiumOverlay.tsx
   1098 apps/viewer/src/components/viewer/CesiumPlacementEditor.tsx
    418 apps/viewer/src/components/viewer/chat/ExecutableCodeBlock.tsx
   1802 apps/viewer/src/components/viewer/ChatPanel.tsx
-  1312 apps/viewer/src/components/viewer/ClashPanel.tsx
-   751 apps/viewer/src/components/viewer/CommandPalette.tsx
+  1314 apps/viewer/src/components/viewer/ClashPanel.tsx
+   752 apps/viewer/src/components/viewer/CommandPalette.tsx
    410 apps/viewer/src/components/viewer/ComparePanel.tsx
   1059 apps/viewer/src/components/viewer/DataConnector.tsx
-  1752 apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+  1842 apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
    536 apps/viewer/src/components/viewer/DrawingSettingsPanel.tsx
    426 apps/viewer/src/components/viewer/DxfUnderlayPanel.tsx
    583 apps/viewer/src/components/viewer/EntityContextMenu.tsx
-   859 apps/viewer/src/components/viewer/ExportDialog.tsx
+   863 apps/viewer/src/components/viewer/ExportDialog.tsx
    531 apps/viewer/src/components/viewer/GLBExportDialog.tsx
   1424 apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts
    435 apps/viewer/src/components/viewer/hierarchy/useHierarchyTree.ts
   1155 apps/viewer/src/components/viewer/HierarchyPanel.tsx
-  1119 apps/viewer/src/components/viewer/IDSPanel.tsx
+  1198 apps/viewer/src/components/viewer/IDSPanel.tsx
    569 apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
    534 apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
-  1709 apps/viewer/src/components/viewer/LensPanel.tsx
+  1714 apps/viewer/src/components/viewer/LensPanel.tsx
   1465 apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+   622 apps/viewer/src/components/viewer/lists/ListPanel.tsx
    548 apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
-  1139 apps/viewer/src/components/viewer/MainToolbar.tsx
+  1165 apps/viewer/src/components/viewer/MainToolbar.tsx
    715 apps/viewer/src/components/viewer/measureHandlers.ts
    407 apps/viewer/src/components/viewer/PdfViewExportDialog.tsx
    574 apps/viewer/src/components/viewer/properties/BsddCard.tsx
@@ -81,7 +83,7 @@
    417 apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
    510 apps/viewer/src/components/viewer/properties/TaskEditCard.tsx
   2146 apps/viewer/src/components/viewer/PropertiesPanel.tsx
-  1729 apps/viewer/src/components/viewer/PropertyEditor.tsx
+  1731 apps/viewer/src/components/viewer/PropertyEditor.tsx
    542 apps/viewer/src/components/viewer/schedule/AnimationSettingsPopover.tsx
    426 apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx
    648 apps/viewer/src/components/viewer/schedule/generate-schedule.ts
@@ -89,47 +91,48 @@
    488 apps/viewer/src/components/viewer/schedule/schedule-animator.ts
    701 apps/viewer/src/components/viewer/ScriptPanel.tsx
    734 apps/viewer/src/components/viewer/SearchInline.tsx
-   509 apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
-   859 apps/viewer/src/components/viewer/SearchModal.filter.tsx
+   534 apps/viewer/src/components/viewer/SearchModal.filter.editors.tsx
+   862 apps/viewer/src/components/viewer/SearchModal.filter.tsx
    404 apps/viewer/src/components/viewer/SearchModal.text.tsx
-  1348 apps/viewer/src/components/viewer/Section2DPanel.tsx
+  1367 apps/viewer/src/components/viewer/Section2DPanel.tsx
   1094 apps/viewer/src/components/viewer/selectionHandlers.ts
    502 apps/viewer/src/components/viewer/SheetSetupPanel.tsx
    437 apps/viewer/src/components/viewer/TitleBlockEditor.tsx
    581 apps/viewer/src/components/viewer/tools/AddElementOverlay.tsx
    501 apps/viewer/src/components/viewer/tools/measure-modes/radius.ts
    869 apps/viewer/src/components/viewer/tools/MeasurementVisuals.tsx
-   755 apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+   760 apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
    694 apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
    436 apps/viewer/src/components/viewer/tools/SectionVisualization.tsx
   1510 apps/viewer/src/components/viewer/tools/SpaceSketchOverlay.tsx
    406 apps/viewer/src/components/viewer/useAnimationLoop.ts
-   980 apps/viewer/src/components/viewer/useGeometryStreaming.ts
+   981 apps/viewer/src/components/viewer/useGeometryStreaming.ts
    946 apps/viewer/src/components/viewer/useMouseControls.ts
    782 apps/viewer/src/components/viewer/ViewerLayout.tsx
-  1819 apps/viewer/src/components/viewer/Viewport.tsx
-  1382 apps/viewer/src/components/viewer/ViewportContainer.tsx
+  1843 apps/viewer/src/components/viewer/Viewport.tsx
+  1539 apps/viewer/src/components/viewer/ViewportContainer.tsx
    511 apps/viewer/src/components/viewer/ZonesPanel.tsx
    862 apps/viewer/src/hooks/ids/idsExportService.ts
    598 apps/viewer/src/hooks/ingest/federationAlign.ts
-   525 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
-   461 apps/viewer/src/hooks/useAnnotation2D.ts
+   458 apps/viewer/src/hooks/ingest/pointCloudAlignment.ts
+   545 apps/viewer/src/hooks/ingest/pointCloudIngest.ts
+   551 apps/viewer/src/hooks/useAnnotation2D.ts
    690 apps/viewer/src/hooks/useBCF.ts
-  1358 apps/viewer/src/hooks/useClash.ts
+  1374 apps/viewer/src/hooks/useClash.ts
    482 apps/viewer/src/hooks/useCompare.ts
-  1353 apps/viewer/src/hooks/useDrawingExport.ts
-  1029 apps/viewer/src/hooks/useDrawingGeneration.ts
-  1226 apps/viewer/src/hooks/useIDS.ts
+  1359 apps/viewer/src/hooks/useDrawingExport.ts
+  1036 apps/viewer/src/hooks/useDrawingGeneration.ts
+  1416 apps/viewer/src/hooks/useIDS.ts
    586 apps/viewer/src/hooks/useIfcCache.ts
-   667 apps/viewer/src/hooks/useIfcFederation.ts
-  2245 apps/viewer/src/hooks/useIfcLoader.ts
+   681 apps/viewer/src/hooks/useIfcFederation.ts
+  2240 apps/viewer/src/hooks/useIfcLoader.ts
    436 apps/viewer/src/hooks/useIfcServer.ts
-   483 apps/viewer/src/hooks/useKeyboardShortcuts.ts
-   493 apps/viewer/src/hooks/useSymbolicAnnotations.ts
+   488 apps/viewer/src/hooks/useKeyboardShortcuts.ts
+   496 apps/viewer/src/hooks/useSymbolicAnnotations.ts
    633 apps/viewer/src/lib/analytics-scrub.ts
    627 apps/viewer/src/lib/clash/persistence.ts
-   419 apps/viewer/src/lib/collab/geometry-sync.ts
-   441 apps/viewer/src/lib/compare/buildFingerprints.ts
+   427 apps/viewer/src/lib/collab/geometry-sync.ts
+   445 apps/viewer/src/lib/compare/buildFingerprints.ts
    436 apps/viewer/src/lib/compare/worldPlacement.ts
    417 apps/viewer/src/lib/export/model-changes.ts
    501 apps/viewer/src/lib/geo/cesium-bridge.ts
@@ -144,8 +147,9 @@
   1141 apps/viewer/src/lib/llm/script-preflight.ts
    410 apps/viewer/src/lib/llm/stream-client.ts
    809 apps/viewer/src/lib/llm/system-prompt.ts
+   403 apps/viewer/src/lib/overlay-parse/symbolic-flat.ts
    491 apps/viewer/src/lib/scripts/templates/create-building.ts
-   598 apps/viewer/src/lib/search/filter-evaluate.ts
+   663 apps/viewer/src/lib/search/filter-evaluate.ts
    450 apps/viewer/src/lib/search/tier1-index.ts
    452 apps/viewer/src/lib/slab-edit.ts
    412 apps/viewer/src/lib/sources/persistence.ts
@@ -155,49 +159,49 @@
    561 apps/viewer/src/services/ifc-cache.ts
    581 apps/viewer/src/store/basketVisibleSet.ts
    485 apps/viewer/src/store/constants.ts
-   579 apps/viewer/src/store/index.ts
+   581 apps/viewer/src/store/index.ts
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    992 apps/viewer/src/store/slices/clashSlice.ts
-  1598 apps/viewer/src/store/slices/collabSlice.ts
+  1599 apps/viewer/src/store/slices/collabSlice.ts
    482 apps/viewer/src/store/slices/dataSlice.ts
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts
    820 apps/viewer/src/store/slices/measurementSlice.ts
-   651 apps/viewer/src/store/slices/modelSlice.ts
-  3277 apps/viewer/src/store/slices/mutationSlice.ts
+   657 apps/viewer/src/store/slices/modelSlice.ts
+  3283 apps/viewer/src/store/slices/mutationSlice.ts
    478 apps/viewer/src/store/slices/pinboardSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts
    536 apps/viewer/src/store/slices/scriptSlice.ts
    574 apps/viewer/src/store/slices/sectionSlice.ts
    571 apps/viewer/src/store/slices/sheetSlice.ts
-   412 apps/viewer/src/store/slices/uiSlice.ts
+   414 apps/viewer/src/store/slices/uiSlice.ts
    497 apps/viewer/src/store/slices/visibilitySlice.ts
    415 apps/viewer/src/store/teardown.ts
    696 apps/viewer/src/store/types.ts
-   457 apps/viewer/src/utils/serverDataModel.ts
+   470 apps/viewer/src/utils/serverDataModel.ts
    422 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
-   417 apps/viewer/vite.config.ts
+   413 apps/viewer/vite.config.ts
    788 packages/bcf/src/ids-reporter.ts
    495 packages/bcf/src/overlay-renderer.ts
    801 packages/bcf/src/reader.ts
    595 packages/bcf/src/viewpoint.ts
    753 packages/bcf/src/writer.ts
-   414 packages/clash/src/adapters/step.ts
+   605 packages/cache/src/glb.ts
    441 packages/clash/src/bcf-bridge.ts
    433 packages/clash/src/duplicates.ts
    547 packages/cli/src/commands/ask.ts
    495 packages/cli/src/commands/create.ts
-   458 packages/cli/src/commands/extract-entities.ts
-   485 packages/cli/src/commands/query.ts
+   518 packages/cli/src/commands/extract-entities.ts
+   609 packages/cli/src/commands/query.ts
    791 packages/cli/src/headless-backend.ts
    457 packages/codegen/src/express-parser.ts
-   660 packages/codegen/src/rust-generator.ts
+   674 packages/codegen/src/rust-generator.ts
    640 packages/codegen/src/typescript-generator.ts
    427 packages/collab-server/src/access-control.ts
    805 packages/collab-server/src/layer-registry-route.ts
-   691 packages/collab-server/src/room-manager.ts
+   727 packages/collab-server/src/room-manager.ts
    662 packages/collab-server/src/room-token.ts
    677 packages/collab-server/src/server.ts
    653 packages/collab/src/doc/entity.ts
@@ -208,12 +212,13 @@
    448 packages/create/src/in-store/apply-style.ts
    535 packages/create/src/in-store/auto-space-detect.ts
   1164 packages/create/src/in-store/extract-walls.ts
+   437 packages/create/src/in-store/generate-spaces.ts
    819 packages/create/src/types.ts
   1106 packages/data/scripts/generate-ifc-schema.ts
-   432 packages/data/src/property-table.ts
+   438 packages/data/src/property-table.ts
    459 packages/data/src/step-serializers.ts
    508 packages/data/src/types.ts
-   439 packages/diff/src/fingerprint.ts
+   440 packages/diff/src/fingerprint.ts
    550 packages/drawing-2d/src/drawing-generator.ts
    507 packages/drawing-2d/src/dxf/convert.ts
    898 packages/drawing-2d/src/dxf/parser.ts
@@ -221,7 +226,7 @@
    428 packages/drawing-2d/src/edge-extractor.ts
    565 packages/drawing-2d/src/gpu-section-cutter.ts
    470 packages/drawing-2d/src/graphic-overrides/presets.ts
-   499 packages/drawing-2d/src/graphic-overrides/rule-engine.ts
+   523 packages/drawing-2d/src/graphic-overrides/rule-engine.ts
    572 packages/drawing-2d/src/index.ts
    436 packages/drawing-2d/src/line-merger.ts
    417 packages/drawing-2d/src/object-styles.ts
@@ -234,105 +239,109 @@
    573 packages/drawing-2d/src/symbols/door-symbol.ts
    808 packages/drawing-2d/src/types.ts
    592 packages/export/src/effective-index.ts
-   824 packages/export/src/ifc5-exporter.ts
+   888 packages/export/src/ifc5-exporter.ts
   1585 packages/export/src/merged-exporter.ts
-   616 packages/export/src/parquet-exporter.ts
+   639 packages/export/src/parquet-exporter.ts
    976 packages/export/src/reference-collector.ts
-   523 packages/export/src/schema-converter.ts
+   524 packages/export/src/schema-converter.ts
    437 packages/extensions/src/testing/runner.ts
    625 packages/geometry/src/coordinate-handler.ts
-  1560 packages/geometry/src/geometry-parallel.ts
-  1757 packages/geometry/src/geometry.worker.ts
+  1648 packages/geometry/src/geometry-parallel.ts
+  1763 packages/geometry/src/geometry.worker.ts
    937 packages/geometry/src/ifc-lite-bridge.ts
-  1537 packages/geometry/src/index.ts
+  1550 packages/geometry/src/index.ts
    730 packages/geometry/src/native-bridge.ts
+   469 packages/ids/src/audit/coherence/index.ts
    904 packages/ids/src/audit/ifc-schema/index.ts
    566 packages/ids/src/audit/structural/index.ts
    467 packages/ids/src/facets/property-facet.ts
-   597 packages/ids/src/parser/xml-parser.ts
+   743 packages/ids/src/parser/xml-parser.ts
    624 packages/ids/src/translation/service.ts
    639 packages/ids/src/types.ts
    841 packages/ids/src/validation/validator.ts
    468 packages/ifcx/src/federated-composition.ts
-   704 packages/ifcx/src/index.ts
+   412 packages/ifcx/src/geometry-extractor.ts
+   706 packages/ifcx/src/index.ts
    415 packages/ifcx/src/writer.ts
    464 packages/lens/src/engine.ts
    426 packages/lens/src/matching.ts
-   416 packages/lens/src/types.ts
+   417 packages/lens/src/types.ts
    812 packages/lists/src/engine.ts
    423 packages/lists/src/types.ts
-   467 packages/mcp/src/backend-query.ts
+   485 packages/mcp/src/backend-query.ts
    420 packages/mcp/src/overlay.ts
    544 packages/mcp/src/server.ts
-   476 packages/mcp/src/tools/diff-fingerprints.ts
+   477 packages/mcp/src/tools/diff-fingerprints.ts
    470 packages/mcp/src/tools/layer-review.ts
    483 packages/mcp/src/tools/mutate.ts
    627 packages/mcp/src/tools/query.ts
-   694 packages/mcp/src/tools/viewer.ts
+   696 packages/mcp/src/tools/viewer.ts
    413 packages/mcp/src/transport/http.ts
    465 packages/merge/src/component-state.ts
    530 packages/merge/src/three-way.ts
    493 packages/mutations/src/bulk-query-engine.ts
-   558 packages/mutations/src/csv-connector.ts
-  1914 packages/mutations/src/mutable-property-view.ts
+   573 packages/mutations/src/csv-connector.ts
+  2121 packages/mutations/src/mutable-property-view.ts
    422 packages/oauth-pkce/src/token-manager.ts
    920 packages/parser/src/columnar-parser.ts
-   467 packages/parser/src/compact-entity-index.ts
+   474 packages/parser/src/compact-entity-index.ts
    530 packages/parser/src/data-store-transport.ts
    827 packages/parser/src/material-resolver.ts
-   796 packages/parser/src/on-demand-extractors.ts
+  1004 packages/parser/src/on-demand-extractors.ts
+   523 packages/parser/src/project-units.ts
    594 packages/parser/src/schedule-extractor.ts
    494 packages/parser/src/source-bytes.ts
+   487 packages/parser/src/spatial-hierarchy-builder.ts
    513 packages/plugin-api/src/types.ts
    678 packages/pointcloud/src/formats/e57-decode.ts
    424 packages/pointcloud/src/formats/pcd.ts
    529 packages/pointcloud/src/streaming/e57-source.ts
    423 packages/provenance/src/certificate.ts
-   410 packages/provenance/src/commutation.ts
-   429 packages/provenance/src/dag-engine.ts
-  1209 packages/provenance/src/merge-battery.ts
-  1032 packages/provenance/src/merge-model.ts
+   412 packages/provenance/src/commutation.ts
+   432 packages/provenance/src/dag-engine.ts
+  1211 packages/provenance/src/merge-battery.ts
+  1033 packages/provenance/src/merge-model.ts
    609 packages/provenance/src/node-hash.ts
-   529 packages/query/src/duckdb-integration.ts
+   535 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
    684 packages/renderer/src/camera.ts
-  3722 packages/renderer/src/index.ts
+  3709 packages/renderer/src/index.ts
    756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts
-   475 packages/renderer/src/pointcloud/point-cloud-renderer.ts
+   477 packages/renderer/src/pointcloud/point-cloud-renderer.ts
    758 packages/renderer/src/pointcloud/point-cloud-spatial-index.ts
    474 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
    462 packages/renderer/src/scene-raycaster.ts
-  4214 packages/renderer/src/scene.ts
+  4353 packages/renderer/src/scene.ts
    639 packages/renderer/src/section-2d-overlay.ts
    514 packages/renderer/src/section-plane.ts
    639 packages/renderer/src/shaders/main.wgsl.ts
    454 packages/renderer/src/shadow-pass.ts
-   768 packages/renderer/src/snap-detector.ts
-   765 packages/renderer/src/symbolic-overlay-pipelines.ts
+   764 packages/renderer/src/snap-detector.ts
+   766 packages/renderer/src/symbolic-overlay-pipelines.ts
    587 packages/sandbox/src/bridge-create.ts
    421 packages/sandbox/src/bridge-query.ts
    498 packages/sandbox/src/bridge-schema.ts
    673 packages/sandbox/src/sandbox.ts
    458 packages/sdk/src/namespaces/bsdd.ts
    875 packages/sdk/src/types.ts
-  1011 packages/server-client/src/client.ts
+  1082 packages/server-client/src/client.ts
    784 packages/server-client/src/data-model-decoder.ts
-   444 packages/server-client/src/parquet-tables.ts
-   595 packages/server-client/src/types.ts
+   466 packages/server-client/src/parquet-tables.ts
+   596 packages/server-client/src/types.ts
    411 packages/source-dalux/src/http-client.ts
    406 packages/source-dalux/src/provider.ts
    432 packages/source-dropbox/src/provider.ts
    415 packages/viewer/src/server.ts
   1486 packages/viewer/src/viewer-html.ts
-   500 scripts/check-agents-md-size.mjs
+   501 scripts/check-agents-md-size.mjs
    680 scripts/check-changeset-bump.mjs
-   526 scripts/check-ci-path-coverage.mjs
+   523 scripts/check-ci-path-coverage.mjs
    574 scripts/check-collab-room-model-target.mjs
    529 scripts/check-generated.mjs
    430 scripts/check-git-lfs.mjs
-   560 scripts/check-isolate-expansion-routing.mjs
+   598 scripts/check-isolate-expansion-routing.mjs
    957 scripts/check-issue-queue.mjs
    448 scripts/check-legacy-entity-coverage.mjs
   1145 scripts/check-loader-hook-specifier-match.mjs
@@ -341,18 +350,18 @@
    855 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
-   607 scripts/check-test-revert-oracle.mjs
+   621 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
    499 scripts/docs/check-doc-samples.mjs
    506 scripts/generate-bim-globals.mjs
    423 scripts/generate-epsg-index.ts
    403 scripts/lib/ci-path-coverage.mjs
-   460 scripts/lib/pr-green-sweep.mjs
+   472 scripts/lib/pr-green-sweep.mjs
   1113 scripts/lib/pr-review-signal.mjs
    443 scripts/lib/prepass-class-boundary.mjs
    734 scripts/lib/refwalk-classify.mjs
-   523 scripts/lib/revert-oracle.mjs
+   528 scripts/lib/revert-oracle.mjs
    494 scripts/lib/rust-source-text-detect.mjs
   1165 scripts/lib/vitest-timeout-audit.mjs
    691 scripts/review/build-context-pack.mjs
@@ -360,6 +369,6 @@
    591 scripts/review/run-reviewer.mjs
    688 scripts/source-text-assertion-detect.mjs
    504 scripts/test-geometry-regression.mjs
-  2180 scripts/test-wasm-contract.mjs
+  2196 scripts/test-wasm-contract.mjs
    678 scripts/typecheck-tests.mjs
    467 scripts/xmatch/score.mjs


### PR DESCRIPTION
`fromPositions` folds only finite coordinates, so an axis whose every vertex is non-finite keeps its initialisers and the function returns `min = +Infinity, max = -Infinity` for that axis — an inverted box, handed straight to `@ifc-lite/spatial`'s BVH by both clash adapters.

Reproduced before changing anything:

```
fromPositions(new Float32Array([NaN,1,1, NaN,2,2]))
  -> { min: [Infinity, 1, 1], max: [-Infinity, 2, 2] }
```

## The false docstring — in three places, not one

The docstring claimed such a box is "rejected by `boxesTouch`". `boxesTouch` (`duplicate-metric.ts`) is called only from `duplicates.ts`. It is never on the broad-phase path: `engine-ts/broad.ts` builds the BVH directly from `ClashElement.bounds`. So on the path the issue is about, nothing rejected it.

The same false claim appeared in three places — the exported docstring, an inline loop comment in `aabb.ts`, and a comment in `duplicates.test.ts`. All three corrected.

## Behaviour: skip-and-report, built on a throw

`fromPositions` now throws `NonFiniteAxisError`, naming the offending axis or axes and the vertex count — the same shape as #4244's `requireFinite`.

A throw alone would be wrong: one corrupt element would abort a whole clash run. But `fromPositions` has no element identity, so it cannot skip on its own. The two production callers (`adapters/step.ts`, `adapters/ifcx.ts`) catch per occurrence/entity, drop only that element, and `console.warn` once with a count — reusing `step.ts`'s existing `missingGlobalIds` warning shape rather than inventing a new channel. Returning a sentinel was rejected: that is the bug.

`fromPositions` is package-internal — `packages/clash` exposes no `./math` subpath and does not re-export it from the index — so the new throw is not a public API change.

## Ripple caught during verification

`duplicates.ts`'s sweep already relied on tolerating a non-finite minimum, and a test asserted on `fromPositions(allNaN)`'s old return value. Since `fromPositions` can no longer produce that box, the test now hand-builds the inverted bound, still exercising the sweep's defence against one arriving from a direct SDK caller. That defence matters: a comparator answering `NaN` breaks `Array.prototype.sort`'s contract, and V8's TimSort then emits an arbitrary permutation of the whole array, so real duplicates elsewhere in the model silently vanish. One unjudgeable element must cost only itself.

## Not done, deliberately

No guard added in `BVH.build`. After this fix the adapters cannot hand it an inverted box, but a direct SDK caller hand-building `ClashElement.bounds` still can. That is a real remaining gap with a wider blast radius than the adapter choke point this issue named — flagged here for a separate issue rather than widened into this PR.

## Verification

Mutation-tested, each applied then restored with a verified-clean `diff`:

| mutation | result |
|---|---|
| remove the throw block | both all-non-finite tests RED (`expected function to throw an error, but it didn't`) |
| disable the y-axis finite fold (`if (false && Number.isFinite(y))`) | the pre-existing partial-fold test went RED with `NonFiniteAxisError: ... axis y`, naming the mutated axis |

The second mutation matters: it proves the pre-existing partial-fold test (a finite `y` alongside non-finite coords) still discriminates, so the new throw did not swallow the case it was supposed to leave alone.

`packages/clash`: 472 passed / 21 skipped across 33 files, against a 465/21/33 baseline — the 7 new tests. `differential.test.ts` and one `obb.test.ts` case are **blocked**, not passing: `packages/wasm/pkg/ifc-lite_bg.wasm` is absent in this environment, so they never report pass or fail.

`check-module-size.mjs` exits 0 with no budgets touched.

Closes #4254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrupt geometry with entirely non-finite coordinates on an axis is now detected instead of creating invisible or invalid bounding boxes.
  - STEP and IFCX imports skip only affected elements, allowing valid model elements to remain available.
  - Imports now issue a warning identifying the model and number of skipped elements rather than failing the entire clash run.

- **Documentation**
  - Clarified handling of invalid and manually supplied inverted bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->