### PR TITLE
test(bcf): pin sanitizeZipComponent's collision counter with a dot-collapse + hash collision

### DIFF
--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -720,6 +720,58 @@ describe('BCF Writer', () => {
     }
   });
 
+  it('keeps two GUIDs that collide under BOTH the sanitizer AND the hash suffix in distinct folders (#4229)', async () => {
+    // sanitizeZipComponent's disambiguation is two independent, lossy
+    // many-to-one mappings of the raw GUID stacked together: dot-collapse
+    // sanitization, then (when sanitization changed the string) an FNV-1a-32
+    // hash of the RAW guid appended as a suffix. The '-2' counter loop is
+    // only ever reached when a raw-string pair collides under BOTH mappings
+    // at once, which is why 'a?b'/'a:b' above -- same cleaned string,
+    // different hash -- never exercises it. This pair does: both raw guids
+    // sanitize (dot-collapse) to 'topicA_X_topicB' AND hash (FNV-1a-32 over
+    // the raw string, matching writer.ts's shortGuidHash exactly) to the
+    // same 'a8ee56f2', so both produce the identical base
+    // 'topicA_X_topicB-a8ee56f2' and only the counter can still tell them
+    // apart. A fixture colliding on only one of the two mappings would keep
+    // passing even with the counter loop deleted, so it would not
+    // discriminate this guard; verified against #4229's search.
+    const raw1 = `topicA${'.'.repeat(34)}X${'.'.repeat(2)}topicB`; // 49 chars
+    const raw2 = `topicA${'.'.repeat(595)}X${'.'.repeat(325)}topicB`; // 933 chars
+
+    const makeTopic = (guid: string, title: string): BCFTopic => ({
+      guid,
+      title,
+      creationDate: new Date().toISOString(),
+      creationAuthor: 'author@example.com',
+      viewpoints: [],
+      comments: [],
+    });
+    const guids = [raw1, raw2];
+    const project: BCFProject = {
+      version: '2.1',
+      topics: new Map(guids.map((g, i) => [g, makeTopic(g, `Topic ${i}`)])),
+    };
+
+    const blob = await writeBCF(project);
+    const zip = await JSZip.loadAsync(await blobToArrayBuffer(blob));
+
+    const markupPaths: string[] = [];
+    zip.forEach((relativePath) => {
+      if (relativePath.endsWith('markup.bcf')) markupPaths.push(relativePath);
+    });
+    // Two distinct folders, not one collapsed by the hash-suffix collision.
+    expect(markupPaths).toHaveLength(2);
+    expect(new Set(markupPaths).size).toBe(2);
+
+    // Round-trip: both topics survive with their original, distinct GUIDs --
+    // neither was silently overwritten in the archive.
+    const readProject = await readBCF(await blob.arrayBuffer());
+    expect([...readProject.topics.keys()].sort()).toEqual([...guids].sort());
+    for (const g of guids) {
+      expect(readProject.topics.get(g)?.guid).toBe(g);
+    }
+  });
+
   // --------------------------------------------------------------------------
   // Fields that a BCF consumer reads but that no fixture pinned. Each of these
   // survived a mutation of the writer: the file stayed readable, so nothing on


### PR DESCRIPTION
## Summary

One of the nine guards approved by the sweep charter #4280, in `packages/bcf`. The guard is correct as shipped; the whole package suite (23 files / 470 tests) stays green with it removed. This PR adds the missing regression test, nothing else.

Closes #4229

### The guard

`sanitizeZipComponent` (`packages/bcf/src/writer.ts`) disambiguates zip path components for topic/viewpoint GUIDs with two independent, lossy many-to-one mappings stacked together: dot-collapse sanitization, then (when sanitization changed the string) an FNV-1a-32 hash of the raw GUID appended as a suffix. A numeric `-2`, `-3`, ... counter is the last line of defense when a raw-string pair collides under **both** mappings at once. Without the counter, the second call returns the same name as the first, and the second topic's `zip.file()` call silently overwrites the first's entry — a topic is dropped from the BCF archive with no error.

### Why the existing fixture doesn't reach it

`writer.test.ts` already has a test ("keeps distinct GUIDs that sanitize identically in distinct folders") using `'a?b'`/`'a:b'`, which collide under dot-collapse-adjacent sanitization but hash differently — the hash suffix alone disambiguates them, so the counter loop is never consulted.

### The new fixture

Two raw strings, verified (independently reimplementing `shortGuidHash`'s FNV-1a-32/`Math.imul` exactly) to collide under **both** mappings:

```
raw1 = "topicA" + "."×34  + "X" + "."×2   + "topicB"   (49 chars)
raw2 = "topicA" + "."×595 + "X" + "."×325 + "topicB"   (933 chars)
```

Both sanitize to `topicA_X_topicB` and both hash to `a8ee56f2`, so both produce the identical base `topicA_X_topicB-a8ee56f2` — only the counter can still tell them apart. A fixture colliding on only one of the two mappings would keep passing even with the counter deleted, so it would not discriminate this guard.

New test in `packages/bcf/src/writer.test.ts`: builds two topics keyed by `raw1`/`raw2`, calls `writeBCF`, asserts the resulting archive has 2 distinct `markup.bcf` paths (not 1), and that `readBCF` round-trips both original GUIDs as separate topics — asserting the corruption (a dropped topic), not the mechanism (whether the counter function ran).

**Mutation applied** (the guard quoted in #4229): the `for (let n = 2; usedNames.has(candidate); n++) { candidate = ...; }` loop replaced with `const candidate = base;` (unconditional).

Pre-mutation: `writer.test.ts` — 48 tests, all passing. Full suite: 23 files / 471 tests (470 + 1 new), all passing.

Post-mutation: `writer.test.ts` — 48 tests, **1 failed** (the new test: `AssertionError: expected [ Array(1) ] to have a length of 2 but got 1`); all other 47 tests, including "keeps distinct GUIDs that sanitize identically...", stayed GREEN. Full suite: 470 passed / 1 failed (471 total) — no collateral damage.

Reverted; full suite back to 23 files / 471 tests, all passing.

## Verification

- Both runs stated above, output quoted (not summarized).
- `node scripts/check-module-size.mjs`: exit 0, `0 new over 400`.
- `git diff --stat upstream/main`: only `packages/bcf/src/writer.test.ts` (52 insertions).
- No changeset: test-only change, no published-package API surface touched.
- No production code changed. The guard was not found to be wrong — it behaves exactly as documented; only the test was missing.