### PR TITLE
fix(parser): remove RELATIONSHIP_TYPES, an unconsumed set with a stale MUST-include comment

### DIFF
--- a/.changeset/relationship-types-remove-unused-export.md
+++ b/.changeset/relationship-types-remove-unused-export.md
@@ -5,7 +5,12 @@
 Remove the unused `RELATIONSHIP_TYPES` export. It carried a comment
 asserting it "MUST include ALL RelationshipType enum values to prevent
 semantic loss," but nothing in the codebase read the set — parsing is
-actually gated by `HIERARCHY_REL_TYPES`, `PROPERTY_REL_TYPES`, and
-`REL_TYPE_MAP`. Consumers relying on `HIERARCHY_REL_TYPES` /
-`PROPERTY_REL_TYPES` / `REL_TYPE_MAP` are unaffected; anyone importing
-`RELATIONSHIP_TYPES` directly should switch to one of those.
+actually gated by the internal `HIERARCHY_REL_TYPES` and
+`PROPERTY_REL_TYPES` sets and by `REL_TYPE_MAP`.
+
+Anyone importing `RELATIONSHIP_TYPES` directly should switch to
+`REL_TYPE_MAP`, which this package still exports and which covers all 15
+`RelationshipType` values. `HIERARCHY_REL_TYPES` and `PROPERTY_REL_TYPES`
+are named above only to describe what really gates parsing — they are
+internal to `columnar-parser-indexes.ts` and have never been part of this
+package's public surface, so they are not available as a migration target.

--- a/.changeset/relationship-types-remove-unused-export.md
+++ b/.changeset/relationship-types-remove-unused-export.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/parser': major
+---
+
+Remove the unused `RELATIONSHIP_TYPES` export. It carried a comment
+asserting it "MUST include ALL RelationshipType enum values to prevent
+semantic loss," but nothing in the codebase read the set — parsing is
+actually gated by `HIERARCHY_REL_TYPES`, `PROPERTY_REL_TYPES`, and
+`REL_TYPE_MAP`. Consumers relying on `HIERARCHY_REL_TYPES` /
+`PROPERTY_REL_TYPES` / `REL_TYPE_MAP` are unaffected; anyone importing
+`RELATIONSHIP_TYPES` directly should switch to one of those.

--- a/packages/parser/src/columnar-parser-indexes.ts
+++ b/packages/parser/src/columnar-parser-indexes.ts
@@ -56,26 +56,6 @@ export const GEOMETRY_TYPES = new Set([
     'IFCSITE', 'IFCBUILDING', 'IFCBUILDINGSTOREY', 'IFCCOVERING',
 ]);
 
