### PR TITLE
docs: explain construction projection after model repositioning

### DIFF
--- a/docs/guide/drawing-2d.md
+++ b/docs/guide/drawing-2d.md
@@ -21,6 +21,23 @@ Each drawing includes:
 | **Architectural symbols** | Door swings, window frames, stair arrows |
 | **Annotations** | Dimensions and labels |
 
+## Drawings After Repositioning
+
+In the viewer, section cuts and construction projection use the model's current
+workspace placement. After [repositioning a model](federation.md#repositioning-models-and-pointclouds),
+the floor and ceiling limits used for construction projection refresh with its
+displayed geometry and storey membership.
+
+To compare the same floor plan before and after a vertical move, move the
+section plane by the same amount, or use the same section percentage for the
+same model bounds. Once drawing generation finishes, the equivalent cut keeps
+the same projection geometry and floor/ceiling bands. Moving only the model
+while keeping an absolute section elevation fixed produces a different cut.
+
+This is a viewer workspace adjustment: it does not rewrite the source IFC
+placements. Existing measurements retain their recorded workspace points and
+are marked stale after movement; remeasure them in the new arrangement.
+
 ## Quick Start
 
 ### Generating a Floor Plan

--- a/docs/guide/federation.md
+++ b/docs/guide/federation.md
@@ -170,6 +170,11 @@ the WebGPU view updates immediately throughout the move.
 
 Both the 3D cut and the 2D drawing resolve section percentages from the same
 placed bounds, including a model moved beyond its original extent.
+Construction projection also uses the placed floor elevations. Moving a model
+and its section plane together preserves the floor/ceiling projection bands and
+the resulting drawing geometry, for either section direction. Floor bands
+refresh when the model moves or its storey membership changes; no reload is
+needed. See [2D drawings after repositioning](drawing-2d.md#drawings-after-repositioning).
 
 ![A real Archicad IFC section after moving the model up 100 metres](../assets/model-reposition-section.png)
 


### PR DESCRIPTION
The repositioning and 2D drawing guides now explain that construction projection uses placed floor elevations, refreshes after movement or storey-membership changes, and preserves equivalent projection bands when the model and section move together. They distinguish an equivalent translated cut from holding an absolute section elevation fixed and remind readers to remeasure stale measurements.

Closes #4368. Documents the verified fix from #4340 / #4332.

Validation: documentation samples pass (382 snippets across 85 documents), diff whitespace passes, and all 69 pending changesets name valid workspace packages. This docs-only change needs no package release entry; the merged implementation changeset already covers viewer, renderer and mutations.

Repository-wide docs checks also exposed existing main issues outside this change: the generated package index omits regex-guard and wasm-lifecycle, and those two recently added packages lack READMEs. No generated region or package file is changed here.
