### PR TITLE
fix(wasm): extract shared @ifc-lite/wasm-lifecycle to dedupe wasm-init-retry/wasm-panic-forward

### DIFF
--- a/.changeset/wasm-helper-dedup.md
+++ b/.changeset/wasm-helper-dedup.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/wasm-lifecycle": minor
+"@ifc-lite/geometry": patch
+"@ifc-lite/parser": patch
+---
+
+New `@ifc-lite/wasm-lifecycle` package: extracts the WASM engine load-retry classification (`initWasmWithRetry`, `isTransientWasmLoadError`) and the cross-realm panic-location forwarder (`takeWasmPanicStash`, `restashWasmPanicLocation`) that `@ifc-lite/geometry` and `@ifc-lite/parser` each carried as an independently-editable "twin" copy, with nothing enforcing the two stayed in sync (#4247).
+
+`@ifc-lite/wasm` — the one package both consumers already depend on — was deliberately not used as the shared home: it ships only the wasm-pack build output with no TypeScript build step, so a hand-written module there would gate every geometry/parser test run on a full Rust→wasm rebuild. `@ifc-lite/wasm-lifecycle` is a plain TypeScript package (its own `tsc` build, same shape as `@ifc-lite/regex-guard`) with no wasm dependency of its own, so it avoids that cost.
+
+`@ifc-lite/geometry` and `@ifc-lite/parser` now each re-export the shared module from their own `wasm-init-retry.ts` / `wasm-panic-forward.ts`, so existing imports are unchanged. No behavior change in either package.

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@ifc-lite/data": "workspace:^",
-    "@ifc-lite/wasm": "workspace:^"
+    "@ifc-lite/wasm": "workspace:^",
+    "@ifc-lite/wasm-lifecycle": "workspace:^"
   },
   "optionalDependencies": {
     "@tauri-apps/api": "^2.11.1"

--- a/packages/geometry/src/wasm-init-retry.ts
+++ b/packages/geometry/src/wasm-init-retry.ts
@@ -3,122 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Resilient one-shot retry around wasm-bindgen's `init()`.
+ * Re-export of the shared WASM load-retry classification (issue #4247).
  *
- * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
- * fetch of `ifc-lite_bg.wasm` (it only falls back to `arrayBuffer`+`instantiate`
- * for the wrong-MIME case), surfacing as `TypeError: Failed to execute
- * 'compile' on 'WebAssembly': HTTP status code is not ok`. A transient blip — a
- * cold CDN edge, a mid-deploy race, a flaky proxy/antivirus — can produce a
- * one-off failure that a second attempt recovers.
- *
- * Extracted from the worker so it is unit-testable without a real wasm bundle.
+ * The real implementation lives in `@ifc-lite/wasm-lifecycle` so
+ * `@ifc-lite/geometry` and `@ifc-lite/parser` share exactly one copy of the
+ * transient-vs-fatal WASM load-failure logic instead of maintaining two
+ * independently-editable "twin" files.
  */
-
-/**
- * True when `message` looks like a transient transport/download failure of the
- * engine binary (worth one retry) rather than a genuine corrupt-module or
- * validation error (which must propagate immediately so real bugs aren't
- * masked).
- *
- * Per the WebAssembly Web API, the streaming loader validates the HTTP response
- * (status, MIME, CORS) and rejects with a `TypeError` BEFORE compiling, so only
- * those transport failures are retry-worthy. Invalid bytes (corrupt module,
- * wrong magic header) reject with a `CompileError` — retrying just refetches
- * the same bad bytes, so those fail fast.
- */
-export function isTransientWasmLoadError(message: string): boolean {
-  // Fail fast on genuine module-validation errors even if a transport-ish word
-  // somehow appears in the message.
-  if (/compileerror|validation error|magic (?:word|number)|invalid (?:wasm|module)/i.test(message)) {
-    return false;
-  }
-  return /HTTP status code is not ok|failed to fetch|network ?error|load failed/i.test(message);
-}
-
-/**
- * A message that already names the thing that failed to load, so re-throwing it
- * with an attribution prefix would only add noise. Deliberately includes
- * `WebAssembly` (the `'compile' on 'WebAssembly'` phrasings) — those are exactly
- * the signatures `isWasmAssetUnavailableError` (wasm-asset-error.ts) matches to
- * drive the #1363 stale-deploy reload, and they must reach it byte-for-byte.
- */
-const SELF_IDENTIFYING = /wasm|webassembly/i;
-
-/**
- * A failed *module* load already carries its own specifier. Prefixing one with
- * `ifc-lite_bg.wasm` would make it look to that same #1363 matcher like a
- * rotated ENGINE BINARY (`/\.wasm/` + "dynamically imported module") and
- * trigger a spurious page reload, so those are passed through untouched.
- */
-const MODULE_LOAD_FAILURE = /dynamically imported module|module script/i;
-
-/**
- * Name the engine binary in a transport failure that names nothing (issue #1903).
- *
- * wasm-bindgen's generated loader `await`s the `fetch()` it starts, so a
- * network-level rejection propagates RAW: WebKit words it `TypeError: Load
- * failed`, Chromium `TypeError: Failed to fetch`, and because the rejection
- * originates inside the fetch rather than in our frames it carries an EMPTY
- * stack. Two words and no frames is unattributable by construction — the toast,
- * `classifyLoadError` in the viewer, and error tracking all see a bare
- * `TypeError` that could have come from anywhere in the load.
- *
- * So when the final failure identifies nothing, re-throw it naming the binary
- * and the call site, preserving the original as `.cause`. Anything that already
- * identifies itself is returned unchanged.
- */
-function attributeEngineLoadFailure(error: unknown, label: string): unknown {
-  if (!(error instanceof Error)) return error;
-  const msg = error.message;
-  if (!isTransientWasmLoadError(msg)) return error;
-  if (SELF_IDENTIFYING.test(msg) || MODULE_LOAD_FAILURE.test(msg)) return error;
-  return new Error(
-    `Failed to load the WASM engine binary (ifc-lite_bg.wasm) in ${label}: ${msg}`,
-    { cause: error },
-  );
-}
-
-export interface InitWasmRetryOptions {
-  /** Delay before the single retry. Default 300ms; pass 0 in tests. */
-  retryDelayMs?: number;
-  /** Injected sleep (tests pass an instant resolver). */
-  sleep?: (ms: number) => Promise<void>;
-  /** Injected logger (defaults to `console.warn`). */
-  warn?: (message: string) => void;
-  /** Context label for the log line. */
-  label?: string;
-}
-
-const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Run `init` once; on a transient-looking failure, wait and retry exactly once.
- * Non-transient failures propagate without a retry. The second failure (if any)
- * propagates to the caller — attributed to the engine binary when the browser's
- * own wording identifies nothing (see {@link attributeEngineLoadFailure}).
- *
- * @param init Thunk that performs the actual `init(...)` call (so callers can
- *   bind their own wasm URL / arguments).
- */
-export async function initWasmWithRetry(
-  init: () => Promise<unknown>,
-  options: InitWasmRetryOptions = {},
-): Promise<void> {
-  const { retryDelayMs = 300, sleep = defaultSleep, warn = console.warn, label = 'wasm' } = options;
-  try {
-    await init();
-    return;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!isTransientWasmLoadError(msg)) throw err;
-    warn(`[${label}] WASM engine load failed (${msg}); retrying once`);
-    await sleep(retryDelayMs);
-    try {
-      await init();
-    } catch (retryErr) {
-      throw attributeEngineLoadFailure(retryErr, label);
-    }
-  }
-}
+export {
+  initWasmWithRetry,
+  isTransientWasmLoadError,
+  type InitWasmRetryOptions,
+} from '@ifc-lite/wasm-lifecycle';

--- a/packages/geometry/src/wasm-panic-forward.ts
+++ b/packages/geometry/src/wasm-panic-forward.ts
@@ -3,116 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Forward a worker realm's wasm panic-location stash to the main thread
- * (#2527 follow-up).
+ * Re-export of the shared worker-to-main-thread wasm panic-location forwarder
+ * (issue #4247).
  *
- * The Rust panic hook (`rust/wasm-bindings/src/utils.rs`) stashes
- * `{ location, at }` on whichever realm's JS global it runs in — `self` in a
- * worker, `window` on the main thread. #2527 taught the main thread to read
- * its OWN global's stash and attach it to a trap's exception event
- * (`apps/viewer/src/lib/analytics-scrub.ts`'s `attachWasmPanicLocation`), but
- * a worker-realm trap leaves that stash stranded in the worker's global,
- * which the main thread can never see across the realm boundary.
- *
- * `takeWasmPanicStash` reads + consumes the stash worker-side so it can ride
- * the worker's own `{type:'error'}` message; `restashWasmPanicLocation`
- * re-plants it on the main thread's global so the EXISTING #2527 gate (same
- * key, same TTL, same consume-once semantics) picks it up unmodified.
- *
- * Location only, never the panic's message — the message can embed
- * model-derived text (see `utils.rs`'s privacy contract); the location alone
- * travels on the error message and through this module.
- *
- * NOTE: this file is intentionally byte-identical to
- * `packages/parser/src/wasm-panic-forward.ts` — both `@ifc-lite/geometry`
- * and `@ifc-lite/parser` need the exact same realm-forwarding contract, and
- * neither package depends on the other (nor is `@ifc-lite/wasm`, the one
- * package both DO depend on, a safe home: it ships only the wasm-pack build
- * output, with no TypeScript build step of its own, and `test`/`typecheck`
- * for either consumer already runs its build via turbo's `^build` — adding a
- * hand-written TS module there would make every geometry/parser test run
- * gate on a full Rust→wasm rebuild). Keep any change to one copy in lockstep
- * with the other; `wasm-panic-forward.test.ts` is duplicated the same way.
+ * The real implementation lives in `@ifc-lite/wasm-lifecycle` so
+ * `@ifc-lite/geometry` and `@ifc-lite/parser` share exactly one copy of the
+ * #2527 realm-forwarding contract instead of maintaining two
+ * independently-editable "twin" files.
  */
-
-/** Kept in lockstep with `PANIC_STASH_KEY` in `rust/wasm-bindings/src/utils.rs`,
- *  `WASM_PANIC_STASH_KEY` in `apps/viewer/src/lib/analytics-scrub.ts`, and this
- *  module's twin at `packages/parser/src/wasm-panic-forward.ts`. */
-export const WASM_PANIC_STASH_KEY = '__ifclite_wasm_panic';
-
-/**
- * Trap-shape text match, kept in lockstep with `WASM_TRAP_TEXT` in
- * `apps/viewer/src/lib/analytics-scrub.ts` and this module's twin at
- * `packages/parser/src/wasm-panic-forward.ts`. Deliberately excludes bare
- * "unreachable" inside network-failure phrasing ("network is unreachable",
- * "host unreachable") — those are not wasm traps.
- */
-const WASM_TRAP_TEXT =
-  /(?<!network is |host |destination |address )\bunreachable\b|\bRuntimeError\b|memory access out of bounds|index out of bounds|indirect call to null|integer (?:overflow|divide by zero)|call stack exhausted/i;
-
-function looksLikeWasmTrap(message: string): boolean {
-  return WASM_TRAP_TEXT.test(message);
-}
-
-export interface WasmPanicStash {
-  location: string;
-  at: number;
-}
-
-/** Validate + narrow an unknown stash value read off a realm global. */
-function readStashShape(value: unknown): WasmPanicStash | undefined {
-  if (typeof value !== 'object' || value === null) return undefined;
-  const { location, at } = value as { location?: unknown; at?: unknown };
-  if (typeof location !== 'string' || location === '') return undefined;
-  // Reject non-finite (`NaN`/`Infinity`) and future timestamps — both pass
-  // the analytics TTL gate's `Date.now() - at <= TTL` check trivially
-  // (`Infinity` makes the delta `-Infinity`; a future `at` makes it
-  // negative), which would let a malformed stash label a later trap.
-  if (typeof at !== 'number' || !Number.isFinite(at) || at > Date.now()) return undefined;
-  return { location, at };
-}
-
-/**
- * Worker-side: read and CONSUME this realm's panic stash so it can be
- * forwarded on the worker's own error message. Consume-once regardless of
- * shape validity — an unconsumed malformed stash must not linger to
- * mislabel a later trap, mirroring the main-thread gate's own rule.
- */
-export function takeWasmPanicStash(realm: object): WasmPanicStash | undefined {
-  const g = realm as Record<string, unknown>;
-  const raw = g[WASM_PANIC_STASH_KEY];
-  delete g[WASM_PANIC_STASH_KEY];
-  return readStashShape(raw);
-}
-
-/**
- * Main-side: re-plant a worker-forwarded stash on this realm's global so the
- * existing #2527 `attachWasmPanicLocation` gate consumes it unmodified.
- *
- * Gated on `errorMessage` looking like a wasm trap: the worker forwards
- * `wasmPanicLocation`/`wasmPanicAt` on ANY `{type:'error'}` message (a stale
- * stash from an earlier suppressed panic can ride out on an ordinary,
- * non-trap worker error), and re-planting unconditionally would let that
- * stale location sit on `globalThis` until an unrelated trap-shaped
- * exception consumed it — mislabeling that trap. Only a message that itself
- * looks like a wasm trap is allowed to re-plant.
- *
- * Never clobbers an existing, unconsumed stash — a genuine main-thread trap
- * that hasn't been captured yet must win over a worker trap that merely
- * arrived first (the older-looking stash, if stale, is simply dropped later
- * by the TTL check at attach time; this function never overwrites either
- * way).
- */
-export function restashWasmPanicLocation(
-  realm: object,
-  location: unknown,
-  at: unknown,
-  errorMessage: string,
-): void {
-  const stash = readStashShape({ location, at });
-  if (!stash) return;
-  if (!looksLikeWasmTrap(errorMessage)) return;
-  const g = realm as Record<string, unknown>;
-  if (g[WASM_PANIC_STASH_KEY] !== undefined) return;
-  g[WASM_PANIC_STASH_KEY] = stash;
-}
+export {
+  WASM_PANIC_STASH_KEY,
+  takeWasmPanicStash,
+  restashWasmPanicLocation,
+  type WasmPanicStash,
+} from '@ifc-lite/wasm-lifecycle';

--- a/packages/parser/src/wasm-init-retry.ts
+++ b/packages/parser/src/wasm-init-retry.ts
@@ -3,122 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Resilient one-shot retry around wasm-bindgen's `init()`.
+ * Re-export of the shared WASM load-retry classification (issue #4247).
  *
- * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
- * fetch of `ifc-lite_bg.wasm` (it only falls back to `arrayBuffer`+`instantiate`
- * for the wrong-MIME case), surfacing as `TypeError: Failed to execute
- * 'compile' on 'WebAssembly': HTTP status code is not ok`. A transient blip — a
- * cold CDN edge, a mid-deploy race, a flaky proxy/antivirus — can produce a
- * one-off failure that a second attempt recovers.
- *
- * Extracted from the worker so it is unit-testable without a real wasm bundle.
+ * The real implementation lives in `@ifc-lite/wasm-lifecycle` so
+ * `@ifc-lite/geometry` and `@ifc-lite/parser` share exactly one copy of the
+ * transient-vs-fatal WASM load-failure logic instead of maintaining two
+ * independently-editable "twin" files.
  */
-
-/**
- * True when `message` looks like a transient transport/download failure of the
- * engine binary (worth one retry) rather than a genuine corrupt-module or
- * validation error (which must propagate immediately so real bugs aren't
- * masked).
- *
- * Per the WebAssembly Web API, the streaming loader validates the HTTP response
- * (status, MIME, CORS) and rejects with a `TypeError` BEFORE compiling, so only
- * those transport failures are retry-worthy. Invalid bytes (corrupt module,
- * wrong magic header) reject with a `CompileError` — retrying just refetches
- * the same bad bytes, so those fail fast.
- */
-export function isTransientWasmLoadError(message: string): boolean {
-  // Fail fast on genuine module-validation errors even if a transport-ish word
-  // somehow appears in the message.
-  if (/compileerror|validation error|magic (?:word|number)|invalid (?:wasm|module)/i.test(message)) {
-    return false;
-  }
-  return /HTTP status code is not ok|failed to fetch|network ?error|load failed/i.test(message);
-}
-
-/**
- * A message that already names the thing that failed to load, so re-throwing it
- * with an attribution prefix would only add noise. Deliberately includes
- * `WebAssembly` (the `'compile' on 'WebAssembly'` phrasings) — those are exactly
- * the signatures `isWasmAssetUnavailableError` (wasm-asset-error.ts) matches to
- * drive the #1363 stale-deploy reload, and they must reach it byte-for-byte.
- */
-const SELF_IDENTIFYING = /wasm|webassembly/i;
-
-/**
- * A failed *module* load already carries its own specifier. Prefixing one with
- * `ifc-lite_bg.wasm` would make it look to that same #1363 matcher like a
- * rotated ENGINE BINARY (`/\.wasm/` + "dynamically imported module") and
- * trigger a spurious page reload, so those are passed through untouched.
- */
-const MODULE_LOAD_FAILURE = /dynamically imported module|module script/i;
-
-/**
- * Name the engine binary in a transport failure that names nothing (issue #1903).
- *
- * wasm-bindgen's generated loader `await`s the `fetch()` it starts, so a
- * network-level rejection propagates RAW: WebKit words it `TypeError: Load
- * failed`, Chromium `TypeError: Failed to fetch`, and because the rejection
- * originates inside the fetch rather than in our frames it carries an EMPTY
- * stack. Two words and no frames is unattributable by construction — the toast,
- * `classifyLoadError` in the viewer, and error tracking all see a bare
- * `TypeError` that could have come from anywhere in the load.
- *
- * So when the final failure identifies nothing, re-throw it naming the binary
- * and the call site, preserving the original as `.cause`. Anything that already
- * identifies itself is returned unchanged.
- */
-function attributeEngineLoadFailure(error: unknown, label: string): unknown {
-  if (!(error instanceof Error)) return error;
-  const msg = error.message;
-  if (!isTransientWasmLoadError(msg)) return error;
-  if (SELF_IDENTIFYING.test(msg) || MODULE_LOAD_FAILURE.test(msg)) return error;
-  return new Error(
-    `Failed to load the WASM engine binary (ifc-lite_bg.wasm) in ${label}: ${msg}`,
-    { cause: error },
-  );
-}
-
-export interface InitWasmRetryOptions {
-  /** Delay before the single retry. Default 300ms; pass 0 in tests. */
-  retryDelayMs?: number;
-  /** Injected sleep (tests pass an instant resolver). */
-  sleep?: (ms: number) => Promise<void>;
-  /** Injected logger (defaults to `console.warn`). */
-  warn?: (message: string) => void;
-  /** Context label for the log line. */
-  label?: string;
-}
-
-const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Run `init` once; on a transient-looking failure, wait and retry exactly once.
- * Non-transient failures propagate without a retry. The second failure (if any)
- * propagates to the caller — attributed to the engine binary when the browser's
- * own wording identifies nothing (see {@link attributeEngineLoadFailure}).
- *
- * @param init Thunk that performs the actual `init(...)` call (so callers can
- *   bind their own wasm URL / arguments).
- */
-export async function initWasmWithRetry(
-  init: () => Promise<unknown>,
-  options: InitWasmRetryOptions = {},
-): Promise<void> {
-  const { retryDelayMs = 300, sleep = defaultSleep, warn = console.warn, label = 'wasm' } = options;
-  try {
-    await init();
-    return;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    if (!isTransientWasmLoadError(msg)) throw err;
-    warn(`[${label}] WASM engine load failed (${msg}); retrying once`);
-    await sleep(retryDelayMs);
-    try {
-      await init();
-    } catch (retryErr) {
-      throw attributeEngineLoadFailure(retryErr, label);
-    }
-  }
-}
+export {
+  initWasmWithRetry,
+  isTransientWasmLoadError,
+  type InitWasmRetryOptions,
+} from '@ifc-lite/wasm-lifecycle';

--- a/packages/parser/src/wasm-panic-forward.ts
+++ b/packages/parser/src/wasm-panic-forward.ts
@@ -3,116 +3,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Forward a worker realm's wasm panic-location stash to the main thread
- * (#2527 follow-up).
+ * Re-export of the shared worker-to-main-thread wasm panic-location forwarder
+ * (issue #4247).
  *
- * The Rust panic hook (`rust/wasm-bindings/src/utils.rs`) stashes
- * `{ location, at }` on whichever realm's JS global it runs in — `self` in a
- * worker, `window` on the main thread. #2527 taught the main thread to read
- * its OWN global's stash and attach it to a trap's exception event
- * (`apps/viewer/src/lib/analytics-scrub.ts`'s `attachWasmPanicLocation`), but
- * a worker-realm trap leaves that stash stranded in the worker's global,
- * which the main thread can never see across the realm boundary.
- *
- * `takeWasmPanicStash` reads + consumes the stash worker-side so it can ride
- * the worker's own `{type:'error'}` message; `restashWasmPanicLocation`
- * re-plants it on the main thread's global so the EXISTING #2527 gate (same
- * key, same TTL, same consume-once semantics) picks it up unmodified.
- *
- * Location only, never the panic's message — the message can embed
- * model-derived text (see `utils.rs`'s privacy contract); the location alone
- * travels on the error message and through this module.
- *
- * NOTE: this file is intentionally byte-identical to
- * `packages/geometry/src/wasm-panic-forward.ts` — both `@ifc-lite/geometry`
- * and `@ifc-lite/parser` need the exact same realm-forwarding contract, and
- * neither package depends on the other (nor is `@ifc-lite/wasm`, the one
- * package both DO depend on, a safe home: it ships only the wasm-pack build
- * output, with no TypeScript build step of its own, and `test`/`typecheck`
- * for either consumer already runs its build via turbo's `^build` — adding a
- * hand-written TS module there would make every geometry/parser test run
- * gate on a full Rust→wasm rebuild). Keep any change to one copy in lockstep
- * with the other; `wasm-panic-forward.test.ts` is duplicated the same way.
+ * The real implementation lives in `@ifc-lite/wasm-lifecycle` so
+ * `@ifc-lite/geometry` and `@ifc-lite/parser` share exactly one copy of the
+ * #2527 realm-forwarding contract instead of maintaining two
+ * independently-editable "twin" files.
  */
-
-/** Kept in lockstep with `PANIC_STASH_KEY` in `rust/wasm-bindings/src/utils.rs`,
- *  `WASM_PANIC_STASH_KEY` in `apps/viewer/src/lib/analytics-scrub.ts`, and this
- *  module's twin at `packages/geometry/src/wasm-panic-forward.ts`. */
-export const WASM_PANIC_STASH_KEY = '__ifclite_wasm_panic';
-
-/**
- * Trap-shape text match, kept in lockstep with `WASM_TRAP_TEXT` in
- * `apps/viewer/src/lib/analytics-scrub.ts` and this module's twin at
- * `packages/geometry/src/wasm-panic-forward.ts`. Deliberately excludes bare
- * "unreachable" inside network-failure phrasing ("network is unreachable",
- * "host unreachable") — those are not wasm traps.
- */
-const WASM_TRAP_TEXT =
-  /(?<!network is |host |destination |address )\bunreachable\b|\bRuntimeError\b|memory access out of bounds|index out of bounds|indirect call to null|integer (?:overflow|divide by zero)|call stack exhausted/i;
-
-function looksLikeWasmTrap(message: string): boolean {
-  return WASM_TRAP_TEXT.test(message);
-}
-
-export interface WasmPanicStash {
-  location: string;
-  at: number;
-}
-
-/** Validate + narrow an unknown stash value read off a realm global. */
-function readStashShape(value: unknown): WasmPanicStash | undefined {
-  if (typeof value !== 'object' || value === null) return undefined;
-  const { location, at } = value as { location?: unknown; at?: unknown };
-  if (typeof location !== 'string' || location === '') return undefined;
-  // Reject non-finite (`NaN`/`Infinity`) and future timestamps — both pass
-  // the analytics TTL gate's `Date.now() - at <= TTL` check trivially
-  // (`Infinity` makes the delta `-Infinity`; a future `at` makes it
-  // negative), which would let a malformed stash label a later trap.
-  if (typeof at !== 'number' || !Number.isFinite(at) || at > Date.now()) return undefined;
-  return { location, at };
-}
-
-/**
- * Worker-side: read and CONSUME this realm's panic stash so it can be
- * forwarded on the worker's own error message. Consume-once regardless of
- * shape validity — an unconsumed malformed stash must not linger to
- * mislabel a later trap, mirroring the main-thread gate's own rule.
- */
-export function takeWasmPanicStash(realm: object): WasmPanicStash | undefined {
-  const g = realm as Record<string, unknown>;
-  const raw = g[WASM_PANIC_STASH_KEY];
-  delete g[WASM_PANIC_STASH_KEY];
-  return readStashShape(raw);
-}
-
-/**
- * Main-side: re-plant a worker-forwarded stash on this realm's global so the
- * existing #2527 `attachWasmPanicLocation` gate consumes it unmodified.
- *
- * Gated on `errorMessage` looking like a wasm trap: the worker forwards
- * `wasmPanicLocation`/`wasmPanicAt` on ANY `{type:'error'}` message (a stale
- * stash from an earlier suppressed panic can ride out on an ordinary,
- * non-trap worker error), and re-planting unconditionally would let that
- * stale location sit on `globalThis` until an unrelated trap-shaped
- * exception consumed it — mislabeling that trap. Only a message that itself
- * looks like a wasm trap is allowed to re-plant.
- *
- * Never clobbers an existing, unconsumed stash — a genuine main-thread trap
- * that hasn't been captured yet must win over a worker trap that merely
- * arrived first (the older-looking stash, if stale, is simply dropped later
- * by the TTL check at attach time; this function never overwrites either
- * way).
- */
-export function restashWasmPanicLocation(
-  realm: object,
-  location: unknown,
-  at: unknown,
-  errorMessage: string,
-): void {
-  const stash = readStashShape({ location, at });
-  if (!stash) return;
-  if (!looksLikeWasmTrap(errorMessage)) return;
-  const g = realm as Record<string, unknown>;
-  if (g[WASM_PANIC_STASH_KEY] !== undefined) return;
-  g[WASM_PANIC_STASH_KEY] = stash;
-}
+export {
+  WASM_PANIC_STASH_KEY,
+  takeWasmPanicStash,
+  restashWasmPanicLocation,
+  type WasmPanicStash,
+} from '@ifc-lite/wasm-lifecycle';

--- a/packages/wasm-lifecycle/package.json
+++ b/packages/wasm-lifecycle/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@ifc-lite/parser",
-  "version": "5.2.0",
-  "description": "IFC/STEP parser for IFC-Lite",
+  "name": "@ifc-lite/wasm-lifecycle",
+  "version": "0.1.0",
+  "description": "Shared WASM engine load-retry classification and cross-realm panic-forwarding, used by @ifc-lite/geometry and @ifc-lite/parser",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,10 +10,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    },
-    "./browser": {
-      "types": "./dist/browser.d.ts",
-      "import": "./dist/browser.js"
     }
   },
   "scripts": {
@@ -22,16 +18,8 @@
     "dev": "pnpm exec tsc --watch",
     "test": "vitest run"
   },
-  "dependencies": {
-    "@ifc-lite/data": "workspace:^",
-    "@ifc-lite/encoding": "workspace:^",
-    "@ifc-lite/ifcx": "workspace:^",
-    "@ifc-lite/wasm": "workspace:^",
-    "@ifc-lite/wasm-lifecycle": "workspace:^",
-    "fflate": "^0.8.3",
-    "jszip": "^3.10.0"
-  },
   "devDependencies": {
+    "@types/node": "^26.4.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   },
@@ -40,16 +28,16 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
-    "directory": "packages/parser"
+    "directory": "packages/wasm-lifecycle"
   },
   "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",
     "bim",
-    "parser",
-    "step",
-    "aec"
+    "wasm",
+    "retry",
+    "panic"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/wasm-lifecycle/src/index.ts
+++ b/packages/wasm-lifecycle/src/index.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+export {
+  initWasmWithRetry,
+  isTransientWasmLoadError,
+  type InitWasmRetryOptions,
+} from './wasm-init-retry.js';
+
+export {
+  WASM_PANIC_STASH_KEY,
+  takeWasmPanicStash,
+  restashWasmPanicLocation,
+  type WasmPanicStash,
+} from './wasm-panic-forward.js';

--- a/packages/wasm-lifecycle/src/wasm-init-retry.test.ts
+++ b/packages/wasm-lifecycle/src/wasm-init-retry.test.ts
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect, vi } from 'vitest';
+import { initWasmWithRetry, isTransientWasmLoadError } from './wasm-init-retry.js';
+
+const noop = () => {};
+const instantSleep = () => Promise.resolve();
+
+describe('isTransientWasmLoadError', () => {
+  it('flags the wasm-bindgen non-OK HTTP status (PostHog issue 019ed949)', () => {
+    expect(
+      isTransientWasmLoadError(
+        "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+      ),
+    ).toBe(true);
+  });
+
+  it('flags transport/network failures (cross-browser)', () => {
+    expect(isTransientWasmLoadError('Failed to fetch')).toBe(true); // Chromium
+    expect(isTransientWasmLoadError('NetworkError when attempting to fetch resource')).toBe(true); // Firefox
+    expect(isTransientWasmLoadError('Load failed')).toBe(true); // Safari
+  });
+
+  it('does NOT flag genuine compile/validation errors (bad bytes never recover on retry)', () => {
+    expect(isTransientWasmLoadError('CompileError: invalid value type')).toBe(false);
+    expect(
+      isTransientWasmLoadError(
+        'CompileError: WebAssembly.instantiateStreaming(): expected magic word 00 61 73 6d',
+      ),
+    ).toBe(false);
+    expect(isTransientWasmLoadError('wasm validation error: at offset 0')).toBe(false);
+    expect(isTransientWasmLoadError('unreachable executed')).toBe(false);
+  });
+});
+
+describe('initWasmWithRetry', () => {
+  it('returns after a single successful init (no retry)', async () => {
+    const init = vi.fn().mockResolvedValue(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on a transient error and succeeds', async () => {
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new TypeError("Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok"),
+      )
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop });
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry a non-transient error and rethrows immediately', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('CompileError: invalid value type'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /CompileError/,
+    );
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the second failure after retrying a transient error', async () => {
+    const init = vi.fn().mockRejectedValue(new Error('Failed to fetch'));
+    await expect(initWasmWithRetry(init, { sleep: instantSleep, warn: noop })).rejects.toThrow(
+      /Failed to fetch/,
+    );
+    expect(init).toHaveBeenCalledTimes(2);
+  });
+
+  // Issue #1903: WebKit rejects a failed fetch with `TypeError: Load failed` and
+  // an EMPTY stack, so a bare rethrow reaches error tracking naming nothing.
+  it('names the engine binary when the final failure identifies nothing (#1903)', async () => {
+    const original = new TypeError('Load failed'); // Safari
+    const init = vi.fn().mockRejectedValue(original);
+    await expect(
+      initWasmWithRetry(init, { sleep: instantSleep, warn: noop, label: 'ifc-lite-bridge' }),
+    ).rejects.toThrow(/Failed to load the WASM engine binary \(ifc-lite_bg\.wasm\) in ifc-lite-bridge: Load failed/);
+    expect(init).toHaveBeenCalledTimes(2);
+    // The original is preserved for programmatic inspection, never swallowed.
+    await initWasmWithRetry(init, { sleep: instantSleep, warn: noop }).catch((err) => {
+      expect((err as Error).cause).toBe(original);
+    });
+  });
+
+  it('names the engine binary for the Chromium wording too', async () => {
+    const init = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(
+      initWasmWithRetry(init, { sleep: instantSleep, warn: noop, label: 'geometry.worker' }),
+    ).rejects.toThrow(/ifc-lite_bg\.wasm.*geometry\.worker.*Failed to fetch/);
+  });
+
+  // The #1363 stale-deploy matchers key on the browser's EXACT wasm phrasing;
+  // rewriting a message that already identifies itself would break them.
+  it('leaves a self-identifying wasm message byte-for-byte intact (#1363 skew recovery)', async () => {
+    const mime =
+      "WebAssembly: Response has unsupported MIME type 'text/plain; charset=utf-8' expected 'application/wasm'";
+    const status = "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok";
+    // #1903: assert the RETRY COUNT too. Preserving the message passes either
+    // way, so without these counts a regression that stopped retrying the
+    // transient `status` error would sail through this case unnoticed.
+    // `mime` is not transient (no transport phrase) so it never even retries;
+    // `status` is, and must survive the retry unchanged.
+    for (const [message, expectedCalls] of [
+      [mime, 1],
+      [status, 2],
+    ] as const) {
+      const init = vi.fn().mockRejectedValue(new TypeError(message));
+      const err = await initWasmWithRetry(init, { sleep: instantSleep, warn: noop })
+        .then(() => null, (e: Error) => e);
+      expect(err?.message).toBe(message);
+      expect(init).toHaveBeenCalledTimes(expectedCalls);
+    }
+  });
+
+  // A failed module load already carries its own specifier. Prefixing it with
+  // `ifc-lite_bg.wasm` would make `isWasmAssetUnavailableError` read it as a
+  // rotated ENGINE BINARY and reload the page for an unrelated chunk.
+  it('does not rewrite a failed dynamic module import into a wasm-asset signature', async () => {
+    const message = 'Failed to fetch dynamically imported module: https://example.test/assets/chunk.js';
+    const init = vi.fn().mockRejectedValue(new TypeError(message));
+    const err = await initWasmWithRetry(init, { sleep: instantSleep, warn: noop })
+      .then(() => null, (e: Error) => e);
+    expect(err?.message).toBe(message);
+    expect(err?.message).not.toMatch(/\.wasm/);
+  });
+
+  // The attribution must never re-type a throwable the bridge discriminates on
+  // (`error instanceof WebAssembly.RuntimeError` marks the fatal, unrecoverable
+  // panic state).
+  it('preserves the throwable identity of a non-transient second failure (#1903)', async () => {
+    // Assert the EXACT instance, not just the class: `toBeInstanceOf` would
+    // also accept a freshly constructed RuntimeError, which is precisely the
+    // re-typing this case exists to forbid.
+    const runtimeError = new WebAssembly.RuntimeError('unreachable');
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Load failed'))
+      .mockRejectedValueOnce(runtimeError);
+    await expect(
+      initWasmWithRetry(init, { sleep: instantSleep, warn: noop }),
+    ).rejects.toBe(runtimeError);
+  });
+
+  it('waits the configured delay before retrying', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const init = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Failed to fetch'))
+      .mockResolvedValueOnce(undefined);
+    await initWasmWithRetry(init, { sleep, warn: noop, retryDelayMs: 500 });
+    expect(sleep).toHaveBeenCalledWith(500);
+  });
+});

--- a/packages/wasm-lifecycle/src/wasm-init-retry.ts
+++ b/packages/wasm-lifecycle/src/wasm-init-retry.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Resilient one-shot retry around wasm-bindgen's `init()`.
+ *
+ * wasm-bindgen's streaming loader rethrows on a non-OK HTTP status or a failed
+ * fetch of `ifc-lite_bg.wasm` (it only falls back to `arrayBuffer`+`instantiate`
+ * for the wrong-MIME case), surfacing as `TypeError: Failed to execute
+ * 'compile' on 'WebAssembly': HTTP status code is not ok`. A transient blip — a
+ * cold CDN edge, a mid-deploy race, a flaky proxy/antivirus — can produce a
+ * one-off failure that a second attempt recovers.
+ *
+ * Extracted from the worker so it is unit-testable without a real wasm bundle.
+ */
+
+/**
+ * True when `message` looks like a transient transport/download failure of the
+ * engine binary (worth one retry) rather than a genuine corrupt-module or
+ * validation error (which must propagate immediately so real bugs aren't
+ * masked).
+ *
+ * Per the WebAssembly Web API, the streaming loader validates the HTTP response
+ * (status, MIME, CORS) and rejects with a `TypeError` BEFORE compiling, so only
+ * those transport failures are retry-worthy. Invalid bytes (corrupt module,
+ * wrong magic header) reject with a `CompileError` — retrying just refetches
+ * the same bad bytes, so those fail fast.
+ */
+export function isTransientWasmLoadError(message: string): boolean {
+  // Fail fast on genuine module-validation errors even if a transport-ish word
+  // somehow appears in the message.
+  if (/compileerror|validation error|magic (?:word|number)|invalid (?:wasm|module)/i.test(message)) {
+    return false;
+  }
+  return /HTTP status code is not ok|failed to fetch|network ?error|load failed/i.test(message);
+}
+
+/**
+ * A message that already names the thing that failed to load, so re-throwing it
+ * with an attribution prefix would only add noise. Deliberately includes
+ * `WebAssembly` (the `'compile' on 'WebAssembly'` phrasings) — those are exactly
+ * the signatures `isWasmAssetUnavailableError` (wasm-asset-error.ts) matches to
+ * drive the #1363 stale-deploy reload, and they must reach it byte-for-byte.
+ */
+const SELF_IDENTIFYING = /wasm|webassembly/i;
+
+/**
+ * A failed *module* load already carries its own specifier. Prefixing one with
+ * `ifc-lite_bg.wasm` would make it look to that same #1363 matcher like a
+ * rotated ENGINE BINARY (`/\.wasm/` + "dynamically imported module") and
+ * trigger a spurious page reload, so those are passed through untouched.
+ */
+const MODULE_LOAD_FAILURE = /dynamically imported module|module script/i;
+
+/**
+ * Name the engine binary in a transport failure that names nothing (issue #1903).
+ *
+ * wasm-bindgen's generated loader `await`s the `fetch()` it starts, so a
+ * network-level rejection propagates RAW: WebKit words it `TypeError: Load
+ * failed`, Chromium `TypeError: Failed to fetch`, and because the rejection
+ * originates inside the fetch rather than in our frames it carries an EMPTY
+ * stack. Two words and no frames is unattributable by construction — the toast,
+ * `classifyLoadError` in the viewer, and error tracking all see a bare
+ * `TypeError` that could have come from anywhere in the load.
+ *
+ * So when the final failure identifies nothing, re-throw it naming the binary
+ * and the call site, preserving the original as `.cause`. Anything that already
+ * identifies itself is returned unchanged.
+ */
+function attributeEngineLoadFailure(error: unknown, label: string): unknown {
+  if (!(error instanceof Error)) return error;
+  const msg = error.message;
+  if (!isTransientWasmLoadError(msg)) return error;
+  if (SELF_IDENTIFYING.test(msg) || MODULE_LOAD_FAILURE.test(msg)) return error;
+  return new Error(
+    `Failed to load the WASM engine binary (ifc-lite_bg.wasm) in ${label}: ${msg}`,
+    { cause: error },
+  );
+}
+
+export interface InitWasmRetryOptions {
+  /** Delay before the single retry. Default 300ms; pass 0 in tests. */
+  retryDelayMs?: number;
+  /** Injected sleep (tests pass an instant resolver). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected logger (defaults to `console.warn`). */
+  warn?: (message: string) => void;
+  /** Context label for the log line. */
+  label?: string;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `init` once; on a transient-looking failure, wait and retry exactly once.
+ * Non-transient failures propagate without a retry. The second failure (if any)
+ * propagates to the caller — attributed to the engine binary when the browser's
+ * own wording identifies nothing (see {@link attributeEngineLoadFailure}).
+ *
+ * @param init Thunk that performs the actual `init(...)` call (so callers can
+ *   bind their own wasm URL / arguments).
+ */
+export async function initWasmWithRetry(
+  init: () => Promise<unknown>,
+  options: InitWasmRetryOptions = {},
+): Promise<void> {
+  const { retryDelayMs = 300, sleep = defaultSleep, warn = console.warn, label = 'wasm' } = options;
+  try {
+    await init();
+    return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!isTransientWasmLoadError(msg)) throw err;
+    warn(`[${label}] WASM engine load failed (${msg}); retrying once`);
+    await sleep(retryDelayMs);
+    try {
+      await init();
+    } catch (retryErr) {
+      throw attributeEngineLoadFailure(retryErr, label);
+    }
+  }
+}

--- a/packages/wasm-lifecycle/src/wasm-panic-forward.test.ts
+++ b/packages/wasm-lifecycle/src/wasm-panic-forward.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import { WASM_PANIC_STASH_KEY, restashWasmPanicLocation, takeWasmPanicStash } from './wasm-panic-forward.js';
+
+describe('takeWasmPanicStash', () => {
+  it('reads and consumes a well-formed stash', () => {
+    const realm: Record<string, unknown> = {
+      [WASM_PANIC_STASH_KEY]: { location: 'geometry/src/mesh_weld.rs:412:9', at: 1000 },
+    };
+    const stash = takeWasmPanicStash(realm);
+    expect(stash).toEqual({ location: 'geometry/src/mesh_weld.rs:412:9', at: 1000 });
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+  });
+
+  it('returns undefined when no stash is present', () => {
+    const realm: Record<string, unknown> = {};
+    expect(takeWasmPanicStash(realm)).toBeUndefined();
+  });
+
+  it('consumes a malformed stash too, so it never lingers to mislabel a later trap', () => {
+    const realm: Record<string, unknown> = { [WASM_PANIC_STASH_KEY]: 'not-an-object' };
+    expect(takeWasmPanicStash(realm)).toBeUndefined();
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+  });
+
+  it('rejects a non-string location or non-number at', () => {
+    const realm1: Record<string, unknown> = { [WASM_PANIC_STASH_KEY]: { location: 42, at: 1000 } };
+    expect(takeWasmPanicStash(realm1)).toBeUndefined();
+    const realm2: Record<string, unknown> = { [WASM_PANIC_STASH_KEY]: { location: 'x.rs:1:1', at: '1000' } };
+    expect(takeWasmPanicStash(realm2)).toBeUndefined();
+  });
+
+  it('rejects a non-finite at (NaN/Infinity), which would otherwise pass the TTL gate trivially', () => {
+    const realmNaN: Record<string, unknown> = { [WASM_PANIC_STASH_KEY]: { location: 'x.rs:1:1', at: NaN } };
+    expect(takeWasmPanicStash(realmNaN)).toBeUndefined();
+    const realmInf: Record<string, unknown> = { [WASM_PANIC_STASH_KEY]: { location: 'x.rs:1:1', at: Infinity } };
+    expect(takeWasmPanicStash(realmInf)).toBeUndefined();
+  });
+
+  it('rejects a future at, which would otherwise pass the TTL gate trivially', () => {
+    const realm: Record<string, unknown> = {
+      [WASM_PANIC_STASH_KEY]: { location: 'x.rs:1:1', at: Date.now() + 60_000 },
+    };
+    expect(takeWasmPanicStash(realm)).toBeUndefined();
+  });
+});
+
+describe('restashWasmPanicLocation', () => {
+  it('re-plants a valid location/at pair on the target realm for a trap-shaped error message', () => {
+    const realm: Record<string, unknown> = {};
+    restashWasmPanicLocation(realm, 'geometry/src/mesh_weld.rs:412:9', 1000, 'unreachable');
+    expect(realm[WASM_PANIC_STASH_KEY]).toEqual({ location: 'geometry/src/mesh_weld.rs:412:9', at: 1000 });
+  });
+
+  it('no-ops when location or at is missing/malformed', () => {
+    const realm: Record<string, unknown> = {};
+    restashWasmPanicLocation(realm, undefined, undefined, 'unreachable');
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+    restashWasmPanicLocation(realm, 42, 1000, 'unreachable');
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+    restashWasmPanicLocation(realm, 'x.rs:1:1', 'not-a-number', 'unreachable');
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+  });
+
+  it('never clobbers an existing, unconsumed stash', () => {
+    const realm: Record<string, unknown> = {
+      [WASM_PANIC_STASH_KEY]: { location: 'already/here.rs:1:1', at: 500 },
+    };
+    restashWasmPanicLocation(realm, 'new/one.rs:2:2', 900, 'unreachable');
+    expect(realm[WASM_PANIC_STASH_KEY]).toEqual({ location: 'already/here.rs:1:1', at: 500 });
+  });
+
+  it('does not re-plant when the error message is not trap-shaped, so a stale stash from an ' +
+    'earlier suppressed panic cannot ride out on an ordinary worker error', () => {
+    const realm: Record<string, unknown> = {};
+    restashWasmPanicLocation(
+      realm,
+      'geometry/src/mesh_weld.rs:412:9',
+      1000,
+      'stream-end received before stream-start',
+    );
+    expect(realm[WASM_PANIC_STASH_KEY]).toBeUndefined();
+  });
+});

--- a/packages/wasm-lifecycle/src/wasm-panic-forward.ts
+++ b/packages/wasm-lifecycle/src/wasm-panic-forward.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Forward a worker realm's wasm panic-location stash to the main thread
+ * (#2527 follow-up).
+ *
+ * The Rust panic hook (`rust/wasm-bindings/src/utils.rs`) stashes
+ * `{ location, at }` on whichever realm's JS global it runs in — `self` in a
+ * worker, `window` on the main thread. #2527 taught the main thread to read
+ * its OWN global's stash and attach it to a trap's exception event
+ * (`apps/viewer/src/lib/analytics-scrub.ts`'s `attachWasmPanicLocation`), but
+ * a worker-realm trap leaves that stash stranded in the worker's global,
+ * which the main thread can never see across the realm boundary.
+ *
+ * `takeWasmPanicStash` reads + consumes the stash worker-side so it can ride
+ * the worker's own `{type:'error'}` message; `restashWasmPanicLocation`
+ * re-plants it on the main thread's global so the EXISTING #2527 gate (same
+ * key, same TTL, same consume-once semantics) picks it up unmodified.
+ *
+ * Location only, never the panic's message — the message can embed
+ * model-derived text (see `utils.rs`'s privacy contract); the location alone
+ * travels on the error message and through this module.
+ *
+ * `@ifc-lite/geometry` and `@ifc-lite/parser` both need the exact same
+ * realm-forwarding contract, and neither package depends on the other. This
+ * used to live as two independently-maintained, doc-comment-linked "twin"
+ * copies (one per package) with nothing enforcing they stayed identical
+ * (issue #4247). `@ifc-lite/wasm` — the one package both consumers already
+ * depend on — was never a viable home for it: that package ships only the
+ * wasm-pack build output with no TypeScript build step of its own, and
+ * `test`/`typecheck` for either consumer already runs its build via turbo's
+ * `^build`, so a hand-written TS module there would gate every
+ * geometry/parser test run on a full Rust→wasm rebuild. `@ifc-lite/wasm-lifecycle`
+ * is a plain TypeScript package (its own `tsc` build, like `@ifc-lite/regex-guard`)
+ * with no wasm dependency of its own, so it carries none of that cost — both
+ * `packages/geometry/src/wasm-panic-forward.ts` and
+ * `packages/parser/src/wasm-panic-forward.ts` are now thin re-exports of this
+ * module, so there is exactly one implementation to keep in sync with.
+ */
+
+/** Kept in lockstep with `PANIC_STASH_KEY` in `rust/wasm-bindings/src/utils.rs`
+ *  and `WASM_PANIC_STASH_KEY` in `apps/viewer/src/lib/analytics-scrub.ts`. */
+export const WASM_PANIC_STASH_KEY = '__ifclite_wasm_panic';
+
+/**
+ * Trap-shape text match, kept in lockstep with `WASM_TRAP_TEXT` in
+ * `apps/viewer/src/lib/analytics-scrub.ts`. Deliberately excludes bare
+ * "unreachable" inside network-failure phrasing ("network is unreachable",
+ * "host unreachable") — those are not wasm traps.
+ */
+const WASM_TRAP_TEXT =
+  /(?<!network is |host |destination |address )\bunreachable\b|\bRuntimeError\b|memory access out of bounds|index out of bounds|indirect call to null|integer (?:overflow|divide by zero)|call stack exhausted/i;
+
+function looksLikeWasmTrap(message: string): boolean {
+  return WASM_TRAP_TEXT.test(message);
+}
+
+export interface WasmPanicStash {
+  location: string;
+  at: number;
+}
+
+/** Validate + narrow an unknown stash value read off a realm global. */
+function readStashShape(value: unknown): WasmPanicStash | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const { location, at } = value as { location?: unknown; at?: unknown };
+  if (typeof location !== 'string' || location === '') return undefined;
+  // Reject non-finite (`NaN`/`Infinity`) and future timestamps — both pass
+  // the analytics TTL gate's `Date.now() - at <= TTL` check trivially
+  // (`Infinity` makes the delta `-Infinity`; a future `at` makes it
+  // negative), which would let a malformed stash label a later trap.
+  if (typeof at !== 'number' || !Number.isFinite(at) || at > Date.now()) return undefined;
+  return { location, at };
+}
+
+/**
+ * Worker-side: read and CONSUME this realm's panic stash so it can be
+ * forwarded on the worker's own error message. Consume-once regardless of
+ * shape validity — an unconsumed malformed stash must not linger to
+ * mislabel a later trap, mirroring the main-thread gate's own rule.
+ */
+export function takeWasmPanicStash(realm: object): WasmPanicStash | undefined {
+  const g = realm as Record<string, unknown>;
+  const raw = g[WASM_PANIC_STASH_KEY];
+  delete g[WASM_PANIC_STASH_KEY];
+  return readStashShape(raw);
+}
+
+/**
+ * Main-side: re-plant a worker-forwarded stash on this realm's global so the
+ * existing #2527 `attachWasmPanicLocation` gate consumes it unmodified.
+ *
+ * Gated on `errorMessage` looking like a wasm trap: the worker forwards
+ * `wasmPanicLocation`/`wasmPanicAt` on ANY `{type:'error'}` message (a stale
+ * stash from an earlier suppressed panic can ride out on an ordinary,
+ * non-trap worker error), and re-planting unconditionally would let that
+ * stale location sit on `globalThis` until an unrelated trap-shaped
+ * exception consumed it — mislabeling that trap. Only a message that itself
+ * looks like a wasm trap is allowed to re-plant.
+ *
+ * Never clobbers an existing, unconsumed stash — a genuine main-thread trap
+ * that hasn't been captured yet must win over a worker trap that merely
+ * arrived first (the older-looking stash, if stale, is simply dropped later
+ * by the TTL check at attach time; this function never overwrites either
+ * way).
+ */
+export function restashWasmPanicLocation(
+  realm: object,
+  location: unknown,
+  at: unknown,
+  errorMessage: string,
+): void {
+  const stash = readStashShape({ location, at });
+  if (!stash) return;
+  if (!looksLikeWasmTrap(errorMessage)) return;
+  const g = realm as Record<string, unknown>;
+  if (g[WASM_PANIC_STASH_KEY] !== undefined) return;
+  g[WASM_PANIC_STASH_KEY] = stash;
+}

--- a/packages/wasm-lifecycle/tsconfig.json
+++ b/packages/wasm-lifecycle/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1070,6 +1070,9 @@ importers:
       '@ifc-lite/wasm':
         specifier: workspace:^
         version: link:../wasm
+      '@ifc-lite/wasm-lifecycle':
+        specifier: workspace:^
+        version: link:../wasm-lifecycle
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -1291,6 +1294,9 @@ importers:
       '@ifc-lite/wasm':
         specifier: workspace:^
         version: link:../wasm
+      '@ifc-lite/wasm-lifecycle':
+        specifier: workspace:^
+        version: link:../wasm-lifecycle
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -1604,6 +1610,18 @@ importers:
         version: 6.0.3
 
   packages/wasm: {}
+
+  packages/wasm-lifecycle:
+    devDependencies:
+      '@types/node':
+        specifier: ^26.4.1
+        version: 26.4.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.11(@edge-runtime/vm@3.2.0)(@types/node@26.4.1)(happy-dom@20.14.0)(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
 
   packages/world-frame-fixtures:
     dependencies:

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -7077,5 +7077,14 @@
     "union2d: function",
     "version: function"
   ],
-  "create-ifc-lite": []
+  "create-ifc-lite": [],
+  "@ifc-lite/wasm-lifecycle": [
+    "InitWasmRetryOptions: interface",
+    "WASM_PANIC_STASH_KEY: const",
+    "WasmPanicStash: interface",
+    "initWasmWithRetry: function",
+    "isTransientWasmLoadError: function",
+    "restashWasmPanicLocation: function",
+    "takeWasmPanicStash: function"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,12 @@
       "@ifc-lite/wasm/*": [
         "packages/wasm/pkg/*"
       ],
+      "@ifc-lite/wasm-lifecycle": [
+        "packages/wasm-lifecycle/dist/index.d.ts"
+      ],
+      "@ifc-lite/wasm-lifecycle/*": [
+        "packages/wasm-lifecycle/dist/*"
+      ],
       "@ifc-lite/geometry": [
         "packages/geometry/dist/index.d.ts"
       ],


### PR DESCRIPTION
## Summary

Closes #4247.

`wasm-init-retry.ts` and `wasm-panic-forward.ts` existed as two independently-maintained "twin" copies, one in `@ifc-lite/geometry` and one in `@ifc-lite/parser`, with nothing enforcing they stayed in sync. Verified against `upstream/main` before this change: the two copies were byte-identical except for doc-comment self-references naming the other file as its twin — not yet diverged, so this is preventive, not a live behavioral bug.

- New `@ifc-lite/wasm-lifecycle` package holds the one real implementation of `initWasmWithRetry`/`isTransientWasmLoadError` and `takeWasmPanicStash`/`restashWasmPanicLocation`/`WASM_PANIC_STASH_KEY`.
- `@ifc-lite/wasm` — the one package both `geometry` and `parser` already depend on — was deliberately **not** used as the shared home (this reasoning was already recorded in the old panic-forward doc comment): it ships only the wasm-pack build output with no TypeScript build step, and `test`/`typecheck` for either consumer already runs its build via turbo's `^build`, so a hand-written TS module there would gate every geometry/parser test run on a full Rust→wasm rebuild. `@ifc-lite/wasm-lifecycle` is a plain TypeScript package (its own `tsc` build, same shape as `@ifc-lite/regex-guard`) with no wasm dependency of its own, so it avoids that cost.
- `packages/geometry/src/wasm-init-retry.ts` / `wasm-panic-forward.ts` and their `packages/parser` counterparts are now thin re-exports of the shared module, so every existing import site (`parser.worker.ts`, `geometry.worker.ts`, `ifc-lite-bridge.ts`, `geometry-parallel.ts`, all the `*-panic-forward.test.ts` files, …) is unchanged.
- Each package's own `wasm-init-retry.test.ts` / `wasm-panic-forward.test.ts` files were left in place unchanged; they now exercise the shared module transitively through the re-export.

## Exports-map check

This repo's convention is a single `"."` export per package (checked `packages/bcf`, `packages/export`, `packages/regex-guard`, etc. — none use subpath exports), so `@ifc-lite/wasm-lifecycle` follows that: one `index.ts` re-exporting both modules, consumed as named imports from the package root rather than a subpath.

## Test evidence (before / after, both unchanged)

- `packages/geometry`: 40 test files / 404 tests passed, before and after.
- `packages/parser`: 111 test files / 1212 passed + 3 skipped, before and after.
- `packages/wasm-lifecycle` (new): 2 test files / 23 tests passed.

## Mutation testing

Two separate mutations to the shared module, each reverted after verifying:

1. `isTransientWasmLoadError` forced to always return `false` (never retry) → `wasm-lifecycle`'s own suite went red (9 failed), **and** `packages/geometry`'s `wasm-init-retry.test.ts` went red (9 failed), **and** `packages/parser`'s `wasm-init-retry.test.ts` went red (9 failed).
2. `takeWasmPanicStash` forced to always return `undefined` (swallow the panic stash) → both geometry's and parser's `wasm-panic-forward.test.ts` + `*-worker-panic-forward.test.ts` suites went red (2 failed each).

Both mutations produced failures in **both** consuming packages from a single edit to the shared module, confirming both are genuinely routed through it rather than either still holding a copy.

## Other housekeeping

- Root `tsconfig.json` path mapping, `pnpm-lock.yaml` importer entries (mirrors the `@ifc-lite/regex-guard` PR's pattern — no `pnpm install` was run; the lockfile addition is hand-written following that template), and `scripts/api-surface.json` (new package's public surface, verified against the TS checker's own output, not hand-guessed) were all updated.
- `node scripts/check-module-size.mjs` exits 0.
- Changeset added: `@ifc-lite/wasm-lifecycle` minor (new package), `@ifc-lite/geometry` / `@ifc-lite/parser` patch (no behavior change, internal re-export).

## Test plan

- [x] `packages/geometry` full suite: 404/404 passing, before and after
- [x] `packages/parser` full suite: 1212/1212 (+3 skipped) passing, before and after
- [x] `packages/wasm-lifecycle` suite: 23/23 passing
- [x] Mutation testing on both shared functions: RED in both consuming packages, reverted
- [x] `check-module-size.mjs` exits 0
- [x] Reference audit: no other file (CI, scripts, docs) names the old file paths