### PR TITLE
fix(perf): balance and randomize ab.sh's within-pair order to remove positional bias

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1344,7 +1344,7 @@ jobs:
       # scripts/docs/ joined it for the same reason in #3200 - the catch-all is
       # per-DIRECTORY, so it goes blind on the next subdirectory anyone adds.
       - name: Run every scripts/ test file (glob catch-all)
-        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs scripts/review/*.test.mjs scripts/review/lib/*.test.mjs
+        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs scripts/review/*.test.mjs scripts/review/lib/*.test.mjs scripts/perf/*.test.mjs
       # Committed codegen output (packages/codegen/generated/**,
       # packages/parser/src/generated/**, packages/data/src/ifc-schema/
       # generated/**) had no CI freshness gate at all — a generator bug fixed

--- a/scripts/perf/ab-order.mjs
+++ b/scripts/perf/ab-order.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Within-pair execution order for ab.sh's interleaved rounds (#4221).
+//
+// ab.sh used to run every round as `base, branch` — interleaving guards
+// against drift ACROSS rounds (a machine that slows down mid-run drags both
+// sides equally), but a fixed order does nothing about a penalty tied to
+// POSITION within a round (thermal ramp, a cache state left by the
+// preceding process, a frequency step on the first process after idle).
+// Whichever side always runs first pays that penalty every round, and it
+// survives the median untouched — a commit compared against itself came out
+// "23.5% faster", confidently, because of this alone.
+//
+// The fix: for each invocation, decide per round which side runs first, but
+// keep the two options BALANCED across all rounds (as close to half base
+// first / half branch first as the round count allows) and RANDOMIZE which
+// specific rounds get which order. Balance makes a constant positional
+// penalty land on both sides equally often, so it cancels in the median
+// instead of accumulating on one side. Randomizing which rounds are which
+// stops the position assignment from correlating with time-based drift too
+// (a fixed alternating pattern, e.g. round 1 base-first / round 2
+// branch-first / round 3 base-first…, could still resonate with a
+// periodic effect).
+
+/**
+ * @param {number} iters positive integer round count
+ * @param {() => number} rand uniform [0,1) generator (defaults to Math.random)
+ * @returns {Array<['base'|'branch', 'base'|'branch']>} one [first, second]
+ *   pair per round.
+ */
+export function roundOrder(iters, rand = Math.random) {
+  if (!Number.isInteger(iters) || iters < 1) {
+    throw new Error(`roundOrder: iters must be a positive integer (got ${iters})`);
+  }
+  const baseFirstCount = Math.ceil(iters / 2);
+  const slots = Array.from({ length: iters }, (_, i) => (i < baseFirstCount ? 'base-first' : 'branch-first'));
+  // Fisher-Yates shuffle.
+  for (let i = slots.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [slots[i], slots[j]] = [slots[j], slots[i]];
+  }
+  return slots.map((s) => (s === 'base-first' ? ['base', 'branch'] : ['branch', 'base']));
+}
+
+// Deterministic PRNG for `--seed`, so a reported run can be replayed exactly
+// (and so tests don't depend on Math.random). mulberry32.
+export function seededRand(seed) {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// CLI: `node ab-order.mjs <iters> [seed]` prints one "first second" line per
+// round (e.g. "base branch"), consumed by ab.sh.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const iters = Number(process.argv[2]);
+  const seedArg = process.argv[3];
+  const rand = seedArg !== undefined ? seededRand(Number(seedArg)) : Math.random;
+  for (const [first, second] of roundOrder(iters, rand)) {
+    console.log(`${first} ${second}`);
+  }
+}

