### PR TITLE
fix(geometry): distinguish NotFound from other io::Errors in .ok()-collapsing rust/geometry fixture helpers

### DIFF
--- a/rust/geometry/tests/csg_quality_regression.rs
+++ b/rust/geometry/tests/csg_quality_regression.rs
@@ -22,17 +22,37 @@
 //! regressed somewhere — most likely the coplanar consolidation or the
 //! collinear simplification in `ClippingProcessor::consolidate_coplanar`.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 use std::path::PathBuf;
 
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally regardless of the flag.
 fn fixture(rel: &str) -> Option<String> {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .join(rel);
-    std::fs::read_to_string(p).ok()
+    match std::fs::read_to_string(&p) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                p.display()
+            );
+            None
+        }
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", p.display()),
+    }
 }
 
 fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {

--- a/rust/geometry/tests/halfspace_clip_cap_regression.rs
+++ b/rust/geometry/tests/halfspace_clip_cap_regression.rs
@@ -19,18 +19,38 @@
 //! 14 tris / −8.4 m³ / 16 open edges; with the section capped they are
 //! 20 tris / +2.06 m³ / 0 open edges.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::{GeometryRouter, Mesh};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally regardless of the flag.
 fn fixture(rel: &str) -> Option<String> {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .join(rel);
-    fs::read_to_string(p).ok()
+    match fs::read_to_string(&p) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                p.display()
+            );
+            None
+        }
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", p.display()),
+    }
 }
 
 fn process_element_only(content: &str, host_id: u32) -> Option<Mesh> {

--- a/rust/geometry/tests/issue_1007_real_opening_no_bridge.rs
+++ b/rust/geometry/tests/issue_1007_real_opening_no_bridge.rs
@@ -21,6 +21,8 @@
 //! the pre-fix tree and PASS after. Runs under `--no-default-features` (pure-Rust
 //! kernel, NO Manifold).
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityIndex, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
@@ -181,8 +183,25 @@ fn open_boundary_edges(tris: &[[[f64; 3]; 3]]) -> usize {
 
 /// Process the host with voids through the VIEWER path and probe every opening's
 /// footprint on each cut plane. Returns the worst per-cap bridged-sample count.
+///
+/// `None` here is overloaded: it also means "host has no voids", checked
+/// below. Only the fixture read itself distinguishes absence from a broken
+/// read: `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet)
+/// and skips unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case it panics
+/// naming the path; any other `io::Error` means the environment is broken,
+/// not merely missing an optional download, so it panics unconditionally.
 fn worst_bridged_samples(path: &str, host_id: u32) -> Option<usize> {
-    let content = std::fs::read_to_string(path).ok()?;
+    let content = match std::fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {path} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            return None;
+        }
+        Err(e) => panic!("fixture {path} exists but could not be read: {e}"),
+    };
     let index: EntityIndex = build_entity_index(&content);
     let voids = build_void_index(&content);
     let opening_ids = voids.get(&host_id).cloned().unwrap_or_default();

--- a/rust/geometry/tests/issue_635_boolean_clipping_test.rs
+++ b/rust/geometry/tests/issue_635_boolean_clipping_test.rs
@@ -26,6 +26,8 @@
 //!       thickness axis hit ZERO wall triangles — i.e. the void cut
 //!       reached the post-clip mesh.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
@@ -39,8 +41,27 @@ fn fixture_path(relative: &str) -> PathBuf {
         .join(relative)
 }
 
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally regardless of the flag.
 fn load_fixture(relative: &str) -> Option<String> {
-    fs::read_to_string(fixture_path(relative)).ok()
+    let p = fixture_path(relative);
+    match fs::read_to_string(&p) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                p.display()
+            );
+            None
+        }
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", p.display()),
+    }
 }
 
 /// Build the void index the same way production does.

--- a/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
+++ b/rust/geometry/tests/issue_964_arbitrary_profile_voids.rs
@@ -22,6 +22,8 @@
 //! holes. The buggy AABB fallback removed ~3% more material (each round/hex
 //! hole grew to its bounding box), which this tolerance rejects.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
@@ -90,12 +92,17 @@ fn bottom_cap_area(mesh: &Mesh) -> f64 {
 fn redundant_openings_do_not_rectangularize_profile_voids() {
     let content = match std::fs::read_to_string(fixture_path()) {
         Ok(s) => s,
-        Err(_) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing at {FIXTURE} and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping issue-964 regression: fixture missing at {FIXTURE}; run `pnpm fixtures`"
             );
             return;
         }
+        Err(e) => panic!("fixture {FIXTURE} exists but could not be read: {e}"),
     };
 
     let void_index = build_void_index_like_production(&content);

