### PR TITLE
feat(viewer): run appearance plans in cancellable WASM workers

### DIFF
--- a/.changeset/free-spoons-mix.md
+++ b/.changeset/free-spoons-mix.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Expose the shared appearance planner as IfcAPI.planAppearance with bounded JSON output. Browser consumers can prepare image/UV edits in a cancellable worker while preserving the live IFC source buffer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "thiserror 2.0.20",
  "tracing",
  "wasm-bindgen",

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -40,6 +40,8 @@ export interface AppearancePlan extends AppearanceEntityPlan {
     sourceIndices: number[];
     /** Final target topology becomes provenance after Apply, including changed UV seams. */
     targetIndices: number[];
+    /** Final canonical vertex pool, including unused slots left by triangle cleanup. */
+    targetVertexCount: number;
     /** UV pairs in canonical triangle-corner order, before fragment remapping. */
     previewCornerUvs: number[];
     /** Canonical target shading normals in renderer Y-up triangle-corner order. */

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -42,6 +42,8 @@ export interface AppearancePlan extends AppearanceEntityPlan {
     targetIndices: number[];
     /** UV pairs in canonical triangle-corner order, before fragment remapping. */
     previewCornerUvs: number[];
+    /** Canonical target shading normals in renderer Y-up triangle-corner order. */
+    targetCornerNormals: number[];
   }>;
   exclusions: Array<{ productId: number; reason: string }>;
 }

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { IfcAttributeValue, NewEntity } from '@ifc-lite/mutations';
+
+/** Canonical planner wire edits, shared by worker transport and atomic application. */
+export interface AppearanceEntityPlan {
+  sourceRevision: string;
+  nextExpressId: number;
+  created: Array<Pick<NewEntity, 'expressId' | 'type' | 'attributes'>>;
+  edits: Array<{ expressId: number; index: number; value: IfcAttributeValue }>;
+  removed: number[];
+}
+
+export type AppearanceMapping =
+  | { kind: 'existingUv'; scale: [number, number]; offset: [number, number]; rotationRadians: number }
+  | { kind: 'planar'; frame: 'item' | 'world'; origin: [number, number, number];
+      axisU: [number, number, number]; axisV: [number, number, number]; metresPerTile: [number, number] }
+  | { kind: 'box'; frame: 'item' | 'world'; origin: [number, number, number]; metresPerTile: [number, number, number] };
+export interface AppearanceRequest {
+  schema: 'IFC4' | 'IFC4X3';
+  sourceRevision: string;
+  nextExpressId: number;
+  productIds: number[];
+  imageUri: string;
+  repeatS: boolean;
+  repeatT: boolean;
+  mapping: AppearanceMapping;
+}
+export interface AppearancePlan extends AppearanceEntityPlan {
+  nextAvailableExpressId: number;
+  items: Array<{
+    productId: number;
+    geometryItemId: number;
+    /** Source IFC coordinates (bottom-left origin), before corner expansion. */
+    texCoords: Array<[number, number]>;
+    /** One-based source triangle-corner indices, before winding correction. */
+    texCoordIndex: Array<[number, number, number]>;
+    /** Final canonical source index layout after placement and welding. */
+    sourceIndices: number[];
+    /** Final target topology becomes provenance after Apply, including changed UV seams. */
+    targetIndices: number[];
+    /** UV pairs in canonical triangle-corner order, before fragment remapping. */
+    previewCornerUvs: number[];
+  }>;
+  exclusions: Array<{ productId: number; reason: string }>;
+}
+export interface AppearanceWorkerRequest {
+  type: 'plan'; id: number; source: Uint8Array; request: AppearanceRequest;
+}
+export type AppearanceWorkerResponse =
+  | { type: 'complete'; id: number; plan: AppearancePlan }
+  | { type: 'error'; id: number; message: string };

