### PR TITLE
fix(geometry): make IFC_LITE_REQUIRE_FIXTURES load-bearing in rust/geometry

### DIFF
--- a/rust/geometry/tests/issue_1007_roof_brep_opening_winding.rs
+++ b/rust/geometry/tests/issue_1007_roof_brep_opening_winding.rs
@@ -40,6 +40,8 @@ use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
+mod support;
+
 const FIXTURE: &str = "issues/1007_roof_brep_opening_winding.ifc";
 
 fn read_fixture() -> Option<String> {
@@ -48,11 +50,21 @@ fn read_fixture() -> Option<String> {
         .join(FIXTURE);
     match std::fs::read_to_string(&path) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!("skipping: fixture {FIXTURE} is an LFS pointer — run `pnpm fixtures`");
             None
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("skipping: fixture {FIXTURE} not present — run `pnpm fixtures`");
             None
         }

--- a/rust/geometry/tests/issue_582_583_regression_test.rs
+++ b/rust/geometry/tests/issue_582_583_regression_test.rs
@@ -21,10 +21,17 @@ use ifc_lite_core::IfcType;
 use ifc_lite_geometry::{GeometryRouter, VoidIndex};
 use rustc_hash::FxHashMap;
 
+mod support;
+
 fn read_fixture(rel: &str) -> Option<String> {
     let path = format!("../../tests/models/{}", rel);
     match std::fs::read_to_string(&path) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping: fixture {path} is a Git LFS pointer; run `pnpm fixtures` from the repo root"
             );
@@ -32,6 +39,11 @@ fn read_fixture(rel: &str) -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping: fixture {path} not present; run `pnpm fixtures` to download (manifest at tests/models/manifest.json)"
             );

--- a/rust/geometry/tests/issue_584_smiley_west_test.rs
+++ b/rust/geometry/tests/issue_584_smiley_west_test.rs
@@ -28,10 +28,17 @@ use ifc_lite_core::IfcType;
 use ifc_lite_geometry::{GeometryRouter, VoidIndex};
 use rustc_hash::FxHashMap;
 
+mod support;
+
 fn read_fixture(rel: &str) -> Option<String> {
     let path = format!("../../tests/models/{}", rel);
     match std::fs::read_to_string(&path) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping: fixture {path} is a Git LFS pointer; run `pnpm fixtures` from the repo root"
             );
@@ -39,6 +46,11 @@ fn read_fixture(rel: &str) -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping: fixture {path} not present. Source from ifcwiki.org and drop \
                  under tests/models/ara3d/. See `rust/geometry/tests/issue_584_smiley_west_test.rs` \

--- a/rust/geometry/tests/issue_604_door_regression.rs
+++ b/rust/geometry/tests/issue_604_door_regression.rs
@@ -19,6 +19,7 @@
 //! The test skips cleanly when the fixture is absent so a fresh clone never
 //! panics.
 
+mod support;
 mod voids_common;
 
 use ifc_lite_core::{EntityDecoder, IfcType};
