### PR TITLE
feat(export): plan URI-safe authored appearance cleanup

### DIFF
--- a/.changeset/hot-zebras-bow.md
+++ b/.changeset/hot-zebras-bow.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": minor
+---
+
+Add a conservative authored appearance cleanup plan that preserves effective IFC references and surviving image URLs.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -789,3 +789,9 @@ await saveFile('entities.csv', csv);
 
 - [Query Guide](querying.md) - Filter data before export
 - [API Reference](../api/typescript.md) - Complete API docs
+
+### Cleaning up authored appearance resources
+
+`planAuthoredResourceCleanup(dataStore, mutationView, candidateIds, protectedValues)` returns `{ entityIds, retainedImageUris }`: a deletion plan for explicitly owned, overlay-created appearance resource entities plus the effective image URLs that survive it. It follows the same effective positional and named reference overrides as STEP export. Source-backed resources, entities outside the candidate set, and live inverse style/texture bindings are retained. The URI set includes independent/source image entities that copy an authored URL, even after its original image entity is removed. Values and references use the existing STEP serializers, retype and attribute-override helpers, with positional overrides taking precedence as they do in the exported file. The optional `protectedValues` iterable carries entity references and saved attribute values needed by Undo/Redo; these references keep the corresponding resource graph alive.
+
+The helper is pure: apply `entityIds` through an atomic mutation transaction, then release image bytes only after that transaction succeeds. Reconcile outside history publication and advance the model revision after deletion. It refuses oversized candidate/reference walks without returning a partial plan. This is authored-resource housekeeping, not a general imported-model cleanup pass.