--- a/scripts/perf/ab-order.test.mjs
+++ b/scripts/perf/ab-order.test.mjs
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * scripts/perf/ab-order.mjs (#4221).
+ *
+ * The regression this guards: ab.sh ran every interleaved round as
+ * `base, branch` — a fixed order. Interleaving cancels drift ACROSS rounds
+ * but not a penalty tied to POSITION within a round (thermal ramp, a warm
+ * cache left by the preceding process, a frequency step). Whichever side
+ * always went first paid that penalty every round, and it survived the
+ * median untouched — a commit compared against itself reported a confident
+ * "23.5% faster" with a byte-identical build on both sides.
+ *
+ * roundOrder() is the fix: for N rounds it hands out ceil(N/2) "base-first"
+ * and floor(N/2) "branch-first" slots (as close to a 50/50 split as N
+ * allows) and shuffles which specific round gets which. These tests pin:
+ *   - the balance property (this is what makes a constant positional
+ *     penalty cancel instead of accumulate),
+ *   - that it's actually randomized (not a fixed alternating pattern, which
+ *     could resonate with a periodic effect instead of cancelling it),
+ *   - and the end-to-end demonstration: feeding a synthetic per-POSITION
+ *     (not per-side) time penalty through ab-report.mjs's own reporting
+ *     logic reports a confident false regression under the OLD fixed order
+ *     and "within noise" under the balanced/randomized order — the exact
+ *     mechanism from #4221, reproduced deterministically without a real
+ *     machine's thermal behaviour.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { roundOrder, seededRand } from './ab-order.mjs';
+
+test('balance: base-first count is ceil(iters/2) for a range of round counts', () => {
+  for (const iters of [1, 2, 3, 4, 5, 6, 7, 10, 11, 20]) {
+    const order = roundOrder(iters, seededRand(iters * 7919 + 1));
+    const baseFirst = order.filter(([first]) => first === 'base').length;
+    assert.equal(order.length, iters);
+    assert.equal(baseFirst, Math.ceil(iters / 2), `iters=${iters}`);
+  }
+});
+
+test('every round is a valid pairing of exactly base and branch', () => {
+  const order = roundOrder(9, seededRand(42));
+  for (const [first, second] of order) {
+    assert.ok(
+      (first === 'base' && second === 'branch') || (first === 'branch' && second === 'base'),
+      `unexpected pair: ${first},${second}`,
+    );
+  }
+});
+
+test('randomized: two different seeds do not produce the same round-by-round order', () => {
+  const a = roundOrder(12, seededRand(1)).map(([f]) => f).join('');
+  const b = roundOrder(12, seededRand(2)).map(([f]) => f).join('');
+  assert.notEqual(a, b, 'two different seeds produced identical orderings — not randomized');
+});
+
+test('THE REGRESSION (#4221) would NOT be a fixed alternating pattern either', () => {
+  // A fixed base,branch,base,branch,... pattern is what shipped before the
+  // fix. A fixed STRICT ALTERNATION (base-first, branch-first, base-first, …)
+  // is a different but related failure mode: it's balanced but not random,
+  // so it could still resonate with a periodic drift source. Confirm the
+  // generator does not degenerate into strict alternation across seeds.
+  const patterns = new Set();
+  for (let seed = 0; seed < 8; seed++) {
+    patterns.add(roundOrder(8, seededRand(seed)).map(([f]) => f).join(''));
+  }
+  assert.ok(patterns.size > 1, 'every seed produced the same order — generator is not actually randomizing');
+});
+
+test('rejects non-positive-integer iters', () => {
+  assert.throws(() => roundOrder(0));
+  assert.throws(() => roundOrder(-3));
+  assert.throws(() => roundOrder(2.5));
+  assert.throws(() => roundOrder(NaN));
+});
+
+test('seededRand is deterministic and reproducible', () => {
+  const a = roundOrder(10, seededRand(123));
+  const b = roundOrder(10, seededRand(123));
+  assert.deepEqual(a, b);
+});
+
+// --- End-to-end demonstration of the #4221 mechanism, deterministically ---
+//
+// A per-POSITION (not per-side) time penalty simulates the thermal-ramp /
+// warm-cache effect the issue describes: whichever process runs first in a
+// round is slower by a fixed amount, regardless of whether it's base or
+// branch. Feed that through ab-report.mjs's own median+noise-gate logic
+// (imported inline below, mirroring its exact formulas) under the OLD fixed
+// order and the NEW balanced/randomized order.
+
+const median = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+};
+const spreadPct = (xs) => {
+  if (xs.length < 2) return 0;
+  const med = median(xs);
+  if (med <= 0) return 0;
+  return ((Math.max(...xs) - Math.min(...xs)) / med) * 100;
+};
+const pct = (cur, base) => (base > 0 ? ((cur - base) / base) * 100 : null);
+
+/**
+ * Simulate ITERS rounds under a given per-round [first, second] order,
+ * where the process running first pays POSITION_PENALTY_MS on top of the
+ * (identical) true cost, plus a small amount of genuine machine jitter.
+ */
+function simulate(order, { truCostMs = 40, positionPenaltyMs = 9, jitter }) {
+  const values = { base: [], branch: [] };
+  let round = 0;
+  for (const [first, second] of order) {
+    round += 1;
+    for (const [side, position] of [[first, 1], [second, 2]]) {
+      const penalty = position === 1 ? positionPenaltyMs : 0;
+      values[side].push(truCostMs + penalty + jitter(round, side));
+    }
+  }
+  return values;
+}
+
+function verdictFor(values) {
+  const bMed = median(values.base);
+  const brMed = median(values.branch);
+  const d = pct(brMed, bMed);
+  const noise = spreadPct(values.base);
+  const real = d != null && Math.abs(d) > Math.max(noise, 3) && Math.abs(brMed - bMed) >= 1;
+  return { bMed, brMed, d, noise, real };
+}
+
+test('THE REGRESSION: fixed base-first order reports a confident false regression on byte-identical code', () => {
+  const ITERS = 7;
+  // Deterministic small jitter (±0.5ms), same generator reused for both
+  // scenarios below so only the ORDER differs.
+  const jitter = (round, side) => seededRand(round * 97 + (side === 'base' ? 1 : 2))() - 0.5;
+  const fixedOrder = Array.from({ length: ITERS }, () => ['base', 'branch']);
+  const values = simulate(fixedOrder, { jitter });
+  const v = verdictFor(values);
+  assert.ok(v.real, `expected a "real" (confident) verdict under fixed order, got ${JSON.stringify(v)}`);
+  assert.ok(v.d < 0, 'branch (always second, never pays the position penalty) reads as the faster side');
+});
+
+test('THE FIX: balanced/randomized order reports within-noise on the identical scenario (#4221)', () => {
+  const ITERS = 7;
+  const jitter = (round, side) => seededRand(round * 97 + (side === 'base' ? 1 : 2))() - 0.5;
+  const balancedOrder = roundOrder(ITERS, seededRand(4221));
+  const values = simulate(balancedOrder, { jitter });
+  const v = verdictFor(values);
+  assert.ok(!v.real, `expected "within noise" under balanced order, got a real verdict: ${JSON.stringify(v)}`);
+});
+
+test('the fix still flags a REAL regression (a genuine per-SIDE, not per-position, slowdown)', () => {
+  const ITERS = 7;
+  const jitter = (round, side) => seededRand(round * 97 + (side === 'base' ? 1 : 2))() - 0.5;
+  const balancedOrder = roundOrder(ITERS, seededRand(4221));
+  // branch is genuinely 30% slower than base, regardless of position.
+  const values = { base: [], branch: [] };
+  let round = 0;
+  for (const [first, second] of balancedOrder) {
+    round += 1;
+    for (const side of [first, second]) {
+      const truCost = side === 'branch' ? 40 * 1.3 : 40;
+      values[side].push(truCost + jitter(round, side));
+    }
+  }
+  const v = verdictFor(values);
+  assert.ok(v.real, `expected the gate to still catch a genuine 30% regression, got ${JSON.stringify(v)}`);
+  assert.ok(v.d > 0, 'branch should read as slower, not faster');
+});

