### PR TITLE
fix(viewer): register layerStackSlice in the teardown seam

### DIFF
--- a/.changeset/layer-stack-teardown-registration.md
+++ b/.changeset/layer-stack-teardown-registration.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Register `layerStackSlice` in the viewer store's teardown seam. Removing a federated layer's model, clearing all models, or loading a new file used to leave the Layers panel's composition (`layerStack`, its `path -> expressId` selection bridge, and the per-layer diff) pointing at a model that no longer exists.

--- a/apps/viewer/src/store/slices/layerStackSlice.teardown.test.ts
+++ b/apps/viewer/src/store/slices/layerStackSlice.teardown.test.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `layerStackSlice`'s participation in the store-wide teardown seam (#4309;
+ * `store/teardown.ts`, `store/teardown-registry.ts`).
+ *
+ * Combines `createModelSlice` with `createLayerStackSlice` in one harness,
+ * the same shape `splitToolSlice.teardown.test.ts` uses (`#4249`/`#4289`) —
+ * `modelSlice.ts`'s `removeModel` / `clearAllModels` dispatch through the
+ * REAL, module-wide `viewerTeardown` (`teardown-registry.ts`), not a
+ * per-slice stub, so a harness that exercises those actions is exercising
+ * the actual registry a missing registration is invisible to.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult } from '@ifc-lite/geometry';
+import { createModelSlice, type ModelSlice } from './modelSlice.js';
+import {
+  createLayerStackSlice,
+  type LayerStackSlice,
+  type LayerStackEntry,
+} from './layerStackSlice.js';
+import { layerStackTeardown } from './layerStackSlice.teardown.js';
+import type { FederatedModel } from '../types.js';
+import type { TeardownState } from '../teardown.js';
+
+type TestState = ModelSlice & LayerStackSlice;
+
+type TestSetState = (
+  partial: Partial<TestState> | ((state: TestState) => Partial<TestState>),
+) => void;
+type TestGetState = () => TestState;
+
+function createMockModel(id: string, name: string): FederatedModel {
+  return {
+    id,
+    name,
+    ifcDataStore: {} as unknown as IfcDataStore,
+    geometryResult: {} as unknown as GeometryResult,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC5',
+    loadedAt: Date.now(),
+    fileSize: 1024,
+    idOffset: 0,
+    maxExpressId: 0,
+  };
+}
+
+/** A minimal layer stack entry — only `id` is load-bearing for the teardown. */
+function makeEntry(id: string, name: string): LayerStackEntry {
+  return {
+    id,
+    name,
+    file: { header: { id, ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: '2026-07-11T00:00:00Z' }, imports: [], schemas: {}, data: [] },
+    nodeCount: 0,
+    byteLength: 0,
+  };
+}
+
+describe('LayerStackSlice — teardown registration (#4309)', () => {
+  let state: TestState;
+  let setState: TestSetState;
+
+  beforeEach(() => {
+    setState = (partial) => {
+      if (typeof partial === 'function') {
+        const updates = (partial as (s: TestState) => Partial<TestState>)(state);
+        state = { ...state, ...updates };
+      } else {
+        state = { ...state, ...partial };
+      }
+    };
+
+    const getState: TestGetState = () => state;
+
+    const modelSlice = createModelSlice(
+      setState as Parameters<typeof createModelSlice>[0],
+      getState as Parameters<typeof createModelSlice>[1],
+      undefined as unknown as Parameters<typeof createModelSlice>[2],
+    );
+    const layerStackSlice = createLayerStackSlice(
+      setState as Parameters<typeof createLayerStackSlice>[0],
+      getState as Parameters<typeof createLayerStackSlice>[1],
+      undefined as unknown as Parameters<typeof createLayerStackSlice>[2],
+    );
+
+    state = { ...modelSlice, ...layerStackSlice };
+  });
+
+  function armLayerStack(...modelIds: string[]) {
+    const entries = modelIds.map((id) => makeEntry(id, `${id}.ifcx`));
+    state.setLayerStack(entries, new Map([['wall-1', 42]]));
+    state.setLayersPanelVisible(true);
+    state.setLayerDiffBusy(true);
+  }
+
+  describe('removeModel', () => {
+    it('clears the layer stack when the removed model is one of its layers (#4309 RED without registration)', () => {
+      state.addModel(createMockModel('layer-a', 'Base'));
+      state.addModel(createMockModel('layer-b', 'Overlay'));
+      armLayerStack('layer-a', 'layer-b');
+      assert.strictEqual(state.layerStack.length, 2);
+      assert.ok(state.layerStackPathToId);
+
+      state.removeModel('layer-a');
+
+      assert.deepStrictEqual(state.layerStack, [], 'layerStack must clear');
+      assert.strictEqual(state.layerStackPathToId, null, 'layerStackPathToId (3D selection bridge) must clear');
+      assert.strictEqual(state.layerStackDiff, null, 'layerStackDiff must clear');
+      assert.strictEqual(state.layerDiffBusy, false, 'layerDiffBusy must clear');
+      // Panel stays docked open over the now-empty composition rather than
+      // being yanked shut under the user for a partial removal.
+      assert.strictEqual(state.layersPanelVisible, true, 'layersPanelVisible must NOT close on model-removed');
+    });
+
+    it('leaves an UNRELATED layer stack alone when the removed model is not one of its layers', () => {
+      state.addModel(createMockModel('layer-a', 'Base'));
+      state.addModel(createMockModel('other-model', 'Unrelated STEP file'));
+      armLayerStack('layer-a');
+
+      state.removeModel('other-model');
+
+      assert.strictEqual(state.layerStack.length, 1);
+      assert.ok(state.layerStackPathToId);
+    });
+  });
+
+  describe('clearAllModels', () => {
+    it('clears the layer stack unconditionally', () => {
+      state.addModel(createMockModel('layer-a', 'Base'));
+      armLayerStack('layer-a');
+
+      state.clearAllModels();
+
+      assert.deepStrictEqual(state.layerStack, []);
+      assert.strictEqual(state.layerStackPathToId, null);
+      assert.strictEqual(state.layerStackDiff, null);
+      assert.strictEqual(state.layerDiffBusy, false);
+      // Same rationale as model-removed: data clears, panel stays as the
+      // user left it rather than closing under them mid-session.
+      assert.strictEqual(state.layersPanelVisible, true);
+    });
+  });
+
+  describe('session-reset', () => {
+    it('clears the layer stack AND closes the panel', () => {
+      state.addModel(createMockModel('layer-a', 'Base'));
+      armLayerStack('layer-a');
+
+      const patch = layerStackTeardown.teardown({ kind: 'session-reset' }, state as unknown as TeardownState);
+
+      assert.deepStrictEqual(patch.layerStack, []);
+      assert.strictEqual(patch.layerStackPathToId, null);
+      assert.strictEqual(patch.layerStackDiff, null);
+      assert.strictEqual(patch.layerDiffBusy, false);
+      assert.strictEqual(patch.layersPanelVisible, false, 'a genuinely new file load closes the layers panel');
+    });
+  });
+});