--- a/packages/export/src/authored-resource-cleanup.test.ts
+++ b/packages/export/src/authored-resource-cleanup.test.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it, expect } from 'vitest';
+import { IfcParser, EntityExtractor } from '@ifc-lite/parser';
+import { StepExporter } from './step-exporter.js';
+import { MutablePropertyView, StoreEditor, type IfcAttributeValue } from '@ifc-lite/mutations';
+import { planAuthoredResourceCleanup } from './authored-resource-cleanup.js';
+
+async function fixture(dangling = false, nested = false) {
+  const source = `ISO-10303-21;
+HEADER;FILE_DESCRIPTION(('Authored GC'),'2;1');FILE_NAME('gc.ifc','',(''),(''),'','','');FILE_SCHEMA(('IFC4'));ENDSEC;
+DATA;
+#10=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.)));
+#11=IFCTRIANGULATEDFACESET(#10,$,.F.,((1,2,3)),$);
+#12=IFCIMAGETEXTURE(.T.,.T.,'DIFFUSE',$,$,'original.png');
+#13=IFCSURFACESTYLEWITHTEXTURES((#12));
+#14=IFCSURFACESTYLE($,.BOTH.,(#13));
+${nested ? '#15=IFCBSPLINESURFACEWITHKNOTS(1,1,((#18,#10),(#10,#18)),.UNSPECIFIED.,.F.,.F.,.F.,(2,2),(2,2),(0.,1.),(0.,1.),.UNSPECIFIED.);' : `#15=IFCSTYLEDITEM(#11,(#${dangling ? 18 : 14}),$);`}
+ENDSEC;END-ISO-10303-21;`;
+  const store = await new IfcParser().parseColumnar(new TextEncoder().encode(source).buffer);
+  const view = new MutablePropertyView(store.properties, 'gc');
+  const editor = new StoreEditor(store, view);
+  const image = editor.addEntity('IfcImageTexture', [true, true, 'DIFFUSE', null, null, 'authored.png']).expressId;
+  const texture = editor.addEntity('IfcSurfaceStyleWithTextures', [[`#${image}`]]).expressId;
+  const style = editor.addEntity('IfcSurfaceStyle', [null, '.BOTH.', [`#${texture}`]]).expressId;
+  const candidates = new Set([12, 13, 14, image, texture, style]);
+  const plan = (protectedValues: string[] = []) => planAuthoredResourceCleanup(store, view, candidates, protectedValues);
+  const collect = (protectedValues: string[] = []) => plan(protectedValues).entityIds;
+  return { store, view, editor, image, texture, style, candidates, collect, plan };
+}
+async function exportedEntity(f: Awaited<ReturnType<typeof fixture>>, id: number) {
+  const output = new StepExporter(f.store, f.view).export({ schema: 'IFC4', applyMutations: true }).content;
+  const parsed = await new IfcParser().parseColumnar(new Uint8Array(output).buffer);
+  const ref = parsed.entityIndex.byId.get(id); expect(ref).toBeDefined();
+  const entity = new EntityExtractor(parsed.source).extractEntity(ref!); expect(entity).not.toBeNull();
+  return entity!;
+}
+describe('authored appearance graph cleanup #4243', () => {
+  it('never collects imported entities and follows effective source style overrides', async () => {
+    const f = await fixture();
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+    f.editor.setPositionalAttribute(15, 1, [`#${f.style}`]);
+    expect(f.collect().size).toBe(0);
+    f.editor.setPositionalAttribute(15, 1, ['#14']);
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+    // The actual STEP writer applies positional overrides after named overrides.
+    f.editor.setAttribute(15, 'Styles', `#${f.style}`);
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+    expect((await exportedEntity(f, 15)).attributes[1]).toEqual([14]);
+  });
+  it('retains an authored resource named by an originally dangling source reference', async () => {
+    const f = await fixture(true);
+    expect(f.style).toBe(18);
+    expect(f.collect().size).toBe(0);
+    f.editor.setPositionalAttribute(15, 1, ['#14']);
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+  });
+  it('preserves nested source-slot refs after unrelated edits, but honors replacing that slot', async () => {
+    const f = await fixture(false, true);
+    f.editor.setPositionalAttribute(15, 0, 2); // UDegree, leaving ControlPointsList unchanged.
+    expect(f.collect().size).toBe(0);
+    f.editor.setPositionalAttribute(15, 2, [['#10', '#10'], ['#10', '#10']]);
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+  });
+  it('retains history-referenced resources and live inverse texture bindings', async () => {
+    const f = await fixture();
+    expect(f.collect([`#${f.style}`]).size).toBe(0);
+    const uv = f.editor.addEntity('IfcTextureVertexList', [[[0, 0], [1, 0], [0, 1]]]).expressId;
+    const map = f.editor.addEntity('IfcIndexedTriangleTextureMap', [[`#${f.image}`], '#11', `#${uv}`, [[1, 2, 3]]]).expressId;
+    f.candidates.add(uv); f.candidates.add(map);
+    expect(f.collect()).toEqual(new Set([f.style, f.texture]));
+    f.editor.removeEntity(map);
+    expect(f.collect()).toEqual(new Set([f.style, f.texture, f.image, uv]));
+  });
+  it('refuses cyclic/deep authored attributes before canonical recursive reference extraction', async () => {
+    const f = await fixture();
+    const cycle: IfcAttributeValue[] = []; cycle.push(cycle);
+    f.view.setPositionalAttribute(15, 1, cycle, true);
+    expect(() => f.collect()).toThrow(/attribute budget/);
+    let deep: IfcAttributeValue = `#${f.style}`;
+    for (let i = 0; i < 100; i++) deep = [deep];
+    f.view.setPositionalAttribute(15, 1, deep, true);
+    expect(() => f.collect()).toThrow(/attribute budget/);
+    expect(f.view.getNewEntity(f.image)).not.toBeNull();
+  });
+  it('reports effective exported image URIs, including copied URLs after the original image is collected', async () => {
+    const f = await fixture();
+    const copy = f.editor.addEntity('IfcImageTexture', [true, true, 'DIFFUSE', null, null, 'authored.png']).expressId;
+    const cleanup = f.plan();
+    expect(cleanup.entityIds.has(f.image)).toBe(true);
+    expect(cleanup.retainedImageUris.has('authored.png')).toBe(true);
+    f.editor.setAttribute(copy, 'URLReference', 'named.png');
+    f.editor.setPositionalAttribute(copy, 5, 'positional.png');
+    f.editor.setAttribute(12, 'URLReference', 'source-named.png');
+    f.editor.setPositionalAttribute(12, 5, 'source-positional.png');
+    expect(f.plan().retainedImageUris).toEqual(new Set(['positional.png', 'source-positional.png']));
+    expect((await exportedEntity(f, copy)).attributes[5]).toBe('positional.png');
+    expect((await exportedEntity(f, 12)).attributes[5]).toBe('source-positional.png');
+  });
+  it('resolves URI ownership with no deletion candidates and ignores references inside strings', async () => {
+    const f = await fixture();
+    f.editor.setPositionalAttribute(12, 5, `original-#${f.style}.png`);
+    const before = new StepExporter(f.store, f.view).export({ schema: 'IFC4', applyMutations: true }).content;
+    const cleanup = planAuthoredResourceCleanup(f.store, f.view, new Set());
+    expect(cleanup.entityIds.size).toBe(0);
+    expect(cleanup.retainedImageUris).toEqual(new Set([`original-#${f.style}.png`, 'authored.png']));
+    expect(f.collect()).toEqual(new Set([f.image, f.texture, f.style]));
+    const after = new StepExporter(f.store, f.view).export({ schema: 'IFC4', applyMutations: true }).content;
+    expect(after).toEqual(before); // Planning never mutates the effective export.
+    f.editor.removeEntity(f.image);
+    expect(planAuthoredResourceCleanup(f.store, f.view, new Set()).retainedImageUris)
+      .toEqual(new Set([`original-#${f.style}.png`]));
+  });
+  it('collects unreachable candidate cycles without dropping externally referenced cycles', async () => {
+    const f = await fixture();
+    f.editor.setPositionalAttribute(f.texture, 0, [`#${f.style}`, `#${f.image}`]);
+    expect(f.collect().size).toBe(3);
+    const unrelated = f.editor.addEntity('IfcSurfaceStyle', [null, '.BOTH.', [`#${f.style}`]]);
+    expect(f.collect().size).toBe(0);
+    f.editor.removeEntity(unrelated.expressId);
+    expect(f.collect().size).toBe(3);
+  });
+});

