### PR TITLE
fix(ids): scan every same-named pset in the IDS overlay write path

### DIFF
--- a/.changeset/ids-overlay-same-named-pset-write.md
+++ b/.changeset/ids-overlay-same-named-pset-write.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ids": patch
+---
+
+`resolveEffectivePropertySets` (the IDS bridge's write overlay, used when an in-session IDS correction is applied) used to look up a property's property set with `result.find(p => p.name === psetName)`, stopping at the first same-named set. An entity carrying two distinct `IfcPropertySet`s sharing a name (e.g. one via the type, one via the occurrence) could have a correction silently land on the wrong set — a value update pushed a duplicate property onto the wrong set while the real one stayed stale, and a delete against the wrong set left the real property fully intact with no error. Every same-named set is now scanned: an update lands on whichever same-named set actually carries the property, a delete removes it from every same-named set that carries it, and a brand-new property (no same-named set has it yet) is created on the first same-named set, matching this function's pre-existing single-pset behaviour.

--- a/packages/ids/src/bridge/property-overlay-resolver.ts
+++ b/packages/ids/src/bridge/property-overlay-resolver.ts
@@ -110,50 +110,79 @@ export function resolveEffectivePropertySets(
   for (const override of overrides) {
     const psetLower = override.psetName.toLowerCase();
     const propLower = override.propName.toLowerCase();
-    const pset = result.find((p) => p.name.toLowerCase() === psetLower);
+    // EVERY set sharing this name, not just the first: an entity can
+    // legitimately carry more than one `IfcPropertySet`/`IfcElementQuantity`
+    // with the same name — one from the type, one from the occurrence, or
+    // several `IfcRelDefinesByProperties` on the occurrence itself (see
+    // `collectAllPropertySets`'s doc and pset-lookup.ts's module doc, the
+    // settled semantics `getPropertyValue`/`getPropertySets` below already
+    // scan). A plain `.find()` here would silently operate on whichever
+    // same-named set happens to come first, even when the targeted
+    // property lives on a LATER one — see ifc-lite issue for the executed
+    // repro (a correction landing on the wrong set, or a delete that
+    // silently no-ops).
+    const matchingSets = result.filter((p) => p.name.toLowerCase() === psetLower);
 
     if (override.deleted) {
-      if (pset) {
+      // Remove the property from EVERY same-named set that carries it, not
+      // only the first. `getPropertyValue` scans same-named sets in order
+      // and returns the first match: leaving a stale copy on a later
+      // same-named set would let it resurface on the very next read,
+      // making the deletion look like it silently never took effect.
+      for (const pset of matchingSets) {
         pset.properties = pset.properties.filter((p) => p.name.toLowerCase() !== propLower);
       }
       continue;
     }
 
-    if (pset) {
-      const idx = pset.properties.findIndex((p) => p.name.toLowerCase() === propLower);
-      if (idx >= 0) {
-        // Keep the property's OWN stored name/casing AND dataType — only
-        // its value changes. The existing entry's `dataType` (resolved by
-        // `projectProperty` from the IFC schema, not from this override)
-        // is what tells `toBaseSI` whether — and by which dimension — to
-        // scale: a non-measure property (IFCLABEL, boolean, identifier)
-        // has no scale and passes through untouched.
-        const existing = pset.properties[idx];
-        pset.properties[idx] = {
-          ...existing,
-          value: toBaseSI(override.value, existing.dataType, scales),
-        };
-      } else {
-        // No existing entry to read a dataType from — this is a
-        // PROPERTY_MISSING correction (#3943): the property is being
-        // CREATED, not updated, so there is no sibling entry whose
-        // `dataType` `toBaseSI` could key off. Fall back to the
-        // dataType the override itself carries (the write path's own
-        // dataType — see `PropertyOverride.dataType`'s doc) and run it
-        // through the SAME `toBaseSI` helper as the branch above, so a
-        // brand-new measure property lands in the same base-SI frame as
-        // every other property in the pset instead of the model's raw
-        // frame. A caller that never supplies `dataType` keeps today's
-        // behaviour — no scale applied.
-        pset.properties.push({
-          name: override.propName,
-          value: toBaseSI(override.value, override.dataType, scales),
-          dataType: override.dataType ?? '',
-        });
-      }
+    // The specific same-named set that actually carries this property, if
+    // any. An update must land on THAT set — not on the first same-named
+    // set, which may carry a different property entirely and would
+    // otherwise receive a wrongly-placed duplicate while the real property
+    // (on a later same-named set) stays stale.
+    const targetSet = matchingSets.find((p) =>
+      p.properties.some((prop) => prop.name.toLowerCase() === propLower)
+    );
+
+    if (targetSet) {
+      const idx = targetSet.properties.findIndex((p) => p.name.toLowerCase() === propLower);
+      // Keep the property's OWN stored name/casing AND dataType — only
+      // its value changes. The existing entry's `dataType` (resolved by
+      // `projectProperty` from the IFC schema, not from this override)
+      // is what tells `toBaseSI` whether — and by which dimension — to
+      // scale: a non-measure property (IFCLABEL, boolean, identifier)
+      // has no scale and passes through untouched.
+      const existing = targetSet.properties[idx];
+      targetSet.properties[idx] = {
+        ...existing,
+        value: toBaseSI(override.value, existing.dataType, scales),
+      };
+    } else if (matchingSets.length > 0) {
+      // No same-named set carries this property yet — a PROPERTY_MISSING
+      // correction (#3943): the property is being CREATED, not updated, so
+      // there is no existing entry whose `dataType` `toBaseSI` could key
+      // off. Fall back to the dataType the override itself carries (see
+      // `PropertyOverride.dataType`'s doc) and run it through the SAME
+      // `toBaseSI` helper as the branch above.
+      //
+      // Which same-named set a brand-new property should land on is
+      // genuinely ambiguous when more than one exists — IFC does not
+      // distinguish between them. We put it on the FIRST same-named set:
+      // that matches this function's own pre-existing single-pset
+      // behaviour exactly (there is only one candidate when a collision
+      // isn't present), and it guarantees the new property is the one
+      // `getPropertyValue`'s first-match-wins scan returns on the very
+      // next read, regardless of how many same-named sets exist.
+      const first = matchingSets[0];
+      first.properties.push({
+        name: override.propName,
+        value: toBaseSI(override.value, override.dataType, scales),
+        dataType: override.dataType ?? '',
+      });
     } else {
-      // Same "no existing entry" reasoning as directly above, for a
-      // correction whose pset doesn't exist on the entity at all yet.
+      // No same-named set at all yet — a correction whose pset doesn't
+      // exist on the entity. Same "no existing entry" dataType reasoning
+      // as directly above.
       result.push({
         name: override.psetName,
         properties: [{

--- a/packages/ids/src/bridge/property-overlay.test.ts
+++ b/packages/ids/src/bridge/property-overlay.test.ts
@@ -44,6 +44,31 @@ function makeStore(): IfcDataStore {
         },
       ],
     ],
+    // A wall carrying TWO distinct `Pset_WallCommon` sets (e.g. one from
+    // `IfcRelDefinesByProperties` on the type, one on the occurrence — a
+    // legitimate model shape `collectAllPropertySets`/`property-overlay-resolver.ts`
+    // both document). The first carries only `IsExternal`; the SECOND
+    // carries `FireRating`. A first-match-only lookup against this shape
+    // finds a `Pset_WallCommon` (the first one) but not the property this
+    // override targets, so it takes the "create" branch against the WRONG
+    // set instead of updating the real one.
+    [
+      4,
+      [
+        {
+          name: 'Pset_WallCommon',
+          properties: [
+            { name: 'IsExternal', value: true, type: 3, dataType: 'IFCBOOLEAN' },
+          ],
+        },
+        {
+          name: 'Pset_WallCommon',
+          properties: [
+            { name: 'FireRating', value: 'NONE', type: 0, dataType: 'IFCLABEL' },
+          ],
+        },
+      ],
+    ],
   ]);
 
   return {
@@ -133,5 +158,45 @@ describe('createDataAccessor property overlay (#3929)', () => {
     // second, differently-cased property that a case-insensitive scan could
     // resolve to either one depending on array order.
     expect(accessor.getPropertySets(3)[0].properties).toHaveLength(1);
+  });
+
+  describe('same-named-pset collision (two distinct Pset_WallCommon sets, #4XXX)', () => {
+    it('an update corrects the value on the SET THAT ACTUALLY CARRIES the property, not the first same-named set', () => {
+      const overrides = new Map<number, PropertyOverride[]>([
+        [4, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: 'F90' }]],
+      ]);
+      const accessor = createDataAccessor(makeStore(), (id) => overrides.get(id));
+
+      expect(accessor.getPropertyValue(4, 'Pset_WallCommon', 'FireRating')?.value).toBe('F90');
+
+      // No duplicate FireRating was created: exactly one property named
+      // FireRating exists across BOTH same-named psets combined.
+      const sets = accessor.getPropertySets(4).filter((p) => p.name === 'Pset_WallCommon');
+      const fireRatingCount = sets
+        .flatMap((s) => s.properties)
+        .filter((p) => p.name === 'FireRating').length;
+      expect(fireRatingCount).toBe(1);
+
+      // The sibling property on the OTHER same-named set is untouched.
+      expect(accessor.getPropertyValue(4, 'Pset_WallCommon', 'IsExternal')?.value).toBe(true);
+    });
+
+    it('a delete removes the property from the set that actually carries it, and the read-back confirms it is gone', () => {
+      const overrides = new Map<number, PropertyOverride[]>([
+        [4, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: null, deleted: true }]],
+      ]);
+      const accessor = createDataAccessor(makeStore(), (id) => overrides.get(id));
+
+      expect(accessor.getPropertyValue(4, 'Pset_WallCommon', 'FireRating')).toBeUndefined();
+
+      const sets = accessor.getPropertySets(4).filter((p) => p.name === 'Pset_WallCommon');
+      const fireRatingCount = sets
+        .flatMap((s) => s.properties)
+        .filter((p) => p.name === 'FireRating').length;
+      expect(fireRatingCount).toBe(0);
+
+      // The other set's own property survives.
+      expect(accessor.getPropertyValue(4, 'Pset_WallCommon', 'IsExternal')?.value).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
`resolveEffectivePropertySets` (`packages/ids/src/bridge/property-overlay-resolver.ts`) — the IDS bridge's write overlay, applied when an in-session IDS correction is applied without re-exporting — looked up a correction's target pset with a plain `.find()`, stopping at the first property set sharing that name:

```ts
const pset = result.find((p) => p.name.toLowerCase() === psetLower);
```

An entity carrying two distinct `IfcPropertySet`s with the same name (e.g. one from the type, one from the occurrence — a legitimate model shape, per the resolver's own docstring) could have a correction silently land on the wrong set:
- **update**: pushed a duplicate property onto the wrong (first) same-named set while the real one, on a later same-named set, stayed stale.
- **delete**: ran against the wrong (first) same-named set and removed nothing — the real property survived untouched, with no error.

Both are one bug (the same first-match `.find()`), surfacing as two distinct failure modes depending on the correction type.

This mirrors the read-path defect family already fixed: `PropertyTable.getProperty` (#2907), `PropertyTable.getProperties` (#3463), and the "settled semantics" documented in `pset-lookup.ts` — scan every same-named set, never stop at the first. The write path never received the same treatment until now.

## Fix
- **Delete** removes the property from every same-named set that carries it (not just the first) — `getPropertyValue` scans same-named sets in order and returns the first match, so leaving a stale copy on a later set would let it resurface on the very next read.
- **Update** resolves to whichever same-named set actually carries the target property, and updates it there.
- **Create** (no same-named set carries the property yet): which same-named set a brand-new property should land on is genuinely ambiguous — IFC doesn't distinguish between duplicate-named psets. This lands it on the *first* same-named set, matching the function's pre-existing single-pset behaviour exactly and guaranteeing the new property is what a first-match-wins read (`getPropertyValue`) returns on the very next read, regardless of how many same-named sets exist.

## Testing
Added a fixture with two distinct `Pset_WallCommon` sets on one entity (first carries only `IsExternal`, second carries `FireRating = "NONE"`) — a same-named-but-different-contents fixture that actually discriminates between first-match and full-scan resolution.

- RED (pre-fix `.find()`): `update` created a duplicate `FireRating` (`expected 2 to be 1`); `delete` silently no-op'd (`getPropertyValue` still returned `{ value: 'NONE', ... }` afterward instead of `undefined`).
- GREEN (post-fix scan): both assertions pass; the untouched sibling property (`IsExternal`) is unaffected in both cases.
- Full `packages/ids` suite: 37 files / 1006 tests pass (1004 pre-existing + 2 new).
- `node scripts/check-module-size.mjs`: OK, exit 0.

Closes #4273