-// IMPORTANT: This set MUST include ALL RelationshipType enum values to prevent semantic loss
-// Missing types will be skipped during parsing, causing incomplete relationship graphs
-export const RELATIONSHIP_TYPES = new Set([
-    'IFCRELCONTAINEDINSPATIALSTRUCTURE', 'IFCRELAGGREGATES',
-    'IFCRELDEFINESBYPROPERTIES', 'IFCRELDEFINESBYTYPE',
-    'IFCRELASSOCIATESMATERIAL', 'IFCRELASSOCIATESCLASSIFICATION',
-    'IFCRELASSOCIATESDOCUMENT',
-    'IFCRELVOIDSELEMENT', 'IFCRELFILLSELEMENT',
-    'IFCRELCONNECTSPATHELEMENTS', 'IFCRELCONNECTSELEMENTS',
-    'IFCRELCONNECTSPORTTOELEMENT', 'IFCRELCONNECTSPORTS',
-    'IFCRELSPACEBOUNDARY',
-    // IfcRelAssignsToGroupByFactor is a subtype of IfcRelAssignsToGroup
-    // (adds a proportional Factor attribute, e.g. zone occupancy share) and
-    // is written to STEP with its own distinct entity keyword — it does not
-    // match the 'IFCRELASSIGNSTOGROUP' string, so it needs its own entry or
-    // every membership assigned through it is silently invisible.
-    'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOGROUPBYFACTOR', 'IFCRELASSIGNSTOPRODUCT',
-    'IFCRELREFERENCEDINSPATIALSTRUCTURE',
-]);
-
 // Map IFC relationship type strings to RelationshipType enum
 // MUST cover ALL RelationshipType enum values (15 types total)
 export const REL_TYPE_MAP: Record<string, RelationshipType> = {

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -51,7 +51,7 @@ export type { IfcSourceBytes, IfcSourceTransfer } from './source-bytes.js';
 export { CompactEntityIndex, CompactEntityIndexBuilder, buildCompactEntityIndex } from './compact-entity-index.js';
 export { scanIfcEntities } from './entity-scanner.js';
 export type { EntityScanPath, EntityScanResult, PreScannedEntityIndex, WasmScanApi } from './entity-scanner.js';
-export { REL_TYPE_MAP, RELATIONSHIP_TYPES, isIfcTypeLikeEntity } from './columnar-parser-indexes.js';
+export { REL_TYPE_MAP, isIfcTypeLikeEntity } from './columnar-parser-indexes.js';
 export { IFC_SUBTYPES, expandTypes, QUERY_REL_TYPE_MAP } from './query-backend-maps.js';
 export { PropertyExtractor } from './property-extractor.js';
 export { QuantityExtractor } from './quantity-extractor.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -6249,7 +6249,6 @@
     "PropertyValue: interface",
     "QUERY_REL_TYPE_MAP: const",
     "QuantityExtractor: class",
-    "RELATIONSHIP_TYPES: const",
     "REL_TYPE_MAP: const",
     "Relationship: interface",
     "RelationshipExtractor: class",


### PR DESCRIPTION
## Summary
- `RELATIONSHIP_TYPES` (`packages/parser/src/columnar-parser-indexes.ts`) carried the comment "IMPORTANT: This set MUST include ALL RelationshipType enum values to prevent semantic loss" — an invariant nothing enforces. Re-grepped `packages/` and `apps/` (excluding `node_modules`/`dist`): the only hits are its own definition and its re-export from `packages/parser/src/index.ts`. The live gating sets are `HIERARCHY_REL_TYPES`, `PROPERTY_REL_TYPES`, and `REL_TYPE_MAP` — none of which reference `RELATIONSHIP_TYPES`.
- Per AGENTS.md ("Only re-export from a package's `index.ts` what has a real consumer: an unused public export is permanent semver liability") and the issue's maintainer comment, removed the export entirely rather than rewording the comment on dead code.
- Checked `REL_TYPE_MAP` (same file, exported on the same line) for the identical failure mode: its "MUST cover ALL RelationshipType enum values (15 types total)" comment is accurate — the map is consumed by `columnar-parser.ts` and `apps/viewer/src/utils/serverDataModel.ts`, and does cover all 15 `RelationshipType` enum values (plus `IFCRELNESTS` aliased onto `Aggregates`). Left unchanged.
- Updated `scripts/api-surface.json` (single-line removal, no reformatting) and added a changeset (`@ifc-lite/parser: major` — the package is at `5.2.0`, so per AGENTS.md's bump rule a removed export is `major`, not `minor`).

## Test plan
- [x] `packages/parser` full suite before (upstream/main, via a throwaway worktree) and after (this branch): both `111 test files passed (111)` / `1212 tests passed | 3 skipped (1215)` — identical counts, confirming nothing else consumed the removed export.
- [x] `node scripts/check-changesets.mjs` — passes (22 pending, all naming workspace packages).
- [x] `node scripts/check-module-size.mjs` — exits 0 (2459 files measured, 0 new over 400; no budget/allowlist edits).
- [x] `packages/parser` compiled cleanly with `tsc`; confirmed `RELATIONSHIP_TYPES` is gone from the built `.d.ts` and `scripts/api-surface.json`'s snapshot now matches.
- Not run: the repo-wide `pnpm check:api-surface` (it walks all 43 packages' built `dist/`, most of which are not built in this environment without a full `pnpm install`/`pnpm build` — out of reach here per the environment's disk constraints). Verified the equivalent narrowly instead (see above).

Closes #4225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the unused `RELATIONSHIP_TYPES` export from the parser package.
  * Use the remaining relationship-type structures, including `REL_TYPE_MAP`, instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->