--- a/packages/export/src/authored-resource-cleanup.ts
+++ b/packages/export/src/authored-resource-cleanup.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { asSourceBytes, type IfcDataStore } from '@ifc-lite/parser';
+import type { IfcAttributeValue, MutablePropertyView } from '@ifc-lite/mutations';
+import { authoredEntityRefs, getEffectiveEntityIndex } from './effective-index.js';
+import { collectRefsInByteRange } from './reference-collector.js';
+import { effectiveAppearanceRecord, effectiveImageUri } from './effective-appearance-record.js';
+
+const RESOURCE_TYPES = new Set(['IFCIMAGETEXTURE', 'IFCTEXTUREVERTEXLIST', 'IFCSURFACESTYLE',
+  'IFCSURFACESTYLEWITHTEXTURES', 'IFCSURFACESTYLESHADING', 'IFCSURFACESTYLERENDERING', 'IFCCOLOURRGB']);
+
+/**
+ * Pure, conservative cleanup plan for explicitly owned appearance resources.
+ * Never returns source-backed entities or entities outside the candidate set.
+ * History supplies creation IDs and saved attribute values as protected values.
+ * Effective slots use the same named/positional precedence as STEP export.
+ * A budget refusal throws before returning any partial deletion plan.
+ */
+export function planAuthoredResourceCleanup(
+  dataStore: IfcDataStore, view: MutablePropertyView,
+  candidateIds: ReadonlySet<number>, protectedValues: Iterable<IfcAttributeValue> = [],
+): { entityIds: Set<number>; retainedImageUris: Set<string> } {
+  if (candidateIds.size > 250_000) throw new Error('Authored appearance cleanup exceeds its entity budget; resources were retained.');
+  const index = getEffectiveEntityIndex(dataStore, view, true);
+  const candidates = new Set([...candidateIds].filter(id => index.isOverlayCreated(id)
+    && !index.isDeleted(id) && RESOURCE_TYPES.has(index.typeOf(id) ?? '')));
+  const live = new Set<number>();
+  const outgoing = new Map<number, number[]>();
+  let work = 0;
+  const account = () => { if (++work > 2_000_000) throw new Error('Authored appearance cleanup exceeds its reference budget; resources were retained.'); };
+  let valueWork = 0, stringUnits = 0;
+  const inspect = (value: IfcAttributeValue | undefined) => {
+    const frames: Array<{ values: ReadonlyArray<IfcAttributeValue | undefined>; cursor: number }> = [{ values: [value], cursor: 0 }];
+    while (frames.length) {
+      const frame = frames[frames.length - 1];
+      if (frame.cursor === frame.values.length) { frames.pop(); continue; }
+      const next = frame.values[frame.cursor++];
+      if (++valueWork > 8_000_000 || frames.length > 64) throw new Error('Authored appearance cleanup exceeds its attribute budget; resources were retained.');
+      if (Array.isArray(next)) {
+        if (next.length > 8_000_000 - valueWork) throw new Error('Authored appearance cleanup exceeds its attribute budget; resources were retained.');
+        frames.push({ values: next, cursor: 0 });
+      } else if (next && typeof next === 'object' && 'typed' in next) {
+        frames.push({ values: [next.typed.type, next.typed.value], cursor: 0 });
+      } else if (typeof next === 'string') {
+        stringUnits += next.length;
+        if (stringUnits > 128 * 1024 * 1024) throw new Error('Authored appearance cleanup exceeds its attribute budget; resources were retained.');
+      }
+    }
+  };
+  const retain = (id: number) => { account(); if (candidates.has(id)) live.add(id); };
+  if (candidates.size) for (const value of protectedValues) {
+    inspect(value);
+    for (const id of authoredEntityRefs(value)) retain(id);
+    if (live.size === candidates.size) break;
+  }
+  const source = asSourceBytes(dataStore.source);
+  const imageUris = new Map<number, string>();
+  const needsGraph = live.size !== candidates.size;
+  const imageRecords = function* () {
+    for (const id of index.byType.get('IFCIMAGETEXTURE') ?? []) {
+      const record = index.get(id); if (record) yield [id, record] as const;
+    }
+  };
+  let sourceBytes = 0, sourceHashes = 0, emittedBytes = 0, emittedHashes = 0;
+  for (const [entityId, record] of needsGraph ? index : imageRecords()) {
+    account();
+    inspect(view.getNewEntity(entityId)?.attributes);
+    for (const value of view.getPositionalMutationsForEntity(entityId)?.values() ?? []) inspect(value);
+    for (const attribute of view.getAttributeMutationsForEntity(entityId)) inspect(attribute.value);
+    const isImage = index.typeOf(entityId) === 'IFCIMAGETEXTURE';
+    let bytes: Uint8Array;
+    if (index.isOverlayCreated(entityId)) {
+      const line = effectiveAppearanceRecord(dataStore, view, index, entityId);
+      bytes = new TextEncoder().encode(line);
+      if (isImage) { const uri = effectiveImageUri(line); if (uri !== undefined) imageUris.set(entityId, uri); }
+    } else {
+      sourceBytes += record.byteLength;
+      if (sourceBytes > 128 * 1024 * 1024) throw new Error('Authored appearance cleanup exceeds its source byte budget; resources were retained.');
+      bytes = source.slice(record.byteOffset, record.byteOffset + record.byteLength);
+      if (bytes.length !== record.byteLength) throw new Error('Incomplete IFC source during appearance cleanup; resources were retained.');
+      // Even an originally dangling source reference may name a later allocated ID.
+      // Account before the canonical writer/scanner allocates output arrays.
+      for (const byte of bytes) if (byte === 35 && ++sourceHashes > 2_000_000) {
+        throw new Error('Authored appearance cleanup exceeds its reference budget; resources were retained.');
+      }
+      if (isImage || index.hasSourceMutation?.(entityId) || view.getEntityTypeMutation(entityId)) {
+        const line = effectiveAppearanceRecord(dataStore, view, index, entityId);
+        bytes = new TextEncoder().encode(line);
+        if (isImage) { const uri = effectiveImageUri(line); if (uri !== undefined) imageUris.set(entityId, uri); }
+      }
+    }
+    emittedBytes += bytes.length;
+    if (emittedBytes > 128 * 1024 * 1024) throw new Error('Authored appearance cleanup exceeds its emitted byte budget; resources were retained.');
+    if (needsGraph) for (const byte of bytes) if (byte === 35 && ++emittedHashes > 2_000_000) {
+      throw new Error('Authored appearance cleanup exceeds its reference budget; resources were retained.');
+    }
+    const groups = needsGraph ? collectRefsInByteRange(bytes, 0, bytes.length) : [];
+    const refs: number[] = [];
+    for (const group of groups) {
+      for (const id of typeof group === 'number' ? [group] : group) {
+        account(); if (candidates.has(id)) refs.push(id);
+      }
+    }
+    if (candidates.has(entityId)) outgoing.set(entityId, refs);
+    else for (const id of refs) retain(id);
+    // Binding entities are intentionally never deletion candidates: their live
+    // inverse link to geometry roots the style/map resources they still name.
+    // Keeping an unbound binding is conservative and cannot break other edits.
+  }
+  const pending = [...live];
+  for (let cursor = 0; cursor < pending.length; cursor++) {
+    for (const id of outgoing.get(pending[cursor]) ?? []) {
+      account(); if (!live.has(id)) { live.add(id); pending.push(id); }
+    }
+  }
+  const entityIds = new Set([...candidates].filter(id => !live.has(id)));
+  return { entityIds, retainedImageUris: new Set([...imageUris].filter(([id]) => !entityIds.has(id)).map(([, uri]) => uri)) };
+}

