### PR TITLE
fix(sdk): convert bim.bcf.createViewpoint() camera/sectionPlane to @ifc-lite/bcf's shapes

### DIFF
--- a/.changeset/fix-bcf-createviewpoint-shapes.md
+++ b/.changeset/fix-bcf-createviewpoint-shapes.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/sdk": patch
+---
+
+`bim.bcf.createViewpoint()` forwarded `camera`/`sectionPlane` to `@ifc-lite/bcf` unchanged, but the two packages use incompatible shapes: a tuple-based, mode/fov-less `camera` versus `@ifc-lite/bcf`'s `{x,y,z}` `ViewerCameraState`, and an `'x'|'y'|'z'` section-plane axis versus its `'down'|'front'|'side'` vocabulary. Following the documented `createViewpoint({ camera: bim.viewer.getCamera(), sectionPlane: bim.viewer.getSection() })` pattern silently produced a camera with `null`/`NaN` coordinates and dropped an enabled section plane's clipping plane entirely, with no error.
+
+`createViewpoint()` now converts both shapes correctly (reusing the same x/y/z ⟷ down/front/side axis convention `apps/viewer/src/sdk/adapters/viewer-adapter.ts` already applies to `getSection()`/`setSection()`), and throws `IncompleteCameraStateError` for a camera missing position/target/up or `MissingSectionBoundsError` for an enabled section plane with no `bounds` (a new, required-when-enabled `ViewpointOptions.bounds: AABB` field — nothing in the SDK's public surface can compute a model's overall bounds, so callers must supply it) instead of silently building a corrupted viewpoint. `extractViewpointState()` gets the equivalent read-side fix, converting `@ifc-lite/bcf`'s object/down-front-side shapes back into the SDK's tuple/x-y-z shapes so a captured viewpoint round-trips straight into `bim.viewer.setCamera()`/`setSection()`.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -182,8 +182,18 @@ export { IDSNamespace } from './namespaces/ids.js';
 export type { IDSValidationSummary, IDSSupportedLocale, IDSValidateOptions } from './namespaces/ids.js';
 
 // BCF — full collaboration: topics, viewpoints, comments, GUID, colors, IDS→BCF
-export { BCFNamespace } from './namespaces/bcf.js';
-export type { TopicOptions, CommentOptions, ViewpointOptions, IDSBCFOptions } from './namespaces/bcf.js';
+export {
+  BCFNamespace,
+  IncompleteCameraStateError,
+  MissingSectionBoundsError,
+} from './namespaces/bcf.js';
+export type {
+  TopicOptions,
+  CommentOptions,
+  ViewpointOptions,
+  ExtractedViewpointState,
+  IDSBCFOptions,
+} from './namespaces/bcf.js';
 
 // Drawing — section cuts, styles, symbols, sheets, SVG, graphic overrides
 export { DrawingNamespace } from './namespaces/drawing.js';

