### PR TITLE
fix(viewer): fold per-model isolate channel into to-scale PDF export

### DIFF
--- a/.changeset/pdf-export-per-model-isolation.md
+++ b/.changeset/pdf-export-per-model-isolation.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the to-scale 3D-view PDF export printing geometry a federated (multi-model) session had hidden or isolated with the per-model "Isolate in 3D" action.
+
+`view-pdf-export-source.ts`'s `gatherDrawnMeshes` folded `hiddenEntities`, `isolatedEntities`, `computedIsolatedIds` (storey/class isolation) and `typeVisibility`, but never read `hiddenEntitiesByModel` / `isolatedEntitiesByModel` — the per-model channel `basketVisibleSet.ts`'s `getVisibleGlobalIds` already applies as an independent, per-model AND. With two or more models loaded and a model-scoped hide or isolate active, the PDF export included that model's geometry even though the viewport did not draw it.
+
+The channel is now applied per model, in that model's own local express-id space (converted from the mesh's global id via `idOffset`, mirroring `getVisibleGlobalIds`), before meshes are handed to `collectViewMeshes`. `ghostExceptEntities` (X-Ray translucency) remains untouched — a ghosted-but-visible entity still exports, matching the sibling `resolveExportVisibility()` (#4333) ruling.

--- a/apps/viewer/src/lib/export/view-pdf/collect-view-meshes.ts
+++ b/apps/viewer/src/lib/export/view-pdf/collect-view-meshes.ts
@@ -38,6 +38,16 @@
  * mesh list already narrowed by `selectModelMeshes` (the same thing the 2D
  * drawing pipeline does), because a printed drawing always draws the building,
  * never the type library.
+ *
+ * A SIXTH channel — `hiddenEntitiesByModel` / `isolatedEntitiesByModel`, the
+ * per-model "Isolate in 3D" allowlist/denylist — is also not folded here, but
+ * NOT deliberately: it is applied by the caller (`view-pdf-export-source.ts`'s
+ * `gatherDrawnMeshes`) directly on the mesh list, in each model's own LOCAL
+ * id space, before this function ever sees the meshes. It could not join the
+ * five above without a `MeshData.modelIndex` this file's callers do not
+ * reliably stamp (see that file's module doc). A caller that narrows the mesh
+ * list before handing it here still owes this channel the same treatment the
+ * other five get — it is not exempt just because it lives upstream.
  */
 
 import type { MeshData } from '@ifc-lite/geometry';

--- a/apps/viewer/src/lib/export/view-pdf/view-pdf-export-source.test.ts
+++ b/apps/viewer/src/lib/export/view-pdf/view-pdf-export-source.test.ts
@@ -157,3 +157,118 @@ describe('readViewPdfSource (#2042)', () => {
     assert.deepEqual(source.view.instancedMeshes, []);
   });
 });
