### PR TITLE
test(cli): cover export-rust-formats.ts's isolation argument

### DIFF
--- a/.changeset/export-rust-formats-isolation-coverage.md
+++ b/.changeset/export-rust-formats-isolation-coverage.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Add direct test coverage for `packages/cli/src/commands/export-rust-formats.ts` (`exportRustFormat`), which previously had none — no file imported it. Mirroring the MCP pattern from #4364/#4386, the new tests mock `GeometryProcessor` and assert on the actual `isolated` argument passed to `gp.exportGlb`/`gp.exportObj` (not just the return value): `undefined` when no `--type` filter is requested, a real `Uint32Array` of matched expressIds when one matches, and a rejection before the exporter is ever called when a filter matches nothing. A mocked test that only checks the return value would not have caught the #4364/#4386 regression, where this file briefly passed an explicit empty `Uint32Array` to mean "no filter" under the new wasm-boundary convention (which reads that as "isolation active, matches nothing") and made every plain `ifc-lite export --format glb`/`obj` fail with a misleading "0 meshes" error.

--- a/packages/cli/src/commands/export-rust-formats.test.ts
+++ b/packages/cli/src/commands/export-rust-formats.test.ts
@@ -26,7 +26,7 @@
  * way and would not have caught this class of bug.
  */
 
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -69,12 +69,16 @@ vi.mock('@ifc-lite/geometry', () => ({
     err instanceof Error && err.message === 'NO_RENDER_GEOMETRY',
 }));
 
-// `countGlbMeshes` runs on the real bytes `gp.exportGlb` returns (a
-// defense-in-depth check independent of what this module passed in), so it
-// is mocked separately to keep the GLB success path deterministic without
-// needing a byte-for-byte real GLB.
+// `countGlbMeshes`/`countObjVertices` run on the real bytes `gp.exportGlb`/
+// `gp.exportObj` return (a defense-in-depth check independent of what this
+// module passed in), so they are mocked separately to keep the success paths
+// deterministic without needing byte-for-byte real GLB/OBJ output. Both
+// default to a non-zero count so the argument-passing tests below (the
+// actual point of this file) exercise the success path; the zero-vertex
+// guard itself gets its own test that overrides `countObjVertices` to 0.
 const countGlbMeshes = vi.hoisted(() => vi.fn(() => 1));
-vi.mock('@ifc-lite/export', () => ({ countGlbMeshes }));
+const countObjVertices = vi.hoisted(() => vi.fn(() => 1));
+vi.mock('@ifc-lite/export', () => ({ countGlbMeshes, countObjVertices }));
 
 import { exportRustFormat } from './export-rust-formats.js';
 import type { IfcDataStore } from '@ifc-lite/parser';
