### PR TITLE
fix(parser,query): surface ambiguous storey containment as a detectable signal (#4311)

### DIFF
--- a/.changeset/ambiguous-storey-signal-4311.md
+++ b/.changeset/ambiguous-storey-signal-4311.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/data": minor
+"@ifc-lite/parser": minor
+"@ifc-lite/query": minor
+---
+
+Surface ambiguous direct storey containment as a detectable signal (#4311), a follow-up to the first-declared-wins tie-break from #4248/#4310.
+
+An element can be named by more than one `IfcRelContainedInSpatialStructure` edge pointing at different storeys — a malformed-but-real shape both `elementToStorey` and `containedIn()` silently resolved to a single answer, with no way for a caller to tell the containment was contested in the source file.
+
+- `SpatialHierarchy` (`@ifc-lite/data`) gains an optional `ambiguousStorey: Set<number>` field: the element ids whose direct storey containment named more than one distinct storey. `SpatialHierarchyBuilder.build()` / `buildFromCache()` (`@ifc-lite/parser`) always populate it (empty when nothing was ambiguous); it also round-trips through the parser worker transport.
+- `EntityNode.containedInAmbiguous()` (`@ifc-lite/query`) answers the same question per-call, for callers using `containedIn()` instead of the parser's aggregate hierarchy.
+
+Neither `elementToStorey`'s nor `containedIn()`'s existing resolution changes — both still return a single winner. Detection reuses the direct-containment lists (`byStorey` / inverse `ContainsElements` edges) each already builds, so it costs no extra graph traversal.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -277,6 +277,7 @@ export interface SpatialHierarchy {
    * predate it fall back to `elementToStorey`.
    */
   elementToContainer?: Map<number, number>;
+  ambiguousStorey?: Set<number>;  // elementIds with >1 storey declared via direct ContainsElements in source (elementToStorey's answer was a tie-break, #4311); optional, older hierarchies omit it
 
   // Helper methods
   getStoreyElements(storeyId: number): number[];

--- a/packages/parser/src/data-store-transport.ts
+++ b/packages/parser/src/data-store-transport.ts
@@ -76,6 +76,7 @@ export interface SpatialHierarchyColumns {
   storeyHeights: Array<[number, number]>;
   elementToStorey: Array<[number, number]>;
   elementToContainer?: Array<[number, number]>;
+  ambiguousStorey?: number[]; // #4311
 }
 
 function serializeSpatialNode(node: SpatialNode): SerializedSpatialNode {
@@ -115,6 +116,7 @@ export function spatialHierarchyToColumns(hierarchy: SpatialHierarchy): SpatialH
     elementToContainer: hierarchy.elementToContainer
       ? [...hierarchy.elementToContainer.entries()]
       : undefined,
+    ambiguousStorey: hierarchy.ambiguousStorey ? [...hierarchy.ambiguousStorey] : undefined, // #4311
   };
 }
 
@@ -130,6 +132,7 @@ export function spatialHierarchyFromColumns(columns: SpatialHierarchyColumns): S
   const elementToContainer = columns.elementToContainer
     ? new Map<number, number>(columns.elementToContainer)
     : undefined;
+  const ambiguousStorey = columns.ambiguousStorey ? new Set<number>(columns.ambiguousStorey) : undefined; // #4311
 
   // elementToSpace is the inverse of bySpace and is what `getContainingSpace`
   // queries. Only this direction is shipped over the wire because it is
@@ -151,6 +154,7 @@ export function spatialHierarchyFromColumns(columns: SpatialHierarchyColumns): S
     storeyHeights,
     elementToStorey,
     elementToContainer,
+    ambiguousStorey, // #4311
 
     getStoreyElements(storeyId: number): number[] {
       return byStorey.get(storeyId) ?? [];

--- a/packages/parser/src/spatial-hierarchy-ambiguity.ts
+++ b/packages/parser/src/spatial-hierarchy-ambiguity.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Detects elements whose direct storey containment is ambiguous in the
+ * SOURCE FILE itself, i.e. more than one `IfcRelContainedInSpatialStructure`
+ * edge names a *different* storey-like spatial structure as the RelatingStructure
+ * for the same element (#4311).
+ *
+ * `elementToStorey` resolves each of these to a single winner (first-declared
+ * wins, see spatial-hierarchy-builder.ts); this module answers the question
+ * that resolution silently discards - was there more than one candidate at
+ * all. It intentionally does NOT depend on how the tie-break itself is
+ * decided (declaration order, reachability, or anything else): the input is
+ * `byStorey`, the per-storey list of DIRECTLY contained elements that
+ * `SpatialHierarchyBuilder.assemble()` already produces regardless of tie-break
+ * strategy, so this stays correct across future changes to the resolution
+ * logic without needing to change with it.
+ *
+ * Two edges that repeat the SAME (storey, element) pair are not ambiguous -
+ * `RelationshipGraphBuilder` dedupes same-source/target/type `IfcRel*`
+ * instances into one edge before either side of this ever sees them
+ * (`relationship-graph.ts`), so a genuine duplicate declaration of the exact
+ * same fact never reaches `byStorey` twice for the same storey. Only a
+ * SECOND, DIFFERENT storey claiming the element counts.
+ */
+
+/** elementId -> storeyId, DIRECT storey containment only (one entry per
+ *  storey; see `SpatialHierarchy.byStorey`). */
+export type ByStorey = ReadonlyMap<number, readonly number[]>;
+
+/**
+ * Returns the set of element ids that appear under more than one distinct
+ * storey in `byStorey`. O(total direct storey-element pairs); no extra graph
+ * traversal beyond what `byStorey` already required to build.
+ */
+export function computeAmbiguousStorey(byStorey: ByStorey): Set<number> {
+  const firstStorey = new Map<number, number>();
+  const ambiguous = new Set<number>();
+  for (const [storeyId, elementIds] of byStorey) {
+    for (const elementId of elementIds) {
+      const seen = firstStorey.get(elementId);
+      if (seen === undefined) {
+        firstStorey.set(elementId, storeyId);
+      } else if (seen !== storeyId) {
+        ambiguous.add(elementId);
+      }
+    }
+  }
+  return ambiguous;
+}

--- a/packages/parser/src/spatial-hierarchy-ambiguity.ts
+++ b/packages/parser/src/spatial-hierarchy-ambiguity.ts
@@ -8,15 +8,21 @@
  * edge names a *different* storey-like spatial structure as the RelatingStructure
  * for the same element (#4311).
  *
- * `elementToStorey` resolves each of these to a single winner (first-declared
- * wins, see spatial-hierarchy-builder.ts); this module answers the question
- * that resolution silently discards - was there more than one candidate at
- * all. It intentionally does NOT depend on how the tie-break itself is
- * decided (declaration order, reachability, or anything else): the input is
- * `byStorey`, the per-storey list of DIRECTLY contained elements that
- * `SpatialHierarchyBuilder.assemble()` already produces regardless of tie-break
- * strategy, so this stays correct across future changes to the resolution
- * logic without needing to change with it.
+ * `elementToStorey` resolves each of these to a single winner, but this
+ * module deliberately treats HOW that winner is picked as an implementation
+ * detail it does not depend on or describe: as shipped on this branch
+ * (pre-#4310), spatial-hierarchy-builder.ts's direct-containment loop
+ * assigns `elementToStorey` unconditionally on every storey it visits, so
+ * the last storey reached in the aggregation-driven tree walk wins, NOT the
+ * first-declared `IfcRelContainedInSpatialStructure` edge - the tie-break is
+ * aggregation-order dependent, not declaration-order dependent. #4310
+ * changes that to first-declared-wins. Either way, this module answers the
+ * question that resolution silently discards - was there more than one
+ * candidate at all. The input is `byStorey`, the per-storey list of
+ * DIRECTLY contained elements that `SpatialHierarchyBuilder.assemble()`
+ * already produces regardless of tie-break strategy, so this stays correct
+ * across past and future changes to the resolution logic without needing to
+ * change with it.
  *
  * Two edges that repeat the SAME (storey, element) pair are not ambiguous -
  * `RelationshipGraphBuilder` dedupes same-source/target/type `IfcRel*`

--- a/packages/parser/src/spatial-hierarchy-attribute-extraction.ts
+++ b/packages/parser/src/spatial-hierarchy-attribute-extraction.ts
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * On-demand attribute extraction for `SpatialHierarchyBuilder`: LongName and
+ * storey elevation. Split out of `spatial-hierarchy-builder.ts` (a pure,
+ * behavior-preserving move, not a rewrite) to keep that file under the
+ * module-size budget; nothing here changes what either function returns.
+ */
+
+import { createLogger, IFC_BUILDING_STOREY_ELEVATION_INDEX, IFC_BUILDING_STOREY_PLACEMENT_INDEX } from '@ifc-lite/data';
+import type { EntityRef } from './types.js';
+import { EntityExtractor } from './entity-extractor.js';
+import type { IfcSourceBytes } from './source-bytes.js';
+import { getAttributeNamesAcrossSchemas } from './ifc-schema.js';
+
+const log = createLogger('SpatialHierarchy');
+
+type EntityIndex = { byId: { get(expressId: number): EntityRef | undefined } };
+
+/**
+ * Read an entity's LongName by schema attribute *name*. IfcSite / IfcBuilding /
+ * IfcBuildingStorey / IfcSpace (and the IFC4.3 facility/infra containers)
+ * declare LongName at index 7, but IfcProject carries it at a different slot,
+ * so resolving by name (not a fixed index) stays correct across the IfcRoot
+ * family. The lookup spans every bundled schema, so IFC4.3 leaves outside the
+ * parser's IFC4 codegen pin resolve too. Returns the trimmed value, or
+ * undefined when the type declares no LongName, it is empty, or no attribute
+ * extractor is available (the buildFromCache path).
+ */
+export function extractLongName(
+  expressId: number,
+  entityIndex: EntityIndex | undefined,
+  attrExtractor: EntityExtractor | undefined
+): string | undefined {
+  if (!entityIndex || !attrExtractor) return undefined;
+  const ref = entityIndex.byId.get(expressId);
+  if (!ref) return undefined;
+  try {
+    const entity = attrExtractor.extractEntity(ref);
+    if (!entity) return undefined;
+    const idx = getAttributeNamesAcrossSchemas(entity.type).indexOf('LongName');
+    if (idx < 0) return undefined;
+    const raw = (entity.attributes || [])[idx];
+    const value = typeof raw === 'string' ? raw.trim() : '';
+    return value.length > 0 ? value : undefined;
+  } catch (error) {
+    log.caught('Failed to extract LongName', error, { operation: 'extractLongName', entityId: expressId });
+    return undefined;
+  }
+}
+
+/**
+ * Extract elevation from an IfcBuildingStorey. Elevation is attribute index 9
+ * in both IFC2x3 and IFC4 (GlobalId, OwnerHistory, Name, Description,
+ * ObjectType, ObjectPlacement, Representation, LongName, CompositionType,
+ * Elevation).
+ */
+export function extractElevation(
+  expressId: number,
+  source: Uint8Array | IfcSourceBytes,
+  entityIndex: EntityIndex
+): number | undefined {
+  const ref = entityIndex.byId.get(expressId);
+  if (!ref) return undefined;
+
+  try {
+    const extractor = new EntityExtractor(source);
+    const entity = extractor.extractEntity(ref);
+    if (!entity) return undefined;
+
+    const attrs = entity.attributes || [];
+
+    // Number from a raw value or a typed value like ['IFCLENGTHMEASURE', 3.0].
+    const extractNumber = (val: any): number | undefined => {
+      if (typeof val === 'number') return val;
+      if (Array.isArray(val) && val.length === 2 && typeof val[1] === 'number') {
+        return val[1];
+      }
+      return undefined;
+    };
+
+    // Read ONLY the Elevation slot: a previous "scan every attribute for a
+    // number < 10000" fallback wrongly treated reference attributes (parsed as
+    // bare express-id numbers, e.g. OwnerHistory #3628 -> 3628) as elevations,
+    // so a storey with a null Elevation got a garbage value instead of falling
+    // through to the ObjectPlacement-Z fallback below (#1289).
+    if (attrs.length > IFC_BUILDING_STOREY_ELEVATION_INDEX) {
+      return extractNumber(attrs[IFC_BUILDING_STOREY_ELEVATION_INDEX]);
+    }
+  } catch (error) {
+    log.caught('Failed to extract elevation', error, {
+      operation: 'extractElevation',
+      entityId: expressId,
+      entityType: 'IfcBuildingStorey',
+    });
+  }
+
+  return undefined;
+}
+
+/**
+ * Resolve a storey's elevation from its ObjectPlacement, used as a fallback when
+ * the Elevation attribute is null. Walks
+ *   IfcBuildingStorey.ObjectPlacement (IfcLocalPlacement)
+ *     -> RelativePlacement (IfcAxis2Placement3D)
+ *       -> Location (IfcCartesianPoint).Coordinates[2]
+ * i.e. the storey's Z relative to its parent spatial container, which matches
+ * the semantics of the Elevation attribute and avoids folding in any site-level
+ * georeferencing Z. Returns the raw (unscaled) Z, or undefined when the chain
+ * can't be resolved.
+ */
+export function extractPlacementElevation(
+  expressId: number,
+  source: Uint8Array | IfcSourceBytes,
+  entityIndex: EntityIndex
+): number | undefined {
+  try {
+    const extractor = new EntityExtractor(source);
+    const readAttrs = (id: number): unknown[] | undefined => {
+      const ref = entityIndex.byId.get(id);
+      if (!ref) return undefined;
+      return extractor.extractEntity(ref)?.attributes ?? undefined;
+    };
+
+    const placementId = readAttrs(expressId)?.[IFC_BUILDING_STOREY_PLACEMENT_INDEX];
+    if (typeof placementId !== 'number') return undefined;
+
+    // IfcLocalPlacement(PlacementRelTo, RelativePlacement) - RelativePlacement
+    // (index 1) is the IfcAxis2Placement3D carrying this storey's own offset.
+    const axisId = readAttrs(placementId)?.[1];
+    if (typeof axisId !== 'number') return undefined;
+
+    // IfcAxis2Placement3D(Location, Axis, RefDirection) - Location (index 0) is
+    // an IfcCartesianPoint.
+    const locationId = readAttrs(axisId)?.[0];
+    if (typeof locationId !== 'number') return undefined;
+
+    // IfcCartesianPoint.Coordinates (index 0) is a list [x, y, z].
+    const coords = readAttrs(locationId)?.[0];
+    if (Array.isArray(coords) && coords.length >= 3 && typeof coords[2] === 'number') {
+      return coords[2];
+    }
+  } catch (error) {
+    log.caught('Failed to extract placement elevation', error, {
+      operation: 'extractPlacementElevation',
+      entityId: expressId,
+      entityType: 'IfcBuildingStorey',
+    });
+  }
+
+  return undefined;
+}

--- a/packages/parser/src/spatial-hierarchy-attributes.ts
+++ b/packages/parser/src/spatial-hierarchy-attributes.ts
@@ -3,13 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * On-demand attribute extraction for `SpatialHierarchyBuilder`: LongName and
- * storey elevation. Split out of `spatial-hierarchy-builder.ts` (a pure,
- * behavior-preserving move, not a rewrite) to keep that file under the
- * module-size budget; nothing here changes what either function returns.
+ * Attribute extraction for spatial hierarchy nodes - reads a node's LongName,
+ * its IfcBuildingStorey Elevation, and the ObjectPlacement-Z fallback
+ * straight off the raw IFC records via `EntityExtractor`.
+ *
+ * Split out of spatial-hierarchy-builder.ts: these three functions share one
+ * concern - resolving values from source bytes when a source is available -
+ * distinct from the tree-building recursion in `buildNode` that calls them.
+ * Same pattern as spatial-hierarchy-canonical-parent.ts, which split out the
+ * cycle-safe canonical-parent resolution for the same reason.
  */
 
-import { createLogger, IFC_BUILDING_STOREY_ELEVATION_INDEX, IFC_BUILDING_STOREY_PLACEMENT_INDEX } from '@ifc-lite/data';
+import {
+  createLogger,
+  IFC_BUILDING_STOREY_ELEVATION_INDEX,
+  IFC_BUILDING_STOREY_PLACEMENT_INDEX,
+} from '@ifc-lite/data';
 import type { EntityRef } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcSourceBytes } from './source-bytes.js';
@@ -17,7 +26,14 @@ import { getAttributeNamesAcrossSchemas } from './ifc-schema.js';
 
 const log = createLogger('SpatialHierarchy');
 
-type EntityIndex = { byId: { get(expressId: number): EntityRef | undefined } };
+/** Source bytes needed to read on-demand attributes off the raw records
+ *  (storey elevation, LongName). Present on the fresh-parse / cache-with-source
+ *  path, absent on the source-less `buildFromCache` fallback. */
+export interface AttributeSource {
+  source: Uint8Array | IfcSourceBytes;
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined } };
+  lengthUnitScale: number;
+}
 
 /**
  * Read an entity's LongName by schema attribute *name*. IfcSite / IfcBuilding /
@@ -26,16 +42,16 @@ type EntityIndex = { byId: { get(expressId: number): EntityRef | undefined } };
  * so resolving by name (not a fixed index) stays correct across the IfcRoot
  * family. The lookup spans every bundled schema, so IFC4.3 leaves outside the
  * parser's IFC4 codegen pin resolve too. Returns the trimmed value, or
- * undefined when the type declares no LongName, it is empty, or no attribute
- * extractor is available (the buildFromCache path).
+ * undefined when the type declares no LongName, it is empty, or no source
+ * buffer is available (the buildFromCache path).
  */
 export function extractLongName(
   expressId: number,
-  entityIndex: EntityIndex | undefined,
+  attrSource: AttributeSource | undefined,
   attrExtractor: EntityExtractor | undefined
 ): string | undefined {
-  if (!entityIndex || !attrExtractor) return undefined;
-  const ref = entityIndex.byId.get(expressId);
+  if (!attrSource || !attrExtractor) return undefined;
+  const ref = attrSource.entityIndex.byId.get(expressId);
   if (!ref) return undefined;
   try {
     const entity = attrExtractor.extractEntity(ref);
@@ -46,7 +62,10 @@ export function extractLongName(
     const value = typeof raw === 'string' ? raw.trim() : '';
     return value.length > 0 ? value : undefined;
   } catch (error) {
-    log.caught('Failed to extract LongName', error, { operation: 'extractLongName', entityId: expressId });
+    log.caught('Failed to extract LongName', error, {
+      operation: 'extractLongName',
+      entityId: expressId,
+    });
     return undefined;
   }
 }
@@ -60,7 +79,7 @@ export function extractLongName(
 export function extractElevation(
   expressId: number,
   source: Uint8Array | IfcSourceBytes,
-  entityIndex: EntityIndex
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined } }
 ): number | undefined {
   const ref = entityIndex.byId.get(expressId);
   if (!ref) return undefined;
@@ -114,7 +133,7 @@ export function extractElevation(
 export function extractPlacementElevation(
   expressId: number,
   source: Uint8Array | IfcSourceBytes,
-  entityIndex: EntityIndex
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined } }
 ): number | undefined {
   try {
     const extractor = new EntityExtractor(source);

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -27,17 +27,13 @@ import type { EntityRef } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcSourceBytes } from './source-bytes.js';
 import { computeCanonicalParent } from './spatial-hierarchy-canonical-parent.js';
-import { extractLongName, extractElevation, extractPlacementElevation } from './spatial-hierarchy-attribute-extraction.js';
+import {
+  type AttributeSource,
+  extractLongName,
+  extractElevation,
+  extractPlacementElevation,
+} from './spatial-hierarchy-attributes.js';
 import { computeAmbiguousStorey } from './spatial-hierarchy-ambiguity.js';
-
-/** Source bytes needed to read on-demand attributes off the raw records
- *  (storey elevation, LongName). Present on the fresh-parse / cache-with-source
- *  path, absent on the source-less `buildFromCache` fallback. */
-interface AttributeSource {
-  source: Uint8Array | IfcSourceBytes;
-  entityIndex: { byId: { get(expressId: number): EntityRef | undefined } };
-  lengthUnitScale: number;
-}
 
 /** Accumulators threaded through the recursion, plus the optional attribute source. */
 interface BuildContext {
@@ -200,7 +196,7 @@ export class SpatialHierarchyBuilder {
     // show both (issue #1634). It lives only in the raw record, so it needs the
     // source bytes; the source-less buildFromCache fallback leaves it undefined,
     // exactly like storey elevation.
-    const rawLongName = extractLongName(expressId, ctx.attrSource?.entityIndex, ctx.attrExtractor);
+    const rawLongName = extractLongName(expressId, ctx.attrSource, ctx.attrExtractor);
     // Fall back to LongName when Name is empty (common for IfcSpace). Left
     // empty, not a fabricated `Entity #<id>` — it flows into the export layer.
     const name = rawName || rawLongName || '';

--- a/packages/parser/src/spatial-hierarchy-builder.ts
+++ b/packages/parser/src/spatial-hierarchy-builder.ts
@@ -17,22 +17,18 @@ import type { EntityTable, StringTable, RelationshipGraph, SpatialHierarchy, Spa
 import {
   IfcTypeEnum,
   RelationshipType,
-  createLogger,
   isBuildingLikeSpatialType,
   isSpaceLikeSpatialType,
   isSpatialStructureType,
   isStoreyLikeSpatialType,
-  IFC_BUILDING_STOREY_ELEVATION_INDEX,
-  IFC_BUILDING_STOREY_PLACEMENT_INDEX,
   findStoreyByElevation,
 } from '@ifc-lite/data';
 import type { EntityRef } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcSourceBytes } from './source-bytes.js';
-import { getAttributeNamesAcrossSchemas } from './ifc-schema.js';
 import { computeCanonicalParent } from './spatial-hierarchy-canonical-parent.js';
-
-const log = createLogger('SpatialHierarchy');
+import { extractLongName, extractElevation, extractPlacementElevation } from './spatial-hierarchy-attribute-extraction.js';
+import { computeAmbiguousStorey } from './spatial-hierarchy-ambiguity.js';
 
 /** Source bytes needed to read on-demand attributes off the raw records
  *  (storey elevation, LongName). Present on the fresh-parse / cache-with-source
@@ -155,6 +151,7 @@ export class SpatialHierarchyBuilder {
       storeyHeights: new Map<number, number>(),
       elementToStorey,
       elementToContainer,
+      ambiguousStorey: computeAmbiguousStorey(byStorey), // #4311
 
       getStoreyElements(storeyId: number): number[] {
         return byStorey.get(storeyId) ?? [];
@@ -203,7 +200,7 @@ export class SpatialHierarchyBuilder {
     // show both (issue #1634). It lives only in the raw record, so it needs the
     // source bytes; the source-less buildFromCache fallback leaves it undefined,
     // exactly like storey elevation.
-    const rawLongName = this.extractLongName(expressId, ctx);
+    const rawLongName = extractLongName(expressId, ctx.attrSource?.entityIndex, ctx.attrExtractor);
     // Fall back to LongName when Name is empty (common for IfcSpace). Left
     // empty, not a fabricated `Entity #<id>` — it flows into the export layer.
     const name = rawName || rawLongName || '';
@@ -224,12 +221,12 @@ export class SpatialHierarchyBuilder {
     let elevation: number | undefined;
     if (typeEnum === IfcTypeEnum.IfcBuildingStorey && ctx.attrSource) {
       const { source, entityIndex, lengthUnitScale } = ctx.attrSource;
-      let rawElevation = this.extractElevation(expressId, source, entityIndex);
+      let rawElevation = extractElevation(expressId, source, entityIndex);
       if (rawElevation === undefined) {
         // Elevation is optional and frequently null (Revit / ArchiCAD). Fall back
         // to the storey's Z from its ObjectPlacement so it still orders + lifts in
         // Exploded mode instead of collapsing to a single floor (#1289).
-        rawElevation = this.extractPlacementElevation(expressId, source, entityIndex);
+        rawElevation = extractPlacementElevation(expressId, source, entityIndex);
       }
       if (rawElevation !== undefined) {
         elevation = rawElevation * lengthUnitScale;
@@ -350,138 +347,5 @@ export class SpatialHierarchyBuilder {
     }
 
     return { expressId, type: typeEnum, name, longName, elevation, children: childNodes, elements: containedElements };
-  }
-
-  /**
-   * Read an entity's LongName by schema attribute *name*. IfcSite / IfcBuilding /
-   * IfcBuildingStorey / IfcSpace (and the IFC4.3 facility/infra containers)
-   * declare LongName at index 7, but IfcProject carries it at a different slot,
-   * so resolving by name (not a fixed index) stays correct across the IfcRoot
-   * family. The lookup spans every bundled schema, so IFC4.3 leaves outside the
-   * parser's IFC4 codegen pin resolve too. Returns the trimmed value, or
-   * undefined when the type declares no LongName, it is empty, or no source
-   * buffer is available (the buildFromCache path).
-   */
-  private extractLongName(expressId: number, ctx: BuildContext): string | undefined {
-    if (!ctx.attrSource || !ctx.attrExtractor) return undefined;
-    const ref = ctx.attrSource.entityIndex.byId.get(expressId);
-    if (!ref) return undefined;
-    try {
-      const entity = ctx.attrExtractor.extractEntity(ref);
-      if (!entity) return undefined;
-      const idx = getAttributeNamesAcrossSchemas(entity.type).indexOf('LongName');
-      if (idx < 0) return undefined;
-      const raw = (entity.attributes || [])[idx];
-      const value = typeof raw === 'string' ? raw.trim() : '';
-      return value.length > 0 ? value : undefined;
-    } catch (error) {
-      log.caught('Failed to extract LongName', error, {
-        operation: 'extractLongName',
-        entityId: expressId,
-      });
-      return undefined;
-    }
-  }
-
-  /**
-   * Extract elevation from an IfcBuildingStorey. Elevation is attribute index 9
-   * in both IFC2x3 and IFC4 (GlobalId, OwnerHistory, Name, Description,
-   * ObjectType, ObjectPlacement, Representation, LongName, CompositionType,
-   * Elevation).
-   */
-  private extractElevation(
-    expressId: number,
-    source: Uint8Array | IfcSourceBytes,
-    entityIndex: { byId: { get(expressId: number): EntityRef | undefined } }
-  ): number | undefined {
-    const ref = entityIndex.byId.get(expressId);
-    if (!ref) return undefined;
-
-    try {
-      const extractor = new EntityExtractor(source);
-      const entity = extractor.extractEntity(ref);
-      if (!entity) return undefined;
-
-      const attrs = entity.attributes || [];
-
-      // Number from a raw value or a typed value like ['IFCLENGTHMEASURE', 3.0].
-      const extractNumber = (val: any): number | undefined => {
-        if (typeof val === 'number') return val;
-        if (Array.isArray(val) && val.length === 2 && typeof val[1] === 'number') {
-          return val[1];
-        }
-        return undefined;
-      };
-
-      // Read ONLY the Elevation slot: a previous "scan every attribute for a
-      // number < 10000" fallback wrongly treated reference attributes (parsed as
-      // bare express-id numbers, e.g. OwnerHistory #3628 -> 3628) as elevations,
-      // so a storey with a null Elevation got a garbage value instead of falling
-      // through to the ObjectPlacement-Z fallback below (#1289).
-      if (attrs.length > IFC_BUILDING_STOREY_ELEVATION_INDEX) {
-        return extractNumber(attrs[IFC_BUILDING_STOREY_ELEVATION_INDEX]);
-      }
-    } catch (error) {
-      log.caught('Failed to extract elevation', error, {
-        operation: 'extractElevation',
-        entityId: expressId,
-        entityType: 'IfcBuildingStorey',
-      });
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Resolve a storey's elevation from its ObjectPlacement, used as a fallback when
-   * the Elevation attribute is null. Walks
-   *   IfcBuildingStorey.ObjectPlacement (IfcLocalPlacement)
-   *     -> RelativePlacement (IfcAxis2Placement3D)
-   *       -> Location (IfcCartesianPoint).Coordinates[2]
-   * i.e. the storey's Z relative to its parent spatial container, which matches
-   * the semantics of the Elevation attribute and avoids folding in any site-level
-   * georeferencing Z. Returns the raw (unscaled) Z, or undefined when the chain
-   * can't be resolved.
-   */
-  private extractPlacementElevation(
-    expressId: number,
-    source: Uint8Array | IfcSourceBytes,
-    entityIndex: { byId: { get(expressId: number): EntityRef | undefined } }
-  ): number | undefined {
-    try {
-      const extractor = new EntityExtractor(source);
-      const readAttrs = (id: number): unknown[] | undefined => {
-        const ref = entityIndex.byId.get(id);
-        if (!ref) return undefined;
-        return extractor.extractEntity(ref)?.attributes ?? undefined;
-      };
-
-      const placementId = readAttrs(expressId)?.[IFC_BUILDING_STOREY_PLACEMENT_INDEX];
-      if (typeof placementId !== 'number') return undefined;
-
-      // IfcLocalPlacement(PlacementRelTo, RelativePlacement) - RelativePlacement
-      // (index 1) is the IfcAxis2Placement3D carrying this storey's own offset.
-      const axisId = readAttrs(placementId)?.[1];
-      if (typeof axisId !== 'number') return undefined;
-
-      // IfcAxis2Placement3D(Location, Axis, RefDirection) - Location (index 0) is
-      // an IfcCartesianPoint.
-      const locationId = readAttrs(axisId)?.[0];
-      if (typeof locationId !== 'number') return undefined;
-
-      // IfcCartesianPoint.Coordinates (index 0) is a list [x, y, z].
-      const coords = readAttrs(locationId)?.[0];
-      if (Array.isArray(coords) && coords.length >= 3 && typeof coords[2] === 'number') {
-        return coords[2];
-      }
-    } catch (error) {
-      log.caught('Failed to extract placement elevation', error, {
-        operation: 'extractPlacementElevation',
-        entityId: expressId,
-        entityType: 'IfcBuildingStorey',
-      });
-    }
-
-    return undefined;
   }
 }

--- a/packages/parser/test/data-store-transport.test.ts
+++ b/packages/parser/test/data-store-transport.test.ts
@@ -5,10 +5,13 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { IfcTypeEnum, type SpatialHierarchy, type SpatialNode } from '@ifc-lite/data';
 import { IfcParser } from '../src/index.js';
 import {
   collectTransferables,
   fromTransport,
+  spatialHierarchyFromColumns,
+  spatialHierarchyToColumns,
   toTransport,
   transportByteSize,
 } from '../src/data-store-transport.js';
@@ -317,5 +320,50 @@ describe('fromTransport source identity (#2183)', () => {
     const two = fromTransport(transportOf(), bytes);
     expect(one.source.contentKey).toBe(two.source.contentKey);
     expect(one.source.byteLength).toBe(bytes.byteLength);
+  });
+});
+
+describe('spatialHierarchyToColumns / spatialHierarchyFromColumns: ambiguousStorey (#4311)', () => {
+  function minimalHierarchy(ambiguousStorey: Set<number>): SpatialHierarchy {
+    const project: SpatialNode = {
+      expressId: 1,
+      type: IfcTypeEnum.IfcProject,
+      name: 'Project',
+      longName: undefined,
+      elevation: undefined,
+      children: [],
+      elements: [],
+    };
+    return {
+      project,
+      byStorey: new Map(),
+      byBuilding: new Map(),
+      bySite: new Map(),
+      bySpace: new Map(),
+      storeyElevations: new Map(),
+      storeyHeights: new Map(),
+      elementToStorey: new Map(),
+      ambiguousStorey,
+      getStoreyElements: () => [],
+      getStoreyByElevation: () => null,
+      getContainingSpace: () => null,
+      getPath: () => [],
+    };
+  }
+
+  it('carries a non-empty ambiguousStorey across the worker transport, not just elementToStorey', () => {
+    const hierarchy = minimalHierarchy(new Set([4]));
+    const columns = spatialHierarchyToColumns(hierarchy);
+    const rebuilt = spatialHierarchyFromColumns(columns);
+    expect(rebuilt.ambiguousStorey).toBeDefined();
+    expect(rebuilt.ambiguousStorey!.has(4)).toBe(true);
+  });
+
+  it('round-trips an empty ambiguousStorey as empty, not absent', () => {
+    const hierarchy = minimalHierarchy(new Set());
+    const columns = spatialHierarchyToColumns(hierarchy);
+    const rebuilt = spatialHierarchyFromColumns(columns);
+    expect(rebuilt.ambiguousStorey).toBeDefined();
+    expect(rebuilt.ambiguousStorey!.size).toBe(0);
   });
 });

--- a/packages/parser/test/spatial-hierarchy-builder.test.ts
+++ b/packages/parser/test/spatial-hierarchy-builder.test.ts
@@ -584,5 +584,54 @@ describe('SpatialHierarchyBuilder', () => {
 
       expect(hierarchy.ambiguousStorey!.has(4)).toBe(true);
     });
+
+    it('flags the same element as ambiguous regardless of which storey elementToStorey resolves to', () => {
+      // spatial-hierarchy-ambiguity.ts's doc claims computeAmbiguousStorey() is
+      // agnostic to the elementToStorey tie-break. Prove it: two fixtures with
+      // IDENTICAL IfcRelContainedInSpatialStructure declaration order (storey A's
+      // edge #200 always declared before storey B's edge #201) but REVERSED
+      // IfcRelAggregates order flip which storey elementToStorey resolves the
+      // wall to (last storey visited in the aggregation-driven tree walk wins,
+      // since the direct-containment loop assigns unconditionally - see
+      // spatial-hierarchy-ambiguity.ts). ambiguousStorey must report `true` for
+      // the wall in BOTH fixtures even though the winner differs between them.
+      const build = (aggregatesOrder: readonly [number, number]) => {
+        const strings = new StringTable();
+        const entities = new EntityTableBuilder(4, strings);
+        entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+        entities.add(2, 'IFCBUILDINGSTOREY', 's0', 'Storey A', '', '');
+        entities.add(3, 'IFCBUILDINGSTOREY', 's1', 'Storey B', '', '');
+        entities.add(4, 'IFCWALL', 'w0', 'Wall', '', '', true);
+
+        const relationships = new RelationshipGraphBuilder();
+        const [first, second] = aggregatesOrder;
+        relationships.addEdge(1, first, RelationshipType.Aggregates, 100);
+        relationships.addEdge(1, second, RelationshipType.Aggregates, 101);
+        // Containment declaration order held constant across both fixtures:
+        // storey A's edge is always declared first, storey B's second.
+        relationships.addEdge(2, 4, RelationshipType.ContainsElements, 200);
+        relationships.addEdge(3, 4, RelationshipType.ContainsElements, 201);
+
+        return new SpatialHierarchyBuilder().build(
+          entities.build(),
+          relationships.build(),
+          strings,
+          new Uint8Array(),
+          { byId: { get: () => undefined } },
+        );
+      };
+
+      const aggregatesAThenB = build([2, 3]);
+      const aggregatesBThenA = build([3, 2]);
+
+      // The winner differs between the two fixtures (proving the tie-break is
+      // aggregation-order dependent, not declaration-order dependent)...
+      expect(aggregatesAThenB.elementToStorey.get(4)).not.toBe(
+        aggregatesBThenA.elementToStorey.get(4),
+      );
+      // ...but the ambiguity signal itself does not.
+      expect(aggregatesAThenB.ambiguousStorey!.has(4)).toBe(true);
+      expect(aggregatesBThenA.ambiguousStorey!.has(4)).toBe(true);
+    });
   });
 });

--- a/packages/parser/test/spatial-hierarchy-builder.test.ts
+++ b/packages/parser/test/spatial-hierarchy-builder.test.ts
@@ -472,4 +472,117 @@ describe('SpatialHierarchyBuilder', () => {
     expect(hierarchy.project.children[0].name).toBe('01');
     expect(hierarchy.project.children[0].longName).toBeUndefined();
   });
+
+  describe('ambiguousStorey (#4311)', () => {
+    it('flags an element with two direct ContainsElements edges naming different storeys', () => {
+      const strings = new StringTable();
+      const entities = new EntityTableBuilder(4, strings);
+      entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+      entities.add(2, 'IFCBUILDINGSTOREY', 's0', 'Storey A', '', '');
+      entities.add(3, 'IFCBUILDINGSTOREY', 's1', 'Storey B', '', '');
+      entities.add(4, 'IFCWALL', 'w0', 'Wall', '', '', true);
+
+      const relationships = new RelationshipGraphBuilder();
+      relationships.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      relationships.addEdge(1, 3, RelationshipType.Aggregates, 101);
+      // Two DIFFERENT storeys both directly contain the same wall — genuinely
+      // ambiguous, unlike a repeated declaration of the same edge.
+      relationships.addEdge(2, 4, RelationshipType.ContainsElements, 200);
+      relationships.addEdge(3, 4, RelationshipType.ContainsElements, 201);
+
+      const hierarchy = new SpatialHierarchyBuilder().build(
+        entities.build(),
+        relationships.build(),
+        strings,
+        new Uint8Array(),
+        { byId: { get: () => undefined } },
+      );
+
+      // elementToStorey still resolves to exactly one storey (tie-break
+      // unchanged by this issue) - the new part is that the ambiguity itself
+      // is now visible.
+      expect(hierarchy.elementToStorey.get(4)).toBeDefined();
+      expect(hierarchy.ambiguousStorey).toBeDefined();
+      expect(hierarchy.ambiguousStorey!.has(4)).toBe(true);
+    });
+
+    it('does NOT flag an element directly contained by only one storey (the ordinary case)', () => {
+      // The important half of this pair: a signal that fires on an everyday,
+      // unambiguous model is worse than no signal at all.
+      const strings = new StringTable();
+      const entities = new EntityTableBuilder(4, strings);
+      entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+      entities.add(2, 'IFCBUILDINGSTOREY', 's0', 'Storey A', '', '');
+      entities.add(3, 'IFCBUILDINGSTOREY', 's1', 'Storey B', '', '');
+      entities.add(4, 'IFCWALL', 'w0', 'Wall', '', '', true);
+
+      const relationships = new RelationshipGraphBuilder();
+      relationships.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      relationships.addEdge(1, 3, RelationshipType.Aggregates, 101);
+      relationships.addEdge(2, 4, RelationshipType.ContainsElements, 200);
+
+      const hierarchy = new SpatialHierarchyBuilder().build(
+        entities.build(),
+        relationships.build(),
+        strings,
+        new Uint8Array(),
+        { byId: { get: () => undefined } },
+      );
+
+      expect(hierarchy.elementToStorey.get(4)).toBe(2);
+      expect(hierarchy.ambiguousStorey).toBeDefined();
+      expect(hierarchy.ambiguousStorey!.has(4)).toBe(false);
+      expect(hierarchy.ambiguousStorey!.size).toBe(0);
+    });
+
+    it('does NOT flag an element whose only duplicate is the SAME storey declared twice', () => {
+      // Two IfcRelContainedInSpatialStructure instances naming the identical
+      // (storey, element) pair collapse to one edge before this ever runs
+      // (RelationshipGraphBuilder's source/target/type dedupe) - so this
+      // fixture also proves the dedupe, not just the flag.
+      const strings = new StringTable();
+      const entities = new EntityTableBuilder(3, strings);
+      entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+      entities.add(2, 'IFCBUILDINGSTOREY', 's0', 'Storey A', '', '');
+      entities.add(3, 'IFCWALL', 'w0', 'Wall', '', '', true);
+
+      const relationships = new RelationshipGraphBuilder();
+      relationships.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      relationships.addEdge(2, 3, RelationshipType.ContainsElements, 200);
+      relationships.addEdge(2, 3, RelationshipType.ContainsElements, 201); // redundant IfcRel
+
+      const hierarchy = new SpatialHierarchyBuilder().build(
+        entities.build(),
+        relationships.build(),
+        strings,
+        new Uint8Array(),
+        { byId: { get: () => undefined } },
+      );
+
+      expect(hierarchy.byStorey.get(2)).toEqual([3]);
+      expect(hierarchy.ambiguousStorey!.has(3)).toBe(false);
+    });
+
+    it('flags on the cache-restore path too (no source buffer needed)', () => {
+      const strings = new StringTable();
+      const entities = new EntityTableBuilder(4, strings);
+      entities.add(1, 'IFCPROJECT', 'p0', 'Project', '', '');
+      entities.add(2, 'IFCBUILDINGSTOREY', 's0', 'Storey A', '', '');
+      entities.add(3, 'IFCBUILDINGSTOREY', 's1', 'Storey B', '', '');
+      entities.add(4, 'IFCWALL', 'w0', 'Wall', '', '', true);
+
+      const relationships = new RelationshipGraphBuilder();
+      relationships.addEdge(1, 2, RelationshipType.Aggregates, 100);
+      relationships.addEdge(1, 3, RelationshipType.Aggregates, 101);
+      relationships.addEdge(2, 4, RelationshipType.ContainsElements, 200);
+      relationships.addEdge(3, 4, RelationshipType.ContainsElements, 201);
+
+      const hierarchy = new SpatialHierarchyBuilder().buildFromCache(
+        entities.build(),
+        relationships.build(),
+      )!;
+
+      expect(hierarchy.ambiguousStorey!.has(4)).toBe(true);
+    });
+  });
 });

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -144,7 +144,19 @@ export class EntityNode {
     const nodes = this.getRelated(RelationshipType.ContainsElements, 'inverse');
     return nodes[0] ?? null;
   }
