### PR TITLE
fix(viewer): isolate lazy workspace panel identities

### DIFF
--- a/apps/viewer/src/lib/panels/mobile-sheet-coverage.test.ts
+++ b/apps/viewer/src/lib/panels/mobile-sheet-coverage.test.ts
@@ -56,6 +56,16 @@ describe('workspace panel registry coverage', () => {
     assert.deepEqual(shared, [], 'these panel ids render the same component — one is showing the other\'s panel');
   });
 
+  it('keeps each panel component identity stable across host renders (#4243)', () => {
+    // A wrapper allocated inside renderPanelBody would pass distinctness but
+    // remount the active editor on every host render, discarding its local state.
+    for (const panel of WORKSPACE_PANELS) {
+      const first = renderPanelBody(panel.id, () => {}) as { type?: unknown };
+      const next = renderPanelBody(panel.id, () => {}) as { type?: unknown };
+      assert.strictEqual(first.type, next.type, `${panel.id} remounts on host render`);
+    }
+  });
+
   it('gives every registered panel a title for the sheet header', () => {
     const untitled = WORKSPACE_PANELS
       .filter((panel) => !getPanelDef(panel.id)?.title)

--- a/apps/viewer/src/lib/panels/renderPanelBody.tsx
+++ b/apps/viewer/src/lib/panels/renderPanelBody.tsx
@@ -41,6 +41,20 @@ const SourcesPanel = lazy(() =>
 
 const AppearancePanel = lazy(() => import('@/components/viewer/appearance/AppearancePanel').then(m => ({ default: m.AppearancePanel })));
 
+// Each lazy panel needs its own stable host identity. Reusing the boundary
+// itself as the body can retain another panel's failed-chunk state on a switch.
+function AppearancePanelBody() {
+  return <ChunkErrorBoundary label="Appearance panel"><Suspense fallback={null}><AppearancePanel /></Suspense></ChunkErrorBoundary>;
+}
+
+function LayersPanelBody({ onClose }: { onClose: () => void }) {
+  return <ChunkErrorBoundary label="Layers panel"><Suspense fallback={null}><LayersPanel onClose={onClose} /></Suspense></ChunkErrorBoundary>;
+}
+
+function SourcesPanelBody({ onClose }: { onClose: () => void }) {
+  return <Suspense fallback={null}><SourcesPanel onClose={onClose} /></Suspense>;
+}
+
 /**
  * Render the body for a workspace panel. `onClose` is the host's "close this
  * panel" handler (re-dock to Information, remove the float, or re-dock the
@@ -50,7 +64,7 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
   switch (id) {
     // Hierarchy's home is the left slot (#1267); it is never routed to the right
     // pane / float / pop-out, but the case keeps the id to body map exhaustive.
-    case 'appearance': return <ChunkErrorBoundary label="Appearance panel"><Suspense fallback={null}><AppearancePanel /></Suspense></ChunkErrorBoundary>;
+    case 'appearance': return <AppearancePanelBody />;
     case 'hierarchy': return <HierarchyPanel />;
     case 'properties': return <PropertiesPanel />;
     case 'compare': return <ComparePanel onClose={onClose} />;
@@ -65,17 +79,7 @@ export function renderPanelBody(id: WorkspacePanelId, onClose: () => void): Reac
     case 'collab': return <RoomPanel onClose={onClose} />;
     case 'zones': return <ZonesPanel onClose={onClose} />;
     case 'loadReport': return <LoadReportPanel onClose={onClose} />;
-    case 'layers': return (
-      <ChunkErrorBoundary label="Layers panel">
-        <Suspense fallback={null}>
-          <LayersPanel onClose={onClose} />
-        </Suspense>
-      </ChunkErrorBoundary>
-    );
-    case 'sources': return (
-      <Suspense fallback={null}>
-        <SourcesPanel onClose={onClose} />
-      </Suspense>
-    );
+    case 'layers': return <LayersPanelBody onClose={onClose} />;
+    case 'sources': return <SourcesPanelBody onClose={onClose} />;
   }
 }


### PR DESCRIPTION
Refs #4243.

Appearance and Layers both returned `ChunkErrorBoundary` as their panel body, failing the existing distinct-panel registry invariant. Sharing that component identity also lets React retain the previous panel boundary when switching hosts. Give each lazy panel a stable, dedicated body component while preserving lazy loading and existing boundaries.

The existing coverage/distinctness tests are unchanged. An additional invariant checks that repeated host renders preserve each panel's component identity, preventing wrappers created during render from remounting its editor.

Validation: root viewer registry shard 4/4; full root typecheck 90/90 including 1847 test files; touched lint and diff checks pass. This fixes the concrete full-viewer-suite failure reported in `mobile-sheet-coverage.test.ts`.