--- a/apps/viewer/src/store/slices/layerStackSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/layerStackSlice.teardown.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The layer-stack slice's contribution to viewer-state teardown (#4309).
+ *
+ * A sibling module rather than a block at the bottom of `layerStackSlice.ts`
+ * to match the group convention `store/teardown.ts` documents (sibling file
+ * once a slice plus its contribution would grow past the ~400-line ratchet;
+ * `splitToolSlice.teardown.ts` is the direct precedent for this same shape).
+ *
+ * `layerStack` / `layerStackPathToId` / `layerStackDiff` / `layerDiffBusy`
+ * hold the IFCX composition behind the Layers panel — each entry keeps the
+ * FULL PARSED layer document (`LayerStackEntry.file`), and
+ * `layerStackPathToId` is the panel's own doc comment's "3D selection
+ * bridge": a `path -> expressId` map into that composition. None of it had a
+ * teardown entry before this file. `useIfcFederation.ts`'s
+ * `loadFederatedIfcxFromBuffers` is the only production caller of
+ * `setLayerStack` (it runs `resetViewerState()` then `clearAllModels()` then
+ * repopulates the stack synchronously), so a *fresh* federated load always
+ * lands correct — the gap is everything else that can leave a *populated*
+ * stack behind:
+ *
+ *   - `modelSlice.removeModel`, called directly from `LayersPanel.tsx` /
+ *     the Models panel, when the removed model is one of THIS composition's
+ *     layers. Each federated layer is registered as its own `FederatedModel`
+ *     with `id: layer.id` (`useIfcFederation.ts`'s per-layer `storeAddModel`
+ *     loop), and `layerStackEntry()` (`lib/layers/stack.ts`) carries that
+ *     same `layer.id` into `LayerStackEntry.id` — so a stale layer is
+ *     detected by `LayerStackEntry.id === scope.modelId`, not by
+ *     `scope.isStale` (a numeric-expressId predicate; `layerStack` entries
+ *     are keyed by model id, not by any single express id).
+ *   - `clearAllModels()` called on its own, outside a federated (re-)load —
+ *     `modelSlice.ts` and `selectionSlice.teardown.ts` both document that
+ *     `clearAllModels()` has call sites (e.g. `GeoreferencingPanel.tsx`'s
+ *     `reloadModelsForAlignment`) that are not followed by
+ *     `resetViewerState()`.
+ *   - a non-federated (STEP / single-file / GLB) load's `session-reset`
+ *     that is not itself preceded by a federation `clearLayerStack()` call
+ *     — belt-and-suspenders with `useIfcLoader.ts`'s explicit call, which
+ *     this contribution does not replace: `useIfcLoader.ts` clears eagerly
+ *     before parsing so `LayersPanel.tsx` cannot render a moment of a
+ *     previous composition beside a loading spinner, while this arm is what
+ *     survives any load path that forgets that call.
+ *
+ * `layersPanelVisible` resets to `false` ONLY on `session-reset`, matching
+ * `bcfSlice.teardown.ts` / `idsSlice.teardown.ts` / `sheetSlice.teardown.ts`:
+ * a genuinely new file (including a non-IFCX one) should not keep a federated
+ * layers panel docked open, but removing one layer out of a live federation,
+ * or clearing all models without a fresh load queued right behind it, leaves
+ * the panel open over now-empty composition data rather than yanking it
+ * closed under the user mid-session — the same choice those three panels
+ * already make for `model-removed` / `all-models-cleared`.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+const emptyStackPatch = {
+  layerStack: [],
+  layerStackPathToId: null,
+  layerStackDiff: null,
+  layerDiffBusy: false,
+} as const;
+
+export const layerStackTeardown = defineSliceTeardown(
+  'layerStackSlice',
+  ['layerStack', 'layerStackPathToId', 'layerStackDiff', 'layerDiffBusy', 'layersPanelVisible'],
+  {
+    'session-reset': () => ({
+      ...emptyStackPatch,
+      layersPanelVisible: false,
+    }),
+    'model-removed': (scope, state) => {
+      const stale = (state.layerStack ?? []).some((entry) => entry.id === scope.modelId);
+      if (!stale) return {};
+      return emptyStackPatch;
+    },
+    'all-models-cleared': () => emptyStackPatch,
+  },
+);

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -49,7 +49,9 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
   'hiddenEntities', 'hiddenEntitiesByModel', 'hierarchyBasketSelection', 'hoverState',
   'hoveredTaskGlobalId', 'idsActiveEntityId', 'idsActiveSpecificationId', 'idsError',
   'idsFocusVisibilityOwned', 'idsLoading', 'idsPanelVisible', 'idsProgress',
