### PR TITLE
test(parser): pin two undefended mutation-hunt gaps (#4223, #4224)

### DIFF
--- a/packages/parser/test/group-members-ifcx-typename-only.test.ts
+++ b/packages/parser/test/group-members-ifcx-typename-only.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Package-level coverage for the IFCX-only branch of
+ * `extractGroupMembersOnDemand` (#1622 IFCX follow-up):
+ *
+ *   // IFCX stores ingest with an EMPTY entityIndex.byId (no STEP byte spans
+ *   // exist), so existence rides the EntityTable there: keep a member when
+ *   // EITHER source knows the id. STEP stores keep byId as the primary gate
+ *   // and resolve identically to before (#1622 IFCX follow-up).
+ *   if (!ref && (!tableType || tableType === 'Unknown')) continue;
+ *
+ * Every other `packages/parser` test reaches this function via the STEP
+ * ingestion path, where `entityIndex.byId` is always populated, so the
+ * `!ref` half of the guard alone would satisfy every one of them — the
+ * "EITHER source" half is otherwise verified only one package over, in
+ * `packages/ifcx`'s `system-membership.test.ts`. This test builds a store
+ * shaped like real IFCX ingest (`entityIndex.byId` missing the member id,
+ * `store.entities.getTypeName` still resolving it) so the invariant is
+ * pinned locally too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipGraphBuilder, RelationshipType } from '@ifc-lite/data';
+import { createSyntheticDataStore } from '../src/synthetic-data-store.js';
+import { extractGroupMembersOnDemand } from '../src/on-demand-extractors.js';
+
+describe('extractGroupMembersOnDemand — IFCX-shaped store (empty entityIndex.byId)', () => {
+  it('keeps a member known only via store.entities.getTypeName', () => {
+    const groupId = 1;
+    const memberId = 2;
+
+    const store = createSyntheticDataStore({
+      schemaVersion: 'IFC4X3',
+      fileSize: 0,
+      entities: [
+        { expressId: groupId, type: 'IfcSystem', name: 'HVAC System' },
+        { expressId: memberId, type: 'IfcPipeSegment', name: 'Pipe' },
+      ],
+    });
+
+    // Simulate real IFCX ingest: entityIndex.byId carries no STEP byte spans,
+    // so it stays EMPTY for the member — existence must ride the EntityTable
+    // (store.entities.getTypeName) instead.
+    store.entityIndex.byId.delete(memberId);
+    expect(store.entityIndex.byId.has(memberId)).toBe(false);
+    // Sanity: the EntityTable still knows the type — this is what the
+    // "EITHER source" branch is meant to fall back to.
+    expect(store.entities.getTypeName(memberId)).toBe('IfcPipeSegment');
+
+    // Wire the group -> member edge the way parseIfcx does (group -> member,
+    // STEP direction).
+    const relBuilder = new RelationshipGraphBuilder();
+    relBuilder.addEdge(groupId, memberId, RelationshipType.AssignsToGroup, 100);
+    store.relationships = relBuilder.build();
+
+    const members = extractGroupMembersOnDemand(store, groupId);
+    expect(members.map((m) => m.id)).toEqual([memberId]);
+    expect(members[0]?.type).toBe('IfcPipeSegment');
+  });
+});

--- a/packages/parser/test/group-members-ifcx-typename-only.test.ts
+++ b/packages/parser/test/group-members-ifcx-typename-only.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect } from 'vitest';
 import { RelationshipGraphBuilder, RelationshipType } from '@ifc-lite/data';
 import { createSyntheticDataStore } from '../src/synthetic-data-store.js';
 import { extractGroupMembersOnDemand } from '../src/on-demand-extractors.js';
