### PR TITLE
test(mutations): pin the addEntity watermark guard and BulkQueryEngine fail-closed selection guard

### DIFF
--- a/packages/mutations/test/bulk-query-engine.test.ts
+++ b/packages/mutations/test/bulk-query-engine.test.ts
@@ -307,6 +307,73 @@ describe('BulkQueryEngine property filter operators', () => {
 });
 
 /**
+ * Regression: github.com/LTplus-AG/ifc-lite/issues/4238
+ *
+ * `select()` must fail closed (throw) when a globalIds/namePattern
+ * restriction is requested but the string table (`strings`) is
+ * unavailable, rather than silently dropping the filter and returning the
+ * full unfiltered candidate set — which would let a caller's bulk edit
+ * (e.g. SET_PROPERTY) apply to every entity in the model instead of the
+ * intended narrow subset.
+ */
+describe('BulkQueryEngine: fail-closed globalIds/namePattern guard (#4238)', () => {
+  function makeEngineNoStrings(count: number) {
+    const entities = makeEntities(count);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    return new BulkQueryEngine(entities, view, null, null, null);
+  }
+
+  it('select() throws when a globalIds filter is requested without a string table', () => {
+    const engine = makeEngineNoStrings(3);
+    expect(() => engine.select({ globalIds: ['1234-guid'] })).toThrow(/globalIds/);
+    expect(() => engine.select({ globalIds: ['1234-guid'] })).toThrow(
+      /refusing to run an unscoped bulk selection/
+    );
+  });
+
+  it('select() throws when a namePattern filter is requested without a string table', () => {
+    const engine = makeEngineNoStrings(3);
+    expect(() => engine.select({ namePattern: 'Wall.*' })).toThrow(/namePattern/);
+    expect(() => engine.select({ namePattern: 'Wall.*' })).toThrow(
+      /refusing to run an unscoped bulk selection/
+    );
+  });
+
+  it('select() narrows correctly (does not throw) when a string table IS available', () => {
+    const entities = makeEntities(3);
+    // entity 1/2/3 -> globalId + name string indices 0/1/2, resolved via
+    // the string table below.
+    entities.globalId[0] = 0;
+    entities.globalId[1] = 1;
+    entities.globalId[2] = 2;
+    entities.name[0] = 0;
+    entities.name[1] = 1;
+    entities.name[2] = 2;
+    const strTable = ['GUID-Alpha', 'GUID-Beta', 'GUID-Gamma'];
+    const strings = { get: (idx: number) => strTable[idx] };
+
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const engine = new BulkQueryEngine(entities, view, null, null, strings);
+
+    // Guard doesn't fire (a string table is present), and the ordinary
+    // narrowing behavior further down in select() still works: the
+    // returned selection is a strict subset of the full candidate set,
+    // not "reject/pass everything unconditionally".
+    expect(() => engine.select({ globalIds: ['GUID-Beta'] })).not.toThrow();
+    const byGlobalId = engine.select({ globalIds: ['GUID-Beta'] });
+    expect(byGlobalId).toEqual([2]);
+    expect(byGlobalId.length).toBeLessThan(3);
+
+    expect(() => engine.select({ namePattern: 'Alpha' })).not.toThrow();
+    const byName = engine.select({ namePattern: 'Alpha' });
+    expect(byName).toEqual([1]);
+    expect(byName.length).toBeLessThan(3);
+  });
+});
+
+/**
  * `BulkQueryEngine.applyAction` writes straight to
  * `MutablePropertyView.setProperty`/`setEntityType`, bypassing the viewer
  * store's own actions and `canCollabEdit()` entirely (BulkPropertyEditor.tsx

--- a/packages/mutations/test/store-editor.test.ts
+++ b/packages/mutations/test/store-editor.test.ts
@@ -184,6 +184,58 @@ describe('StoreEditor', () => {
     expect(() => editor.addEntity('IFCRECTANGLEPROFILEDEF', [])).not.toThrow();
   });
 
+  // Regression: github.com/LTplus-AG/ifc-lite/issues/4239
+  // The watermark is seeded once at construction from a scan of
+  // store.entityIndex.byId. If the store grows afterward (lazy index
+  // hydration finishing late, or a federated merge adding entities) without
+  // StoreEditor being reconstructed, the next addEntity() must notice the
+  // collision and refresh the watermark — or it hands out an id that's
+  // already taken, producing two records with the same STEP id on export.
+  it('addEntity refreshes a stale watermark when the store grows after construction (#4239)', () => {
+    const store = makeStore(10);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    // Grow the store's byId AFTER construction — this is what a late
+    // hydration or federated merge looks like. StoreEditor's watermark
+    // (seeded at 10, the max at construction time) doesn't know id 11
+    // now exists.
+    store.entityIndex.byId.set(11, {
+      expressId: 11,
+      type: 'IFCWALL',
+      byteOffset: 0,
+      byteLength: 1,
+      lineNumber: 11,
+    });
+
+    const ref = editor.addEntity('IFCDIRECTION', [[0, 0, 1]]);
+
+    // Without the guard, addEntity would silently hand back id 11 again —
+    // a duplicate STEP entity number. The guard must notice the collision
+    // against the now-grown byId and reallocate above it.
+    expect(ref.expressId).not.toBe(11);
+    expect(ref.expressId).toBeGreaterThan(11);
+
+    // The new entity must not be recorded under the id that the
+    // pre-existing (post-hydration) store entity #11 already owns.
+    expect(editor.getNewEntity(11)).toBeNull();
+  });
+
+  // Companion ordinary-path check: when the store does NOT grow after
+  // construction, the guard's `if` is false and the watermark from
+  // construction stands untouched — addEntity must still return 11. This
+  // proves the test above discriminates the guard's specific collision
+  // condition rather than failing for any unrelated reason.
+  it('addEntity returns the expected next id when the store does not grow after construction', () => {
+    const store = makeStore(10);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    const ref = editor.addEntity('IFCDIRECTION', [[0, 0, 1]]);
+
+    expect(ref.expressId).toBe(11);
+  });
+
   it('addEntity routes through a registered normalizer (canonical name + registry check)', async () => {
     const { setEntityTypeNormalizer } = await import('../src/store-editor.js');
     const store = makeStore(5);

--- a/packages/mutations/test/store-editor.test.ts
+++ b/packages/mutations/test/store-editor.test.ts
@@ -200,7 +200,9 @@ describe('StoreEditor', () => {
     // hydration or federated merge looks like. StoreEditor's watermark
     // (seeded at 10, the max at construction time) doesn't know id 11
     // now exists.
-    store.entityIndex.byId.set(11, {
+    // `makeStore` builds a real Map; `MutationEntityByIdIndex` deliberately
+    // exposes only the read methods, so reach the concrete map to grow it.
+    (store.entityIndex.byId as Map<number, MutationEntityRef>).set(11, {
       expressId: 11,
       type: 'IFCWALL',
       byteOffset: 0,


### PR DESCRIPTION
## Summary

Two of the nine guards approved by the sweep charter #4280, both in `packages/mutations`. Each is correct as shipped; the whole package suite stays green with the guard removed. This PR adds the missing regression tests, nothing else.

Closes #4239
Closes #4238

### #4239 — `StoreEditor.addEntity()` stale-watermark collision guard

`StoreEditor` seeds its id watermark once at construction from a scan of `store.entityIndex.byId`. If the store grows afterward (late index hydration, federated merge) without `StoreEditor` being reconstructed, `addEntity()` re-checks whether the allocator's next id now collides with the store before creating the entity, and refreshes the watermark if so. Without it, the allocator hands back an already-used id, and export emits two records with the same STEP id.

New test in `packages/mutations/test/store-editor.test.ts`: constructs `StoreEditor` on a store seeded 1-10, then grows `store.entityIndex.byId` to include id 11 **after** construction (simulating late hydration), then calls `addEntity()` and asserts the returned id is not 11 and is greater than 11, and that id 11 is not claimed as a new entity. A companion test asserts the ordinary path (no post-construction growth) still returns 11 — this is what proves the first test is discriminating the specific collision condition, not failing for an unrelated reason.

**Mutation applied** (the guard quoted in #4239, short-circuited): `if (this.store.entityIndex.byId.has(nextId) || ...)` → `if (false && (...))`.

Pre-mutation: `Test Files 12 passed | 1 skipped (13)`, `Tests 245 passed | 10 skipped (255)` (baseline 240/10 + 5 new tests across both files).

Post-mutation: only the new `'addEntity refreshes a stale watermark...'` test went RED (`AssertionError: expected 11 not to be 11`); all other 14 tests in `store-editor.test.ts`, including the companion ordinary-path test, stayed GREEN.

Reverted; suite back to 245 passed | 10 skipped.

### #4238 — `BulkQueryEngine.select()` globalId/namePattern fail-closed guards

`select()` throws when a `globalIds` or `namePattern` restriction is requested but the string table is unavailable, rather than silently dropping the filter and returning the full unscoped candidate set — which would let a bulk edit (e.g. `SET_PROPERTY`) apply to every entity in the model instead of the intended subset.

New tests in `packages/mutations/test/bulk-query-engine.test.ts`: construct `BulkQueryEngine` with `strings: null` and assert `select({ globalIds: [...] })` and `select({ namePattern: ... })` each throw, matching both the filter name and the refusal message. A third test constructs the engine with a real string table and asserts neither call throws, and that the returned selection is a strict subset of the candidate set (not "reject/pass everything unconditionally") — proving the guard tests discriminate the missing-string-table condition specifically.

**Mutations applied** (quoted in #4238, one at a time, reverted between):
- `globalIds` guard short-circuited (`if (false && criteria.globalIds ...)`): only the `globalIds` test failed (`expected [Function] to throw an error`); `namePattern` and the ordinary-path test stayed green.
- `namePattern` guard short-circuited the same way: only the `namePattern` test failed; the other two stayed green.

This confirms the two guard tests are independent.

## Verification

- Both runs stated above, output quoted (not summarized).
- `node scripts/check-module-size.mjs`: exit 0, `0 new over 400`.
- `git diff --stat upstream/main`: only `packages/mutations/test/store-editor.test.ts` and `packages/mutations/test/bulk-query-engine.test.ts` (119 insertions, 0 deletions).
- No changeset: test-only change, no published-package API surface touched.
- No production code changed. No guard was found to be wrong — both behave exactly as documented.

## Conflict note

An unrelated open PR (#4287) adds a ReDoS guard (`compileGuardedRegex`) to `bulk-query-engine.ts`'s `namePattern` regex construction, further down in `select()`. This PR is based on unmodified `upstream/main` and does not touch or assume that change; the fail-closed guards tested here are unaffected by it.