### PR TITLE
perf(export): scan unchanged appearance dependencies from source bytes

### DIFF
--- a/.changeset/major-mangos-stare.md
+++ b/.changeset/major-mangos-stare.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": patch
+---
+
+Scan unchanged appearance dependencies directly from source bytes while preserving edit validation and compressed-source support.

--- a/docs/architecture/evidence/appearance/appearance-apply-ifcopenshell-oracle.json
+++ b/docs/architecture/evidence/appearance/appearance-apply-ifcopenshell-oracle.json
@@ -1,0 +1,113 @@
+{
+  "oracle": "0.8.2",
+  "schema": "IFC4",
+  "archiveBytes": 41838491,
+  "ifcBytes": 75484967,
+  "authoredImages": 1,
+  "authoredTriangleMaps": 115,
+  "mappedTriangles": 120862,
+  "products": [
+    [
+      745,
+      "IfcBuildingElementProxy",
+      "building element"
+    ],
+    [
+      405,
+      "IfcDoor",
+      "door 01"
+    ],
+    [
+      506,
+      "IfcRoof",
+      "roof 01"
+    ],
+    [
+      547,
+      "IfcRoof",
+      "Roof 02"
+    ],
+    [
+      587,
+      "IfcRoof",
+      "Roof 03"
+    ],
+    [
+      792,
+      "IfcRoof",
+      "Roof 05"
+    ],
+    [
+      23,
+      "IfcWall",
+      "outer wall 01"
+    ],
+    [
+      201,
+      "IfcWall",
+      "outer wall 02"
+    ],
+    [
+      667,
+      "IfcWall",
+      "main building walls"
+    ],
+    [
+      833,
+      "IfcWall",
+      "other walls"
+    ],
+    [
+      248,
+      "IfcWindow",
+      "window 07"
+    ],
+    [
+      280,
+      "IfcWindow",
+      "window 05"
+    ],
+    [
+      305,
+      "IfcWindow",
+      "window 04"
+    ],
+    [
+      340,
+      "IfcWindow",
+      "window 08"
+    ],
+    [
+      365,
+      "IfcWindow",
+      "window 02"
+    ],
+    [
+      446,
+      "IfcWindow",
+      "window 06"
+    ],
+    [
+      471,
+      "IfcWindow",
+      "window 03"
+    ],
+    [
+      627,
+      "IfcWindow",
+      "window 01"
+    ],
+    [
+      151,
+      "IfcGeographicElement",
+      "terrain"
+    ],
+    [
+      706,
+      "IfcBuilding",
+      "porch"
+    ]
+  ],
+  "jpegBytes": 987467,
+  "imageDigestMatches": true
+}

--- a/docs/architecture/evidence/appearance/appearance-apply-paired-manifest.json
+++ b/docs/architecture/evidence/appearance/appearance-apply-paired-manifest.json
@@ -1,0 +1,13 @@
+{
+  "base": {
+    "apps/viewer/src/lib/appearance/apply-plan.ts": "fa6ad5251eff5be1b975bb0e4f518374576b135c28398ce522cbfc1a850794a0",
+    "apps/viewer/src/lib/appearance/command.ts": "4d7e9904c6b67941a717b192f37765a7dc8c27b1e59f0a537be04ee8f3651a23",
+    "packages/export/src/appearance-dependencies.ts": "f8db520a4df7ff93a593d30f42fee323047cf8eea47019940786d7526073ac62"
+  },
+  "combined": {
+    "apps/viewer/src/lib/appearance/apply-plan.ts": "efe1dbda97c240a55996446df0fdc5c9daeb822f4811072b460acce48367b99b",
+    "apps/viewer/src/lib/appearance/command.ts": "ddf6d35e0c9f3992a302262d02ffddd94a1637d0ebac0943bff594698fb2a1fe",
+    "packages/export/src/appearance-dependencies.ts": "1f0cf39f6cebfe7361585cbefbb3d06df570b8435ec35a0e29638e436eee52cd"
+  },
+  "wasm": "69773df4b6f0e2f4bfe4b3461b3cbf25fae41d6aa1b8e493fc8971238cc7ef3a"
+}