--- a/packages/sdk/src/namespaces/bcf-viewpoint.ts
+++ b/packages/sdk/src/namespaces/bcf-viewpoint.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shape adapter between the SDK's public `ViewpointOptions`/
+ * `ExtractedViewpointState` (tuple camera, x/y/z section-plane axis — the
+ * shapes `bim.viewer.getCamera()`/`getSection()`/`setCamera()`/`setSection()`
+ * use) and `@ifc-lite/bcf`'s `ViewerCameraState`/`ViewerSectionPlane`
+ * (object camera, down/front/side axis).
+ *
+ * `BCFNamespace.createViewpoint()`/`extractViewpointState()` in bcf.ts used
+ * to forward the SDK shape to `@ifc-lite/bcf` unchanged: the library read
+ * `camera.position.x` off a 3-tuple (always undefined) and an 'x'|'y'|'z'
+ * axis never matched its 'down'|'front'|'side' switch, so a documented
+ * `createViewpoint({ camera: bim.viewer.getCamera(), sectionPlane:
+ * bim.viewer.getSection() })` call silently produced a corrupted camera and
+ * dropped the section cut with no error (#4251). Split out of bcf.ts to
+ * keep that file under the house 400-line module-size budget.
+ */
+
+import type { AABB } from '../types.js';
+
+// ============================================================================
+// Option types for the namespace API
+// ============================================================================
+
+export interface ViewpointOptions {
+  /**
+   * Camera state from bim.viewer.getCamera(). `position`/`target`/`up` are
+   * REQUIRED if `camera` is passed at all — `createViewpoint()` throws
+   * `IncompleteCameraStateError` rather than building a viewpoint with
+   * missing coordinates (#4251). `bim.viewer.getCamera()` returns only
+   * `{ mode }` when no viewport is mounted (headless, or before first
+   * paint); callers in that situation must supply position/target/up
+   * themselves or omit `camera`.
+   *
+   * The SDK's `CameraState` carries no field-of-view (the renderer's real
+   * FOV isn't part of its public surface), so the viewpoint's FOV is always
+   * written as a fixed default (`Math.PI / 4`), matching the placeholder
+   * `@ifc-lite/bcf` itself uses for orthographic cameras.
+   */
+  camera?: {
+    mode: 'perspective' | 'orthographic';
+    position?: [number, number, number];
+    target?: [number, number, number];
+    up?: [number, number, number];
+  };
+  /** Section plane from bim.viewer.getSection(). Requires `bounds` (below)
+   * when `enabled` is true — see `bounds`. */
+  sectionPlane?: {
+    axis: 'x' | 'y' | 'z';
+    position: number;
+    enabled: boolean;
+    flipped: boolean;
+  };
+  /**
+   * The model's overall axis-aligned bounding box, REQUIRED when
+   * `sectionPlane.enabled` is true — `@ifc-lite/bcf` needs it to convert a
+   * percentage-along-axis section plane into an absolute clipping-plane
+   * location, and nothing in the SDK's public surface (`bim.viewer.*`,
+   * `bim.spatial.*`) can compute a model's bounds (`bim.spatial.queryBounds`
+   * does the reverse: it queries entities inside an already-known box).
+   * Omitting `bounds` while `sectionPlane.enabled` is true throws
+   * `MissingSectionBoundsError` instead of silently dropping the clipping
+   * plane (#4251).
+   */
+  bounds?: AABB;
+  /** Component selection/visibility */
+  components?: {
+    selection?: Array<{ GlobalId: string }>;
+    visibility?: {
+      defaultVisibility: boolean;
+      exceptions?: Array<{ GlobalId: string }>;
+    };
+    coloring?: Array<{
+      color: string;
+      components: Array<{ GlobalId: string }>;
+    }>;
+  };
+}
+
+/**
+ * State extracted from a BCF viewpoint, shaped to round-trip straight back
+ * into `bim.viewer.setCamera()` / `bim.viewer.setSection()` — the same
+ * tuple camera + x/y/z section-plane axis vocabulary `ViewpointOptions`
+ * documents as input from `getCamera()`/`getSection()`.
+ */
+export interface ExtractedViewpointState {
+  camera?: {
+    mode: 'perspective' | 'orthographic';
+    position: [number, number, number];
+    target: [number, number, number];
+    up: [number, number, number];
+  };
+  sectionPlane?: {
+    axis: 'x' | 'y' | 'z';
+    position: number;
+    enabled: boolean;
+    flipped: boolean;
+  };
+  selectedGuids: string[];
+  hiddenGuids: string[];
+  visibleGuids: string[];
+  coloredGuids: Array<{ color: string; guids: string[] }>;
+}
+
+// ============================================================================
+// Errors — reject, do not silently coerce (#4251)
+// ============================================================================
+
+/**
+ * Thrown by createViewpoint() when `options.camera` is missing (or missing
+ * position/target/up). Forwarding an incomplete camera used to build a
+ * viewpoint whose coordinates silently read back as `null`
+ * (`JSON.stringify` drops `undefined`; `-undefined` is `NaN`, which
+ * serializes as `null`) — see #4251.
+ */
+export class IncompleteCameraStateError extends Error {
+  constructor(missing: string[]) {
+    super(
+      `bim.bcf.createViewpoint(): camera is missing ${missing.join(', ')}. ` +
+        `Pass position/target/up as [number, number, number] tuples, or omit ` +
+        `camera entirely — bim.viewer.getCamera() returns only { mode } when ` +
+        `no viewport is mounted.`
+    );
+    this.name = 'IncompleteCameraStateError';
+  }
+}
+
+/**
+ * Thrown by createViewpoint() when `options.sectionPlane.enabled` is true
+ * but `options.bounds` was not supplied. @ifc-lite/bcf's
+ * `sectionPlaneToClippingPlane` needs both an `enabled` section plane and a
+ * `bounds` argument to build a clipping plane; without `bounds` the SDK
+ * used to forward `sectionPlane` alone and the library silently produced no
+ * `clippingPlanes` at all — see #4251.
+ */
+export class MissingSectionBoundsError extends Error {
+  constructor() {
+    super(
+      `bim.bcf.createViewpoint(): options.sectionPlane.enabled is true but ` +
+        `options.bounds was not provided. Pass the model's overall AABB as ` +
+        `{ min: [x, y, z], max: [x, y, z] }.`
+    );
+    this.name = 'MissingSectionBoundsError';
+  }
+}
+
+// ============================================================================
+// Conversion helpers
+// ============================================================================
+
+/** FOV (radians) written into every viewpoint camera — the SDK's public
+ * CameraState carries no FOV field, so there is no real value to forward.
+ * Matches @ifc-lite/bcf's own orthographic placeholder default. */
+export const DEFAULT_VIEWPOINT_FOV = Math.PI / 4;
+
+export function toVec3(t: [number, number, number]): { x: number; y: number; z: number } {
+  return { x: t[0], y: t[1], z: t[2] };
+}
+
+export function toTuple(p: { x: number; y: number; z: number }): [number, number, number] {
+  return [p.x, p.y, p.z];
+}
+
+/** Names the fields missing from a `ViewpointOptions.camera` (or the whole
+ * `camera` object) so `IncompleteCameraStateError` can say exactly what a
+ * caller needs to add. Empty array means the camera is complete. */
+export function collectMissingCameraFields(camera: ViewpointOptions['camera']): string[] {
+  if (!camera) return ['camera'];
+  const missing: string[] = [];
+  if (!camera.position) missing.push('camera.position');
+  if (!camera.target) missing.push('camera.target');
+  if (!camera.up) missing.push('camera.up');
+  return missing;
+}
+
+/**
+ * SDK axis ('x'|'y'|'z', as returned by bim.viewer.getSection()) <->
+ * @ifc-lite/bcf / viewer-store axis ('down'|'front'|'side'). Identical to
+ * apps/viewer/src/sdk/adapters/viewer-adapter.ts's AXIS_TO_STORE /
+ * STORE_TO_AXIS, which already performs this exact remap on the way in/out
+ * of bim.viewer.getSection()/setSection() — reused here rather than
+ * inventing a third convention.
+ */
+export const SDK_AXIS_TO_BCF_AXIS: Record<'x' | 'y' | 'z', 'down' | 'front' | 'side'> = {
+  x: 'side',
+  y: 'down',
+  z: 'front',
+};
+export const BCF_AXIS_TO_SDK_AXIS: Record<'down' | 'front' | 'side', 'x' | 'y' | 'z'> = {
+  side: 'x',
+  down: 'y',
+  front: 'z',
+};
+
+export interface BcfViewerCameraState {
+  position: { x: number; y: number; z: number };
+  target: { x: number; y: number; z: number };
+  up: { x: number; y: number; z: number };
+  fov: number;
+  isOrthographic?: boolean;
+}
+
+export interface BcfViewerSectionPlane {
+  axis: 'down' | 'front' | 'side';
+  position: number;
+  enabled: boolean;
+  flipped: boolean;
+}

--- a/packages/sdk/src/namespaces/bcf.test.ts
+++ b/packages/sdk/src/namespaces/bcf.test.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lock-in tests for bim.bcf.createViewpoint()/extractViewpointState()'s
+ * shape adapter between the SDK's documented ViewpointOptions (tuple
+ * camera, x/y/z section-plane axis) and @ifc-lite/bcf's ViewerCameraState/
+ * ViewerSectionPlane (object camera, down/front/side axis).
+ *
+ * The bug being pinned (#4251): createViewpoint() used to forward
+ * ViewpointOptions.camera/sectionPlane to @ifc-lite/bcf unchanged. The
+ * library read `camera.position.x` off a 3-tuple (always undefined,
+ * serializing as null/NaN->null) and never matched an 'x'|'y'|'z' section
+ * axis against its 'down'|'front'|'side' switch, so an enabled section
+ * plane silently produced no clippingPlanes at all. Both failures resolved
+ * successfully with no error.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BCFNamespace,
+  IncompleteCameraStateError,
+  MissingSectionBoundsError,
+} from './bcf.js';
+
+const CAMERA = {
+  mode: 'perspective' as const,
+  position: [1, 2, 3] as [number, number, number],
+  target: [4, 5, 6] as [number, number, number],
+  up: [0, 1, 0] as [number, number, number],
+};
+
+const BOUNDS = {
+  min: [-10, -10, -10] as [number, number, number],
+  max: [10, 10, 10] as [number, number, number],
+};
+
+describe('BCFNamespace.createViewpoint — camera shape (#4251 defect 1)', () => {
+  it('throws IncompleteCameraStateError rather than silently corrupting a positionless camera', async () => {
+    const ns = new BCFNamespace();
+    await expect(ns.createViewpoint({ camera: { mode: 'perspective' } })).rejects.toThrow(
+      IncompleteCameraStateError
+    );
+  });
+
+  it('throws IncompleteCameraStateError when camera is omitted entirely', async () => {
+    const ns = new BCFNamespace();
+    await expect(ns.createViewpoint({})).rejects.toThrow(IncompleteCameraStateError);
+    await expect(ns.createViewpoint()).rejects.toThrow(IncompleteCameraStateError);
+  });
+
+  it('a complete documented camera round-trips to real coordinate values, not null/NaN', async () => {
+    const ns = new BCFNamespace();
+    const out = (await ns.createViewpoint({ camera: CAMERA })) as {
+      perspectiveCamera?: {
+        cameraViewPoint: { x: number; y: number; z: number };
+        cameraDirection: { x: number; y: number; z: number };
+        cameraUpVector: { x: number; y: number; z: number };
+        fieldOfView: number;
+      };
+    };
+
+    // viewer (Y-up) -> BCF (Z-up): BCF.x = v.x, BCF.y = -v.z, BCF.z = v.y
+    expect(out.perspectiveCamera?.cameraViewPoint).toEqual({ x: 1, y: -3, z: 2 });
+    expect(out.perspectiveCamera?.fieldOfView).toBeGreaterThan(0);
+    expect(Number.isFinite(out.perspectiveCamera?.fieldOfView)).toBe(true);
+    // Direction = normalize(target - position) in viewer coords, then converted.
+    // target - position = (3, 3, 3) -> normalized (1/sqrt3 each) -> BCF (x, -z, y)
+    const d = out.perspectiveCamera!.cameraDirection;
+    expect(d.x).toBeCloseTo(1 / Math.sqrt(3), 5);
+    expect(d.y).toBeCloseTo(-1 / Math.sqrt(3), 5);
+    expect(d.z).toBeCloseTo(1 / Math.sqrt(3), 5);
+  });
+});
+
+describe('BCFNamespace.createViewpoint — sectionPlane shape (#4251 defect 2)', () => {
+  it('throws MissingSectionBoundsError for an enabled section plane with no bounds', async () => {
+    const ns = new BCFNamespace();
+    await expect(
+      ns.createViewpoint({
+        camera: CAMERA,
+        sectionPlane: { axis: 'x', position: 5, enabled: true, flipped: false },
+      })
+    ).rejects.toThrow(MissingSectionBoundsError);
+  });
+
+  it('does not throw for a disabled section plane even without bounds', async () => {
+    const ns = new BCFNamespace();
+    const out = (await ns.createViewpoint({
+      camera: CAMERA,
+      sectionPlane: { axis: 'x', position: 5, enabled: false, flipped: false },
+    })) as { clippingPlanes?: unknown[] };
+    expect('clippingPlanes' in out).toBe(false);
+  });
+
+  it('a documented sectionPlane + bounds produces a real clipping plane at the right coordinates', async () => {
+    const ns = new BCFNamespace();
+    // axis 'x' -> SDK_AXIS_TO_BCF_AXIS -> 'side'; position 75% along x in [-10,10] -> x = 5
+    const out = (await ns.createViewpoint({
+      camera: CAMERA,
+      sectionPlane: { axis: 'x', position: 75, enabled: true, flipped: false },
+      bounds: BOUNDS,
+    })) as { clippingPlanes?: Array<{ location: { x: number; y: number; z: number } }> };
+
+    expect(out.clippingPlanes).toHaveLength(1);
+    // viewer 'side' location = { x: 5, y: 0, z: 0 } -> BCF (x, -z, y) = { x: 5, y: -0, z: 0 }
+    expect(out.clippingPlanes![0].location).toEqual({ x: 5, y: -0, z: 0 });
+  });
+
+  it('axis y (down, per bim.viewer.getSection()) maps to the model-up axis, not x', async () => {
+    const ns = new BCFNamespace();
+    const out = (await ns.createViewpoint({
+      camera: CAMERA,
+      sectionPlane: { axis: 'y', position: 100, enabled: true, flipped: false },
+      bounds: BOUNDS,
+    })) as { clippingPlanes?: Array<{ location: { x: number; y: number; z: number } }> };
+
+    // axis 'y' -> 'down' -> viewer location.y = max.y = 10 -> BCF z = 10, BCF x/y = 0
+    expect(out.clippingPlanes![0].location).toEqual({ x: 0, y: -0, z: 10 });
+  });
+});
+
+describe('BCFNamespace.extractViewpointState — read-path symmetry (#4251)', () => {
+  it('round-trips camera/sectionPlane back into bim.viewer.setCamera()/setSection() shapes', async () => {
+    const ns = new BCFNamespace();
+    const viewpoint = await ns.createViewpoint({
+      camera: CAMERA,
+      sectionPlane: { axis: 'z', position: 50, enabled: true, flipped: false },
+      bounds: BOUNDS,
+    });
+
+    const state = await ns.extractViewpointState(viewpoint, BOUNDS);
+
+    expect(state.camera?.mode).toBe('perspective');
+    // camera position round-trips through cameraToPerspective -> perspectiveToCamera,
+    // which reconstructs position from direction * targetDistance rather than the
+    // original absolute position, so assert the SDK tuple shape + the target/up values,
+    // which are preserved exactly.
+    expect(Array.isArray(state.camera?.position)).toBe(true);
+    expect(state.camera?.up).toEqual([0, 1, 0]);
+
+    expect(state.sectionPlane?.axis).toBe('z');
+    expect(state.sectionPlane?.enabled).toBe(true);
+    expect(state.sectionPlane?.flipped).toBe(false);
+  });
+
+  it('omits sectionPlane when no bounds is supplied to extractViewpointState', async () => {
+    const ns = new BCFNamespace();
+    const viewpoint = await ns.createViewpoint({
+      camera: CAMERA,
+      sectionPlane: { axis: 'z', position: 50, enabled: true, flipped: false },
+      bounds: BOUNDS,
+    });
+
+    const state = await ns.extractViewpointState(viewpoint);
+    expect(state.sectionPlane).toBeUndefined();
+  });
+});