@@ -196,6 +200,25 @@ describe('exportRustFormat: `isolated` argument passed to gp.exportObj (the OBJ 
       expect.stringContaining('Filter matched 0 entities'),
     );
     expect(gp.exportObj).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly (never writes the file) when countObjVertices reports 0 vertices (#4386)', async () => {
+    stubExit();
+    // `gp.exportObj` "succeeds" with header-only bytes (no real geometry
+    // pipeline here to produce zero output on its own), so drive the guard
+    // directly through its actual signal: `countObjVertices` returning 0.
+    gp.exportObj.mockReturnValue(new TextEncoder().encode('o Empty\n'));
+    countObjVertices.mockReturnValueOnce(0);
+    const out = outFile('zero-vertices.obj');
+
+    await expect(
+      exportRustFormat('obj', ['--out', out], FAKE_STORE, SAMPLE_IFC, [], false, false),
+    ).rejects.toThrow(ProcessExited);
+
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('OBJ export produced 0 vertices'),
+    );
+    expect(existsSync(out)).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/export-rust-formats.test.ts
+++ b/packages/cli/src/commands/export-rust-formats.test.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `export-rust-formats.ts` (`exportRustFormat`) had ZERO direct test coverage
+ * before this file: nothing imported it, and `export.zero-match.test.ts`
+ * (which drives it indirectly through `exportCommand` over the real wasm
+ * boundary) only observes success/failure, never the actual argument this
+ * module hands across the `GeometryProcessor` boundary.
+ *
+ * That blind spot is exactly what let a real regression ship: #4364 redefined
+ * `GeometryProcessor.exportGlb`'s (and #4386's `exportObj`'s) `isolated`
+ * parameter so an explicit empty `Uint32Array` means "isolation filter
+ * active, matching nothing" (`undefined` means "no filter"). This file used
+ * to pass an explicit empty array to mean "no filter" for both, so a plain
+ * `ifc-lite export --format glb` (no `--type`) started failing with
+ * "GLB export produced 0 meshes" — nothing caught it, because the CLI suite
+ * had no test for this file and the MCP suite mocks the export boundary
+ * without asserting on it either (fixed by this same follow-up on the MCP
+ * side, `packages/mcp/src/tools/export-init-dispose.test.ts`).
+ *
+ * `GeometryProcessor` is mocked here (mirroring the MCP pattern above) so the
+ * assertions can read `mock.calls[N][i]` — the actual value handed across the
+ * boundary — rather than only the return value, which a mock satisfies either
+ * way and would not have caught this class of bug.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const gp = vi.hoisted(() => {
+  const init = vi.fn(async () => undefined);
+  const exportGlb = vi.fn();
+  const exportObj = vi.fn();
+  const exportStep = vi.fn();
+  const exportJsonld = vi.fn();
+  const exportIfcx = vi.fn();
+  const exportUsd = vi.fn();
+  const dispose = vi.fn();
+  class GeometryProcessor {
+    init = init;
+    exportGlb = exportGlb;
+    exportObj = exportObj;
+    exportStep = exportStep;
+    exportJsonld = exportJsonld;
+    exportIfcx = exportIfcx;
+    exportUsd = exportUsd;
+    dispose = dispose;
+  }
+  return {
+    init,
+    exportGlb,
+    exportObj,
+    exportStep,
+    exportJsonld,
+    exportIfcx,
+    exportUsd,
+    dispose,
+    GeometryProcessor,
+  };
+});
+
+vi.mock('@ifc-lite/geometry', () => ({
+  GeometryProcessor: gp.GeometryProcessor,
+  isNoRenderGeometryError: (err: unknown) =>
+    err instanceof Error && err.message === 'NO_RENDER_GEOMETRY',
+}));
+
+// `countGlbMeshes` runs on the real bytes `gp.exportGlb` returns (a
+// defense-in-depth check independent of what this module passed in), so it
+// is mocked separately to keep the GLB success path deterministic without
+// needing a byte-for-byte real GLB.
+const countGlbMeshes = vi.hoisted(() => vi.fn(() => 1));
+vi.mock('@ifc-lite/export', () => ({ countGlbMeshes }));
+
+import { exportRustFormat } from './export-rust-formats.js';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+const __dirname = new URL('.', import.meta.url).pathname;
+// Any real file works: `rustExportContext` only reads it off disk
+// (`store.source.byteLength === 0` below forces that path) and hands the
+// bytes straight to the mocked `GeometryProcessor`, which never inspects them.
+const SAMPLE_IFC = join(__dirname, '../../../../apps/viewer/public/samples/hello-wall.ifc');
+
+/** A store whose `source.byteLength` is 0, forcing `rustExportContext` to read `filePath` from disk. */
+const FAKE_STORE = { source: { byteLength: 0 } } as unknown as IfcDataStore;
+
+const REFS = [{ expressId: 42 }, { expressId: 43 }];
+
+const dirs: string[] = [];
+function outFile(name: string): string {
+  const d = mkdtempSync(join(tmpdir(), 'ifclite-export-rust-formats-'));
+  dirs.push(d);
+  return join(d, name);
+}
+
+/**
+ * `fatal()` (packages/cli/src/output.ts) writes to stderr and calls the REAL
+ * `process.exit(1)`, which does not throw — it would kill the test runner.
+ * Mirrors `export.zero-match.test.ts`'s approach: stub `process.exit` to
+ * throw instead, so the "matched 0 entities" guard can be asserted with
+ * `.rejects.toThrow()` like any other rejection.
+ */
+class ProcessExited extends Error {
+  constructor(readonly code: number | undefined) {
+    super(`process.exit(${code})`);
+  }
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function stubExit(): void {
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    throw new ProcessExited(code);
+  }) as never);
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+}
+
+describe('exportRustFormat: `isolated` argument passed to gp.exportGlb (#4364)', () => {
+  it('passes `undefined` (not an empty Uint32Array) when no filter was requested', async () => {
+    gp.exportGlb.mockReturnValue(new Uint8Array([1, 2, 3]));
+    const out = outFile('no-filter.glb');
+
+    await exportRustFormat('glb', ['--out', out], FAKE_STORE, SAMPLE_IFC, [], false, false);
+
+    expect(gp.exportGlb).toHaveBeenCalledTimes(1);
+    const isolatedArg = gp.exportGlb.mock.calls[0]?.[3];
+    expect(isolatedArg).toBeUndefined();
+  });
+
+  it('passes a real Uint32Array of matched expressIds when a filter matches', async () => {
+    gp.exportGlb.mockReturnValue(new Uint8Array([1, 2, 3]));
+    const out = outFile('filtered.glb');
+
+    await exportRustFormat('glb', ['--out', out], FAKE_STORE, SAMPLE_IFC, REFS, true, false);
+
+    expect(gp.exportGlb).toHaveBeenCalledTimes(1);
+    const isolatedArg = gp.exportGlb.mock.calls[0]?.[3];
+    expect(isolatedArg).toBeInstanceOf(Uint32Array);
+    expect(Array.from(isolatedArg as Uint32Array)).toEqual([42, 43]);
+  });
+
+  it('rejects before calling gp.exportGlb when the filter matches nothing', async () => {
+    stubExit();
+    const out = outFile('zero-match.glb');
+
+    await expect(
+      exportRustFormat('glb', ['--out', out], FAKE_STORE, SAMPLE_IFC, [], true, false),
+    ).rejects.toThrow(ProcessExited);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Filter matched 0 entities'),
+    );
+    expect(gp.exportGlb).not.toHaveBeenCalled();
+  });
+});
+
+describe('exportRustFormat: `isolated` argument passed to gp.exportObj (the OBJ twin, #4386)', () => {
+  it('passes `undefined` (not an empty Uint32Array) when no filter was requested', async () => {
+    gp.exportObj.mockReturnValue(new TextEncoder().encode('o Wall\n'));
+    const out = outFile('no-filter.obj');
+
+    await exportRustFormat('obj', ['--out', out], FAKE_STORE, SAMPLE_IFC, [], false, false);
+
+    expect(gp.exportObj).toHaveBeenCalledTimes(1);
+    const isolatedArg = gp.exportObj.mock.calls[0]?.[3];
+    expect(isolatedArg).toBeUndefined();
+  });
+
+  it('passes a real Uint32Array of matched expressIds when a filter matches', async () => {
+    gp.exportObj.mockReturnValue(new TextEncoder().encode('o Wall\n'));
+    const out = outFile('filtered.obj');
+
+    await exportRustFormat('obj', ['--out', out], FAKE_STORE, SAMPLE_IFC, REFS, true, false);
+
+    expect(gp.exportObj).toHaveBeenCalledTimes(1);
+    const isolatedArg = gp.exportObj.mock.calls[0]?.[3];
+    expect(isolatedArg).toBeInstanceOf(Uint32Array);
+    expect(Array.from(isolatedArg as Uint32Array)).toEqual([42, 43]);
+  });
+
+  it('rejects before calling gp.exportObj when the filter matches nothing', async () => {
+    stubExit();
+    const out = outFile('zero-match.obj');
+
+    await expect(
+      exportRustFormat('obj', ['--out', out], FAKE_STORE, SAMPLE_IFC, [], true, false),
+    ).rejects.toThrow(ProcessExited);
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining('Filter matched 0 entities'),
+    );
+    expect(gp.exportObj).not.toHaveBeenCalled();
+  });
+});
+
+describe('exportRustFormat: whole-model formats never gate on filterRequested', () => {
+  it('ifcx ignores a filter (wholeModelFormat=true) and never calls exportObj/exportGlb', async () => {
+    gp.exportIfcx.mockReturnValue(new Uint8Array([1]));
+    const out = outFile('whole.ifcx');
+
+    await exportRustFormat('ifcx', ['--out', out], FAKE_STORE, SAMPLE_IFC, REFS, true, true);
+
+    expect(gp.exportIfcx).toHaveBeenCalledTimes(1);
+    expect(gp.exportGlb).not.toHaveBeenCalled();
+    expect(gp.exportObj).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`packages/cli/src/commands/export-rust-formats.ts` (`exportRustFormat`) had **zero direct test coverage** — no file imported it. `export.zero-match.test.ts` drives it indirectly through `exportCommand` over the real wasm boundary, but only observes success/failure, never the actual argument this module hands across the `GeometryProcessor` boundary. That blind spot is exactly what let the regression in #4364/#4386 ship: this file briefly passed an explicit empty `Uint32Array` to mean "no filter" under the wasm boundary's new convention (`undefined` = no filter, empty = active filter matching nothing), making every plain `ifc-lite export --format glb`/`obj` (no `--type`) fail with a misleading "GLB export produced 0 meshes" error. Nothing in the CLI suite caught it, and the MCP suite mocks the same boundary without asserting on it (also fixed in #4364/#4386).

**Stacked on #4386** (`fix-obj-isolation-empty-match`), which is itself stacked on #4364 (`fix-4328-glb-isolation-empty-match`) — both still open at the time of writing. I branched from #4386's head so these tests exercise the already-fixed `filterActive ? isolated : undefined` shape for both GLB and OBJ. This PR adds test files plus one changeset; it does not touch any line #4364/#4386 own.

- `packages/cli/src/commands/export-rust-formats.test.ts` (new): mocks `GeometryProcessor` (mirroring `packages/mcp/src/tools/export-init-dispose.test.ts`'s pattern) and asserts on `mock.calls[N][3]` — the actual `isolated` argument — for `exportGlb` and `exportObj` across all three states: no filter → `undefined`; a filter that matches → a real `Uint32Array` of matched expressIds; a filter that matches nothing → rejects with "Filter matched 0 entities" *before* the exporter is ever called. Also covers that a whole-model format (`ifcx`) never gates on `filterRequested`.
- `.changeset/export-rust-formats-isolation-coverage.md`: patch changeset for `@ifc-lite/cli`.

## Revert-proof (each assertion reddens for the right reason)

Reverting either call site back to the pre-fix shape (`gp.exportGlb(bytes, false, new Uint32Array(), isolated, '')` / `gp.exportObj(bytes, true, new Uint32Array(), isolated)`, dropping `filterActive ? isolated : undefined`) reddens **exactly** the two "no filter" tests:

```
AssertionError: expected Uint32Array[] to be undefined
 FAIL  ... > passes `undefined` (not an empty Uint32Array) when no filter was requested
 FAIL  ... > passes `undefined` (not an empty Uint32Array) when no filter was requested
Tests  2 failed | 5 passed (7)
```

Disabling the zero-match guard (`if (false && filterActive && isolated.length === 0)`) reddens **exactly** the two "matches nothing" tests:

```
AssertionError: promise resolved "undefined" instead of rejecting
 FAIL  ... > rejects before calling gp.exportGlb when the filter matches nothing
 FAIL  ... > rejects before calling gp.exportObj when the filter matches nothing
Tests  2 failed | 5 passed (7)
```

Both mutations reverted; suite is green (7/7) at HEAD.

## CI note

`test.yml` triggers only on `pull_request: branches: [main]`, so this stacked PR gets none of its real CI lanes until #4364/#4386 merge to `main` and this rebases onto it. Please treat CI as not-yet-run rather than passing.

## Test plan

- [x] `packages/cli`: new `export-rust-formats.test.ts` — 7/7 pass
- [x] Revert-proof above for both mutated call sites
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget
- Pre-existing, unrelated failures in the wider `packages/cli` suite: a stale `@ifc-lite/codegen` dist (`Cannot find package '@ifc-lite/codegen/ifc4'`) blocks ~52 suites including `clash.test.ts`/`gym.test.ts` in this sandbox — reproduces on plain `upstream/main`/the base branch, unrelated to this change; the new test file mocks around the boundary entirely and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
