### PR TITLE
fix(cli): query --group-by aggregation cannot distinguish no-data from a real zero

### DIFF
--- a/.changeset/cli-group-by-matched-entities.md
+++ b/.changeset/cli-group-by-matched-entities.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Fix `query --group-by --sum/--avg/--min/--max --json` reporting a fabricated `0` for a group that has no data for the aggregated quantity, indistinguishable from a group whose real aggregate genuinely computes to `0`. Each group entry now carries `matchedEntities`, the count of entities in that group that actually had the quantity — `matchedEntities: 0` means the numeric field is fabricated, not measured. The existing numeric field's type is unchanged (still always a number) so this is additive, not breaking.
+
+The non-JSON (table) rendering now annotates a no-data group's line with `(no data)`, and the trailing warning now fires only when no group in the result matched any data, instead of when the grand total across all groups happened to be `0` (which previously both missed a no-data group mixed in with real-data groups, and falsely warned when a real aggregate legitimately cancels to `0`, e.g. summing `-5` and `5`).
+
+`schedule --subtotals` already propagated a genuine `null` for a no-data subtotal end-to-end (CSV and JSON), so it needed no change.

--- a/packages/cli/src/commands/query-output.test.ts
+++ b/packages/cli/src/commands/query-output.test.ts
@@ -370,6 +370,135 @@ describe('outputGroupBy', () => {
     maxJson.spy.mockRestore();
     expect(JSON.parse(maxJson.chunks.join(''))['IfcWall'].NetVolume).toBe(10);
   });