--- a/rust/geometry/tests/issue_979_feature_element_profiles.rs
+++ b/rust/geometry/tests/issue_979_feature_element_profiles.rs
@@ -12,15 +12,35 @@
 //! floor-plan projection drew spurious rectangles inside walls. AC20-FZK-Haus
 //! carries 17 `IFCOPENINGELEMENT` entities — a good regression fixture.
 
+mod support;
+
 use ifc_lite_geometry::extract_profiles;
 use std::path::PathBuf;
 
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally regardless of the flag.
 fn fixture(rel: &str) -> Option<String> {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("..")
         .join(rel);
-    std::fs::read_to_string(p).ok()
+    match std::fs::read_to_string(&p) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                p.display()
+            );
+            None
+        }
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", p.display()),
+    }
 }
 
 #[test]

--- a/rust/geometry/tests/voids_common/production.rs
+++ b/rust/geometry/tests/voids_common/production.rs
@@ -22,9 +22,22 @@ pub fn fixture_path(relative: &str) -> PathBuf {
 }
 
 /// Load a fixture if present; return `None` so callers can skip gracefully.
+///
+/// Distinguishes a genuinely absent file from a broken read. `NotFound` is
+/// the fresh-clone case (`pnpm fixtures` not run yet) and is the only case
+/// callers should treat as skippable; any other `io::Error` (permission
+/// denied, corrupt read, ...) means the environment is broken rather than
+/// merely missing an optional download, so it panics unconditionally. This
+/// helper does not itself consult `IFC_LITE_REQUIRE_FIXTURES` — each caller
+/// asserts `!support::require_fixtures()` before treating `None` as a skip,
+/// matching the pattern the rest of this crate's fixture-backed tests use.
 pub fn load_fixture(relative: &str) -> Option<String> {
     let path = fixture_path(relative);
-    fs::read_to_string(&path).ok()
+    match fs::read_to_string(&path) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", path.display()),
+    }
 }
 
 /// Find the express ID of an entity by GUID (attribute index 0).

--- a/rust/geometry/tests/voids_production_test.rs
+++ b/rust/geometry/tests/voids_production_test.rs
@@ -26,6 +26,7 @@
 //! large model downloads does not flake. Preserves every assertion from
 //! the former `production_void_path_test.rs`.
 
+mod support;
 mod voids_common;
 
 use ifc_lite_core::{build_entity_index, EntityDecoder};
@@ -47,6 +48,13 @@ struct FixtureWallCase {
     host: HostLocator,
     /// When known, the exact opening IDs expected for the host.
     expected_openings: Option<&'static [u32]>,
+    /// Whether `pnpm fixtures` can ever supply this fixture (i.e. it is
+    /// listed in `tests/models/manifest.json`). `IFC_LITE_REQUIRE_FIXTURES=1`
+    /// only enforces presence for manifest-backed fixtures — a case whose
+    /// fixture the download step can never provide (see
+    /// `production_smiley_all_host_walls_have_holes` below) must stay a
+    /// permanent, silent skip or this loop would fail CI unconditionally.
+    manifest_backed: bool,
 }
 
 /// Reproducers for issues #604 (single-wall door fixture, wall #55 /
@@ -60,12 +68,16 @@ fn production_fixture_walls_have_holes() {
             fixture: "tests/models/various/issue-604-door.ifc",
             host: HostLocator::ById(55),
             expected_openings: Some(&[2438]),
+            manifest_backed: true,
         },
         FixtureWallCase {
             name: "issue_584_smiley_wall_0NQVcwUgj2fup5UuFaDTfC",
+            // NOT in tests/models/manifest.json — `pnpm fixtures` never
+            // supplies this one; see `production_smiley_all_host_walls_have_holes`.
             fixture: "tests/models/ara3d/AC-20-Smiley-West-10-Bldg.ifc",
             host: HostLocator::ByGuid("0NQVcwUgj2fup5UuFaDTfC"),
             expected_openings: None,
+            manifest_backed: false,
         },
     ];
 
