### PR TITLE
feat(authoring): create textured captured surfaces through canonical native IFC planner

### DIFF
--- a/.changeset/captured-surface-native-planner.md
+++ b/.changeset/captured-surface-native-planner.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Add canonical captured textured mesh planning for IFC4 and IFC4X3, preserving UV seams and image ownership in a bounded IfcBuildingElementProxy creation plan.

--- a/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
@@ -82,3 +82,36 @@ test('real WASM annotation creation preserves canonical owner/UV frame and share
   assert.ok(source.byteLength > 0);
   planner.dispose();
 });
+
+test('real WASM authors the public boulder without losing a triangle or UV seam (#4380)', async t => {
+  const fixture = process.env.IFCLITE_CAPTURED_MESH_FIXTURE;
+  if (!fixture) { t.skip('Set IFCLITE_CAPTURED_MESH_FIXTURE to the public boulder JSON described in native capture evidence'); return; }
+  const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  const bytes = await readFile(fixture);
+  const capture = JSON.parse(bytes.toString()) as {
+    vertices: CapturedMeshRequest['mesh']['positions']; triangles: CapturedMeshRequest['mesh']['triangles'];
+    uvs: CapturedMeshRequest['mesh']['uvs']; uv_triangles: CapturedMeshRequest['mesh']['uvTriangles'];
+  };
+  const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: await readFile(wasmUrl) });
+  const api = new IfcAPI();
+  try {
+    const input: CapturedMeshRequest = { ...request, imageUri: 'textures/boulder.jpg', mesh: {
+      positions: capture.vertices, triangles: capture.triangles, uvs: capture.uvs, uvTriangles: capture.uv_triangles,
+    } };
+    const result = JSON.parse(new TextDecoder().decode(api.planCapturedMesh(source, JSON.stringify(input)))) as CapturedMeshPlan;
+    assert.equal(result.mesh.indices.length, capture.triangles.length * 3);
+    assert.equal(result.mesh.texture.url, input.imageUri);
+    result.mesh.indices.forEach((index, corner) => {
+      const face = Math.floor(corner / 3), local = corner % 3;
+      const expected = capture.vertices[capture.triangles[face][local]];
+      const uv = capture.uvs[capture.uv_triangles[face][local]];
+      for (let axis = 0; axis < 3; axis++) {
+        const world = result.mesh.positions[index * 3 + axis] + (result.mesh.origin?.[axis] ?? 0) + result.rtcOffset[axis];
+        assert.ok(Math.abs(world - expected[axis]) < 1e-4);
+      }
+      assert.ok(Math.abs(result.mesh.uvs[index * 2] - uv[0]) < 1e-6);
+      assert.ok(Math.abs(result.mesh.uvs[index * 2 + 1] - (1 - uv[1])) < 1e-6);
+    });
+  } finally { api.free(); }
+});

--- a/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import { createAppearancePlanner, type AppearanceWorker } from './planner-worker-client.js';
+import type { CapturedMeshRequest, CapturedMeshPlan, AppearanceWorkerRequest } from './planner-types.js';
+const source = new TextEncoder().encode(`ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('annotation creation contract'),'2;1');
+FILE_NAME('plane.ifc','2026-09-09',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0Project000000000000000',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40=IFCBUILDINGSTOREY('0Storey0000000000000000',$,'Level',$,$,#41,$,$,.ELEMENT.,0.);
+#41=IFCLOCALPLACEMENT($,#5);
+ENDSEC;
+END-ISO-10303-21;`);
+const request: CapturedMeshRequest = {
+  schema: 'IFC4', sourceRevision: 'annotation-wasm', nextExpressId: 100,
+  containerId: 40, GlobalId: '0aaaaaaaaaaaaaaaaaaaaa', containmentGlobalId: '0bbbbbbbbbbbbbbbbbbbbb',
+  Name: 'Image reference', imageUri: 'textures/image.png',
+  mesh: { positions: [[2,3,4],[3,3,4],[3,4,4],[2,4,5]], triangles: [[0,1,2],[0,2,3]],
+    uvs: [[0,0],[1,0],[1,1],[0,1],[0.2,0.2]], uvTriangles: [[0,1,2],[4,2,3]] },
+};
+test('real WASM annotation creation preserves canonical owner/UV frame and shares cancellation/stale fences (#4380)', async t => {
+  const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  try { await access(wasmUrl); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    t.skip('Build WASM with pnpm build:wasm to run annotation contract'); return;
+  }
+  const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: await readFile(wasmUrl) });
+  const api = new IfcAPI();
+  let result: CapturedMeshPlan;
+  try {
+    result = JSON.parse(new TextDecoder().decode(api.planCapturedMesh(source, JSON.stringify(request)))) as CapturedMeshPlan;
+    assert.equal(result.mesh.express_id, result.objectId);
+    assert.equal(result.mesh.geometry_item_id, result.geometryItemId);
+    assert.equal(result.coordinateSpace, 'ifc-z-up');
+    assert.equal(result.mesh.texture.url, request.imageUri);
+    assert.deepEqual(result.mesh.color, [1, 1, 1, 1]);
+    assert.equal(result.mesh.indices.length, 6);
+    result.mesh.indices.forEach((index, corner) => {
+      const face = Math.floor(corner / 3), local = corner % 3;
+      const expected = request.mesh.positions[request.mesh.triangles[face][local]];
+      const uv = request.mesh.uvs[request.mesh.uvTriangles[face][local]];
+      const world = result.mesh.positions.slice(index*3,index*3+3).map((p,axis)=>p+(result.mesh.origin?.[axis]??0)+result.rtcOffset[axis]);
+      assert.deepEqual(world, expected);
+      assert.ok(Math.abs(result.mesh.uvs[index*2]-uv[0])<1e-6);
+      assert.ok(Math.abs(result.mesh.uvs[index*2+1]-(1-uv[1]))<1e-6);
+    });
+    assert.ok(result.plan.created.some(e => e.type === 'IfcBuildingElementProxy' && e.attributes[0] === request.GlobalId));
+    assert.ok(result.plan.created.some(e => e.type === 'IfcRelContainedInSpatialStructure' && e.attributes[5] === '#40'));
+    assert.throws(() => api.planCapturedMesh(source, JSON.stringify({ ...request, containerId: 1 })), /IfcSpatialElement/);
+  } finally { api.free(); }
+  const { runCapturedMeshPlanning } = await import('../../workers/appearance.worker.js');
+  assert.equal((await runCapturedMeshPlanning(source, request)).objectId, result.objectId);
+  let latest: AppearanceWorkerRequest | undefined;
+  let terminated = 0;
+  const worker: AppearanceWorker = { onmessage: null, onerror: null, onmessageerror: null,
+    postMessage(message) { latest = structuredClone(message); }, terminate() { terminated++; } };
+  const planner = createAppearancePlanner({ workerFactory: () => worker });
+  const stale = planner.capturedMeshPlan(source, request);
+  assert.equal(latest?.type, 'captured-mesh-plan');
+  assert.ok(latest);
+  assert.notEqual(latest.source.buffer, source.buffer);
+  worker.onmessage?.(new MessageEvent('message', { data: { type: 'captured-mesh-complete', id: latest.id,
+    result: { ...result, plan: { ...result.plan, nextExpressId: 999 } } } }));
+  await assert.rejects(stale, /stale/);
+  const cancelled = planner.capturedMeshPlan(source, request);
+  planner.cancel();
+  await assert.rejects(cancelled, /cancelled/);
+  assert.equal(terminated, 2);
+  assert.ok(source.byteLength > 0);
+  planner.dispose();
+});

--- a/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
@@ -115,3 +115,22 @@ test('real WASM authors the public boulder without losing a triangle or UV seam 
     });
   } finally { api.free(); }
 });