--- a/packages/export/src/effective-appearance-record.ts
+++ b/packages/export/src/effective-appearance-record.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { asSourceBytes, parseStepValue, type IfcDataStore } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { EffectiveEntityIndex } from './effective-index.js';
+import { serializeEntityArgs } from './attribute-real-slots.js';
+import { applyOverlayEntityOverrides } from './step-overlay-attribute-overrides.js';
+import { applySourceLineMutations } from './step-attribute-mutations.js';
+import { splitTopLevelArgs } from './step-argument-parser.js';
+import { retypeArgTokens } from './retype.js';
+import type { IfcSchemaVersion } from './schema-converter.js';
+
+/** Compose the existing STEP writers; never invent a second override policy. */
+export function effectiveAppearanceRecord(
+  store: IfcDataStore, view: MutablePropertyView, index: EffectiveEntityIndex, id: number,
+): string {
+  const record = index.get(id);
+  if (!record) throw new Error('Missing IFC entity during appearance cleanup; resources were retained.');
+  const schema = (store.schemaVersion as IfcSchemaVersion) || 'IFC4';
+  const named = new Map(view.getAttributeMutationsForEntity(id).map(({ name, value }) => [name, value]));
+  const created = view.getNewEntity(id);
+  if (created) {
+    const retype = view.getEntityTypeMutation(id);
+    const type = retype?.newType ?? created.type;
+    let args = serializeEntityArgs(created.type, created.attributes, schema);
+    if (retype) args = retypeArgTokens(splitTopLevelArgs(args), created.type, type, retype.predefinedType, schema).tokens.join(',');
+    args = applyOverlayEntityOverrides(args, type, named, view.getPositionalMutationsForEntity(id), schema);
+    return `#${id}=${type.toUpperCase()}(${args});`;
+  }
+  const source = asSourceBytes(store.source);
+  const original = source.decodeUtf8(record.byteOffset, record.byteOffset + record.byteLength);
+  const result = applySourceLineMutations(view, id, original, record.type, named, schema, true);
+  if (result.unreadable) throw new Error('Unreadable edited IFC entity during appearance cleanup; resources were retained.');
+  return result.text;
+}
+
+/** URLReference occupies slot 5 after the inherited IfcSurfaceTexture fields. */
+export function effectiveImageUri(line: string): string | undefined {
+  const start = line.indexOf('('), end = line.lastIndexOf(')');
+  if (start < 0 || end < start) throw new Error('Unreadable IFC image during appearance cleanup; resources were retained.');
+  const argument = splitTopLevelArgs(line.slice(start + 1, end))[5];
+  if (argument === undefined) return undefined;
+  const value = parseStepValue(argument);
+  return typeof value === 'string' ? value : undefined;
+}

