### PR TITLE
test(viewer): pin removeRemoteAnnotation cleanup and drawingRequestQueue cancel revision guards

### DIFF
--- a/apps/viewer/src/hooks/drawingRequestQueue.test.ts
+++ b/apps/viewer/src/hooks/drawingRequestQueue.test.ts
@@ -46,3 +46,18 @@ it('cancels queued work and invalidates the running publication (#3921)', async 
   await Promise.all([running, pending]);
   assert.deepEqual(events, []);
 });
+
+it('invalidates an in-flight run when cancel() is called with nothing queued after it', async () => {
+  const queue = createDrawingRequestQueue();
+  let release!: () => void;
+  const blocked = new Promise<void>(resolve => { release = resolve; });
+  let currentAtPublish: boolean | undefined;
+  const running = queue.request(async isCurrent => {
+    await blocked;
+    currentAtPublish = isCurrent();
+  });
+  queue.cancel();
+  release();
+  await running;
+  assert.equal(currentAtPublish, false);
+});

--- a/apps/viewer/src/store/slices/annotationsSlice.test.ts
+++ b/apps/viewer/src/store/slices/annotationsSlice.test.ts
@@ -162,6 +162,36 @@ describe('AnnotationsSlice', () => {
         'deleting a pin we never persisted must not add a storage entry',
       );
     });
+
+    it('cleans up a stale storage entry left over from before the pin flipped to remote', () => {
+      // Create a local pin (persisted)...
+      state.beginDraft({ x: 0, y: 0, z: 0 }, null, null);
+      const id = state.commitDraft('local, then flipped remote out-of-band')!;
+      assert.ok(persistedIds().includes(id), 'sanity: pin was persisted while local');
+      const current = state.annotations.get(id)!;
+
+      // ...then flip its `remote` flag directly on the in-memory map, bypassing
+      // upsertRemoteAnnotation (which would clean the storage entry itself).
+      // This reproduces the scenario where a pin's ownership resolves to
+      // remote by some path other than upsertRemoteAnnotation, leaving the
+      // old localStorage entry stale.
+      const flipped = new Map(state.annotations);
+      flipped.set(id, { ...current, remote: true });
+      setState({ annotations: flipped });
+      assert.strictEqual(state.annotations.get(id)?.remote, true, 'sanity: pin is now flagged remote');
+      assert.ok(
+        persistedIds().includes(id),
+        'sanity: the storage entry from before the flip is still there (stale)',
+      );
+
+      state.removeRemoteAnnotation(id);
+
+      assert.strictEqual(state.annotations.has(id), false, 'removed from in-memory map');
+      assert.ok(
+        !persistedIds().includes(id),
+        'removeRemoteAnnotation must clean up the stale storage entry even though the pin is now flagged remote',
+      );
+    });
   });
 
   describe('upsertRemoteAnnotation — persistence symmetry', () => {


### PR DESCRIPTION
## Summary

Adds regression tests for two documented-but-untested guards in `apps/viewer`. Both are coverage gaps only — as far as testing shows, both shipped behaviors are already correct; no production code changes.

Closes #4222
Closes #4258

## #4222 — `annotationsSlice.removeRemoteAnnotation` stale-storage cleanup

`removeRemoteAnnotation` has an unconditional `saveToStorage(next)` whose own comment documents that it must run even when the pin is now flagged `remote: true`, to clean up a stale `localStorage` entry left over from before the flag flipped by some path other than `upsertRemoteAnnotation`. No existing test seeded that scenario (a pin that is in-memory `remote: true` while still having a stale storage entry under its id).

**Test added** (`apps/viewer/src/store/slices/annotationsSlice.test.ts`): commits a local pin (persisted), then flips its `remote` flag directly on the in-memory map — bypassing `upsertRemoteAnnotation`, which would otherwise clean the storage entry itself — leaving a stale entry. Calls `removeRemoteAnnotation` and asserts the stale storage entry is gone.

Why this fixture discriminates: the one existing test that upserts a `remote: true` annotation over a previously-local one exercises `upsertRemoteAnnotation`'s own cleanup, not `removeRemoteAnnotation`'s — by the time `removeRemoteAnnotation` runs in that scenario the storage entry is already clean, so a missing guard there is never observed. This new test flips the flag out-of-band specifically so the stale entry still exists when `removeRemoteAnnotation` runs.

**Pre-mutation** — `npx tsx --import ./src/test/vite-module-hooks.mjs --test src/store/slices/annotationsSlice.test.ts`:
```
# tests 17
# pass 17
# fail 0
```

**Mutation applied** (from the issue, not committed — reverted after verification):
```diff
-      saveToStorage(next);
+      if (!existing.remote) saveToStorage(next);
```

**Post-mutation** — same command:
```
# tests 17
# pass 16
# fail 1
not ok 3 - cleans up a stale storage entry left over from before the pin flipped to remote
  error: 'removeRemoteAnnotation must clean up the stale storage entry even though the pin is now flagged remote'
```
All 16 pre-existing tests stayed green; only the new test failed. Mutation reverted, `git diff` confirmed clean before committing.

## #4258 — `drawingRequestQueue.cancel()` revision bump

`cancel()` bumps `revision` so an in-flight run's `isCurrent()` check flips `false`, letting the caller skip publishing a superseded drawing. The existing test ("cancels queued work and invalidates the running publication (#3921)") always calls `queue.request()` again immediately after `cancel()` — and `request()` *also* bumps `revision` — so removing the `revision++` inside `cancel()` itself left that test green; the coverage gap masked whether `cancel()`'s own bump does anything.

**Test added** (`apps/viewer/src/hooks/drawingRequestQueue.test.ts`): starts a `request()` that blocks on a promise, calls `queue.cancel()` — **no `request()` call follows it** — then releases the block and asserts the in-flight run observed `isCurrent() === false` at publish time. This is the exact untested path `useDrawingGeneration.ts`'s unmount cleanup exercises in production (`cancel()` with nothing queued after it).

**Pre-mutation** — `npx tsx --import ./src/test/vite-module-hooks.mjs --test src/hooks/drawingRequestQueue.test.ts`:
```
# tests 4
# pass 4
# fail 0
```

**Mutation applied** (from the issue, not committed — reverted after verification):
```diff
-    cancel() { revision++; pending = undefined; },
+    cancel() { pending = undefined; },
```

**Post-mutation** — same command:
```
# tests 4
# pass 3
# fail 1
not ok 4 - invalidates an in-flight run when cancel() is called with nothing queued after it
  AssertionError: Expected values to be strictly equal: true !== false
```
All 3 pre-existing tests stayed green; only the new test failed. Mutation reverted, `git diff` confirmed clean before committing.

## Provenance

Both tests are cherry-picked (test files only, hand-extracted via `git show <branch>:<path>`) from two prepared-but-unopened upstream branches, `fix-annotations-remove-remote-guard-test` and `hunt/drawing-request-queue-cancel-revision`. Neither branch was merged; both carried unrelated stale-base Rust/CI changes that are deliberately NOT included here — `git diff --stat upstream/main HEAD` for this branch shows only the two test files.

## Changeset

Not needed. Per `AGENTS.md`, a changeset is required for changes to published `packages/*`; this PR touches only `apps/viewer/**` test files, which is an app, not a published package.

## Verification

- `node scripts/check-module-size.mjs` → exit 0 (informational notes only, no new files over budget)
- `git diff --stat upstream/main HEAD` → only the two test files changed