+
+  /**
+   * #4252: a group with NO NetVolume quantity data at all must be
+   * distinguishable in --json from a group whose real aggregate genuinely
+   * computes to 0. Discriminating fixture: `noDataBim` has doors that carry
+   * no NetVolume quantity anywhere (fabricated 0, matchedEntities 0);
+   * `zeroBim` has doors whose NetVolume values are -5 and 5, so the real
+   * average/sum genuinely is 0 (matchedEntities 2, the same numeric 0 but
+   * NOT fabricated). If both rendered identically on matchedEntities, this
+   * test would be vacuous — it asserts they diverge on that field despite
+   * an identical `NetVolume: 0`.
+   *
+   * Kills reverting `entry.matchedEntities = groupMatched.get(key) ?? 0`
+   * (or dropping it): with it gone, both cases collapse back to
+   * `{count, NetVolume: 0}` and cannot be told apart, which is #4252 itself.
+   */
+  it('distinguishes a group with no quantity data from a group whose real value is 0 (avg, json)', () => {
+    const noDataBim = fakeBim({ quantities: {} });
+    const doors = [{ ref: 1, type: 'IfcDoor' }, { ref: 2, type: 'IfcDoor' }] as FakeEntity[];
+
+    const noData = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', noDataBim, true, undefined, 'avg');
+    noData.spy.mockRestore();
+    const noDataEntry = JSON.parse(noData.chunks.join(''))['IfcDoor'];
+    expect(noDataEntry.NetVolume).toBe(0);
+    expect(noDataEntry.matchedEntities).toBe(0);
+
+    const zeroBim = fakeBim({
+      quantities: {
+        1: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: -5 }] }],
+        2: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: 5 }] }],
+      },
+    });
+    const zero = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', zeroBim, true, undefined, 'avg');
+    zero.spy.mockRestore();
+    const zeroEntry = JSON.parse(zero.chunks.join(''))['IfcDoor'];
+    expect(zeroEntry.NetVolume).toBe(0);
+    expect(zeroEntry.matchedEntities).toBe(2);
+  });
+
+  /**
+   * Same discriminating pair as above, but for --sum: an empty group's
+   * fabricated 0 total must carry matchedEntities: 0, while a real sum that
+   * cancels to 0 (values -5 and 5) must carry matchedEntities: 2. Confirms
+   * the fix is not avg-only — sum shares the exact same ambiguity.
+   */
+  it('distinguishes a group with no quantity data from a real cancelling-to-0 sum (json)', () => {
+    const noDataBim = fakeBim({ quantities: {} });
+    const doors = [{ ref: 1, type: 'IfcDoor' }, { ref: 2, type: 'IfcDoor' }] as FakeEntity[];
+
+    const noData = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', noDataBim, true, undefined, 'sum');
+    noData.spy.mockRestore();
+    const noDataEntry = JSON.parse(noData.chunks.join(''))['IfcDoor'];
+    expect(noDataEntry.NetVolume).toBe(0);
+    expect(noDataEntry.matchedEntities).toBe(0);
+
+    const zeroBim = fakeBim({
+      quantities: {
+        1: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: -5 }] }],
+        2: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: 5 }] }],
+      },
+    });
+    const zero = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', zeroBim, true, undefined, 'sum');
+    zero.spy.mockRestore();
+    const zeroEntry = JSON.parse(zero.chunks.join(''))['IfcDoor'];
+    expect(zeroEntry.NetVolume).toBe(0);
+    expect(zeroEntry.matchedEntities).toBe(2);
+  });
+
+  /**
+   * min/max share the same ambiguity: an empty group fabricates 0 (there is
+   * no real min/max), while a group with actual values of 0 (e.g. [0, 0])
+   * is a genuine min/max of 0. matchedEntities must tell them apart.
+   */
+  it('distinguishes a group with no quantity data from a real min/max of 0 (json)', () => {
+    const noDataBim = fakeBim({ quantities: {} });
+    const doors = [{ ref: 1, type: 'IfcDoor' }, { ref: 2, type: 'IfcDoor' }] as FakeEntity[];
+
+    const noDataMin = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', noDataBim, true, undefined, 'min');
+    noDataMin.spy.mockRestore();
+    const noDataEntry = JSON.parse(noDataMin.chunks.join(''))['IfcDoor'];
+    expect(noDataEntry.NetVolume).toBe(0);
+    expect(noDataEntry.matchedEntities).toBe(0);
+
+    const realZeroBim = fakeBim({
+      quantities: {
+        1: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: 0 }] }],
+        2: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: 0 }] }],
+      },
+    });
+    const realZeroMin = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', realZeroBim, true, undefined, 'min');
+    realZeroMin.spy.mockRestore();
+    const realZeroEntry = JSON.parse(realZeroMin.chunks.join(''))['IfcDoor'];
+    expect(realZeroEntry.NetVolume).toBe(0);
+    expect(realZeroEntry.matchedEntities).toBe(2);
+  });
+
+  /**
+   * Text-mode counterpart: a no-data group's line is annotated "(no data)"
+   * while a group whose real average genuinely is 0 prints the plain
+   * number with no annotation — the two paths (json / text) must agree
+   * on the same underlying signal (#4252 noted they previously diverged:
+   * text already had a signal, json had none).
+   */
+  it('annotates only the no-data group with "(no data)" in text mode, not a real-zero group', () => {
+    const doors = [{ ref: 1, type: 'IfcDoor' }, { ref: 2, type: 'IfcDoor' }] as FakeEntity[];
+    const noDataBim = fakeBim({ quantities: {} });
+
+    const noData = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', noDataBim, false, undefined, 'avg');
+    noData.spy.mockRestore();
+    expect(noData.chunks.join('')).toContain('(no data)');
+
+    const zeroBim = fakeBim({
+      quantities: {
+        1: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: -5 }] }],
+        2: [{ name: 'Qto_DoorBaseQuantities', quantities: [{ name: 'NetVolume', value: 5 }] }],
+      },
+    });
+    const zero = captureStdout();
+    outputGroupBy(doors, 'type', 'NetVolume', zeroBim, false, undefined, 'avg');
+    zero.spy.mockRestore();
+    expect(zero.chunks.join('')).not.toContain('(no data)');
+  });
 });
 
 describe('computeUniqueValues', () => {

--- a/packages/cli/src/commands/query-output.ts
+++ b/packages/cli/src/commands/query-output.ts
@@ -228,6 +228,12 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
   // Compute per-group aggregation if a quantity is specified alongside --group-by
   const mode = aggMode ?? 'sum';
   const groupAgg = new Map<string, number>();
+  // #4252: how many of the group's entities actually carried `sumQuantity`
+  // (getQuantityValue returned non-null). A group where this is 0 has NO
+  // data for the quantity — its aggregated value below is a fabricated 0,
+  // not a real sum/avg/min/max, and must be told apart from a group whose
+  // real aggregate genuinely computes to 0.
+  const groupMatched = new Map<string, number>();
   if (sumQuantity) {
     for (const [key, groupEntities] of groups) {
       const vals: number[] = [];
@@ -235,8 +241,10 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
         const val = getQuantityValue(bim, e.ref, sumQuantity);
         if (val !== null) vals.push(val);
       }
-      // Shared finite-guarded reduction; an empty group stays 0 here.
+      // Shared finite-guarded reduction; an empty group stays 0 here, but
+      // groupMatched (below) records that it is a fabricated 0.
       groupAgg.set(key, aggregateFinite(vals, mode) ?? 0);
+      groupMatched.set(key, vals.length);
     }
   }
 
@@ -249,7 +257,15 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
     if (groupLimit) entries = entries.slice(0, groupLimit);
     for (const [key, groupEntities] of entries) {
       const entry: Record<string, unknown> = { count: groupEntities.length };
-      if (sumQuantity) entry[sumQuantity] = groupAgg.get(key) ?? 0;
+      if (sumQuantity) {
+        entry[sumQuantity] = groupAgg.get(key) ?? 0;
+        // #4252: always present alongside sumQuantity (all four aggregation
+        // modes share the same "0 matched" ambiguity, not just avg) so a
+        // JSON consumer can tell a real 0 from a group with no quantity
+        // data at all: matchedEntities === 0 means the number above is
+        // fabricated, not measured.
+        entry.matchedEntities = groupMatched.get(key) ?? 0;
+      }
       if (sumQuantity && mode !== 'sum') entry.aggregation = mode;
       result[key] = entry;
     }
@@ -262,16 +278,28 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
     for (const [key, groupEntities] of sorted) {
       if (sumQuantity) {
         const agg = groupAgg.get(key) ?? 0;
-        process.stdout.write(`  ${key}:  ${groupEntities.length} elements,  ${sumQuantity} ${modeLabel}: ${mode === 'avg' ? agg.toFixed(4) : agg}\n`);
+        const matchedCount = groupMatched.get(key) ?? 0;
+        // #4252: annotate a group whose aggregate is fabricated (no entity
+        // in the group carried this quantity at all) so the text rendering
+        // agrees with the --json matchedEntities field, instead of printing
+        // a bare 0 indistinguishable from a real zero aggregate.
+        const noData = matchedCount === 0 ? '  (no data)' : '';
+        process.stdout.write(`  ${key}:  ${groupEntities.length} elements,  ${sumQuantity} ${modeLabel}: ${mode === 'avg' ? agg.toFixed(4) : agg}${noData}\n`);
       } else {
         process.stdout.write(`  ${key}: ${groupEntities.length}\n`);
       }
     }
     if (sumQuantity) {
-      const grandTotal = [...groupAgg.values()].reduce((a, b) => a + b, 0);
+      const totalMatched = [...groupMatched.values()].reduce((a, b) => a + b, 0);
       process.stdout.write(`\n  Total: ${entities.length} entities in ${groups.size} groups\n`);
-      if (grandTotal === 0 && entities.length > 0) {
-        process.stderr.write(`\n  Warning: All ${sumQuantity} values are 0. The file may not contain quantity data for this property.\n`);
+      // #4252: warn only when NO group in the result matched any quantity
+      // data — the prior check compared the grand total to 0, which both
+      // missed a mix of real-data and no-data groups (the ones with data
+      // could sum to nonzero and mask a same-run no-data group) and
+      // false-flagged a real aggregate that legitimately cancels to 0
+      // (e.g. sum of [-5, 5]).
+      if (totalMatched === 0 && entities.length > 0) {
+        process.stderr.write(`\n  Warning: No ${sumQuantity} quantity data found for any entity. The values above are 0 because none was found, not because the property genuinely measures 0.\n`);
       }
       process.stdout.write('\n');
     } else {


### PR DESCRIPTION
## Summary

`query --group-by --sum/--avg/--min/--max --json` fabricated an aggregated value of `0` for a group that has no data at all for the quantity, byte-for-byte identical to a group whose real aggregate genuinely computes to `0`. A consumer of the JSON (agent, script, report generator) could not tell the two apart. Text mode already had a coarse signal (a warning keyed on the grand total across ALL groups being 0), but it both missed a no-data group mixed in with real-data groups, and false-fired when a real aggregate legitimately cancels to 0 (e.g. summing `-5` and `5`).

Root cause: `packages/cli/src/commands/query-output.ts`'s `outputGroupBy` computed each group's aggregate with `aggregateFinite(vals, mode) ?? 0`, discarding `aggregateFinite`'s deliberate `null` (documented in `query-aggregation.ts` as "no finite value was seen ... rather than a fabricated `0`") before it ever reached the JSON or table output.

## What changed

- `outputGroupBy` now also tracks, per group, `matchedEntities` — the count of entities in that group that actually carried the aggregated quantity (`getQuantityValue` returned non-null).
- **`--json`**: every group entry with a `sumQuantity` now also carries `matchedEntities`. `matchedEntities: 0` means the numeric field next to it is fabricated, not measured. The existing numeric field's type is unchanged (still always a `number`), so this is additive — an existing consumer reading only the numeric field sees no change in shape or values, and gains the new field to opt into the distinction.
- **Text mode**: a no-data group's line is now annotated `(no data)`, and the trailing warning fires only when no group in the result matched anything (previously: when the grand total across all groups was 0).
- Applied uniformly across all four modes (`sum`, `avg`, `min`, `max`) — they share the same "0 matched entities" ambiguity, not just `avg`. `count` (the entity count, not a quantity-derived value) is unambiguous and untouched.

## Siblings checked

- `query --sum` / `query --avg|--min|--max` (flat, ungrouped): already unambiguous — `matched === 0` takes an explicit early-return error branch (`outputSum`) or emits a `matchedEntities`/`error` field (`outputAggregation`, `outputSum`). No change needed.
- `schedule --subtotals`: already propagates `aggregateFinite`'s genuine `null` straight through `computeValues` → `SubtotalValue.value` → CSV (blank cell) and JSON (`null`), with no `?? 0` anywhere in that path. No change needed.
- No MCP tool or other consumer in this repo reads `query --group-by --json`'s per-group aggregate field (grepped `packages/mcp`, `apps/viewer`, and README/docs) — the MCP `count_entities` tool's own `group_by` support is a separate, count-only implementation unaffected by this change.

## Test plan

- [x] `query-output.test.ts`: new discriminating-fixture tests for avg, sum, and min/max — a group with genuinely no quantity data (`matchedEntities: 0`) vs. a group whose real aggregate computes to exactly 0 via `[-5, 5]` or `[0, 0]` (`matchedEntities: 2`), asserting they now diverge on `matchedEntities` despite an identical numeric `0`.
- [x] Text-mode test: only the no-data group's line gets `(no data)`; the real-zero group's line does not.
- [x] RED/GREEN: reverted the fix to the pre-patch `?? 0` behavior, confirmed the 4 new tests fail (naming `matchedEntities` as `undefined` / missing `(no data)`), restored the fix, confirmed all pass.
- [x] `packages/cli` vitest: `query-output.test.ts` + `query-aggregation.test.ts` — 46/46 passing.
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget.
- [x] `git diff --stat upstream/main HEAD` lists only the touched files (query-output.ts, query-output.test.ts, changeset).

Closes #4252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Grouped query results now distinguish genuine aggregate values of `0` from groups with no matching data.
  - JSON output includes a `matchedEntities` count for each group.
  - Table output labels groups without data as `(no data)`.
  - Warnings now appear only when no groups contain matching data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->