+import type { EntityRef } from '../src/types.js';
 
 describe('extractGroupMembersOnDemand — IFCX-shaped store (empty entityIndex.byId)', () => {
   it('keeps a member known only via store.entities.getTypeName', () => {
@@ -44,7 +45,11 @@ describe('extractGroupMembersOnDemand — IFCX-shaped store (empty entityIndex.b
     // Simulate real IFCX ingest: entityIndex.byId carries no STEP byte spans,
     // so it stays EMPTY for the member — existence must ride the EntityTable
     // (store.entities.getTypeName) instead.
-    store.entityIndex.byId.delete(memberId);
+    // `entityIndex.byId` is typed as the read-only-shaped `EntityByIdIndex`
+    // (no `delete`), but `createSyntheticDataStore` builds it as a concrete
+    // `Map<number, EntityRef>` — cast to that, matching the same escape hatch
+    // `packages/export/src/entity-iteration.ts` uses for the real store.
+    (store.entityIndex.byId as unknown as Map<number, EntityRef>).delete(memberId);
     expect(store.entityIndex.byId.has(memberId)).toBe(false);
     // Sanity: the EntityTable still knows the type — this is what the
     // "EITHER source" branch is meant to fall back to.

--- a/packages/parser/test/material-usage-duplicate-forward-target.test.ts
+++ b/packages/parser/test/material-usage-duplicate-forward-target.test.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression for a documented-but-untested invariant in
+ * `buildMaterialUsageIndex`: duplicate forward `DefinesByType` edges
+ * (malformed double-typing — the same type→occurrence pair asserted by two
+ * distinct `IfcRelDefinesByType` rows, or a single relation whose
+ * `RelatedObjects` lists the same occurrence twice) must not double that
+ * occurrence's contribution to a material's usage row.
+ *
+ * Uses the server-shaped (source-less, facade-graph) store, same as
+ * `material-fraction-and-associations.test.ts`, so `getRelated(typeId,
+ * DefinesByType, 'forward')` can be made to return a literal duplicate
+ * target without depending on how any particular relationship-graph
+ * implementation would (or wouldn't) already dedupe its edges.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipType } from '@ifc-lite/data';
+import { buildMaterialUsageIndex } from '../src/material-resolver.js';
+import type { IfcDataStore } from '../src/columnar-parser.js';
+import type { EntityRef } from '../src/types.js';
+
+type Edge = { target: number; type: RelationshipType; relationshipId: number };
+
+function facadeGraph(forwardEdges: Map<number, Edge[]>, inverseEdges: Map<number, Edge[]>) {
+    const accessor = (edges: Map<number, Edge[]>) => ({
+        offsets: new Map<number, number>(),
+        counts: new Map<number, number>(),
+        edgeTargets: new Uint32Array(0),
+        edgeTypes: new Uint16Array(0),
+        edgeRelIds: new Uint32Array(0),
+        getEdges: (id: number, type?: RelationshipType) => {
+            const e = edges.get(id) || [];
+            return type !== undefined ? e.filter((x) => x.type === type) : e;
+        },
+        getTargets: (id: number, type?: RelationshipType) => {
+            const e = edges.get(id) || [];
+            return (type !== undefined ? e.filter((x) => x.type === type) : e).map((x) => x.target);
+        },
+        hasAnyEdges: (id: number) => (edges.get(id)?.length ?? 0) > 0,
+    });
+    return {
+        forward: accessor(forwardEdges),
+        inverse: accessor(inverseEdges),
+        getRelated: (id: number, type: RelationshipType, direction: 'forward' | 'inverse') => {
+            const edges = (direction === 'forward' ? forwardEdges : inverseEdges).get(id) || [];
+            return edges.filter((e) => e.type === type).map((e) => e.target);
+        },
+        hasRelationship: () => false,
+        getRelationshipsBetween: () => [],
+    };
+}
+
+function buildStore(): IfcDataStore {
+    // #11 door occurrence, #20 door type, #30 material. Type #20 carries the
+    // material association; #20 -> #11 is asserted by TWO distinct
+    // IfcRelDefinesByType rows (relationshipId 1 and 2) — malformed, but the
+    // comment in buildMaterialUsageIndex explicitly claims this must not
+    // double-count.
+    const byId = new Map<number, EntityRef>([
+        [11, { expressId: 11, type: 'IFCDOOR', byteOffset: 0, byteLength: 0, lineNumber: 0 }],
+        [20, { expressId: 20, type: 'IFCDOORTYPE', byteOffset: 0, byteLength: 0, lineNumber: 0 }],
+        [30, { expressId: 30, type: 'IFCMATERIAL', byteOffset: 0, byteLength: 0, lineNumber: 0 }],
+    ]);
+    const AM = RelationshipType.AssociatesMaterial;
+    const DT = RelationshipType.DefinesByType;
+    const forwardEdges = new Map<number, Edge[]>([
+        [30, [{ target: 20, type: AM, relationshipId: 0 }]],
+        // Duplicate forward DefinesByType edges: two relations, same pair.
+        [20, [
+            { target: 11, type: DT, relationshipId: 1 },
+            { target: 11, type: DT, relationshipId: 2 },
+        ]],
+    ]);
+    const inverseEdges = new Map<number, Edge[]>([
+        [20, [{ target: 30, type: AM, relationshipId: 0 }]],
+        [11, [{ target: 20, type: DT, relationshipId: 1 }, { target: 20, type: DT, relationshipId: 2 }]],
+    ]);
+    return {
+        source: new Uint8Array(0),
+        entityIndex: { byId, byType: new Map<string, number[]>() },
+        relationships: facadeGraph(forwardEdges, inverseEdges),
+        entities: { getName: (id: number) => (id === 30 ? 'Concrete' : '') },
+    } as unknown as IfcDataStore;
+}
+
+describe('buildMaterialUsageIndex duplicate forward DefinesByType edges (undefended dedup)', () => {
+    it('yields exactly one unmultiplied row for the (material, occurrence) pair', () => {
+        const store = buildStore();
+        const usage = buildMaterialUsageIndex(store);
+
+        const concrete = usage.get(30);
+        expect(concrete).toBeDefined();
+        // Exactly one entry for occurrence #11 — not one per duplicate edge —
+        // and its weight is the leaf's own weight (1), never doubled.
+        expect(concrete!.entries).toEqual([{ entityId: 11, weight: 1 }]);
+    });
+});


### PR DESCRIPTION
## Summary

Sweep charter #4280: two `packages/parser` guards are correct as shipped and each one's own comment explains why it's load-bearing, but deleting either leaves the whole package suite green.

- **#4223** — `buildMaterialUsageIndex`'s duplicate-forward-target dedup (`material-resolver.ts`): a duplicate `IfcRelDefinesByType` edge to the same occurrence must not double that occurrence's weight/quantity contribution in material usage totals.
- **#4224** — `extractGroupMembersOnDemand`'s IFCX member-inclusion branch (`on-demand-extractors.ts`): a member known only via `store.entities.getTypeName` (empty `entityIndex.byId`, the shape of real IFCX ingest) must still be kept in a group/zone member list.

New tests:
- `packages/parser/test/material-usage-duplicate-forward-target.test.ts` — builds a facade relationship graph with a genuine duplicate forward `DefinesByType` edge (two distinct relations, same type→occurrence pair) and asserts the material's usage row has exactly one entry for that occurrence with unmultiplied weight.
- `packages/parser/test/group-members-ifcx-typename-only.test.ts` — builds a synthetic store shaped like real IFCX ingest (`entityIndex.byId` missing the member id, `store.entities.getTypeName` still resolving it) and asserts the member survives `extractGroupMembersOnDemand`.

Both fixtures discriminate: the dedup test has a real duplicate edge pair (a fixture without one would pass either way), and the IFCX test genuinely deletes the member from `entityIndex.byId` before asserting the EntityTable fallback keeps it.

## The bar (per #4280)

**1. New tests pass on unmodified `main`:**
```
Test Files  113 passed (113)
     Tests  1214 passed | 3 skipped (1217)
```
(1212 baseline + 2 new, matching each issue's reported baseline of 111 files / 1212 tests.)

**2. Re-applying each issue's exact mutation, in isolation, turns only the new test red and leaves every pre-existing test in the package green:**

#4223 mutation (`material-resolver.ts`):
```diff
-const uniqueTargets = targets.length > 1 ? [...new Set(targets)] : targets;
+const uniqueTargets = targets;
```
Result:
```
Test Files  1 failed | 112 passed (113)
     Tests  1 failed | 1213 passed | 3 skipped (1217)
```
Only `material-usage-duplicate-forward-target.test.ts` fails.

#4224 mutation (`on-demand-extractors.ts`):
```diff
-if (!ref && (!tableType || tableType === 'Unknown')) continue;
+if (!ref) continue;
```
Result:
```
Test Files  1 failed | 112 passed (113)
     Tests  1 failed | 1213 passed | 3 skipped (1217)
```
Only `group-members-ifcx-typename-only.test.ts` fails.

Both mutations were reverted after verification; the diff here is test-only.

## Scope

Only #4223 and #4224 from #4280's table. No production code changed, no changeset (no API-surface change).

Closes #4223
Closes #4224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming group members remain discoverable when indexed IFCX type information is available without STEP byte spans.
  - Added regression coverage ensuring duplicate material-definition relationships do not double-count an occurrence in material usage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->