### PR TITLE
fix(renderer): distinguish an active-but-empty isolate set from no isolation in shadow occluder collection

### DIFF
--- a/.changeset/shadow-occluder-empty-isolate.md
+++ b/.changeset/shadow-occluder-empty-isolate.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix sun shadow occluder collection treating an active-but-empty isolation set the same as no isolation, which let a fully isolated-out textured mesh or standalone mesh keep casting a phantom shadow instead of casting nothing.

--- a/packages/renderer/src/shadow-occluders.test.ts
+++ b/packages/renderer/src/shadow-occluders.test.ts
@@ -119,6 +119,51 @@ describe('collectShadowOccluders', () => {
     assert.deepEqual(kinds, ['instanced']);
   });
 
+  // Three-state check on `isolatedIds`, matching `entity-visibility.ts`'s documented
+  // rule ("an EMPTY set means isolate nothing... do not collapse the two"):
+  //   1. no isolation (undefined)        → everything casts.
+  //   2. non-empty isolation             → only the matched subset casts.
+  //   3. active-but-empty isolation      → NOTHING casts (the bug: `anyVisible`'s
+  //      `hasIsolate = isolatedIds != null && isolatedIds.size > 0` collapsed this
+  //      to "no isolation active" and let the whole batch cast a phantom shadow).
+  it('casts nothing (not everything) for a textured/individual mesh under an active-but-empty isolate set', () => {
+    const mesh: Mesh = {
+      expressId: 900,
+      vertexBuffer: buf('mesh-v'),
+      indexBuffer: buf('mesh-i'),
+      indexCount: 6,
+      color: [1, 1, 1, 1],
+      transform: { m: originModelMatrix(undefined) },
+      hydrated: false,
+    } as unknown as Mesh;
+    const draws = collectShadowOccluders(
+      { batches: [], instanced: [], textured: [texturedMesh()], meshes: [mesh] },
+      { isolatedIds: new Set<number>() },
+    );
+    assert.deepEqual(draws, [], 'isolate-to-nothing must cast nothing, not the whole scene');
+  });
+
+  it('casts everything when isolatedIds is absent (no isolation active)', () => {
+    const draws = collectShadowOccluders(
+      { batches: [], instanced: [], textured: [texturedMesh()] },
+      { isolatedIds: undefined },
+    );
+    assert.equal(draws.length, 1, 'no isolation active → the textured mesh still casts');
+  });
+
+  it('casts only the matched subset for a non-empty isolate set', () => {
+    const draws = collectShadowOccluders(
+      { batches: [], instanced: [], textured: [texturedMesh()] },
+      { isolatedIds: new Set([900]) },
+    );
+    assert.equal(draws.length, 1, 'the isolated textured mesh still casts');
+    const drawsExcluded = collectShadowOccluders(
+      { batches: [], instanced: [], textured: [texturedMesh()] },
+      { isolatedIds: new Set([12345]) },
+    );
+    assert.deepEqual(drawsExcluded, [], 'a non-matching isolate set excludes the textured mesh');
+  });
+
   it('lets a transparent (glass) batch pass light — it does not cast', () => {
     const glass: BatchedMesh = { ...flatBatch(1), color: [0.6, 0.8, 1, 0.3] };
     const draws = collectShadowOccluders({ batches: [glass], instanced: [], textured: [] });

--- a/packages/renderer/src/shadow-occluders.ts
+++ b/packages/renderer/src/shadow-occluders.ts
@@ -90,16 +90,22 @@ export function originModelMatrix(
   return out;
 }
 
-/** Whether a batch/mesh with these ids has at least one visible element. */
+/**
+ * Whether a batch/mesh with these ids has at least one visible element.
+ *
+ * Delegates to {@link isEntityVisible} rather than re-deriving the hide/isolate
+ * rule here: a prior version treated `isolatedIds` as active only when
+ * `.size > 0`, which collapsed an active-but-empty isolate set (isolate to
+ * nothing) into "no isolation active" and let a fully isolated-out batch keep
+ * casting a phantom shadow. `isolatedIds` is meaningfully nullable — `null`/
+ * `undefined` means no isolation, an empty `Set` means isolate nothing — and
+ * only `isEntityVisible` gets that right everywhere else in this module.
+ */
 function anyVisible(ids: readonly number[], vis: ShadowVisibility | undefined): boolean {
   if (!vis) return true;
   const { hiddenIds, isolatedIds } = vis;
-  const hasIsolate = isolatedIds != null && isolatedIds.size > 0;
-  if (!hiddenIds && !hasIsolate) return true;
   for (const id of ids) {
-    if (hiddenIds?.has(id)) continue;
-    if (hasIsolate && !isolatedIds!.has(id)) continue;
-    return true;
+    if (isEntityVisible(id, hiddenIds, isolatedIds)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- Sweep for the "empty collection means absent" fail-open shape (same family as #4364/#4386's `isolated_active: !opts.isolated.is_empty()`), scoped to code paths not already claimed by an open PR.
- `anyVisible()` in `packages/renderer/src/shadow-occluders.ts` derived `hasIsolate = isolatedIds != null && isolatedIds.size > 0`, which collapsed an active-but-empty isolation `Set` (a real, reachable state — see `entity-visibility.ts`'s documented contract: `null`/`undefined` = no isolation, empty `Set` = isolate nothing) into "no isolation active". A textured mesh or standalone mesh under that state kept casting a shadow for the whole scene instead of casting nothing, disagreeing with every other visibility surface in the renderer (`isEntityVisible`, `classifyBatchVisibility`, `picking-manager.ts`, `scene.ts`).
- Fixed by delegating `anyVisible()` to the existing `isEntityVisible()` helper — the same canonical check `classifyBatchVisibility()` already uses in this file — instead of re-deriving the hide/isolate rule.

## Test plan

- [x] RED: added a test asserting `collectShadowOccluders` casts nothing under an active-but-empty `isolatedIds` set; failed against the pre-fix code (`actual` still contained a `'textured'` draw).
- [x] GREEN: same test passes after the fix.
- [x] Three-state coverage added: no isolation → everything casts; non-empty isolation → only the matched subset casts; active-but-empty isolation → nothing casts.
- [x] Mutation test: reverted `anyVisible()` to the old `hasIsolate`-gated logic — the new test fails (1 of 30); restored the fix — all 30 pass.
- [x] Full `packages/renderer` suite: 1449 passed, 1 pre-existing skip, 0 failures.
- [x] `node scripts/check-module-size.mjs`: `EXIT=0`, `0 new over 400`.
- [x] Changeset added (`@ifc-lite/renderer` patch).

No mocked boundary here — `collectShadowOccluders`/`anyVisible`/`isEntityVisible` are plain, dependency-free functions exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed phantom shadows from meshes that are fully excluded by an active, empty isolation filter.
  * Shadow casting now correctly reflects visibility isolation: no filter casts normally, selective filters cast only matching meshes, and empty filters cast no shadows.

* **Tests**
  * Added coverage for all isolation-filter states affecting mesh shadow casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #4485