--- a/apps/viewer/src/lib/appearance/planner-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/planner-wasm.test.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import type { AppearanceRequest } from './planner-types.js';
+
+// Original controlled IFC4 fixture: one directly represented triangle, no
+// geometric/style authoring mocked. Its existing texture has source bottom-left UVs.
+const source = new TextEncoder().encode(`ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Appearance worker contract'),'2;1');
+FILE_NAME('appearance.ifc','2026-09-09T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0$ScRe4drECQ4DMSqUjd6d',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCBUILDINGELEMENTPROXY('1ProxyImageTexture00000',$,'Triangle',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#14));
+#14=IFCTRIANGULATEDFACESET(#15,$,.F.,((1,2,3)),$);
+#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.)));
+#20=IFCIMAGETEXTURE(.T.,.T.,$,$,$,'old.png');
+#21=IFCTEXTUREVERTEXLIST(((0.,0.),(1.,0.),(0.,1.)));
+#22=IFCINDEXEDTRIANGLETEXTUREMAP((#20),#14,#21,$);
+ENDSEC;
+END-ISO-10303-21;
+`);
+const request: AppearanceRequest = {
+  schema: 'IFC4', sourceRevision: 'wasm-contract', nextExpressId: 100, productIds: [10],
+  imageUri: 'appearance/new.png', repeatS: false, repeatT: true,
+  mapping: { kind: 'existingUv', scale: [2, 3], offset: [0.25, 0.5], rotationRadians: 0 },
+};
+test('actual WASM worker function plans source-corner UVs and survives rejected requests (#4243)', async t => {
+  const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  try { await access(wasmUrl); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    t.skip('Build the WASM artifact with pnpm build:wasm to run the actual appearance contract'); return;
+  }
+  const { default: init } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: await readFile(wasmUrl) });
+  const { runAppearancePlanning } = await import('../../workers/appearance.worker.js');
+  const result = await runAppearancePlanning(source, request);
+  assert.equal(source.byteLength > 0, true, 'WASM must leave caller storage attached');
+  assert.equal(result.sourceRevision, 'wasm-contract');
+  assert.equal(result.nextExpressId, 100);
+  assert.equal(result.nextAvailableExpressId, 108);
+  assert.equal(result.created[0].type, 'IfcImageTexture');
+  assert.deepEqual(result.created[0].attributes.slice(0, 2), ['.F.', '.T.']);
+  assert.deepEqual(result.removed, [22]);
+  assert.deepEqual(result.exclusions, []);
+  assert.equal(result.items[0].geometryItemId, 14);
+  assert.deepEqual(result.items[0].texCoords, [[0.25, 0.5], [2.25, 0.5], [0.25, 3.5]]);
+  assert.deepEqual(result.items[0].previewCornerUvs, [0.25, 0.5, 2.25, 0.5, 0.25, -2.5]);
+  await assert.rejects(runAppearancePlanning(source, { ...request, nextExpressId: 20 }), /watermark/);
+  assert.equal((await runAppearancePlanning(source, request)).created.length, 8);
+});

--- a/apps/viewer/src/lib/appearance/planner-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/planner-wasm.test.ts
@@ -57,6 +57,7 @@ test('actual WASM worker function plans source-corner UVs and survives rejected 
   assert.deepEqual(result.removed, [22]);
   assert.deepEqual(result.exclusions, []);
   assert.equal(result.items[0].geometryItemId, 14);
+  assert.equal(result.items[0].targetVertexCount, 3);
   assert.deepEqual(result.items[0].texCoords, [[0.25, 0.5], [2.25, 0.5], [0.25, 3.5]]);
   assert.deepEqual(result.items[0].previewCornerUvs, [0.25, 0.5, 2.25, 0.5, 0.25, -2.5]);
   // The IFC +Z triangle normal must arrive in the renderer +Y frame.

--- a/apps/viewer/src/lib/appearance/planner-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/planner-wasm.test.ts
@@ -59,6 +59,8 @@ test('actual WASM worker function plans source-corner UVs and survives rejected 
   assert.equal(result.items[0].geometryItemId, 14);
   assert.deepEqual(result.items[0].texCoords, [[0.25, 0.5], [2.25, 0.5], [0.25, 3.5]]);
   assert.deepEqual(result.items[0].previewCornerUvs, [0.25, 0.5, 2.25, 0.5, 0.25, -2.5]);
+  // The IFC +Z triangle normal must arrive in the renderer +Y frame.
+  assert.deepEqual(result.items[0].targetCornerNormals.map(v => v === 0 ? 0 : v), [0, 1, 0, 0, 1, 0, 0, 1, 0]);
   await assert.rejects(runAppearancePlanning(source, { ...request, nextExpressId: 20 }), /watermark/);
   assert.equal((await runAppearancePlanning(source, request)).created.length, 8);
 });

