### PR TITLE
fix(viewer): preserve mutable layer-stack reset types

### DIFF
--- a/apps/viewer/src/store/slices/layerStackSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/layerStackSlice.teardown.ts
@@ -55,13 +55,17 @@
  */
 
 import { defineSliceTeardown } from '../teardown.js';
+import type { LayerStackSlice } from './layerStackSlice.js';
 
-const emptyStackPatch = {
+const emptyStackPatch: Pick<
+  LayerStackSlice,
+  'layerStack' | 'layerStackPathToId' | 'layerStackDiff' | 'layerDiffBusy'
+> = {
   layerStack: [],
   layerStackPathToId: null,
   layerStackDiff: null,
   layerDiffBusy: false,
-} as const;
+};
 
 export const layerStackTeardown = defineSliceTeardown(
   'layerStackSlice',


### PR DESCRIPTION
The layer-stack reset patch inferred `layerStack` as `readonly []`, which is incompatible with the mutable array in viewer state and breaks viewer/embed typechecking. Type the patch from the existing `LayerStackSlice` fields so its empty values retain the state contract. Runtime teardown behavior is unchanged.

Closes #4373.

Validation: reproduced the two TS2322 errors on main at `48aec224d`; final root `pnpm typecheck` passes all 90 tasks, with all 1,877 test files covered. Existing layer-stack teardown behavior tests pass 4/4 through root Turbo (including the production viewer build). Targeted oxlint, module-size and whitespace checks pass. Independent review of this exact one-file diff found no issues. No published package, public API, or user-facing behavior changes, so no changeset or guide update is needed.

Hosted CI remains queued; it is not being represented as green. The maintainer authorized local verification and admin merge without waiting for the hosted queue. Local issue-queue and review-signal commands exit successfully; the latter reports unknown queue state and a rate-limited CodeRabbit response, so our explicit independent diff review is the review evidence.