--- a/packages/export/src/index.ts
+++ b/packages/export/src/index.ts
@@ -61,3 +61,5 @@ export { columnsToParquet, isParquet } from './columns-to-parquet.js';
 // are the guard's internals, and the parity suite imports them from the module
 // directly. Callers need the two functions and the options type.
 export { escapeCsvCell, guardSpreadsheetFormula, type CsvCellOptions } from './csv-cell.js';
+
+export { planAuthoredResourceCleanup } from './authored-resource-cleanup.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4187,7 +4187,8 @@
     "isParquet: function",
     "needsConversion: function",
     "parseGLB: function",
-    "parseGLBToMeshData: function"
+    "parseGLBToMeshData: function",
+    "planAuthoredResourceCleanup: function"
   ],
   "@ifc-lite/extensions": [
     "ACTION_INTENTS: const",


### PR DESCRIPTION
Refs #4243.

Superseded authored textures cannot release their image bytes safely while effective IFC entities still reference them. This adds `planAuthoredResourceCleanup`, a pure export-layer plan returning owned entity IDs that can be removed and image URLs that survive. An independently created `IfcImageTexture` copying an authored URL retains that URL even after the original image entity is collected.

The plan uses the existing STEP serializers, retype helpers and named/positional override writers. It preserves imported/source entities, inverse style/map bindings and history-protected references. Iterative graph traversal and explicit attribute/reference/byte budgets reject excessive work without returning a partial deletion plan. It does not change normal export or load behavior.

Eight behavioral tests use the real parser, editor and STEP exporter: source overrides (including nested and dangling references), history roots, inverse bindings, candidate cycles, hostile cyclic/deep values, copied URLs, actual emitted override precedence, and URI-only queries with quoted `#` characters.

Validation on this isolated branch:
- Root `pnpm test --filter=@ifc-lite/export`: 1,226 passed, 36 fixture skips.
- Root `pnpm typecheck`: 90/90 tasks passed, including test sources.
- `pnpm docs:check-samples`: 380 snippets compiled.
- API snapshot regenerated with exactly one new export; touched oxlint, module-size and diff checks pass.

This export-only foundation targets main and needs neither #4267 nor #4263. The concrete viewer consumer remains in the following appearance UI slice: its command/history lifecycle uses this plan, #4267 atomic mutation preparation and #4263 model asset/export ownership. That later integration performs atomic deletion before releasing image leases and publishes the resulting model revision. This draft adds the API, not automatic viewer cleanup. Export minor changeset created with `pnpm changeset`; guide updated in the same change.
