### PR TITLE
test(merge): pin opsForComponentChange's oursVisible nulling loop (#4240)

### DIFF
--- a/packages/merge/src/merge-layer.test.ts
+++ b/packages/merge/src/merge-layer.test.ts
@@ -74,6 +74,56 @@ describe('applyResolutions', () => {
     const applied = applyResolutions(plan, []);
     expect(applied.unresolved).toHaveLength(1);
   });
+
+  it('adopting theirs nulls an attribute ours independently added to the conflicting component', () => {
+    // Dedicated fixture (not conflictingPlanInputs(), which several other
+    // tests in this file share): ours adds Comments to the same component
+    // theirs conflicts on via FireRating. opsForComponentChange's docstring
+    // says every key visible on ancestor OR ours that `next` no longer
+    // carries must be explicitly nulled -- otherwise, under the target
+    // stack's per-attribute LWW composition, ours' Comments would keep
+    // shining through from the layer beneath even though the reviewer
+    // chose "adopt theirs entirely". The ancestor half of this nulling is
+    // already covered above (FireRating going from REI60 to REI120/REI90);
+    // this pins the oursVisible half, which no other assertion in this
+    // package references.
+    const COMMENTS = 'bsi::ifc::v5a::Pset_FireSafety::Comments';
+    const oursAddsComments = {
+      ancestor: [base],
+      ours: [
+        base,
+        makeLayer([{ path: 'wall-1', attributes: { [COMMENTS]: 'recheck Q3' } }], 'ours'),
+      ],
+      theirs: [base, makeLayer([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'theirs')],
+    };
+    const plan = planThreeWayMerge(oursAddsComments);
+    expect(plan.conflicts).toHaveLength(1);
+
+    const theirs = applyResolutions(plan, [
+      { path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'theirs' },
+    ]);
+    expect(theirs.ops).toEqual([
+      {
+        op: 'set-component',
+        path: 'wall-1',
+        componentKey: 'pset:Pset_FireSafety',
+        attributes: { [FIRE]: 'REI120', [COMMENTS]: null },
+      },
+    ]);
+    const emitted = theirs.ops[0];
+    if (emitted?.op !== 'set-component') throw new Error('expected a set-component op');
+
+    // Composing ours + the emitted op must not let Comments shine through:
+    // this is what "explicitly null it" is actually for, under per-attribute
+    // last-write-wins composition of the target stack.
+    const composed = extractStackState([
+      ...oursAddsComments.ours,
+      makeLayer([{ path: 'wall-1', attributes: emitted.attributes }], 'merged'),
+    ]);
+    expect(composed.get('wall-1')?.components.get('pset:Pset_FireSafety')).toEqual({
+      [FIRE]: 'REI120',
+    });
+  });
 });
 
 describe('buildMergeLayer', () => {


### PR DESCRIPTION
## Summary

Sweep charter #4280: `packages/merge`'s `opsForComponentChange` (`three-way.ts`) has two nulling loops per its own docstring — every attribute visible on the ancestor OR the ours side that the new value no longer carries must be explicitly nulled, so a stale opinion doesn't shine through under IFCX's per-attribute last-write-wins composition. The `ancestor` half already had a test; the `oursVisible` half had none — deleting that loop leaves the full `packages/merge` suite green.

New test in `packages/merge/src/merge-layer.test.ts`, `applyResolutions` describe block: a dedicated fixture (not the file's shared `conflictingPlanInputs()`, which three other tests reuse — mutating that shared fixture in an earlier draft of this test made an unrelated pre-existing test fail alongside the new one, which is exactly the failure mode #4280 rules out) where `ours` independently adds a `Comments` attribute to the same component `theirs` conflicts on via `FireRating`. Asserts:
1. The `theirs`-resolution op nulls `Comments` (`{ FireRating: 'REI120', Comments: null }`).
2. Composing `ours` with that emitted op actually drops `Comments` under real per-attribute LWW composition — not just that the op object looks right.

This checks the other side of the two-way rule: the `ancestor` half (FireRating REI60 -> REI120) is already covered by the existing `theirs.ops` assertion above it in the same test; this test isolates the `oursVisible` half specifically.

## The bar (per #4280)

**1. New test passes on unmodified `main`:**
```
Test Files  9 passed | 1 skipped (10)
     Tests  110 passed | 4 skipped (114)
```
(109 baseline + 1 new, matching the issue's reported baseline of 109 tests.)

**2. Re-applying the mutation (deleting the `oursVisible` nulling loop in the `set-component` path) turns only the new test red and leaves every pre-existing test in the file/package green:**

```diff
   const attributes: ComponentAttributes = {};
   for (const attr of Object.keys(ancestor ?? {})) {
     if (!(attr in next)) attributes[attr] = null;
   }
-  for (const attr of Object.keys(oursVisible ?? {})) {
-    if (!(attr in next)) attributes[attr] = null;
-  }
   Object.assign(attributes, next);
```
Result:
```
Test Files  1 failed | 8 passed | 1 skipped (10)
     Tests  1 failed | 109 passed | 4 skipped (114)
```
Only the new `adopting theirs nulls an attribute ours independently added...` test fails; all 109 pre-existing tests stay green.

The mutation was reverted after verification; the diff here is test-only.

## Scope

Only #4240 from #4280's table. No production code changed, no changeset (no API-surface change).

Closes #4240