--- a/docs/architecture/evidence/appearance/appearance-apply-paired-summary.json
+++ b/docs/architecture/evidence/appearance/appearance-apply-paired-summary.json
@@ -1,0 +1,83 @@
+{
+  "runs": [
+    {
+      "pair": 1,
+      "variant": "base",
+      "applyMs": 1685.6399999856949,
+      "maxFrameGapMs": 1683.3099999999977,
+      "longTasks": [
+        {
+          "at": 24873.194999933243,
+          "duration": 1686
+        }
+      ]
+    },
+    {
+      "pair": 1,
+      "variant": "combined",
+      "applyMs": 988.7150000333786,
+      "maxFrameGapMs": 983.3199999999997,
+      "longTasks": [
+        {
+          "at": 24954.355000019073,
+          "duration": 989
+        }
+      ]
+    },
+    {
+      "pair": 2,
+      "variant": "base",
+      "applyMs": 1684.5649999380112,
+      "maxFrameGapMs": 1683.3149999999987,
+      "longTasks": [
+        {
+          "at": 24851.77999997139,
+          "duration": 1685
+        }
+      ]
+    },
+    {
+      "pair": 2,
+      "variant": "combined",
+      "applyMs": 1068.9199999570847,
+      "maxFrameGapMs": 1066.6549999999988,
+      "longTasks": [
+        {
+          "at": 25113.25,
+          "duration": 1069
+        }
+      ]
+    },
+    {
+      "pair": 3,
+      "variant": "base",
+      "applyMs": 1795.1000000238419,
+      "maxFrameGapMs": 1792.130000000001,
+      "longTasks": [
+        {
+          "at": 25092.705000042915,
+          "duration": 1795
+        }
+      ]
+    },
+    {
+      "pair": 3,
+      "variant": "combined",
+      "applyMs": 1086.8050000667572,
+      "maxFrameGapMs": 1084.2300000000032,
+      "longTasks": [
+        {
+          "at": 25026.554999947548,
+          "duration": 1087
+        }
+      ]
+    }
+  ],
+  "medianApplyMs": {
+    "base": 1685.6399999856949,
+    "combined": 1068.9199999570847
+  },
+  "medianChangePercent": -36.586697042894336,
+  "geometryAndUvIdentity": "all115 sorted part byte fingerprints identical across A/B and Redo; non-target model unchanged",
+  "runtime": "69773df4b6f0e2f4bfe4b3461b3cbf25fae41d6aa1b8e493fc8971238cc7ef3a"
+}

--- a/packages/export/src/appearance-dependencies.test.ts
+++ b/packages/export/src/appearance-dependencies.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
-import { IfcParser } from '@ifc-lite/parser';
+import { IfcParser, compressSource, compressSourceInPlace } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor, type IfcAttributeValue } from '@ifc-lite/mutations';
 import { captureAppearanceDependencies } from './appearance-dependencies.js';
 