-  
+
+  /**
+   * True when this element has more than one direct
+   * `IfcRelContainedInSpatialStructure` edge, i.e. `containedIn()`'s answer
+   * (first-declared wins) was a tie-break rather than the only candidate the
+   * source file declared (#4311). Duplicate edges naming the SAME structure
+   * collapse to one before either method ever sees them (relationship-graph
+   * dedupe), so this only fires on genuinely different candidates.
+   */
+  containedInAmbiguous(): boolean {
+    return this.getRelated(RelationshipType.ContainsElements, 'inverse').length > 1;
+  }
+
   // Aggregation
   decomposes(): EntityNode[] {
     return this.getRelated(RelationshipType.Aggregates, 'forward');

--- a/packages/query/test/entity-node.test.ts
+++ b/packages/query/test/entity-node.test.ts
@@ -150,6 +150,41 @@ describe('EntityNode', () => {
       const project = new EntityNode(store, 1);
       expect(project.containedIn()).toBeNull();
     });
+
+    // #4311: containedIn() only ever returns ONE answer (first-declared wins);
+    // containedInAmbiguous() is how a caller learns whether that answer was a
+    // tie-break or the only candidate the source file declared.
+    it('containedInAmbiguous() is false for the ordinary single-container case', () => {
+      const store = buildSpatialStore();
+      const wall = new EntityNode(store, 10);
+      expect(wall.containedInAmbiguous()).toBe(false);
+    });
+
+    it('containedInAmbiguous() is false when there is no container at all', () => {
+      const store = buildSpatialStore();
+      const project = new EntityNode(store, 1);
+      expect(project.containedInAmbiguous()).toBe(false);
+    });
+
+    it('containedInAmbiguous() is true when two different storeys directly contain the same element', () => {
+      const store = createMockStore({
+        entities: [
+          { expressId: 1, type: 'IFCPROJECT', globalId: 'proj-1', name: 'My Project' },
+          { expressId: 4, type: 'IFCBUILDINGSTOREY', globalId: 'storey-1', name: 'Level 0' },
+          { expressId: 5, type: 'IFCBUILDINGSTOREY', globalId: 'storey-2', name: 'Level 1' },
+          { expressId: 10, type: 'IFCWALL', globalId: 'wall-1', name: 'Exterior Wall' },
+        ],
+        relationships: [
+          { source: 1, target: 4, type: RelationshipType.Aggregates, relId: 100 },
+          { source: 1, target: 5, type: RelationshipType.Aggregates, relId: 101 },
+          { source: 4, target: 10, type: RelationshipType.ContainsElements, relId: 200 },
+          { source: 5, target: 10, type: RelationshipType.ContainsElements, relId: 201 },
+        ],
+      });
+      const wall = new EntityNode(store, 10);
+      expect(wall.containedIn()).not.toBeNull(); // still resolves to a single answer
+      expect(wall.containedInAmbiguous()).toBe(true);
+    });
   });
 
   // ── Aggregation ───────────────────────────────────────────────

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -291,7 +291,6 @@
    523 packages/parser/src/project-units.ts
    594 packages/parser/src/schedule-extractor.ts
    494 packages/parser/src/source-bytes.ts