+
+/**
+ * The per-model "Isolate in 3D" channel (`hiddenEntitiesByModel` /
+ * `isolatedEntitiesByModel`) — federation-only, keyed by `modelId`, values in
+ * that model's LOCAL express-id space. Neither `hiddenEntities` /
+ * `isolatedEntities` nor `computeIsolationFilterSet` cover it (confirmed by
+ * grep against `basketVisibleSet.ts`'s `getVisibleGlobalIds`, which applies
+ * it as a third, independent, per-candidate AND). Before the fix this file
+ * exists to pin, a model-scoped hide/isolate was invisible to the PDF export:
+ * `readViewPdfSource` printed geometry the viewport does not show.
+ *
+ * The fixture puts a SECOND model's meshes at a LOCAL express id (1) that
+ * COLLIDES with the first model's local id (1) — only the `idOffset` tells
+ * them apart. An off-by-one, or a fix that forgot the offset conversion, is
+ * invisible on a single-model fixture and would silently drop or keep the
+ * wrong entity here.
+ */
+describe('readViewPdfSource — per-model isolation channel (#4328 follow-up)', () => {
+  const SMALL_ID_OFFSET = 0;
+  const LARGE_ID_OFFSET = 1_000_000;
+
+  function idMesh(globalId: number): MeshData {
+    return {
+      expressId: globalId,
+      ifcType: 'IfcWall',
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array(9),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1],
+    };
+  }
+
+  function geometryOf(meshes: MeshData[]): GeometryResult {
+    const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } };
+    return {
+      meshes,
+      totalTriangles: meshes.length,
+      totalVertices: meshes.length * 3,
+      coordinateInfo: {
+        originShift: { x: 0, y: 0, z: 0 },
+        originalBounds: bounds,
+        shiftedBounds: bounds,
+        hasLargeCoordinates: false,
+      },
+    };
+  }
+
+  /**
+   * `small` (idOffset 0): one mesh at local/global id 1.
+   * `large` (idOffset 1_000_000): two meshes, local ids 1 and 2 — global ids
+   * 1_000_001 and 1_000_002. Local id 1 COLLIDES with `small`'s local id 1.
+   */
+  function seedTwoModels(overrides: {
+    hiddenEntitiesByModel?: Map<string, Set<number>>;
+    isolatedEntitiesByModel?: Map<string, Set<number>>;
+  } = {}): void {
+    const small = {
+      ...fixtureModel('small', { idOffset: SMALL_ID_OFFSET }),
+      geometryResult: geometryOf([idMesh(SMALL_ID_OFFSET + 1)]),
+    };
+    const large = {
+      ...fixtureModel('large', { idOffset: LARGE_ID_OFFSET }),
+      geometryResult: geometryOf([idMesh(LARGE_ID_OFFSET + 1), idMesh(LARGE_ID_OFFSET + 2)]),
+    };
+    useViewerStore.setState({
+      ...fixtureModels(small, large),
+      hiddenEntities: new Set<number>(),
+      isolatedEntities: null,
+      classFilter: null,
+      selectedStoreys: new Set<number>(),
+      hiddenEntitiesByModel: overrides.hiddenEntitiesByModel ?? new Map(),
+      isolatedEntitiesByModel: overrides.isolatedEntitiesByModel ?? new Map(),
+      projectionMode: 'orthographic',
+      sectionPlane: { ...useViewerStore.getState().sectionPlane, enabled: false },
+    });
+
+    const canvas = document.createElement('canvas');
+    Object.defineProperty(canvas, 'clientHeight', { value: 500, configurable: true });
+    setGlobalCanvasRef({ current: canvas });
+    setGlobalRendererRef({ current: fakeRenderer() });
+  }
+
+  afterEach(() => {
+    clearGlobalRefs();
+  });
+
+  const ids = (meshes: readonly MeshData[]): number[] =>
+    meshes.map((m) => m.expressId).sort((a, b) => a - b);
+
+  it('no per-model channel active: unchanged output (both models, all meshes)', () => {
+    seedTwoModels();
+    const source = readViewPdfSource(useViewerStore.getState());
+    assert.deepEqual(ids(source.view.meshes), [1, 1_000_001, 1_000_002]);
+  });
+
+  it('isolatedEntitiesByModel scoped to "large" drops that model\'s non-isolated mesh, leaves "small" untouched', () => {
+    // `large` local id 1 is isolated; local id 2 must drop. `small`'s local id
+    // 1 (which COLLIDES with `large`'s local id 1) carries no entry for
+    // 'small' in the map and must be untouched — proving the channel is
+    // scoped per model, not a flat id match.
+    seedTwoModels({ isolatedEntitiesByModel: new Map([['large', new Set([1])]]) });
+    const source = readViewPdfSource(useViewerStore.getState());
+    assert.deepEqual(
+      ids(source.view.meshes),
+      [1, 1_000_001],
+      'small model mesh (global 1) and large model\'s isolated local-id-1 mesh (global 1,000,001) survive; large\'s local-id-2 mesh (global 1,000,002) does not',
+    );
+  });
+
+  it('hiddenEntitiesByModel scoped to "large" drops only that model\'s named local id', () => {
+    seedTwoModels({ hiddenEntitiesByModel: new Map([['large', new Set([2])]]) });
+    const source = readViewPdfSource(useViewerStore.getState());
+    assert.deepEqual(ids(source.view.meshes), [1, 1_000_001]);
+  });
+});