--- a/scripts/perf/ab.sh
+++ b/scripts/perf/ab.sh
@@ -11,8 +11,13 @@
 # base-vs-branch delta with one command:
 #
 #   - It builds perf_probe from BOTH a base ref and the working tree.
-#   - It runs them INTERLEAVED (base, branch, base, branch, …) so a machine that
+#   - It runs them INTERLEAVED, one round per iteration, so a machine that
 #     slows down mid-run drags BOTH sides equally instead of faking a delta.
+#     Within each round, which side runs FIRST is balanced and randomized
+#     across rounds (scripts/perf/ab-order.mjs) rather than always
+#     base-then-branch — a fixed order lets any penalty tied to position
+#     (not identity) survive interleaving and read as a confident delta on
+#     two byte-identical builds (#4221).
 #   - It reports per-phase median + spread and refuses a verdict when the base's
 #     OWN run-to-run spread is too wide (the machine is too noisy to trust).
 #   - It fingerprints mesh/vertex/triangle counts so a "faster" run that changed
@@ -124,12 +129,27 @@ if [ ! -x "$BASE_BIN" ] || [ ! -x "$BRANCH_BIN" ]; then
 fi
 
 # --- Interleaved runs -----------------------------------------------------
-# One --iters=1 probe run per side per round, alternating, so drift hits both.
+# One --iters=1 probe run per side per round, alternating, so a machine that
+# slows down over the course of the whole run does not favour one side.
+#
+# Interleaving alone does not cancel a penalty tied to POSITION within a
+# round (thermal ramp, a cache state left by the preceding process, a
+# frequency step on the first process after idle) — whichever side always
+# runs first pays that every round, and it survives the median like a real
+# regression would (#4221). ab-order.mjs decides, per invocation, which side
+# runs first each round: balanced across rounds (as close to half base-first
+# / half branch-first as ITERS allows) and randomly assigned to specific
+# rounds, so a fixed positional penalty lands on both sides roughly equally
+# often and cancels out instead of accumulating on one.
+ORDER_FILE="$TMP_ROOT/order.txt"
+node "$ROOT/scripts/perf/ab-order.mjs" "$ITERS" > "$ORDER_FILE"
 RUNS_JSONL="$TMP_ROOT/runs.jsonl"
 : > "$RUNS_JSONL"