--- a/apps/viewer/src/lib/appearance/planner-worker-client.test.ts
+++ b/apps/viewer/src/lib/appearance/planner-worker-client.test.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAppearancePlanner, type AppearanceWorker } from './planner-worker-client.js';
+import type { AppearancePlan, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from './planner-types.js';
+const request: AppearanceRequest = {
+  schema: 'IFC4', sourceRevision: 'first', nextExpressId: 100, productIds: [10],
+  imageUri: 'image.png', repeatS: true, repeatT: true,
+  mapping: { kind: 'existingUv', scale: [1, 1], offset: [0, 0], rotationRadians: 0 },
+};
+const plan = (revision = 'first'): AppearancePlan => ({ sourceRevision: revision, nextExpressId: 100,
+  nextAvailableExpressId: 100, created: [], edits: [], removed: [], items: [], exclusions: [] });
+class FakeWorker implements AppearanceWorker {
+  onmessage: AppearanceWorker['onmessage'] = null;
+  onerror: AppearanceWorker['onerror'] = null;
+  onmessageerror: AppearanceWorker['onmessageerror'] = null;
+  terminated = 0;
+  posted: AppearanceWorkerRequest | undefined;
+  postMessage(message: AppearanceWorkerRequest) {
+    assert.equal(arguments.length, 1, 'live source must never be passed in a transfer list');
+    this.posted = structuredClone(message);
+  }
+  terminate() { this.terminated++; }
+  emit(message: AppearanceWorkerResponse) { this.onmessage?.({ data: message } as MessageEvent<AppearanceWorkerResponse>); }
+  complete(result = plan()) { this.emit({ type: 'complete', id: this.posted!.id, plan: result }); }
+}
+function setup(timeoutMs = 120_000) {
+  const workers: FakeWorker[] = [];
+  const client = createAppearancePlanner({ timeoutMs, workerFactory: () => {
+    const worker = new FakeWorker(); workers.push(worker); return worker;
+  } });
+  return { workers, client };
+}
+describe('appearance worker ownership (#4243)', () => {
+  it('rejects an oversized source before spawning a worker or cloning its bytes', async () => {
+    const { client, workers } = setup();
+    const source = new Uint8Array(128 * 1024 * 1024 + 1);
+    await assert.rejects(client.plan(source, request), /exceeds 128 MiB/);
+    assert.equal(workers.length, 0);
+    assert.equal(source.byteLength, 128 * 1024 * 1024 + 1);
+    client.dispose();
+  });
+  it('preserves source storage and clears handlers/worker on success', async () => {
+    const { client, workers } = setup();
+    const source = new Uint8Array([1, 2, 3]);
+    const pending = client.plan(source, request);
+    assert.deepEqual(workers[0].posted?.source, source);
+    assert.notStrictEqual(workers[0].posted?.source.buffer, source.buffer);
+    workers[0].complete(); await pending;
+    assert.deepEqual([...source], [1, 2, 3]);
+    assert.equal(workers[0].terminated, 1); assert.equal(workers[0].onmessage, null);
+    client.dispose(); assert.equal(workers[0].terminated, 1);
+  });
+  it('a newer job rejects the previous one and ignores already-queued stale callbacks', async () => {
+    const { client, workers } = setup();
+    const first = client.plan(new Uint8Array(1), request);
+    const rejected = assert.rejects(first, { name: 'AbortError' });
+    const staleCallback = workers[0].onmessage!;
+    const next = client.plan(new Uint8Array(1), { ...request, sourceRevision: 'second' });
+    await rejected;
+    staleCallback({ data: { type: 'complete', id: 1, plan: plan() } } as MessageEvent<AppearanceWorkerResponse>);
+    assert.equal(workers[0].terminated, 1); assert.equal(workers[1].terminated, 0);
+    workers[1].emit({ type: 'complete', id: 1, plan: plan() });
+    assert.equal(workers[1].terminated, 0, 'wrong job id cannot settle the active worker');
+    workers[1].complete(plan('second')); await next;
+    assert.equal(workers[1].terminated, 1);
+  });
+  it('aborted/disposed clients spawn no worker and cancellation releases an active worker', async () => {
+    const { client, workers } = setup();
+    const signal = AbortSignal.abort();
+    await assert.rejects(client.plan(new Uint8Array(), request, { signal }), { name: 'AbortError' });
+    assert.equal(workers.length, 0);
+    const controller = new AbortController();
+    const pending = client.plan(new Uint8Array(), request, { signal: controller.signal });
+    const rejected = assert.rejects(pending, { name: 'AbortError' });
+    controller.abort(); await rejected; assert.equal(workers[0].terminated, 1);
+    client.dispose(); await assert.rejects(client.plan(new Uint8Array(), request), /disposed/);
+    assert.equal(workers.length, 1);
+  });
+  it('rejects factory/postMessage failures without retaining worker ownership', async () => {
+    const broken = createAppearancePlanner({ workerFactory: () => { throw new Error('CSP blocked'); } });
+    await assert.rejects(broken.plan(new Uint8Array(), request), /CSP blocked/);
+    const worker = new FakeWorker(); worker.postMessage = () => { throw new Error('clone failed'); };
+    const client = createAppearancePlanner({ workerFactory: () => worker });
+    await assert.rejects(client.plan(new Uint8Array(), request), /clone failed/);
+    assert.equal(worker.terminated, 1); assert.equal(worker.onerror, null); client.dispose();
+    assert.equal(worker.terminated, 1);
+  });
+  it('terminates on timeout, crashes, unreadable messages, and mismatched model revisions', async t => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    const { client, workers } = setup(100);
+    const timeout = client.plan(new Uint8Array(), request);
+    const timedOut = assert.rejects(timeout, /stopped responding/);
+    t.mock.timers.tick(100); await timedOut;
+    const crash = client.plan(new Uint8Array(), request);
+    workers[1].onerror?.({ message: 'worker crashed' } as ErrorEvent);
+    await assert.rejects(crash, /worker crashed/);
+    const unreadable = client.plan(new Uint8Array(), request);
+    workers[2].onmessageerror?.({} as MessageEvent);
+    await assert.rejects(unreadable, /unreadable/);
+    const mismatch = client.plan(new Uint8Array(), request); workers[3].complete(plan('wrong'));
+    await assert.rejects(mismatch, /stale model/);
+    assert.ok(workers.every(worker => worker.terminated === 1));
+    t.mock.timers.tick(500); assert.ok(workers.every(worker => worker.terminated === 1));
+  });
+  it('propagates canonical eligibility errors and releases the worker', async () => {
+    const { client, workers } = setup();
+    const pending = client.plan(new Uint8Array(), request);
+    workers[0].emit({ type: 'error', id: workers[0].posted!.id, message: 'Invalid appearance mapping parameters' });
+    await assert.rejects(pending, /Invalid appearance mapping/);
+    assert.equal(workers[0].terminated, 1);
+  });
+});

