### PR TITLE
fix(viewer): expose IfcWorkPlan creation in the schedule authoring UI

### DIFF
--- a/.changeset/expose-workplan-authoring.md
+++ b/.changeset/expose-workplan-authoring.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+The Generate schedule dialog's Advanced panel can now add a standalone
+`IfcWorkPlan` container alongside the generated `IfcWorkSchedule`
+(`schedule-utils.ts`'s new `buildWorkPlanInfo`). Previously `IfcWorkPlan` was
+parsed, serialized, and scriptable via `bim.author.addIfcWorkPlan`, but the
+schedule authoring UI had no way to create one.
+
+The plan is intentionally standalone, not grouped with the schedule: neither
+relation the schema allows for that grouping round-trips today.
+`schedule-extractor.ts`'s `IfcRelAssignsToControl` pass only resolves
+`RelatedObjects` through the task table, so a schedule assigned to a plan
+that way is silently dropped on read (the same blindness the existing
+`assignSchedulesToWorkPlan` SDK helper would hit); a parallel `IfcRelNests`
+gap is tracked separately (#4329/#4330). Shipping a UI that produces a
+grouping relation whose read path drops it would be worse than the missing
+feature, so this PR emits the plan with no `taskGlobalIds` and no relation
+at all.
+
+`GanttToolbar`'s schedule filter dropdown now excludes `kind === 'WorkPlan'`
+entries — one never directly controls a task, so listing it as a filter
+option would always resolve to zero rows.

--- a/apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx
@@ -103,7 +103,7 @@ export function GanttToolbar({ onClose, onOpenGenerate, onOpenImport, canGenerat
     if (!scheduleData) return [];
     return [
       { value: ALL_SCHEDULES_SENTINEL, label: 'All tasks' },
-      ...scheduleData.workSchedules.map(s => ({
+      ...scheduleData.workSchedules.filter(s => s.kind === 'WorkSchedule').map(s => ({ // 'WorkPlan' never controls tasks directly
         value: s.globalId,
         label: s.name || s.globalId,
       })),

--- a/apps/viewer/src/components/viewer/schedule/GenerateAdvancedPanel.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GenerateAdvancedPanel.tsx
@@ -36,6 +36,18 @@ export interface GenerateAdvancedPanelProps {
     key: K,
     value: GenerateScheduleOptions[K],
   ) => void;
+  /**
+   * Whether to add a standalone `IfcWorkPlan` container alongside the
+   * generated `IfcWorkSchedule`. Kept out of `GenerateScheduleOptions` (its
+   * own on/off + name pair here) rather than folded into the generator's
+   * options — the plan isn't grouped with the schedule (see
+   * `buildWorkPlanInfo`'s doc comment for why), so it doesn't belong to the
+   * generation algorithm itself.
+   */
+  createWorkPlan: boolean;
+  onCreateWorkPlanChange: (next: boolean) => void;
+  workPlanName: string;
+  onWorkPlanNameChange: (next: string) => void;
 }
 
 export function GenerateAdvancedPanel({
@@ -48,6 +60,10 @@ export function GenerateAdvancedPanel({
   linkSequences,
   skipEmptyGroups,
   onChange,
+  createWorkPlan,
+  onCreateWorkPlanChange,
+  workPlanName,
+  onWorkPlanNameChange,
 }: GenerateAdvancedPanelProps) {
   return (
     <div className="rounded-md border">
@@ -121,6 +137,23 @@ export function GenerateAdvancedPanel({
             checked={skipEmptyGroups}
             onChange={(v) => onChange('skipEmptyGroups', v)}
           />
+          <ToggleRow
+            label="Add an IfcWorkPlan container"
+            description="A standalone plan entity alongside the schedule — not yet grouped with it (grouping doesn't round-trip)."
+            checked={createWorkPlan}
+            onChange={onCreateWorkPlanChange}
+          />
+          {createWorkPlan && (
+            <div className="grid gap-1.5">
+              <Label htmlFor="gen-plan-name">Work plan name</Label>
+              <Input
+                id="gen-plan-name"
+                value={workPlanName}
+                onChange={(e) => onWorkPlanNameChange(e.target.value)}
+                placeholder="Project plan"
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx
@@ -30,7 +30,6 @@ import { Label } from '@/components/ui/label';
 import { useViewerStore } from '@/store';
 import { resolveScheduleSourceModelId } from '@/store/slices/schedule-edit-helpers';
 import { useIfc } from '@/hooks/useIfc';
-import { serializeScheduleToStep } from '@ifc-lite/parser';
 import {
   generateScheduleFromSpatialHierarchy,
   canGenerateScheduleFrom,
@@ -40,7 +39,7 @@ import {
   type GenerateScheduleOptions,
   type GenerateOrder,
 } from './generate-schedule';
-import { formatDateTime } from './schedule-utils';
+import { formatDateTime, buildWorkPlanInfo, logGeneratedScheduleDebug } from './schedule-utils';
 import { HeightStrategyPanel } from './HeightStrategyPanel';
 import { GenerateAdvancedPanel } from './GenerateAdvancedPanel';
 
@@ -78,6 +77,10 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
   const [options, setOptions] = useState<GenerateScheduleOptions>(DEFAULT_OPTIONS);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // Standalone IfcWorkPlan — see `buildWorkPlanInfo`'s doc comment for why
+  // it's kept out of `GenerateScheduleOptions` and composed in here instead.
+  const [createWorkPlan, setCreateWorkPlan] = useState(false);
+  const [workPlanName, setWorkPlanName] = useState('Project plan');
 
   // Reset form state on every (re)open so users can reuse the dialog.
   useEffect(() => {
@@ -88,6 +91,8 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
       setOptions({ ...DEFAULT_OPTIONS, startDate: defaultStartDate() });
       setAdvancedOpen(false);
       setSubmitting(false);
+      setCreateWorkPlan(false);
+      setWorkPlanName('Project plan');
     }
   }, [open]);
 
@@ -122,40 +127,22 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
     if (!preview || preview.empty) return;
     setSubmitting(true);
 
-    // DEBUG: full inspection of what's being added to the model. Dumps the
-    // extraction (tasks + work schedules + sequences) *and* the STEP lines
-    // the serializer will emit when the file is exported. Safe to keep —
-    // runs only on user-initiated generation and only logs to console.
-    try {
-      const extraction = preview.extraction;
-      const stepPreview = serializeScheduleToStep(extraction, {
-        // These IDs don't matter for inspection — the export adapter
-        // remaps them to the host file's ID space at injection time.
-        nextId: 1_000_000,
-      });
-      /* eslint-disable no-console */
-      console.groupCollapsed(
-        `%c[IfcTask] Generated schedule — ${extraction.tasks.length} task(s), ${stepPreview.lines.length} STEP line(s)`,
-        'color:#6ea2ff;font-weight:bold',
-      );
-      console.log('options', options);
-      console.log('workSchedules', extraction.workSchedules);
-      console.log('tasks', extraction.tasks);
-      console.log('sequences', extraction.sequences);
-      console.log('stats', stepPreview.stats);
-      console.log('STEP preview (first 50 lines):');
-      for (const line of stepPreview.lines.slice(0, 50)) console.log(line);
-      if (stepPreview.lines.length > 50) {
-        console.log(`… ${stepPreview.lines.length - 50} more line(s). Full STEP:`);
-        console.log(stepPreview.lines.join('\n'));
-      }
-      console.log('raw extraction (JSON)', JSON.stringify(extraction, null, 2));
-      console.groupEnd();
-      /* eslint-enable no-console */
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('[IfcTask] Debug log failed (non-fatal):', err);
-    }
+    // Compose in the optional standalone IfcWorkPlan. A new object, not a
+    // mutation of `preview.extraction` — that object is `useMemo`-cached
+    // and reused across renders until `options` changes, so mutating it
+    // in place would leak the plan into a later preview that didn't ask
+    // for one.
+    const extraction = createWorkPlan
+      ? {
+          ...preview.extraction,
+          workSchedules: [
+            ...preview.extraction.workSchedules,
+            buildWorkPlanInfo(preview.extraction.workSchedules[0]?.globalId ?? 'workplan', workPlanName),
+          ],
+        }
+      : preview.extraction;
+
+    logGeneratedScheduleDebug(extraction, options);
 
     // rAF gives the button time to paint its pressed state before we swap
     // the Gantt rows; cheap-but-visible feedback.
@@ -164,13 +151,13 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
       // Legacy single-model sessions fall back to '__legacy__' so the
       // dirty flag still pairs with the viewer's model identity.
       const sourceModelId = resolveScheduleSourceModelId(models, activeModelId, '__legacy__');
-      commitGeneratedSchedule(preview.extraction, sourceModelId);
+      commitGeneratedSchedule(extraction, sourceModelId);
       setGanttPanelVisible(true);
       setAnimationEnabled(true);
       setSubmitting(false);
       onOpenChange(false);
     });
-  }, [preview, options, commitGeneratedSchedule, setGanttPanelVisible, setAnimationEnabled, onOpenChange, activeModelId, models]);
+  }, [preview, options, createWorkPlan, workPlanName, commitGeneratedSchedule, setGanttPanelVisible, setAnimationEnabled, onOpenChange, activeModelId, models]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -311,6 +298,10 @@ export function GenerateScheduleDialog({ open, onOpenChange }: GenerateScheduleD
               linkSequences={options.linkSequences}
               skipEmptyGroups={options.skipEmptyGroups}
               onChange={handleChange}
+              createWorkPlan={createWorkPlan}
+              onCreateWorkPlanChange={setCreateWorkPlan}
+              workPlanName={workPlanName}
+              onWorkPlanNameChange={setWorkPlanName}
             />
 
             {/* Live summary */}

--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
@@ -5,7 +5,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { ScheduleExtraction, ScheduleTaskInfo } from '@ifc-lite/parser';
-import { flattenTaskTree } from './schedule-utils.js';
+import { flattenTaskTree, buildWorkPlanInfo } from './schedule-utils.js';
 
 function task(
   globalId: string,
@@ -82,5 +82,28 @@ describe('flattenTaskTree', () => {
     const rows = flattenTaskTree(data, new Set(['A', 'B']), 'some-other-schedule');
 
     assert.deepEqual(rows, []);
+  });
+});
+
+describe('buildWorkPlanInfo', () => {
+  it('builds a standalone IfcWorkPlan with the given name and no task links', () => {
+    const plan = buildWorkPlanInfo('seed-1', 'Project plan');
+
+    assert.equal(plan.kind, 'WorkPlan');
+    assert.equal(plan.name, 'Project plan');
+    assert.deepEqual(plan.taskGlobalIds, []);
+    assert.equal(typeof plan.globalId, 'string');
+    assert.ok(plan.globalId.length > 0);
+  });
+
+  it('is deterministic for the same seed and distinct for different seeds', () => {
+    const a1 = buildWorkPlanInfo('schedule-gid-A', 'Plan A');
+    const a2 = buildWorkPlanInfo('schedule-gid-A', 'Plan A (renamed)');
+    const b = buildWorkPlanInfo('schedule-gid-B', 'Plan A');
+
+    // Same seed -> same globalId, independent of the name.
+    assert.equal(a1.globalId, a2.globalId);
+    // Different seed -> different globalId.
+    assert.notEqual(a1.globalId, b.globalId);
   });
 });

--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
@@ -7,7 +7,8 @@
  * task-tree flattener that feeds the virtualized list.
  */
 
-import type { ScheduleExtraction, ScheduleTaskInfo } from '@ifc-lite/parser';
+import type { ScheduleExtraction, ScheduleTaskInfo, WorkScheduleInfo } from '@ifc-lite/parser';
+import { deterministicGlobalId, serializeScheduleToStep } from '@ifc-lite/parser';
 import type { GanttTimeScale } from '@/store';
 import { taskStartEpoch, taskFinishEpoch } from '@/store';
 
@@ -237,6 +238,69 @@ export function taskBarGeometry(
 /**
  * Produce a short "5d" / "3h" / "2w" label from an ISO 8601 duration string.
  */
+/**
+ * Build a standalone `IfcWorkPlan` container to add alongside a generated
+ * `IfcWorkSchedule`.
+ *
+ * Grouping an `IfcWorkPlan` around its `IfcWorkSchedule`s doesn't round-trip
+ * yet on either relation the schema allows: `schedule-extractor.ts`'s
+ * `IfcRelNests` pass only resolves a nesting parent through the task table
+ * (a plan nesting a schedule is dropped), and its `IfcRelAssignsToControl`
+ * pass has the same task-only blindness (a schedule assigned to a plan that
+ * way is dropped too). So this plan intentionally carries no
+ * `taskGlobalIds` and is emitted as an unrelated top-level entity — the
+ * schema-visible container the issue asked for, without a relation whose
+ * read path would silently drop it.
+ */
+export function buildWorkPlanInfo(seed: string, name: string): WorkScheduleInfo {
+  return {
+    expressId: 0,
+    globalId: deterministicGlobalId(`gen-workplan|${seed}`),
+    kind: 'WorkPlan',
+    name,
+    taskGlobalIds: [],
+  };
+}
+
+/**
+ * Debug dump of a just-generated schedule — the extraction (tasks + work
+ * schedules + sequences) *and* the STEP lines the serializer will emit when
+ * the file is exported. Called from `GenerateScheduleDialog`'s submit
+ * handler; safe to keep in production — runs only on user-initiated
+ * generation and only logs to console.
+ */
+export function logGeneratedScheduleDebug(extraction: ScheduleExtraction, options: unknown): void {
+  try {
+    const stepPreview = serializeScheduleToStep(extraction, {
+      // These IDs don't matter for inspection — the export adapter remaps
+      // them to the host file's ID space at injection time.
+      nextId: 1_000_000,
+    });
+    /* eslint-disable no-console */
+    console.groupCollapsed(
+      `%c[IfcTask] Generated schedule — ${extraction.tasks.length} task(s), ${stepPreview.lines.length} STEP line(s)`,
+      'color:#6ea2ff;font-weight:bold',
+    );
+    console.log('options', options);
+    console.log('workSchedules', extraction.workSchedules);
+    console.log('tasks', extraction.tasks);
+    console.log('sequences', extraction.sequences);
+    console.log('stats', stepPreview.stats);
+    console.log('STEP preview (first 50 lines):');
+    for (const line of stepPreview.lines.slice(0, 50)) console.log(line);
+    if (stepPreview.lines.length > 50) {
+      console.log(`… ${stepPreview.lines.length - 50} more line(s). Full STEP:`);
+      console.log(stepPreview.lines.join('\n'));
+    }
+    console.log('raw extraction (JSON)', JSON.stringify(extraction, null, 2));
+    console.groupEnd();
+    /* eslint-enable no-console */
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[IfcTask] Debug log failed (non-fatal):', err);
+  }
+}
+
 export function formatDurationShort(iso: string | undefined): string {
   if (!iso) return '—';
   const m = iso.match(/^P(?:(\d+(?:\.\d+)?)Y)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)W)?(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/);

--- a/packages/parser/test/schedule-roundtrip.test.ts
+++ b/packages/parser/test/schedule-roundtrip.test.ts
@@ -320,4 +320,47 @@ describe('schedule roundtrip — serializer ↔ parser', () => {
     expect(parsed.sequences[0].timeLagDuration).toBe('P2D');
     expect(parsed.sequences[0].timeLagSeconds).toBe(172_800);
   });
+
+  it('round-trips a standalone IfcWorkPlan added alongside a schedule (#4323)', async () => {
+    // The viewer's Generate dialog can now add a standalone IfcWorkPlan
+    // (apps/viewer/.../schedule-utils.ts's buildWorkPlanInfo) — a
+    // WorkScheduleInfo with kind: 'WorkPlan' and an empty taskGlobalIds,
+    // deliberately not grouped with the schedule via IfcRelAssignsToControl
+    // or IfcRelNests (neither round-trips today). This proves the plan
+    // itself — the entity the issue asked for — survives serialize+parse
+    // as an independent IFCWORKPLAN with no relation invented for it.
+    const extraction = makeExtraction();
+    extraction.workSchedules.push({
+      expressId: 0,
+      globalId: 'plan-standalone',
+      kind: 'WorkPlan',
+      name: 'Project plan',
+      taskGlobalIds: [],
+    });
+
+    const result = serializeScheduleToStep(extraction, {
+      nextId: 100,
+      ownerHistoryId: 10,
+      resolveProductExpressId: (gid) => (gid === 'wall-A' ? 11 : gid === 'wall-B' ? 12 : undefined),
+    });
+    expect(result.lines.some(l => l.includes('=IFCWORKPLAN('))).toBe(true);
+    // No IfcRelAssignsToControl referencing the plan — it has no
+    // taskGlobalIds, so the serializer must not invent a relation for it.
+    const controlRels = result.lines.filter(l => l.includes('=IFCRELASSIGNSTOCONTROL('));
+    expect(controlRels).toHaveLength(1); // only the schedule's own task assignment
+
+    const final = splice(buildBaseStep(), result.lines);
+    const store = await parseStep(final);
+    const parsed = extractScheduleOnDemand(store);
+
+    expect(parsed.workSchedules).toHaveLength(2);
+    const plan = parsed.workSchedules.find(ws => ws.kind === 'WorkPlan');
+    expect(plan).toBeDefined();
+    expect(plan!.name).toBe('Project plan');
+    // Standalone: no tasks resolve as controlled by the plan.
+    expect(plan!.taskGlobalIds).toHaveLength(0);
+    const schedule = parsed.workSchedules.find(ws => ws.kind === 'WorkSchedule');
+    expect(schedule).toBeDefined();
+    expect(schedule!.taskGlobalIds).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
Closes #4323

## Verified on `upstream/main` before building (per the issue)
- `packages/parser/src/schedule-extractor.ts` extracts `IfcWorkPlan`; the read model's `WorkScheduleInfo.kind` is `'WorkSchedule' | 'WorkPlan'`.
- `packages/parser/src/schedule-serializer.ts`: `const entity = ws.kind === 'WorkPlan' ? 'IFCWORKPLAN' : 'IFCWORKSCHEDULE';`
- `packages/create/src/ifc-creator.ts` exposes `addIfcWorkPlan` / `assignSchedulesToWorkPlan` (the latter delegates to `addIfcRelAssignsToControl`).
- `grep -rn "WorkPlan" apps/viewer/src/components/viewer/schedule/` returned nothing before this PR — the generator always produced a bare `IfcWorkSchedule`.

## What this PR does
The Generate schedule dialog's Advanced panel gets a new toggle: "Add an IfcWorkPlan container" + a name field. When enabled, `GenerateScheduleDialog.tsx` composes a standalone `WorkScheduleInfo` (`kind: 'WorkPlan'`, built by the new `buildWorkPlanInfo` in `schedule-utils.ts`) into the extraction alongside the generated schedule, before it's committed to the store and exported through the existing `schedule-serializer.ts` path. No new STEP emission — this reuses the serializer that already handles `IfcWorkPlan`.

## Relation ruling — why the plan is standalone (no grouping)
I traced whether grouping the plan around the schedule would round-trip, since a UI whose output silently drops on reload is worse than the missing feature:

- **`IfcRelAssignsToControl`** (what `assignSchedulesToWorkPlan` already uses): `schedule-extractor.ts`'s Pass 5 only resolves `RelatedObjects` through `taskByExpressId`. A schedule assigned to a plan this way — an `IfcWorkSchedule`, not an `IfcTask` — is silently dropped on read. This applies to the *existing* SDK helper too, not just anything I'd add.
- **`IfcRelNests`**: on `upstream/main`, the same task-only blindness applies to nesting a schedule under a plan. PR #4330 (open, `fix-schedule-nests-4`, targets issue #4329) fixes exactly this by adding `WorkScheduleInfo.childScheduleGlobalIds` / `.parentPlanGlobalId`, but it hasn't merged and also restructures `schedule-extractor.ts` into a new `schedule-types.ts`.

Since neither relation round-trips today, this PR does **not** stack on #4330 and does **not** emit a grouping relation. The plan is emitted with `taskGlobalIds: []` — a genuinely standalone `IfcWorkPlan` entity, which is what the issue asked for at minimum ("the entities I expected to see"). Grouping is deferred; I did not open a new issue for it per instruction — the maintainer will decide.

Round-trip proof (`packages/parser/test/schedule-roundtrip.test.ts`, new test `round-trips a standalone IfcWorkPlan added alongside a schedule (#4323)`): serialize a `WorkScheduleInfo` with `kind: 'WorkPlan'` + a real `IfcWorkSchedule`, re-parse with the real columnar parser, assert exactly one `IFCWORKPLAN` line, exactly one `IFCRELASSIGNSTOCONTROL` line (only the schedule's own task assignment — none invented for the plan), and that the parsed plan comes back with `kind: 'WorkPlan'`, the right name, and zero `taskGlobalIds`.

## Second gap found (read direction) — not fixed here beyond one line
The issue flagged this as unverified. I checked: `GanttToolbar.tsx`'s schedule-filter dropdown lists every entry in `scheduleData.workSchedules` — `IfcWorkPlan` included — as a flat, indistinguishable option. Selecting a `WorkPlan` entry there always resolves to zero tasks, because `flattenTaskTree`'s `controllingScheduleGlobalIds` filter never matches a plan (plans don't directly control tasks). Before this PR that was latent (no viewer-generated file ever had a `WorkPlan`); after this PR a user who enables the new toggle would immediately hit it. I fixed the immediate consequence — `GanttToolbar.tsx` now excludes `kind === 'WorkPlan'` from that dropdown — but rendering a `WorkPlan` as an actual container (indentation, grouping) in the Gantt panel is unaddressed and out of this PR's bound.

## Scoped out
- Grouping schedules under the plan (`IfcRelNests` / `IfcRelAssignsToControl`) — blocked on the read-path fixes above.
- #4322 (cost/5D) — different feature.
- Broader Gantt-panel `WorkPlan`-as-container UI (indentation, distinct icon, grouped rows) — the one-line dropdown exclusion above is the only read-direction change in this PR.

## Verification
- `packages/parser`: full suite green — 111 files, 1215 passed / 3 skipped (`npx vitest run` from `packages/parser`).
- New round-trip test: green; mutation-tested by reverting `schedule-serializer.ts`'s `entity = ws.kind === 'WorkPlan' ? ... ` to always `'IFCWORKSCHEDULE'` — exactly the new test reddens (34 others stay green), then restored.
- `node scripts/check-module-size.mjs`: same pre-existing failures as on a clean `upstream/main` checkout (unrelated `renderer/index.ts` / `renderer/scene.ts` over-budget rows); zero new/changed rows for any file this PR touches. `generate-schedule.ts` (already allowlisted at its exact current size) is untouched — new logic was kept out of it and split into `schedule-utils.ts` instead.
- `apps/viewer` unit/component tests: **BLOCKED** in my sandbox — `apps/viewer`'s test runner (`node:test` via `tsx`) can't resolve `jszip`/`@ifc-lite/wasm` through the chain `schedule-utils.ts` → `@/store`, a pre-existing environment gap (no built wasm dist), not something this PR introduced. A full-project `tsc --noEmit` run did complete (595 pre-existing errors from stale dist across unrelated packages) and reported **zero** errors in any file this PR touches.
- `git diff --stat upstream/main HEAD` lists exactly the 7 files below, no surprises after rebasing onto a `main` that advanced (PR #4337) mid-session.

## Files changed
- `apps/viewer/src/components/viewer/schedule/GenerateScheduleDialog.tsx`
- `apps/viewer/src/components/viewer/schedule/GenerateAdvancedPanel.tsx`
- `apps/viewer/src/components/viewer/schedule/schedule-utils.ts`
- `apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts`
- `apps/viewer/src/components/viewer/schedule/GanttToolbar.tsx`
- `packages/parser/test/schedule-roundtrip.test.ts`
- `.changeset/expose-workplan-authoring.md`