-for i in $(seq 1 "$ITERS"); do
-  echo "ab.sh: round $i/$ITERS" >&2
-  for side in base branch; do
+i=0
+while IFS=' ' read -r first second; do
+  i=$((i + 1))
+  echo "ab.sh: round $i/$ITERS ($first first)" >&2
+  for side in "$first" "$second"; do
     bin="$BASE_BIN"; [ "$side" = branch ] && bin="$BRANCH_BIN"
     # Run from ROOT so relative fixture handling and on-disk fixtures resolve.
     out="$("$bin" "${ABS_FIXTURES[@]}" --iters 1 --json 2>/dev/null)"
@@ -138,7 +158,7 @@ for i in $(seq 1 "$ITERS"); do
       for (const p of JSON.parse(out)) console.log(JSON.stringify({ side, ...p }));
     ' "$side" "$out" >> "$RUNS_JSONL"
   done
-done
+done < "$ORDER_FILE"
 
 # --- Report ---------------------------------------------------------------
 REPORT_ARGS=("$RUNS_JSONL" "--base" "$BASE_SHA" "--branch" "$BRANCH_DESC")


### PR DESCRIPTION
Closes #4221

## The bug

`scripts/perf/ab.sh` ran every interleaved round as `base, branch` — a
fixed order. Interleaving cancels drift **across** rounds (a machine
that slows down over the whole run drags both sides equally), but it
does nothing about a penalty tied to **position** within a round
(thermal ramp, a cache state left by the preceding process, a
frequency step on the first process after idle). Whichever side always
ran first paid that penalty every round, and it survived the median
untouched — a commit compared against itself could read as a
confident, gate-passing "real change."

The reporter's own gate is structurally blind to this: it compares the
delta against the *base side's own run-to-run spread*, and a fixed
positional penalty adds no spread — so it sails through as a real
delta.

## The fix

`scripts/perf/ab-order.mjs` decides, per invocation, which side runs
first each round:

- **Balanced** — as close to half base-first / half branch-first as
  `--iters` allows (`ceil(iters/2)` base-first slots), so a constant
  positional penalty lands on both sides roughly equally often and
  cancels in the median instead of accumulating on one side.
