### PR TITLE
fix(ids): drop imports left behind by a move, and tighten the unused-locals baseline

### DIFF
--- a/packages/ids/src/audit/ifc-schema/index.ts
+++ b/packages/ids/src/audit/ifc-schema/index.ts
@@ -28,7 +28,6 @@ import {
   isEntitySubtypeOf,
   RESERVED_PSET_PREFIXES,
   type IfcEntityInfo,
-  type IfcPropertyInfo,
   type IfcSchemaVersion,
 } from '@ifc-lite/data';
 

--- a/packages/ids/src/constraints/match-family.ts
+++ b/packages/ids/src/constraints/match-family.ts
@@ -23,7 +23,6 @@ import {
   compareBoolean,
   compareNumeric,
   compareString,
-  numericEpsilon,
   isStrictNumericLiteral,
   isBooleanLiteral,
 } from './comparators.js';

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -23,8 +23,7 @@ import type {
   TranslationService,
   PartOfRelation,
 } from '../types.js';
-import { checkFacet, facetPasses, filterByFacet, type FacetCheckResult } from '../facets/index.js';
-import { formatConstraint } from '../constraints/index.js';
+import { checkFacet, facetPasses, filterByFacet } from '../facets/index.js';
 import { ApplicabilityPropertyIndex } from './property-index.js';
 import { UnsafeRegexPatternError } from '@ifc-lite/regex-guard';
 import { formatFailureReason, formatRequirementDescription } from './format-failure-reason.js';

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -1,6 +1,6 @@
 {
-  "apps/viewer": 283,
-  "apps/viewer-embed": 285,
+  "apps/viewer": 266,
+  "apps/viewer-embed": 268,
   "examples/babylonjs-viewer": 1,
   "examples/collab-demo": 1,
   "examples/threejs-collab": 1,
@@ -24,7 +24,7 @@
   "packages/export": 2,
   "packages/extensions": 4,
   "packages/geometry": 7,
-  "packages/ids": 10,
+  "packages/ids": 9,
   "packages/ifcx": 7,
   "packages/lens": 0,
   "packages/lists": 0,
@@ -37,6 +37,7 @@
   "packages/pointcloud": 1,
   "packages/provenance": 0,
   "packages/query": 2,
+  "packages/regex-guard": 0,
   "packages/renderer": 1,
   "packages/sandbox": 1,
   "packages/sdk": 11,
@@ -50,5 +51,6 @@
   "packages/spatial": 0,
   "packages/timing-ladder": 0,
   "packages/viewer": 0,
+  "packages/wasm-lifecycle": 0,
   "packages/world-frame-fixtures": 0
 }


### PR DESCRIPTION
`pnpm run lint` fails on `origin/main`: `packages/ids: 13 (baseline 10, +3)`.

`IfcPropertyInfo`, `FacetCheckResult`, `formatConstraint` and `numericEpsilon` had their USAGES removed while their imports stayed. Exactly what the gate's own message predicts: "almost always imports left behind by a move or a rename".

## Why nobody saw them

`check-unused-locals` cannot measure a package that does not compile standalone, and two `as const` typecheck breaks had stopped `packages/ids` compiling. **A compile break does not add one failure, it silences every gate downstream of compiling**, and the backlog then surfaces as a regression the moment someone fixes the compile.

Anyone reading `lint` during that window saw "these packages do not compile standalone" and would reasonably have filed it under the typecheck failure rather than as its own backlog.

## The baseline tightens more than +3 suggests

    apps/viewer        283 -> 266   (-17)
    apps/viewer-embed  285 -> 268   (-17)
    packages/ids        10 ->   9

Those viewer improvements are **other people's cleanups that the gate could not credit** while the package would not compile. Same masking, seen from the other side. The ratchet refuses slack in both directions, so they are committed rather than left loose for the next regression to ride in on.

`--update` also adds `packages/regex-guard` and `packages/wasm-lifecycle` at 0. I diffed the baseline file rather than trusting the flag, because this repo has been bitten by `--update` annexing unrelated rows. Both are new packages entering at the tightest possible value, not slack.

## Scope reduced mid-review

This started as a three-part fix, also covering the two `as const` typecheck breaks (#4348's `host.test.ts` and #4339's `layerStackSlice.teardown.ts`). Both landed on main from #4371 and #4374 while this was in review, so it is reduced to the half still needed rather than pushed as written. I verified main's typecheck passes now and only lint remains red.

## Verified

`pnpm run lint` exit 0 · `pnpm turbo typecheck` exit 0 · `@ifc-lite/ids` 1025 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9