### PR TITLE
feat(viewer): retain textured GLB captures on the canonical load path

### DIFF
--- a/.changeset/fuzzy-boulders-retain-appearance.md
+++ b/.changeset/fuzzy-boulders-retain-appearance.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": minor
+---
+
+Retain embedded GLB base-colour image bytes and UV coordinates, including texture transforms and node rotation/scale. Expose encoded image resources for host-owned decoding; reject unsupported capture appearance instead of silently dropping it.

--- a/apps/viewer/src/hooks/ingest/glbTextureValidation.ts
+++ b/apps/viewer/src/hooks/ingest/glbTextureValidation.ts
@@ -9,7 +9,7 @@ export async function prepareGlbViewerModel(buffer: ArrayBuffer, decode: (archiv
   const result = await parseGlbViewerModel(buffer);
   const bitmaps = await decode({ originalResources: result.originalResources ?? new Map() });
   if (isStale()) return null;
-  validateOpaqueGlbImages(bitmaps);
+  if (!await validateOpaqueGlbImages(bitmaps, isStale)) return null;
   attachTextureBitmaps(result.geometryResult.meshes, bitmaps);
   for (const mesh of result.geometryResult.meshes) {
     if (mesh.textureRef && !mesh.textureBitmap) throw new Error('GLB: embedded texture could not be decoded');
@@ -18,20 +18,33 @@ export async function prepareGlbViewerModel(buffer: ArrayBuffer, decode: (archiv
 }
 
 /** The current textured renderer only supports opaque captured surfaces. */
-export function validateOpaqueGlbImages(bitmaps: TextureBitmapStore | null): void {
-  for (const bitmap of new Set(bitmaps?.values())) {
-    // Scan a row at a time: no second full-image RGBA allocation for large scans.
-    const canvas = new OffscreenCanvas(bitmap.width, 1);
+export async function validateOpaqueGlbImages(bitmaps: TextureBitmapStore | null, isStale: () => boolean): Promise<boolean> {
+  const seen = new Set<ImageBitmap>();
+  for (const [path, bitmap] of bitmaps ?? []) {
+    if (seen.has(bitmap) || /\.jpe?g$/i.test(path)) continue; // JPEG has no alpha channel.
+    seen.add(bitmap);
+    // Bounded readback strips, rather than a second full-image RGBA allocation.
+    const stripHeight = Math.min(64, bitmap.height);
+    const canvas = new OffscreenCanvas(bitmap.width, stripHeight);
     const context = canvas.getContext('2d', { willReadFrequently: true });
     if (!context) throw new Error('GLB: cannot validate texture opacity');
-    for (let y = 0; y < bitmap.height; y++) {
-      context.clearRect(0, 0, bitmap.width, 1);
-      context.drawImage(bitmap, 0, y, bitmap.width, 1, 0, 0, bitmap.width, 1);
-      const rgba = context.getImageData(0, 0, bitmap.width, 1).data;
-      for (let i = 3; i < rgba.length; i += 4) {
-        if (rgba[i] !== 255) throw new Error('GLB: images with transparent pixels require unsupported material alpha semantics');
+    let lastYield = performance.now();
+    try {
+      for (let y = 0; y < bitmap.height; y += stripHeight) {
+        if (isStale()) return false;
+        const height = Math.min(stripHeight, bitmap.height - y);
+        context.clearRect(0, 0, bitmap.width, stripHeight);
+        context.drawImage(bitmap, 0, y, bitmap.width, height, 0, 0, bitmap.width, height);
+        const rgba = context.getImageData(0, 0, bitmap.width, height).data;
+        for (let i = 3; i < rgba.length; i += 4) {
+          if (rgba[i] !== 255) throw new Error('GLB: images with transparent pixels require unsupported material alpha semantics');
+        }
+        if (performance.now() - lastYield > 16) {
+          await new Promise<void>(resolve => setTimeout(resolve, 0));
+          lastYield = performance.now();
+        }
       }
-    }
-    canvas.width = 0;
+    } finally { canvas.width = 0; }
   }
+  return !isStale();
 }

--- a/apps/viewer/src/hooks/ingest/glbTextureValidation.ts
+++ b/apps/viewer/src/hooks/ingest/glbTextureValidation.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { attachTextureBitmaps, type TextureBitmapStore } from '@/utils/textureResources.js';
+
+import { parseGlbViewerModel } from './viewerModelIngest.js';
+
+export async function prepareGlbViewerModel(buffer: ArrayBuffer, decode: (archive: { originalResources: Map<string, Uint8Array> }) => Promise<TextureBitmapStore | null>, isStale: () => boolean) {
+  const result = await parseGlbViewerModel(buffer);
+  const bitmaps = await decode({ originalResources: result.originalResources ?? new Map() });
+  if (isStale()) return null;
+  validateOpaqueGlbImages(bitmaps);
+  attachTextureBitmaps(result.geometryResult.meshes, bitmaps);
+  for (const mesh of result.geometryResult.meshes) {
+    if (mesh.textureRef && !mesh.textureBitmap) throw new Error('GLB: embedded texture could not be decoded');
+  }
+  return result;
+}
+
+/** The current textured renderer only supports opaque captured surfaces. */
+export function validateOpaqueGlbImages(bitmaps: TextureBitmapStore | null): void {
+  for (const bitmap of new Set(bitmaps?.values())) {
+    // Scan a row at a time: no second full-image RGBA allocation for large scans.
+    const canvas = new OffscreenCanvas(bitmap.width, 1);
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) throw new Error('GLB: cannot validate texture opacity');
+    for (let y = 0; y < bitmap.height; y++) {
+      context.clearRect(0, 0, bitmap.width, 1);
+      context.drawImage(bitmap, 0, y, bitmap.width, 1, 0, 0, bitmap.width, 1);
+      const rgba = context.getImageData(0, 0, bitmap.width, 1).data;
+      for (let i = 3; i < rgba.length; i += 4) {
+        if (rgba[i] !== 255) throw new Error('GLB: images with transparent pixels require unsupported material alpha semantics');
+      }
+    }
+    canvas.width = 0;
+  }
+}

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -4,7 +4,7 @@
 
 import { CompactEntityIndex, parseIfcx, createSyntheticDataStore, attachDataStoreAccessors, contiguousSourceBytes, type IfcDataStore, type IfcSourceBytes, type IfcStoreData, type PointCloudExtraction } from '@ifc-lite/parser';
 import { type GeometryResult, type MeshData, type PointCloudAsset } from '@ifc-lite/geometry';
-import { loadGLBToMeshData } from '@ifc-lite/cache';
+import { parseGLB, parseGLBToMeshData, parseGLBImageResources } from '@ifc-lite/cache';
 import type { SchemaVersion } from '../../store/types.js';
 import { calculateMeshBounds, createCoordinateInfo, normalizeColor } from '../../utils/localParsingUtils.js';
 
@@ -26,6 +26,8 @@ export interface ViewerModelPayload {
   dataStore: IfcDataStore;
   geometryResult: GeometryResult;
   schemaVersion: SchemaVersion;
+  /** Encoded GLB base-colour images, retained through the canonical load owner. */
+  originalResources?: Map<string, Uint8Array>;
   /** IFCX path ↔ expressId maps (only present for IFCX-parsed models). */
   pathToId?: Map<string, number>;
   idToPath?: Map<number, string>;
@@ -240,13 +242,17 @@ export function convertIfcxPointClouds(extractions: PointCloudExtraction[]): Poi
 }
 
 export async function parseGlbViewerModel(buffer: ArrayBuffer): Promise<ViewerModelPayload> {
-  const meshes = loadGLBToMeshData(new Uint8Array(buffer));
+  const { json, bin } = parseGLB(new Uint8Array(buffer));
+  if (!bin) throw new Error('GLB has no binary buffer');
+  const meshes = parseGLBToMeshData(json, bin);
+  const originalResources = parseGLBImageResources(json, bin);
   if (meshes.length === 0) {
     throw new Error('glb-empty');
   }
 
   const { bounds, stats } = calculateMeshBounds(meshes);
   return {
+    originalResources,
     dataStore: createMinimalGlbDataStore(buffer, meshes.length),
     geometryResult: {
       meshes,

--- a/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
@@ -43,7 +43,7 @@ it('#4380 canonical primary and federated GLB loads retain UVs, independent text
     const primary=[...useViewerStore.getState().models.values()][0];assert.ok(primary?.geometryResult);assert.equal(primary.loadState,'complete');
     const first=primary.geometryResult.meshes[0];assert.deepEqual([...first.uvs!],[0,0,1,0,0,1]);assert.ok(first.textureBitmap);assert.deepEqual(modelAppearanceAssets.exportOriginals(primary.id).resources.get('textures/glb-image-0.png'),png);
     await act(async()=>api!.loadFile(fixture(),{kind:'federated',modelId:'second-capture'}));
-    const second=useViewerStore.getState().models.get('second-capture');assert.ok(second?.geometryResult);assert.equal(second.loadState,'complete');
+    const second=useViewerStore.getState().models.get('second-capture');assert.ok(second?.geometryResult);assert.notEqual(second.loadState,'error');
     const other=second.geometryResult.meshes[0];assert.notEqual(other.expressId,first.expressId);assert.notEqual(other.textureRef!.textureId,first.textureRef!.textureId);assert.strictEqual(other.textureBitmap,first.textureBitmap);
     assert.deepEqual(modelAppearanceAssets.exportOriginals(second.id).resources.get('textures/glb-image-0.png'),png);
     useViewerStore.getState().removeModel(primary.id);assert.equal(closed,0,'shared image survives the remaining model');

--- a/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '@/test/setup-dom.js';
+import { afterEach, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { modelAppearanceAssets } from '@/lib/appearance/model-assets.js';
+import { useIfcLoader } from './useIfcLoader.js';
+
+// Real PNG and GLB framing; only the browser image decoder/canvas are replaced.
+const png = new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLbtAAAAABJRU5ErkJggg==','base64'));
+function fixture(): File {
+  const positions=new Float32Array([0,0,0,1,0,0,0,1,0]); const uv=new Float32Array([0,0,1,0,0,1]);
+  const data=new Uint8Array(positions.byteLength+uv.byteLength+png.length);data.set(new Uint8Array(positions.buffer));data.set(new Uint8Array(uv.buffer),positions.byteLength);data.set(png,positions.byteLength+uv.byteLength);
+  const json={asset:{version:'2.0'},nodes:[{mesh:0,extras:{expressId:42}}],meshes:[{primitives:[{attributes:{POSITION:0,TEXCOORD_0:1},material:0}]}],materials:[{pbrMetallicRoughness:{baseColorTexture:{index:0}}}],textures:[{source:0}],images:[{mimeType:'image/png',bufferView:2}],buffers:[{byteLength:data.length}],bufferViews:[{buffer:0,byteLength:positions.byteLength},{buffer:0,byteOffset:positions.byteLength,byteLength:uv.byteLength},{buffer:0,byteOffset:positions.byteLength+uv.byteLength,byteLength:png.length}],accessors:[{bufferView:0,componentType:5126,count:3,type:'VEC3'},{bufferView:1,componentType:5126,count:3,type:'VEC2'}]};
+  const text=new TextEncoder().encode(JSON.stringify(json));const textLength=Math.ceil(text.length/4)*4,binLength=Math.ceil(data.length/4)*4;const bytes=new Uint8Array(28+textLength+binLength);const view=new DataView(bytes.buffer);view.setUint32(0,0x46546c67,true);view.setUint32(4,2,true);view.setUint32(8,bytes.length,true);view.setUint32(12,textLength,true);view.setUint32(16,0x4e4f534a,true);bytes.fill(32,20,20+textLength);bytes.set(text,20);view.setUint32(20+textLength,binLength,true);view.setUint32(24+textLength,0x004e4942,true);bytes.set(data,28+textLength);return new File([bytes],'capture.glb');
+}
+class OpaqueCanvas {
+  width = 1;
+  getContext() {
+    return {
+      clearRect() {}, drawImage() {},
+      getImageData() { return { data: new Uint8ClampedArray([255, 0, 0, 255]) }; },
+    };
+  }
+}
+const oldDecoder=globalThis.createImageBitmap, oldCanvas=globalThis.OffscreenCanvas;
+afterEach(()=>{Object.defineProperty(globalThis,'createImageBitmap',{value:oldDecoder,configurable:true,writable:true});Object.defineProperty(globalThis,'OffscreenCanvas',{value:oldCanvas,configurable:true,writable:true});useViewerStore.getState().resetViewerState();useViewerStore.getState().clearAllModels();});
+
+it('#4380 canonical primary and federated GLB loads retain UVs, independent texture IDs and original bytes until last model removal',async()=>{
+  let closed=0;
+  Object.defineProperty(globalThis,'createImageBitmap',{configurable:true,writable:true,value:async()=>({width:1,height:1,close(){closed++;}})});
+  Object.defineProperty(globalThis,'OffscreenCanvas',{configurable:true,writable:true,value:OpaqueCanvas});
+  useViewerStore.getState().resetViewerState();useViewerStore.getState().clearAllModels();
+  let api:ReturnType<typeof useIfcLoader>|undefined;function Probe(){api=useIfcLoader();return null;}
+  const host=document.createElement('div');document.body.appendChild(host);const root=createRoot(host);
+  try {
+    await act(async()=>root.render(<Probe/>));
+    await act(async()=>api!.loadFile(fixture()));
+    const primary=[...useViewerStore.getState().models.values()][0];assert.ok(primary?.geometryResult);assert.equal(primary.loadState,'complete');
+    const first=primary.geometryResult.meshes[0];assert.deepEqual([...first.uvs!],[0,0,1,0,0,1]);assert.ok(first.textureBitmap);assert.deepEqual(modelAppearanceAssets.exportOriginals(primary.id).resources.get('textures/glb-image-0.png'),png);
+    await act(async()=>api!.loadFile(fixture(),{kind:'federated',modelId:'second-capture'}));
+    const second=useViewerStore.getState().models.get('second-capture');assert.ok(second?.geometryResult);assert.equal(second.loadState,'complete');
+    const other=second.geometryResult.meshes[0];assert.notEqual(other.expressId,first.expressId);assert.notEqual(other.textureRef!.textureId,first.textureRef!.textureId);assert.strictEqual(other.textureBitmap,first.textureBitmap);
+    assert.deepEqual(modelAppearanceAssets.exportOriginals(second.id).resources.get('textures/glb-image-0.png'),png);
+    useViewerStore.getState().removeModel(primary.id);assert.equal(closed,0,'shared image survives the remaining model');
+    useViewerStore.getState().removeModel(second.id);assert.equal(closed,1,'last source releases the shared bitmap exactly once');
+  } finally {await act(async()=>root.unmount());host.remove();}
+});
+
+it('#4380 a superseded pending image decode cannot replace the newer GLB or report its cancellation as a load error',async()=>{
+  let releaseFirst:((bitmap: {width:number;height:number;close():void})=>void)|undefined;
+  let started:()=>void=()=>{};const decoding=new Promise<void>(resolve=>{started=resolve;});let count=0,closed=0;
+  Object.defineProperty(globalThis,'createImageBitmap',{configurable:true,writable:true,value:async()=>{
+    if (++count===1) {started();return new Promise(resolve=>{releaseFirst=resolve;});}
+    return {width:1,height:1,close(){closed++;}};
+  }});
+  Object.defineProperty(globalThis,'OffscreenCanvas',{configurable:true,writable:true,value:OpaqueCanvas});
+  useViewerStore.getState().resetViewerState();useViewerStore.getState().clearAllModels();
+  let api:ReturnType<typeof useIfcLoader>|undefined;function Probe(){api=useIfcLoader();return null;}
+  const host=document.createElement('div');document.body.appendChild(host);const root=createRoot(host);
+  try {
+    await act(async()=>root.render(<Probe/>));
+    await act(async()=>{
+      const oldLoad=api!.loadFile(fixture());await decoding;
+      await api!.loadFile(fixture());
+      releaseFirst!({width:1,height:1,close(){closed++;}});
+      await oldLoad;
+    });
+    const models=[...useViewerStore.getState().models.values()];assert.equal(models.length,1);assert.equal(models[0].loadState,'complete');assert.ok(models[0].geometryResult?.meshes[0].textureBitmap);assert.equal(useViewerStore.getState().error,null);assert.equal(closed,1,'only stale decoder result is closed');
+  } finally {await act(async()=>root.unmount());host.remove();}
+});

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -60,7 +60,8 @@ import { useIfcCache, getCached, deleteCached } from './useIfcCache.js';
 // Server hook
 import { useIfcServer } from './useIfcServer.js';
 
-import { getMaxExpressId, parseGlbViewerModel, parseIfcxViewerModel } from './ingest/viewerModelIngest.js';
+import { prepareGlbViewerModel } from './ingest/glbTextureValidation.js';
+import { getMaxExpressId, parseIfcxViewerModel } from './ingest/viewerModelIngest.js';
 import { boundedIteratorReturn } from './ingest/streamCleanup.js';
 import {
   createGeometryProcessorDisposer,
@@ -1046,7 +1047,8 @@ export function useIfcLoader() {
         setGeometryStreamingActive(false);
 
         try {
-          const result = await parseGlbViewerModel(buffer);
+          const result = await prepareGlbViewerModel(buffer, appearanceLoad!.decode, () => loadSessionRef.current !== currentSession);
+          if (!result) return;
           if (target.kind === 'primary') {
             setGeometryResult(result.geometryResult);
             setIfcDataStore(null);
@@ -1059,11 +1061,14 @@ export function useIfcLoader() {
             result.geometryResult, result.schemaVersion, { loadPath: 'wasm' },
           );
 
+          if (loadSessionRef.current !== currentSession) return;
+          appearanceLoad?.finish(useViewerStore.getState().models.has(modelId));
           setProgress({ phase: 'Complete', percent: 100 });
           captureModelLoaded({ format: 'glb', file_size_mb: Math.round(fileSizeMB * 100) / 100, load_target: target.kind, load_path: 'wasm', total_elapsed_ms: Math.round(performance.now() - totalStartTime), was_hidden: wasHidden() }, snapshotFromGeometry(fileSizeMB, result.geometryResult));
           setLoading(false);
           return;
         } catch (err: unknown) {
+          if (loadSessionRef.current !== currentSession) return;
           console.error('[useIfc] GLB parsing failed:', err);
           const message = err instanceof Error ? err.message : String(err);
           updateModel(modelId, { loadState: 'error', loadError: message });

--- a/docs/architecture/evidence/captured-glb/README.md
+++ b/docs/architecture/evidence/captured-glb/README.md
@@ -2,7 +2,7 @@
 
 The offline `tools/texture-authoring/derive-boulder-glb.mjs` packages the public
 [Poly Haven boulder_01](https://polyhaven.com/a/boulder_01) glTF/BIN/diffuse JPEG
-as a GLB. Poly Haven assets are CC0. The derivation **explicitly removes normal
+as a GLB. Poly Haven assets are [CC0](https://polyhaven.com/license). The derivation **explicitly removes normal
 and metallic/roughness maps**, producing an albedo-only fixture; the production
 importer refuses those unsupported maps on the original full material.
 Geometry, indexed UV seams, and diffuse JPEG bytes are unchanged.
@@ -20,7 +20,9 @@ Recorded hashes:
 An actual run through the built cache decoder retained 67,042 vertices,
 66,122 triangles, 67,042 UV pairs, and the exact diffuse JPEG digest above.
 The sampler defaults to repeat in both directions; it is not silently clamped
-to satisfy a downstream authoring limitation.
+to satisfy a downstream authoring limitation. Measured U range is
+[0.00126901979, 0.99843168259] and V range is
+[0.00172561407, 0.99873685837], inside the native capture planner’s [0, 1] range.
 
 Automated invariants include an asymmetric seam, texture transform, rotated
 nonuniform node scale, inverse-transpose normals, mirrored winding, a 12,000-node

--- a/docs/architecture/evidence/captured-glb/README.md
+++ b/docs/architecture/evidence/captured-glb/README.md
@@ -1,0 +1,29 @@
+# Captured GLB ingest evidence (#4380)
+
+The offline `tools/texture-authoring/derive-boulder-glb.mjs` packages the public
+[Poly Haven boulder_01](https://polyhaven.com/a/boulder_01) glTF/BIN/diffuse JPEG
+as a GLB. Poly Haven assets are CC0. The derivation **explicitly removes normal
+and metallic/roughness maps**, producing an albedo-only fixture; the production
+importer refuses those unsupported maps on the original full material.
+Geometry, indexed UV seams, and diffuse JPEG bytes are unchanged.
+
+Source glTF download:
+`https://dl.polyhaven.org/file/ph-assets/Models/gltf/1k/boulder_01/boulder_01_1k.gltf`
+
+Recorded hashes:
+
+- Source glTF: `51487934db898b4c24072780a451e34eca5c02e3ada24a62bbc600bbc4019e92`
+- Source BIN: `7f5b06503d62bd95bfe9c6b8a354a5cc8ff04a4d271a8cf87a3e3125db4232d7`
+- Diffuse JPEG: `c38f0e918f6dc16b8d386ba3cdd89805c78320c119a1ceec85856f82b09a65b8`
+- Derived GLB: `b6a0b51894427c37505632f4d4513d0424f0d84b014554755aa53eb74af6dcd6`
+
+An actual run through the built cache decoder retained 67,042 vertices,
+66,122 triangles, 67,042 UV pairs, and the exact diffuse JPEG digest above.
+The sampler defaults to repeat in both directions; it is not silently clamped
+to satisfy a downstream authoring limitation.
+
+Automated invariants include an asymmetric seam, texture transform, rotated
+nonuniform node scale, inverse-transpose normals, mirrored winding, a 12,000-node
+scene chain, and explicit rejection of unsupported appearance or image ranges.
+This is ingest evidence; it does not establish IFC creation, portable export,
+shared-room behavior, or scan reconstruction acceptance.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -859,3 +859,18 @@ and dimensions. The file budget is 512 MiB of unique pixel/resource bytes, with
 The current RGBA wire favors exact, wasm-free roundtrips over compressed file
 size. It can make IFCX substantially larger than IFCZIP. Original source images
 are archival alongside pixels, rather than a second mandatory decoder pipeline.
+
+## Importing textured GLB captures
+
+Use **Open** or **Add model** for an opaque textured GLB. Embedded base-colour
+PNG/JPEG images and their UV seams now follow the same model load path for
+primary and federated models. Original encoded images remain available to
+capture authoring while the model is loaded. Node translation, rotation and
+scale are applied once; UV texture transforms and repeat/clamp are preserved.
+
+This capture slice supports albedo, not a complete glTF material renderer.
+Unsupported texture alpha modes, transparent pixels, additional material maps,
+compression, external resources, mirrored repeat and UV sets beyond
+`TEXCOORD_0` stop import with a diagnostic rather than produce an untextured
+success. Images use the existing inventory limits (32 MiB per encoded image,
+8192 px maximum edge, 16 megapixels per image).

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -140,3 +140,20 @@ Serialization borrows valid sorted columns synchronously, preserving stable dupl
 `BinaryCacheWriter.write` accepts `compressGeometryChunksInWorker: true` to run geometry chunk compression in one lazily created browser module worker. The viewer enables it to keep codec work off the UI thread. The default is `false`, preserving workerless SDK and Node use. The existing compression size floor and four-chunk concurrency limit remain in effect; disabling `compressGeometryChunks` creates no worker. Cache format, chunk order, compressed-versus-raw selection and readers are unchanged.
 
 The browser application must bundle the package worker asset and permit module workers. Worker startup, codec and transport failures reject the cache write; there is no silent main-thread retry. Only newly serialized chunk buffers cross the worker boundary, and the worker terminates after geometry serialization succeeds or fails. Source/model data stay with the caller. This moves compression CPU rather than eliminating it; include cache completion when measuring cold loads.
+
+### Textured GLB capture import
+
+`parseGLBToMeshData` and `loadGLBToMeshData` preserve base-colour `TEXCOORD_0`
+coordinates (including normalized integer UVs and `KHR_texture_transform`),
+texture references, node TRS/matrices and mirrored winding. UV vertices remain
+separate across seams. Node translation stays in the double-precision `origin`.
+Use `parseGLBImageResources(parsed.json, parsed.bin)` to obtain original encoded
+PNG/JPEG images keyed by each mesh's `textureRef.url`. Decode these at the host
+boundary; this package never allocates browser image objects.
+
+This is opaque captured-albedo import. Embedded base-colour PNG/JPEG images and
+repeat/clamp samplers are supported. External images/buffers, other UV sets,
+mirrored repeat, sparse accessors, compression, skinning/morphs, vertex colours,
+additional material maps, and textured MASK/BLEND produce explicit errors.
+The viewer also refuses transparent image pixels, retains original bytes with
+the model, and releases images on removal. It does not claim full PBR fidelity.

--- a/packages/cache/src/glb-accessor.ts
+++ b/packages/cache/src/glb-accessor.ts
@@ -60,13 +60,15 @@ function getComponentCount(type: string): number {
 export function readAccessorData(
   gltf: GLTFDocument,
   bin: Uint8Array,
-  accessorIdx: number
+  accessorIdx: number,
+  expectedType?: string
 ): Float32Array | Uint32Array | Uint16Array | Uint8Array {
   const accessor = gltf.accessors?.[accessorIdx];
   if (!accessor) {
     throw new Error(`Accessor ${accessorIdx} not found`);
   }
 
+  if (expectedType && accessor.type !== expectedType) throw new Error(`GLB: accessor ${accessorIdx} must be ${expectedType}`);
   if (accessor.sparse) throw new Error('GLB: sparse accessors are not supported');
   const bufferView = gltf.bufferViews?.[accessor.bufferView];
   if (!bufferView) {

--- a/packages/cache/src/glb-accessor.ts
+++ b/packages/cache/src/glb-accessor.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { GLTFDocument } from './glb-types.js';
+// Component types
+const COMPONENT_BYTE = 5120;
+const COMPONENT_UNSIGNED_BYTE = 5121;
+const COMPONENT_SHORT = 5122;
+const COMPONENT_UNSIGNED_SHORT = 5123;
+const COMPONENT_UNSIGNED_INT = 5125;
+const COMPONENT_FLOAT = 5126;
+
+/**
+ * Get the byte size for a glTF component type
+ */
+function getComponentSize(componentType: number): number {
+  switch (componentType) {
+    case COMPONENT_BYTE:
+    case COMPONENT_UNSIGNED_BYTE:
+      return 1;
+    case COMPONENT_SHORT:
+    case COMPONENT_UNSIGNED_SHORT:
+      return 2;
+    case COMPONENT_UNSIGNED_INT:
+    case COMPONENT_FLOAT:
+      return 4;
+    default:
+      throw new Error(`Unknown component type: ${componentType}`);
+  }
+}
+
+/**
+ * Get the number of components for an accessor type
+ */
+function getComponentCount(type: string): number {
+  switch (type) {
+    case 'SCALAR':
+      return 1;
+    case 'VEC2':
+      return 2;
+    case 'VEC3':
+      return 3;
+    case 'VEC4':
+      return 4;
+    case 'MAT2':
+      return 4;
+    case 'MAT3':
+      return 9;
+    case 'MAT4':
+      return 16;
+    default:
+      throw new Error(`Unknown accessor type: ${type}`);
+  }
+}
+
+/**
+ * Read accessor data as a typed array
+ */
+export function readAccessorData(
+  gltf: GLTFDocument,
+  bin: Uint8Array,
+  accessorIdx: number
+): Float32Array | Uint32Array | Uint16Array | Uint8Array {
+  const accessor = gltf.accessors?.[accessorIdx];
+  if (!accessor) {
+    throw new Error(`Accessor ${accessorIdx} not found`);
+  }
+
+  if (accessor.sparse) throw new Error('GLB: sparse accessors are not supported');
+  const bufferView = gltf.bufferViews?.[accessor.bufferView];
+  if (!bufferView) {
+    throw new Error(`BufferView ${accessor.bufferView} not found`);
+  }
+
+  if (bufferView.buffer !== 0 || gltf.buffers?.[0]?.uri) throw new Error('GLB: external buffers are not supported');
+  const componentSize = getComponentSize(accessor.componentType);
+  const componentCount = getComponentCount(accessor.type);
+  const elementSize = componentSize * componentCount;
+  const byteStride = bufferView.byteStride ?? elementSize;
+
+  const bufferOffset = (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
+
+  // `accessor.count` comes straight from the (untrusted) GLB JSON chunk and
+  // is REQUIRED by the glTF spec, but nothing here enforced that at runtime:
+  // a missing/non-numeric `count` makes it `undefined`/NaN, and `NaN * x` is
+  // NaN. Every arithmetic bounds comparison below (`< 0`, `> bin.byteLength`)
+  // is false against NaN, so the bounds check was silently bypassed rather
+  // than rejecting the malformed accessor. Control then fell through to a
+  // typed-array constructor built from that same NaN count, which coerces to
+  // an element count of 0 (ToIndex(NaN) === 0) — producing a silently EMPTY
+  // mesh reported as a successful import instead of throwing.
+  if (!Number.isInteger(accessor.count) || accessor.count < 0) {
+    throw new Error(`GLB: accessor ${accessorIdx} has an invalid count: ${accessor.count}`);
+  }
+
+  // Bounds-check the full byte range this accessor claims against the actual
+  // BIN chunk BEFORE slicing/constructing anything. `accessor.count` /
+  // `byteOffset` come straight from the (untrusted) GLB JSON chunk; without
+  // this, `bin.slice()` below silently CLAMPS on a truncated/malformed BIN
+  // (fewer bytes than asked), and the typed-array constructor that follows
+  // still requests the ORIGINALLY declared element count against that
+  // shorter buffer — a raw `RangeError: Invalid typed array length` (or
+  // "range consisting of offset and length are out of bounds", depending on
+  // engine) escapes instead of a diagnosable domain error.
+  const neededBytes = byteStride === elementSize
+    ? accessor.count * elementSize
+    : accessor.count > 0
+      ? (accessor.count - 1) * byteStride + elementSize
+      : 0;
+  if (![bufferOffset, neededBytes, byteStride, bufferView.byteLength, accessor.byteOffset ?? 0, bufferView.byteOffset ?? 0].every(Number.isSafeInteger) || byteStride < elementSize || (accessor.byteOffset ?? 0) < 0 || (bufferView.byteOffset ?? 0) < 0 || (accessor.byteOffset ?? 0) + neededBytes > bufferView.byteLength || bufferOffset < 0 || neededBytes < 0 || bufferOffset + neededBytes > bin.byteLength) {
+    throw new Error(
+      `GLB: accessor ${accessorIdx} reads bytes [${bufferOffset}, ${bufferOffset + neededBytes}) ` +
+      `but the BIN chunk is only ${bin.byteLength} bytes`,
+    );
+  }
+
+  // If data is tightly packed, we can use a view directly
+  if (byteStride === elementSize) {
+    const byteLength = accessor.count * elementSize;
+    const slice = bin.slice(bufferOffset, bufferOffset + byteLength);
+
+    switch (accessor.componentType) {
+      case COMPONENT_FLOAT:
+        return new Float32Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
+      case COMPONENT_UNSIGNED_INT:
+        return new Uint32Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
+      case COMPONENT_UNSIGNED_SHORT:
+        return new Uint16Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
+      case COMPONENT_UNSIGNED_BYTE:
+        return slice;
+      default:
+        throw new Error(`Unsupported component type for reading: ${accessor.componentType}`);
+    }
+  }
+
+  // Handle strided data
+  const result =
+    accessor.componentType === COMPONENT_FLOAT
+      ? new Float32Array(accessor.count * componentCount)
+      : accessor.componentType === COMPONENT_UNSIGNED_INT
+        ? new Uint32Array(accessor.count * componentCount)
+        : accessor.componentType === COMPONENT_UNSIGNED_SHORT
+          ? new Uint16Array(accessor.count * componentCount)
+          : new Uint8Array(accessor.count * componentCount);
+
+  const dataView = new DataView(bin.buffer, bin.byteOffset, bin.byteLength);
+
+  for (let i = 0; i < accessor.count; i++) {
+    const elementOffset = bufferOffset + i * byteStride;
+    for (let c = 0; c < componentCount; c++) {
+      const byteOffset = elementOffset + c * componentSize;
+      let value: number;
+
+      switch (accessor.componentType) {
+        case COMPONENT_FLOAT:
+          value = dataView.getFloat32(byteOffset, true);
+          break;
+        case COMPONENT_UNSIGNED_INT:
+          value = dataView.getUint32(byteOffset, true);
+          break;
+        case COMPONENT_UNSIGNED_SHORT:
+          value = dataView.getUint16(byteOffset, true);
+          break;
+        case COMPONENT_UNSIGNED_BYTE:
+          value = dataView.getUint8(byteOffset);
+          break;
+        default:
+          throw new Error(`Unsupported component type: ${accessor.componentType}`);
+      }
+
+      result[i * componentCount + c] = value;
+    }
+  }
+
+  return result;
+}
+

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -37,6 +37,10 @@ describe('captured GLB appearance #4380', () => {
     expect(mesh.color[0]).toBeCloseTo(0.5370987);
     expect([...parseGLBImageResources(json,bin).get(mesh.textureRef!.url)!]).toEqual([137,80,78,71,13,10,26,10]);
   });
+  it('honours OPAQUE material alpha independently of the stored factor', () => {
+    const {json,bin}=capture(); json.materials![0].pbrMetallicRoughness!.baseColorFactor=[1,1,1,0];
+    expect(parseGLBToMeshData(json,bin)[0].color[3]).toBe(1);
+  });
   it('bakes KHR_texture_transform once without flipping glTF top-down V', () => {
     const {json,bin}=capture(); json.materials![0].pbrMetallicRoughness!.baseColorTexture!.extensions={KHR_texture_transform:{offset:[0.2,0.3],scale:[2,3],rotation:Math.PI/2}};
     const [mesh]=parseGLBToMeshData(json,bin); expect(mesh.uvs![2]).toBeCloseTo(0.2); expect(mesh.uvs![3]).toBeCloseTo(1.3);

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it, expect } from 'vitest';
+import { parseGLBToMeshData } from './glb.js';
+import { parseGLBImageResources } from './glb-images.js';
+import type { GLTFDocument } from './glb-types.js';
+
+function capture(): { json: GLTFDocument; bin: Uint8Array } {
+  // Two triangles duplicate the shared geometric corner with distinct UVs: an atlas seam.
+  const positions = new Float32Array([0,0,0, 1,0,0, 0,1,1, 0,0,0, 0,1,1, -1,0,0]);
+  const uvs = new Float32Array([0,0, 0.5,0, 0.5,1, 1,0, 1,1, 0.5,0]);
+  const png = new Uint8Array([137,80,78,71,13,10,26,10]);
+  const bin = new Uint8Array(positions.byteLength + uvs.byteLength + png.byteLength);
+  bin.set(new Uint8Array(positions.buffer)); bin.set(new Uint8Array(uvs.buffer), positions.byteLength); bin.set(png, positions.byteLength + uvs.byteLength);
+  return { bin, json: {
+    asset: { version:'2.0' }, nodes:[{ mesh:0, translation:[1000000,20,30], rotation:[0,0,Math.SQRT1_2,Math.SQRT1_2], scale:[2,3,4] }],
+    meshes:[{primitives:[{ attributes:{ POSITION:0, TEXCOORD_0:1 }, material:0 }]}],
+    buffers:[{byteLength:bin.length}], bufferViews:[{buffer:0,byteLength:positions.byteLength},{buffer:0,byteOffset:positions.byteLength,byteLength:uvs.byteLength},{buffer:0,byteOffset:positions.byteLength+uvs.byteLength,byteLength:png.byteLength}],
+    accessors:[{bufferView:0,componentType:5126,count:6,type:'VEC3'},{bufferView:1,componentType:5126,count:6,type:'VEC2'}],
+    materials:[{pbrMetallicRoughness:{baseColorTexture:{index:0},baseColorFactor:[0.25,0.5,1,1]}}],
+    textures:[{source:0}], images:[{bufferView:2,mimeType:'image/png'}],
+  }};
+}
+
+describe('captured GLB appearance #4380', () => {
+  it('keeps seam UVs, encoded bytes, tint, and georeferenced TRS with inverse-transpose normals', () => {
+    const {json,bin}=capture(); const [mesh]=parseGLBToMeshData(json,bin);
+    expect([...mesh.uvs!]).toEqual([0,0,0.5,0,0.5,1,1,0,1,1,0.5,0]);
+    expect(mesh.origin).toEqual([1000000,20,30]);
+    expect(mesh.positions[3]).toBeCloseTo(0); expect(mesh.positions[4]).toBeCloseTo(2);
+    expect(mesh.positions[6]).toBeCloseTo(-3); expect(mesh.positions[8]).toBeCloseTo(4);
+    const e1=[mesh.positions[3]-mesh.positions[0],mesh.positions[4]-mesh.positions[1],mesh.positions[5]-mesh.positions[2]];
+    const e2=[mesh.positions[6]-mesh.positions[0],mesh.positions[7]-mesh.positions[1],mesh.positions[8]-mesh.positions[2]];
+    expect(e1.reduce((sum,x,i)=>sum+x*mesh.normals[i],0)).toBeCloseTo(0);
+    expect(e2.reduce((sum,x,i)=>sum+x*mesh.normals[i],0)).toBeCloseTo(0);
+    expect(mesh.color[0]).toBeCloseTo(0.5370987);
+    expect([...parseGLBImageResources(json,bin).get(mesh.textureRef!.url)!]).toEqual([137,80,78,71,13,10,26,10]);
+  });
+  it('bakes KHR_texture_transform once without flipping glTF top-down V', () => {
+    const {json,bin}=capture(); json.materials![0].pbrMetallicRoughness!.baseColorTexture!.extensions={KHR_texture_transform:{offset:[0.2,0.3],scale:[2,3],rotation:Math.PI/2}};
+    const [mesh]=parseGLBToMeshData(json,bin); expect(mesh.uvs![2]).toBeCloseTo(0.2); expect(mesh.uvs![3]).toBeCloseTo(1.3);
+  });
+  it('reverses mirrored winding without reversing UV ownership', () => {
+    const {json,bin}=capture(); json.nodes![0].scale=[-1,1,1];
+    const [mesh]=parseGLBToMeshData(json,bin); expect([...mesh.indices]).toEqual([0,2,1,3,5,4]); expect(mesh.uvs![6]).toBe(1);
+  });
+  it('rejects unsupported alpha, wrap, required compression, and image ranges explicitly', () => {
+    const {json,bin}=capture(); json.materials![0].alphaMode='BLEND'; expect(()=>parseGLBToMeshData(json,bin)).toThrow(/MASK\/BLEND/);
+    delete json.materials![0].alphaMode; json.samplers=[{wrapS:33648}];json.textures![0].sampler=0;expect(()=>parseGLBToMeshData(json,bin)).toThrow(/mirrored/);
+    delete json.textures![0].sampler;json.extensionsRequired=['KHR_draco_mesh_compression'];expect(()=>parseGLBToMeshData(json,bin)).toThrow(/required extension/);
+    delete json.extensionsRequired;json.bufferViews![2].byteLength=bin.length;expect(()=>parseGLBImageResources(json,bin)).toThrow(/exceeds/);
+  });
+  it('bounds deep scene walks without consuming the call stack', () => {
+    const {json,bin}=capture(); const leaf=json.nodes![0];json.nodes=Array.from({length:12000},(_,i)=>i===11999?leaf:{children:[i+1]});json.scenes=[{nodes:[0]}];
+    expect(parseGLBToMeshData(json,bin)).toHaveLength(1);
+  });
+});

--- a/packages/cache/src/glb-images.ts
+++ b/packages/cache/src/glb-images.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { MeshData } from '@ifc-lite/geometry';
+import type { GLTFDocument, GLTFPrimitive } from './glb-types.js';
+import { readAccessorData } from './glb-accessor.js';
+
+function imagePath(index: number, mime: string): string {
+  return `textures/glb-image-${index}.${mime === 'image/png' ? 'png' : 'jpg'}`;
+}
+
+/** Encoded embedded base-colour images. Browser decoding belongs to the host. */
+function imageResources(gltf: GLTFDocument, bin: Uint8Array, copy: boolean): Map<string, Uint8Array> {
+  const resources = new Map<string, Uint8Array>();
+  let total = 0;
+  for (const material of gltf.materials ?? []) {
+    const reference = material.pbrMetallicRoughness?.baseColorTexture;
+    if (!reference) continue;
+    const index = gltf.textures?.[reference.index]?.source;
+    const image = index === undefined ? undefined : gltf.images?.[index];
+    if (!image || index === undefined || image.bufferView === undefined || image.uri !== undefined) {
+      throw new Error('GLB: base-colour textures require embedded PNG/JPEG buffer views');
+    }
+    if (image.mimeType !== 'image/png' && image.mimeType !== 'image/jpeg') throw new Error('GLB: unsupported image MIME type');
+    const path = imagePath(index, image.mimeType);
+    if (resources.has(path)) continue;
+    const view = gltf.bufferViews?.[image.bufferView];
+    const start = view?.byteOffset ?? 0, length = view?.byteLength;
+    if (!view || view.buffer !== 0 || length === undefined || !Number.isSafeInteger(start) || !Number.isSafeInteger(length) || start < 0 || length <= 0 || start + length > bin.byteLength) {
+      throw new Error('GLB: image buffer view exceeds the embedded buffer');
+    }
+    total += length;
+    if (resources.size >= 256 || total > 256 * 1024 * 1024) throw new Error('GLB: embedded images exceed the 256-image / 256 MiB limit');
+    resources.set(path, copy ? bin.slice(start, start + length) : bin.subarray(start, start + length));
+  }
+  return resources;
+}
+
+export function primitiveTexture(gltf: GLTFDocument, bin: Uint8Array, primitive: GLTFPrimitive, vertexCount: number): Pick<MeshData, 'uvs' | 'textureRef'> {
+  if (primitive.targets?.length || primitive.extensions?.KHR_draco_mesh_compression || primitive.attributes.COLOR_0 !== undefined) {
+    throw new Error('GLB: morph targets, Draco compression and vertex colours are not supported for capture appearance');
+  }
+  const material = primitive.material === undefined ? undefined : gltf.materials?.[primitive.material];
+  if (primitive.material !== undefined && !material) throw new Error('GLB: material index does not exist');
+  if (material?.normalTexture || material?.emissiveTexture || material?.occlusionTexture || material?.pbrMetallicRoughness?.metallicRoughnessTexture || Object.keys(material?.extensions ?? {}).some(key => key !== 'KHR_materials_unlit')) {
+    throw new Error('GLB: material maps/extensions beyond base colour are not supported for capture appearance');
+  }
+  const reference = material?.pbrMetallicRoughness?.baseColorTexture;
+  if (!reference) return {};
+  if (material?.alphaMode && material.alphaMode !== 'OPAQUE') throw new Error('GLB: textured MASK/BLEND materials are not supported');
+  const transform = reference.extensions?.KHR_texture_transform;
+  if ((transform?.texCoord ?? reference.texCoord ?? 0) !== 0) throw new Error('GLB: only TEXCOORD_0 is supported');
+  const accessor = primitive.attributes.TEXCOORD_0;
+  if (accessor === undefined || gltf.accessors?.[accessor]?.type !== 'VEC2') throw new Error('GLB: textured primitive requires TEXCOORD_0 VEC2');
+  const raw = readAccessorData(gltf, bin, accessor);
+  const declaration = gltf.accessors![accessor];
+  const divisor = raw instanceof Float32Array ? 1 : declaration.normalized && raw instanceof Uint16Array ? 65535 : declaration.normalized && raw instanceof Uint8Array ? 255 : 0;
+  if (!divisor || raw.length !== vertexCount * 2) throw new Error('GLB: texture coordinates must match every vertex and use float or normalized unsigned components');
+  const offset = transform?.offset ?? [0, 0], scale = transform?.scale ?? [1, 1], rotation = transform?.rotation ?? 0;
+  if (offset.length !== 2 || scale.length !== 2 || ![...offset, ...scale, rotation].every(Number.isFinite)) throw new Error('GLB: invalid texture transform');
+  const uvs = new Float32Array(raw.length), c = Math.cos(rotation), s = Math.sin(rotation);
+  for (let i = 0; i < raw.length; i += 2) {
+    const u = raw[i] / divisor * scale[0], v = raw[i + 1] / divisor * scale[1];
+    uvs[i] = offset[0] + c * u - s * v;
+    uvs[i + 1] = offset[1] + s * u + c * v;
+    if (!Number.isFinite(uvs[i]) || !Number.isFinite(uvs[i + 1])) throw new Error('GLB: non-finite texture coordinates');
+  }
+  const texture = gltf.textures?.[reference.index], image = texture?.source === undefined ? undefined : gltf.images?.[texture.source];
+  if (!texture || texture.source === undefined || !image?.mimeType) throw new Error('GLB: texture image does not exist');
+  const sampler = texture.sampler === undefined ? undefined : gltf.samplers?.[texture.sampler];
+  if (texture.sampler !== undefined && !sampler) throw new Error('GLB: sampler does not exist');
+  const wrap = (value = 10497) => {
+    if (value !== 10497 && value !== 33071) throw new Error('GLB: mirrored texture repeat is not supported');
+    return value === 10497;
+  };
+  return { uvs, textureRef: { textureId: reference.index + 1, url: imagePath(texture.source, image.mimeType), repeatS: wrap(sampler?.wrapS), repeatT: wrap(sampler?.wrapT) } };
+}
+
+export function parseGLBImageResources(gltf: GLTFDocument, bin: Uint8Array): Map<string, Uint8Array> { return imageResources(gltf, bin, true); }
+export function validateGLBImages(gltf: GLTFDocument, bin: Uint8Array): void { imageResources(gltf, bin, false); }

--- a/packages/cache/src/glb-transform.ts
+++ b/packages/cache/src/glb-transform.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { GLTFNode } from './glb-types.js';
+/** Column-major 4x4 (glTF node-transform convention). */
+export type Mat4 = number[];
+
+export const MAT4_IDENTITY: Mat4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Column-major 4x4 multiply `a * b`. */
+export function mat4Mul(a: Mat4, b: Mat4): Mat4 {
+  const out = new Array<number>(16);
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[k * 4 + row] * b[col * 4 + k];
+      out[col * 4 + row] = s;
+    }
+  }
+  return out;
+}
+
+/** A node's local transform: its `matrix` (column-major) or a translation matrix. */
+export function nodeLocalMat4(nd: GLTFNode): Mat4 {
+  const finite = (values: number[] | undefined, count: number) => values === undefined || (values.length === count && values.every(Number.isFinite));
+  if (!finite(nd.matrix, 16) || !finite(nd.translation, 3) || !finite(nd.rotation, 4) || !finite(nd.scale, 3)) throw new Error('GLB: invalid node transform');
+  if (nd.matrix) {
+    if (nd.translation || nd.rotation || nd.scale || nd.matrix[3] !== 0 || nd.matrix[7] !== 0 || nd.matrix[11] !== 0 || nd.matrix[15] !== 1) throw new Error('GLB: invalid affine node matrix');
+    return nd.matrix;
+  }
+  const [x, y, z, w] = nd.rotation ?? [0, 0, 0, 1];
+  if (Math.abs(Math.hypot(x, y, z, w) - 1) > 1e-5) throw new Error('GLB: rotation quaternion must be normalized');
+  const [sx, sy, sz] = nd.scale ?? [1, 1, 1];
+  const t = nd.translation ?? [0, 0, 0];
+  return [
+    (1 - 2 * (y*y + z*z))*sx, 2*(x*y + z*w)*sx, 2*(x*z - y*w)*sx, 0,
+    2*(x*y - z*w)*sy, (1 - 2*(x*x + z*z))*sy, 2*(y*z + x*w)*sy, 0,
+    2*(x*z + y*w)*sz, 2*(y*z - x*w)*sz, (1 - 2*(x*x + y*y))*sz, 0,
+    t[0], t[1], t[2], 1,
+  ];
+}
+
+/** True when a 4x4's upper-left 3x3 is the identity (within epsilon) — i.e. the
+ *  node carries pure translation, so vertices need no rotation/scale baking. */
+export function linearIsIdentity(m: Mat4): boolean {
+  const e = 1e-6;
+  return (
+    Math.abs(m[0] - 1) < e && Math.abs(m[1]) < e && Math.abs(m[2]) < e &&
+    Math.abs(m[4]) < e && Math.abs(m[5] - 1) < e && Math.abs(m[6]) < e &&
+    Math.abs(m[8]) < e && Math.abs(m[9]) < e && Math.abs(m[10] - 1) < e
+  );
+}
+
+
+/** Inverse transpose for normals, including nonuniform scale. */
+export function normalMatrix(m: Mat4): number[] {
+  const a=m[0], b=m[4], c=m[8], d=m[1], e=m[5], f=m[9], g=m[2], h=m[6], i=m[10];
+  const det=a*(e*i-f*h)-b*(d*i-f*g)+c*(d*h-e*g);
+  if (!Number.isFinite(det) || Math.abs(det) < 1e-15) throw new Error('GLB: singular node scale cannot preserve surface normals');
+  return [(e*i-f*h)/det,(c*h-b*i)/det,(b*f-c*e)/det,(f*g-d*i)/det,(a*i-c*g)/det,(c*d-a*f)/det,(d*h-e*g)/det,(b*g-a*h)/det,(a*e-b*d)/det];
+}
+export function mirrored(m: Mat4): boolean {
+  return m[0]*(m[5]*m[10]-m[9]*m[6])-m[4]*(m[1]*m[10]-m[9]*m[2])+m[8]*(m[1]*m[6]-m[5]*m[2]) < 0;
+}

--- a/packages/cache/src/glb-types.ts
+++ b/packages/cache/src/glb-types.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Minimal glTF type definitions for parsing
+export interface GLTFDocument {
+  asset: { version: string; generator?: string };
+  extensionsRequired?: string[];
+  scene?: number;
+  scenes?: Array<{ nodes?: number[] }>;
+  nodes?: GLTFNode[];
+  meshes?: GLTFMesh[];
+  materials?: GLTFMaterial[];
+  accessors?: GLTFAccessor[];
+  bufferViews?: GLTFBufferView[];
+  buffers?: GLTFBuffer[];
+  images?: Array<{ bufferView?: number; mimeType?: string; uri?: string }>;
+  textures?: Array<{ source?: number; sampler?: number }>;
+  samplers?: Array<{ wrapS?: number; wrapT?: number }>;
+}
+
+export interface GLTFNode {
+  mesh?: number;
+  name?: string;
+  extras?: { expressId?: number };
+  children?: number[];
+  /** Node-local translation (xyz). The from-meshes exporter places all geometry
+   *  under a single translated root node, so this is composed down the hierarchy. */
+  translation?: number[];
+  rotation?: number[];
+  scale?: number[];
+  skin?: number;
+  /** Node-local column-major 4x4 (glTF convention). The from-bytes instanced
+   *  exporter places each shared-template occurrence with a node MATRIX (rotation +
+   *  translation); mutually exclusive with `translation` per the glTF spec. */
+  matrix?: number[];
+}
+
+export interface GLTFMesh {
+  primitives: GLTFPrimitive[];
+  name?: string;
+}
+
+export interface GLTFPrimitive {
+  attributes: {
+    POSITION: number;
+    NORMAL?: number;
+    TEXCOORD_0?: number;
+    [name: string]: number | undefined;
+  };
+  targets?: unknown[];
+  extensions?: Record<string, unknown>;
+  indices?: number;
+  mode?: number;
+  material?: number;
+}
+
+export interface GLTFMaterial {
+  pbrMetallicRoughness?: {
+    baseColorTexture?: { index: number; texCoord?: number; extensions?: { KHR_texture_transform?: { offset?: number[]; scale?: number[]; rotation?: number; texCoord?: number } } };
+    metallicRoughnessTexture?: unknown;
+    baseColorFactor?: [number, number, number, number] | number[];
+  };
+  normalTexture?: unknown;
+  emissiveTexture?: unknown;
+  occlusionTexture?: unknown;
+  extensions?: Record<string, unknown>;
+  alphaMode?: 'OPAQUE' | 'MASK' | 'BLEND';
+}
+
+export interface GLTFAccessor {
+  sparse?: unknown;
+  normalized?: boolean;
+  bufferView: number;
+  byteOffset?: number;
+  componentType: number;
+  count: number;
+  type: 'SCALAR' | 'VEC2' | 'VEC3' | 'VEC4' | 'MAT2' | 'MAT3' | 'MAT4';
+  min?: number[];
+  max?: number[];
+}
+
+export interface GLTFBufferView {
+  buffer: number;
+  byteOffset?: number;
+  byteLength: number;
+  byteStride?: number;
+  target?: number;
+}
+
+export interface GLTFBuffer {
+  byteLength: number;
+  uri?: string;
+}
+

--- a/packages/cache/src/glb.test.ts
+++ b/packages/cache/src/glb.test.ts
@@ -23,7 +23,7 @@ function buildGLB(materials: Array<[number, number, number, number]>): Uint8Arra
     const v = i * 9;
     verts.set([0, 0, 0, 1, 0, 0, 0, 1, 0], v);
     norms.set([0, 0, 1, 0, 0, 1, 0, 0, 1], v);
-    idx.set([i * 3, i * 3 + 1, i * 3 + 2], i * 3);
+    idx.set([0, 1, 2], i * 3); // Each primitive has its own three-vertex accessor.
   }
 
   const posBytes = new Uint8Array(verts.buffer);

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -212,7 +212,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     ) {
       return [...DEFAULT_COLOR];
     }
-    return [linearToSrgb(r), linearToSrgb(g), linearToSrgb(b), a];
+    return [linearToSrgb(r), linearToSrgb(g), linearToSrgb(b), material?.pbrMetallicRoughness?.baseColorTexture ? 1 : a];
   };
 
   for (let nodeIdx = 0; nodeIdx < gltf.nodes.length; nodeIdx++) {
@@ -238,7 +238,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       if (posAccessorIdx === undefined) continue;
 
       // Read position data
-      const positions = readAccessorData(gltf, bin, posAccessorIdx);
+      const positions = readAccessorData(gltf, bin, posAccessorIdx, 'VEC3');
       if (!(positions instanceof Float32Array)) {
         throw new Error('Position data must be Float32');
       }
@@ -246,7 +246,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       // Read normal data (optional, generate if missing)
       let normals: Float32Array;
       if (normAccessorIdx !== undefined) {
-        const normData = readAccessorData(gltf, bin, normAccessorIdx);
+        const normData = readAccessorData(gltf, bin, normAccessorIdx, 'VEC3');
         if (!(normData instanceof Float32Array)) {
           throw new Error('Normal data must be Float32');
         }
@@ -259,7 +259,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
       // Read index data (optional for non-indexed geometry)
       let indices: Uint32Array;
       if (idxAccessorIdx !== undefined) {
-        const idxData = readAccessorData(gltf, bin, idxAccessorIdx);
+        const idxData = readAccessorData(gltf, bin, idxAccessorIdx, 'SCALAR');
         if (idxData instanceof Float32Array) {
           throw new Error('Index data cannot be Float32');
         }

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -11,6 +11,7 @@
 
 import type { MeshData } from '@ifc-lite/geometry';
 import { safeUtf8Decode } from '@ifc-lite/data';
+import { primitiveTexture, validateGLBImages } from './glb-images.js';
 import { linearToSrgb } from './glb-color.js';
 
 // glTF 2.0 constants
@@ -19,14 +20,7 @@ const GLB_VERSION = 2;
 const CHUNK_TYPE_JSON = 0x4e4f534a; // 'JSON'
 const CHUNK_TYPE_BIN = 0x004e4942; // 'BIN\0'
 
-// Component types
-const COMPONENT_BYTE = 5120;
-const COMPONENT_UNSIGNED_BYTE = 5121;
-const COMPONENT_SHORT = 5122;
-const COMPONENT_UNSIGNED_SHORT = 5123;
-const COMPONENT_UNSIGNED_INT = 5125;
-const COMPONENT_FLOAT = 5126;
-
+import { readAccessorData } from './glb-accessor.js';
 /** Parsed GLB structure */
 export interface ParsedGLB {
   json: GLTFDocument;
@@ -40,78 +34,7 @@ export interface GLBMapping {
   nodeToExpressId: Map<number, number>;
 }
 
-// Minimal glTF type definitions for parsing
-interface GLTFDocument {
-  asset: { version: string; generator?: string };
-  scene?: number;
-  scenes?: Array<{ nodes?: number[] }>;
-  nodes?: GLTFNode[];
-  meshes?: GLTFMesh[];
-  materials?: GLTFMaterial[];
-  accessors?: GLTFAccessor[];
-  bufferViews?: GLTFBufferView[];
-  buffers?: GLTFBuffer[];
-}
-
-interface GLTFNode {
-  mesh?: number;
-  name?: string;
-  extras?: { expressId?: number };
-  children?: number[];
-  /** Node-local translation (xyz). The from-meshes exporter places all geometry
-   *  under a single translated root node, so this is composed down the hierarchy. */
-  translation?: number[];
-  /** Node-local column-major 4x4 (glTF convention). The from-bytes instanced
-   *  exporter places each shared-template occurrence with a node MATRIX (rotation +
-   *  translation); mutually exclusive with `translation` per the glTF spec. */
-  matrix?: number[];
-}
-
-interface GLTFMesh {
-  primitives: GLTFPrimitive[];
-  name?: string;
-}
-
-interface GLTFPrimitive {
-  attributes: {
-    POSITION: number;
-    NORMAL?: number;
-  };
-  indices?: number;
-  mode?: number;
-  material?: number;
-}
-
-interface GLTFMaterial {
-  pbrMetallicRoughness?: {
-    baseColorFactor?: [number, number, number, number] | number[];
-  };
-  alphaMode?: 'OPAQUE' | 'MASK' | 'BLEND';
-}
-
-interface GLTFAccessor {
-  bufferView: number;
-  byteOffset?: number;
-  componentType: number;
-  count: number;
-  type: 'SCALAR' | 'VEC2' | 'VEC3' | 'VEC4' | 'MAT2' | 'MAT3' | 'MAT4';
-  min?: number[];
-  max?: number[];
-}
-
-interface GLTFBufferView {
-  buffer: number;
-  byteOffset?: number;
-  byteLength: number;
-  byteStride?: number;
-  target?: number;
-}
-
-interface GLTFBuffer {
-  byteLength: number;
-  uri?: string;
-}
-
+import type { GLTFDocument, GLTFMesh } from './glb-types.js';
 /**
  * Parse a GLB (binary glTF) file
  *
@@ -217,205 +140,7 @@ export function extractGLBMapping(gltf: GLTFDocument): GLBMapping {
   return { expressIdToNode, expressIdToMesh, nodeToExpressId };
 }
 
-/**
- * Get the byte size for a glTF component type
- */
-function getComponentSize(componentType: number): number {
-  switch (componentType) {
-    case COMPONENT_BYTE:
-    case COMPONENT_UNSIGNED_BYTE:
-      return 1;
-    case COMPONENT_SHORT:
-    case COMPONENT_UNSIGNED_SHORT:
-      return 2;
-    case COMPONENT_UNSIGNED_INT:
-    case COMPONENT_FLOAT:
-      return 4;
-    default:
-      throw new Error(`Unknown component type: ${componentType}`);
-  }
-}
-
-/**
- * Get the number of components for an accessor type
- */
-function getComponentCount(type: string): number {
-  switch (type) {
-    case 'SCALAR':
-      return 1;
-    case 'VEC2':
-      return 2;
-    case 'VEC3':
-      return 3;
-    case 'VEC4':
-      return 4;
-    case 'MAT2':
-      return 4;
-    case 'MAT3':
-      return 9;
-    case 'MAT4':
-      return 16;
-    default:
-      throw new Error(`Unknown accessor type: ${type}`);
-  }
-}
-
-/**
- * Read accessor data as a typed array
- */
-function readAccessorData(
-  gltf: GLTFDocument,
-  bin: Uint8Array,
-  accessorIdx: number
-): Float32Array | Uint32Array | Uint16Array | Uint8Array {
-  const accessor = gltf.accessors?.[accessorIdx];
-  if (!accessor) {
-    throw new Error(`Accessor ${accessorIdx} not found`);
-  }
-
-  const bufferView = gltf.bufferViews?.[accessor.bufferView];
-  if (!bufferView) {
-    throw new Error(`BufferView ${accessor.bufferView} not found`);
-  }
-
-  const componentSize = getComponentSize(accessor.componentType);
-  const componentCount = getComponentCount(accessor.type);
-  const elementSize = componentSize * componentCount;
-  const byteStride = bufferView.byteStride ?? elementSize;
-
-  const bufferOffset = (bufferView.byteOffset ?? 0) + (accessor.byteOffset ?? 0);
-
-  // `accessor.count` comes straight from the (untrusted) GLB JSON chunk and
-  // is REQUIRED by the glTF spec, but nothing here enforced that at runtime:
-  // a missing/non-numeric `count` makes it `undefined`/NaN, and `NaN * x` is
-  // NaN. Every arithmetic bounds comparison below (`< 0`, `> bin.byteLength`)
-  // is false against NaN, so the bounds check was silently bypassed rather
-  // than rejecting the malformed accessor. Control then fell through to a
-  // typed-array constructor built from that same NaN count, which coerces to
-  // an element count of 0 (ToIndex(NaN) === 0) — producing a silently EMPTY
-  // mesh reported as a successful import instead of throwing.
-  if (!Number.isInteger(accessor.count) || accessor.count < 0) {
-    throw new Error(`GLB: accessor ${accessorIdx} has an invalid count: ${accessor.count}`);
-  }
-
-  // Bounds-check the full byte range this accessor claims against the actual
-  // BIN chunk BEFORE slicing/constructing anything. `accessor.count` /
-  // `byteOffset` come straight from the (untrusted) GLB JSON chunk; without
-  // this, `bin.slice()` below silently CLAMPS on a truncated/malformed BIN
-  // (fewer bytes than asked), and the typed-array constructor that follows
-  // still requests the ORIGINALLY declared element count against that
-  // shorter buffer — a raw `RangeError: Invalid typed array length` (or
-  // "range consisting of offset and length are out of bounds", depending on
-  // engine) escapes instead of a diagnosable domain error.
-  const neededBytes = byteStride === elementSize
-    ? accessor.count * elementSize
-    : accessor.count > 0
-      ? (accessor.count - 1) * byteStride + elementSize
-      : 0;
-  if (bufferOffset < 0 || neededBytes < 0 || bufferOffset + neededBytes > bin.byteLength) {
-    throw new Error(
-      `GLB: accessor ${accessorIdx} reads bytes [${bufferOffset}, ${bufferOffset + neededBytes}) ` +
-      `but the BIN chunk is only ${bin.byteLength} bytes`,
-    );
-  }
-
-  // If data is tightly packed, we can use a view directly
-  if (byteStride === elementSize) {
-    const byteLength = accessor.count * elementSize;
-    const slice = bin.slice(bufferOffset, bufferOffset + byteLength);
-
-    switch (accessor.componentType) {
-      case COMPONENT_FLOAT:
-        return new Float32Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
-      case COMPONENT_UNSIGNED_INT:
-        return new Uint32Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
-      case COMPONENT_UNSIGNED_SHORT:
-        return new Uint16Array(slice.buffer, slice.byteOffset, accessor.count * componentCount);
-      case COMPONENT_UNSIGNED_BYTE:
-        return slice;
-      default:
-        throw new Error(`Unsupported component type for reading: ${accessor.componentType}`);
-    }
-  }
-
-  // Handle strided data
-  const result =
-    accessor.componentType === COMPONENT_FLOAT
-      ? new Float32Array(accessor.count * componentCount)
-      : accessor.componentType === COMPONENT_UNSIGNED_INT
-        ? new Uint32Array(accessor.count * componentCount)
-        : accessor.componentType === COMPONENT_UNSIGNED_SHORT
-          ? new Uint16Array(accessor.count * componentCount)
-          : new Uint8Array(accessor.count * componentCount);
-
-  const dataView = new DataView(bin.buffer, bin.byteOffset, bin.byteLength);
-
-  for (let i = 0; i < accessor.count; i++) {
-    const elementOffset = bufferOffset + i * byteStride;
-    for (let c = 0; c < componentCount; c++) {
-      const byteOffset = elementOffset + c * componentSize;
-      let value: number;
-
-      switch (accessor.componentType) {
-        case COMPONENT_FLOAT:
-          value = dataView.getFloat32(byteOffset, true);
-          break;
-        case COMPONENT_UNSIGNED_INT:
-          value = dataView.getUint32(byteOffset, true);
-          break;
-        case COMPONENT_UNSIGNED_SHORT:
-          value = dataView.getUint16(byteOffset, true);
-          break;
-        case COMPONENT_UNSIGNED_BYTE:
-          value = dataView.getUint8(byteOffset);
-          break;
-        default:
-          throw new Error(`Unsupported component type: ${accessor.componentType}`);
-      }
-
-      result[i * componentCount + c] = value;
-    }
-  }
-
-  return result;
-}
-
-/** Column-major 4x4 (glTF node-transform convention). */
-type Mat4 = number[];
-
-const MAT4_IDENTITY: Mat4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
-
-/** Column-major 4x4 multiply `a * b`. */
-function mat4Mul(a: Mat4, b: Mat4): Mat4 {
-  const out = new Array<number>(16);
-  for (let col = 0; col < 4; col++) {
-    for (let row = 0; row < 4; row++) {
-      let s = 0;
-      for (let k = 0; k < 4; k++) s += a[k * 4 + row] * b[col * 4 + k];
-      out[col * 4 + row] = s;
-    }
-  }
-  return out;
-}
-
-/** A node's local transform: its `matrix` (column-major) or a translation matrix. */
-function nodeLocalMat4(nd: GLTFNode): Mat4 {
-  if (Array.isArray(nd.matrix) && nd.matrix.length === 16) return nd.matrix;
-  const t = nd.translation;
-  return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, t?.[0] ?? 0, t?.[1] ?? 0, t?.[2] ?? 0, 1];
-}
-
-/** True when a 4x4's upper-left 3x3 is the identity (within epsilon) — i.e. the
- *  node carries pure translation, so vertices need no rotation/scale baking. */
-function linearIsIdentity(m: Mat4): boolean {
-  const e = 1e-6;
-  return (
-    Math.abs(m[0] - 1) < e && Math.abs(m[1]) < e && Math.abs(m[2]) < e &&
-    Math.abs(m[4]) < e && Math.abs(m[5] - 1) < e && Math.abs(m[6]) < e &&
-    Math.abs(m[8]) < e && Math.abs(m[9]) < e && Math.abs(m[10] - 1) < e
-  );
-}
-
+import { type Mat4, MAT4_IDENTITY, mat4Mul, nodeLocalMat4, linearIsIdentity, normalMatrix, mirrored } from './glb-transform.js';
 /**
  * Parse GLB geometry into MeshData format
  *
@@ -425,6 +150,10 @@ function linearIsIdentity(m: Mat4): boolean {
  */
 export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshData[] {
   const meshes: MeshData[] = [];
+  for (const extension of gltf.extensionsRequired ?? []) {
+    if (!['KHR_texture_transform', 'KHR_materials_unlit'].includes(extension)) throw new Error(`GLB: unsupported required extension ${extension}`);
+  }
+  validateGLBImages(gltf, bin);
   const mapping = extractGLBMapping(gltf);
 
   if (!gltf.nodes || !gltf.meshes) {
@@ -444,12 +173,17 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     const seen = new Set<number>();
     const roots = gltf.scenes?.[gltf.scene ?? 0]?.nodes ?? gltf.nodes.map((_, i) => i);
     const walk = (idx: number, parent: Mat4): void => {
+      const pending: Array<[number, Mat4]> = [[idx, parent]];
+      while (pending.length) {
+      const [idx, parent] = pending.pop()!;
       const nd = gltf.nodes?.[idx];
-      if (!nd || seen.has(idx)) return; // guard against malformed cycles
+      if (!nd || seen.has(idx)) continue; // finite iterative walk
+      if (nd.skin !== undefined) throw new Error('GLB: skinned capture meshes are not supported');
       seen.add(idx);
       const world = mat4Mul(parent, nodeLocalMat4(nd));
       nodeWorldM.set(idx, world);
-      for (const c of nd.children ?? []) walk(c, world);
+      for (const c of nd.children ?? []) pending.push([c, world]);
+      }
     };
     for (const r of roots) walk(r, MAT4_IDENTITY);
     // Extraction below iterates ALL nodes, not just scene-reachable ones. Walk any
@@ -468,7 +202,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     if (materialIdx === undefined) return [...DEFAULT_COLOR];
     const material = gltf.materials?.[materialIdx];
     const factor = material?.pbrMetallicRoughness?.baseColorFactor;
-    if (!Array.isArray(factor) || factor.length < 3) return [...DEFAULT_COLOR];
+    if (!Array.isArray(factor) || factor.length < 3) return material?.pbrMetallicRoughness?.baseColorTexture ? [1, 1, 1, 1] : [...DEFAULT_COLOR];
     const r = factor[0], g = factor[1], b = factor[2], a = factor.length >= 4 ? factor[3] : 1.0;
     if (
       typeof r !== 'number' || !Number.isFinite(r) ||
@@ -485,7 +219,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
     const node = gltf.nodes[nodeIdx];
     if (node.mesh === undefined) continue;
 
-    const mesh = gltf.meshes[node.mesh];
+    const mesh: GLTFMesh | undefined = gltf.meshes[node.mesh];
     if (!mesh || !mesh.primitives.length) continue;
 
     const expressId = mapping.nodeToExpressId.get(nodeIdx) ?? nodeIdx;
@@ -540,6 +274,16 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
         }
       }
 
+      if (positions.length % 3 || indices.length % 3 || normals.length !== positions.length || !positions.every(Number.isFinite) || !normals.every(Number.isFinite) || indices.some(index => index >= positions.length / 3)) throw new Error('GLB: invalid triangle geometry');
+      if (normAccessorIdx === undefined) {
+        for (let i = 0; i < indices.length; i += 3) {
+          const a=indices[i]*3, b=indices[i+1]*3, c=indices[i+2]*3;
+          const ux=positions[b]-positions[a], uy=positions[b+1]-positions[a+1], uz=positions[b+2]-positions[a+2];
+          const vx=positions[c]-positions[a], vy=positions[c+1]-positions[a+1], vz=positions[c+2]-positions[a+2];
+          for (const index of [a,b,c]) { normals[index]+=uy*vz-uz*vy; normals[index+1]+=uz*vx-ux*vz; normals[index+2]+=ux*vy-uy*vx; }
+        }
+        for (let i=0;i<normals.length;i+=3) { const length=Math.hypot(normals[i],normals[i+1],normals[i+2])||1; normals[i]/=length; normals[i+1]/=length; normals[i+2]/=length; }
+      }
       // Apply the node's composed world transform. The TRANSLATION rides each mesh
       // as `MeshData.origin` (world = origin + position) and is kept OUT of the f32
       // vertex buffer: the exporter emits scene-centre-relative vertices precisely so
@@ -561,22 +305,28 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
           outPositions[i + 1] = m[1] * x + m[5] * y + m[9] * z;
           outPositions[i + 2] = m[2] * x + m[6] * y + m[10] * z;
         }
+        const n = normalMatrix(m);
         outNormals = new Float32Array(normals.length);
         for (let i = 0; i + 2 < normals.length; i += 3) {
           const x = normals[i], y = normals[i + 1], z = normals[i + 2];
-          const nx = m[0] * x + m[4] * y + m[8] * z;
-          const ny = m[1] * x + m[5] * y + m[9] * z;
-          const nz = m[2] * x + m[6] * y + m[10] * z;
+          const nx = n[0] * x + n[3] * y + n[6] * z;
+          const ny = n[1] * x + n[4] * y + n[7] * z;
+          const nz = n[2] * x + n[5] * y + n[8] * z;
           const len = Math.hypot(nx, ny, nz) || 1;
           outNormals[i] = nx / len;
           outNormals[i + 1] = ny / len;
           outNormals[i + 2] = nz / len;
         }
       }
+      if (mirrored(m)) {
+        for (let i=0;i<indices.length;i+=3) [indices[i+1],indices[i+2]]=[indices[i+2],indices[i+1]];
+      }
       const origin: [number, number, number] | undefined =
         t[0] !== 0 || t[1] !== 0 || t[2] !== 0 ? t : undefined;
 
+      const texture = primitiveTexture(gltf, bin, primitive, positions.length / 3);
       meshes.push({
+        ...texture,
         expressId,
         positions: outPositions,
         normals: outNormals,

--- a/packages/cache/src/index.ts
+++ b/packages/cache/src/index.ts
@@ -96,3 +96,5 @@ export {
 } from './glb.js';
 
 export type { ParsedGLB, GLBMapping } from './glb.js';
+
+export { parseGLBImageResources } from './glb-images.js';

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -159,6 +159,7 @@
     "loadGLBToMeshData: function",
     "openGeometryChunksV13: function",
     "parseGLB: function",
+    "parseGLBImageResources: function",
     "parseGLBToMeshData: function",
     "readGeometryHeadV13: function",
     "readInstancedShards: function",

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -122,7 +122,7 @@
   1226 apps/viewer/src/hooks/useIDS.ts
    586 apps/viewer/src/hooks/useIfcCache.ts
    667 apps/viewer/src/hooks/useIfcFederation.ts
-  2240 apps/viewer/src/hooks/useIfcLoader.ts
+  2245 apps/viewer/src/hooks/useIfcLoader.ts
    436 apps/viewer/src/hooks/useIfcServer.ts
    483 apps/viewer/src/hooks/useKeyboardShortcuts.ts
    493 apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -185,7 +185,6 @@
    801 packages/bcf/src/reader.ts
    595 packages/bcf/src/viewpoint.ts
    753 packages/bcf/src/writer.ts
-   605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts
    433 packages/clash/src/duplicates.ts

--- a/tools/texture-authoring/derive-boulder-glb.mjs
+++ b/tools/texture-authoring/derive-boulder-glb.mjs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// Offline fixture preparation, not a production import path. Inputs are the
+// original CC0 Poly Haven boulder_01 glTF, BIN and diffuse JPEG downloads.
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+const [folder, output] = process.argv.slice(2);
+if (!folder || !output) throw new Error('Usage: node tools/texture-authoring/derive-boulder-glb.mjs <download-folder> <output.glb>');
+const json = JSON.parse(await readFile(join(folder, 'boulder_01_1k.gltf'), 'utf8'));
+const geometry = await readFile(join(folder, 'boulder_01.bin'));
+const image = await readFile(join(folder, 'textures/boulder_01_diff_1k.jpg'));
+// F5 creates captured albedo surfaces. Explicitly derive an ALBEDO-ONLY fixture:
+// discard normal/metallic-roughness maps; do not imply full PBR import support.
+json.materials = [{ pbrMetallicRoughness: { baseColorTexture: { index: 0 }, metallicFactor: 0, roughnessFactor: 1 } }];
+json.textures = [{ source: 0, sampler: 0 }];
+json.images = [{ mimeType: 'image/jpeg', bufferView: json.bufferViews.length }];
+json.bufferViews.push({ buffer: 0, byteOffset: geometry.length, byteLength: image.length });
+const data = Buffer.concat([geometry, image]);
+json.buffers = [{ byteLength: data.length }];
+const jsonText = Buffer.from(JSON.stringify(json));
+const text = Buffer.alloc(Math.ceil(jsonText.length / 4) * 4, 32); jsonText.copy(text);
+const bin = Buffer.alloc(Math.ceil(data.length / 4) * 4); data.copy(bin);
+const header = Buffer.alloc(12); header.writeUInt32LE(0x46546c67, 0); header.writeUInt32LE(2, 4); header.writeUInt32LE(28 + text.length + bin.length, 8);
+const chunk = (bytes, kind) => { const h = Buffer.alloc(8); h.writeUInt32LE(bytes.length, 0); h.writeUInt32LE(kind, 4); return Buffer.concat([h, bytes]); };
+const glb = Buffer.concat([header, chunk(text, 0x4e4f534a), chunk(bin, 0x004e4942)]);
+await writeFile(output, glb);
+console.log(JSON.stringify({ output, bytes: glb.length, sha256: createHash('sha256').update(glb).digest('hex'), imageSha256: createHash('sha256').update(image).digest('hex'), vertices: json.accessors[0].count, triangles: json.accessors[3].count / 3, derivation: 'Albedo-only; original geometry, UVs, indices and diffuse JPEG bytes unchanged' }, null, 2));


### PR DESCRIPTION
Textured GLB captures previously lost their UVs and encoded images on the normal Open/Add model path. This retains embedded base-colour PNG/JPEG resources, UV seams, texture transforms and node TRS, and gives the existing model appearance inventory ownership through decoding, federation, export access and removal. Unsupported captured appearance now produces an explicit diagnostic.

Part of ready, assigned #4380; this prerequisite intentionally leaves that issue open for the integrated Create from region workflow. Captured albedo is the scope: additional PBR maps and unsupported alpha semantics are refused, not silently flattened.

Validation:

- Root Turbo full typecheck: 94 tasks, 1,889 test files covered.
- Cache tests: 23 files, including UV seam/transform, inverse-transpose normals, mirrored winding, deep scene traversal and unsupported image/material regressions.
- Actual `useIfcLoader.loadFile` primary + federated textured GLB tests retain exact PNG bytes, distinct renderer texture IDs and shared-image leases; final removal closes exactly once. A superseded pending decoder cannot replace or report an error against the newer model.
- Public CC0 Poly Haven boulder albedo fixture: 67,042 vertices, 66,122 triangles, 67,042 UV pairs and byte-identical diffuse JPEG. Source/derived hashes and the explicit albedo-only offline derivation are recorded in `docs/architecture/evidence/captured-glb/README.md`.
- Documentation samples: 383 snippets compiled. Cache minor changeset and generated API snapshot included.

The old 605-line GLB module is split into bounded parsing/accessor/transform/image modules. The existing large loader gains five integration/guard lines; its exact budget is updated. No new model-loading pipeline or browser decoder is added to the headless cache package. This PR does not claim captured IFC creation, export/share round trips, or full PBR fidelity.


Independent integration review checked image/URI ownership, OPAQUE alpha handling, canonical load finalization, texture samplers and bounded source decoding. No blocking review defect remains. Main required-context ruleset was checked: the parity lane is a documented no-op for this TypeScript/cache-only diff. The full local typecheck, package/viewer tests, build and documentation evidence above support the user-authorized admin merge while cloud CI is queued; queued checks are not claimed green.