@@ -45,6 +46,11 @@ const DOOR_ID: u32 = 2390;
 
 fn read_fixture() -> Option<String> {
     if !Path::new(FIXTURE).exists() {
+        assert!(
+            !support::require_fixtures(),
+            "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+             run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+        );
         eprintln!(
             "skipping issue-604 regression: fixture missing at {FIXTURE} — \
              run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_819_triangulated_normals.rs
+++ b/rust/geometry/tests/issue_819_triangulated_normals.rs
@@ -29,6 +29,8 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/819_IFC4TessellationComplex.ifc";
 
 // Five largest IFCTRIANGULATEDFACESET entities in the file. All five
@@ -45,6 +47,11 @@ fn lfs_pointer_prefix() -> String {
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with(&lfs_pointer_prefix()) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping issue-819 regression: fixture at {FIXTURE} is a Git LFS \
                  pointer — run `pnpm fixtures` from the repo root to download it",
@@ -53,6 +60,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-819 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_820_trimmed_curve_planeangleunit.rs
+++ b/rust/geometry/tests/issue_820_trimmed_curve_planeangleunit.rs
@@ -30,6 +30,8 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/820_RadianValuesOverPI.ifc";
 
 // `#2173 IFCEXTRUDEDAREASOLID` — the wall body. Its profile is
@@ -51,6 +53,11 @@ fn lfs_pointer_prefix() -> String {
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with(&lfs_pointer_prefix()) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             // The fixture is a Git LFS pointer, not the real bytes — happens
             // on fresh clones before `pnpm fixtures` runs. Skip cleanly so
             // the misleading IFC-parse error on the pointer text never
@@ -63,6 +70,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-820 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_821_difference_emptied_host.rs
+++ b/rust/geometry/tests/issue_821_difference_emptied_host.rs
@@ -40,6 +40,8 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/821_TallBuilding.ifc";
 
 // Outside walls on Level 1 (#140). All three are the same pattern: an
@@ -56,6 +58,11 @@ fn lfs_pointer_prefix() -> String {
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with(&lfs_pointer_prefix()) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping issue-821 regression: fixture at {FIXTURE} is a Git LFS \
                  pointer — run `pnpm fixtures` from the repo root to download it",
@@ -64,6 +71,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-821 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_828_sectioned_solid_horizontal.rs
+++ b/rust/geometry/tests/issue_828_sectioned_solid_horizontal.rs
@@ -22,6 +22,8 @@
 use ifc_lite_core::{EntityDecoder, EntityScanner, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/828_sectioned-solid.ifc";
 
 /// See `issue_820_trimmed_curve_planeangleunit::lfs_pointer_prefix` for
@@ -33,6 +35,11 @@ fn lfs_pointer_prefix() -> String {
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with(&lfs_pointer_prefix()) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping issue-828 regression: fixture at {FIXTURE} is a Git LFS \
                  pointer — run `pnpm fixtures` from the repo root to download it",
@@ -41,6 +48,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-828 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_832_opening_representations.rs
+++ b/rust/geometry/tests/issue_832_opening_representations.rs
@@ -30,6 +30,8 @@ use ifc_lite_geometry::GeometryRouter;
 use rustc_hash::FxHashMap;
 use voids_common::production::fold_origin;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/832_opening_representations.ifc";
 
 /// (wall_id, opening_id, label).  Wall #222 is the broken one in the screenshot.
@@ -60,6 +62,11 @@ fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-832 regression: fixture missing at {FIXTURE} — \
                  add it from the issue attachment"

--- a/rust/geometry/tests/issue_842_bspline_and_sphere.rs
+++ b/rust/geometry/tests/issue_842_bspline_and_sphere.rs
@@ -13,11 +13,18 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/842_rational_bspline_surface.ifc";
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             // PR #657 removed Git LFS from this repo (fixtures live in a
             // GitHub Release now), but a contributor cloning before that
             // change can still have an LFS pointer at this path. Skip
@@ -31,6 +38,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-842 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` to fetch it"

--- a/rust/geometry/tests/issue_844_terrain_and_alignment.rs
+++ b/rust/geometry/tests/issue_844_terrain_and_alignment.rs
@@ -19,12 +19,19 @@
 use ifc_lite_core::{has_geometry_by_name, EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/844_terrain_and_alignment.ifc";
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-844 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` to fetch it"

--- a/rust/geometry/tests/issue_845_wall_elemented_case.rs
+++ b/rust/geometry/tests/issue_845_wall_elemented_case.rs
@@ -23,17 +23,29 @@
 use ifc_lite_core::EntityDecoder;
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/845_wall_elemented_case.ifc";
 const PANEL_FORWARD_ID: u32 = 145;
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!("issue-845 fixture is an LFS pointer — skipping");
             None
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("issue-845 fixture missing — skipping (run `pnpm fixtures`)");
             None
         }

--- a/rust/geometry/tests/issue_846_revolved_beam.rs
+++ b/rust/geometry/tests/issue_846_revolved_beam.rs
@@ -14,12 +14,19 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/846_revolved_beam.ifc";
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-846 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` to fetch it"

--- a/rust/geometry/tests/issue_853_slab_pocket.rs
+++ b/rust/geometry/tests/issue_853_slab_pocket.rs
@@ -21,12 +21,19 @@ use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/853_slab_pocket.ifc";
 const SLAB_ID: u32 = 303;
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             // PR #657 removed Git LFS from this repo (fixtures live in a
             // GitHub Release now), but a contributor cloning before that
             // change can still have an LFS pointer at this path. Skip
@@ -40,6 +47,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("issue-853 fixture missing — skipping (run `pnpm fixtures`)");
             None
         }

--- a/rust/geometry/tests/issue_854_rect_hollow_fillet.rs
+++ b/rust/geometry/tests/issue_854_rect_hollow_fillet.rs
@@ -23,6 +23,8 @@
 use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/854_air_terminal_hollow_fillet.ifc";
 const AIR_TERMINAL_ID: u32 = 331;
 
@@ -30,6 +32,11 @@ fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("issue-854 fixture missing — skipping (run `pnpm fixtures`)");
             None
         }

--- a/rust/geometry/tests/issue_859_linear_placement.rs
+++ b/rust/geometry/tests/issue_859_linear_placement.rs
@@ -28,16 +28,28 @@
 use ifc_lite_core::EntityDecoder;
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/859_linear_placement_of_signal.ifc";
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!("issue-859 fixture is an LFS pointer — skipping");
             None
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("issue-859 fixture missing — skipping (run `pnpm fixtures`)");
             None
         }

--- a/rust/geometry/tests/issue_859_railway_renders_in_view.rs
+++ b/rust/geometry/tests/issue_859_railway_renders_in_view.rs
@@ -24,6 +24,8 @@
 use ifc_lite_core::{has_geometry_by_name, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::GeometryRouter;
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/859_linear_placement_of_signal.ifc";
 
 /// Matches `apps/viewer/src/components/viewer/useGeometryStreaming.ts:75`.
@@ -37,9 +39,21 @@ const MAX_REASONABLE_OFFSET: f32 = 50_000.0;
 
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
-        Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => None,
+        Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
+            None
+        }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("issue-859 fixture missing — skipping (run `pnpm fixtures`)");
             None
         }

--- a/rust/geometry/tests/issue_953_trimmed_curve_cartesian.rs
+++ b/rust/geometry/tests/issue_953_trimmed_curve_cartesian.rs
@@ -35,6 +35,8 @@
 use ifc_lite_core::{EntityDecoder, IfcSchema, IfcType};
 use ifc_lite_geometry::{GeometryRouter, ProfileProcessor, TessellationQuality};
 
+mod support;
+
 const FIXTURE: &str = "../../tests/models/issues/953_trimmed_curve_cartesian_arc.ifc";
 
 /// `#206` — the `IfcArbitraryClosedProfileDef` whose outer curve is the
@@ -54,6 +56,11 @@ fn lfs_pointer_prefix() -> String {
 fn read_fixture() -> Option<String> {
     match std::fs::read_to_string(FIXTURE) {
         Ok(s) if s.starts_with(&lfs_pointer_prefix()) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download real bytes"
+            );
             eprintln!(
                 "skipping issue-953 regression: fixture at {FIXTURE} is a Git LFS \
                  pointer — run `pnpm fixtures` from the repo root to download it",
@@ -62,6 +69,11 @@ fn read_fixture() -> Option<String> {
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-953 regression: fixture missing at {FIXTURE} — \
                  run `pnpm fixtures` from the repo root to download it",

--- a/rust/geometry/tests/issue_960_segmented_roof_clip.rs
+++ b/rust/geometry/tests/issue_960_segmented_roof_clip.rs
@@ -37,22 +37,38 @@ use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter};
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
+mod support;
+
 const FIXTURE: &str = "issues/960_house_segmented_roof_clip.ifc";
 
 /// Read a `tests/models/` fixture, returning `None` (skip the test) when it is
-/// absent or still an LFS pointer — never panic, so fresh clones without
-/// `pnpm fixtures` stay green.
+/// absent or still an LFS pointer — unless `IFC_LITE_REQUIRE_FIXTURES=1` (set
+/// by CI's `csg-accept-gates` job after it fetches and verifies the corpus),
+/// in which case a missing fixture is a hard `panic!` instead: this test's
+/// pinned Z-bound assertions below never ran without the fixture, and CI must
+/// not report that as a pass. Local `cargo test` without the flag stays green
+/// on a fresh clone as before.
 fn read_fixture() -> Option<String> {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../tests/models")
         .join(FIXTURE);
     match std::fs::read_to_string(&path) {
         Ok(s) if s.starts_with("version https://git-lfs.github.com/spec/") => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {FIXTURE} is an LFS pointer and IFC_LITE_REQUIRE_FIXTURES=1 — \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("skipping: fixture {FIXTURE} is an LFS pointer — run `pnpm fixtures`");
             None
         }
         Ok(s) => Some(s),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {FIXTURE} not present and IFC_LITE_REQUIRE_FIXTURES=1 — \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!("skipping: fixture {FIXTURE} not present — run `pnpm fixtures`");
             None
         }

--- a/rust/geometry/tests/support/mod.rs
+++ b/rust/geometry/tests/support/mod.rs
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Shared `IFC_LITE_REQUIRE_FIXTURES` handling for `rust/geometry`'s
+//! fixture-backed integration tests.
+//!
+//! `rust/export/src/test_support.rs` is the canonical home for this
+//! convention, but it is private to the export crate and unreachable from
+//! here; `rust/processing/tests/issue_3821_boolean_failure_drain.rs`
+//! duplicates the same parse locally for the same reason. This module is
+//! that same duplication, shared across `rust/geometry`'s integration test
+//! binaries (each `tests/*.rs` file is its own crate, so a `mod support;`
+//! import is required, but the parse logic itself must match byte-for-byte
+//! — see [`require_fixtures`]).
+//!
+//! Unset, empty, or `"0"` means "off" (skip a missing fixture — the
+//! historical default, unaffected by this module). `"1"` means "on": a
+//! missing fixture becomes a hard `panic!` instead of a skip. The
+//! `csg-accept-gates` CI job sets `IFC_LITE_REQUIRE_FIXTURES=1` after an
+//! unconditional `Verify fixtures` step, so on a correct run this costs
+//! nothing and turns fixture drift into a loud failure instead of a
+//! quietly-smaller test suite (issue #2802's failure mode: a passing
+//! skip-shaped test is indistinguishable, in the only output anyone reads,
+//! from one that actually asserted something). An unrecognised value (e.g.
+//! `true`, `yes`, a typo) PANICS rather than falling through to "off":
+//! guessing "off" for a misconfigured gate would recreate exactly the
+//! silent-pass problem this module exists to close.
+
+/// Parse `IFC_LITE_REQUIRE_FIXTURES`, failing closed on the config itself.
+#[allow(dead_code)]
+pub fn require_fixtures() -> bool {
+    match std::env::var("IFC_LITE_REQUIRE_FIXTURES") {
+        Err(std::env::VarError::NotPresent) => false,
+        Ok(v) if v.is_empty() || v == "0" => false,
+        Ok(v) if v == "1" => true,
+        other => panic!(
+            "IFC_LITE_REQUIRE_FIXTURES must be unset, \"\", \"0\" or \"1\"; got {other:?}"
+        ),
+    }
+}


### PR DESCRIPTION
## Summary

The `csg-accept-gates` job (`.github/workflows/test.yml`) sets `IFC_LITE_REQUIRE_FIXTURES=1` on its `cargo test -p ifc-lite-geometry` steps, but that variable was dead code for this crate: only `rust/export` and `rust/processing` read it (`grep -rn IFC_LITE_REQUIRE_FIXTURES rust/`). Every skip-on-missing-fixture test in `rust/geometry` that reads from the downloaded `tests/models` corpus — `issue_960_segmented_roof_clip.rs` and 18 others — could pass having examined nothing, with no visible difference from a real pass in the only CI output anyone reads.

This closes that gap without changing what any test asserts, and without touching the job's non-required status (that stays a deliberate, separately-discussed policy call — see the workflow's own comment above the job).

## What changed

- Added `rust/geometry/tests/support/mod.rs`: a `require_fixtures()` helper parsing `IFC_LITE_REQUIRE_FIXTURES` exactly the way `rust/export/src/test_support.rs` documents it (canonical home, but private to that crate) and the way `rust/processing/tests/issue_3821_boolean_failure_drain.rs` already duplicates it locally for the same reason (each `tests/*.rs` file is its own crate).
- In each of the 19 fixture-backed `rust/geometry` tests below, the skip-on-missing branch now does `assert!(!support::require_fixtures(), "...")` before returning `None`. Unset (local dev), the assert is a no-op and the pre-existing skip-and-eprintln behavior is unchanged. With `IFC_LITE_REQUIRE_FIXTURES=1`, a missing fixture is now a named panic instead of a silent skip.

Files fixed (all read from the downloaded `tests/models` corpus, all had the skip-on-missing shape):
`issue_960_segmented_roof_clip.rs`, `issue_1007_roof_brep_opening_winding.rs`, `issue_582_583_regression_test.rs`, `issue_584_smiley_west_test.rs`, `issue_604_door_regression.rs`, `issue_819_triangulated_normals.rs`, `issue_820_trimmed_curve_planeangleunit.rs`, `issue_821_difference_emptied_host.rs`, `issue_828_sectioned_solid_horizontal.rs`, `issue_832_opening_representations.rs`, `issue_842_bspline_and_sphere.rs`, `issue_844_terrain_and_alignment.rs`, `issue_845_wall_elemented_case.rs`, `issue_846_revolved_beam.rs`, `issue_853_slab_pocket.rs`, `issue_854_rect_hollow_fillet.rs`, `issue_859_linear_placement.rs`, `issue_859_railway_renders_in_view.rs`, `issue_953_trimmed_curve_cartesian.rs`.

## Verdict on every other fixture-reading `rust/geometry` test

Checked whether any other test in the crate has the same skip-on-missing shape rather than fixing only the one named in the brief:

- **Needed nothing (already fails hard, cannot pass vacuously):** `issue_098_v5c.rs`, `issue_098_atomic_cut.rs`, `issue_098_reveal_wall.rs` — `include_str!` of a baked-in fixture, compiled in. `issue_1910_storey_generalization.rs`, `issue_1910_building_geometry_rtc.rs`, `issue_1164_swept_disk_trimmed_line.rs`, `issue_1348_swept_disk_composite_arc.rs`, `issue_1485_duct_elbow_surface_curve_swept.rs`, `nested_mapped_item.rs` — read a checked-in `tests/fixtures/*.ifc` with `.expect(...)` / `.unwrap_or_else(|e| panic!(...))`, which already panics on a missing file regardless of the env var.
- **Same defect class, NOT fixed here (flagged as follow-up):** `csg_quality_regression.rs`, `halfspace_clip_cap_regression.rs`, `issue_1155_halfspace_flyaway.rs`, `issue_979_feature_element_profiles.rs`, and other `tests/models`-backed tests use a differently-shaped `fixture(rel) -> Option<String>` helper that does `std::fs::read_to_string(p).ok()`, collapsing every `io::Error` (not just `NotFound`) into `None`. That shares the same vacuous-pass risk but needs a different-shaped fix (distinguishing `NotFound` from other I/O errors first, matching the canonical pattern) rather than the `NotFound`-arm patch this PR applies. Left alone to keep this PR's diff mechanical and low-risk; a maintainer or follow-up PR should decide whether to fold these into `support::require_fixtures()` too.
- **Not checked / out of scope for this pass:** the remaining `rust/geometry` tests that reference `tests/models` only through `#[ignore]`d cases (`ar_wall_test.rs`, `test_infra_rtc.rs` — both read undownloadable private `tests/models/local/` files and are excluded from the default `cargo test` run, so they cannot render this gate vacuous today) were confirmed excluded by construction, not exhaustively re-derived beyond that.

## Verification

All done against a fresh clone of `upstream/main`, cargo 1.93.0-nightly, from the fixture-absent state (fresh clone has no `tests/models/` corpus).

**RED** (before the fix, `issue_960_segmented_roof_clip.rs`, fixture absent, `IFC_LITE_REQUIRE_FIXTURES=1`):
```
skipping: fixture issues/960_house_segmented_roof_clip.ifc not present — run `pnpm fixtures`
test segmented_roof_walls_render_without_slivers_or_drops ... ok
test result: ok. 1 passed; 0 failed;
```

**GREEN** (after the fix, same conditions):
```
thread '...' panicked at rust/geometry/tests/issue_960_segmented_roof_clip.rs:67:13:
fixture issues/960_house_segmented_roof_clip.ifc not present and IFC_LITE_REQUIRE_FIXTURES=1 — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)
test result: FAILED. 0 passed; 1 failed;
```

**Both directions**, spot-checked on `issue_960_segmented_roof_clip.rs`, `issue_1007_roof_brep_opening_winding.rs` (different fixture-path shape), and `issue_604_door_regression.rs` (different `Path::exists()` shape, not the `match`/`NotFound` arm):
- Unset, fixture absent → skips cleanly (unchanged from before this PR).
- Unset or `=1`, fixture present → runs and passes exactly as before.

**Full-crate regression**, `IFC_LITE_REQUIRE_FIXTURES=1` with the full fixture corpus fetched, matching all three of the job's `cargo test` steps exactly:
- default features: 1286 passed, 0 failed
- `csg_manifold_gate`: 1286 passed, 0 failed
- `csg_topology_gate`: 1285 passed, 0 failed (pre-existing `#[cfg(feature = ...)]` test-count difference, unrelated to this change — no `FAILED` line in either run)
- `csg_manifold_gate,csg_topology_gate`: 1287 passed, 0 failed
- Same run with the var unset (fixtures present): 1286 passed, 0 failed — identical to the `=1` default-features run, confirming the assertion counts are unchanged by this PR.

**Mutation test**: on `issue_960_segmented_roof_clip.rs`, removed the two `assert!(!support::require_fixtures(), ...)` calls and reran with the fixture absent and `IFC_LITE_REQUIRE_FIXTURES=1` — it reddened back to a vacuous `ok`, confirming the enforcement is load-bearing. Restored before committing.

**Clippy**, all three feature combinations with `--all-targets -- -D warnings` (matching the job's own three Clippy steps): clean.

**Module-size gate**, `node scripts/check-module-size.mjs`: `EXIT=0`, `OK (2569 files measured, 338 allowlisted, 0 new over 400)`. No Rust-side allowlist twin touched — the new file (`rust/geometry/tests/support/mod.rs`, 41 lines) is far under any budget.

## Scope

Does not make `csg-accept-gates` blocking and does not add it to the aggregate `test` gate's `needs:` list or `results` map — the workflow's own comment documents that as a deliberate, separately-discussed policy call (pinned measurements of a known-worse fallback path for a configuration nothing ships). This PR only closes whether the gate can report a pass without having examined its fixtures; it does not touch whether the gate blocks a merge.

## unqueued

Found while briefing issue #4219 (a gate-can-pass-vacuously audit), not a `ready`-queue issue. Per instructions, no new issue was opened — this PR carries `unqueued` and this section explains why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added consistent fixture-availability checks across geometry regression tests.
  - Tests continue to skip when required fixture files are unavailable by default.
  - When fixture enforcement is enabled, missing or incomplete fixtures now fail tests with guidance to download them.
  - Added validation for the fixture-enforcement setting, including handling for invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->