+
+
+test('oversized capture refuses before allocating a worker or cloning mesh rows (#4380)', async () => {
+  let workers = 0;
+  const planner = createAppearancePlanner({ workerFactory: () => {
+    workers++;
+    throw new Error('A rejected capture must never allocate a worker');
+  } });
+  try {
+    for (const field of ['positions', 'triangles', 'uvs'] as const) {
+      const mesh = { ...request.mesh, [field]: Array(200_001).fill(request.mesh[field][0]) };
+      await assert.rejects(planner.capturedMeshPlan(source, { ...request, mesh }), /1..200000/);
+    }
+    await assert.rejects(planner.capturedMeshPlan(source, {
+      ...request, mesh: { ...request.mesh, uvTriangles: [] },
+    }), /one UV triangle per face/);
+    assert.equal(workers, 0);
+  } finally { planner.dispose(); }
+});

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -108,13 +108,28 @@ export interface AnnotationPlanePlan {
       repeat_s: boolean; repeat_t: boolean };
   };
 }
+export interface CapturedMeshRequest extends Omit<AnnotationPlaneRequest, 'frame'> {
+  mesh: {
+    /** IFC world Z-up metres. Triangle and UV indices are zero-based. */
+    positions: [number, number, number][];
+    triangles: [number, number, number][];
+    /** IFC V-up UVs; the returned canonical mesh already uses GPU top-down UVs. */
+    uvs: [number, number][];
+    uvTriangles: [number, number, number][];
+  };
+}
+export interface CapturedMeshPlan extends Omit<AnnotationPlanePlan, 'annotationId' | 'frame'> {
+  objectId: number;
+}
 export type AppearanceWorkerJob =
+  | { type: 'captured-mesh-plan'; request: CapturedMeshRequest }
   | { type: 'annotation-plan'; request: AnnotationPlaneRequest }
   | { type: 'plan'; request: AppearanceRequest }
   | { type: 'catalog'; request: AppearanceCatalogRequest }
   | { type: 'page-plan'; request: PageAppearanceRequest; rgba: Uint8Array };
 export type AppearanceWorkerRequest = AppearanceWorkerJob & { id: number; source: Uint8Array };
 export type AppearanceWorkerResponse =
+  | { type: 'captured-mesh-complete'; id: number; result: CapturedMeshPlan }
   | { type: 'annotation-complete'; id: number; result: AnnotationPlanePlan }
   | { type: 'complete'; id: number; plan: AppearancePlan }
   | { type: 'catalog-complete'; id: number; catalog: AppearanceCatalog }