-   487 packages/parser/src/spatial-hierarchy-builder.ts
    513 packages/plugin-api/src/types.ts
    678 packages/pointcloud/src/formats/e57-decode.ts
    424 packages/pointcloud/src/formats/pcd.ts


### PR DESCRIPTION
Closes #4311

## Sequencing

#4311's own text says it is "in scope but standalone from the tie-break fix" — unlike #4314, which the maintainer explicitly told to wait for #4310 ("this builds on its final shape"). No such instruction exists on #4311 or its parent #4248 thread.

Checked #4310's status: still open/unmerged (stacked on #4285, also open). This PR does not touch `spatial-hierarchy-canonical-parent.ts` (the reachability logic #4310/#4285 modify) or the tie-break assignment in `elementToStorey` at all — it only reads the already-built `byStorey` map (direct containment per storey, unaffected by which tie-break strategy wins) and the raw inverse `ContainsElements` edges. Verified independence by reading #4310's diff and #4248/#4314's full comment threads before starting.

## What "ambiguous" means here

Two direct `IfcRelContainedInSpatialStructure` edges naming **different** storeys for the same element → ambiguous. Two edges naming the **same** storey are NOT ambiguous — `RelationshipGraphBuilder` already dedupes same-(source,target,type) `IfcRel*` instances into one edge before either detector ever sees them, so a literal duplicate declaration never presents as `>1` edge. Covered by a dedicated test (`does NOT flag an element whose only duplicate is the SAME storey declared twice`).