--- a/apps/viewer/src/lib/appearance/planner-worker-client.test.ts
+++ b/apps/viewer/src/lib/appearance/planner-worker-client.test.ts
@@ -35,10 +35,14 @@ function setup(timeoutMs = 120_000) {
 }
 describe('appearance worker ownership (#4243)', () => {
   it('rejects an oversized source before spawning a worker or cloning its bytes', async () => {
-    const { client, workers } = setup();
+    let attempted = 0;
+    const client = createAppearancePlanner({ workerFactory: () => {
+      attempted++;
+      throw new Error('Oversized source reached the worker boundary');
+    } });
     const source = new Uint8Array(128 * 1024 * 1024 + 1);
     await assert.rejects(client.plan(source, request), /exceeds 128 MiB/);
-    assert.equal(workers.length, 0);
+    assert.equal(attempted, 0);
     assert.equal(source.byteLength, 128 * 1024 * 1024 + 1);
     client.dispose();
   });

--- a/apps/viewer/src/lib/appearance/planner-worker-client.ts
+++ b/apps/viewer/src/lib/appearance/planner-worker-client.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { AppearancePlan, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from './planner-types.js';
+
+export interface AppearanceWorker {
+  onmessage: ((event: MessageEvent<AppearanceWorkerResponse>) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+  onmessageerror: ((event: MessageEvent) => void) | null;
+  postMessage(message: AppearanceWorkerRequest): void;
+  terminate(): void;
+}
+export interface AppearancePlanner {
+  plan(source: Uint8Array, request: AppearanceRequest, options?: { signal?: AbortSignal }): Promise<AppearancePlan>;
+  cancel(): void;
+  dispose(): void;
+}
+const aborted = () => new DOMException('Appearance planning was cancelled', 'AbortError');
+
+/** New requests supersede old jobs. Cancellation terminates CPU-heavy Rust
+ * immediately rather than waiting for the worker event loop to receive it. */
+export function createAppearancePlanner(options: {
+  workerFactory?: () => AppearanceWorker;
+  timeoutMs?: number;
+} = {}): AppearancePlanner {
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error('Invalid appearance worker timeout');
+  const createWorker = options.workerFactory ?? (() =>
+    new Worker(new URL('../../workers/appearance.worker.ts', import.meta.url), { type: 'module' }));
+  let cancelActive: (() => void) | undefined;
+  let sequence = 0;
+  let disposed = false;
+  const cancel = () => cancelActive?.();
+  return {
+    cancel,
+    dispose() { disposed = true; cancel(); },
+    plan(source, request, { signal } = {}) {
+      cancel();
+      if (disposed) return Promise.reject(new Error('Appearance planner is disposed'));
+      if (signal?.aborted) return Promise.reject(aborted());
+      // Match the Rust source budget before structured clone and WASM upload
+      // allocate additional copies of the effective IFC snapshot.
+      if (source.byteLength > 128 * 1024 * 1024) {
+        return Promise.reject(new Error('Appearance source exceeds 128 MiB. Use a smaller IFC model.'));
+      }
+      const id = ++sequence;
+      return new Promise((resolve, reject) => {
+        let worker: AppearanceWorker;
+        try { worker = createWorker(); }
+        catch (error) { reject(new Error(`Cannot start appearance worker: ${error instanceof Error ? error.message : String(error)}`)); return; }
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const finish = (error?: Error, plan?: AppearancePlan) => {
+          if (settled) return;
+          settled = true;
+          if (timer !== undefined) clearTimeout(timer);
+          signal?.removeEventListener('abort', onAbort);
+          worker.onmessage = null; worker.onerror = null; worker.onmessageerror = null;
+          worker.terminate();
+          if (sequence === id) cancelActive = undefined;
+          if (error) reject(error); else resolve(plan!);
+        };
+        const onAbort = () => finish(aborted());
+        cancelActive = onAbort;
+        signal?.addEventListener('abort', onAbort, { once: true });
+        timer = setTimeout(() => finish(new Error('Appearance planning stopped responding. Try a smaller scope.')), timeoutMs);
+        worker.onmessage = event => {
+          const message = event.data;
+          if (!message || message.id !== id || settled || sequence !== id) return;
+          if (message.type === 'error') { finish(new Error(message.message)); return; }
+          if (message.type !== 'complete') return;
+          if (!message.plan || message.plan.sourceRevision !== revision || message.plan.nextExpressId !== allocationStart) {
+            finish(new Error('Appearance worker returned a stale model revision')); return;
+          }
+          finish(undefined, message.plan);
+        };
+        worker.onerror = event => finish(new Error(event.message || 'Appearance worker crashed'));
+        worker.onmessageerror = () => finish(new Error('Appearance worker sent an unreadable message'));
+        const revision = request.sourceRevision, allocationStart = request.nextExpressId;
+        try {
+          // Structured clone copies the source. Never transfer its buffer: the
+          // caller may be using that same storage for the live IFC model.
+          worker.postMessage({ type: 'plan', id, source, request });
+        } catch (error) { finish(error instanceof Error ? error : new Error(String(error))); }
+        // A custom factory may have triggered abort synchronously during setup.
+        if (signal?.aborted) onAbort();
+      });
+    },
+  };
+}

--- a/apps/viewer/src/workers/appearance.worker.ts
+++ b/apps/viewer/src/workers/appearance.worker.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import init, { IfcAPI } from '@ifc-lite/wasm';
+import type { AppearancePlan, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from '../lib/appearance/planner-types.js';
+
+/** Canonical Rust does graph eligibility, projection and IFC authoring. Exported
+ * within the viewer for real-WASM contract tests; production calls only in this
+ * worker. One job per worker bounds retained WebAssembly.Memory to that job. */
+export async function runAppearancePlanning(source: Uint8Array, request: AppearanceRequest): Promise<AppearancePlan> {
+  await init();
+  const api = new IfcAPI();
+  try {
+    const bytes = api.planAppearance(source, JSON.stringify(request));
+    return JSON.parse(new TextDecoder().decode(bytes)) as AppearancePlan;
+  } finally {
+    api.free();
+  }
+}
+
+const isWorkerScope = typeof self !== 'undefined' &&
+  typeof (globalThis as { window?: unknown }).window === 'undefined' &&
+  typeof (self as unknown as Worker).postMessage === 'function';
+if (isWorkerScope) {
+  self.onmessage = async (event: MessageEvent<AppearanceWorkerRequest>) => {
+    const job = event.data;
+    if (!job || job.type !== 'plan') return;
+    try {
+      const plan = await runAppearancePlanning(job.source, job.request);
+      (self as unknown as Worker).postMessage({ type: 'complete', id: job.id, plan } satisfies AppearanceWorkerResponse);
+    } catch (error) {
+      (self as unknown as Worker).postMessage({ type: 'error', id: job.id,
+        message: error instanceof Error ? error.message : String(error) } satisfies AppearanceWorkerResponse);
+    }
+  };
+}

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -79,6 +79,11 @@ UTF-8 `AppearancePlan` JSON bytes and never mutates the source. Run this
 synchronous operation in a dedicated worker; terminate that worker to cancel.
 Free the `IfcAPI` handle in `finally` when the job ends.
 
+The browser client rejects source snapshots above 128 MiB before copying them to
+the worker. The binding limits request JSON to 256 KiB and serialized results to
+64 MiB; the Rust planner separately bounds aggregate geometry and texture work.
+Budget errors require a smaller source or scope and do not return a partial edit.
+
 The request supplies `schema` (`IFC4` or `IFC4X3`), `sourceRevision`, the reserved
 `nextExpressId` allocator watermark, `productIds`, a safe relative `imageUri`,
 `repeatS`, `repeatT`, and `mapping`. Mapping accepts `existingUv` with scale,

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -71,6 +71,35 @@ class IfcAPI {
 
 The methods below reflect the real `IfcAPI` surface (see `packages/wasm/pkg/ifc-lite.d.ts`). There is no single `parse()` call: scanning, geometry, and export are separate entry points.
 
+#### Appearance Planning
+
+`IfcAPI.planAppearance(content, requestJson)` accepts an effective IFC STEP
+snapshot as `Uint8Array` and an `AppearanceRequest` JSON string. It returns
+UTF-8 `AppearancePlan` JSON bytes and never mutates the source. Run this
+synchronous operation in a dedicated worker; terminate that worker to cancel.
+Free the `IfcAPI` handle in `finally` when the job ends.
+
+The request supplies `schema` (`IFC4` or `IFC4X3`), `sourceRevision`, the reserved
+`nextExpressId` allocator watermark, `productIds`, a safe relative `imageUri`,
+`repeatS`, `repeatT`, and `mapping`. Mapping accepts `existingUv` with scale,
+offset and rotation in radians; `planar` with an item/world frame, orthonormal
+axes, origin and tile dimensions in metres; or `box` with an item/world frame,
+origin and three tile dimensions in metres. Exact shapes are defined in
+`rust/processing/src/appearance/types.rs`.
+
+Only direct, unshared `IfcTriangulatedFaceSet` Body representations are initially
+eligible. The result reports exclusions per product; hosts must obtain explicit
+acceptance of a reduced scope. Plans contain created IFC entities, positional
+attribute edits and canonical source/target triangle indices with preview UVs
+in triangle-corner order. Consumers must validate geometry provenance; matching
+vertex counts alone cannot establish UV correspondence.
+
+Before committing, the host must revalidate the source revision and allocator,
+retain the referenced image bytes, and prepare all renderer and IFC changes.
+Apply the complete plan atomically with one undo entry. Package the image at its
+relative URI when exporting IFCZIP. Planning does not provide asset persistence,
+GPU preview, history or collaboration by itself.
+
 #### Entity Scanning
 
 SIMD-accelerated scanners that return entity references for the data-model layer to decode.

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -606,6 +606,13 @@ export class IfcAPI {
      */
     parseSymbolicRepresentations(content: string): SymbolicRepresentationCollection;
     /**
+     * Plan image/UV edits against an effective IFC snapshot without mutating it.
+     * JSON input uses AppearanceRequest; output is UTF-8 AppearancePlan JSON.
+     * Call from a worker, then validate sourceRevision and allocator before an
+     * atomic host commit. Preview UVs describe an unsplit canonical mesh item.
+     */
+    planAppearance(content: Uint8Array, request_json: string): Uint8Array;
+    /**
      * Process geometry for a subset of pre-scanned entities → flat
      * MeshCollection. Takes raw bytes + pre-pass data from buildPrePassOnce.
      * Thin wrapper over [`IfcAPI::produce_batch`]; converts each produced mesh
@@ -2026,6 +2033,7 @@ export interface InitOutput {
     readonly ifcapi_parseGridAxes: (a: number, b: number, c: number) => number;
     readonly ifcapi_parseGridLines: (a: number, b: number, c: number) => number;
     readonly ifcapi_parseSymbolicRepresentations: (a: number, b: number, c: number) => number;
+    readonly ifcapi_planAppearance: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly ifcapi_processGeometryBatch: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number) => number;
     readonly ifcapi_processGeometryBatchFromSource: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number) => number;
     readonly ifcapi_processGeometryBatchInstanced: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number, c1: number) => void;

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -31,6 +31,7 @@ threads = ["dep:wasm-bindgen-rayon"]
 console-tracing = ["dep:tracing", "ifc-lite-processing/observability"]
 
 [dependencies]
+serde_json = "1.0"
 # Optional: only compiled for the threaded bundle (--features threads). Needs
 # the atomics/shared-memory target-features to build, so it must stay optional.
 wasm-bindgen-rayon = { version = "1.3.0", optional = true }

--- a/rust/wasm-bindings/src/api/appearance.rs
+++ b/rust/wasm-bindings/src/api/appearance.rs
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Appearance edits use the same Rust planner in native and browser hosts.
+use super::IfcAPI;
+use ifc_lite_processing::appearance::{plan_appearance, AppearanceRequest};
+use wasm_bindgen::prelude::*;
+
+fn plan_json(content: &[u8], request_json: &str) -> Result<Vec<u8>, String> {
+    if request_json.len() > 256 * 1024 {
+        return Err("Appearance request exceeds the scope budget".into());
+    }
+    let request: AppearanceRequest = serde_json::from_str(request_json)
+        .map_err(|error| format!("Invalid appearance request: {error}"))?;
+    let plan = plan_appearance(content, &request)?;
+    encode_bounded(&plan)
+}
+
+// A writer ceiling stops serialization before allocating an oversized JSON buffer.
+// The host then holds UTF-8 bytes, a JS string and its parsed/structured-cloned graph.
+fn encode_bounded(value: &impl serde::Serialize) -> Result<Vec<u8>, String> {
+    struct Output(Vec<u8>);
+    impl std::io::Write for Output {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if bytes.len() > (64 * 1024 * 1024usize).saturating_sub(self.0.len()) {
+                return Err(std::io::Error::other("Appearance JSON exceeds 64 MiB. Choose fewer objects or simplify the source mesh."));
+            }
+            self.0.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+    }
+    let mut output = Output(Vec::new());
+    serde_json::to_writer(&mut output, value).map_err(|error| format!("Cannot encode appearance plan: {error}"))?;
+    Ok(output.0)
+}
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Plan image/UV edits against an effective IFC snapshot without mutating it.
+    /// JSON input uses AppearanceRequest; output is UTF-8 AppearancePlan JSON.
+    /// Call from a worker, then validate sourceRevision and allocator before an
+    /// atomic host commit. Preview UVs describe an unsplit canonical mesh item.
+    #[wasm_bindgen(js_name = planAppearance)]
+    pub fn plan_appearance(&self, content: &[u8], request_json: &str) -> Result<Vec<u8>, JsError> {
+        plan_json(content, request_json).map_err(|message| JsError::new(&message))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{plan_json, encode_bounded};
+
+    #[test]
+    fn issue_4243_serialization_stops_at_the_output_budget() {
+        // Reused strings keep the test input small while serialized output expands.
+        let chunk = "x".repeat(1024 * 1024);
+        let fields = vec![&chunk; 65];
+        assert!(encode_bounded(&fields).unwrap_err().contains("exceeds 64 MiB"));
+        assert_eq!(encode_bounded(&vec!["small"]).unwrap(), br#"["small"]"#);
+    }
+
+
+    #[test]
+    fn issue_4243_rejects_malformed_and_oversized_requests_before_source_processing() {
+        assert!(plan_json(b"", "{").unwrap_err().contains("Invalid appearance request"));
+        assert!(plan_json(b"", &" ".repeat(256 * 1024 + 1)).unwrap_err().contains("scope budget"));
+    }
+}

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! JavaScript API for IFC-Lite: modern async/await parsing. Kept short: this
-//! file is AT its `module_size_ratchet` budget, so a new `mod` costs a line.
+//! JavaScript API for IFC-Lite; feature methods live in focused child modules.
 
 mod alignment_lines;
+mod appearance;
 mod bool2d;
 mod clash;
 mod clash_solid;


### PR DESCRIPTION
The shared Rust appearance planner can now run through WASM in a dedicated viewer worker. Changing settings cancels the previous worker immediately; results carry the source revision and allocator watermark so a stale result cannot be accepted as a current plan. The caller's live IFC buffer remains attached.

This is the browser transport slice, stacked on #4272. It does not expose the Appearance dock or apply an IFC edit by itself; the atomic command and integrated UI follow separately. Refs #4243.

The client rejects sources above 128 MiB before structured cloning. The binding bounds request JSON at 256 KiB and stops serialization before the result exceeds 64 MiB, in addition to the native geometry/texture budgets. Worker errors, abort, timeout and unreadable messages terminate the worker and reject the pending job. WASM handles are freed in `finally`.

Validation:

- Fresh `pnpm build:wasm` from the final parent and binding source; generated committed declarations are in sync.
- Full root `pnpm typecheck`: 90 tasks pass, including test sources.
- Seven worker lifecycle tests pass, covering latest-wins cancellation, stale revisions, factory/transport failures and source ownership.
- Actual rebuilt WASM contract passes: real IFC input produces the expected edit, triangle-corner UVs and canonical target normals in renderer Y-up coordinates, rejects an invalid allocator, and succeeds again afterward.
- `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass on the final native parent. The unchanged binding passed both on its isolated slice; the final rebased worker is verified by a fresh WASM build, full root typecheck and real-WASM contract test.
- Public WASM guide and CLI-created minor changeset included. API surface generation remains unchanged because the binding is documented in its generated WASM declarations.

Performance scope: planning is opt-in and dispatched to a separate worker. This slice does not change the ordinary load path; the native parent carries its interleaved load regression check. No latency or responsiveness claim is made from mocked worker tests.