-  'interactionMode', 'isolatedEntities', 'isolatedEntitiesByModel', 'lensAppliedColors',
+  'interactionMode', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId', 'layersPanelVisible',
+  'lensAppliedColors',
   'lensAppliedHiddenIds', 'lensAutoColorLegend', 'lensColorMap',
   'lensHiddenIds', 'lensPanelVisible', 'lensRuleCounts', 'lensRuleEntityIds',
   'lensRuleIsolation', 'listExecuting', 'listPanelVisible', 'listResult', 'loading',
@@ -87,6 +89,7 @@ const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
   'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'classFilter',
   'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
   'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId',
   'meshColorBackup', 'models', 'pinboardEntities', 'selectedEntities', 'selectedEntitiesSet',
   'selectedEntity', 'selectedEntityId', 'selectedEntityIds', 'selectedModelId', 'selectedStoreys',
 ];
@@ -132,6 +135,7 @@ const PINNED_MODEL_REMOVED_KEYS: readonly string[] = [
   'cloudAnnotation2DPoints', 'cloudAnnotations2D', 'contextMenu', 'drawing2DDisplayOptions', 'geometryResult',
   'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
   'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId',
   'measure2DCurrent', 'measure2DResults', 'measure2DSnapPoint', 'measure2DStart', 'meshColorBackup', 'models', 'pinboardEntities',
   'polygonArea2DPoints', 'polygonArea2DResults',
   'selectedAnnotation2D', 'selectedEntities', 'selectedEntitiesSet',
@@ -175,6 +179,13 @@ function modelRemovedFixture() {
     ifcDataStore: null,
     geometryResult: null,
     mutationViews: new Map(),
+    // #4309: a federated layer stack where entry 'A' is the model being
+    // removed (`LayerStackEntry.id` mirrors the `FederatedModel.id`
+    // `useIfcFederation.ts`'s per-layer `storeAddModel` loop assigns it).
+    layerStack: [{ id: 'A', name: 'a.ifcx' }],
+    layerStackPathToId: new Map([['wall-1', 42]]),
+    layerStackDiff: { layerId: 'A', diff: { added: [], deleted: [], modified: [] } },
+    layerDiffBusy: true,
   } as unknown as Parameters<typeof modelRemovedScope>[0];
 }
 