@@ -73,6 +85,15 @@ fn production_fixture_walls_have_holes() {
         let content = match load_fixture(case.fixture) {
             Some(c) => c,
             None => {
+                if case.manifest_backed {
+                    assert!(
+                        !support::require_fixtures(),
+                        "[{}] fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                         run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                        case.name,
+                        case.fixture
+                    );
+                }
                 eprintln!(
                     "[{}] fixture {} missing — skipping production void test",
                     case.name, case.fixture


### PR DESCRIPTION
## Summary

#4365 made `IFC_LITE_REQUIRE_FIXTURES` load-bearing for 19 `rust/geometry` tests whose skip-on-missing branch matched a `NotFound` `match` arm, but its PR body explicitly left one thing unfixed: a differently-shaped `fn fixture(rel) -> Option<String>` helper that does `std::fs::read_to_string(p).ok()`, collapsing every `io::Error` (not just `NotFound`) into a silent skip. That means a permissions error, a corrupt read, or any other I/O fault reads identically to "fixture legitimately not downloaded" — and, before this PR, a missing fixture through this helper shape could still pass vacuously even with `IFC_LITE_REQUIRE_FIXTURES=1` set.

This closes that gap for every test that reaches it, without changing what any test asserts.

## Enumeration

#4365's PR body named 4 files carrying this shape and said "and other `tests/models`-backed tests" without listing them. I re-derived the full list by grepping `rust/geometry/tests` for every `fn fixture*(...)`/`load_fixture`/inline `read_to_string(...).ok()` (or `Err(_) => skip`) pattern and checking each call site:

- `csg_quality_regression.rs`, `halfspace_clip_cap_regression.rs`, `issue_979_feature_element_profiles.rs` — the 3 named files with this exact `fn fixture(rel) -> Option<String>` shape whose non-ignored tests read a `tests/models`-corpus fixture.
- `issue_635_boolean_clipping_test.rs` — same shape, local `load_fixture`.
- `issue_964_arbitrary_profile_voids.rs` — same collapse inlined as `match ... Err(_) => skip` rather than via a named helper.
- `issue_1007_real_opening_no_bridge.rs` — `worst_bridged_samples(path, host_id) -> Option<usize>` collapses the read error into the same `Option` it also uses to mean "host has no voids"; only the read path needed the fix.
- `voids_common/production.rs`'s shared `load_fixture`, used (uncontrolled) by `voids_production_test.rs`'s non-`#[ignore]`d `production_fixture_walls_have_holes`.

**`issue_1155_halfspace_flyaway.rs`** was also named in #4365's list and does have the identical `fn fixture(rel) -> Option<String>` `.ok()` shape, but its only caller does `fixture(FIXTURE).expect("issue #1155 fixture must be staged")` — an unconditional panic on any missing/corrupt fixture, independent of `IFC_LITE_REQUIRE_FIXTURES`. It already fails correctly and was never vacuous, so it is intentionally left unchanged (verified: reverting the fixture file locally still fails the test, flag unset or set).

Everything else `tests/models`-backed in the crate either already panics unconditionally (`.expect()`/`.unwrap_or_else(panic!)` after presence is confirmed), is `#[ignore]`d (excluded from the default run by construction, same category #4365 already confirmed), or uses a `try_exists()`-based `fixture_present()` that already distinguishes `NotFound` from other errors (a different, pre-existing pattern, not touched here).

## The fix

Each affected helper now matches on `io::Error::kind()`:
- `NotFound`: skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case `assert!(!support::require_fixtures(), ...)` panics naming the path — same convention #4365 established.
- any other `io::Error` (permission denied, corrupt read, `IsADirectory`, ...): panics unconditionally, **regardless of the flag**. Reasoning: a fixture that exists but can't be read means the environment is broken, not that an optional download was skipped — collapsing that into "absent" would let a broken checkout silently report a smaller, passing suite even on a fresh clone with the flag unset.

`voids_production_test.rs`'s `production_fixture_walls_have_holes` loop has a second case (`AC-20-Smiley-West-10-Bldg.ifc`) that is **not** in `tests/models/manifest.json` — `pnpm fixtures` can never supply it (documented on its `#[ignore]`d sibling test). A blanket gate there would fail CI unconditionally for a fixture that can never be downloaded, so a `manifest_backed: bool` field on the case struct keeps that one a permanent, silent skip while the issue-604 case (which *is* manifest-backed) gets the same enforcement as everywhere else.

## Verification

All against a scratch worktree off `upstream/main` (re-fetched immediately before rebasing), cargo 1.93.0-nightly, full fixture corpus present via a local reference (not committed).

**RED** (before, `issue_979_feature_element_profiles.rs`, fixture absent, `IFC_LITE_REQUIRE_FIXTURES=1`):
```
running 3 tests
test ac20_extracts_no_feature_element_profiles ... ok
test legacy_opening_spellings_emit_no_profiles_either ... ok
test legacy_spellings_are_labelled_with_their_resolved_type ... ok
test result: ok. 3 passed; 0 failed; ...
```

**GREEN** (after, same conditions):
```
thread 'ac20_extracts_no_feature_element_profiles' panicked at rust/geometry/tests/issue_979_feature_element_profiles.rs:35:13:
fixture .../tests/models/ara3d/AC20-FZK-Haus.ifc not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)
test result: FAILED. 0 passed; 3 failed; ...
```

Same RED→GREEN pattern individually confirmed (original file swapped back in, fixture hidden via per-file symlinks so the real corpus was never modified) for `csg_quality_regression.rs`, `halfspace_clip_cap_regression.rs`, `issue_635_boolean_clipping_test.rs` (9/9 tests), `issue_964_arbitrary_profile_voids.rs`, `issue_1007_real_opening_no_bridge.rs`, and `voids_production_test.rs`.

**Four combinations**, all 7 fixed files:
- present + flag set → runs and passes.
- present + flag unset → runs and passes.
- **absent + flag set → fails loudly, naming the missing path** (shown above; also verified in combination across all 7 test binaries with `--no-fail-fast`).
- absent + flag unset → skips cleanly, unchanged (verified across all 7 binaries in one run: `ok`, non-fixture-dependent sub-tests still ran, no `FAILED`).

**Non-`NotFound` I/O error**: replaced a fixture path with a directory (`Is a directory (os error 21)`) and ran `issue_964_arbitrary_profile_voids.rs` with the flag **unset** — it still panicked (`fixture ... exists but could not be read: Is a directory (os error 21)`), confirming a broken read is never silently treated as "absent" regardless of the flag.

**Mutation test**: removed the `assert!(!support::require_fixtures(), ...)` guard in `issue_979_feature_element_profiles.rs`'s helper, replacing it with an `eprintln!("MUTATION-MARKER: ...")` so the mutated branch's execution is directly observable rather than inferred. With the fixture hidden and the flag set: `MUTATION-MARKER: guard removed, this line ran` printed 3 times and the suite reported `ok. 3 passed; 0 failed` — confirming both that the guard is load-bearing and that the mutated code path actually executed. Reverted before committing.

**Full-crate regression**, `rust/geometry`, matching #4365's own check:
- `IFC_LITE_REQUIRE_FIXTURES=1`, full fixture corpus: **1286 passed, 0 failed**
- unset, full fixture corpus: **1286 passed, 0 failed**

Identical to each other and to #4365's own recorded baseline (1286/0, default features) — confirms no assertion changed, only the enforcement path.

**Clippy** (`cargo clippy --tests --all-targets -- -D warnings`, `rust/geometry`): clean.

**Module-size gate**: `node scripts/check-module-size.mjs` → `EXIT=0`, `check-module-size: OK (2620 files measured, 331 allowlisted, 0 new over 400)`. The Rust ratchet (`cargo test -p ifc-lite-processing --test module_size_ratchet`) also passes: all touched files are under `tests/` and exempt from that gate by its own `is_exempt` rule, so no allowlist row was needed even though `issue_635_boolean_clipping_test.rs` (939 lines) and `issue_1007_real_opening_no_bridge.rs` (424 lines) are over 400.

## Not changed

- `issue_1155_halfspace_flyaway.rs` (see above — already correct, no live defect).
- `mesh_welding_calibration.rs`, `cdt_volume_watertight_verify.rs`, `polygonal_bounded_half_space_side_regression.rs`, `wall_opening_cut_regression.rs`, `rect_param_census.rs`, and similar: these skip on a plain `Path::exists()`/`try_exists()` check with **no** `IFC_LITE_REQUIRE_FIXTURES` gate at all — a different, pre-existing gap (the same *mechanical* fix #4365 applied to its 19 files, just not yet applied here) rather than the `.ok()`-collapsing shape this PR targets. Flagging as a candidate follow-up rather than folding in here, to keep this diff mechanical and matching the specific defect class named in #4365, the same restraint #4365 itself exercised.

## Changeset

Not added. #4365 — the direct predecessor for this exact class of change (rust/geometry test-file-only, no package version implication) — shipped without one, and I'm following that established precedent rather than introducing a changeset format for a case the immediately-preceding PR determined didn't need one.

## unqueued

No ready-queue issue covers this; it is a named follow-up from #4365's own PR body, not a new finding. Per instructions, no issue was opened — this PR carries `unqueued`.

Refs #4365 (predecessor; the follow-up gap its own PR body flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)