An unreachable-vs-reachable storey pair (#4314's residual case) is treated as ambiguous too: #4311 is about what the *source file* declared, independent of which candidates survive tree-reachability filtering — that's #4314's concern, not this one's.

## Shape of the signal

- `SpatialHierarchy.ambiguousStorey?: Set<number>` (`@ifc-lite/data`) — additive optional field, same pattern as the existing `elementToContainer?` field. Populated by `SpatialHierarchyBuilder` on both `build()` and `buildFromCache()` (`packages/parser/src/spatial-hierarchy-ambiguity.ts`, `computeAmbiguousStorey(byStorey)`), and threaded through the parser worker transport (`data-store-transport.ts`) so it survives the worker → main-thread handoff, not just direct in-process builds.
- `EntityNode.containedInAmbiguous(): boolean` (`@ifc-lite/query`) — the per-call equivalent for `containedIn()` callers, which have no aggregate hierarchy view. `containedIn()`'s inverse-edge list is already deduped at the graph layer, so `.length > 1` is sufficient — no extra Set needed.

Neither `elementToStorey` nor `containedIn()` changes what they return; this only makes the ambiguity itself visible.

## Cost

Detection reuses data the builder already computes: `computeAmbiguousStorey` iterates `byStorey`'s existing per-storey element lists (the same lists `elementToStorey` is built from), no extra graph traversal. `containedInAmbiguous()` reuses `containedIn()`'s own inverse-edge lookup. Not opt-in — the marginal cost is one Map/Set walk over data already in hand.

## Module-size gate

`packages/parser/src/spatial-hierarchy-builder.ts` was already at its allowlisted budget (487/487, zero headroom) before this change. Rather than raise the budget, split its three on-demand attribute-extraction methods (`extractLongName`, `extractElevation`, `extractPlacementElevation` — pure, behavior-preserving move, not a rewrite) into `packages/parser/src/spatial-hierarchy-attribute-extraction.ts`. The builder file shrank to 351 lines (allowlist row removed, now under the 400-line limit); `packages/data/src/types.ts` had exactly 1 line of headroom, used by a single-line field addition. `node scripts/check-module-size.mjs` exits 0.

## Tests

- `packages/parser/test/spatial-hierarchy-builder.test.ts`, new `describe('ambiguousStorey (#4311)')`: flags a genuine two-storey duplicate; does NOT flag the ordinary single-storey case (the important half — a signal that fires on ordinary models is worse than none); does NOT flag a same-storey duplicate edge; flags on the cache-restore path too.
- `packages/parser/test/data-store-transport.test.ts`: `ambiguousStorey` round-trips through `spatialHierarchyToColumns`/`spatialHierarchyFromColumns` (both non-empty and empty-not-absent cases) — this is the worker-transport path a real running app actually uses.
- `packages/query/test/entity-node.test.ts`: `containedInAmbiguous()` false for the ordinary case and the no-container case, true for a genuine two-storey duplicate.

Mutation-tested: reverted the builder's `ambiguousStorey` field to a hardcoded empty Set — exactly the 2 ambiguity-specific parser tests reddened, all others (including the ordinary/non-ambiguous fixtures) stayed green. Reverted the transport's serialization to `undefined` — exactly the 2 transport round-trip tests reddened. Reverted `containedInAmbiguous()` to `return false` — exactly the 1 query test asserting `true` reddened. All reverted afterward.

Full suites: `packages/parser` 111 files / 1220 tests passed, 3 skipped (pre-existing, unrelated). `packages/query` 19 files / 286 tests passed. `packages/data` 23 files / 288 tests passed.

## api-surface / changeset

No `scripts/api-surface.json` update needed: it snapshots module-level exports only (`checker.getExportsOfModule`, serialized as `"Name: kind"` — read the script to confirm). `SpatialHierarchy` stays `interface`, `SpatialHierarchyBuilder` and `EntityNode` stay `class` — I added a field and a method, not a new top-level export, so no snapshot entry changes. Verified none of the touched files are re-exported anywhere new.

Changeset: `@ifc-lite/data` minor (4.0.0, additive optional field), `@ifc-lite/parser` minor (5.2.0, new capability), `@ifc-lite/query` minor (2.2.0, new public method).

## Not checked

`packages/ifcx/src/hierarchy-builder.ts` also constructs a `SpatialHierarchy`-shaped object for the IFC5/IfcX pipeline (a different composition format, not classic `IfcRelContainedInSpatialStructure` edges). Left it as-is — `ambiguousStorey` is optional and simply absent there, which is the same degraded-but-safe behavior the pre-existing `elementToContainer?` field already has for that path. Not investigated whether IfcX has an analogous ambiguity concept.

`apps/server`'s Rust `canonical_parent` path (flagged as a third path in #4310's PR body) was not touched or investigated here — #4311 only names `elementToStorey` and `containedIn()`, both TypeScript.