@@ -209,7 +220,9 @@ const PINNED_OWNED_KEYS: readonly string[] = [
   'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel', 'hierarchyBasketSelection',
   'hoverState', 'hoveredTaskGlobalId', 'idsActiveEntityId', 'idsActiveSpecificationId',
   'idsError', 'idsFocusVisibilityOwned', 'idsLoading', 'idsPanelVisible', 'idsProgress',
-  'ifcDataStore', 'interactionMode', 'isolatedEntities', 'isolatedEntitiesByModel', 'lensAppliedColors',
+  'ifcDataStore', 'interactionMode', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId', 'layersPanelVisible',
+  'lensAppliedColors',
   'lensAppliedHiddenIds', 'lensAutoColorLegend',
   'lensColorMap', 'lensHiddenIds', 'lensPanelVisible', 'lensRuleCounts', 'lensRuleEntityIds',
   'lensRuleIsolation', 'listExecuting', 'listPanelVisible', 'listResult', 'loading',

--- a/apps/viewer/src/store/teardown-registry.ts
+++ b/apps/viewer/src/store/teardown-registry.ts
@@ -73,6 +73,7 @@ import { addElementTeardown } from './slices/addElementSlice.teardown.js';
 import { modelPlacementTeardown } from './slices/modelPlacementSlice.js';
 import { pointCloudTeardown } from './slices/pointCloudSlice.js';
 import { zonesTeardown } from './slices/zonesSlice.js';
+import { layerStackTeardown } from './slices/layerStackSlice.teardown.js';
 
 /**
  * Every slice teardown the viewer store knows about.
@@ -111,6 +112,7 @@ export const viewerTeardownRegistry: readonly AnySliceTeardown[] = createTeardow
   pointCloudTeardown,
   modelPlacementTeardown,
   zonesTeardown,
+  layerStackTeardown,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

`layerStackSlice` (`apps/viewer/src/store/slices/layerStackSlice.ts`) holds the IFCX layer stack behind the Layers panel — `layerStack: LayerStackEntry[]` (each entry keeps the FULL PARSED layer document), `layerStackPathToId: Map<string, number> | null` (the slice's own doc comment calls this the "3D selection bridge"), and `layerStackDiff` — with no entry in `apps/viewer/src/store/teardown-registry.ts`.

`setLayerStack` has exactly one production call site: `useIfcFederation.ts`'s `loadFederatedIfcxFromBuffers`, which runs `resetViewerState()` then `clearAllModels()` then repopulates the stack synchronously — so a *fresh* federated load always lands correct. The gap is everything that can leave a *populated* stack behind afterward:

- **`modelSlice.removeModel`**, reachable directly from the Models panel, when the removed model is one of the composition's layers. Each federated layer is registered as its own `FederatedModel` with `id: layer.id` (`useIfcFederation.ts`'s per-layer `storeAddModel` loop), and `layerStackEntry()` (`lib/layers/stack.ts`) carries that same `layer.id` into `LayerStackEntry.id` — so removing one layer's model left `LayersPanel.tsx` still rendering the old composition, and `layerStackPathToId` still pointing 3D selection at express ids of a model that's gone.
- **`clearAllModels()`** called on its own — `modelSlice.ts` / `selectionSlice.teardown.ts` both document call sites (e.g. `GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`) not followed by `resetViewerState()`.
- Belt-and-suspenders for any load path that forgets `useIfcLoader.ts`'s existing explicit `clearLayerStack()` call on session-reset.

Closes #4309

## The fix

`layerStackSlice.teardown.ts` (sibling file, matching the `splitToolSlice.teardown.ts` shape from #4289) adds a `layerStackTeardown` contribution owning `layerStack`, `layerStackPathToId`, `layerStackDiff`, `layerDiffBusy`, and `layersPanelVisible`, registered in `teardown-registry.ts`.

- **`session-reset`** — unconditional clear, `layersPanelVisible: false`.
- **`model-removed`** — clears only when the removed model is one of `layerStack`'s entries (`entry.id === scope.modelId`); leaves an unrelated stack alone. `layersPanelVisible` is untouched.
- **`all-models-cleared`** — unconditional clear. `layersPanelVisible` is untouched.

**Panel-visibility ruling:** `layersPanelVisible` resets to `false` only on `session-reset`, matching the existing convention in `bcfSlice.teardown.ts` / `idsSlice.teardown.ts` / `sheetSlice.teardown.ts` (all three panel-visible flags there reset only on session-reset, not on `model-removed`/`all-models-cleared`). A genuinely new file load closes the layers panel; removing one layer out of a live federation, or an `all-models-cleared` not immediately followed by a fresh load, clears the composition data but leaves the panel open rather than yanking it shut under the user mid-session.

`teardown-registry.test.ts`'s four pinned key lists (session-reset, all-models-cleared, model-removed, owned) are widened accordingly. The `model-removed` fixture (`modelRemovedFixture()`) gains a `layerStack` entry with `id: 'A'`, the model the fixture removes, so the pin actually exercises this slice's membership check rather than passing vacuously.

## Stacking decision

Branched off `upstream/main`, not stacked on #4289 (`fix/4249-splittool-teardown`). #4289 is still open (mergeable status fluctuates as `main` advances; MERGEABLE as of 2026-09-09) — it hasn't landed, and its `teardown-exemptions.ts` (added by its own completeness guard) currently carries a `layerStackSlice` exemption entry describing this exact gap as "KNOWN GAP ... left for a follow-up." **Whichever of these two PRs lands second will need a small merge-time fix**: once this PR is in, #4289's `layerStackSlice` exemption entry becomes stale (the slice is registered, not exempt) and must be deleted, or its own completeness guard will correctly flag it as a *redundant* exemption (registered AND exempt) per that PR's own description of what the guard checks. I did not touch `teardown-exemptions.ts` here since it does not exist on `main` yet.

## Verification

- **RED/GREEN**: `apps/viewer/src/store/slices/layerStackSlice.teardown.test.ts` (new, 4 tests) — reproduces the stale state through the REAL `viewerTeardown` registry (via `createModelSlice`'s actual `removeModel`/`clearAllModels`, the same harness shape as `splitToolSlice.teardown.test.ts`), asserting real post-teardown VALUES (`layerStack` is `[]`, `layerStackPathToId` is `null`, etc.), not that a function was called. 4/4 GREEN.
- **Mutation test**: removed the `layerStackTeardown,` line from `viewerTeardownRegistry` — 2 of 4 subtests reddened (`removeModel`'s and `clearAllModels`'s), naming #4309-shaped failures. The `session-reset` subtest calls the teardown arm directly rather than through the registry, so it's unaffected by this particular mutation (expected — it's proving the arm's own shape, not the wiring). Restored, GREEN again.
- **`teardown-registry.test.ts`**: 5/5 GREEN, including "registers every teardown a slice exports" (the filesystem sweep that would catch a written-but-unregistered contribution) and all four pinned-key-list tests (which now include the widened `layerStack*`/`layerDiffBusy`/`layersPanelVisible` keys in both directions — dropped and added).
- **`layerStackSlice.test.ts`** (pre-existing): 10/10 GREEN, unaffected.
- `node scripts/check-module-size.mjs`: exit 1, but the two failing files (`packages/renderer/src/index.ts`, `packages/renderer/src/scene.ts`) are untouched by this branch (`git diff --stat upstream/main HEAD` for those two paths is empty) — pre-existing on `upstream/main`. None of my new/changed files are over budget.
- `git diff --stat upstream/main HEAD`: exactly the 5 files listed above (2 modified, 3 new).
- Changeset: `.changeset/layer-stack-teardown-registration.md` (patch, `@ifc-lite/viewer`).

Environment note: `apps/viewer` tests here required wiring several missing per-package `node_modules` symlinks and building `@ifc-lite/codegen`'s `dist/` locally (the environment's own copy has a dangling symlink into a deleted `/tmp` path) before any test in this transitive import chain would run — this is the same documented `apps/viewer` blocker class (`fflate`/`jszip`/`@noble/hashes`/missing wasm), not a defect in this change; all numbers above are genuinely GREEN runs, not counted-as-green blocked runs.

## Not checked

- Whether the same "known gap" language also needs updating anywhere else that cites the old unregistered state (I did not search beyond `teardown-exemptions.ts` on #4289's branch, which this PR does not touch).
