### PR TITLE
fix(codegen): normalize CRLF/CR line endings before parsing an EXPRESS schema

### DIFF
--- a/.changeset/crlf-codegen-normalize.md
+++ b/.changeset/crlf-codegen-normalize.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/codegen": patch
+---
+
+Normalize CRLF/lone-CR line endings before parsing an EXPRESS `.exp` schema, so a schema fetched or generated fresh on Windows no longer leaks a stray `\r` into the generated TypeScript output (which breaks `tsc` on the emitted code).

--- a/packages/codegen/src/generator.ts
+++ b/packages/codegen/src/generator.ts
@@ -58,6 +58,12 @@ export function generateFromSchema(
   outputDir: string,
   options: GeneratorOptions = {}
 ): FullGeneratedCode {
+  // Normalize line endings so a CRLF (or lone-CR) source file can never leak
+  // a stray \r into a generated string literal downstream (#4220). This is
+  // the single boundary both generateFromFile and direct callers funnel
+  // through before the content reaches the parser.
+  schemaContent = schemaContent.replace(/\r\n?/g, '\n');
+
   console.log('📖 Parsing EXPRESS schema...');
   const schema = parseExpressSchema(schemaContent);
 

--- a/packages/codegen/test/generator.test.ts
+++ b/packages/codegen/test/generator.test.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the top-level generator orchestration (generateFromSchema).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateFromSchema } from '../src/generator.js';
+
+describe('generateFromSchema — CRLF line endings (#4220)', () => {
+  let outputDir: string;
+
+  afterEach(() => {
+    if (outputDir) rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it('should not leak a stray \\r into generated code for a CRLF-sourced schema', () => {
+    // Built programmatically (not committed as a file) so no editor or git
+    // normalization can strip the \r before it reaches the generator under
+    // test — a CRLF .exp file read straight off disk, before it is ever
+    // `git add`-ed, is exactly the case this reproduces.
+    const crlfSchema = [
+      'SCHEMA TEST;',
+      '',
+      'TYPE IfcActionRequestTypeEnum = ENUMERATION OF',
+      '  (EMAIL',
+      '  ,FAX',
+      '  ,USERDEFINED',
+      '  ,NOTDEFINED);',
+      'END_TYPE;',
+      '',
+      'ENTITY IfcWall',
+      '  SUBTYPE OF (IfcElement);',
+      'END_ENTITY;',
+      '',
+      'END_SCHEMA;',
+    ].join('\r\n');
+    expect(crlfSchema).toContain('\r\n');
+
+    outputDir = mkdtempSync(join(tmpdir(), 'ifc-codegen-4220-'));
+    const code = generateFromSchema(crlfSchema, outputDir, { skipCollisionCheck: true });
+
+    expect(code.schemaRegistry).toContain('IfcActionRequestTypeEnum');
+    expect(code.schemaRegistry).not.toContain('\r');
+    expect(code.entities).not.toContain('\r');
+    expect(code.types).not.toContain('\r');
+  });
+
+  it('should produce identical output for LF and CRLF versions of the same schema', () => {
+    const lfSchema = [
+      'SCHEMA TEST;',
+      '',
+      'TYPE IfcActionRequestTypeEnum = ENUMERATION OF',
+      '  (EMAIL',
+      '  ,FAX',
+      '  ,USERDEFINED',
+      '  ,NOTDEFINED);',
+      'END_TYPE;',
+      '',
+      'ENTITY IfcWall',
+      '  SUBTYPE OF (IfcElement);',
+      'END_ENTITY;',
+      '',
+      'END_SCHEMA;',
+    ].join('\n');
+    const crlfSchema = lfSchema.replace(/\n/g, '\r\n');
+
+    const lfOut = mkdtempSync(join(tmpdir(), 'ifc-codegen-4220-lf-'));
+    const crlfOut = mkdtempSync(join(tmpdir(), 'ifc-codegen-4220-crlf-'));
+    try {
+      const lfCode = generateFromSchema(lfSchema, lfOut, { skipCollisionCheck: true });
+      const crlfCode = generateFromSchema(crlfSchema, crlfOut, { skipCollisionCheck: true });
+
+      expect(crlfCode.schemaRegistry).toBe(lfCode.schemaRegistry);
+      expect(crlfCode.entities).toBe(lfCode.entities);
+      expect(crlfCode.types).toBe(lfCode.types);
+      expect(crlfCode.enums).toBe(lfCode.enums);
+      expect(crlfCode.selects).toBe(lfCode.selects);
+    } finally {
+      rmSync(lfOut, { recursive: true, force: true });
+      rmSync(crlfOut, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The EXPRESS-to-TypeScript codegen pipeline had no `\r` handling anywhere. A `.exp` schema with CRLF line endings (e.g. downloaded fresh from buildingSMART or generated on a Windows checkout before it is `git add`-ed and normalized by `.gitattributes`) had its raw `\r` bytes carried straight through into generated string literals, breaking `tsc` on the emitted output.
- `generateFromSchema` (in `packages/codegen/src/generator.ts`) now normalizes `\r\n` and lone `\r` to `\n` before parsing. This is the single boundary both `generateFromFile` (the CLI's actual file-read path) and any direct `generateFromSchema` caller funnel through, so the fix can't be bypassed by a future caller of the public API.
- LF input is unaffected: `scripts/check-codegen-sync.mjs` confirms all 4 committed generated-output targets still match a fresh regeneration byte-for-byte.

## Reproduction (before fix, on `upstream/main`)
```
python3 -c "
data = open('packages/codegen/schemas/IFC4_ADD2_TC1.exp', 'rb').read()
data = data.replace(b'\r\n', b'\n').replace(b'\n', b'\r\n')
open('/tmp/IFC4_ADD2_TC1_CRLF.exp', 'wb').write(data)
"
node packages/codegen/dist/cli.js /tmp/IFC4_ADD2_TC1_CRLF.exp -o /tmp/out
grep -cP '\r' /tmp/out/schema-registry.ts   # 267
tsc --noEmit --skipLibCheck /tmp/out/schema-registry.ts
# error TS1002: Unterminated string literal.
```
After the fix, the same CRLF input produces 0 `\r` bytes and `tsc` compiles cleanly.

## Test plan
- [x] New `packages/codegen/test/generator.test.ts`: RED before the fix (CRLF-fixture test fails), GREEN after — fixture built programmatically (`.join('\r\n')`) so no tooling can normalize it away.
- [x] Mutation test: reverted the normalization line, confirmed exactly the 2 new tests reddened and all 126 others stayed green; restored the fix.
- [x] Both directions: `generateFromSchema` on LF input is byte-identical to before (`scripts/check-codegen-sync.mjs` passes, exit 0).
- [x] `node scripts/check-module-size.mjs` — exit 0 (generator.ts had headroom under its budget; no allowlist changes).
- [x] `packages/codegen` full test suite: 128/128 passing.
- [x] `tsc --noEmit` on `packages/codegen` — clean.

Closes #4220