--- a/apps/viewer/src/lib/export/view-pdf/view-pdf-export-source.ts
+++ b/apps/viewer/src/lib/export/view-pdf/view-pdf-export-source.ts
@@ -6,8 +6,9 @@
  * Gather everything the to-scale 3D-view PDF export needs from the live viewer
  * — store state, renderer camera, viewport canvas — in one place (#2042).
  *
- * DEFECT CLASS — an export that draws a different model from the screen. Two
- * ways that happens, and both are folded here rather than at the call site:
+ * DEFECT CLASS — an export that draws a different model from the screen.
+ * Three ways that happens, and all three are folded here rather than at the
+ * call site:
  *
  *  1. **The instanced half goes missing** (#2558). GPU-instanced occurrences
  *     never appear in `geometryResult.meshes`; the Cesium world view read that
@@ -21,6 +22,26 @@
  *     storey while the screen shows one, so this resolves the full allowlist
  *     through `computeIsolationFilterSet` — the shared derivation, not a
  *     restatement of it.
+ *  3. **The per-model "Isolate in 3D" channel is a separate map.**
+ *     `hiddenEntitiesByModel` / `isolatedEntitiesByModel` (federation-only,
+ *     keyed by `modelId`, values in that model's LOCAL express-id space) are
+ *     not part of `state.hiddenEntities` / `state.isolatedEntities` or
+ *     `computeIsolationFilterSet` at all — `getVisibleGlobalIds` in
+ *     `basketVisibleSet.ts` applies them as a THIRD, independent AND, per
+ *     candidate, scoped to that candidate's own model. An export that folded
+ *     only `hiddenEntities`/`isolatedEntities`/`computedIsolatedIds` would
+ *     print a federated model the user isolated away with a model-scoped
+ *     hide/isolate — the same "export disagrees with the viewport" class as
+ *     (2), just via the channel neither `hiddenEntities` nor
+ *     `computeIsolationFilterSet` covers. `gatherDrawnMeshes` below applies
+ *     it inline, per model, in that model's own LOCAL id space (mirroring
+ *     `getVisibleGlobalIds`), rather than converting it to a global `Set` and
+ *     handing it to `collectViewMeshes`: `collectViewMeshes`'s existing
+ *     `modelVisibility` gate keys off `MeshData.modelIndex`, and this file's
+ *     meshes carry no reliable `modelIndex` (only `ViewportContainer`'s render
+ *     memo stamps that, via `geometryWithModelIndex`) — inventing one here
+ *     would be a second, parallel identity scheme for the same models this
+ *     loop already indexes correctly by `modelId`.
  *
  * The camera is read once, imperatively, at the moment this is called: it is
  * not store state, so nothing re-renders when the user orbits. Callers refresh
@@ -86,14 +107,22 @@ export function readViewPdfSource(state: ViewerState): ViewPdfSource {
 
 /**
  * Every visible model's real-building geometry, instanced occurrences included,
- * in federated global-id space.
+ * in federated global-id space, with the per-model "Isolate in 3D" channel
+ * (`hiddenEntitiesByModel` / `isolatedEntitiesByModel`) already applied.
  *
  * `selectModelMeshes` drops type-library geometry for the same reason the 2D
  * drawing pipeline does: a printed drawing draws the building, never the type
  * library (#2058).
  */
 function gatherDrawnMeshes(state: ViewerState): MeshData[] {
-  const results: { geometry: GeometryResult; instancedModelRange: InstancedModelRange | null }[] = [];
+  const results: {
+    geometry: GeometryResult;
+    instancedModelRange: InstancedModelRange | null;
+    /** `null` for the legacy single-model slot, which has no per-model
+     *  hide/isolate channel to look up. */
+    modelId: string | null;
+    idOffset: number;
+  }[] = [];
 
   if (state.models.size > 0) {
     for (const model of state.models.values()) {
@@ -105,21 +134,41 @@ function gatherDrawnMeshes(state: ViewerState): MeshData[] {
       results.push({
         geometry: model.geometryResult,
         instancedModelRange: { modelId: model.id, idOffset: model.idOffset ?? 0, maxExpressId: model.maxExpressId ?? 0 },
+        modelId: model.id,
+        idOffset: model.idOffset ?? 0,
       });
     }
   } else if (state.geometryResult) {
     // The legacy single-model slot is provably the sole model loaded — nothing
     // else to wrongly include, so `null` (no filter) is correct.
-    results.push({ geometry: state.geometryResult, instancedModelRange: null });
+    results.push({ geometry: state.geometryResult, instancedModelRange: null, modelId: null, idOffset: 0 });
   }
 
   const meshes: MeshData[] = [];
-  for (const { geometry, instancedModelRange } of results) {
+  for (const { geometry, instancedModelRange, modelId, idOffset } of results) {
+    // Per-model "Isolate in 3D" channel for THIS model only, in its own LOCAL
+    // express-id space — same lookup `getVisibleGlobalIds` (basketVisibleSet.ts)
+    // does per candidate. A model absent from either map is unrestricted by
+    // this channel, matching the store's own convention (an emptied Set is
+    // deleted from the map, never left present-and-empty; see
+    // `showEntityInModel`/`clearModelVisibility` in `visibilitySlice.ts`).
+    const modelHidden = modelId ? state.hiddenEntitiesByModel.get(modelId) : undefined;
+    const modelIsolated = modelId ? state.isolatedEntitiesByModel.get(modelId) : undefined;
+
     // Appended one at a time, NOT `push(...meshes)`: the argument count would
     // be one model's whole mesh list, which on a large federated model can
     // exceed the engine's maximum argument count and throw a RangeError. Same
     // failure mode as `clipMeshesToHalfSpace` in packages/drawing-2d.
     for (const mesh of selectModelMeshes(withInstancedMeshes(geometry, instancedModelRange).meshes)) {
+      if (modelHidden || modelIsolated) {
+        // `mesh.expressId` is already global (offset baked in — see
+        // `withInstancedMeshes`'s doc and `basketVisibleSet.ts`'s
+        // `collectVisibleCandidates`); the by-model maps are LOCAL, so
+        // subtract the offset back out before checking them.
+        const localId = mesh.expressId - idOffset;
+        if (modelHidden?.has(localId)) continue;
+        if (modelIsolated && !modelIsolated.has(localId)) continue;
+      }
       meshes.push(mesh);
     }
   }


### PR DESCRIPTION
## Summary

The to-scale 3D-view PDF export (`apps/viewer/src/lib/export/view-pdf/`) resolves its own visibility from the store, separately from `resolveExportVisibility()` (#4333). It correctly handles the class-filter bug shape — `classFilter` and `selectedStoreys` via the shared `computeIsolationFilterSet`, plus `typeVisibility` and the global `hiddenEntities`/`isolatedEntities` — but never reads `hiddenEntitiesByModel` / `isolatedEntitiesByModel`, the per-model "Isolate in 3D" channel.

**Consequence:** with a federated (multi-model) session and a model-scoped hide or isolate active, the PDF export included geometry the user cannot see in the viewport — an export disagreeing with the viewport, the same class of defect #2558/#2578 fixed for the instanced half and storey/class isolation.

Fixed by applying the channel in `gatherDrawnMeshes` (`view-pdf-export-source.ts`), per model, in that model's own local express-id space (converted from the mesh's already-global `expressId` via `idOffset`), mirroring exactly what `basketVisibleSet.ts`'s `getVisibleGlobalIds` already does per candidate for the basket/pinboard feature. `collect-view-meshes.ts`'s module doc is updated to name this as a sixth, upstream-applied channel so a future audit doesn't rediscover the same gap.

## Why not route through `resolveExportVisibility()` (#4333)?

Considered and rejected. That resolver is scoped to **one model at a time** and returns per-model id sets (`hiddenLocalIds`/`isolatedLocalIds`/`hiddenGlobalIds`/`isolatedGlobalIds`). The PDF collector instead merges every visible model's meshes into one flat list, already in global id space, before any filter runs (`meshes: readonly MeshData[]` on `ViewMeshInput`). Re-deriving per-model scoping from an already-merged list, or calling the resolver once per model and threading the results back through `collectViewMeshes`'s existing channels, would need a reliable `MeshData.modelIndex` — and this file's meshes don't carry one (only `ViewportContainer`'s render-time memo stamps that, via `geometryWithModelIndex`). Inventing a second identity scheme for the same models this loop already indexes correctly by `modelId` string was the actual risk here, not a benefit — a mismatch there would silently drop or keep the wrong entities, which is worse than the gap being fixed. `ghostExceptEntities` (X-Ray) is deliberately left untouched, matching #4333's ruling that X-Ray ghosting is translucency, not hiding.

## Verification

- RED/GREEN on `view-pdf-export-source.test.ts`: added three tests with two federated models (`small`, idOffset 0; `large`, idOffset 1,000,000) whose LOCAL express ids collide (both use local id 1), so an off-by-one in the offset conversion would be invisible on a single-model fixture. Confirmed RED against the pre-fix code (temporarily restored via `git show`, not `git stash`) — the two new tests failed exactly as expected, the pre-existing three and the "no channel active" case still passed — then restored the fix and confirmed all 6 pass.
- Both directions: no per-model channel active → unchanged output (all meshes present); channel active → only the named model's excluded ids drop, the other model (and that model's own colliding local id) is untouched.
- Federated id-space proof: `large`'s local id 1 (global 1,000,001) and `small`'s local id 1 (global 1) are distinguished correctly by both the isolate and hide tests.
- Full `view-pdf` suite (85 tests across all 7 files in the directory) passes with no regressions.
- `node scripts/check-module-size.mjs`: `EXIT=0`, 0 new files over budget; the three touched files are 128–296 lines, well under budget.
- Real (not blocked): all of the above ran under `apps/viewer`'s `tsx --test` runner, node_modules borrowed read-only from a sibling worktree per this session's environment notes; `@ifc-lite/codegen` needed a fresh local `tsc` build (its dist in the borrowed tree predates the current `package.json` exports map). Not run: the broader `apps/viewer` suite / typecheck (out of scope for this targeted fix, and would need the same per-package build workaround at a scale not attempted here).

## `unqueued`

Found during an export-surface audit (confirmed independently twice), not a queued issue. Per standing direction, no new issue was filed for this — this PR carries `unqueued` and states the reason here instead. #4333 is the originating PR (issue #4328); the PDF surface was deliberately excluded from it as a different output format with a different failure mode, recorded in its PR comment rather than filed separately. This PR is **not stacked** on #4333 — it branches from `main` directly and touches only `apps/viewer/src/lib/export/view-pdf/*`, none of the files #4333 touches (`exportVisibility.ts` is unmodified here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed to-scale 3D PDF exports in federated sessions so hidden or isolated model elements are excluded correctly.
  * Ensured per-model visibility settings apply independently, even when different models use overlapping element IDs.
  * Preserved X-Ray translucency behavior for visible ghosted elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->