### PR TITLE
fix(viewer): keep construction projection consistent after model moves

### DIFF
--- a/.changeset/moody-dolls-find.md
+++ b/.changeset/moody-dolls-find.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/viewer": patch
+"@ifc-lite/renderer": patch
+---
+
+Keep construction projection scoped to the same floor after repositioning a model. Clarify the renderer contract for rebuilding surviving instance bounds during a flat-geometry reset.

--- a/.changeset/moody-dolls-find.md
+++ b/.changeset/moody-dolls-find.md
@@ -1,6 +1,7 @@
 ---
 "@ifc-lite/viewer": patch
 "@ifc-lite/renderer": patch
+"@ifc-lite/mutations": patch
 ---
 
-Keep construction projection scoped to the same floor after repositioning a model. Clarify the renderer contract for rebuilding surviving instance bounds during a flat-geometry reset.
+Keep construction projection scoped to the same floor after repositioning a model. Remove unused declarations left after the atomic-overlay and batch-upload refactors, and clarify the renderer contract for rebuilding surviving instance bounds during a flat-geometry reset.

--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -548,3 +548,20 @@ for (const flipped of [false, true]) it(`keeps construction bands and lines when
     }
   }
 });
+
+it('recomputes projection bands when storey membership changes on the same geometry (#4332)', async () => {
+  const geometryResult = geometry(STOREY_MESHES, [0, -3, 0], [4, 6, 4]);
+  const source = contiguousSourceBytes(new TextEncoder().encode(NO_PROFILE_IFC));
+  const drawings = await generateSequence([STOREY_UPPER, STOREY_LOWER].map((upperSlabStorey) => ({
+    geometryResult, typeVisibility: ALL_VISIBLE,
+    ifcDataStore: { source, spatialHierarchy: spatialHierarchy(new Map([
+      [BASEMENT_SLAB, STOREY_LOWER], [CUT_WALL, STOREY_LOWER], [UPPER_SLAB, upperSlabStorey],
+    ])) },
+  })));
+  const [twoStoreys, oneStorey] = drawings;
+  assert.ok(twoStoreys); assert.ok(oneStorey);
+  assert.equal(twoStoreys.config.projectionBelowDepth, 4.5);
+  assert.equal(twoStoreys.config.projectionAboveDepth, 1.5);
+  assert.equal(oneStorey.config.projectionBelowDepth, 9, 'a single storey uses the full model extent');
+  assert.equal(oneStorey.config.projectionAboveDepth, 9, 'old membership must not retain a phantom ceiling');
+});

--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -156,12 +156,19 @@ const SPACES_HIDDEN: TypeVisibilityGate = { ...ALL_VISIBLE, spaces: false };
 interface HarnessOptions {
   geometryResult: GeometryResult;
   typeVisibility: TypeVisibilityGate;
+  flipped?: boolean;
   ifcDataStore: { source: IfcSourceBytes; spatialHierarchy?: SpatialHierarchy } | null;
 }
 
 /** Drive the real hook once, with construction projection ON, and return the
  *  drawing it publishes. */
 async function generate(options: HarnessOptions): Promise<Drawing2D | null> {
+  return (await generateSequence([options]))[0];
+}
+
+/** Keep the hook mounted so regeneration exercises its caches. */
+async function generateSequence(sequence: HarnessOptions[]): Promise<Array<Drawing2D | null>> {
+  let options = sequence[0];
   let drawing: Drawing2D | null = null;
   let run: (() => Promise<void>) | null = null;
 
@@ -170,7 +177,7 @@ async function generate(options: HarnessOptions): Promise<Drawing2D | null> {
       activeTool: 'select',
       geometryResult: options.geometryResult,
       ifcDataStore: options.ifcDataStore,
-      sectionPlane: { axis: 'down', position: 50, flipped: false },
+      sectionPlane: { axis: 'down', position: 50, flipped: options.flipped ?? false },
       displayOptions: {
         showHiddenLines: false,
         useSymbolicRepresentations: false,
@@ -202,10 +209,15 @@ async function generate(options: HarnessOptions): Promise<Drawing2D | null> {
   document.body.appendChild(container);
   let root: Root | null = null;
   try {
-    await act(async () => { root = createRoot(container); root.render(<Harness />); });
-    assert.ok(run, 'harness never rendered — the hook was not called');
-    await act(async () => { await run!(); });
-    return drawing;
+    root = createRoot(container);
+    const drawings: Array<Drawing2D | null> = [];
+    for (options of sequence) {
+      await act(async () => { root!.render(<Harness />); });
+      assert.ok(run, 'harness never rendered — the hook was not called');
+      await act(async () => { await run!(); });
+      drawings.push(drawing);
+    }
+    return drawings;
   } finally {
     if (root) await act(async () => { root!.unmount(); });
     container.remove();
@@ -504,4 +516,34 @@ describe('useDrawingGeneration construction projection: profile route mirrors th
       `mirror; got ${[...ids]}`,
     );
   });
+});
+
+
+for (const flipped of [false, true]) it(`keeps construction bands and lines when the model and cut move together (flipped: ${flipped}, #4332)`, async () => {
+  const source = {
+    source: contiguousSourceBytes(new TextEncoder().encode(NO_PROFILE_IFC)),
+    spatialHierarchy: spatialHierarchy(new Map([
+      [BASEMENT_SLAB, STOREY_LOWER], [CUT_WALL, STOREY_LOWER], [UPPER_SLAB, STOREY_UPPER],
+    ])),
+  };
+  // Same model/source/hierarchy for every generation. Only the displayed
+  // origins and cut bounds move; the source buffers stay in their local frame.
+  const drawings = await generateSequence([0, 100, -100, 0].map((y) => ({
+    geometryResult: geometry(STOREY_MESHES.map((mesh) => ({ ...mesh, origin: [0, y, 0] })), [0, -3 + y, 0], [4, 6 + y, 4]),
+    typeVisibility: ALL_VISIBLE, ifcDataStore: source, flipped,
+  })));
+  const first = drawings[0];
+  assert.ok(first?.lines.some((line) => line.category === 'projection'), 'real mesh projection must produce lines');
+  for (const next of drawings.slice(1)) {
+    assert.ok(next);
+    assert.equal(next.config.projectionBelowDepth, first.config.projectionBelowDepth, 'floor band follows the placed model');
+    assert.equal(next.config.projectionAboveDepth, first.config.projectionAboveDepth, 'ceiling band follows the placed model');
+    assert.equal(next.lines.length, first.lines.length);
+    for (let i = 0; i < first.lines.length; i++) {
+      const { depth: expectedDepth, ...expectedLine } = first.lines[i];
+      const { depth, ...line } = next.lines[i];
+      assert.deepEqual(line, expectedLine, 'moving along the cut normal preserves every projected endpoint and style');
+      assert.ok(Math.abs(depth - expectedDepth) < 1e-5, 'projection depth is stable within float32 rounding at 100 m');
+    }
+  }
 });