--- a/packages/sdk/src/namespaces/bcf.test.ts
+++ b/packages/sdk/src/namespaces/bcf.test.ts
@@ -122,28 +122,46 @@ describe('BCFNamespace.createViewpoint — sectionPlane shape (#4251 defect 2)',
 });
 
 describe('BCFNamespace.extractViewpointState — read-path symmetry (#4251)', () => {
-  it('round-trips camera/sectionPlane back into bim.viewer.setCamera()/setSection() shapes', async () => {
-    const ns = new BCFNamespace();
-    const viewpoint = await ns.createViewpoint({
-      camera: CAMERA,
-      sectionPlane: { axis: 'z', position: 50, enabled: true, flipped: false },
-      bounds: BOUNDS,
-    });
+  it.each([
+    ['x', 'side'],
+    ['y', 'down'],
+    ['z', 'front'],
+  ] as const)(
+    'round-trips camera/sectionPlane (axis %s, BCF %s) back into bim.viewer.setCamera()/setSection() shapes',
+    async (sdkAxis, bcfAxis) => {
+      const ns = new BCFNamespace();
+      const viewpoint = await ns.createViewpoint({
+        camera: CAMERA,
+        sectionPlane: { axis: sdkAxis, position: 50, enabled: true, flipped: false },
+        bounds: BOUNDS,
+      });
 
-    const state = await ns.extractViewpointState(viewpoint, BOUNDS);
+      // Sanity check the write side actually used the expected BCF axis name,
+      // so a failure below is attributable to the read path
+      // (BCF_AXIS_TO_SDK_AXIS), not a write-side (SDK_AXIS_TO_BCF_AXIS) drift.
+      const created = viewpoint as { clippingPlanes?: unknown[] };
+      expect(created.clippingPlanes).toHaveLength(1);
 
-    expect(state.camera?.mode).toBe('perspective');
-    // camera position round-trips through cameraToPerspective -> perspectiveToCamera,
-    // which reconstructs position from direction * targetDistance rather than the
-    // original absolute position, so assert the SDK tuple shape + the target/up values,
-    // which are preserved exactly.
-    expect(Array.isArray(state.camera?.position)).toBe(true);
-    expect(state.camera?.up).toEqual([0, 1, 0]);
+      const state = await ns.extractViewpointState(viewpoint, BOUNDS);
 
-    expect(state.sectionPlane?.axis).toBe('z');
-    expect(state.sectionPlane?.enabled).toBe(true);
-    expect(state.sectionPlane?.flipped).toBe(false);
-  });
+      expect(state.camera?.mode).toBe('perspective');
+      // camera position round-trips through cameraToPerspective -> perspectiveToCamera,
+      // which reconstructs position from direction * targetDistance rather than the
+      // original absolute position, so assert the SDK tuple shape + the target/up values,
+      // which are preserved exactly.
+      expect(Array.isArray(state.camera?.position)).toBe(true);
+      expect(state.camera?.up).toEqual([0, 1, 0]);
+
+      // The load-bearing assertion: BCF_AXIS_TO_SDK_AXIS[bcfAxis] must recover
+      // the exact SDK axis that was sent in, not some other axis. A swap
+      // between any two entries (e.g. side<->x mapped to the wrong letter,
+      // or down mapped to 'x' instead of 'y') reddens this for the axis it
+      // corrupts.
+      expect(state.sectionPlane?.axis).toBe(sdkAxis);
+      expect(state.sectionPlane?.enabled).toBe(true);
+      expect(state.sectionPlane?.flipped).toBe(false);
+    }
+  );
 
   it('omits sectionPlane when no bounds is supplied to extractViewpointState', async () => {
     const ns = new BCFNamespace();

--- a/packages/sdk/src/namespaces/bcf.ts
+++ b/packages/sdk/src/namespaces/bcf.ts
@@ -10,6 +10,25 @@
  * converting between IDS reports and BCF topics.
  */
 
+import type { AABB } from '../types.js';
+import {
+  type ViewpointOptions,
+  type ExtractedViewpointState,
+  type BcfViewerCameraState,
+  type BcfViewerSectionPlane,
+  IncompleteCameraStateError,
+  MissingSectionBoundsError,
+  DEFAULT_VIEWPOINT_FOV,
+  toVec3,
+  toTuple,
+  collectMissingCameraFields,
+  SDK_AXIS_TO_BCF_AXIS,
+  BCF_AXIS_TO_SDK_AXIS,
+} from './bcf-viewpoint.js';
+
+export type { ViewpointOptions, ExtractedViewpointState };
+export { IncompleteCameraStateError, MissingSectionBoundsError };
+
 // ============================================================================
 // Option types for the namespace API
 // ============================================================================
@@ -30,35 +49,6 @@ export interface CommentOptions {
   author: string;
   comment: string;
   viewpointGuid?: string;
-}
-
-export interface ViewpointOptions {
-  /** Camera state from bim.viewer.getCamera() */
-  camera?: {
-    mode: 'perspective' | 'orthographic';
-    position?: [number, number, number];
-    target?: [number, number, number];
-    up?: [number, number, number];
-  };
-  /** Section plane from bim.viewer.getSection() */
-  sectionPlane?: {
-    axis: 'x' | 'y' | 'z';
-    position: number;
-    enabled: boolean;
-    flipped: boolean;
-  };
-  /** Component selection/visibility */
-  components?: {
-    selection?: Array<{ GlobalId: string }>;
-    visibility?: {
-      defaultVisibility: boolean;
-      exceptions?: Array<{ GlobalId: string }>;
-    };
-    coloring?: Array<{
-      color: string;
-      components: Array<{ GlobalId: string }>;
-    }>;
-  };
 }
 
 export interface IDSBCFOptions {
@@ -152,16 +142,55 @@ export class BCFNamespace {
   // Viewpoints
   // --------------------------------------------------------------------------
 
-  /** Create a BCF viewpoint from viewer camera/section state. */
+  /**
+   * Create a BCF viewpoint from viewer camera/section state.
+   *
+   * Converts the SDK's tuple-based `camera`/x-y-z `sectionPlane` shapes
+   * (`bim.viewer.getCamera()`/`getSection()`) into `@ifc-lite/bcf`'s
+   * object-based `ViewerCameraState`/`ViewerSectionPlane` shapes. Throws
+   * `IncompleteCameraStateError` for a camera missing position/target/up,
+   * and `MissingSectionBoundsError` for an enabled section plane with no
+   * `bounds` — see #4251.
+   */
   async createViewpoint(options?: ViewpointOptions): Promise<unknown> {
     const mod = await loadBCF();
-    if (!options) return (mod.createViewpoint as AnyFn)({});
+
+    const missingCamera = collectMissingCameraFields(options?.camera);
+    if (missingCamera.length > 0) {
+      throw new IncompleteCameraStateError(missingCamera);
+    }
+    const camera = options!.camera!;
 
     // Map SDK's GlobalId (IFC convention) to BCF library's guid-based lists
-    const comps = options.components;
-    const bcfOptions: Record<string, unknown> = {};
-    if (options.camera) bcfOptions.camera = options.camera;
-    if (options.sectionPlane) bcfOptions.sectionPlane = options.sectionPlane;
+    const comps = options?.components;
+    const bcfOptions: Record<string, unknown> = {
+      camera: {
+        position: toVec3(camera.position!),
+        target: toVec3(camera.target!),
+        up: toVec3(camera.up!),
+        fov: DEFAULT_VIEWPOINT_FOV,
+        isOrthographic: camera.mode === 'orthographic',
+      } satisfies BcfViewerCameraState,
+    };
+
+    if (options?.sectionPlane) {
+      const sp = options.sectionPlane;
+      if (sp.enabled && !options.bounds) {
+        throw new MissingSectionBoundsError();
+      }
+      bcfOptions.sectionPlane = {
+        axis: SDK_AXIS_TO_BCF_AXIS[sp.axis],
+        position: sp.position,
+        enabled: sp.enabled,
+        flipped: sp.flipped,
+      } satisfies BcfViewerSectionPlane;
+    }
+    if (options?.bounds) {
+      bcfOptions.bounds = {
+        min: toVec3(options.bounds.min),
+        max: toVec3(options.bounds.max),
+      };
+    }
 
     if (comps?.selection) {
       bcfOptions.selectedGuids = comps.selection.map(c => c.GlobalId);
@@ -191,10 +220,54 @@ export class BCFNamespace {
     (mod.addViewpointToTopic as AnyFn)(topic, viewpoint);
   }
 
-  /** Extract viewer state from a BCF viewpoint. */
-  async extractViewpointState(viewpoint: unknown): Promise<unknown> {
+  /**
+   * Extract viewer state from a BCF viewpoint.
+   *
+   * Converts `@ifc-lite/bcf`'s object-based `camera`/`sectionPlane`
+   * (`down`/`front`/`side` axis) back into the SDK's tuple `camera` /
+   * `x`/`y`/`z` `sectionPlane` shapes, so the result round-trips straight
+   * into `bim.viewer.setCamera()`/`setSection()` — the same conversion
+   * `createViewpoint()` performs in reverse (#4251). Pass `bounds` (the
+   * model's AABB) to also recover `sectionPlane`; without it
+   * `@ifc-lite/bcf` cannot place a clipping plane and `sectionPlane` is
+   * omitted, matching `createViewpoint()`'s own bounds requirement.
+   */
+  async extractViewpointState(viewpoint: unknown, bounds?: AABB): Promise<ExtractedViewpointState> {
     const mod = await loadBCF();
-    return (mod.extractViewpointState as AnyFn)(viewpoint);
+    const bcfBounds = bounds
+      ? { min: toVec3(bounds.min), max: toVec3(bounds.max) }
+      : undefined;
+    const raw = (mod.extractViewpointState as AnyFn)(viewpoint, bcfBounds) as {
+      camera?: BcfViewerCameraState;
+      sectionPlane?: BcfViewerSectionPlane;
+      selectedGuids: string[];
+      hiddenGuids: string[];
+      visibleGuids: string[];
+      coloredGuids: Array<{ color: string; guids: string[] }>;
+    };
+
+    return {
+      camera: raw.camera
+        ? {
+            mode: raw.camera.isOrthographic ? 'orthographic' : 'perspective',
+            position: toTuple(raw.camera.position),
+            target: toTuple(raw.camera.target),
+            up: toTuple(raw.camera.up),
+          }
+        : undefined,
+      sectionPlane: raw.sectionPlane
+        ? {
+            axis: BCF_AXIS_TO_SDK_AXIS[raw.sectionPlane.axis],
+            position: raw.sectionPlane.position,
+            enabled: raw.sectionPlane.enabled,
+            flipped: raw.sectionPlane.flipped,
+          }
+        : undefined,
+      selectedGuids: raw.selectedGuids,
+      hiddenGuids: raw.hiddenGuids,
+      visibleGuids: raw.visibleGuids,
+      coloredGuids: raw.coloredGuids,
+    };
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`bim.bcf.createViewpoint()` forwarded `ViewpointOptions.camera`/`sectionPlane` to `@ifc-lite/bcf`'s `createViewpoint` unchanged, but the two packages use incompatible shapes for both fields:

- `camera`: SDK uses `{ mode, position?: [x,y,z], target?: [x,y,z], up?: [x,y,z] }` (tuples, optional, no FOV); `@ifc-lite/bcf` requires `ViewerCameraState` — `{ position: {x,y,z}, target: {x,y,z}, up: {x,y,z}, fov, isOrthographic? }`.
- `sectionPlane`: SDK uses axis `'x'|'y'|'z'`; `@ifc-lite/bcf` uses `'down'|'front'|'side'`, and only emits a clipping plane when both `enabled` and a separate `bounds: {min, max}` argument (which the SDK never forwarded — `ViewpointOptions` had no `bounds` field at all) are present.

Following the JSDoc-documented pattern — `createViewpoint({ camera: bim.viewer.getCamera(), sectionPlane: bim.viewer.getSection() })` — silently produced a camera whose coordinates read back as `null`/`NaN`, and silently dropped an enabled section plane's clipping plane entirely. Both calls resolved successfully with no error, no thrown exception, no console warning.

Verified against **both** states of `apps/viewer/src/sdk/adapters/viewer-adapter.ts`'s `getCamera()`:
- On current `upstream/main`, `getCamera()` returns only `{ mode }` (no position/target/up at all) — so today's documented pattern is not merely corrupted, it is fully positionless from the start.
- Against #4277 (`fix/sdk-camera-adapter-4264-4266`, open/unmerged), which wires `getCamera()` to return real `position`/`target`/`up` tuples in renderer space with no axis remapping — feeding that real output into the old `createViewpoint()` reproduces the issue's exact `{ y: null }`/`fieldOfView: null` corruption, since the library still reads `.position.x` off a 3-tuple.

## Design: reject, don't coerce

Matching this repo's house style for exactly this class of defect (a named error thrown at the point of entry rather than a sentinel or silent degrade):

- `IncompleteCameraStateError` — thrown when `options.camera` is provided but missing `position`/`target`/`up` (or omitted entirely while other options are set). Message names exactly which fields are missing.
- `MissingSectionBoundsError` — thrown when `options.sectionPlane.enabled` is `true` but no `options.bounds` was supplied. `ViewpointOptions` gains a new `bounds?: AABB` field (reusing the SDK's existing `AABB` type from `packages/sdk/src/types.ts`, the same shape `bim.spatial.queryBounds` already accepts) — nothing in the SDK's public surface (`bim.viewer.*`, `bim.spatial.*`) can produce a model's overall bounding box, so the caller must supply it explicitly; the SDK can no longer silently drop the clipping plane in its absence.

Shape *conversion* (tuple↔object, axis vocabulary) is coercion in the sense that it adapts a well-formed but differently-shaped input — that's the same class of fix PR #2841 made for `bim.list.execute()` (cited in the issue as precedent). What's rejected is data that's *missing*, not data that's merely shaped differently.

## Coordinate/axis convention

The `'x'|'y'|'z'` ⟷ `'down'|'front'|'side'` section-plane axis map is copied verbatim from `apps/viewer/src/sdk/adapters/viewer-adapter.ts`'s existing `AXIS_TO_STORE`/`STORE_TO_AXIS` tables (`x: 'side', y: 'down', z: 'front'`), which already perform this exact remap on the way in/out of `bim.viewer.getSection()`/`setSection()`. No new coordinate convention was invented.

## Read path

`extractViewpointState()` had the same defect in reverse: it returned `@ifc-lite/bcf`'s native `ViewerCameraState`/`ViewerSectionPlane` (object camera, down/front/side axis) untyped (`Promise<unknown>`), which would silently corrupt a subsequent `bim.viewer.setCamera()`/`setSection()` call the same way the write path corrupted `createViewpoint()`. Fixed to convert back into the SDK's tuple/x-y-z shapes and typed as `ExtractedViewpointState`, so a captured viewpoint round-trips.

## Tests (`packages/sdk/src/namespaces/bcf.test.ts`, new — none existed before)

RED/GREEN, both directions, real coordinate values (not just presence):
- Incomplete/missing camera → `IncompleteCameraStateError` (both "positionless camera" and "camera omitted entirely").
- A complete documented camera → real BCF coordinates (`cameraViewPoint`, `cameraDirection`, `fieldOfView` all finite, non-null, matching the viewer→BCF axis-flip formula).
- Enabled section plane without `bounds` → `MissingSectionBoundsError`; disabled section plane without `bounds` → no throw.
- A documented `sectionPlane` + `bounds` → a real `clippingPlanes[0].location` at the expected coordinates for two different axes (catches an axis swap, not just "a plane exists").
- Read-path round-trip: `createViewpoint()` → `extractViewpointState()` → SDK-shaped `camera`/`sectionPlane` (mode, axis, enabled, flipped all preserved).

**Mutation testing** (guard disabled, confirmed a #4251 test went RED with the *old* symptom reappearing, then restored — committed before mutating, restored via `Edit`, not `git checkout`):
- `IncompleteCameraStateError` guard disabled → both camera tests fail with a raw `TypeError` instead of the named error.
- `MissingSectionBoundsError` guard disabled → the "throws" test fails because the call now *resolves* with a viewpoint that has no `clippingPlanes` key — reproducing defect 2 exactly.
- `SDK_AXIS_TO_BCF_AXIS` map corrupted → 3 tests go RED (both direct axis tests plus the read-path round-trip), proving the axis convention is load-bearing.

## Docs

`ViewpointOptions.camera`/`sectionPlane` JSDoc updated to state the position/target/up requirement, the FOV default and why it's a default (SDK's `CameraState` never carries FOV, not even after #4277), and the new `bounds` requirement/rationale.

## Module size

`bcf.ts` grew past the 400-line budget with these changes; split the shape adapter (types, error classes, conversion helpers, axis maps) into a new `packages/sdk/src/namespaces/bcf-viewpoint.ts`. `node scripts/check-module-size.mjs` exits 0; no budgets or allowlist entries touched.

## Verification
- `npx tsc --noEmit -p packages/sdk` — no errors in `bcf.ts`/`bcf-viewpoint.ts`/`bcf.test.ts`.
- `vitest run src/namespaces/bcf.test.ts` — 11/11 passing (8 named cases plus the 3-axis `it.each` read-path-symmetry block).
- Full `packages/sdk` suite: 88 passed; 10 failures pre-existing and unrelated — `Cannot find package '@ifc-lite/lists'/'@ifc-lite/data'/'@ifc-lite/ids'/'@ifc-lite/parser'/'@ifc-lite/clash'` — sibling packages whose `dist/` wasn't built in this sandboxed environment (reproduces identically on a clean `upstream/main` checkout with the same partial build; not caused by this change).
- `git diff --stat upstream/main HEAD` lists exactly the 5 files touched.

## Not checked
- Whether `components` (selection/visibility/coloring GUID lists) has an equivalent read/write shape asymmetry — `extractViewpointState` returns flat GUID arrays while `createViewpoint` expects structured selection/visibility/coloring objects; this is an existing, intentional design difference the issue didn't call out, and changing it would be a separate, larger change.
- The two other coverage gaps the issue names (`bsdd.ts`'s `maxCacheEntries` clamp, `export.ts`'s `dfjson()` guard) — not touched; the issue's own text marks them "not fixed here" and this PR does not address them.

Closes #4251

