### PR TITLE
fix(ci): reconcile merged appearance renderer module budgets

### DIFF
--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -305,7 +305,7 @@
    535 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
    684 packages/renderer/src/camera.ts
-  3707 packages/renderer/src/index.ts
+  3708 packages/renderer/src/index.ts
    756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts
    477 packages/renderer/src/pointcloud/point-cloud-renderer.ts
@@ -313,7 +313,7 @@
    474 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
    462 packages/renderer/src/scene-raycaster.ts
-  4196 packages/renderer/src/scene.ts
+  4205 packages/renderer/src/scene.ts
    639 packages/renderer/src/section-2d-overlay.ts
    514 packages/renderer/src/section-plane.ts
    639 packages/renderer/src/shaders/main.wgsl.ts


### PR DESCRIPTION
The merged appearance and translation changes leave two existing renderer module budgets below the current source sizes, causing the module-size gate to fail on main. Reconcile those existing entries to the measured 3,708 and 4,205 lines; no production code changes.

Validation: `node scripts/check-module-size.mjs` passes on this branch. The parent reports exactly these two over-budget files.

Follow-up for ready issue #4243; the broader feature issue remains open.
