### PR TITLE
docs: complete shared utility package landing pages

### DIFF
--- a/.changeset/chatty-webs-brush.md
+++ b/.changeset/chatty-webs-brush.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/regex-guard": patch
+"@ifc-lite/wasm-lifecycle": patch
+---
+
+Add package READMEs documenting the shared regex guard and WASM lifecycle APIs, usage contracts, and limitations.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -49,9 +49,11 @@ ifc-lite ships its public npm packages under the `@ifc-lite/*` scope, plus the `
 | [`@ifc-lite/merge`](https://www.npmjs.com/package/@ifc-lite/merge) | Three-way merge engine for IFCX layers — MergePlan with auto-merged ops and explicit conflict records, merge-layer emission, rebase, and revert. |
 | [`@ifc-lite/oauth-pkce`](https://www.npmjs.com/package/@ifc-lite/oauth-pkce) | Browser OAuth 2.0 Authorization Code + PKCE flow, shared by ifc-lite's file-source providers |
 | [`@ifc-lite/plugin-api`](https://www.npmjs.com/package/@ifc-lite/plugin-api) | Dependency-free type surface for ifc-lite file-source plugins |
+| [`@ifc-lite/regex-guard`](https://www.npmjs.com/package/@ifc-lite/regex-guard) | A shared, dependency-free guard against catastrophic-backtracking (ReDoS) regex patterns compiled from untrusted input |
 | [`@ifc-lite/source-dalux`](https://www.npmjs.com/package/@ifc-lite/source-dalux) | Dalux Build (Box) file-source provider for ifc-lite |
 | [`@ifc-lite/source-dropbox`](https://www.npmjs.com/package/@ifc-lite/source-dropbox) | Dropbox file-source provider for ifc-lite |
 | [`@ifc-lite/source-msgraph`](https://www.npmjs.com/package/@ifc-lite/source-msgraph) | Microsoft Graph (OneDrive/SharePoint) file-source provider for ifc-lite |
+| [`@ifc-lite/wasm-lifecycle`](https://www.npmjs.com/package/@ifc-lite/wasm-lifecycle) | Shared WASM engine load-retry classification and cross-realm panic-forwarding, used by @ifc-lite/geometry and @ifc-lite/parser |
 <!-- END GENERATED: package-index -->
 
 ---

--- a/packages/regex-guard/README.md
+++ b/packages/regex-guard/README.md
@@ -1,0 +1,36 @@
+# @ifc-lite/regex-guard
+
+Dependency-free validation for regular-expression patterns supplied by users or
+model files. Shared by IFC pattern-validation and editing tools.
+
+## Usage
+
+```typescript
+import { compileGuardedRegex } from '@ifc-lite/regex-guard';
+
+const pattern = compileGuardedRegex('^Wall-[0-9]+$', 'i');
+console.log(pattern.test('Wall-42')); // true
+```
+
+`compileGuardedRegex(pattern, flags?, { maxLength? }?)` validates the pattern
+before constructing a JavaScript `RegExp`. Rejected patterns throw
+`UnsafeRegexPatternError`, which exposes `pattern` and `reason`. A malformed
+pattern that passes the guard can still throw the native `SyntaxError`.
+
+Other exports:
+
+- `assertGuardedRegexPattern(pattern, { maxLength? }?)`: validate without compiling.
+- `hasCatastrophicBacktrackingShape(pattern)`: detect the nested-quantifier shapes
+  covered by the heuristic.
+- `MAX_GUARDED_REGEX_PATTERN_LENGTH`: the default limit of 256 characters.
+
+## Limits
+
+This is a heuristic, not a guarantee of bounded execution time. It rejects
+known nested-quantifier patterns such as `(a+)+` and caps pattern length, but
+it does not analyze every possible backtracking shape. It does not move matches
+to a worker, enforce a match timeout, or replace JavaScript's regex engine.
+
+## License
+
+MPL-2.0.

--- a/packages/wasm-lifecycle/README.md
+++ b/packages/wasm-lifecycle/README.md
@@ -1,0 +1,37 @@
+# @ifc-lite/wasm-lifecycle
+
+Shared WASM initialization retry and panic-location forwarding for
+`@ifc-lite/geometry` and `@ifc-lite/parser`. This TypeScript package does not
+load or ship a WASM binary; callers supply their own initialization function
+and worker-message transport.
+
+## Initialization
+
+`initWasmWithRetry(init, options?)` accepts an asynchronous initialization
+callback and returns `Promise<void>`. It runs the callback once and retries
+exactly once for a transient-looking load failure, after a default 300 ms delay.
+Non-transient errors propagate immediately; a failed retry also propagates.
+The callback's result is not returned.
+
+`InitWasmRetryOptions` supports `retryDelayMs`, an injected `sleep`, an injected
+`warn` logger, and a context `label`. `isTransientWasmLoadError(message)` exposes
+the same message classifier for callers that need it independently.
+
+## Forwarding panic locations
+
+`takeWasmPanicStash(realm)` reads and consumes a realm's panic stash. It returns
+a validated `WasmPanicStash` containing `location` and `at`, or `undefined`.
+Consumption also removes malformed data so it cannot label a later error.
+
+After transporting that data with a worker error, call
+`restashWasmPanicLocation(realm, location, at, errorMessage)` in the receiving
+realm. It accepts valid location/timestamp data only for a trap-shaped error
+message and does not overwrite an existing stash. `WASM_PANIC_STASH_KEY` exposes
+the shared key used by the Rust panic hook and viewer error handling.
+
+Only the source location and timestamp belong in the stash. Panic messages can
+contain model-derived text and are not part of this forwarding contract.
+
+## License
+
+MPL-2.0.


### PR DESCRIPTION
The published regex-guard and wasm-lifecycle packages lacked npm landing pages, and the generated TypeScript package index omitted both. Add READMEs describing the existing APIs and their limits, regenerate the index from package metadata, and include a documentation changeset for both packages.

Closes #4378.

Validation: all 45 published packages have READMEs; all four generated doc regions are current; 383 code snippets typecheck across 87 documents (nine intentionally skipped); all 72 pending changesets name valid workspace packages; git diff --check passes. Documentation only, with no API or runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added API reference coverage for the regex protection package.
  - Added usage guidance for guarded regular-expression compilation, validation, length limits, error handling, and known heuristic limitations.
  - Added documentation for WebAssembly lifecycle handling, including initialization retries, configurable retry behavior, panic recovery, validation rules, and licensing.

- **Chores**
  - Prepared patch-release notes for the regex protection and WebAssembly lifecycle packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->