@@ -41,6 +41,22 @@ describe('effective appearance dependency replay guard #4243', () => {
     f.view.removePositionalMutation(16, 0);
     f.editor.setPositionalAttribute(12, 5, 'changed.png');
     expect(() => guard.validate(f.view)).toThrow(/IFC geometry or appearance changed/);
+  });
+  it('preserves source dependencies across compressed block boundaries (#4243)', async () => {
+    const f = await fixture(), guard = f.capture();
+    const bytes = f.store.source.slice(0, f.store.source.byteLength);
+    expect(compressSourceInPlace(f.store.source, compressSource(bytes, 17))).toBe(true);
+    expect(() => guard.validate(f.view)).not.toThrow();
+    f.editor.setPositionalAttribute(10, 0, [[0, 0, 0], [4, 0, 0], [0, 1, 0]]);
+    expect(() => guard.validate(f.view)).toThrow(/IFC geometry or appearance changed/);
+  });
+  it('keeps source-byte dependencies sensitive to deletion and named overrides (#4243)', async () => {
+    const f = await fixture(), guard = f.capture();
+    f.editor.setAttribute(19, 'Name', 'Changed source product');
+    expect(() => guard.validate(f.view)).toThrow(/IFC geometry or appearance changed/);
+    const deleted = await fixture(), beforeDelete = deleted.capture();
+    deleted.editor.removeEntity(10);
+    expect(() => beforeDelete.validate(deleted.view)).toThrow(/IFC geometry or appearance changed/);
   });
   it('follows effective SDK-created placement and point-list chains, including named overrides', async () => {
     const f = await fixture();

--- a/packages/export/src/appearance-dependencies.ts
+++ b/packages/export/src/appearance-dependencies.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { getAttributeNamesAcrossSchemas, type IfcDataStore } from '@ifc-lite/parser';
+import { asSourceBytes, getAttributeNamesAcrossSchemas, type IfcDataStore } from '@ifc-lite/parser';
 import type { IfcAttributeValue, MutablePropertyView } from '@ifc-lite/mutations';
 import { getEffectiveEntityIndex } from './effective-index.js';
 import { effectiveAppearanceRecord } from './effective-appearance-record.js';
@@ -34,6 +34,7 @@ export function captureAppearanceDependencies(
       throw new Error('Appearance dependency validation exceeds its entity budget. Choose a smaller IFC model.');
     }
     const index = getEffectiveEntityIndex(store, current, true);
+    const source = asSourceBytes(store.source);
     const rows = new Map<number, { line: string; refs: readonly number[] }>();
     let bytes = 0, values = 0, strings = 0, refs = 0;
     // Native planning accepts 128MiB source + 64MiB output. The effective
@@ -63,6 +64,23 @@ export function captureAppearanceDependencies(
       const record = index.get(id);
       if (!record) { result = { line: '', refs: [] }; rows.set(id, result); return result; }
       if (record.byteLength > byteLimit - bytes) refuse();
+      const type = index.typeOf(id) ?? '';
+      // Unchanged source dependencies are already represented by an immutable
+      // marker below. Scan their original bytes directly instead of decoding,
+      // rewriting and encoding large coordinate lists solely to find edges.
+      // Binding rows still need their EXPRESS target slot for inverse traversal.
+      const original = !index.isOverlayCreated(id) && !index.hasSourceMutation?.(id)
+        && !current.getEntityTypeMutation(id);
+      if (original && !BINDINGS.has(type)) {
+        const span = source.slice(record.byteOffset, record.byteOffset + record.byteLength);
+        if (span.length !== record.byteLength) throw new Error('Truncated IFC source during appearance validation.');
+        bytes += span.length;
+        for (let offset = 0; offset < span.length; offset++) {
+          if (span[offset] === 0x23 && ++refs > 2_000_000) refuse();
+        }
+        result = { line: '', refs: collectRefsInByteRange(span, 0, span.length) };
+        rows.set(id, result); return result;
+      }
       inspect(current.getNewEntity(id)?.attributes);
       for (const value of current.getPositionalMutationsForEntity(id)?.values() ?? []) inspect(value);
       for (const attribute of current.getAttributeMutationsForEntity(id)) inspect(attribute.value);
@@ -77,7 +95,7 @@ export function captureAppearanceDependencies(
       for (const char of line) if (char === '#' && ++refs > 2_000_000) refuse();
       const encoded = encoder.encode(line);
       let forward: readonly number[] = collectRefsInByteRange(encoded, 0, encoded.length);
-      const type = index.typeOf(id) ?? '', relating = RELATING.get(type);
+      const relating = RELATING.get(type);
       if (relating) {
         // Membership is validated by the complete row, but peer products sharing
         // a type/material are not dependencies of this object's appearance.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -910,3 +910,21 @@ distributions directly to the TypeScript entrypoint and retain their provenance.
 `--skip-branch-build` labels its input as supplied distribution, not a verified
 current-commit build. The wrapper retains the temporary base through child exit
 and then removes it while preserving the child failure status.
+
+### Appearance dependency validation: immutable source byte scan (#4243)
+
+The Apply CPU profile identified effective dependency capture and repeated overlay
+copies as the dominant main-thread work. Unchanged source rows already use
+immutable markers in history checkpoints; decoding, rewriting and re-encoding
+large coordinate rows only to extract references therefore adds no validation
+information. Read those non-binding rows with the canonical source-byte scanner.
+Keep edited, authored, retyped and inverse-binding rows on the effective STEP
+writer path, with unchanged byte/reference budgets and compressed-source support.
+
+Three interleaved fresh-browser Convento pairs showed a consistent end-to-end
+Apply improvement when combined with removing nested appearance transactions.
+This is a combined result, not an isolated speedup for the scanner. Geometry,
+UVs, owner identity, Undo/Redo and the untouched federated model were checked;
+the remaining main-thread stall still fails the intended smoothness requirement.
+Do not treat fewer copies or a faster helper microbenchmark as acceptance: retain
+the paired interaction measurement and continue profiling transaction preparation.


### PR DESCRIPTION
Whole-model appearance Apply repeatedly decoded and re-encoded unchanged IFC coordinate rows to discover dependencies. Scan those immutable, non-binding rows directly from canonical source bytes; edited, authored, retyped and inverse-binding rows continue through the effective STEP writer. Preserve byte/reference limits and refuse truncated source spans.

Part of ready issue #4243. Stacked on #4313; this is the dependency-scanning slice only.

Validation:
- Root `pnpm typecheck`: 90 tasks passed.
- Root Turbo export tests: 1,235 passed / 36 skipped, including actual Convento, compressed source block boundaries, SDK mutations, deletion, inverse bindings and hostile values.
- Touched lint and diff checks passed.
- Three interleaved fresh-browser Convento pairs combined this change with the separately reviewed removal of nested appearance transactions: median Apply 1685.64 → 1068.92 ms. This is a combined result, with no isolated speedup attributed to this helper. The remaining roughly one-second frame stall is still an open UX blocker.
- All 115 geometry/UV part byte fingerprints match across six runs and Redo; the other federated model remains unchanged. Independent IFCOpenShell validates 115 texture maps / 120,862 triangles across 20 products, all UV indices, and the byte-identical 987,467-byte JPEG in the normal IFCZIP download.

Paired summaries, immutable source/runtime hashes, and IFCOpenShell output are committed under `docs/architecture/evidence/appearance/appearance-apply-*`. The performance ledger records the mechanism and its limits. No renderer patch or fixture-specific behavior was used. Main-target CI and parent landing remain required before merge readiness.
