### PR TITLE
fix(authoring): retain captured image repeat samplers

### DIFF
--- a/.changeset/captured-sampler-fidelity.md
+++ b/.changeset/captured-sampler-fidelity.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Preserve supplied captured-image repeatS/repeatT sampler flags in authored IFC and canonical meshes.

--- a/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/captured-mesh-wasm.test.ts
@@ -60,6 +60,13 @@ test('real WASM annotation creation preserves canonical owner/UV frame and share
     assert.ok(result.plan.created.some(e => e.type === 'IfcBuildingElementProxy' && e.attributes[0] === request.GlobalId));
     assert.ok(result.plan.created.some(e => e.type === 'IfcRelContainedInSpatialStructure' && e.attributes[5] === '#40'));
     assert.throws(() => api.planCapturedMesh(source, JSON.stringify({ ...request, containerId: 1 })), /IfcSpatialElement/);
+    for (const repeatS of [false, true]) for (const repeatT of [false, true]) {
+      const sampled = JSON.parse(new TextDecoder().decode(api.planCapturedMesh(source, JSON.stringify({ ...request, repeatS, repeatT })))) as CapturedMeshPlan;
+      assert.equal(sampled.mesh.texture.repeat_s, repeatS);
+      assert.equal(sampled.mesh.texture.repeat_t, repeatT);
+      assert.deepEqual(sampled.mesh.uvs, result.mesh.uvs);
+    }
+
   } finally { api.free(); }
   const { runCapturedMeshPlanning } = await import('../../workers/appearance.worker.js');
   assert.equal((await runCapturedMeshPlanning(source, request)).objectId, result.objectId);

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -109,6 +109,9 @@ export interface AnnotationPlanePlan {
   };
 }
 export interface CapturedMeshRequest extends Omit<AnnotationPlaneRequest, 'frame'> {
+  /** Original sampler; omitted means non-repeating. */
+  repeatS?: boolean;
+  repeatT?: boolean;
   mesh: {
     /** IFC world Z-up metres. Triangle and UV indices are zero-based. */
     positions: [number, number, number][];

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -682,3 +682,8 @@ The UTF-8 JSON response contains `plan`, `objectId`, `geometryItemId`, `mesh`,
 canonical mesh UVs are already top-down for GPU upload; do not flip them again.
 A fresh import can weld vertices differently, so round-trip correspondence is
 measured per triangle corner rather than by assuming an identical vertex layout.
+
+Captured mesh requests accept optional `repeatS` and `repeatT` booleans to retain
+an imported image sampler on the authored `IfcImageTexture` and canonical mesh.
+Both default to `false` when omitted. This does not extend the current supported
+UV range: capture coordinates must still lie within `[0, 1]`.

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -138,3 +138,6 @@ an already segmented textured triangle mesh, retaining independent UV seams and
 the original image URI. It uses the same native authoring and geometry path as
 annotation creation. See [captured surface creation](../../docs/api/wasm.md#captured-textured-surface-creation)
 for coordinate, budget and atomic host-commit requirements.
+
+Captured-mesh planning preserves optional `repeatS`/`repeatT` image sampler flags
+(default `false`); UVs remain bounded to `[0, 1]`.

--- a/rust/processing/src/appearance/annotation.rs
+++ b/rust/processing/src/appearance/annotation.rs
@@ -44,7 +44,7 @@ pub(super) struct AuthoredProductPlan {
     pub mesh:crate::types::mesh::MeshData,
     pub rtc_offset:[f64;3],
 }
-pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest, captured:Option<&super::captured_types::CapturedMesh>) -> Result<AuthoredProductPlan,String> {
+pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest, captured:Option<&super::captured_types::CapturedMesh>, repeat:[bool;2]) -> Result<AuthoredProductPlan,String> {
     let r=request;
     if !matches!(r.schema.as_str(), "IFC4"|"IFC4X3") || r.source_revision.len()>4096 || r.name.len()>1024
         || !valid_guid(&r.global_id) || !valid_guid(&r.containment_global_id) || r.global_id==r.containment_global_id {
@@ -114,7 +114,7 @@ pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest
     let triangles:Vec<[i64;3]>=captured.map_or_else(|| vec![[1,2,3],[1,3,4]], |m| m.triangles.iter().map(|r|r.map(|i|i64::from(i)+1)).collect());
     let index_value=||A::List(triangles.iter().map(|row|A::List(row.iter().copied().map(A::Integer).collect())).collect());
     let item=author.add(IfcType::IfcTriangulatedFaceSet,vec![A::EntityRef(points),A::Null,A::Enum("F".into()),index_value(),A::Null]);
-    let image=author.add(IfcType::IfcImageTexture,vec![A::Enum("F".into()),A::Enum("F".into()),A::Null,A::Null,A::Null,A::String(r.image_uri.clone())]);
+    let image=author.add(IfcType::IfcImageTexture,vec![A::Enum(if repeat[0] {"T"} else {"F"}.into()),A::Enum(if repeat[1] {"T"} else {"F"}.into()),A::Null,A::Null,A::Null,A::String(r.image_uri.clone())]);
     let uv=captured.map_or_else(|| vec![[0.,0.],[1.,0.],[1.,1.],[0.,1.]], |m|m.uvs.clone());
     let uv_triangles:Vec<[u32;3]>=captured.map_or_else(||vec![[1,2,3],[1,3,4]], |m|m.uv_triangles.iter().map(|r|r.map(|i|i+1)).collect());
     let vertices=author.add(IfcType::IfcTextureVertexList,vec![A::List(uv.iter().map(|v|A::List(v.iter().copied().map(A::Float).collect())).collect())]);
@@ -138,7 +138,7 @@ pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest
     let (_,info)=crate::prepass::surface_style_from_styled_item(&author.entities[&styled],&mut source.decoder).ok_or("Generated style failed canonical resolution")?;
     styles.geometry_style_index.insert(item,info);
     let textures=FxHashMap::from_iter([(item,ResolvedTextureMap { texture_id:image,
-        texture:TextureSource::Image(ImageTextureRef { url:r.image_uri.clone(),repeat_s:false,repeat_t:false }),
+        texture:TextureSource::Image(ImageTextureRef { url:r.image_uri.clone(),repeat_s:repeat[0],repeat_t:repeat[1] }),
         tex_coords:uv.iter().map(|v|v.map(|x|x as f32)).collect(),tex_coord_index:Some(uv_triangles) })]);
     let mut meshes=canonical::produce(&mut source,annotation,&textures,Some(&styles))?;
     if meshes.len()!=1 { return Err("Canonical annotation geometry did not produce exactly one textured plane".into()); }
@@ -152,7 +152,7 @@ pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest
 
 /// Create one bounded textured annotation through the shared native product planner.
 pub fn plan_annotation_plane(bytes: &[u8], request: &AnnotationPlaneRequest) -> Result<AnnotationPlanePlan,String> {
-    let AuthoredProductPlan {plan,product_id,geometry_item_id,mesh,rtc_offset}=plan_textured_product(bytes,request,None)?;
+    let AuthoredProductPlan {plan,product_id,geometry_item_id,mesh,rtc_offset}=plan_textured_product(bytes,request,None,[false,false])?;
     let f=&request.frame;
     let uv=mesh.uvs.as_ref().ok_or("Missing canonical annotation UVs")?;
     let tolerance=f.size_metres[0].min(f.size_metres[1])*1e-6;

--- a/rust/processing/src/appearance/captured.rs
+++ b/rust/processing/src/appearance/captured.rs
@@ -36,7 +36,7 @@ pub fn plan_captured_mesh(bytes:&[u8],request:&CapturedMeshRequest)->Result<Capt
         next_express_id:request.next_express_id,container_id:request.container_id,global_id:request.global_id.clone(),
         containment_global_id:request.containment_global_id.clone(),name:request.name.clone(),image_uri:request.image_uri.clone(),
         frame:AnnotationPlaneFrame {origin:request.mesh.positions[0],axis_u:[1.,0.,0.],axis_v:[0.,1.,0.],size_metres:[1.,1.]} };
-    let result=plan_textured_product(bytes,&r,Some(&request.mesh))?;
+    let result=plan_textured_product(bytes,&r,Some(&request.mesh),[request.repeat_s,request.repeat_t])?;
     let uvs=result.mesh.uvs.as_ref().ok_or("Captured image coordinates were lost")?;
     // Check the actual native triangle corners, including seams and image V.
     // This is a refusal boundary for float precision loss, never a silent repair.

--- a/rust/processing/src/appearance/captured_tests.rs
+++ b/rust/processing/src/appearance/captured_tests.rs
@@ -7,7 +7,7 @@ fn fixture()->(String,CapturedMeshRequest) {
     let source=CONTROLLED_IFC.replace("#37=IFCINDEXEDTRIANGLETEXTUREMAP", "#40=IFCBUILDINGSTOREY('0Storey0000000000000000',$,'Level',$,$,#11,$,$,.ELEMENT.,0.);\n#37=IFCINDEXEDTRIANGLETEXTUREMAP");
     (source,CapturedMeshRequest {schema:"IFC4".into(),source_revision:"capture-test".into(),next_express_id:100,
         container_id:40,global_id:"0aaaaaaaaaaaaaaaaaaaaa".into(),containment_global_id:"0bbbbbbbbbbbbbbbbbbbbb".into(),
-        name:"Captured surface".into(),image_uri:"textures/captured.png".into(),mesh:CapturedMesh {
+        name:"Captured surface".into(),repeat_s:false,repeat_t:false,image_uri:"textures/captured.png".into(),mesh:CapturedMesh {
             positions:vec![[2.,3.,4.],[3.,3.,4.],[3.,4.,4.],[2.,4.,5.]],triangles:vec![[0,1,2],[0,2,3]],
             uvs:vec![[0.,0.],[1.,0.],[1.,1.],[0.,1.],[0.2,0.2]],uv_triangles:vec![[0,1,2],[4,2,3]] }})
 }
@@ -109,4 +109,20 @@ fn issue_4380_georeferenced_capture_reopens_at_same_world_triangle_corners() {
             assert!((world-value).abs()<1e-6);
         }
     }
+}
+
+#[test]
+fn issue_4380_capture_retains_each_original_sampler_combination_on_reimport() {
+    for repeat_s in [false,true] { for repeat_t in [false,true] {
+        let (source,mut request)=fixture();
+        request.repeat_s=repeat_s;request.repeat_t=repeat_t;
+        let plan=plan_captured_mesh(source.as_bytes(),&request).unwrap();
+        let texture=plan.mesh.texture.as_ref().unwrap();
+        assert_eq!((texture.repeat_s,texture.repeat_t),(repeat_s,repeat_t));
+        let restored=crate::process_geometry(apply(&source,&plan.plan).as_bytes());
+        let mesh=restored.meshes.iter().find(|mesh|mesh.express_id==plan.object_id).unwrap();
+        let texture=mesh.texture.as_ref().unwrap();
+        assert_eq!((texture.repeat_s,texture.repeat_t),(repeat_s,repeat_t));
+        assert_eq!(mesh.uvs,plan.mesh.uvs);
+    } }
 }

--- a/rust/processing/src/appearance/captured_types.rs
+++ b/rust/processing/src/appearance/captured_types.rs
@@ -30,6 +30,11 @@ pub struct CapturedMeshRequest {
     #[serde(rename="Name")]
     pub name:String,
     pub image_uri:String,
+    /// Original image sampler. Omitted fields retain the non-repeating default.
+    #[serde(default)]
+    pub repeat_s:bool,
+    #[serde(default)]
+    pub repeat_t:bool,
     pub mesh:CapturedMesh,
 }
 #[derive(Debug,Serialize)]


### PR DESCRIPTION
Refs #4380

Captured glTF sources can use repeating image samplers even when all UVs lie in the first tile. Preserve explicit `repeatS`/`repeatT` on authored `IfcImageTexture` and canonical meshes instead of forcing both flags off. Omitted fields remain false, so existing annotation/capture callers keep their behavior; UV support remains bounded to `[0, 1]`.

Validation: all four sampler combinations survive native authoring and normal IFC reimport; the real WASM contract tests the same combinations and the public 66,122-triangle boulder. Root typecheck passes (1889 test sources), root viewer contract suite passes (3 tests, zero skips), full Rust workspace tests and exact workspace clippy pass. Regenerated WASM has no binding declaration changes. API documentation and a WASM patch changeset are included.

Performance verdict: sampler metadata correctness change; ordinary import and geometry production algorithms are unchanged. No performance improvement or new timing claim is made. The retained geometry/UV assertions and real-boulder triangle correspondence establish output fidelity.

Current-branch Python wheel was rebuilt and passes all four required in-tree parity comparisons (one unchanged triangle-density advisory). Cloud checks remain queued; local equivalents support the explicitly authorized admin merge.