- **Randomized** — which specific rounds get which order is shuffled
  (Fisher-Yates), not a fixed alternating pattern, so the position
  assignment can't resonate with a periodic drift source either.

`ab.sh` now reads that order instead of looping `for side in base
branch` every round.

I considered the issue's other two remedies (auto-running a null
comparison every invocation; deriving the noise floor from the null's
magnitude instead of the base side's own spread) but didn't take
either: both add real runtime cost (a whole extra build+run pair per
invocation) or risk masking genuine regressions by mixing the two
sides' variability into one noise estimate. Balanced/randomized order
is the standard remedy for positional bias specifically, structurally
prevents the bias from forming rather than trying to detect it after
the fact, and costs nothing extra at runtime.

## Verification

**Real self-comparison, upstream/main, MacBook (Apple Silicon), native
`profiling` build, `advanced_model.ifc` fixture (35MB):**

Before the fix (HEAD vs itself, fixed order, `--iters 10`): small
deltas, correctly caught by the noise gate on this quiet machine
(`⚠️ machine too noisy`) — this dev machine didn't show a strong
enough thermal/frequency effect to reproduce the reporter's specific
+23.5% false positive today, but the structural defect (fixed
base-first order, gate reading only the base side's spread) is present
in the code regardless of whether it manifests on a given run.

After the fix (same self-comparison, balanced/randomized order,
`--iters 10`): also correctly within noise, with the round log now
showing the order actually alternating unpredictably
(`round 1/10 (branch first)`, `round 4/10 (base first)`, …) instead of
the old fixed `base, branch, base, branch`.

Because the real machine didn't hand me a strong organic bias to
falsify against, I also reproduced the exact mechanism
deterministically in `scripts/perf/ab-order.test.mjs`: a synthetic
per-**position** (not per-side) time penalty fed through the same
median/noise-gate formulas `ab-report.mjs` uses reports a confident
"real change" under the old fixed order (two byte-identical builds,
byte-identical cost, yet the side that never pays the position penalty
reads as faster) and **within noise** under the new balanced/random
order — same synthetic penalty, only the order changed.

**Real regression still caught:** injected a deliberate 60ms
`std::thread::sleep` into the entity-scan phase
(`rust/processing/src/processor/mod.rs`, reverted before commit) and
re-ran `ab.sh` with the balanced/randomized order against upstream/main
HEAD, `--iters 9`:

```
VERDICT: a phase moved beyond the noise floor (✅ faster / ⛔ slower). ...
{"fingerprintDrift": false, "tooNoisy": false, "realChange": true}
parse         +172.5%  ⛔
entity-scan   +174.4%  ⛔
TOTAL          +42.6%  ⛔
```

The gate fires correctly on a genuine regression under the new order —
the fix doesn't just make the gate quieter, it still flags real
slowdowns.

**Mutation test:** reverted `roundOrder()`'s balance/shuffle to a
no-op (always `['base', 'branch']`) — 4 of 9 tests in
`ab-order.test.mjs` go RED, including the balance-property test and
the direct before/after #4221 demonstration test. Restored with `git
checkout` and confirmed GREEN again.

**Also fixed:** `scripts/perf/ab-order.test.mjs` landed in a
subdirectory the "Run every scripts/ test file (glob catch-all)" CI
step didn't reach — its own comment warns this is per-directory and
"goes blind on the next subdirectory anyone adds." Added
`scripts/perf/*.test.mjs` to that glob so the new test actually runs
in CI.

## Not checked

- Whether the reporter's original machine (where the +23.5% false
  positive was measured) would show a stronger effect than mine —
  I don't have access to reproduce on that hardware.
- The browser cold-load A/B harness (`scripts/perf/browser-ab-report.mjs`,
  `browser-cold-ab.sh`) has its own separate interleaving; this PR only
  touches the native `ab.sh` / `ab-report.mjs` pair the issue names.
- No changeset: this is a `scripts/`-only change with no published
  package effect (`node scripts/check-changesets.mjs` passes without
  one).

`node scripts/check-module-size.mjs` exits 0.