--- a/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingGeneration.projection.test.tsx
@@ -533,17 +533,18 @@ for (const flipped of [false, true]) it(`keeps construction bands and lines when
     typeVisibility: ALL_VISIBLE, ifcDataStore: source, flipped,
   })));
   const first = drawings[0];
-  assert.ok(first?.lines.some((line) => line.category === 'projection'), 'real mesh projection must produce lines');
+  assert.ok(first);
+  assert.ok(first.lines.some((line) => line.category === 'projection'), 'real mesh projection must produce lines');
   for (const next of drawings.slice(1)) {
     assert.ok(next);
     assert.equal(next.config.projectionBelowDepth, first.config.projectionBelowDepth, 'floor band follows the placed model');
     assert.equal(next.config.projectionAboveDepth, first.config.projectionAboveDepth, 'ceiling band follows the placed model');
     assert.equal(next.lines.length, first.lines.length);
     for (let i = 0; i < first.lines.length; i++) {
-      const { depth: expectedDepth, ...expectedLine } = first.lines[i];
-      const { depth, ...line } = next.lines[i];
-      assert.deepEqual(line, expectedLine, 'moving along the cut normal preserves every projected endpoint and style');
-      assert.ok(Math.abs(depth - expectedDepth) < 1e-5, 'projection depth is stable within float32 rounding at 100 m');
+      const expected: Drawing2D['lines'][number] = first.lines[i];
+      const actual: Drawing2D['lines'][number] = next.lines[i];
+      assert.deepEqual({ ...actual, depth: expected.depth }, expected, 'moving along the cut normal preserves every projected endpoint and style');
+      assert.ok(Math.abs(actual.depth - expected.depth) < 1e-5, 'projection depth is stable within float32 rounding at 100 m');
     }
   }
 });

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -182,12 +182,12 @@ export function useDrawingGeneration({
   // Cache for per-storey floor levels used to scope construction projection to
   // the current floor. Unlike source profiles, these are DISPLAYED mesh-Y
   // values: a placement or geometry edit invalidates them even if the model
-  // identity stays unchanged (#4332).
-  const storeyFloorsCacheRef = useRef<{
+  // identity stays unchanged (#4332). Weak keys must not keep an unloaded
+  // model's mesh buffers alive while the hidden drawing panel stays mounted.
+  const storeyFloorsCacheRef = useRef(new WeakMap<GeometryResult, {
     floors: number[];
-    geometry: GeometryResult;
     elementToStorey: ReadonlyMap<number, number>;
-  } | null>(null);
+  }>());
 
   // Generate drawing when panel opens
   const computeDrawing = useCallback(async (isRegenerate = false, isCurrent: () => boolean = () => true) => {
@@ -419,11 +419,11 @@ export function useDrawingGeneration({
         sh !== undefined &&
         sh.byBuilding.size <= 1;
       if (canScopeFloor && sh) {
-        const cached = storeyFloorsCacheRef.current;
-        const floorsCurrent = cached?.geometry === geometryResult && cached.elementToStorey === sh.elementToStorey;
+        const cached = storeyFloorsCacheRef.current.get(geometryResult);
+        const floorsCurrent = cached?.elementToStorey === sh.elementToStorey;
         const floors = floorsCurrent ? cached.floors : storeyFloorsFromMeshes(modelMeshes, sh.elementToStorey);
         if (!floorsCurrent) {
-          storeyFloorsCacheRef.current = { floors, geometry: geometryResult, elementToStorey: sh.elementToStorey };
+          storeyFloorsCacheRef.current.set(geometryResult, { floors, elementToStorey: sh.elementToStorey });
         }
         // Need ≥2 storeys to scope: with 0/1 storey there is no "other floor"
         // to exclude, and full extent keeps an overhead roof projecting.

--- a/apps/viewer/src/hooks/useDrawingGeneration.ts
+++ b/apps/viewer/src/hooks/useDrawingGeneration.ts
@@ -180,12 +180,13 @@ export function useDrawingGeneration({
   } | null>(null);
 
   // Cache for per-storey floor levels used to scope construction projection to
-  // the current floor (issue #979 follow-up). Derived from mesh-Y, so it only
-  // changes when the model/visibility set changes — keyed on the same
-  // `modelCacheKey` as the profile cache.
+  // the current floor. Unlike source profiles, these are DISPLAYED mesh-Y
+  // values: a placement or geometry edit invalidates them even if the model
+  // identity stays unchanged (#4332).
   const storeyFloorsCacheRef = useRef<{
     floors: number[];
-    sourceId: string | null;
+    geometry: GeometryResult;
+    elementToStorey: ReadonlyMap<number, number>;
   } | null>(null);
 
   // Generate drawing when panel opens
@@ -419,12 +420,10 @@ export function useDrawingGeneration({
         sh.byBuilding.size <= 1;
       if (canScopeFloor && sh) {
         const cached = storeyFloorsCacheRef.current;
-        const floors =
-          cached && cached.sourceId === modelCacheKey
-            ? cached.floors
-            : storeyFloorsFromMeshes(modelMeshes, sh.elementToStorey);
-        if (!cached || cached.sourceId !== modelCacheKey) {
-          storeyFloorsCacheRef.current = { floors, sourceId: modelCacheKey };
+        const floorsCurrent = cached?.geometry === geometryResult && cached.elementToStorey === sh.elementToStorey;
+        const floors = floorsCurrent ? cached.floors : storeyFloorsFromMeshes(modelMeshes, sh.elementToStorey);
+        if (!floorsCurrent) {
+          storeyFloorsCacheRef.current = { floors, geometry: geometryResult, elementToStorey: sh.elementToStorey };
         }
         // Need ≥2 storeys to scope: with 0/1 storey there is no "other floor"
         // to exclude, and full extent keeps an overhead roof projecting.

--- a/apps/viewer/src/lib/export/portable-ifc.ts
+++ b/apps/viewer/src/lib/export/portable-ifc.ts
@@ -9,6 +9,8 @@ interface Resources {
   exportResources(modelId: string): { modelPath?: string; resources: Map<string, Uint8Array> };
 }
 function safePath(path: string): string {
+  // Archive paths deliberately reject ASCII control characters as unsafe names.
+  // eslint-disable-next-line no-control-regex
   if (!path || path.startsWith('/') || /[\\\\\u0000-\u001f\u007f:]/.test(path) || path.split('/').some(part => !part || part === '..' || part === '.')) {
     throw new Error('Cannot package this texture archive: it contains an unsafe relative path. Rename its model/image entries and reload.');
   }

--- a/apps/viewer/src/lib/panels/mobile-sheet-coverage.test.ts
+++ b/apps/viewer/src/lib/panels/mobile-sheet-coverage.test.ts
@@ -22,6 +22,8 @@
 import '@/test/setup-dom.js';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { isValidElement, Suspense, type ReactNode } from 'react';
+import { ChunkErrorBoundary } from '@/components/ChunkErrorBoundary';
 import { WORKSPACE_PANELS, getPanelDef } from './registry.js';
 import { renderPanelBody } from './renderPanelBody.js';
 
@@ -44,9 +46,16 @@ describe('workspace panel registry coverage', () => {
     // Properties. Compares the element TYPE, which is the component function.
     const byType = new Map<unknown, string[]>();
     for (const panel of WORKSPACE_PANELS) {
-      const body = renderPanelBody(panel.id, () => {}) as { type?: unknown } | null;
-      const type = body?.type;
-      if (type === undefined) continue;
+      let body = renderPanelBody(panel.id, () => {});
+      // #4243: Layers and Appearance share loading/error hosts, not content.
+      // Compare the actual panel beneath those hosts so the fall-through
+      // regression remains detectable without rejecting legitimate wrappers.
+      while (isValidElement<{ children?: ReactNode }>(body) &&
+        (body.type === ChunkErrorBoundary || body.type === Suspense)) {
+        body = body.props.children;
+      }
+      assert.ok(isValidElement(body), `${panel.id} must have panel content beneath its loading/error hosts`);
+      const type = body.type;
       const ids = byType.get(type) ?? [];
       ids.push(panel.id);
       byType.set(type, ids);

--- a/packages/mutations/src/atomic-overlay.test.ts
+++ b/packages/mutations/src/atomic-overlay.test.ts
@@ -201,7 +201,7 @@ describe('atomic overlay editing #4243', () => {
   });
 
   it('retains detached cyclic publication and refuses rollback over escaped changes #4243', () => {
-    const { view, editor, item } = fixture();
+    const { view, item } = fixture();
     const cycle: IfcAttributeValue[] = [1];
     cycle.push(cycle);
     let escaped: MutablePropertyView | undefined;

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -1105,10 +1105,9 @@ export class Renderer {
     }
 
     /**
-     * Set (or clear, with `null`) a streamed point-cloud asset's per-vertex
-     * GPU model matrix (column-major, 16 floats) — issue #1804's
-     * `IfcMapConversion` alignment toggle. Cheap: takes effect on the next
-     * frame's uniform write, no GPU buffer rewrite.
+     * Set/clear a streamed cloud's column-major model matrix (16 floats) for
+     * IfcMapConversion alignment (#1804). Applied on the next frame's uniform
+     * write without rewriting vertex buffers.
      */
     setPointCloudTransform(
         handle: import('./pointcloud/point-cloud-renderer.js').PointCloudAssetHandle,

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3792,22 +3792,12 @@ export class Scene {
   }
 
   /**
-   * Clear flat/batched geometry (meshes, batches, buckets, textured meshes,
-   * colour overlays, streaming state, residency bookkeeping) WITHOUT
-   * touching GPU-instanced templates (#2073). A reshape that still has at
-   * least one model present should call this instead of `clear()`, then
-   * reconcile instanced ownership with `removeInstancedTemplatesForModel`
-   * for any model that did NOT survive — that way a still-loaded model's
-   * repeated geometry (windows, doors, bolts, ...) stays resident across a
-   * visibility toggle / in-place content mutation / federated model add
-   * instead of silently vanishing (nothing re-uploads instanced shard bytes
-   * after their one-time drain).
-   *
-   * Bounding boxes are only dropped for ids with NO surviving instanced
-   * occurrence — an instanced-only id's box must outlive this call so
-   * raycast / measure / section keep working for the geometry that was
-   * just retained; a flat-only id's box is stale the moment its mesh data
-   * is gone, so it is dropped like everything else here.
+   * Clear flat/batched geometry, textures, overlays and streaming/residency
+   * state while preserving GPU-instanced templates (#2073). Reshapes use this
+   * instead of clear(), then removeInstancedTemplatesForModel for departed
+   * models: surviving shards are not uploaded again after their initial drain.
+   * Drop retained flat bounds and rebuild boxes from surviving instances so
+   * picking and sections cannot see a removed flat contribution (#4226).
    */
   clearFlatGeometry(): void {
     this.appearanceController?.forget();

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -24,7 +24,7 @@ import {
   rayIntersectsBox,
 } from './scene-raycaster.js';
 import { selectBoundingBoxesInRect } from './scene-rect-select.js';
-import { mergeGeometry, splitMeshDataForBufferLimit, cachedWorldAabb, worldAabbFromPieces, destroyGpuResources } from './scene-geometry.js';
+import { splitMeshDataForBufferLimit, cachedWorldAabb, worldAabbFromPieces, destroyGpuResources } from './scene-geometry.js';
 import { sumResidentGpuBytes, type ResidentGpuBytes } from './render-stats.js';
 import { composeInstancedOverrideColor } from './instanced-override-color.js';
 import { bucketBaseKeyFor, type SpatialChunkingConfig } from './chunk-grid.js';
@@ -2512,19 +2512,6 @@ export class Scene {
       this.sharedFrameOrigins.set(modelIndex, [result.origin[0] - offset[0], result.origin[1] - offset[1], result.origin[2] - offset[2]]);
     }
     return this.modelTranslations.registerDrawable(result, modelIndex);
-  }
-
-  /**
-   * Merge multiple mesh geometries into single vertex/index buffers.
-   * Delegates to the extracted mergeGeometry() utility.
-   */
-  private mergeGeometry(meshDataArray: MeshData[], forcedOrigin?: [number, number, number]): {
-    vertexData: Float32Array;
-    indices: Uint32Array;
-    bounds: { min: [number, number, number]; max: [number, number, number] };
-    origin: [number, number, number];
-  } {
-    return mergeGeometry(meshDataArray, forcedOrigin);
   }
 
   /**

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -1,6 +1,6 @@
 {
-  "apps/viewer": 301,
-  "apps/viewer-embed": 303,
+  "apps/viewer": 283,
+  "apps/viewer-embed": 285,
   "examples/babylonjs-viewer": 1,
   "examples/collab-demo": 1,
   "examples/threejs-collab": 1,
@@ -25,7 +25,7 @@
   "packages/extensions": 4,
   "packages/geometry": 7,
   "packages/ids": 10,
-  "packages/ifcx": 16,
+  "packages/ifcx": 7,
   "packages/lens": 0,
   "packages/lists": 0,
   "packages/mcp": 4,

--- a/tests/e2e/model-reposition.e2e.spec.ts
+++ b/tests/e2e/model-reposition.e2e.spec.ts
@@ -274,3 +274,44 @@ test('sectioning follows a real IFC moved above its original extent (#4226)', as
   await info.attach('Real IFC section after 100 m elevation move', { body: await page.screenshot(), contentType: 'image/png' });
   expect(await page.evaluate(() => [...globalThis.__ifc_lite_viewer_store__.getState().modelPlacement.placements.values()][0].translation)).toEqual([0, 0, 100]);
 });
+
+test('construction projection is invariant when the model and cut move together (#4332)', async ({ page }, info) => {
+  test.skip(!existsSync(IFC), 'Real IFC fixture missing — run pnpm fixtures');
+  const errors: string[] = [];
+  page.on('console', (message) => { if (message.text().includes('Profile extraction failed')) errors.push(message.text()); });
+  await page.goto('/'); await load(page, IFC, 1);
+  await page.evaluate(() => {
+    const s = globalThis.__ifc_lite_viewer_store__.getState();
+    s.updateDrawing2DDisplayOptions({ showConstructionProjection: true });
+    s.setSectionPlaneAxis('down'); s.setSectionPlanePosition(50); s.setSectionPlaneEnabled(true); s.setActiveTool('section');
+  });
+  await page.waitForFunction(() => {
+    const s = globalThis.__ifc_lite_viewer_store__.getState();
+    return s.drawing2DStatus === 'ready' && s.drawing2D?.lines.some((line) => line.category === 'projection');
+  });
+  const snapshot = () => page.evaluate(() => {
+    const drawing = globalThis.__ifc_lite_viewer_store__.getState().drawing2D!;
+    const lines = drawing.lines.filter((line) => line.category === 'projection').map((line) =>
+      [line.entityId, line.line.start.x, line.line.start.y, line.line.end.x, line.line.end.y]);
+    lines.sort((a, b) => { for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return a[i] - b[i]; return 0; });
+    return { position: drawing.config.plane.position, bands: [drawing.config.projectionBelowDepth, drawing.config.projectionAboveDepth], lines };
+  });
+  const before = await snapshot();
+  await page.evaluate(() => {
+    const s = globalThis.__ifc_lite_viewer_store__.getState();
+    s.openReposition([...s.models.keys()]); s.previewModelTranslation([0, 0, 100]); s.applyModelTranslation(); s.closeReposition(); s.setActiveTool('section');
+  });
+  await page.waitForFunction((expected) => {
+    const s = globalThis.__ifc_lite_viewer_store__.getState();
+    return s.drawing2DStatus === 'ready' && Math.abs((s.drawing2D?.config.plane.position ?? 0) - expected) < 0.0001;
+  }, before.position + 100);
+  const after = await snapshot();
+  expect(errors).toEqual([]);
+  expect(after.lines).toHaveLength(before.lines.length);
+  for (let i = 0; i < before.bands.length; i++) expect(after.bands[i]).toBeCloseTo(before.bands[i]!, 5);
+  await info.attach('Construction projection before and after 100 m move', { body: JSON.stringify({ before, after }), contentType: 'application/json' });
+  for (let i = 0; i < before.lines.length; i++) {
+    expect(after.lines[i][0]).toBe(before.lines[i][0]);
+    for (let axis = 1; axis < 5; axis++) expect(Math.abs(after.lines[i][axis] - before.lines[i][axis])).toBeLessThan(0.005);
+  }
+});


### PR DESCRIPTION
Moving a model and its section cut together reused construction-projection floor elevations from the old placement. On the real Archicad AC20-FZK-Haus fixture, a 100 m vertical move expanded the drawing from 250 to 826 projection lines. It now retains 250 lines, matching endpoints and floor/ceiling bands.

Cache floors in a WeakMap keyed by displayed geometry, checking storey membership before reuse. Moves, geometry replacements and membership changes invalidate stale elevations; the cache cannot keep unloaded geometry buffers alive. Source-derived profiles retain the existing authored-frame cache and placement-at-use behavior.

Closes #4332; completes the deferred projection finding from #4270 / #4226. The source-byte GLB finding from #4256 was already fixed: the mounted dialog and desktop/mobile quick-export regressions passed, and its stale review thread is resolved.

Validation:
- Seven mounted projection tests pass, including positive/negative/return moves, both section directions, and changed storey membership on unchanged geometry. Reverting only the production fix makes three assertions fail (7 passes → 4 passes / 3 failures); restoration is verified.
- Strict production-browser regression reproduces 250 → 826 before the fix and passes afterward. All four repositioning browser scenarios pass with no skips or flakes.
- The panel-coverage regression passes and still detects a deliberately misrouted Appearance → Layers body (3 passes → 2 passes / 1 failure).
- Final full viewer/renderer/mutations suites, typecheck, lint and hosted CI are tracked in the validation comment before merge.

Integration cleanup needed to clear existing main gates: remove an unused scene wrapper and test binding left by the batch-upload/atomic-overlay refactors; tighten the measured unused-declaration baseline; shorten/correct reset documentation; compare actual panel content beneath shared loading/error hosts in the mobile registry test. The first full viewer run had 7,475 passes, eight skips and only that wrapper-identity test failure. No renderer public API or runtime rendering behavior changes.