--- a/apps/viewer/src/lib/appearance/planner-worker-client.ts
+++ b/apps/viewer/src/lib/appearance/planner-worker-client.ts
@@ -50,6 +50,15 @@ export function createAppearancePlanner(options: {
     if (job.type === 'page-plan' && job.rgba.byteLength > 128 * 1024 * 1024) {
       return Promise.reject(new Error('Page raster payload exceeds 128 MiB. Use a smaller source.'));
     }
+    // Refuse oversized capture arrays before structured clone and JSON encoding
+    // allocate copies; semantic geometry validation remains canonical Rust.
+    if (job.type === 'captured-mesh-plan') {
+      const mesh = job.request.mesh;
+      if ([mesh.positions.length, mesh.triangles.length, mesh.uvs.length].some(n => n === 0 || n > 200_000)
+        || mesh.uvTriangles.length !== mesh.triangles.length) {
+        return Promise.reject(new Error('Captured mesh needs 1..200000 position, triangle and UV rows, with one UV triangle per face'));
+      }
+    }
     if ('productIds' in request && request.productIds.length > 10_000) {
       return Promise.reject(new Error('Appearance scope exceeds 10000 owners. Choose a smaller scope.'));
     }

--- a/apps/viewer/src/lib/appearance/planner-worker-client.ts
+++ b/apps/viewer/src/lib/appearance/planner-worker-client.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import type { AnnotationPlanePlan, AnnotationPlaneRequest, PageAppearancePlan, PageAppearanceRequest, AppearanceCatalog, AppearanceCatalogRequest, AppearancePlan, AppearanceRequest, AppearanceWorkerJob, AppearanceWorkerRequest, AppearanceWorkerResponse } from './planner-types.js';
+import type { CapturedMeshPlan, CapturedMeshRequest, AnnotationPlanePlan, AnnotationPlaneRequest, PageAppearancePlan, PageAppearanceRequest, AppearanceCatalog, AppearanceCatalogRequest, AppearancePlan, AppearanceRequest, AppearanceWorkerJob, AppearanceWorkerRequest, AppearanceWorkerResponse } from './planner-types.js';
 
 export interface AppearanceWorker {
   onmessage: ((event: MessageEvent<AppearanceWorkerResponse>) => void) | null;
@@ -11,6 +11,7 @@ export interface AppearanceWorker {
   terminate(): void;
 }
 export interface AppearancePlanner {
+  capturedMeshPlan(source: Uint8Array, request: CapturedMeshRequest, options?: { signal?: AbortSignal }): Promise<CapturedMeshPlan>;
   annotationPlan(source: Uint8Array, request: AnnotationPlaneRequest, options?: { signal?: AbortSignal }): Promise<AnnotationPlanePlan>;
   plan(source: Uint8Array, request: AppearanceRequest, options?: { signal?: AbortSignal }): Promise<AppearancePlan>;
   pagePlan(source: Uint8Array, request: PageAppearanceRequest, rgba: Uint8Array, options?: { signal?: AbortSignal }): Promise<PageAppearancePlan>;
@@ -100,6 +101,20 @@ export function createAppearancePlanner(options: {
         if (message.type !== 'complete' || !message.plan || message.plan.sourceRevision !== revision
           || message.plan.nextExpressId !== allocationStart) throw new Error('Appearance worker returned a stale model revision');
         return message.plan;
+      }, options);
+    },
+    capturedMeshPlan(source, request, options) {
+      const revision = request.sourceRevision, allocationStart = request.nextExpressId;
+      return run(source, { type: 'captured-mesh-plan', request }, message => {
+        if (message.type !== 'captured-mesh-complete' || !message.result
+          || message.result.plan?.sourceRevision !== revision || message.result.plan.nextExpressId !== allocationStart
+          || message.result.coordinateSpace !== 'ifc-z-up'
+          || message.result.mesh?.express_id !== message.result.objectId
+          || message.result.mesh.geometry_item_id !== message.result.geometryItemId
+          || message.result.mesh.texture?.url !== request.imageUri) {
+          throw new Error('Appearance worker returned a stale or invalid captured mesh plan');
+        }
+        return message.result;
       }, options);
     },
     annotationPlan(source, request, options) {

--- a/apps/viewer/src/lib/appearance/snapshot.test.ts
+++ b/apps/viewer/src/lib/appearance/snapshot.test.ts
@@ -35,6 +35,7 @@ function catalogBoundary(beforeReply?: () => Promise<void>): AppearancePlanner {
       return { sourceRevision: request.sourceRevision, products: [], types: [], missingProductIds: [] };
     },
     async plan() { throw new Error('This test must not create geometry'); },
+    async capturedMeshPlan() { throw new Error('This catalog test must not create captured objects'); },
     async annotationPlan() { throw new Error('This catalog test must not create annotations'); },
     async pagePlan() { throw new Error('This catalog test must not plan a page'); },
     cancel() {}, dispose() {},

--- a/apps/viewer/src/test/appearance-controller.harness.tsx
+++ b/apps/viewer/src/test/appearance-controller.harness.tsx
@@ -53,7 +53,7 @@ class ControlledWorker implements AppearanceWorker {
       }).catch(error => this.onerror?.({ message: String(error) } as ErrorEvent));
       return;
     }
-    if (message.type === 'page-plan' || message.type === 'annotation-plan') throw new Error('Image-only controller fixture received a page plan');
+    if (message.type === 'page-plan' || message.type === 'annotation-plan' || message.type === 'captured-mesh-plan') throw new Error('Image-only controller fixture received a page plan');
     this.message = structuredClone(message);
     this.lateMessage = this.onmessage;
   }

--- a/apps/viewer/src/workers/appearance.worker.ts
+++ b/apps/viewer/src/workers/appearance.worker.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import init, { IfcAPI } from '@ifc-lite/wasm';
 import { decodePagePlan } from '../lib/appearance/page-plan-output.js';
-import type { AnnotationPlanePlan, AnnotationPlaneRequest, PageAppearancePlan, PageAppearanceRequest, AppearanceCatalog, AppearanceCatalogRequest, AppearancePlan, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from '../lib/appearance/planner-types.js';
+import type { CapturedMeshPlan, CapturedMeshRequest, AnnotationPlanePlan, AnnotationPlaneRequest, PageAppearancePlan, PageAppearanceRequest, AppearanceCatalog, AppearanceCatalogRequest, AppearancePlan, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from '../lib/appearance/planner-types.js';
 
 /** Canonical Rust does graph eligibility, projection and IFC authoring. Exported
  * within the viewer for real-WASM contract tests; production calls only in this
@@ -25,6 +25,10 @@ export function runPageAppearancePlanning(source: Uint8Array, request: PageAppea
   return runAppearanceJob(api => api.planPageAppearance(source, JSON.stringify(request), rgba), decodePagePlan);
 }
 
+export function runCapturedMeshPlanning(source: Uint8Array, request: CapturedMeshRequest): Promise<CapturedMeshPlan> {
+  return runAppearanceJob(api => api.planCapturedMesh(source, JSON.stringify(request)));
+}
+
 export function runAnnotationPlanePlanning(source: Uint8Array, request: AnnotationPlaneRequest): Promise<AnnotationPlanePlan> {
   return runAppearanceJob(api => api.planAnnotationPlane(source, JSON.stringify(request)));
 }
@@ -35,12 +39,14 @@ const isWorkerScope = typeof self !== 'undefined' &&
 if (isWorkerScope) {
   self.onmessage = async (event: MessageEvent<AppearanceWorkerRequest>) => {
     const job = event.data;
-    if (!job || (job.type !== 'plan' && job.type !== 'catalog' && job.type !== 'page-plan' && job.type !== 'annotation-plan')) return;
+    if (!job || (job.type !== 'plan' && job.type !== 'catalog' && job.type !== 'page-plan' && job.type !== 'annotation-plan' && job.type !== 'captured-mesh-plan')) return;
     try {
       const response: AppearanceWorkerResponse = job.type === 'plan'
         ? { type: 'complete', id: job.id, plan: await runAppearancePlanning(job.source, job.request) }
         : job.type === 'catalog'
           ? { type: 'catalog-complete', id: job.id, catalog: await runAppearanceCatalog(job.source, job.request) }
+          : job.type === 'captured-mesh-plan'
+            ? { type: 'captured-mesh-complete', id: job.id, result: await runCapturedMeshPlanning(job.source, job.request) }
           : job.type === 'annotation-plan'
             ? { type: 'annotation-complete', id: job.id, result: await runAnnotationPlanePlanning(job.source, job.request) }
             : { type: 'page-complete', id: job.id, result: await runPageAppearancePlanning(job.source, job.request, job.rgba) };

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -653,3 +653,32 @@ worker teardown and stale-result validation with image/page planning and catalog
 requests. Its `mesh` is canonical native Z-up geometry, while UVs already use
 bitmap top-down orientation. See [calibrated annotations](rust.md#calibrated-image-annotations)
 for the exact coordinate/containment contract and bounded refusal conditions.
+
+### Captured textured surface creation
+
+`IfcAPI.planCapturedMesh(source, requestJson)` plans one explicitly segmented
+textured surface as `IfcBuildingElementProxy`. It shares annotation creation's
+canonical placement, container validation, IFC entity planning and ordinary
+geometry producer. It does not decode a scan, reconstruct a surface, or infer a
+semantic class.
+
+The request contains `schema` (`IFC4` or `IFC4X3`), `sourceRevision`,
+`nextExpressId`, `containerId`, `GlobalId`, `containmentGlobalId`, `Name`,
+`imageUri`, and `mesh`. The mesh contains `positions` in IFC world Z-up metres,
+zero-based `triangles`, independent `uvs` in IFC V-up convention, and zero-based
+`uvTriangles`. Independent UV indices retain seams without conflating geometry
+and image vertices. The non-repeating image must cover UVs within `[0, 1]`.
+
+Each of the position, UV and triangle arrays is bounded to 200,000 rows. The
+request and serialized result each have a 64 MiB ceiling. Invalid indices,
+non-finite coordinates, degenerate triangles, stale allocation, duplicate IFC
+identities and unrepresentable canonical coordinates fail before publication.
+The planner retains original image URI ownership; callers must bundle the exact
+image bytes and publish the entity plan, canonical mesh, hierarchy and history
+atomically after checking the revision and allocator again.
+
+The UTF-8 JSON response contains `plan`, `objectId`, `geometryItemId`, `mesh`,
+`coordinateSpace: 'ifc-z-up'`, and `rtcOffset`. As with annotation creation,
+canonical mesh UVs are already top-down for GPU upload; do not flip them again.
+A fresh import can weld vertices differently, so round-trip correspondence is
+measured per triangle corner rather than by assuming an identical vertex layout.

--- a/docs/architecture/evidence/captured-mesh/README.md
+++ b/docs/architecture/evidence/captured-mesh/README.md
@@ -44,3 +44,9 @@ Input fingerprints:
 and branch source on AC20-FZK-Haus. Counts are unchanged; quantization, noise and
 lack of an exclusive idle-machine window make timing inconclusive. This is not a
 browser worker-pool or capture-creation performance claim.
+
+Adversarial review also runs the required four in-tree IfcOpenShell parity
+comparisons with a wheel rebuilt from this branch: all four match (the existing
+triangle-density advisory remains). The worker client refuses oversized capture
+row arrays before worker allocation or structured cloning; the native planner
+independently validates geometry, indices, numeric bounds and image coordinates.

--- a/docs/architecture/evidence/captured-mesh/README.md
+++ b/docs/architecture/evidence/captured-mesh/README.md
@@ -1,0 +1,46 @@
+# Captured mesh native authoring (#4380)
+
+This foundation authors an already segmented triangle surface into an existing
+IFC model. It does not establish the capture import UI, segmentation, automatic
+classification, reconstruction, or a browser end-to-end Save workflow.
+
+The public real-file oracle uses [Boulder 01 by Rico Cilliers / Poly Haven](https://polyhaven.com/a/boulder_01),
+CC0, with 67,042 source position/UV rows and 66,122 triangles. The pre-existing
+capture adapter converted glTF Y-up to IFC Z-up `(x, -z, y)`, raised minimum Z to
+zero, and converted texture V to IFC V-up. It retained full triangle topology and
+the original 1K diffuse JPEG. No Python IFC writer is part of this implementation.
+
+Reproduce with `IFCLITE_CAPTURED_MESH_FIXTURE` pointing to the adapter's
+`boulder.json`:
+
+```sh
+IFCLITE_CAPTURED_MESH_FIXTURE=/path/to/boulder.json cargo test -p ifc-lite-processing appearance::captured --lib -- --nocapture
+IFCLITE_CAPTURED_MESH_FIXTURE=/path/to/boulder.json TEST_SHARDS=1000003 TEST_SHARD=179174 pnpm test --filter=@ifc-lite/viewer --env-mode=loose
+```
+
+The native oracle authors the real mesh, applies its entity plan to an IFC
+snapshot and loads it through `process_geometry`. It compares each triangle's
+world-space corners and associated UV corners, with a 1e-6 metre / UV tolerance.
+The ordinary importer can weld vertices differently from the isolated canonical
+product planner; it produced 196,855 vertices while retaining all 66,122 faces.
+Vertex-array identity would incorrectly reject this valid representation.
+
+The actual WASM oracle checks every authored corner against the source capture
+(1e-4 metre and 1e-6 UV refusal tolerances), the owner and geometry-item identity,
+and the retained JPEG URI. A second small non-planar mesh has an intentional UV
+seam, and exercises the real worker route, stale allocator rejection and
+cancellation. Native tests additionally cover rotated millimetre containers,
+5,000-km georeferencing, IFC4X3 entity slots, malformed indices and degenerate
+triangles. These tests establish image correspondence; actual image decoding,
+GPU rendering, host history and portable export are downstream acceptance.
+
+Input fingerprints:
+
+- Derived `boulder.json`: SHA-256 `2dfa4e3b07dc138ba82317c09b60b41bd40feacf62f2025409b50d2fef569752`.
+- Original diffuse JPEG: SHA-256 `c38f0e918f6dc16b8d386ba3cdd89805c78320c119a1ceec85856f82b09a65b8`.
+- Tested generated WASM: SHA-256 `498146de2117229de433704e94ceb2cd9dce6358d79ad5b78eb5d61abfe037b3`.
+
+[Native ordinary-load smoke samples](native-load.json) compare the exact base
+and branch source on AC20-FZK-Haus. Counts are unchanged; quantization, noise and
+lack of an exclusive idle-machine window make timing inconclusive. This is not a
+browser worker-pool or capture-creation performance claim.

--- a/docs/architecture/evidence/captured-mesh/native-load.json
+++ b/docs/architecture/evidence/captured-mesh/native-load.json
@@ -1,0 +1,252 @@
+{
+  "base": "cce73c3de",
+  "branch": "c05f789d5",
+  "kind": "native ordinary-load smoke; not a worker-pool performance claim",
+  "command": "scripts/perf/probe.sh <fixture> --iters 5 --json",
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "platform": "macOS-26.6.2-arm64-arm-64bit",
+  "limitation": "Own tests/builds were idle, but exclusive machine idleness was not established. Millisecond quantization and noisy samples do not support a speedup or regression conclusion. Captured mesh creation itself is not timed.",
+  "outputIdentity": "All runs: 285 meshes, 35940 vertices, 19456 triangles; no byte/hash identity claim.",
+  "runs": [
+    {
+      "pair": 0,
+      "side": "base",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.31,
+          "parseMs": 3,
+          "entityScanMs": 1,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 6,
+          "facetedBrepMs": 0,
+          "totalMs": 9,
+          "allTotalsMs": [
+            12,
+            12,
+            10,
+            9,
+            14
+          ],
+          "allWallMs": [
+            13.343459000000001,
+            13.531709,
+            11.316125,
+            10.176459000000001,
+            15.384292
+          ],
+          "pointCacheHits": 51748,
+          "pointCacheMisses": 9084,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    },
+    {
+      "pair": 0,
+      "side": "branch",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.09,
+          "parseMs": 4,
+          "entityScanMs": 2,
+          "lookupMs": 1,
+          "preprocessMs": 0,
+          "geometryMs": 5,
+          "facetedBrepMs": 0,
+          "totalMs": 9,
+          "allTotalsMs": [
+            11,
+            10,
+            9,
+            10,
+            9
+          ],
+          "allWallMs": [
+            12.2875,
+            10.510542,
+            10.329708,
+            11.32025,
+            10.489500000000001
+          ],
+          "pointCacheHits": 51748,
+          "pointCacheMisses": 9084,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    },
+    {
+      "pair": 1,
+      "side": "branch",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.32,
+          "parseMs": 4,
+          "entityScanMs": 2,
+          "lookupMs": 1,
+          "preprocessMs": 0,
+          "geometryMs": 8,
+          "facetedBrepMs": 0,
+          "totalMs": 13,
+          "allTotalsMs": [
+            13,
+            13,
+            13,
+            16,
+            42
+          ],
+          "allWallMs": [
+            13.941291,
+            13.783709,
+            13.464625,
+            17.107375,
+            42.967959
+          ],
+          "pointCacheHits": 51708,
+          "pointCacheMisses": 9076,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    },
+    {
+      "pair": 1,
+      "side": "base",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.2,
+          "parseMs": 3,
+          "entityScanMs": 2,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 5,
+          "facetedBrepMs": 0,
+          "totalMs": 9,
+          "allTotalsMs": [
+            12,
+            11,
+            9,
+            10,
+            12
+          ],
+          "allWallMs": [
+            12.778583,
+            11.984625000000001,
+            9.965042,
+            11.014875,
+            12.788667
+          ],
+          "pointCacheHits": 51748,
+          "pointCacheMisses": 9084,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    },
+    {
+      "pair": 2,
+      "side": "base",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.36,
+          "parseMs": 4,
+          "entityScanMs": 2,
+          "lookupMs": 1,
+          "preprocessMs": 0,
+          "geometryMs": 6,
+          "facetedBrepMs": 0,
+          "totalMs": 11,
+          "allTotalsMs": [
+            14,
+            16,
+            11,
+            12,
+            13
+          ],
+          "allWallMs": [
+            14.628167,
+            17.361709,
+            11.878167,
+            13.242125,
+            14.3405
+          ],
+          "pointCacheHits": 51724,
+          "pointCacheMisses": 9084,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    },
+    {
+      "pair": 2,
+      "side": "branch",
+      "result": [
+        {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.25,
+          "parseMs": 3,
+          "entityScanMs": 2,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 6,
+          "facetedBrepMs": 0,
+          "totalMs": 9,
+          "allTotalsMs": [
+            11,
+            10,
+            9,
+            10,
+            10
+          ],
+          "allWallMs": [
+            11.793458999999999,
+            11.476,
+            10.51775,
+            10.69875,
+            10.6275
+          ],
+          "pointCacheHits": 51836,
+          "pointCacheMisses": 9116,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      ]
+    }
+  ]
+}

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -132,3 +132,9 @@ plan for an explicit spatial container, reusing canonical native geometry. Run i
 in a worker and publish its typed entities, source-image lease and returned mesh
 as one existing model/history transaction. See the [WASM API guide](../../docs/api/wasm.md#calibrated-annotation-creation)
 for the Z-up geometry/top-down UV and allocator/source validation contract.
+
+`IfcAPI.planCapturedMesh` creates a bounded `IfcBuildingElementProxy` plan from
+an already segmented textured triangle mesh, retaining independent UV seams and
+the original image URI. It uses the same native authoring and geometry path as
+annotation creation. See [captured surface creation](../../docs/api/wasm.md#captured-textured-surface-creation)
+for coordinate, budget and atomic host-commit requirements.

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -631,6 +631,12 @@ export class IfcAPI {
      */
     planAppearance(content: Uint8Array, request_json: string): Uint8Array;
     /**
+     * Create a captured textured surface through canonical native geometry.
+     * Input is CapturedMeshRequest; output UTF-8 CapturedMeshPlan JSON.
+     * Does not mutate the IFC snapshot or decode the host-owned image.
+     */
+    planCapturedMesh(content: Uint8Array, request_json: string): Uint8Array;
+    /**
      * Finite-page composition over original canonical albedo. RGBA is supplied
      * separately from the bounded JSON request. Result: IFPA magic, little-endian
      * u32 JSON byte length, metadata JSON, then PNG bytes addressed by metadata.
@@ -2062,6 +2068,7 @@ export interface InitOutput {
     readonly ifcapi_parseSymbolicRepresentations: (a: number, b: number, c: number) => number;
     readonly ifcapi_planAnnotationPlane: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly ifcapi_planAppearance: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
+    readonly ifcapi_planCapturedMesh: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly ifcapi_planPageAppearance: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
     readonly ifcapi_processGeometryBatch: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number, a1: number, b1: number) => number;
     readonly ifcapi_processGeometryBatchFromSource: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number, l: number, m: number, n: number, o: number, p: number, q: number, r: number, s: number, t: number, u: number, v: number, w: number, x: number, y: number, z: number) => number;

--- a/rust/processing/src/appearance/annotation.rs
+++ b/rust/processing/src/appearance/annotation.rs
@@ -37,10 +37,14 @@ impl Author {
     }
 }
 
-/// Create one bounded, textured IfcAnnotation in an explicitly chosen spatial
-/// container. The source image is retained, not baked. Native production is the
-/// same element funnel used by ordinary imports; no live model is mutated.
-pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> Result<AnnotationPlanePlan, String> {
+pub(super) struct AuthoredProductPlan {
+    pub plan: AppearancePlan,
+    pub product_id:u32,
+    pub geometry_item_id:u32,
+    pub mesh:crate::types::mesh::MeshData,
+    pub rtc_offset:[f64;3],
+}
+pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest, captured:Option<&super::captured_types::CapturedMesh>) -> Result<AuthoredProductPlan,String> {
     let r=request;
     if !matches!(r.schema.as_str(), "IFC4"|"IFC4X3") || r.source_revision.len()>4096 || r.name.len()>1024
         || !valid_guid(&r.global_id) || !valid_guid(&r.containment_global_id) || r.global_id==r.containment_global_id {
@@ -103,28 +107,31 @@ pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> 
     let direction=author.add(IfcType::IfcDirection,vec![vector(u)]);
     let axes=author.add(IfcType::IfcAxis2Placement3D,vec![A::EntityRef(point),A::EntityRef(axis),A::EntityRef(direction)]);
     let placement=author.add(IfcType::IfcLocalPlacement,vec![container.get_ref(5).map_or(A::Null,A::EntityRef),A::EntityRef(axes)]);
-    let mut point_attributes=vec![A::List([[0.,0.,0.],[size[0],0.,0.],[size[0],size[1],0.],[0.,size[1],0.]].into_iter().map(vector).collect())];
+    let vertices = captured.map_or_else(|| vec![[0.,0.,0.],[size[0],0.,0.],[size[0],size[1],0.],[0.,size[1],0.]], |m| m.positions.iter().map(|p| std::array::from_fn(|i| (p[i]-f.origin[i])/scale)).collect());
+    let mut point_attributes=vec![A::List(vertices.into_iter().map(vector).collect())];
     if r.schema=="IFC4X3" { point_attributes.push(A::Null); } // TagList, IFC4X3 only.
     let points=author.add(IfcType::IfcCartesianPointList3D,point_attributes);
-    let triangles=[[1,2,3],[1,3,4]];
-    let index_value=||A::List(triangles.into_iter().map(|row|A::List(row.into_iter().map(A::Integer).collect())).collect());
+    let triangles:Vec<[i64;3]>=captured.map_or_else(|| vec![[1,2,3],[1,3,4]], |m| m.triangles.iter().map(|r|r.map(|i|i64::from(i)+1)).collect());
+    let index_value=||A::List(triangles.iter().map(|row|A::List(row.iter().copied().map(A::Integer).collect())).collect());
     let item=author.add(IfcType::IfcTriangulatedFaceSet,vec![A::EntityRef(points),A::Null,A::Enum("F".into()),index_value(),A::Null]);
     let image=author.add(IfcType::IfcImageTexture,vec![A::Enum("F".into()),A::Enum("F".into()),A::Null,A::Null,A::Null,A::String(r.image_uri.clone())]);
-    let uv=[[0.,0.],[1.,0.],[1.,1.],[0.,1.]];
-    let vertices=author.add(IfcType::IfcTextureVertexList,vec![A::List(uv.into_iter().map(|v|A::List(v.into_iter().map(A::Float).collect())).collect())]);
-    author.add(IfcType::IfcIndexedTriangleTextureMap,vec![refs(&[image]),A::EntityRef(item),A::EntityRef(vertices),index_value()]);
+    let uv=captured.map_or_else(|| vec![[0.,0.],[1.,0.],[1.,1.],[0.,1.]], |m|m.uvs.clone());
+    let uv_triangles:Vec<[u32;3]>=captured.map_or_else(||vec![[1,2,3],[1,3,4]], |m|m.uv_triangles.iter().map(|r|r.map(|i|i+1)).collect());
+    let vertices=author.add(IfcType::IfcTextureVertexList,vec![A::List(uv.iter().map(|v|A::List(v.iter().copied().map(A::Float).collect())).collect())]);
+    author.add(IfcType::IfcIndexedTriangleTextureMap,vec![refs(&[image]),A::EntityRef(item),A::EntityRef(vertices),A::List(uv_triangles.iter().map(|r|A::List(r.iter().map(|i|A::Integer(i64::from(*i))).collect())).collect())]);
     let white=author.add(IfcType::IfcColourRgb,vec![A::Null,A::Float(1.),A::Float(1.),A::Float(1.)]);
     let shading=author.add(IfcType::IfcSurfaceStyleShading,vec![A::EntityRef(white),A::Float(0.)]);
     let texture=author.add(IfcType::IfcSurfaceStyleWithTextures,vec![refs(&[image])]);
     let style=author.add(IfcType::IfcSurfaceStyle,vec![A::String("Registered image".into()),A::Enum("BOTH".into()),refs(&[shading,texture])]);
     let styled=author.add(IfcType::IfcStyledItem,vec![A::EntityRef(item),refs(&[style]),A::Null]);
-    let shape=author.add(IfcType::IfcShapeRepresentation,vec![A::EntityRef(contexts[0]),A::String("Annotation".into()),A::String("Tessellation".into()),refs(&[item])]);
+    let shape=author.add(IfcType::IfcShapeRepresentation,vec![A::EntityRef(contexts[0]),A::String(if captured.is_some() {"Body"} else {"Annotation"}.into()),A::String("Tessellation".into()),refs(&[item])]);
     let product_shape=author.add(IfcType::IfcProductDefinitionShape,vec![A::Null,A::Null,refs(&[shape])]);
     let owner=project.get_ref(1).map_or(A::Null,A::EntityRef);
     let mut annotation_attributes=vec![A::String(r.global_id.clone()),owner.clone(),A::String(r.name.clone()),A::Null,
-        A::String("IfcLite:RegisteredImage".into()),A::EntityRef(placement),A::EntityRef(product_shape)];
-    if r.schema=="IFC4X3" { annotation_attributes.push(A::Enum("USERDEFINED".into())); }
-    let annotation=author.add(IfcType::IfcAnnotation,annotation_attributes);
+        A::String(if captured.is_some() {"IfcLite:CapturedSurface"} else {"IfcLite:RegisteredImage"}.into()),A::EntityRef(placement),A::EntityRef(product_shape)];
+    if captured.is_some() { annotation_attributes.extend([A::Null,A::Enum("USERDEFINED".into())]); }
+    else if r.schema=="IFC4X3" { annotation_attributes.push(A::Enum("USERDEFINED".into())); }
+    let annotation=author.add(if captured.is_some() {IfcType::IfcBuildingElementProxy} else {IfcType::IfcAnnotation},annotation_attributes);
     author.add(IfcType::IfcRelContainedInSpatialStructure,vec![A::String(r.containment_global_id.clone()),owner,A::Null,A::Null,refs(&[annotation]),A::EntityRef(r.container_id)]);
     source.decoder.inject_shared_cache(&author.entities);
     let mut styles=crate::prepass::ResolvedPrepass::default();
@@ -132,14 +139,21 @@ pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> 
     styles.geometry_style_index.insert(item,info);
     let textures=FxHashMap::from_iter([(item,ResolvedTextureMap { texture_id:image,
         texture:TextureSource::Image(ImageTextureRef { url:r.image_uri.clone(),repeat_s:false,repeat_t:false }),
-        tex_coords:uv.map(|v|v.map(|x|x as f32)).to_vec(),tex_coord_index:Some(vec![[1,2,3],[1,3,4]]) })]);
+        tex_coords:uv.iter().map(|v|v.map(|x|x as f32)).collect(),tex_coord_index:Some(uv_triangles) })]);
     let mut meshes=canonical::produce(&mut source,annotation,&textures,Some(&styles))?;
     if meshes.len()!=1 { return Err("Canonical annotation geometry did not produce exactly one textured plane".into()); }
     let mesh=meshes.remove(0);
-    if mesh.indices.len()!=6 || mesh.positions.len()!=12 || mesh.uvs.as_ref().is_none_or(|uv|uv.len()!=8)
+    if mesh.indices.len()!=triangles.len()*3 || mesh.uvs.as_ref().is_none_or(|uv|uv.len()!=mesh.positions.len()/3*2)
         || mesh.positions.iter().chain(&mesh.normals).any(|v|!v.is_finite()) {
-        return Err("Canonical annotation geometry collapsed or lost its texture coordinates".into());
+        return Err("Canonical authored geometry collapsed or lost its texture coordinates".into());
     }
+    Ok(AuthoredProductPlan { plan:author.plan, product_id:annotation, geometry_item_id:item, mesh, rtc_offset })
+}
+
+/// Create one bounded textured annotation through the shared native product planner.
+pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> Result<AnnotationPlanePlan,String> {
+    let AuthoredProductPlan {plan,product_id,geometry_item_id,mesh,rtc_offset}=plan_textured_product(bytes,request,None)?;
+    let f=&request.frame;
     let uv=mesh.uvs.as_ref().ok_or("Missing canonical annotation UVs")?;
     let tolerance=f.size_metres[0].min(f.size_metres[1])*1e-6;
     for (i,p) in mesh.positions.chunks_exact(3).enumerate() {
@@ -150,8 +164,8 @@ pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> 
             return Err("Annotation frame loses precision in canonical geometry; move closer to the model origin or increase its size".into());
         }
     }
-    Ok(AnnotationPlanePlan { plan:author.plan,annotation_id:annotation,geometry_item_id:item,mesh,
-        coordinate_space:"ifc-z-up",rtc_offset,frame:r.frame.clone() })
+    Ok(AnnotationPlanePlan { plan,annotation_id:product_id,geometry_item_id,mesh,
+        coordinate_space:"ifc-z-up",rtc_offset,frame:request.frame.clone() })
 }
 
 #[cfg(test)]

--- a/rust/processing/src/appearance/captured.rs
+++ b/rust/processing/src/appearance/captured.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::{captured_types::*,annotation_types::*,annotation::plan_textured_product};
+const MAX_ROWS:usize=200_000;
+
+fn validate(mesh:&CapturedMesh)->Result<(),String> {
+    if [mesh.positions.len(),mesh.triangles.len(),mesh.uvs.len()].iter().any(|n|*n==0 || *n>MAX_ROWS)
+        || mesh.uv_triangles.len()!=mesh.triangles.len() {
+        return Err("Captured mesh needs 1..200000 position, triangle and UV rows, with one UV triangle per face".into());
+    }
+    if mesh.positions.iter().flatten().any(|v|!v.is_finite() || v.abs()>1e9)
+        || mesh.uvs.iter().flatten().any(|v|!v.is_finite() || !(0. ..=1.).contains(v)) {
+        return Err("Captured coordinates must be finite world metres within +/-1e9 and UVs within the non-repeating image".into());
+    }
+    for (face,uv) in mesh.triangles.iter().zip(&mesh.uv_triangles) {
+        if face.iter().any(|i|*i as usize>=mesh.positions.len()) || uv.iter().any(|i|*i as usize>=mesh.uvs.len()) {
+            return Err("Captured geometry or UV triangle index is out of bounds".into());
+        }
+        let [a,b,c]=face.map(|i|mesh.positions[i as usize]);
+        let ab:[f64;3]=std::array::from_fn(|i|b[i]-a[i]);
+        let ac:[f64;3]=std::array::from_fn(|i|c[i]-a[i]);
+        let cross=[ab[1]*ac[2]-ab[2]*ac[1],ab[2]*ac[0]-ab[0]*ac[2],ab[0]*ac[1]-ab[1]*ac[0]];
+        if cross.iter().map(|v|v*v).sum::<f64>()<=1e-24 {
+            return Err("Captured mesh contains a degenerate triangle".into());
+        }
+    }
+    Ok(())
+}
+/// Author a bounded existing captured surface as IfcBuildingElementProxy.
+/// Decoding, reconstruction, classification and image ownership stay with callers.
+pub fn plan_captured_mesh(bytes:&[u8],request:&CapturedMeshRequest)->Result<CapturedMeshPlan,String> {
+    validate(&request.mesh)?;
+    if request.name.trim().is_empty() { return Err("Captured object requires a Name".into()); }
+    let r=AnnotationPlaneRequest {schema:request.schema.clone(),source_revision:request.source_revision.clone(),
+        next_express_id:request.next_express_id,container_id:request.container_id,global_id:request.global_id.clone(),
+        containment_global_id:request.containment_global_id.clone(),name:request.name.clone(),image_uri:request.image_uri.clone(),
+        frame:AnnotationPlaneFrame {origin:request.mesh.positions[0],axis_u:[1.,0.,0.],axis_v:[0.,1.,0.],size_metres:[1.,1.]} };
+    let result=plan_textured_product(bytes,&r,Some(&request.mesh))?;
+    let uvs=result.mesh.uvs.as_ref().ok_or("Captured image coordinates were lost")?;
+    // Check the actual native triangle corners, including seams and image V.
+    // This is a refusal boundary for float precision loss, never a silent repair.
+    for (face,indices) in result.mesh.indices.chunks_exact(3).enumerate() {
+        for (corner,index) in indices.iter().enumerate() {
+            let p=request.mesh.positions[request.mesh.triangles[face][corner] as usize];
+            let uv=request.mesh.uvs[request.mesh.uv_triangles[face][corner] as usize];
+            let i=*index as usize;
+            for (axis,expected) in p.iter().enumerate() {
+                let actual=f64::from(result.mesh.positions[i*3+axis])+result.mesh.origin[axis]+result.rtc_offset[axis];
+                if (actual-expected).abs()>1e-4 { return Err("Captured mesh loses world precision in canonical geometry".into()); }
+            }
+            if (f64::from(uvs[i*2])-uv[0]).abs()>1e-6 || (f64::from(uvs[i*2+1])-(1.-uv[1])).abs()>1e-6 {
+                return Err("Captured triangle image correspondence was not preserved".into());
+            }
+        }
+    }
+    Ok(CapturedMeshPlan {plan:result.plan,object_id:result.product_id,geometry_item_id:result.geometry_item_id,
+        mesh:result.mesh,coordinate_space:"ifc-z-up",rtc_offset:result.rtc_offset})
+}
+
+#[cfg(test)]
+#[path="captured_tests.rs"]
+mod tests;

--- a/rust/processing/src/appearance/captured_tests.rs
+++ b/rust/processing/src/appearance/captured_tests.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::*;
+use crate::appearance::tests::{apply,CONTROLLED_IFC};
+fn fixture()->(String,CapturedMeshRequest) {
+    let source=CONTROLLED_IFC.replace("#37=IFCINDEXEDTRIANGLETEXTUREMAP", "#40=IFCBUILDINGSTOREY('0Storey0000000000000000',$,'Level',$,$,#11,$,$,.ELEMENT.,0.);\n#37=IFCINDEXEDTRIANGLETEXTUREMAP");
+    (source,CapturedMeshRequest {schema:"IFC4".into(),source_revision:"capture-test".into(),next_express_id:100,
+        container_id:40,global_id:"0aaaaaaaaaaaaaaaaaaaaa".into(),containment_global_id:"0bbbbbbbbbbbbbbbbbbbbb".into(),
+        name:"Captured surface".into(),image_uri:"textures/captured.png".into(),mesh:CapturedMesh {
+            positions:vec![[2.,3.,4.],[3.,3.,4.],[3.,4.,4.],[2.,4.,5.]],triangles:vec![[0,1,2],[0,2,3]],
+            uvs:vec![[0.,0.],[1.,0.],[1.,1.],[0.,1.],[0.2,0.2]],uv_triangles:vec![[0,1,2],[4,2,3]] }})
+}
+#[test]
+fn issue_4380_captured_nonplanar_surface_seam_roundtrips_through_normal_import() {
+    let (source,r)=fixture();
+    let plan=plan_captured_mesh(source.as_bytes(),&r).unwrap();
+    let restored=crate::process_geometry(apply(&source,&plan.plan).as_bytes());
+    let mesh=restored.meshes.iter().find(|m|m.express_id==plan.object_id).unwrap();
+    assert_eq!(mesh.positions,plan.mesh.positions);
+    assert_eq!(mesh.indices,plan.mesh.indices);
+    assert_eq!(mesh.uvs,plan.mesh.uvs);
+    assert_eq!(mesh.texture.as_ref().unwrap().url.as_deref(),Some(r.image_uri.as_str()));
+    assert!(plan.plan.created.iter().any(|e|e.r#type=="IfcBuildingElementProxy"));
+}
+#[test]
+fn issue_4380_capture_rejects_invalid_triangle_uv_and_degenerate_inputs() {
+    let (source,r)=fixture();
+    let mut invalid=r.clone();invalid.mesh.triangles[0][0]=999;
+    assert!(plan_captured_mesh(source.as_bytes(),&invalid).is_err());
+    invalid=r.clone();invalid.mesh.uv_triangles.pop();
+    assert!(plan_captured_mesh(source.as_bytes(),&invalid).is_err());
+    invalid=r.clone();invalid.mesh.positions[0]=invalid.mesh.positions[1];
+    assert!(plan_captured_mesh(source.as_bytes(),&invalid).is_err());
+    invalid=r.clone();invalid.mesh.uvs[0][0]=f64::NAN;
+    assert!(plan_captured_mesh(source.as_bytes(),&invalid).is_err());
+}

--- a/rust/processing/src/appearance/captured_tests.rs
+++ b/rust/processing/src/appearance/captured_tests.rs
@@ -52,7 +52,14 @@ fn issue_4380_public_boulder_exact_triangle_image_correspondence() {
     let Ok(path)=std::env::var("IFCLITE_CAPTURED_MESH_FIXTURE") else {
         eprintln!("Skipping external captured surface: fetch the public Poly Haven boulder fixture and set IFCLITE_CAPTURED_MESH_FIXTURE");return;
     };
-    let input:serde_json::Value=serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    let bytes=match std::fs::read(path) {
+        Ok(bytes)=>bytes,
+        Err(error) if error.kind()==std::io::ErrorKind::NotFound=>{
+            eprintln!("Skipping missing captured fixture; run pnpm fixtures and fetch the public capture described in the authoring evidence");return;
+        },
+        Err(error)=>panic!("Cannot read captured fixture: {error}"),
+    };
+    let input:serde_json::Value=serde_json::from_slice(&bytes).unwrap();
     let (source,mut request)=fixture();
     request.mesh=serde_json::from_value(serde_json::json!({"positions":input["vertices"],"triangles":input["triangles"],"uvs":input["uvs"],"uvTriangles":input["uv_triangles"]})).unwrap();
     let plan=plan_captured_mesh(source.as_bytes(),&request).unwrap();
@@ -86,4 +93,20 @@ fn issue_4380_ifc4x3_captured_proxy_has_tag_and_predefined_type_slots() {
     assert_eq!(proxy.attributes[8],".USERDEFINED.");
     let points=result.plan.created.iter().find(|e|e.r#type=="IfcCartesianPointList3D").unwrap();
     assert_eq!(points.attributes.len(),2);
+}
+#[test]
+fn issue_4380_georeferenced_capture_reopens_at_same_world_triangle_corners() {
+    let (source,mut request)=fixture();
+    let source=source.replace("#4=IFCCARTESIANPOINT((0.,0.,0.));", "#4=IFCCARTESIANPOINT((5000000.,6000000.,100.));");
+    for p in &mut request.mesh.positions { for axis in 0..3 {p[axis]+=[5000000.,6000000.,100.][axis];} }
+    let result=plan_captured_mesh(source.as_bytes(),&request).unwrap();
+    let restored=crate::process_geometry(apply(&source,&result.plan).as_bytes());
+    let mesh=restored.meshes.iter().find(|m|m.express_id==result.object_id).unwrap();
+    for (corner,index) in mesh.indices.iter().enumerate() {
+        let expected=request.mesh.positions[request.mesh.triangles[corner/3][corner%3] as usize];
+        for (axis,value) in expected.iter().enumerate() {
+            let world=f64::from(mesh.positions[*index as usize*3+axis])+mesh.origin[axis]+restored.metadata.coordinate_info.origin_shift[axis];
+            assert!((world-value).abs()<1e-6);
+        }
+    }
 }

--- a/rust/processing/src/appearance/captured_tests.rs
+++ b/rust/processing/src/appearance/captured_tests.rs
@@ -35,3 +35,55 @@ fn issue_4380_capture_rejects_invalid_triangle_uv_and_degenerate_inputs() {
     invalid=r.clone();invalid.mesh.uvs[0][0]=f64::NAN;
     assert!(plan_captured_mesh(source.as_bytes(),&invalid).is_err());
 }
+#[test]
+fn issue_4380_captured_surface_rotated_millimetre_container_retains_world_vertices() {
+    let (source,request)=fixture();
+    let source=source.replace(".LENGTHUNIT.,$,.METRE.",".LENGTHUNIT.,.MILLI.,.METRE.")
+        .replace("'Level',$,$,#11", "'Level',$,$,#41")
+        .replace("#37=IFCINDEXEDTRIANGLETEXTUREMAP", "#41=IFCLOCALPLACEMENT($,#42);\n#42=IFCAXIS2PLACEMENT3D(#43,#44,#45);\n#43=IFCCARTESIANPOINT((10000.,20000.,3000.));\n#44=IFCDIRECTION((0.,0.,1.));\n#45=IFCDIRECTION((0.,1.,0.));\n#37=IFCINDEXEDTRIANGLETEXTUREMAP");
+    let result=plan_captured_mesh(source.as_bytes(),&request).unwrap();
+    let restored=crate::process_geometry(apply(&source,&result.plan).as_bytes());
+    let mesh=restored.meshes.iter().find(|m|m.express_id==result.object_id).unwrap();
+    assert_eq!(mesh.positions,result.mesh.positions);
+    assert_eq!(mesh.uvs,result.mesh.uvs);
+}
+#[test]
+fn issue_4380_public_boulder_exact_triangle_image_correspondence() {
+    let Ok(path)=std::env::var("IFCLITE_CAPTURED_MESH_FIXTURE") else {
+        eprintln!("Skipping external captured surface: fetch the public Poly Haven boulder fixture and set IFCLITE_CAPTURED_MESH_FIXTURE");return;
+    };
+    let input:serde_json::Value=serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    let (source,mut request)=fixture();
+    request.mesh=serde_json::from_value(serde_json::json!({"positions":input["vertices"],"triangles":input["triangles"],"uvs":input["uvs"],"uvTriangles":input["uv_triangles"]})).unwrap();
+    let plan=plan_captured_mesh(source.as_bytes(),&request).unwrap();
+    assert_eq!(plan.mesh.indices.len(),request.mesh.triangles.len()*3);
+    let restored=crate::process_geometry(apply(&source,&plan.plan).as_bytes());
+    let mesh=restored.meshes.iter().find(|m|m.express_id==plan.object_id).unwrap();
+    assert_eq!(mesh.indices.len(),plan.mesh.indices.len());
+    for (left,right) in mesh.indices.iter().zip(&plan.mesh.indices) {
+        for axis in 0..3 {
+            let a=f64::from(mesh.positions[*left as usize*3+axis])+mesh.origin[axis];
+            let b=f64::from(plan.mesh.positions[*right as usize*3+axis])+plan.mesh.origin[axis];
+            assert!((a-b).abs()<1e-6,"roundtrip triangle corner difference {}",(a-b).abs());
+        }
+        for axis in 0..2 {
+            let a=mesh.uvs.as_ref().unwrap()[*left as usize*2+axis];
+            let b=plan.mesh.uvs.as_ref().unwrap()[*right as usize*2+axis];
+            assert!((a-b).abs()<1e-6,"roundtrip triangle UV difference {}",(a-b).abs());
+        }
+    }
+    eprintln!("Public capture verified {} triangles, {} vertices",mesh.indices.len()/3,mesh.positions.len()/3);
+}
+#[test]
+fn issue_4380_ifc4x3_captured_proxy_has_tag_and_predefined_type_slots() {
+    let (source,mut request)=fixture();
+    request.schema="IFC4X3".into();
+    let source=source.replace("FILE_SCHEMA(('IFC4'))","FILE_SCHEMA(('IFC4X3'))");
+    let result=plan_captured_mesh(source.as_bytes(),&request).unwrap();
+    let proxy=result.plan.created.iter().find(|e|e.r#type=="IfcBuildingElementProxy").unwrap();
+    assert_eq!(proxy.attributes.len(),9);
+    assert_eq!(proxy.attributes[7],serde_json::Value::Null);
+    assert_eq!(proxy.attributes[8],".USERDEFINED.");
+    let points=result.plan.created.iter().find(|e|e.r#type=="IfcCartesianPointList3D").unwrap();
+    assert_eq!(points.attributes.len(),2);
+}

--- a/rust/processing/src/appearance/captured_types.rs
+++ b/rust/processing/src/appearance/captured_types.rs
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use serde::{Deserialize,Serialize};
+use super::AppearancePlan;
+use crate::types::mesh::MeshData;
+
+/// Explicit segmented surface, not a point cloud or an inferred BIM class.
+#[derive(Debug,Clone,Deserialize)]
+#[serde(rename_all="camelCase",deny_unknown_fields)]
+pub struct CapturedMesh {
+    /// IFC world Z-up metres, independently indexed from UV vertices.
+    pub positions:Vec<[f64;3]>,
+    /// Zero-based triangle indices; winding is retained.
+    pub triangles:Vec<[u32;3]>,
+    /// IFC UV convention: V increases upwards. Image bytes remain external.
+    pub uvs:Vec<[f64;2]>,
+    pub uv_triangles:Vec<[u32;3]>,
+}
+#[derive(Debug,Clone,Deserialize)]
+#[serde(rename_all="camelCase",deny_unknown_fields)]
+pub struct CapturedMeshRequest {
+    pub schema:String,
+    pub source_revision:String,
+    pub next_express_id:u32,
+    pub container_id:u32,
+    #[serde(rename="GlobalId")]
+    pub global_id:String,
+    pub containment_global_id:String,
+    #[serde(rename="Name")]
+    pub name:String,
+    pub image_uri:String,
+    pub mesh:CapturedMesh,
+}
+#[derive(Debug,Serialize)]
+#[serde(rename_all="camelCase")]
+pub struct CapturedMeshPlan {
+    pub plan:AppearancePlan,
+    pub object_id:u32,
+    pub geometry_item_id:u32,
+    pub mesh:MeshData,
+    pub coordinate_space:&'static str,
+    pub rtc_offset:[f64;3],
+}

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -5,6 +5,10 @@
 //! geometry changes. Plans are applied atomically by the host mutation editor.
 mod budget;
 mod annotation;
+mod captured;
+mod captured_types;
+pub use captured::plan_captured_mesh;
+pub use captured_types::{CapturedMesh, CapturedMeshRequest, CapturedMeshPlan};
 mod annotation_types;
 mod calibration;
 mod canonical;

--- a/rust/wasm-bindings/src/api/captured_mesh.rs
+++ b/rust/wasm-bindings/src/api/captured_mesh.rs
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::{appearance::{decode_request, encode_bounded}, IfcAPI};
+use ifc_lite_processing::appearance::{plan_captured_mesh, CapturedMeshRequest};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl IfcAPI {
+    /// Create a captured textured surface through canonical native geometry.
+    /// Input is CapturedMeshRequest; output UTF-8 CapturedMeshPlan JSON.
+    /// Does not mutate the IFC snapshot or decode the host-owned image.
+    #[wasm_bindgen(js_name = planCapturedMesh)]
+    pub fn plan_captured_mesh(&self, content: &[u8], request_json: &str) -> Result<Vec<u8>, JsError> {
+        let result=(|| {
+            let request: CapturedMeshRequest=decode_request(request_json)?;
+            encode_bounded(&plan_captured_mesh(content,&request)?)
+        })();
+        result.map_err(|message: String|JsError::new(&message))
+    }
+}

--- a/rust/wasm-bindings/src/api/captured_mesh.rs
+++ b/rust/wasm-bindings/src/api/captured_mesh.rs
@@ -1,7 +1,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-use super::{appearance::{decode_request, encode_bounded}, IfcAPI};
+use super::{appearance::encode_bounded, IfcAPI};
 use ifc_lite_processing::appearance::{plan_captured_mesh, CapturedMeshRequest};
 use wasm_bindgen::prelude::*;
 
@@ -13,7 +13,8 @@ impl IfcAPI {
     #[wasm_bindgen(js_name = planCapturedMesh)]
     pub fn plan_captured_mesh(&self, content: &[u8], request_json: &str) -> Result<Vec<u8>, JsError> {
         let result=(|| {
-            let request: CapturedMeshRequest=decode_request(request_json)?;
+            if request_json.len()>64*1024*1024 { return Err("Captured mesh request exceeds 64 MiB".into()); }
+            let request: CapturedMeshRequest=serde_json::from_str(request_json).map_err(|e|format!("Invalid captured mesh request: {e}"))?;
             encode_bounded(&plan_captured_mesh(content,&request)?)
         })();
         result.map_err(|message: String|JsError::new(&message))

--- a/rust/wasm-bindings/src/api/mod.rs
+++ b/rust/wasm-bindings/src/api/mod.rs
@@ -8,6 +8,7 @@ mod alignment_lines;
 mod appearance;
 mod appearance_page;
 mod annotation_plane;
+mod captured_mesh;
 mod appearance_calibration;
 mod bool2d;
 mod clash;

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1066,3 +1066,16 @@ source/runtime identity and functional Undo/Redo evidence are recorded under
 ### Calibrated image annotation creation (#4308)
 
 The opt-in native annotation planner reuses canonical placement, schema validation and per-element geometry production. A source-matched ordinary worker-load A/B observed a small increase with overlapping samples and identical geometry/provenance; no speedup or zero-cost claim is made. Final JavaScript/assets were identical while the verified IFC WASM was swapped, so this checks runtime size/initialization effects without invoking annotation creation. See [the exact runtime hashes and paired samples](annotation-plane-load-evidence.json). Annotation creation and the downstream Save Into Model UI are outside this load measurement.
+
+### Captured mesh authoring (#4380)
+
+The opt-in captured-surface planner shares annotation authoring's canonical
+product path; it does not modify ordinary geometry loading. Interleaved native
+ordinary-load probes retained all mesh/vertex/triangle counts, but quantized and
+noisy samples were inconclusive. Exclusive machine idleness was not established,
+so these are smoke evidence only, not a speedup, regression or browser worker-pool
+latency claim. The lesson is to compare triangle-corner geometry and UVs across
+capture authoring and normal import: valid canonical welding may change vertex
+layout while preserving the surface and seams. [Raw source-matched samples and
+limitations](../../docs/architecture/evidence/captured-mesh/native-load.json)
+record the experiment; capture-creation and integrated UI timing remain separate.


### PR DESCRIPTION
Refs #4380

Author an already segmented textured surface as one `IfcBuildingElementProxy` in an existing IFC4/IFC4X3 model. The native planner shares annotation creation's container placement, units, entity authoring and canonical geometry producer; independent geometry/UV indices preserve seams and the original image URI. A bounded WASM worker contract returns the entity plan and canonical mesh for the host's atomic creation transaction.

This is the native foundation slice. Capture decoding, integrated object-creation UI, history/export/share acceptance and segmentation remain in #4380. There is no semantic inference or parallel Python IFC writer.

Validation: full root typecheck (94 tasks, 1888 test sources), full build, `cargo test --workspace`, exact workspace clippy, real WASM worker contracts and pre-allocation capture bound (3 passed with the public boulder, zero skips), documentation samples (383), module-size check, and API snapshot regeneration. Native tests cover non-planar UV seams, malformed input, rotated millimetre containers, IFC4X3 slots and 5,000-km georeferencing. Poly Haven's real 66,122-triangle boulder preserves every triangle's world/UV correspondence through native authoring and normal IFC import; its original JPEG URI is retained. See `docs/architecture/evidence/captured-mesh/README.md` for fingerprints, tolerances and reproduction.

Perf verdict: interleaved base/branch native ordinary-load samples retained 285 meshes / 35,940 vertices / 19,456 triangles. Samples were noisy and quantized, with no exclusive idle-machine window; timings are inconclusive and make no browser worker-pool or capture-creation speed claim. Raw measurements and limits are committed beside the evidence, with the lesson in the performance ledger. Published WASM changeset and API documentation are included.


Adversarial follow-up: worker capture row cardinalities are now checked before structured cloning. Full root typecheck and the real boulder WASM suite rerun after the fix (3 passed, zero skips). A fresh branch-built Python wheel passes the four required in-tree parity comparisons; comparator unit tests also pass. Cloud checks remain queued; local evidence is used under the maintainer-authorized admin-merge workflow.
