### PR TITLE
fix(parser): read/write IfcRelNests for IfcWorkPlan nesting IfcWorkSchedule

### DIFF
--- a/.changeset/fix-workplan-nests-crash.md
+++ b/.changeset/fix-workplan-nests-crash.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/parser": patch
+"@ifc-lite/viewer": patch
 ---
 
 Fix a crash in `serializeScheduleToStep` when exporting a `WorkScheduleInfo`
@@ -14,3 +15,11 @@ which threw `TypeError: Cannot read properties of undefined (reading
 serializer treats an absent field the same as an empty array (both mean "no
 nested schedules to write"), so a producer that has no opinion on
 `IfcRelNests` grouping doesn't have to populate it.
+
+Now that both relations round-trip, the viewer's "Generate schedule" dialog
+also composes the grouping instead of shipping an orphan: `buildWorkPlanInfo`
+takes the generated `IfcWorkSchedule`(s) globalIds and sets
+`childScheduleGlobalIds` on the plan it builds, so a plan created through the
+dialog groups its schedule on export and survives a
+parse -> serialize -> reparse round trip. A plan generated with no schedules
+still emits no `IfcRelNests` relation.

--- a/.changeset/fix-workplan-nests-crash.md
+++ b/.changeset/fix-workplan-nests-crash.md
@@ -1,0 +1,16 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Fix a crash in `serializeScheduleToStep` when exporting a `WorkScheduleInfo`
+built without `childScheduleGlobalIds` — the field the `IfcWorkPlan` ->
+`IfcWorkSchedule` `IfcRelNests` grouping fix added. The viewer's standalone
+`IfcWorkPlan` builder (`buildWorkPlanInfo` in `apps/viewer`) constructs a
+`WorkScheduleInfo` with `kind: 'WorkPlan'` and no `childScheduleGlobalIds`,
+which threw `TypeError: Cannot read properties of undefined (reading
+'length')` on export.
+
+`childScheduleGlobalIds` is now optional on `WorkScheduleInfo`; the
+serializer treats an absent field the same as an empty array (both mean "no
+nested schedules to write"), so a producer that has no opinion on
+`IfcRelNests` grouping doesn't have to populate it.

--- a/.changeset/workplan-nests-workschedule.md
+++ b/.changeset/workplan-nests-workschedule.md
@@ -30,3 +30,19 @@ Found by comparing against buildingSMART's own IFC4 spec reference file for
 `IfcTask`, which uses this exact pattern. ifc-lite's own round-trip suite
 couldn't see the gap: it round-trips the writer through the reader, so a
 relation the writer never emitted couldn't appear as a mismatch there.
+
+A CodeRabbit finding then caught an unguarded append of the same shape in
+the `IfcWorkPlan` -> `IfcWorkSchedule` `IfcRelNests` pass (two distinct
+`IfcRelNests` entities nesting the same pair duplicated the edge); fixed
+with the same `includes()` guard the `IfcRelAssignsToControl` pass's
+grouping half already used. A sweep for the same shape elsewhere in this
+file found two more unguarded identity-list appends and fixed both: the
+task/subtask `IfcRelNests` hierarchy (`childGlobalIds`), and
+`IfcRelAssignsToControl`'s task-mapping half (`taskGlobalIds` /
+`controllingScheduleGlobalIds`, guarded together on one predicate so the
+paired arrays stay in lockstep). `IfcRelAssignsToProcess`'s
+`productExpressIds` / `productGlobalIds` append was deliberately left
+unguarded: that relation carries a `QuantityInProcess` attribute, so the
+same product can legitimately repeat across relations to the same task as
+separate quantity assignments — it is a multiset, not an identity set, and
+guarding it would silently drop real data.

--- a/.changeset/workplan-nests-workschedule.md
+++ b/.changeset/workplan-nests-workschedule.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/parser": patch
+---
+
+`schedule-extractor.ts` now reads an `IfcRelNests` relation whose `RelatingObject`
+is an `IfcWorkPlan` nesting `IfcWorkSchedule`s — `WorkScheduleInfo` gained
+`childScheduleGlobalIds` (on the plan) and `parentPlanGlobalId` (on the
+schedule) to carry it. Previously the `IfcRelNests` pass only resolved a
+nesting parent through the task table, so a plan grouping schedules was
+silently dropped on load with no trace in the extraction result.
+
+`schedule-serializer.ts` now emits that `IFCRELNESTS` relation on export from
+`WorkScheduleInfo.childScheduleGlobalIds`; previously it wrote `IFCRELNESTS`
+only for task/subtask hierarchy, so an authored `IfcWorkPlan` never grouped
+its schedules in the written STEP.
+
+Found by comparing against buildingSMART's own IFC4 spec reference file for
+`IfcTask`, which uses this exact pattern. ifc-lite's own round-trip suite
+couldn't see the gap: it round-trips the writer through the reader, so a
+relation the writer never emitted couldn't appear as a mismatch there.

--- a/.changeset/workplan-nests-workschedule.md
+++ b/.changeset/workplan-nests-workschedule.md
@@ -14,6 +14,18 @@ silently dropped on load with no trace in the extraction result.
 only for task/subtask hierarchy, so an authored `IfcWorkPlan` never grouped
 its schedules in the written STEP.
 
+`schedule-extractor.ts`'s `IfcRelAssignsToControl` pass now also resolves a
+`WorkPlan` grouping a `WorkSchedule` through that relation (the SDK's
+`assignSchedulesToWorkPlan` bridge in `packages/create/src/ifc-creator.ts`
+emits exactly this relation, not `IfcRelNests`) into the same
+`childScheduleGlobalIds` / `parentPlanGlobalId` fields — previously that pass
+only resolved `RelatedObjects` through the task table too, so an
+SDK-authored plan grouping was silently dropped on load the same way. A file
+that groups the same pair through both relations is not double-counted. The
+serializer still canonicalizes every grouping to `IFCRELNESTS` on write, so a
+plan grouped via either relation survives an edit-triggered
+strip-and-regenerate round trip.
+
 Found by comparing against buildingSMART's own IFC4 spec reference file for
 `IfcTask`, which uses this exact pattern. ifc-lite's own round-trip suite
 couldn't see the gap: it round-trips the writer through the reader, so a

--- a/apps/viewer/src/components/viewer/schedule/GenerateAdvancedPanel.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GenerateAdvancedPanel.tsx
@@ -37,12 +37,11 @@ export interface GenerateAdvancedPanelProps {
     value: GenerateScheduleOptions[K],
   ) => void;
   /**
-   * Whether to add a standalone `IfcWorkPlan` container alongside the
+   * Whether to add a standalone `IfcWorkPlan` container that groups the
    * generated `IfcWorkSchedule`. Kept out of `GenerateScheduleOptions` (its
    * own on/off + name pair here) rather than folded into the generator's
-   * options — the plan isn't grouped with the schedule (see
-   * `buildWorkPlanInfo`'s doc comment for why), so it doesn't belong to the
-   * generation algorithm itself.
+   * options, as an optional feature (see `buildWorkPlanInfo`'s doc comment
+   * for round-trip details).
    */
   createWorkPlan: boolean;
   onCreateWorkPlanChange: (next: boolean) => void;
@@ -139,7 +138,7 @@ export function GenerateAdvancedPanel({
           />
           <ToggleRow
             label="Add an IfcWorkPlan container"
-            description="A standalone plan entity alongside the schedule — not yet grouped with it (grouping doesn't round-trip)."
+            description="A standalone plan entity that groups the generated schedule(s). The grouping survives export and re-import."
             checked={createWorkPlan}
             onChange={onCreateWorkPlanChange}
           />

--- a/apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx
@@ -137,7 +137,14 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
           ...preview.extraction,
           workSchedules: [
             ...preview.extraction.workSchedules,
-            buildWorkPlanInfo(preview.extraction.workSchedules[0]?.globalId ?? 'workplan', workPlanName),
+            buildWorkPlanInfo(
+              preview.extraction.workSchedules[0]?.globalId ?? 'workplan',
+              workPlanName,
+              // Group the generated IfcWorkSchedule(s) under this plan so
+              // the relation round-trips (see buildWorkPlanInfo's doc
+              // comment) instead of shipping a decorative orphan.
+              preview.extraction.workSchedules.map(s => s.globalId),
+            ),
           ],
         }
       : preview.extraction;

--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
@@ -5,6 +5,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { ScheduleExtraction, ScheduleTaskInfo } from '@ifc-lite/parser';
+import {
+  serializeScheduleToStep,
+  extractScheduleOnDemand,
+  StepTokenizer,
+  ColumnarParser,
+} from '@ifc-lite/parser';
 import { flattenTaskTree, buildWorkPlanInfo } from './schedule-utils.js';
 
 function task(
@@ -105,5 +111,129 @@ describe('buildWorkPlanInfo', () => {
     assert.equal(a1.globalId, a2.globalId);
     // Different seed -> different globalId.
     assert.notEqual(a1.globalId, b.globalId);
+  });
+
+  it('groups the given schedule globalIds into childScheduleGlobalIds, deduped', () => {
+    const plan = buildWorkPlanInfo('seed-2', 'Project plan', ['ws-a', 'ws-b', 'ws-a']);
+
+    assert.deepEqual(plan.childScheduleGlobalIds, ['ws-a', 'ws-b']);
+  });
+
+  it('defaults childScheduleGlobalIds to an empty array, not undefined, when no schedules are given', () => {
+    // A plan generated with no schedules must still carry a defined-but-empty
+    // array: this function always knows the full answer (it's the sole
+    // producer of the plan), so there is no "not checked yet" state to
+    // preserve here the way the extractor's unresolved-reference case has.
+    const plan = buildWorkPlanInfo('seed-3', 'Empty plan');
+
+    assert.deepEqual(plan.childScheduleGlobalIds, []);
+  });
+});
+
+/** Run the real worker-free parser on a STEP buffer (no wasm involved). */
+async function parseStep(stepText: string) {
+  const buffer = new TextEncoder().encode(stepText).buffer.slice(0) as ArrayBuffer;
+  const source = new Uint8Array(buffer);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(buffer, entityRefs, {});
+}
+
+function buildBaseStep(): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('test workplan roundtrip'),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    "#1=IFCPROJECT('proj-gid',#10,'RoundTripProject',$,$,$,$,$,$);",
+    "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+function splice(stepText: string, lines: string[]): string {
+  const endSec = stepText.lastIndexOf('ENDSEC;');
+  return stepText.slice(0, endSec) + lines.join('\n') + '\n' + stepText.slice(endSec);
+}
+
+describe('buildWorkPlanInfo — regenerate round-trip through the real parser', () => {
+  it('a plan built WITH a schedule groups it, and the grouping survives parse -> serialize -> reparse', async () => {
+    const schedule = {
+      expressId: 0,
+      globalId: 'ws-generated',
+      kind: 'WorkSchedule',
+      name: 'Generated Schedule',
+      taskGlobalIds: [],
+    } as unknown as ScheduleExtraction['workSchedules'][number];
+    const plan = buildWorkPlanInfo('ws-generated', 'Project plan', ['ws-generated']);
+    const extraction: ScheduleExtraction = {
+      hasSchedule: true,
+      workSchedules: [schedule, plan],
+      tasks: [],
+      sequences: [],
+    } as unknown as ScheduleExtraction;
+
+    const result = serializeScheduleToStep(extraction, { nextId: 100, ownerHistoryId: 10 });
+    // Regenerate path: this must be the STEP text a fresh export produces,
+    // not source bytes copied through unchanged.
+    assert.ok(result.lines.some(l => l.includes('IFCRELNESTS')));
+    assert.equal(result.stats.relNests, 1);
+
+    const final = splice(buildBaseStep(), result.lines);
+    const store = await parseStep(final);
+    const parsed = extractScheduleOnDemand(store);
+
+    const reparsedPlan = parsed.workSchedules.find(w => w.kind === 'WorkPlan');
+    const reparsedSchedule = parsed.workSchedules.find(w => w.kind === 'WorkSchedule');
+    assert.ok(reparsedPlan, 'reparsed WorkPlan should exist');
+    assert.ok(reparsedSchedule, 'reparsed WorkSchedule should exist');
+    // Direction: plan -> schedule, not the reverse.
+    assert.deepEqual(reparsedPlan!.childScheduleGlobalIds, ['ws-generated']);
+    assert.equal(reparsedSchedule!.parentPlanGlobalId, plan.globalId);
+    // Cardinality: exactly one relation, one child.
+    assert.equal(reparsedPlan!.childScheduleGlobalIds!.length, 1);
+  });
+
+  it('a plan built WITHOUT any schedules produces no spurious IFCRELNESTS relation', async () => {
+    const plan = buildWorkPlanInfo('empty-plan-seed', 'Empty plan');
+    const extraction: ScheduleExtraction = {
+      hasSchedule: true,
+      workSchedules: [plan],
+      tasks: [],
+      sequences: [],
+    } as unknown as ScheduleExtraction;
+
+    const result = serializeScheduleToStep(extraction, { nextId: 100, ownerHistoryId: 10 });
+    assert.ok(!result.lines.some(l => l.includes('IFCRELNESTS')));
+    assert.equal(result.stats.relNests, 0);
+
+    const final = splice(buildBaseStep(), result.lines);
+    const store = await parseStep(final);
+    const parsed = extractScheduleOnDemand(store);
+
+    const reparsedPlan = parsed.workSchedules.find(w => w.kind === 'WorkPlan');
+    assert.ok(reparsedPlan, 'reparsed WorkPlan should exist');
+    assert.deepEqual(reparsedPlan!.childScheduleGlobalIds, []);
   });
 });

--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
@@ -240,25 +240,35 @@ export function taskBarGeometry(
  */
 /**
  * Build a standalone `IfcWorkPlan` container to add alongside a generated
- * `IfcWorkSchedule`.
+ * `IfcWorkSchedule`, grouping it via `childScheduleGlobalIds`.
  *
- * Grouping an `IfcWorkPlan` around its `IfcWorkSchedule`s doesn't round-trip
- * yet on either relation the schema allows: `schedule-extractor.ts`'s
- * `IfcRelNests` pass only resolves a nesting parent through the task table
- * (a plan nesting a schedule is dropped), and its `IfcRelAssignsToControl`
- * pass has the same task-only blindness (a schedule assigned to a plan that
- * way is dropped too). So this plan intentionally carries no
- * `taskGlobalIds` and is emitted as an unrelated top-level entity — the
- * schema-visible container the issue asked for, without a relation whose
- * read path would silently drop it.
+ * `schedule-extractor.ts` now resolves an `IfcWorkPlan` nesting an
+ * `IfcWorkSchedule` on both relations the schema allows (`IfcRelNests` and
+ * `IfcRelAssignsToControl`), and `schedule-serializer.ts` emits `IFCRELNESTS`
+ * for any plan whose `childScheduleGlobalIds` is non-empty — so the grouping
+ * this builds here now round-trips instead of being silently dropped.
+ *
+ * `scheduleGlobalIds` is always assigned into `childScheduleGlobalIds` as an
+ * array, never left `undefined`, matching the extractor's own convention
+ * (`schedule-extractor.ts`'s Pass 4): this function is a full producer of a
+ * `WorkScheduleInfo`, so it always knows definitively whether the plan has
+ * schedules to group, the same way the extractor always knows once a file
+ * has been walked. An empty array here means "deliberately grouped
+ * nothing", not "grouping wasn't attempted" — there is no "not checked"
+ * state for a plan this function constructs from scratch.
  */
-export function buildWorkPlanInfo(seed: string, name: string): WorkScheduleInfo {
+export function buildWorkPlanInfo(
+  seed: string,
+  name: string,
+  scheduleGlobalIds: string[] = [],
+): WorkScheduleInfo {
   return {
     expressId: 0,
     globalId: deterministicGlobalId(`gen-workplan|${seed}`),
     kind: 'WorkPlan',
     name,
     taskGlobalIds: [],
+    childScheduleGlobalIds: [...new Set(scheduleGlobalIds.filter(Boolean))],
   };
 }
 

--- a/packages/parser/src/schedule-extractor.ts
+++ b/packages/parser/src/schedule-extractor.ts
@@ -295,7 +295,17 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     }
   }
 
-  // Pass 5: IfcRelAssignsToControl — map schedules to tasks.
+  // Pass 5: IfcRelAssignsToControl — map schedules to tasks, and (a second,
+  // distinct grouping path from Pass 4b's IfcRelNests) IfcWorkPlan grouping
+  // IfcWorkSchedule. The SDK's scripting bridge
+  // (`assignSchedulesToWorkPlan` in packages/create/src/ifc-creator.ts)
+  // emits exactly this relation — RelatingControl the plan, RelatedObjects
+  // the schedules — not IfcRelNests, so a plan grouped through that bridge
+  // must resolve here too or the SDK-authored grouping never reads back.
+  // If a source file expresses the same WorkPlan->WorkSchedule pair through
+  // *both* relations, Pass 4b (IfcRelNests) runs first and wins:
+  // `parentPlanGlobalId` is set-once (guarded below and in Pass 4b), and
+  // `childScheduleGlobalIds` is deduped so the pair is not double-counted.
   for (const relId of relAssignsControlIds) {
     const ref = store.entityIndex.byId.get(relId);
     if (!ref) continue;
@@ -309,9 +319,23 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     if (!schedule) continue;
     for (const objId of objects) {
       const task = taskByExpressId.get(objId);
-      if (!task) continue;
-      schedule.taskGlobalIds.push(task.globalId);
-      task.controllingScheduleGlobalIds.push(schedule.globalId);
+      if (task) {
+        schedule.taskGlobalIds.push(task.globalId);
+        task.controllingScheduleGlobalIds.push(schedule.globalId);
+        continue;
+      }
+      // Not a task — check whether this is a WorkPlan grouping a
+      // WorkSchedule via IfcRelAssignsToControl instead of IfcRelNests.
+      if (schedule.kind !== 'WorkPlan') continue;
+      const childSchedule = scheduleByExpressId.get(objId);
+      if (!childSchedule || childSchedule.kind !== 'WorkSchedule') continue;
+      const siblings = (schedule.childScheduleGlobalIds ??= []);
+      if (!siblings.includes(childSchedule.globalId)) {
+        siblings.push(childSchedule.globalId);
+      }
+      if (!childSchedule.parentPlanGlobalId) {
+        childSchedule.parentPlanGlobalId = schedule.globalId;
+      }
     }
   }
 

--- a/packages/parser/src/schedule-extractor.ts
+++ b/packages/parser/src/schedule-extractor.ts
@@ -3,19 +3,54 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Schedule (4D) extractor — parses IfcTask, IfcTaskTime, IfcRelSequence,
+ * Schedule (4D) extractor — walks IfcTask, IfcTaskTime, IfcRelSequence,
  * IfcRelAssignsToProcess, IfcRelAssignsToControl, IfcRelNests, IfcWorkSchedule,
- * IfcWorkPlan, IfcLagTime from a parsed IfcDataStore and returns a normalized
- * ScheduleExtraction that the viewer can drive a Gantt/4D animation from.
+ * IfcWorkPlan, IfcLagTime entities in a parsed IfcDataStore and assembles a
+ * normalized ScheduleExtraction that the viewer can drive a Gantt/4D
+ * animation from.
  *
  * Handles IFC4 / IFC4X3. IFC2X3 has a different IfcTask layout (no TaskTime
  * attribute, ScheduleStart/ScheduleFinish/TaskOwner instead) and is supported
  * with best-effort degradation.
+ *
+ * STEP attribute-index layouts, the record types themselves, and the small
+ * pure/single-entity helpers (`asString` et al., `extractTaskTime`,
+ * `extractLagTimeSeconds`) live in `schedule-types.ts` — this file owns only
+ * the cross-entity orchestration (the multi-pass walk below that wires those
+ * records together via their IFC relationships).
  */
 
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcDataStore } from './columnar-parser.js';
 import { parseIso8601Duration } from './iso8601-duration.js';
+import {
+  TASK_ATTR,
+  TASK_ATTR_2X3,
+  REL_SEQUENCE_ATTR,
+  REL_ASSIGNS_TO_PROCESS_ATTR,
+  REL_ASSIGNS_TO_CONTROL_ATTR,
+  REL_NESTS_ATTR,
+  WORK_SCHEDULE_ATTR,
+  WORK_PLAN_ATTR,
+  asString,
+  asNumber,
+  asBoolean,
+  asEnum,
+  asRef,
+  asRefList,
+  sequenceTypeFromString,
+  extractTaskTime,
+  extractLagTimeSeconds,
+} from './schedule-types.js';
+import type {
+  SequenceTypeEnum,
+  TaskDurationType,
+  ScheduleTaskTimeInfo,
+  ScheduleTaskInfo,
+  ScheduleSequenceInfo,
+  WorkScheduleInfo,
+  ScheduleExtraction,
+} from './schedule-types.js';
 
 // Re-exported for backward compatibility — this is where consumers
 // (including this package's own public surface, see index.ts) have always
@@ -25,326 +60,18 @@ import { parseIso8601Duration } from './iso8601-duration.js';
 // visible in one place.
 export { parseIso8601Duration };
 
-/** IFC4 STEP attribute indices for IfcTask. */
-const TASK_ATTR = {
-  GlobalId: 0,
-  Name: 2,
-  Description: 3,
-  ObjectType: 4,
-  Identification: 5,
-  LongDescription: 6,
-  Status: 7,
-  WorkMethod: 8,
-  IsMilestone: 9,
-  Priority: 10,
-  TaskTime: 11,
-  PredefinedType: 12,
-} as const;
-
-/**
- * IFC2X3 IfcTask layout — the attributes IfcTask itself adds over IfcObject
- * (TaskId, Status, WorkMethod, IsMilestone, Priority). IFC2X3 schedule times
- * live on `IfcScheduleTimeControl` and link to IfcTask via `IfcRelAssignsTasks`
- * — we don't resolve those here yet; best-effort 2x3 models only surface task
- * metadata without dates.
- */
-const TASK_ATTR_2X3 = {
-  GlobalId: 0,
-  Name: 2,
-  Description: 3,
-  ObjectType: 4,
-  TaskId: 5,
-  Status: 6,
-  WorkMethod: 7,
-  IsMilestone: 8,
-  Priority: 9,
-} as const;
-
-const TASK_TIME_ATTR = {
-  Name: 0,
-  DurationType: 3,
-  ScheduleDuration: 4,
-  ScheduleStart: 5,
-  ScheduleFinish: 6,
-  EarlyStart: 7,
-  EarlyFinish: 8,
-  LateStart: 9,
-  LateFinish: 10,
-  FreeFloat: 11,
-  TotalFloat: 12,
-  IsCritical: 13,
-  StatusTime: 14,
-  ActualDuration: 15,
-  ActualStart: 16,
-  ActualFinish: 17,
-  RemainingTime: 18,
-  Completion: 19,
-} as const;
-
-const REL_SEQUENCE_ATTR = {
-  GlobalId: 0,
-  RelatingProcess: 4,
-  RelatedProcess: 5,
-  TimeLag: 6,
-  SequenceType: 7,
-  UserDefinedSequenceType: 8,
-} as const;
-
-const REL_ASSIGNS_TO_PROCESS_ATTR = {
-  RelatedObjects: 4,
-  RelatingProcess: 6,
-} as const;
-
-const REL_ASSIGNS_TO_CONTROL_ATTR = {
-  RelatedObjects: 4,
-  RelatingControl: 6,
-} as const;
-
-const REL_NESTS_ATTR = {
-  RelatingObject: 4,
-  RelatedObjects: 5,
-} as const;
-
-const WORK_SCHEDULE_ATTR = {
-  GlobalId: 0,
-  Name: 2,
-  Description: 3,
-  ObjectType: 4,
-  Identification: 5,
-  CreationDate: 6,
-  Purpose: 8,
-  Duration: 9,
-  TotalFloat: 10,
-  StartTime: 11,
-  FinishTime: 12,
-  PredefinedType: 13,
-} as const;
-
-const WORK_PLAN_ATTR = WORK_SCHEDULE_ATTR;
-
-const LAG_TIME_ATTR = {
-  LagValue: 3,
-  DurationType: 4,
-} as const;
-
-export type SequenceTypeEnum =
-  | 'START_START'
-  | 'START_FINISH'
-  | 'FINISH_START'
-  | 'FINISH_FINISH'
-  | 'USERDEFINED'
-  | 'NOTDEFINED';
-
-export type TaskDurationType = 'WORKTIME' | 'ELAPSEDTIME' | 'NOTDEFINED';
-
-export interface ScheduleTaskTimeInfo {
-  scheduleStart?: string;
-  scheduleFinish?: string;
-  scheduleDuration?: string;
-  actualStart?: string;
-  actualFinish?: string;
-  actualDuration?: string;
-  earlyStart?: string;
-  earlyFinish?: string;
-  lateStart?: string;
-  lateFinish?: string;
-  freeFloat?: string;
-  totalFloat?: string;
-  remainingTime?: string;
-  durationType?: TaskDurationType;
-  statusTime?: string;
-  isCritical?: boolean;
-  completion?: number;
-}
-
-export interface ScheduleTaskInfo {
-  expressId: number;
-  globalId: string;
-  name: string;
-  description?: string;
-  objectType?: string;
-  identification?: string;
-  longDescription?: string;
-  status?: string;
-  workMethod?: string;
-  isMilestone: boolean;
-  priority?: number;
-  predefinedType?: string;
-  taskTime?: ScheduleTaskTimeInfo;
-  /** Parent task globalId (from IfcRelNests where this task is in RelatedObjects). */
-  parentGlobalId?: string;
-  /** Child task globalIds (from IfcRelNests where this task is RelatingObject). */
-  childGlobalIds: string[];
-  /** expressIds of products assigned to this task via IfcRelAssignsToProcess. */
-  productExpressIds: number[];
-  /** globalIds of the same products (aligned with productExpressIds by index). */
-  productGlobalIds: string[];
-  /** WorkSchedule globalIds that control this task via IfcRelAssignsToControl. */
-  controllingScheduleGlobalIds: string[];
-}
-
-export interface ScheduleSequenceInfo {
-  globalId: string;
-  relatingTaskGlobalId: string;
-  relatedTaskGlobalId: string;
-  sequenceType: SequenceTypeEnum;
-  userDefinedSequenceType?: string;
-  /** Lag value expressed in seconds if it resolves to an IfcDuration; otherwise undefined. */
-  timeLagSeconds?: number;
-  /** Original lag duration string (ISO 8601 like 'P1D'), if available. */
-  timeLagDuration?: string;
-}
-
-export interface WorkScheduleInfo {
-  expressId: number;
-  globalId: string;
-  kind: 'WorkSchedule' | 'WorkPlan';
-  name: string;
-  description?: string;
-  identification?: string;
-  creationDate?: string;
-  purpose?: string;
-  duration?: string;
-  startTime?: string;
-  finishTime?: string;
-  predefinedType?: string;
-  /** Root task globalIds directly assigned via IfcRelAssignsToControl. */
-  taskGlobalIds: string[];
-}
-
-export interface ScheduleExtraction {
-  workSchedules: WorkScheduleInfo[];
-  tasks: ScheduleTaskInfo[];
-  sequences: ScheduleSequenceInfo[];
-  /** True if we encountered any scheduling entity (useful for empty-state UI). */
-  hasSchedule: boolean;
-}
-
-function asString(v: unknown): string | undefined {
-  if (typeof v === 'string' && v.length > 0) return v;
-  return undefined;
-}
-
-function asNumber(v: unknown): number | undefined {
-  if (typeof v === 'number' && Number.isFinite(v)) return v;
-  return undefined;
-}
-
-function asBoolean(v: unknown): boolean | undefined {
-  if (typeof v === 'boolean') return v;
-  // STEP booleans are typically stored as '.T.' / '.F.' after parsing
-  if (typeof v === 'string') {
-    if (v === '.T.' || v === 'T') return true;
-    if (v === '.F.' || v === 'F') return false;
-  }
-  return undefined;
-}
-
-function asEnum(v: unknown): string | undefined {
-  if (typeof v !== 'string' || v.length === 0) return undefined;
-  // STEP enum looks like .PLANNED.
-  const match = v.match(/^\.([A-Z_]+)\.$/);
-  return match ? match[1] : undefined;
-}
-
-function asRef(v: unknown): number | undefined {
-  if (typeof v === 'number' && Number.isInteger(v) && v > 0) return v;
-  return undefined;
-}
-
-function asRefList(v: unknown): number[] {
-  if (!Array.isArray(v)) return [];
-  const out: number[] = [];
-  for (const x of v) {
-    const id = asRef(x);
-    if (id !== undefined) out.push(id);
-  }
-  return out;
-}
-
-function sequenceTypeFromString(s: string | undefined): SequenceTypeEnum {
-  switch (s) {
-    case 'START_START':
-    case 'START_FINISH':
-    case 'FINISH_START':
-    case 'FINISH_FINISH':
-    case 'USERDEFINED':
-    case 'NOTDEFINED':
-      return s;
-    default:
-      return 'FINISH_START';
-  }
-}
-
-function durationTypeFromString(s: string | undefined): TaskDurationType | undefined {
-  switch (s) {
-    case 'WORKTIME':
-    case 'ELAPSEDTIME':
-    case 'NOTDEFINED':
-      return s;
-    default:
-      return undefined;
-  }
-}
-
-function extractTaskTime(
-  extractor: EntityExtractor,
-  store: IfcDataStore,
-  taskTimeId: number,
-): ScheduleTaskTimeInfo | undefined {
-  const ref = store.entityIndex.byId.get(taskTimeId);
-  if (!ref) return undefined;
-  const entity = extractor.extractEntity(ref);
-  if (!entity) return undefined;
-  const t = entity.type.toUpperCase();
-  if (t !== 'IFCTASKTIME' && t !== 'IFCTASKTIMERECURRING') return undefined;
-  const a = entity.attributes || [];
-  return {
-    durationType: durationTypeFromString(asEnum(a[TASK_TIME_ATTR.DurationType])),
-    scheduleDuration: asString(a[TASK_TIME_ATTR.ScheduleDuration]),
-    scheduleStart: asString(a[TASK_TIME_ATTR.ScheduleStart]),
-    scheduleFinish: asString(a[TASK_TIME_ATTR.ScheduleFinish]),
-    earlyStart: asString(a[TASK_TIME_ATTR.EarlyStart]),
-    earlyFinish: asString(a[TASK_TIME_ATTR.EarlyFinish]),
-    lateStart: asString(a[TASK_TIME_ATTR.LateStart]),
-    lateFinish: asString(a[TASK_TIME_ATTR.LateFinish]),
-    freeFloat: asString(a[TASK_TIME_ATTR.FreeFloat]),
-    totalFloat: asString(a[TASK_TIME_ATTR.TotalFloat]),
-    isCritical: asBoolean(a[TASK_TIME_ATTR.IsCritical]),
-    statusTime: asString(a[TASK_TIME_ATTR.StatusTime]),
-    actualDuration: asString(a[TASK_TIME_ATTR.ActualDuration]),
-    actualStart: asString(a[TASK_TIME_ATTR.ActualStart]),
-    actualFinish: asString(a[TASK_TIME_ATTR.ActualFinish]),
-    remainingTime: asString(a[TASK_TIME_ATTR.RemainingTime]),
-    completion: asNumber(a[TASK_TIME_ATTR.Completion]),
-  };
-}
-
-function extractLagTimeSeconds(
-  extractor: EntityExtractor,
-  store: IfcDataStore,
-  lagId: number,
-): { seconds?: number; duration?: string } {
-  const ref = store.entityIndex.byId.get(lagId);
-  if (!ref) return {};
-  const entity = extractor.extractEntity(ref);
-  if (!entity) return {};
-  if (entity.type.toUpperCase() !== 'IFCLAGTIME') return {};
-  const a = entity.attributes || [];
-  const lagValue = a[LAG_TIME_ATTR.LagValue];
-  // lagValue is an IfcTimeOrRatioSelect — either a typed wrapper like
-  // ['IFCDURATION', 'P1D'] or a direct ratio number.
-  if (Array.isArray(lagValue) && lagValue.length === 2) {
-    const typeName = String(lagValue[0]).toUpperCase();
-    const inner = lagValue[1];
-    if (typeName === 'IFCDURATION' && typeof inner === 'string') {
-      return { seconds: parseIso8601Duration(inner), duration: inner };
-    }
-  } else if (typeof lagValue === 'string') {
-    return { seconds: parseIso8601Duration(lagValue), duration: lagValue };
-  }
-  return {};
-}
+// Re-exported so `import ... from './schedule-extractor.js'` (this
+// package's public surface, see index.ts) still resolves every type it did
+// before the schedule-types.ts split.
+export type {
+  SequenceTypeEnum,
+  TaskDurationType,
+  ScheduleTaskTimeInfo,
+  ScheduleTaskInfo,
+  ScheduleSequenceInfo,
+  WorkScheduleInfo,
+  ScheduleExtraction,
+};
 
 /**
  * Extract all scheduling data from a parsed IFC store.
@@ -454,7 +181,7 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     const children = asRefList(a[REL_NESTS_ATTR.RelatedObjects]);
     if (parent === undefined) continue;
     const parentTask = taskByExpressId.get(parent);
-    if (!parentTask) continue; // nesting over non-task entities — ignore
+    if (!parentTask) continue; // parent isn't a task — task/subtask nesting only; IfcWorkPlan -> IfcWorkSchedule nesting is handled in a separate pass below, once schedules are extracted
     for (const childId of children) {
       const childTask = taskByExpressId.get(childId);
       if (!childTask) continue;
@@ -515,6 +242,7 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
       finishTime: asString(a[layout.FinishTime]),
       predefinedType: asEnum(a[layout.PredefinedType]),
       taskGlobalIds: [],
+      childScheduleGlobalIds: [],
     };
     if (globalId) globalIdByExpressId.set(expressId, globalId);
     return info;
@@ -532,6 +260,32 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     if (info) {
       workSchedules.push(info);
       scheduleByExpressId.set(id, info);
+    }
+  }
+
+  // Pass 4b: walk IfcRelNests again — IfcWorkPlan nesting IfcWorkSchedule.
+  // Real-world files use IfcRelNests for this grouping (confirmed against the
+  // buildingSMART IFC4 spec's own reference example), distinct from Pass 2's
+  // task/subtask hierarchy above, which only resolves parents through
+  // taskByExpressId and silently skips a WorkPlan RelatingObject.
+  for (const relId of relNestsIds) {
+    const ref = store.entityIndex.byId.get(relId);
+    if (!ref) continue;
+    const entity = extractor.extractEntity(ref);
+    if (!entity) continue;
+    const a = entity.attributes || [];
+    const parent = asRef(a[REL_NESTS_ATTR.RelatingObject]);
+    const children = asRefList(a[REL_NESTS_ATTR.RelatedObjects]);
+    if (parent === undefined) continue;
+    const parentPlan = scheduleByExpressId.get(parent);
+    if (!parentPlan || parentPlan.kind !== 'WorkPlan') continue; // not a work-plan nest
+    for (const childId of children) {
+      const childSchedule = scheduleByExpressId.get(childId);
+      if (!childSchedule || childSchedule.kind !== 'WorkSchedule') continue;
+      parentPlan.childScheduleGlobalIds.push(childSchedule.globalId);
+      if (!childSchedule.parentPlanGlobalId) {
+        childSchedule.parentPlanGlobalId = parentPlan.globalId;
+      }
     }
   }
 

--- a/packages/parser/src/schedule-extractor.ts
+++ b/packages/parser/src/schedule-extractor.ts
@@ -288,7 +288,13 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
       // invariant visible to the checker without a non-null assertion, and
       // without treating "absent" any differently from "empty" — both still
       // mean "no nested schedules yet" everywhere else that reads it.
-      (parentPlan.childScheduleGlobalIds ??= []).push(childSchedule.globalId);
+      // Two distinct IfcRelNests entities can nest the same WorkPlan/
+      // WorkSchedule pair (a source file may repeat the relation), so guard
+      // the push the same way Pass 5 below guards its own append.
+      const childGlobalIds = (parentPlan.childScheduleGlobalIds ??= []);
+      if (!childGlobalIds.includes(childSchedule.globalId)) {
+        childGlobalIds.push(childSchedule.globalId);
+      }
       if (!childSchedule.parentPlanGlobalId) {
         childSchedule.parentPlanGlobalId = parentPlan.globalId;
       }

--- a/packages/parser/src/schedule-extractor.ts
+++ b/packages/parser/src/schedule-extractor.ts
@@ -185,7 +185,10 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     for (const childId of children) {
       const childTask = taskByExpressId.get(childId);
       if (!childTask) continue;
-      parentTask.childGlobalIds.push(childTask.globalId);
+      // A source file may repeat the relation; guard as Pass 4b/5 do below.
+      if (!parentTask.childGlobalIds.includes(childTask.globalId)) {
+        parentTask.childGlobalIds.push(childTask.globalId);
+      }
       if (!childTask.parentGlobalId) {
         childTask.parentGlobalId = parentTask.globalId;
       }
@@ -193,6 +196,12 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
   }
 
   // Pass 3: resolve IfcRelAssignsToProcess — products assigned to tasks.
+  // NOT deduped, deliberately: IfcRelAssignsToProcess carries a
+  // QuantityInProcess attribute (not extracted here, but real in the
+  // schema), so the same product can legitimately repeat across relations
+  // to the same task as separate quantity assignments. Unlike the identity
+  // lists elsewhere in this file, this pair is a multiset — dedup would
+  // silently drop a legitimate repeated assignment.
   for (const relId of relAssignsProcessIds) {
     const ref = store.entityIndex.byId.get(relId);
     if (!ref) continue;
@@ -326,8 +335,14 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     for (const objId of objects) {
       const task = taskByExpressId.get(objId);
       if (task) {
-        schedule.taskGlobalIds.push(task.globalId);
-        task.controllingScheduleGlobalIds.push(schedule.globalId);
+        // A source file may repeat the relation; guard both paired arrays
+        // on one predicate to keep them in lockstep. IfcRelAssignsToControl
+        // carries no quantity attribute, so this pair is a pure identity
+        // edge, unlike Pass 3's productExpressIds/productGlobalIds above.
+        if (!schedule.taskGlobalIds.includes(task.globalId)) {
+          schedule.taskGlobalIds.push(task.globalId);
+          task.controllingScheduleGlobalIds.push(schedule.globalId);
+        }
         continue;
       }
       // Not a task — check whether this is a WorkPlan grouping a

--- a/packages/parser/src/schedule-extractor.ts
+++ b/packages/parser/src/schedule-extractor.ts
@@ -282,7 +282,13 @@ export function extractScheduleOnDemand(store: IfcDataStore): ScheduleExtraction
     for (const childId of children) {
       const childSchedule = scheduleByExpressId.get(childId);
       if (!childSchedule || childSchedule.kind !== 'WorkSchedule') continue;
-      parentPlan.childScheduleGlobalIds.push(childSchedule.globalId);
+      // This extractor is the sole producer of `parentPlan`: every
+      // WorkScheduleInfo it builds above sets `childScheduleGlobalIds: []`,
+      // so the field is never actually absent here. `??=` makes that
+      // invariant visible to the checker without a non-null assertion, and
+      // without treating "absent" any differently from "empty" — both still
+      // mean "no nested schedules yet" everywhere else that reads it.
+      (parentPlan.childScheduleGlobalIds ??= []).push(childSchedule.globalId);
       if (!childSchedule.parentPlanGlobalId) {
         childSchedule.parentPlanGlobalId = parentPlan.globalId;
       }

--- a/packages/parser/src/schedule-serializer-builders.ts
+++ b/packages/parser/src/schedule-serializer-builders.ts
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * STEP-line builders for `schedule-serializer.ts` — the low-level string
+ * encoding helpers (`escStr`, `optStr`, `optEnum`, `optBool`, `optReal`,
+ * `ownerRef`, `refList`, `ensureGlobalId`) and the per-entity builders that
+ * turn one `WorkScheduleInfo` / `ScheduleTaskInfo` record into its
+ * `#N=IFC...(...);` line (`buildWorkControl`, `buildTaskTime`, `buildTask`,
+ * plus the small predicates/resolvers those two lean on).
+ *
+ * `schedule-serializer.ts` owns the orchestration — which entities to emit,
+ * in what order, and how their cross-references (`IFCRELNESTS`,
+ * `IFCRELASSIGNSTOCONTROL`, `IFCRELASSIGNSTOPROCESS`, `IFCRELSEQUENCE`) wire
+ * together — and calls into this module for "how does one entity's own
+ * attribute line get written". Same split as `schedule-types.ts` on the
+ * read side: single-entity encoding kept apart from cross-entity wiring.
+ */
+
+import type { ScheduleTaskInfo, WorkScheduleInfo } from './schedule-extractor.js';
+import { deterministicGlobalId } from './deterministic-global-id.js';
+
+export function escStr(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "''");
+}
+
+export function optStr(v: string | undefined | null): string {
+  return v === undefined || v === null || v === '' ? '$' : `'${escStr(v)}'`;
+}
+
+export function optEnum(v: string | undefined | null): string {
+  return v === undefined || v === null || v === '' ? '$' : `.${v}.`;
+}
+
+function optBool(v: boolean | undefined | null): string {
+  return v === undefined || v === null ? '$' : v ? '.T.' : '.F.';
+}
+
+function optReal(v: number | undefined | null): string {
+  if (v === undefined || v === null || !Number.isFinite(v)) return '$';
+  // Integer-format avoids "1.0" → "1." re-import differences across viewers.
+  return Number.isInteger(v) ? `${v}.` : String(v);
+}
+
+export function ownerRef(ownerHistoryId: number | undefined): string {
+  return ownerHistoryId !== undefined ? `#${ownerHistoryId}` : '$';
+}
+
+export function refList(ids: number[]): string {
+  return ids.length === 0 ? '$' : `(${ids.map(id => `#${id}`).join(',')})`;
+}
+
+export function ensureGlobalId(existing: string | undefined, seed: string): string {
+  // Round-tripping should preserve whatever GlobalId the upstream extraction
+  // saw, even when it isn't exactly 22 chars (some authoring tools emit
+  // shorter ids). Only invent a deterministic value when the input is empty.
+  if (existing && existing.length > 0) return existing;
+  return deterministicGlobalId(seed);
+}
+
+export function buildWorkControl(id: number, ws: WorkScheduleInfo, owner: string): string {
+  const entity = ws.kind === 'WorkPlan' ? 'IFCWORKPLAN' : 'IFCWORKSCHEDULE';
+  const globalId = ensureGlobalId(ws.globalId, `ws|${ws.kind}|${ws.name}`);
+  // Deterministic fallback ordering — don't touch `Date.now()` here, it would
+  // give identical inputs different STEP output and break diff-based export
+  // round-trips. Anchor on whatever the upstream extractor already picked,
+  // then on the schedule's own start/finish time.
+  const creationDate = ws.creationDate ?? ws.startTime ?? ws.finishTime ?? '1970-01-01T00:00:00';
+  // `StartTime` is REQUIRED on IfcWorkControl in IFC4 (ENTITY IfcWorkControl
+  // ... StartTime : IfcDateTime) — emitting `$` would fail schema
+  // validation on strict viewers. Fall back through the same deterministic
+  // chain as `creationDate`. `FinishTime` IS optional, but writing a real
+  // value is still friendlier than `$` when the schedule's own `startTime`
+  // is the only datum we have.
+  const startTime = ws.startTime ?? ws.finishTime ?? creationDate;
+  const finishTime = ws.finishTime ?? startTime;
+  // IFC4: GlobalId, OwnerHistory, Name, Description, ObjectType,
+  //       Identification, CreationDate, Creators, Purpose,
+  //       Duration, TotalFloat, StartTime, FinishTime, PredefinedType
+  return [
+    `#${id}=${entity}(`,
+    `'${globalId}',`,
+    `${owner},`,
+    `'${escStr(ws.name)}',`,
+    `${optStr(ws.description)},`,
+    `$,`,
+    `${optStr(ws.identification)},`,
+    `'${escStr(creationDate)}',`,
+    `$,`,
+    `${optStr(ws.purpose)},`,
+    `${optStr(ws.duration)},`,
+    `$,`,
+    `'${escStr(startTime)}',`,
+    `'${escStr(finishTime)}',`,
+    `${optEnum(ws.predefinedType)});`,
+  ].join('');
+}
+
+export function taskHasTimeData(task: ScheduleTaskInfo): boolean {
+  const t = task.taskTime;
+  if (!t) return false;
+  return Boolean(
+    t.scheduleStart || t.scheduleFinish || t.scheduleDuration
+    || t.actualStart || t.actualFinish || t.actualDuration
+    || t.earlyStart || t.earlyFinish || t.lateStart || t.lateFinish
+    || t.freeFloat || t.totalFloat || t.remainingTime || t.statusTime
+    || t.durationType || t.isCritical !== undefined || t.completion !== undefined,
+  );
+}
+
+export function buildTaskTime(id: number, task: ScheduleTaskInfo): string {
+  const t = task.taskTime!;
+  // IFC4: Name, DataOrigin, UDDataOrigin, DurationType,
+  //       ScheduleDuration, ScheduleStart, ScheduleFinish,
+  //       Early/Late Start/Finish, FreeFloat, TotalFloat, IsCritical,
+  //       StatusTime, ActualDuration, ActualStart, ActualFinish,
+  //       RemainingTime, Completion
+  return [
+    `#${id}=IFCTASKTIME(`,
+    `$,$,$,`,
+    `${optEnum(t.durationType)},`,
+    `${optStr(t.scheduleDuration)},`,
+    `${optStr(t.scheduleStart)},`,
+    `${optStr(t.scheduleFinish)},`,
+    `${optStr(t.earlyStart)},`,
+    `${optStr(t.earlyFinish)},`,
+    `${optStr(t.lateStart)},`,
+    `${optStr(t.lateFinish)},`,
+    `${optStr(t.freeFloat)},`,
+    `${optStr(t.totalFloat)},`,
+    `${optBool(t.isCritical)},`,
+    `${optStr(t.statusTime)},`,
+    `${optStr(t.actualDuration)},`,
+    `${optStr(t.actualStart)},`,
+    `${optStr(t.actualFinish)},`,
+    `${optStr(t.remainingTime)},`,
+    `${optReal(t.completion)});`,
+  ].join('');
+}
+
+export function buildTask(
+  id: number,
+  task: ScheduleTaskInfo,
+  owner: string,
+  taskTimeId: number | undefined,
+): string {
+  const globalId = ensureGlobalId(task.globalId, `task|${task.name}`);
+  const taskTimeRef = taskTimeId !== undefined ? `#${taskTimeId}` : '$';
+  // IFC4: GlobalId, OwnerHistory, Name, Description, ObjectType,
+  //       Identification, LongDescription, Status, WorkMethod, IsMilestone,
+  //       Priority, TaskTime, PredefinedType
+  return [
+    `#${id}=IFCTASK(`,
+    `'${globalId}',`,
+    `${owner},`,
+    `'${escStr(task.name)}',`,
+    `${optStr(task.description)},`,
+    `${optStr(task.objectType)},`,
+    `${optStr(task.identification)},`,
+    `${optStr(task.longDescription)},`,
+    `${optStr(task.status)},`,
+    `${optStr(task.workMethod)},`,
+    `${task.isMilestone ? '.T.' : '.F.'},`,
+    `${task.priority !== undefined ? Math.trunc(task.priority) : '$'},`,
+    `${taskTimeRef},`,
+    `${optEnum(task.predefinedType)});`,
+  ].join('');
+}
+
+export function resolveProductIds(
+  task: ScheduleTaskInfo,
+  resolver?: (gid: string) => number | undefined,
+): number[] {
+  // Prefer expressIds when they're present and non-zero (the in-memory schedule
+  // path). When only globalIds are known (e.g. round-tripping through the SDK
+  // boundary), use the caller-supplied resolver to look them up against the
+  // current model — falls back to expressIds whenever the resolver returns
+  // undefined.
+  //
+  // Walk the union of both arrays so global-id-only entries (common for
+  // generated schedules where expressId was never filled in) still hit the
+  // resolver instead of being silently dropped.
+  const out: number[] = [];
+  const count = Math.max(task.productExpressIds.length, task.productGlobalIds.length);
+  for (let i = 0; i < count; i++) {
+    const expressId = task.productExpressIds[i];
+    const globalId = task.productGlobalIds[i];
+    if (resolver && globalId) {
+      const resolved = resolver(globalId);
+      if (resolved !== undefined && resolved > 0) {
+        out.push(resolved);
+        continue;
+      }
+    }
+    if (expressId !== undefined && expressId > 0) out.push(expressId);
+  }
+  return out;
+}

--- a/packages/parser/src/schedule-serializer.ts
+++ b/packages/parser/src/schedule-serializer.ts
@@ -175,7 +175,10 @@ export function serializeScheduleToStep(
 
   // ── 4b. Work-plan → work-schedule grouping (IfcRelNests) ──────────
   for (const plan of data.workSchedules) {
-    if (plan.kind !== 'WorkPlan' || plan.childScheduleGlobalIds.length === 0) continue;
+    // Absent is equivalent to empty here — a producer that doesn't know
+    // about IfcRelNests grouping (e.g. the viewer's standalone-IfcWorkPlan
+    // builder) omits the field entirely rather than setting `[]`.
+    if (plan.kind !== 'WorkPlan' || !plan.childScheduleGlobalIds?.length) continue;
     const parentId = scheduleExpressIdByGlobalId.get(plan.globalId);
     if (parentId === undefined) continue;
     const childIds: number[] = [];

--- a/packages/parser/src/schedule-serializer.ts
+++ b/packages/parser/src/schedule-serializer.ts
@@ -175,9 +175,10 @@ export function serializeScheduleToStep(
 
   // ── 4b. Work-plan → work-schedule grouping (IfcRelNests) ──────────
   for (const plan of data.workSchedules) {
-    // Absent is equivalent to empty here — a producer that doesn't know
-    // about IfcRelNests grouping (e.g. the viewer's standalone-IfcWorkPlan
-    // builder) omits the field entirely rather than setting `[]`.
+    // `?.length` treats `undefined` and `[]` the same — both mean "emit no
+    // relation for this plan" — so any producer is free to use either for
+    // "no schedules grouped", whether that's "deliberately none" or a field
+    // it doesn't populate at all.
     if (plan.kind !== 'WorkPlan' || !plan.childScheduleGlobalIds?.length) continue;
     const parentId = scheduleExpressIdByGlobalId.get(plan.globalId);
     if (parentId === undefined) continue;

--- a/packages/parser/src/schedule-serializer.ts
+++ b/packages/parser/src/schedule-serializer.ts
@@ -23,6 +23,12 @@
  * STEP source buffer. Re-running it with the same inputs produces the same
  * output (deterministic), which keeps round-trip exports stable and makes
  * unit tests simple.
+ *
+ * The low-level STEP string encoding and the per-entity line builders
+ * (`buildWorkControl`, `buildTaskTime`, `buildTask`, …) live in
+ * `schedule-serializer-builders.ts` — this file owns only the orchestration:
+ * which entities and relationships to emit, in what order, and how their
+ * express IDs cross-reference each other.
  */
 
 import type {
@@ -31,8 +37,21 @@ import type {
   ScheduleSequenceInfo,
   WorkScheduleInfo,
 } from './schedule-extractor.js';
-import { deterministicGlobalId } from './deterministic-global-id.js';
 import { secondsToIso8601Duration } from './iso8601-duration.js';
+import { deterministicGlobalId } from './deterministic-global-id.js';
+import {
+  escStr,
+  optStr,
+  optEnum,
+  ownerRef,
+  refList,
+  ensureGlobalId,
+  buildWorkControl,
+  taskHasTimeData,
+  buildTaskTime,
+  buildTask,
+  resolveProductIds,
+} from './schedule-serializer-builders.js';
 
 export interface SerializeScheduleOptions {
   /** First free express ID for the synthesized entities. */
@@ -66,48 +85,6 @@ export interface SerializeScheduleResult {
     assignsToProcess: number;
     relNests: number;
   };
-}
-
-// ─────────────────────────────────────────────────────────────────────────
-// STEP encoding helpers (kept local — same convention as @ifc-lite/create)
-// ─────────────────────────────────────────────────────────────────────────
-
-function escStr(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/'/g, "''");
-}
-
-function optStr(v: string | undefined | null): string {
-  return v === undefined || v === null || v === '' ? '$' : `'${escStr(v)}'`;
-}
-
-function optEnum(v: string | undefined | null): string {
-  return v === undefined || v === null || v === '' ? '$' : `.${v}.`;
-}
-
-function optBool(v: boolean | undefined | null): string {
-  return v === undefined || v === null ? '$' : v ? '.T.' : '.F.';
-}
-
-function optReal(v: number | undefined | null): string {
-  if (v === undefined || v === null || !Number.isFinite(v)) return '$';
-  // Integer-format avoids "1.0" → "1." re-import differences across viewers.
-  return Number.isInteger(v) ? `${v}.` : String(v);
-}
-
-function ownerRef(ownerHistoryId: number | undefined): string {
-  return ownerHistoryId !== undefined ? `#${ownerHistoryId}` : '$';
-}
-
-function refList(ids: number[]): string {
-  return ids.length === 0 ? '$' : `(${ids.map(id => `#${id}`).join(',')})`;
-}
-
-function ensureGlobalId(existing: string | undefined, seed: string): string {
-  // Round-tripping should preserve whatever GlobalId the upstream extraction
-  // saw, even when it isn't exactly 22 chars (some authoring tools emit
-  // shorter ids). Only invent a deterministic value when the input is empty.
-  if (existing && existing.length > 0) return existing;
-  return deterministicGlobalId(seed);
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -196,6 +173,25 @@ export function serializeScheduleToStep(
     stats.relNests += 1;
   }
 
+  // ── 4b. Work-plan → work-schedule grouping (IfcRelNests) ──────────
+  for (const plan of data.workSchedules) {
+    if (plan.kind !== 'WorkPlan' || plan.childScheduleGlobalIds.length === 0) continue;
+    const parentId = scheduleExpressIdByGlobalId.get(plan.globalId);
+    if (parentId === undefined) continue;
+    const childIds: number[] = [];
+    for (const childGid of plan.childScheduleGlobalIds) {
+      const cid = scheduleExpressIdByGlobalId.get(childGid);
+      if (cid !== undefined) childIds.push(cid);
+    }
+    if (childIds.length === 0) continue;
+    const relId = nextId++;
+    const relGid = deterministicGlobalId(`rel-nests-plan|${plan.globalId}`);
+    lines.push(
+      `#${relId}=IFCRELNESTS('${relGid}',${owner},$,$,#${parentId},${refList(childIds)});`,
+    );
+    stats.relNests += 1;
+  }
+
   // ── 5. Products → tasks (IfcRelAssignsToProcess) ─────────────────
   for (const task of data.tasks) {
     if (task.productExpressIds.length === 0 && task.productGlobalIds.length === 0) continue;
@@ -248,147 +244,4 @@ export function serializeScheduleToStep(
   }
 
   return { lines, nextId, stats };
-}
-
-// ─────────────────────────────────────────────────────────────────────────
-// Internal builders
-// ─────────────────────────────────────────────────────────────────────────
-
-function buildWorkControl(id: number, ws: WorkScheduleInfo, owner: string): string {
-  const entity = ws.kind === 'WorkPlan' ? 'IFCWORKPLAN' : 'IFCWORKSCHEDULE';
-  const globalId = ensureGlobalId(ws.globalId, `ws|${ws.kind}|${ws.name}`);
-  // Deterministic fallback ordering — don't touch `Date.now()` here, it would
-  // give identical inputs different STEP output and break diff-based export
-  // round-trips. Anchor on whatever the upstream extractor already picked,
-  // then on the schedule's own start/finish time.
-  const creationDate = ws.creationDate ?? ws.startTime ?? ws.finishTime ?? '1970-01-01T00:00:00';
-  // `StartTime` is REQUIRED on IfcWorkControl in IFC4 (ENTITY IfcWorkControl
-  // ... StartTime : IfcDateTime) — emitting `$` would fail schema
-  // validation on strict viewers. Fall back through the same deterministic
-  // chain as `creationDate`. `FinishTime` IS optional, but writing a real
-  // value is still friendlier than `$` when the schedule's own `startTime`
-  // is the only datum we have.
-  const startTime = ws.startTime ?? ws.finishTime ?? creationDate;
-  const finishTime = ws.finishTime ?? startTime;
-  // IFC4: GlobalId, OwnerHistory, Name, Description, ObjectType,
-  //       Identification, CreationDate, Creators, Purpose,
-  //       Duration, TotalFloat, StartTime, FinishTime, PredefinedType
-  return [
-    `#${id}=${entity}(`,
-    `'${globalId}',`,
-    `${owner},`,
-    `'${escStr(ws.name)}',`,
-    `${optStr(ws.description)},`,
-    `$,`,
-    `${optStr(ws.identification)},`,
-    `'${escStr(creationDate)}',`,
-    `$,`,
-    `${optStr(ws.purpose)},`,
-    `${optStr(ws.duration)},`,
-    `$,`,
-    `'${escStr(startTime)}',`,
-    `'${escStr(finishTime)}',`,
-    `${optEnum(ws.predefinedType)});`,
-  ].join('');
-}
-
-function taskHasTimeData(task: ScheduleTaskInfo): boolean {
-  const t = task.taskTime;
-  if (!t) return false;
-  return Boolean(
-    t.scheduleStart || t.scheduleFinish || t.scheduleDuration
-    || t.actualStart || t.actualFinish || t.actualDuration
-    || t.earlyStart || t.earlyFinish || t.lateStart || t.lateFinish
-    || t.freeFloat || t.totalFloat || t.remainingTime || t.statusTime
-    || t.durationType || t.isCritical !== undefined || t.completion !== undefined,
-  );
-}
-
-function buildTaskTime(id: number, task: ScheduleTaskInfo): string {
-  const t = task.taskTime!;
-  // IFC4: Name, DataOrigin, UDDataOrigin, DurationType,
-  //       ScheduleDuration, ScheduleStart, ScheduleFinish,
-  //       Early/Late Start/Finish, FreeFloat, TotalFloat, IsCritical,
-  //       StatusTime, ActualDuration, ActualStart, ActualFinish,
-  //       RemainingTime, Completion
-  return [
-    `#${id}=IFCTASKTIME(`,
-    `$,$,$,`,
-    `${optEnum(t.durationType)},`,
-    `${optStr(t.scheduleDuration)},`,
-    `${optStr(t.scheduleStart)},`,
-    `${optStr(t.scheduleFinish)},`,
-    `${optStr(t.earlyStart)},`,
-    `${optStr(t.earlyFinish)},`,
-    `${optStr(t.lateStart)},`,
-    `${optStr(t.lateFinish)},`,
-    `${optStr(t.freeFloat)},`,
-    `${optStr(t.totalFloat)},`,
-    `${optBool(t.isCritical)},`,
-    `${optStr(t.statusTime)},`,
-    `${optStr(t.actualDuration)},`,
-    `${optStr(t.actualStart)},`,
-    `${optStr(t.actualFinish)},`,
-    `${optStr(t.remainingTime)},`,
-    `${optReal(t.completion)});`,
-  ].join('');
-}
-
-function buildTask(
-  id: number,
-  task: ScheduleTaskInfo,
-  owner: string,
-  taskTimeId: number | undefined,
-): string {
-  const globalId = ensureGlobalId(task.globalId, `task|${task.name}`);
-  const taskTimeRef = taskTimeId !== undefined ? `#${taskTimeId}` : '$';
-  // IFC4: GlobalId, OwnerHistory, Name, Description, ObjectType,
-  //       Identification, LongDescription, Status, WorkMethod, IsMilestone,
-  //       Priority, TaskTime, PredefinedType
-  return [
-    `#${id}=IFCTASK(`,
-    `'${globalId}',`,
-    `${owner},`,
-    `'${escStr(task.name)}',`,
-    `${optStr(task.description)},`,
-    `${optStr(task.objectType)},`,
-    `${optStr(task.identification)},`,
-    `${optStr(task.longDescription)},`,
-    `${optStr(task.status)},`,
-    `${optStr(task.workMethod)},`,
-    `${task.isMilestone ? '.T.' : '.F.'},`,
-    `${task.priority !== undefined ? Math.trunc(task.priority) : '$'},`,
-    `${taskTimeRef},`,
-    `${optEnum(task.predefinedType)});`,
-  ].join('');
-}
-
-function resolveProductIds(
-  task: ScheduleTaskInfo,
-  resolver?: (gid: string) => number | undefined,
-): number[] {
-  // Prefer expressIds when they're present and non-zero (the in-memory schedule
-  // path). When only globalIds are known (e.g. round-tripping through the SDK
-  // boundary), use the caller-supplied resolver to look them up against the
-  // current model — falls back to expressIds whenever the resolver returns
-  // undefined.
-  //
-  // Walk the union of both arrays so global-id-only entries (common for
-  // generated schedules where expressId was never filled in) still hit the
-  // resolver instead of being silently dropped.
-  const out: number[] = [];
-  const count = Math.max(task.productExpressIds.length, task.productGlobalIds.length);
-  for (let i = 0; i < count; i++) {
-    const expressId = task.productExpressIds[i];
-    const globalId = task.productGlobalIds[i];
-    if (resolver && globalId) {
-      const resolved = resolver(globalId);
-      if (resolved !== undefined && resolved > 0) {
-        out.push(resolved);
-        continue;
-      }
-    }
-    if (expressId !== undefined && expressId > 0) out.push(expressId);
-  }
-  return out;
 }

--- a/packages/parser/src/schedule-serializer.ts
+++ b/packages/parser/src/schedule-serializer.ts
@@ -31,12 +31,7 @@
  * express IDs cross-reference each other.
  */
 
-import type {
-  ScheduleExtraction,
-  ScheduleTaskInfo,
-  ScheduleSequenceInfo,
-  WorkScheduleInfo,
-} from './schedule-extractor.js';
+import type { ScheduleExtraction, ScheduleSequenceInfo } from './schedule-extractor.js';
 import { secondsToIso8601Duration } from './iso8601-duration.js';
 import { deterministicGlobalId } from './deterministic-global-id.js';
 import {

--- a/packages/parser/src/schedule-types.ts
+++ b/packages/parser/src/schedule-types.ts
@@ -1,0 +1,357 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Schedule (4D) shapes and sub-entity extractors — STEP attribute-index
+ * layouts for IfcTask / IfcTaskTime / IfcRelSequence / IfcRelAssignsToProcess
+ * / IfcRelAssignsToControl / IfcRelNests / IfcWorkSchedule / IfcWorkPlan /
+ * IfcLagTime, the public `ScheduleExtraction` record types built from them,
+ * and the small pure helpers (`asString` et al.) plus single-entity
+ * sub-extractors (`extractTaskTime`, `extractLagTimeSeconds`) that turn one
+ * STEP entity's attribute array into a typed field.
+ *
+ * `schedule-extractor.ts` owns the orchestration — walking `byType` arrays
+ * and wiring these records together across passes — and imports everything
+ * it needs from here. Splitting "how one entity's attributes decode" from
+ * "how entities cross-reference each other" keeps each file to one concern,
+ * the same shape as this package's `spatial-hierarchy-canonical-parent.ts`
+ * being split out of `spatial-hierarchy-builder.ts`.
+ */
+
+import { EntityExtractor } from './entity-extractor.js';
+import type { IfcDataStore } from './columnar-parser.js';
+import { parseIso8601Duration } from './iso8601-duration.js';
+
+/** IFC4 STEP attribute indices for IfcTask. */
+export const TASK_ATTR = {
+  GlobalId: 0,
+  Name: 2,
+  Description: 3,
+  ObjectType: 4,
+  Identification: 5,
+  LongDescription: 6,
+  Status: 7,
+  WorkMethod: 8,
+  IsMilestone: 9,
+  Priority: 10,
+  TaskTime: 11,
+  PredefinedType: 12,
+} as const;
+
+/**
+ * IFC2X3 IfcTask layout — the attributes IfcTask itself adds over IfcObject
+ * (TaskId, Status, WorkMethod, IsMilestone, Priority). IFC2X3 schedule times
+ * live on `IfcScheduleTimeControl` and link to IfcTask via `IfcRelAssignsTasks`
+ * — we don't resolve those here yet; best-effort 2x3 models only surface task
+ * metadata without dates.
+ */
+export const TASK_ATTR_2X3 = {
+  GlobalId: 0,
+  Name: 2,
+  Description: 3,
+  ObjectType: 4,
+  TaskId: 5,
+  Status: 6,
+  WorkMethod: 7,
+  IsMilestone: 8,
+  Priority: 9,
+} as const;
+
+const TASK_TIME_ATTR = {
+  Name: 0,
+  DurationType: 3,
+  ScheduleDuration: 4,
+  ScheduleStart: 5,
+  ScheduleFinish: 6,
+  EarlyStart: 7,
+  EarlyFinish: 8,
+  LateStart: 9,
+  LateFinish: 10,
+  FreeFloat: 11,
+  TotalFloat: 12,
+  IsCritical: 13,
+  StatusTime: 14,
+  ActualDuration: 15,
+  ActualStart: 16,
+  ActualFinish: 17,
+  RemainingTime: 18,
+  Completion: 19,
+} as const;
+
+export const REL_SEQUENCE_ATTR = {
+  GlobalId: 0,
+  RelatingProcess: 4,
+  RelatedProcess: 5,
+  TimeLag: 6,
+  SequenceType: 7,
+  UserDefinedSequenceType: 8,
+} as const;
+
+export const REL_ASSIGNS_TO_PROCESS_ATTR = {
+  RelatedObjects: 4,
+  RelatingProcess: 6,
+} as const;
+
+export const REL_ASSIGNS_TO_CONTROL_ATTR = {
+  RelatedObjects: 4,
+  RelatingControl: 6,
+} as const;
+
+export const REL_NESTS_ATTR = {
+  RelatingObject: 4,
+  RelatedObjects: 5,
+} as const;
+
+export const WORK_SCHEDULE_ATTR = {
+  GlobalId: 0,
+  Name: 2,
+  Description: 3,
+  ObjectType: 4,
+  Identification: 5,
+  CreationDate: 6,
+  Purpose: 8,
+  Duration: 9,
+  TotalFloat: 10,
+  StartTime: 11,
+  FinishTime: 12,
+  PredefinedType: 13,
+} as const;
+
+export const WORK_PLAN_ATTR = WORK_SCHEDULE_ATTR;
+
+const LAG_TIME_ATTR = {
+  LagValue: 3,
+  DurationType: 4,
+} as const;
+
+export type SequenceTypeEnum =
+  | 'START_START'
+  | 'START_FINISH'
+  | 'FINISH_START'
+  | 'FINISH_FINISH'
+  | 'USERDEFINED'
+  | 'NOTDEFINED';
+
+export type TaskDurationType = 'WORKTIME' | 'ELAPSEDTIME' | 'NOTDEFINED';
+
+export interface ScheduleTaskTimeInfo {
+  scheduleStart?: string;
+  scheduleFinish?: string;
+  scheduleDuration?: string;
+  actualStart?: string;
+  actualFinish?: string;
+  actualDuration?: string;
+  earlyStart?: string;
+  earlyFinish?: string;
+  lateStart?: string;
+  lateFinish?: string;
+  freeFloat?: string;
+  totalFloat?: string;
+  remainingTime?: string;
+  durationType?: TaskDurationType;
+  statusTime?: string;
+  isCritical?: boolean;
+  completion?: number;
+}
+
+export interface ScheduleTaskInfo {
+  expressId: number;
+  globalId: string;
+  name: string;
+  description?: string;
+  objectType?: string;
+  identification?: string;
+  longDescription?: string;
+  status?: string;
+  workMethod?: string;
+  isMilestone: boolean;
+  priority?: number;
+  predefinedType?: string;
+  taskTime?: ScheduleTaskTimeInfo;
+  /** Parent task globalId (from IfcRelNests where this task is in RelatedObjects). */
+  parentGlobalId?: string;
+  /** Child task globalIds (from IfcRelNests where this task is RelatingObject). */
+  childGlobalIds: string[];
+  /** expressIds of products assigned to this task via IfcRelAssignsToProcess. */
+  productExpressIds: number[];
+  /** globalIds of the same products (aligned with productExpressIds by index). */
+  productGlobalIds: string[];
+  /** WorkSchedule globalIds that control this task via IfcRelAssignsToControl. */
+  controllingScheduleGlobalIds: string[];
+}
+
+export interface ScheduleSequenceInfo {
+  globalId: string;
+  relatingTaskGlobalId: string;
+  relatedTaskGlobalId: string;
+  sequenceType: SequenceTypeEnum;
+  userDefinedSequenceType?: string;
+  /** Lag value expressed in seconds if it resolves to an IfcDuration; otherwise undefined. */
+  timeLagSeconds?: number;
+  /** Original lag duration string (ISO 8601 like 'P1D'), if available. */
+  timeLagDuration?: string;
+}
+
+export interface WorkScheduleInfo {
+  expressId: number;
+  globalId: string;
+  kind: 'WorkSchedule' | 'WorkPlan';
+  name: string;
+  description?: string;
+  identification?: string;
+  creationDate?: string;
+  purpose?: string;
+  duration?: string;
+  startTime?: string;
+  finishTime?: string;
+  predefinedType?: string;
+  /** Root task globalIds directly assigned via IfcRelAssignsToControl. */
+  taskGlobalIds: string[];
+  /**
+   * Parent IfcWorkPlan globalId, when this schedule is nested under a work
+   * plan via IfcRelNests (this schedule as a RelatedObject). Undefined for
+   * a WorkPlan itself, or a WorkSchedule with no nesting parent.
+   */
+  parentPlanGlobalId?: string;
+  /**
+   * Child IfcWorkSchedule globalIds nested under this work plan via
+   * IfcRelNests (this record as the RelatingObject). Empty for a plain
+   * WorkSchedule, or a WorkPlan with no nested schedules.
+   */
+  childScheduleGlobalIds: string[];
+}
+
+export interface ScheduleExtraction {
+  workSchedules: WorkScheduleInfo[];
+  tasks: ScheduleTaskInfo[];
+  sequences: ScheduleSequenceInfo[];
+  /** True if we encountered any scheduling entity (useful for empty-state UI). */
+  hasSchedule: boolean;
+}
+
+export function asString(v: unknown): string | undefined {
+  if (typeof v === 'string' && v.length > 0) return v;
+  return undefined;
+}
+
+export function asNumber(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  return undefined;
+}
+
+export function asBoolean(v: unknown): boolean | undefined {
+  if (typeof v === 'boolean') return v;
+  // STEP booleans are typically stored as '.T.' / '.F.' after parsing
+  if (typeof v === 'string') {
+    if (v === '.T.' || v === 'T') return true;
+    if (v === '.F.' || v === 'F') return false;
+  }
+  return undefined;
+}
+
+export function asEnum(v: unknown): string | undefined {
+  if (typeof v !== 'string' || v.length === 0) return undefined;
+  // STEP enum looks like .PLANNED.
+  const match = v.match(/^\.([A-Z_]+)\.$/);
+  return match ? match[1] : undefined;
+}
+
+export function asRef(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isInteger(v) && v > 0) return v;
+  return undefined;
+}
+
+export function asRefList(v: unknown): number[] {
+  if (!Array.isArray(v)) return [];
+  const out: number[] = [];
+  for (const x of v) {
+    const id = asRef(x);
+    if (id !== undefined) out.push(id);
+  }
+  return out;
+}
+
+export function sequenceTypeFromString(s: string | undefined): SequenceTypeEnum {
+  switch (s) {
+    case 'START_START':
+    case 'START_FINISH':
+    case 'FINISH_START':
+    case 'FINISH_FINISH':
+    case 'USERDEFINED':
+    case 'NOTDEFINED':
+      return s;
+    default:
+      return 'FINISH_START';
+  }
+}
+
+function durationTypeFromString(s: string | undefined): TaskDurationType | undefined {
+  switch (s) {
+    case 'WORKTIME':
+    case 'ELAPSEDTIME':
+    case 'NOTDEFINED':
+      return s;
+    default:
+      return undefined;
+  }
+}
+
+export function extractTaskTime(
+  extractor: EntityExtractor,
+  store: IfcDataStore,
+  taskTimeId: number,
+): ScheduleTaskTimeInfo | undefined {
+  const ref = store.entityIndex.byId.get(taskTimeId);
+  if (!ref) return undefined;
+  const entity = extractor.extractEntity(ref);
+  if (!entity) return undefined;
+  const t = entity.type.toUpperCase();
+  if (t !== 'IFCTASKTIME' && t !== 'IFCTASKTIMERECURRING') return undefined;
+  const a = entity.attributes || [];
+  return {
+    durationType: durationTypeFromString(asEnum(a[TASK_TIME_ATTR.DurationType])),
+    scheduleDuration: asString(a[TASK_TIME_ATTR.ScheduleDuration]),
+    scheduleStart: asString(a[TASK_TIME_ATTR.ScheduleStart]),
+    scheduleFinish: asString(a[TASK_TIME_ATTR.ScheduleFinish]),
+    earlyStart: asString(a[TASK_TIME_ATTR.EarlyStart]),
+    earlyFinish: asString(a[TASK_TIME_ATTR.EarlyFinish]),
+    lateStart: asString(a[TASK_TIME_ATTR.LateStart]),
+    lateFinish: asString(a[TASK_TIME_ATTR.LateFinish]),
+    freeFloat: asString(a[TASK_TIME_ATTR.FreeFloat]),
+    totalFloat: asString(a[TASK_TIME_ATTR.TotalFloat]),
+    isCritical: asBoolean(a[TASK_TIME_ATTR.IsCritical]),
+    statusTime: asString(a[TASK_TIME_ATTR.StatusTime]),
+    actualDuration: asString(a[TASK_TIME_ATTR.ActualDuration]),
+    actualStart: asString(a[TASK_TIME_ATTR.ActualStart]),
+    actualFinish: asString(a[TASK_TIME_ATTR.ActualFinish]),
+    remainingTime: asString(a[TASK_TIME_ATTR.RemainingTime]),
+    completion: asNumber(a[TASK_TIME_ATTR.Completion]),
+  };
+}
+
+export function extractLagTimeSeconds(
+  extractor: EntityExtractor,
+  store: IfcDataStore,
+  lagId: number,
+): { seconds?: number; duration?: string } {
+  const ref = store.entityIndex.byId.get(lagId);
+  if (!ref) return {};
+  const entity = extractor.extractEntity(ref);
+  if (!entity) return {};
+  if (entity.type.toUpperCase() !== 'IFCLAGTIME') return {};
+  const a = entity.attributes || [];
+  const lagValue = a[LAG_TIME_ATTR.LagValue];
+  // lagValue is an IfcTimeOrRatioSelect — either a typed wrapper like
+  // ['IFCDURATION', 'P1D'] or a direct ratio number.
+  if (Array.isArray(lagValue) && lagValue.length === 2) {
+    const typeName = String(lagValue[0]).toUpperCase();
+    const inner = lagValue[1];
+    if (typeName === 'IFCDURATION' && typeof inner === 'string') {
+      return { seconds: parseIso8601Duration(inner), duration: inner };
+    }
+  } else if (typeof lagValue === 'string') {
+    return { seconds: parseIso8601Duration(lagValue), duration: lagValue };
+  }
+  return {};
+}

--- a/packages/parser/src/schedule-types.ts
+++ b/packages/parser/src/schedule-types.ts
@@ -216,15 +216,15 @@ export interface WorkScheduleInfo {
   parentPlanGlobalId?: string;
   /**
    * Child IfcWorkSchedule globalIds nested under this work plan via
-   * IfcRelNests (this record as the RelatingObject). Empty (or absent) for
-   * a plain WorkSchedule, or a WorkPlan with no nested schedules.
+   * IfcRelNests or IfcRelAssignsToControl (this record as the parent side).
+   * Empty (or absent) for a plain WorkSchedule, or a WorkPlan with no
+   * nested schedules.
    *
-   * Optional so a `WorkScheduleInfo` built without knowledge of
-   * `IfcRelNests` grouping (e.g. the viewer's standalone-`IfcWorkPlan`
-   * builder) doesn't have to populate a field it has no opinion on.
-   * Absent and `[]` are equivalent everywhere this field is read — neither
-   * the extractor nor the serializer distinguishes "unknown/legacy" from
-   * "known and empty"; both mean "no nested schedules to write or report".
+   * Optional so a `WorkScheduleInfo` built without any opinion on grouping
+   * doesn't have to populate a field it never touches. Absent and `[]` are
+   * equivalent everywhere this field is read — neither the extractor nor
+   * the serializer distinguishes "unknown/legacy" from "known and empty";
+   * both mean "no nested schedules to write or report".
    */
   childScheduleGlobalIds?: string[];
 }

--- a/packages/parser/src/schedule-types.ts
+++ b/packages/parser/src/schedule-types.ts
@@ -216,10 +216,17 @@ export interface WorkScheduleInfo {
   parentPlanGlobalId?: string;
   /**
    * Child IfcWorkSchedule globalIds nested under this work plan via
-   * IfcRelNests (this record as the RelatingObject). Empty for a plain
-   * WorkSchedule, or a WorkPlan with no nested schedules.
+   * IfcRelNests (this record as the RelatingObject). Empty (or absent) for
+   * a plain WorkSchedule, or a WorkPlan with no nested schedules.
+   *
+   * Optional so a `WorkScheduleInfo` built without knowledge of
+   * `IfcRelNests` grouping (e.g. the viewer's standalone-`IfcWorkPlan`
+   * builder) doesn't have to populate a field it has no opinion on.
+   * Absent and `[]` are equivalent everywhere this field is read — neither
+   * the extractor nor the serializer distinguishes "unknown/legacy" from
+   * "known and empty"; both mean "no nested schedules to write or report".
    */
-  childScheduleGlobalIds: string[];
+  childScheduleGlobalIds?: string[];
 }
 
 export interface ScheduleExtraction {

--- a/packages/parser/test/schedule-extractor.test.ts
+++ b/packages/parser/test/schedule-extractor.test.ts
@@ -177,6 +177,23 @@ describe('extractScheduleOnDemand', () => {
     expect(b?.parentGlobalId).toBe('root-gid');
   });
 
+  it('dedupes when two IfcRelNests entities nest the same task/subtask pair', () => {
+    // Two distinct IFCRELNESTS entities (#20 and #21) both nest root (#10)
+    // over child-a (#11) — reached via two independent relation entities,
+    // not two identical iterations of the same one.
+    const lines = [
+      "#10=IFCTASK('root-gid',$,'Project',$,$,$,$,$,$,.F.,$,$,$);",
+      "#11=IFCTASK('child-a-gid',$,'Foundation',$,$,$,$,$,$,.F.,$,$,.CONSTRUCTION.);",
+      "#20=IFCRELNESTS('rel-gid',$,$,$,#10,(#11));",
+      "#21=IFCRELNESTS('rel-gid-2',$,$,$,#10,(#11));",
+    ];
+    const store = buildStoreFromStep(lines);
+    const result = extractScheduleOnDemand(store);
+    const root = result.tasks.find(t => t.globalId === 'root-gid');
+    // A duplicated relation must not duplicate the edge.
+    expect(root?.childGlobalIds).toEqual(['child-a-gid']);
+  });
+
   it('extracts IfcRelSequence dependencies with lag time', () => {
     const lines = [
       "#10=IFCTASK('pred-gid',$,'Predecessor',$,$,$,$,$,$,.F.,$,$,.CONSTRUCTION.);",
@@ -208,6 +225,25 @@ describe('extractScheduleOnDemand', () => {
     expect(result.workSchedules[0].name).toBe('Main schedule');
     expect(result.workSchedules[0].predefinedType).toBe('PLANNED');
     expect(result.workSchedules[0].taskGlobalIds).toEqual(['task-a-gid', 'task-b-gid']);
+    const t = result.tasks.find(x => x.globalId === 'task-a-gid');
+    expect(t?.controllingScheduleGlobalIds).toEqual(['sched-gid']);
+  });
+
+  it('dedupes when two IfcRelAssignsToControl entities assign the same task to the same schedule', () => {
+    // Two distinct IFCRELASSIGNSTOCONTROL entities (#40 and #41) both assign
+    // task-a (#10) to schedule (#30) — reached via two independent relation
+    // entities, not two identical iterations of the same one. The paired
+    // arrays (schedule.taskGlobalIds / task.controllingScheduleGlobalIds)
+    // must stay in lockstep: both dedupe, or neither would.
+    const lines = [
+      "#10=IFCTASK('task-a-gid',$,'Task A',$,$,$,$,$,$,.F.,$,$,.CONSTRUCTION.);",
+      "#30=IFCWORKSCHEDULE('sched-gid',$,'Main schedule','desc','Planning','S1','2024-01-01T00:00:00',$,'Construction',$,$,'2024-01-01T00:00:00','2024-06-01T00:00:00',.PLANNED.);",
+      "#40=IFCRELASSIGNSTOCONTROL('rel-gid',$,$,$,(#10),$,#30);",
+      "#41=IFCRELASSIGNSTOCONTROL('rel-gid-2',$,$,$,(#10),$,#30);",
+    ];
+    const store = buildStoreFromStep(lines);
+    const result = extractScheduleOnDemand(store);
+    expect(result.workSchedules[0].taskGlobalIds).toEqual(['task-a-gid']);
     const t = result.tasks.find(x => x.globalId === 'task-a-gid');
     expect(t?.controllingScheduleGlobalIds).toEqual(['sched-gid']);
   });

--- a/packages/parser/test/schedule-roundtrip.test.ts
+++ b/packages/parser/test/schedule-roundtrip.test.ts
@@ -462,3 +462,164 @@ describe('schedule roundtrip — IfcWorkPlan nests IfcWorkSchedule (IfcRelNests)
     expect(schedule.parentPlanGlobalId).toBe('plan-gid');
   });
 });
+
+describe('schedule roundtrip — IfcWorkPlan groups IfcWorkSchedule via IfcRelAssignsToControl', () => {
+  /**
+   * `packages/create/src/ifc-creator.ts`'s `assignSchedulesToWorkPlan` (the
+   * SDK's scripting bridge) groups schedules under a work plan by emitting
+   * exactly `IFCRELASSIGNSTOCONTROL('gid',#owner,$,$,(refs),$,#planId)` —
+   * RelatingControl the plan, RelatedObjects the schedules — never
+   * IfcRelNests. Before Pass 5's fix, `schedule-extractor.ts` only resolved
+   * a `RelatedObjects` entry through `taskByExpressId`, so a work schedule
+   * there (not a task) fell through the `if (!task) continue;` unnoticed —
+   * the grouping was dropped without a trace, symmetrically with the
+   * IfcRelNests gap #4329/#4330 fixed above.
+   */
+  it('reads a WorkPlan grouping a WorkSchedule via IfcRelAssignsToControl (the SDK bridge shape)', async () => {
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('workplan assigns-to-control'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('0eVhmaYyb3sBLb0LoNiW62',#10,'Work Plan #1',$,$,$,$,$,$,$,$,$,$,$);",
+      "#794=IFCWORKSCHEDULE('2LoWUCZHr7YvZks8lmqjcw',#10,'Sub Schedule',$,$,$,$,$,$,$,$,$,$,.PLANNED.);",
+      // Exactly the shape addIfcRelAssignsToControl emits: RelatedObjects
+      // then RelatingControl, RelatingControl is the WorkPlan.
+      "#784=IFCRELASSIGNSTOCONTROL('rel-gid-1',#10,$,$,(#794),$,#778);",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const parsed = extractScheduleOnDemand(store);
+
+    expect(parsed.hasSchedule).toBe(true);
+    expect(parsed.workSchedules).toHaveLength(2);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    const schedule = parsed.workSchedules.find(ws => ws.kind === 'WorkSchedule')!;
+    expect(plan).toBeDefined();
+    expect(schedule).toBeDefined();
+
+    // The grouping edge must resolve both directions, same contract as the
+    // IfcRelNests path above.
+    expect(plan.childScheduleGlobalIds).toEqual(['2LoWUCZHr7YvZks8lmqjcw']);
+    expect(schedule.parentPlanGlobalId).toBe('0eVhmaYyb3sBLb0LoNiW62');
+    // And it must not be mistaken for a task assignment.
+    expect(plan.taskGlobalIds).toHaveLength(0);
+  });
+
+  it('a WorkPlan with an unresolved IfcRelAssignsToControl stays distinguishable from one with no grouping at all', async () => {
+    // RelatedObjects references an expressId that resolves to nothing (no
+    // such entity) — the plan must come back with childScheduleGlobalIds
+    // empty/absent, not a spurious entry, and this must not be conflated
+    // with "absent = never checked".
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('workplan assigns-to-control unresolved'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('plan-unresolved',#10,'Work Plan #1',$,$,$,$,$,$,$,$,$,$,$);",
+      "#784=IFCRELASSIGNSTOCONTROL('rel-gid-2',#10,$,$,(#999),$,#778);",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const parsed = extractScheduleOnDemand(store);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    expect(plan).toBeDefined();
+    expect(plan.childScheduleGlobalIds ?? []).toHaveLength(0);
+  });
+
+  it('the regenerate path: extraction sourced from IfcRelAssignsToControl survives serialize + reparse (canonicalized to IfcRelNests)', async () => {
+    // Simulates the edit-triggered strip-and-regenerate path
+    // (apps/viewer/src/sdk/adapters/export-adapter.ts): a file authored via
+    // the SDK bridge (IfcRelAssignsToControl) is opened, a task edit
+    // triggers extractScheduleOnDemand + serializeScheduleToStep instead of
+    // byte-preservation, and the plan/schedule grouping must survive.
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('regenerate path'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('plan-regen',#10,'Work Plan',$,$,$,$,$,$,$,$,$,$,$);",
+      "#794=IFCWORKSCHEDULE('sched-regen',#10,'Sub Schedule',$,$,$,$,$,$,$,$,$,$,.PLANNED.);",
+      "#784=IFCRELASSIGNSTOCONTROL('rel-gid-3',#10,$,$,(#794),$,#778);",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const opened = extractScheduleOnDemand(store);
+    const openedPlan = opened.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    expect(openedPlan.childScheduleGlobalIds).toEqual(['sched-regen']);
+
+    // Regenerate — this is the serializer path a task edit triggers.
+    const result = serializeScheduleToStep(opened, { nextId: 900, ownerHistoryId: 10 });
+
+    // The serializer canonicalizes work-plan grouping to IfcRelNests on
+    // write (its only emission path for `childScheduleGlobalIds`, added by
+    // #4330) regardless of which relation the source used — it does not
+    // (and structurally cannot, since there is one write section) emit a
+    // second IfcRelAssignsToControl for the same pair.
+    const nestsLines = result.lines.filter(l => l.includes('=IFCRELNESTS('));
+    expect(nestsLines).toHaveLength(1);
+    const controlLines = result.lines.filter(l => l.includes('=IFCRELASSIGNSTOCONTROL('));
+    expect(controlLines).toHaveLength(0);
+
+    const final = splice(buildBaseStep(), result.lines);
+    const store2 = await parseStep(final);
+    const reparsed = extractScheduleOnDemand(store2);
+
+    const plan = reparsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    const schedule = reparsed.workSchedules.find(ws => ws.kind === 'WorkSchedule')!;
+    expect(plan.childScheduleGlobalIds).toEqual(['sched-regen']);
+    expect(schedule.parentPlanGlobalId).toBe('plan-regen');
+  });
+
+  it('when a file groups the same pair via BOTH IfcRelNests and IfcRelAssignsToControl, the pair is not double-counted and IfcRelNests (Pass 4b, which runs first) wins the parentPlanGlobalId', async () => {
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('workplan both relations'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('plan-both',#10,'Work Plan',$,$,$,$,$,$,$,$,$,$,$);",
+      "#794=IFCWORKSCHEDULE('sched-both',#10,'Sub Schedule',$,$,$,$,$,$,$,$,$,$,.PLANNED.);",
+      "#784=IFCRELNESTS('rel-nests-both',#10,$,$,#778,(#794));",
+      "#785=IFCRELASSIGNSTOCONTROL('rel-control-both',#10,$,$,(#794),$,#778);",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const parsed = extractScheduleOnDemand(store);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    const schedule = parsed.workSchedules.find(ws => ws.kind === 'WorkSchedule')!;
+    // Not duplicated: one entry, not two.
+    expect(plan.childScheduleGlobalIds).toEqual(['sched-both']);
+    expect(schedule.parentPlanGlobalId).toBe('plan-both');
+  });
+});

--- a/packages/parser/test/schedule-roundtrip.test.ts
+++ b/packages/parser/test/schedule-roundtrip.test.ts
@@ -364,3 +364,101 @@ describe('schedule roundtrip — serializer ↔ parser', () => {
     expect(schedule!.taskGlobalIds).toHaveLength(2);
   });
 });
+
+describe('schedule roundtrip — IfcWorkPlan nests IfcWorkSchedule (IfcRelNests)', () => {
+  /**
+   * Minimal, hand-authored STEP fragment (not run through our own
+   * serializer) modeled on buildingSMART's own IFC4 spec reference example
+   * for IfcTask ("IfcTask.ifc"), which groups a work schedule under a work
+   * plan via IfcRelNests:
+   *
+   *   #778=IFCWORKPLAN(...);
+   *   #784=IFCRELNESTS('...',#owner,$,$,#778,(#794));
+   *   #794=IFCWORKSCHEDULE(...);
+   *
+   * Asserting against this independently-authored STEP text (rather than
+   * only round-tripping our own writer's output) is the point: a reader
+   * that silently drops IfcRelNests whose RelatingObject is a WorkPlan
+   * would still pass a self round-trip, because our writer never emitted
+   * that relation either. See schedule-extractor.ts Pass 2's comment and
+   * the "nesting over non-task entities" history for why that mattered.
+   */
+  it('reads a real-shaped WorkPlan → WorkSchedule IfcRelNests', async () => {
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('workplan nests'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('0eVhmaYyb3sBLb0LoNiW62',#10,'Work Plan #1',$,$,$,'2010-09-23T16:26:16',$,$,$,$,'2010-09-23T00:00:00',$,$);",
+      "#794=IFCWORKSCHEDULE('2LoWUCZHr7YvZks8lmqjcw',#10,'Sub Schedule',$,$,$,'2010-09-23T16:26:42',$,$,$,$,'2010-09-23T00:00:00',$,.PLANNED.);",
+      "#784=IFCRELNESTS('0if6u97Ln58xH$wewg0rH3',#10,$,$,#778,(#794));",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const parsed = extractScheduleOnDemand(store);
+
+    expect(parsed.hasSchedule).toBe(true);
+    expect(parsed.workSchedules).toHaveLength(2);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    const schedule = parsed.workSchedules.find(ws => ws.kind === 'WorkSchedule')!;
+    expect(plan).toBeDefined();
+    expect(schedule).toBeDefined();
+
+    // The grouping edge must resolve both directions.
+    expect(plan.childScheduleGlobalIds).toEqual(['2LoWUCZHr7YvZks8lmqjcw']);
+    expect(schedule.parentPlanGlobalId).toBe('0eVhmaYyb3sBLb0LoNiW62');
+  });
+
+  it('writes an IfcWorkPlan → IfcWorkSchedule IfcRelNests on export, and it re-parses', async () => {
+    const extraction: ScheduleExtraction = {
+      hasSchedule: true,
+      tasks: [],
+      sequences: [],
+      workSchedules: [
+        {
+          expressId: 0,
+          globalId: 'plan-gid',
+          kind: 'WorkPlan',
+          name: 'The Plan',
+          taskGlobalIds: [],
+          childScheduleGlobalIds: ['sched-gid'],
+        },
+        {
+          expressId: 0,
+          globalId: 'sched-gid',
+          kind: 'WorkSchedule',
+          name: 'The Schedule',
+          taskGlobalIds: [],
+          childScheduleGlobalIds: [],
+        },
+      ],
+    };
+
+    const result = serializeScheduleToStep(extraction, { nextId: 100, ownerHistoryId: 10 });
+
+    // Assert against the expected STEP shape directly — not only that our
+    // own reader agrees with our own writer.
+    const nestsLine = result.lines.find(l => l.startsWith('#') && l.includes('=IFCRELNESTS('));
+    expect(nestsLine).toBeDefined();
+    // WorkPlan (#100, emitted first) nests WorkSchedule (#101).
+    expect(nestsLine).toMatch(/=IFCRELNESTS\('[^']+',#10,\$,\$,#100,\(#101\)\);/);
+    expect(result.stats.relNests).toBe(1);
+
+    const final = splice(buildBaseStep(), result.lines);
+    const store = await parseStep(final);
+    const parsed = extractScheduleOnDemand(store);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    const schedule = parsed.workSchedules.find(ws => ws.kind === 'WorkSchedule')!;
+    expect(plan.childScheduleGlobalIds).toEqual(['sched-gid']);
+    expect(schedule.parentPlanGlobalId).toBe('plan-gid');
+  });
+});

--- a/packages/parser/test/schedule-roundtrip.test.ts
+++ b/packages/parser/test/schedule-roundtrip.test.ts
@@ -417,6 +417,38 @@ describe('schedule roundtrip — IfcWorkPlan nests IfcWorkSchedule (IfcRelNests)
     expect(schedule.parentPlanGlobalId).toBe('0eVhmaYyb3sBLb0LoNiW62');
   });
 
+  it('dedupes when two IfcRelNests entities nest the same WorkPlan/WorkSchedule pair', async () => {
+    // Two distinct IFCRELNESTS entities (#784 and #785) both nest the same
+    // WorkPlan (#778) -> WorkSchedule (#794) pair — the duplicate is reached
+    // via two independent relation entities, not two identical iterations
+    // of the same one, so a per-relation guard can't hide the gap.
+    const step = [
+      'ISO-10303-21;',
+      'HEADER;',
+      "FILE_DESCRIPTION(('workplan nests duplicate'),'2;1');",
+      "FILE_NAME('','',(''),(''),'','','');",
+      "FILE_SCHEMA(('IFC4'));",
+      'ENDSEC;',
+      'DATA;',
+      "#1=IFCPROJECT('p',#10,'P',$,$,$,$,$,$);",
+      "#10=IFCOWNERHISTORY($,$,$,.NOCHANGE.,$,$,$,0);",
+      "#778=IFCWORKPLAN('0eVhmaYyb3sBLb0LoNiW62',#10,'Work Plan #1',$,$,$,'2010-09-23T16:26:16',$,$,$,$,'2010-09-23T00:00:00',$,$);",
+      "#794=IFCWORKSCHEDULE('2LoWUCZHr7YvZks8lmqjcw',#10,'Sub Schedule',$,$,$,'2010-09-23T16:26:42',$,$,$,$,'2010-09-23T00:00:00',$,.PLANNED.);",
+      "#784=IFCRELNESTS('0if6u97Ln58xH$wewg0rH3',#10,$,$,#778,(#794));",
+      "#785=IFCRELNESTS('dup-rel-nests-2222222222',#10,$,$,#778,(#794));",
+      'ENDSEC;',
+      'END-ISO-10303-21;',
+    ].join('\n');
+
+    const store = await parseStep(step);
+    const parsed = extractScheduleOnDemand(store);
+
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan')!;
+    expect(plan).toBeDefined();
+    // A duplicated relation must not duplicate the edge.
+    expect(plan.childScheduleGlobalIds).toEqual(['2LoWUCZHr7YvZks8lmqjcw']);
+  });
+
   it('writes an IfcWorkPlan → IfcWorkSchedule IfcRelNests on export, and it re-parses', async () => {
     const extraction: ScheduleExtraction = {
       hasSchedule: true,

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -281,7 +281,6 @@
    530 packages/parser/src/data-store-transport.ts
    827 packages/parser/src/material-resolver.ts
    796 packages/parser/src/on-demand-extractors.ts
-   594 packages/parser/src/schedule-extractor.ts
    494 packages/parser/src/source-bytes.ts
    513 packages/plugin-api/src/types.ts
    678 packages/pointcloud/src/formats/e57-decode.ts


### PR DESCRIPTION
## Summary

- **Scope note (added after the second push):** this PR now also completes the viewer's authoring path, not just the read/write relations. Until this push, the parser could read and write a `WorkPlan` -> `WorkSchedule` grouping, but the one place a user can *create* an `IfcWorkPlan` — the viewer's "Generate schedule" dialog, via `buildWorkPlanInfo()` in `apps/viewer` — still deliberately built an ungrouped, orphan `IfcWorkPlan`. Its doc comment said why: neither relation round-tripped yet. That's exactly what this PR fixed, so the workaround was obsolete the moment the read/write fix landed, and shipping this PR without also updating the one authoring call site would have left the feature half-done — parser reads groupings, parser writes groupings, and the only UI that creates a `WorkPlan` still produces a decorative one. #4329's own text describes the read gap; it does not mention the authoring path, so flagging plainly here rather than letting it be found in review. See "Authoring path (viewer)" below for the two-file change and its test.
- **Scope note (added after the first push):** this PR originally fixed only the `IfcRelNests` direction. It has been extended to also cover `IfcRelAssignsToControl`, a second, distinct relation that expresses the same `IfcWorkPlan` -> `IfcWorkSchedule` grouping — see the updated per-relation verdict below. #4329's own text describes the `IfcRelNests` gap; the `IfcRelAssignsToControl` gap is noted in #4329's body but wasn't in its title/scope, flagging here so it isn't discovered only in review.
- `IfcWorkPlan` groups `IfcWorkSchedule`s via `IfcRelNests` **or** `IfcRelAssignsToControl`. ifc-lite handled neither relation, in either direction — dropped silently on read, never emitted on write. Fixes #4329.
- `schedule-extractor.ts`: the `IfcRelNests` pass only ever resolved a nesting parent through the task table (`taskByExpressId`); a `WorkPlan` `RelatingObject` fell through the `continue` unnoticed, and `WorkScheduleInfo` had no field for a nesting parent/children even if it had matched. Added a second `IfcRelNests` pass (after work schedules/plans are extracted) that resolves `WorkPlan -> WorkSchedule` grouping into two new fields: `childScheduleGlobalIds` (on the plan) and `parentPlanGlobalId` (on the schedule). The `IfcRelAssignsToControl` pass (Pass 5) had the identical gap — it only resolved `RelatedObjects` through the task table too — and now also lands in the same two fields when `RelatingControl` is a `WorkPlan` and a `RelatedObjects` entry resolves to a `WorkSchedule`. This matters concretely because the SDK's `assignSchedulesToWorkPlan` bridge (`packages/create/src/ifc-creator.ts`) emits exactly `IfcRelAssignsToControl`, never `IfcRelNests` — so a plan grouped through the scripting bridge could not be read back even with the original `IfcRelNests`-only fix.
- `schedule-serializer.ts`: added a matching write section that emits `IFCRELNESTS` for a work plan's `childScheduleGlobalIds`, alongside the existing task/subtask `IFCRELNESTS`, `IFCRELASSIGNSTOCONTROL`, `IFCRELASSIGNSTOPROCESS` and `IFCRELSEQUENCE` sections. No separate write path was added for `IfcRelAssignsToControl` grouping: the serializer canonicalizes every work-plan grouping to `IFCRELNESTS` on export regardless of which relation the source file used, so a plan grouped via either relation on read survives an edit-triggered strip-and-regenerate round trip. If a source file expresses the same `WorkPlan` -> `WorkSchedule` pair through *both* relations, the `IfcRelNests` pass runs first and its result is not overwritten by the `IfcRelAssignsToControl` pass; the pair is also not double-counted in `childScheduleGlobalIds`.

## Evidence this is real

buildingSMART's own IFC4 spec reference file for `IfcTask` uses exactly this pattern:

```
#778= IFCWORKPLAN('0eVhmaYyb3sBLb0LoNiW62',#201,'Work Plan #1',...);
#784= IFCRELNESTS('0if6u97Ln58xH$wewg0rH3',#201,$,$,#778,(#783,#794));
#794= IFCWORKSCHEDULE('2LoWUCZHr7YvZks8lmqjcw',#201,...);
```

ifc-lite's `schedule-roundtrip.test.ts` round-trips its own writer through its own reader, so a relation the writer never emitted could not appear as a mismatch there — that suite was structurally blind to this gap.

## Per-relation verdict (as requested)

- `IfcTask` -> `IfcTask` (WBS subtask hierarchy) via `IfcRelNests`: already correct.
- `IfcWorkPlan` -> `IfcWorkSchedule` via `IfcRelNests`: was silently dropped; fixed here.
- `IfcWorkPlan` -> `IfcWorkSchedule` via `IfcRelAssignsToControl` (the relation `#4323`'s `assignSchedulesToWorkPlan` actually emits): **also** was silently dropped, for the same reason — the pass only resolved `RelatedObjects` through the task table. **Now fixed here too**, in the same push that added this note. Previously this was flagged as noted-but-not-fixed; re-verified against this PR's own head and closed in scope rather than left for a follow-up, since it's the same user-visible defect (a `WorkPlan`'s grouping silently disappearing) in the other relation a real producer (the SDK bridge) actually emits.

## Files split, not budgets raised

`schedule-extractor.ts` and `schedule-serializer.ts` both grew past 400 lines from this change alone. The first pass at this PR hand-edited `scripts/module-size-allowlist.txt` to raise `schedule-extractor.ts`'s recorded budget and add a new row for `schedule-serializer.ts` — exactly the two things `check-module-size.mjs --update` refuses to do without `--allow-raise`, done by hand instead of through the tool. That's a green gate obtained by moving the threshold rather than by staying under it, so it's undone here in favor of actually splitting both files:

- `schedule-extractor.ts` -> orchestration (the multi-pass walk that wires records together) stays; STEP attribute-index layouts, the record types, and the small pure/single-entity helpers (`asString` et al., `extractTaskTime`, `extractLagTimeSeconds`) moved to a new `schedule-types.ts`. Same shape as this package's existing `spatial-hierarchy-canonical-parent.ts` split out of `spatial-hierarchy-builder.ts`.
- `schedule-serializer.ts` -> orchestration stays; STEP string encoding (`escStr`, `optStr`, …) and the per-entity line builders (`buildWorkControl`, `buildTaskTime`, `buildTask`, …) moved to a new `schedule-serializer-builders.ts`.

Both new files land at 199 and 357 lines — under the 400-line house rule, so neither needed an allowlist row. `schedule-extractor.ts` itself dropped from 594 (its old recorded budget) to 348, so its allowlist row was **deleted**, not lowered, per the gate's own "the total must trend down" rule. `node scripts/check-module-size.mjs` is green with `scripts/module-size-allowlist.txt` diffing from `upstream/main` by exactly that one deletion.

## Authoring path (viewer)

Two files, small change:

- `apps/viewer/src/components/viewer/schedule/schedule-utils.ts` — `buildWorkPlanInfo()` now takes a third argument, the generated schedule(s)' globalIds, and assigns them into `childScheduleGlobalIds` (deduped). This field is always set to an array — never left `undefined` — matching the extractor's own convention: this function fully constructs the `WorkScheduleInfo` from scratch, so it always knows definitively whether the plan groups any schedules, the same way the extractor always knows once a file has been walked. An empty array means "deliberately grouped nothing," not "grouping wasn't attempted" — there's no "not checked yet" state to preserve here. The doc comment, which asserted the now-fixed round-trip limitation, is rewritten to describe the current behavior instead.
- `apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx` (~line 140) — the call site now passes `preview.extraction.workSchedules.map(s => s.globalId)` as that third argument, so the plan generated when "create a work plan" is checked actually groups the schedule(s) shown in the preview.

**Serializer needed no change** — confirmed by reading `schedule-serializer.ts`'s Pass 4b, which already emits `IFCRELNESTS` for any `plan.childScheduleGlobalIds?.length`. Its own comment citing the viewer builder as an example of a producer that *doesn't* populate the field was now stale (it does, as of this push) and has been rewritten too, along with the same stale claim in `schedule-types.ts`'s field doc comment.

Test: `apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts` gained a `describe` block that serializes a `buildWorkPlanInfo` output through the real `serializeScheduleToStep` (the regenerate path the dialog itself calls — not a byte-preservation copy) and reparses it with the real parser (`StepTokenizer` + `ColumnarParser`, no wasm on this path). Both directions are asserted: a plan built **with** a schedule groups it (`IFCRELNESTS` emitted, `childScheduleGlobalIds` and `parentPlanGlobalId` both correct after reparse) and a plan built **without** any produces no spurious relation (`stats.relNests === 0`). RED confirmed against the pre-fix `buildWorkPlanInfo` (reverted locally, not part of this diff) before restoring the fix; mutation-tested the dedupe line with both a marker (confirmed it executes on every call) and a real mutant (dropping the dedupe/filter step), which the "deduped" test alone catches. `GenerateScheduleDialog.tsx`'s call-site edit type-checks cleanly (`tsc --noEmit`); no test harness in this repo currently mounts that dialog component, so the call site itself isn't mutation-testable the way the pure function is — flagging that limitation rather than skipping it silently.

## Left out on purpose

The SDK's `WorkScheduleData` (`packages/sdk/src/types.ts`) and the sandbox bridge's `WORK_SCHEDULE_FIELDS` schema (`packages/sandbox/src/bridge-schedule.ts`) are hand-mirrored duplicates of `WorkScheduleInfo` and do **not** expose the two new fields (`childScheduleGlobalIds` / `parentPlanGlobalId`) to scripts yet. That's a deliberate scope cut, not an oversight — flagging plainly so it isn't mistaken for done.

## Test plan

- [x] `packages/parser/test/schedule-roundtrip.test.ts` — added a read test asserting against an independently-authored STEP fragment (not our own writer's output) and a write test asserting the emitted `IFCRELNESTS` STEP line shape directly, plus its round-trip.
- [x] Mutation-tested both halves separately, before and after the file split: reverting the extractor's new pass reddens the read test (and the round-trip half of the write test); reverting the serializer's new section reddens only the write test's line-shape assertion. Each half has a test that only it can turn green.
- [x] Full `packages/parser` suite: 76 files, 857 passed, 1 pre-existing skip, exit 0 — identical counts before and after the split, confirming it's behaviour-neutral.
- [x] `node scripts/check-module-size.mjs` — exit 0, no allowlist raise, no new-file exemption; the one allowlist change is a row deletion.
- [x] `git diff --stat` against the branch's merge-base lists only the intended files (two split-out files added, the two touched sources, the test file, the changeset, and the one-line allowlist deletion).

**Added in the scope-extension push (`IfcRelAssignsToControl`):**
- [x] A read test using a hand-authored STEP fragment shaped exactly like `assignSchedulesToWorkPlan`'s output (`IFCRELASSIGNSTOCONTROL` with the plan as `RelatingControl`) — RED against the pre-extension extractor (`expected [] to deeply equal ['2LoWUCZHr7YvZks8lmqjcw']`), GREEN after.
- [x] A regenerate-path test: parse an `IfcRelAssignsToControl`-grouped file, re-serialize (the same `serializeScheduleToStep` call the viewer's edit-triggered strip-and-regenerate path uses), reparse, confirm the grouping survives and is canonicalized to `IFCRELNESTS` on export (`IFCRELASSIGNSTOCONTROL` count 0, `IFCRELNESTS` count 1 in the regenerated output) — also RED before, GREEN after.
- [x] An unresolved-reference test: a `WorkPlan` whose `IfcRelAssignsToControl` references a non-existent expressId stays at `childScheduleGlobalIds: []`, not conflated with "never checked".
- [x] A both-relations test: the same pair expressed via both `IfcRelNests` and `IfcRelAssignsToControl` in one file is not double-counted in `childScheduleGlobalIds`, and `IfcRelNests` (which runs first) wins `parentPlanGlobalId`.
- [x] Mutation-tested the three added lines in the extended `IfcRelAssignsToControl` pass individually (a `console.log` marker per mutant, confirmed to fire, plus the expected test(s) reddening): the `schedule.kind !== 'WorkPlan'` guard, the `childScheduleGlobalIds` dedupe check, and the `parentPlanGlobalId` set-once guard — each has a test that only it turns green.
- [x] `packages/parser` suite re-run after the extension: 118 files, 1272 passed, 7 failed (pre-existing `@ifc-lite/wasm` build wall in `parser.worker.ts` tests — genuinely unrelated to this change, confirmed unchanged before/after), 3 skipped. `schedule-roundtrip.test.ts` + `schedule-extractor.test.ts` + `schedule-serializer.test.ts`: 41/41.
- [x] `node scripts/check-module-size.mjs` re-run — exit 0, unchanged.
- [x] `node scripts/check-changesets.mjs` re-run — exit 0; the existing changeset for this PR was updated in place to describe both relations rather than adding a second one for the same package/PR.

**Added in the authoring-path push (viewer):**
- [x] `schedule-utils.test.ts`: real-parser regenerate round trip, both directions (with schedules / without), described above under "Authoring path (viewer)".
- [x] Mutation-tested the dedupe line: a `console.error` marker (fired on every `buildWorkPlanInfo` call, confirmed), then a real mutant dropping `[...new Set(...filter(Boolean))]` down to the raw array — caught by the "deduped" test, all else green.
- [x] `packages/parser`'s `schedule-roundtrip.test.ts` + `schedule-extractor.test.ts` + `schedule-serializer.test.ts` re-run after this push: still 41/41 (comment-only changes there, no functional edit).
- [x] Full `packages/parser` suite re-run: 116/118 files, 1272 passed, 7 failed, 3 skipped — identical to the counts already reported above; the 2 failing files are the same pre-existing `@ifc-lite/wasm` build wall (`parser.worker.ts` tests, `parser-worker-panic-forward.test.ts`), confirmed unrelated by re-checking the failure messages (`Failed to resolve entry for package "@ifc-lite/wasm"`).
- [x] `node scripts/check-module-size.mjs` re-run — exit 0; none of the four touched files is within range of its house-rule budget (largest is 390 lines).
- [x] `node scripts/check-changesets.mjs` re-run — exit 0; extended this PR's other existing changeset (the `buildWorkPlanInfo` crash-fix one) to also cover `@ifc-lite/viewer` and describe the new grouping, rather than adding a third changeset.
- [x] Confirmed `closingIssuesReferences` still reads exactly #4329 after this push.

## Queue gate

This closes issue #4329, which I filed as part of this change and is unlabelled — I'm not positioned to self-apply `ready`, so this PR carries `unqueued` per the issue-queue gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for work plan–work schedule nesting across supported IFC relationship types.
  * Generated work plans now retain their schedule grouping when exported and re-imported.
  * The schedule-generation dialog now creates linked work plan and schedule groupings.

* **Bug Fixes**
  * Fixed crashes when exporting work schedules without nested-schedule information.
  * Prevented duplicate nesting relationships during parsing and export.

* **Tests**
  * Added coverage for parsing, exporting, and round-tripping nested work plans and schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

**Scope note (added after CodeRabbit's Pass 4b finding was fixed):** CodeRabbit flagged one unguarded duplicate-edge append (`IfcRelNests`'s `IfcWorkPlan`->`IfcWorkSchedule` grouping, Pass 4b) and it was fixed with an `includes()` guard matching `IfcRelAssignsToControl`'s WorkPlan-grouping half. A follow-up sweep of the same file for the same append shape found two more sites, and left one deliberately alone:

- `schedule-extractor.ts` Pass 2 (`IfcRelNests` task/subtask hierarchy, `childGlobalIds`) — unguarded, same bug shape as Pass 4b. **Fixed** with its own `includes()` guard.
- `schedule-extractor.ts` Pass 5's task-mapping half (`IfcRelAssignsToControl`, `taskGlobalIds` / `controllingScheduleGlobalIds`) — unguarded, while Pass 5's WorkPlan-grouping half already had the guard. **Fixed**; both paired arrays are guarded on one shared predicate so they can't desynchronise.
- `schedule-extractor.ts` Pass 3 (`IfcRelAssignsToProcess`, `productExpressIds` / `productGlobalIds`) — **left unguarded, deliberately**. `IfcRelAssignsToProcess` carries a `QuantityInProcess` attribute (real in the schema, not extracted here), so the same product can legitimately appear across multiple relations to the same task as separate quantity assignments. This pair is a multiset, not an identity set; deduping it would silently drop real assignment data.

Each fixed site has its own RED test (a fixture with two distinct relation entities over the same pair) and was mutation-tested individually — a `console.error` probe confirming the mutated line executed on both relations, then the specific test reddening, restored via `cp` from a snapshot (never `git stash`).

Full `packages/parser` suite after this push: 120 files, 1284 passed, 3 skipped, 0 failed (this environment has a working Rust/wasm-pack toolchain, so the `@ifc-lite/wasm`-dependent tests that were reported failing/blocked in earlier review comments on this PR ran and passed here too). `node scripts/check-module-size.mjs` — exit 0, `schedule-extractor.ts` is 399 lines, no allowlist change needed. `pnpm --filter @ifc-lite/parser typecheck` — OK.
