### PR TITLE
fix(cache): validate embedded GLB image MIME signatures

### DIFF
--- a/.changeset/glb-encoded-image-signatures.md
+++ b/.changeset/glb-encoded-image-signatures.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Reject embedded GLB images whose PNG/JPEG signature disagrees with their declared MIME type, preventing transparent PNG data from bypassing JPEG opacity handling.

--- a/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.glbTextures.test.tsx
@@ -8,14 +8,15 @@ import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useViewerStore } from '@/store';
 import { modelAppearanceAssets } from '@/lib/appearance/model-assets.js';
+import { prepareGlbViewerModel } from './ingest/glbTextureValidation.js';
 import { useIfcLoader } from './useIfcLoader.js';
 
 // Real PNG and GLB framing; only the browser image decoder/canvas are replaced.
 const png = new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLbtAAAAABJRU5ErkJggg==','base64'));
-function fixture(): File {
+function fixture(mimeType = 'image/png', image = png): File {
   const positions=new Float32Array([0,0,0,1,0,0,0,1,0]); const uv=new Float32Array([0,0,1,0,0,1]);
-  const data=new Uint8Array(positions.byteLength+uv.byteLength+png.length);data.set(new Uint8Array(positions.buffer));data.set(new Uint8Array(uv.buffer),positions.byteLength);data.set(png,positions.byteLength+uv.byteLength);
-  const json={asset:{version:'2.0'},nodes:[{mesh:0,extras:{expressId:42}}],meshes:[{primitives:[{attributes:{POSITION:0,TEXCOORD_0:1},material:0}]}],materials:[{pbrMetallicRoughness:{baseColorTexture:{index:0}}}],textures:[{source:0}],images:[{mimeType:'image/png',bufferView:2}],buffers:[{byteLength:data.length}],bufferViews:[{buffer:0,byteLength:positions.byteLength},{buffer:0,byteOffset:positions.byteLength,byteLength:uv.byteLength},{buffer:0,byteOffset:positions.byteLength+uv.byteLength,byteLength:png.length}],accessors:[{bufferView:0,componentType:5126,count:3,type:'VEC3'},{bufferView:1,componentType:5126,count:3,type:'VEC2'}]};
+  const data=new Uint8Array(positions.byteLength+uv.byteLength+image.length);data.set(new Uint8Array(positions.buffer));data.set(new Uint8Array(uv.buffer),positions.byteLength);data.set(image,positions.byteLength+uv.byteLength);
+  const json={asset:{version:'2.0'},nodes:[{mesh:0,extras:{expressId:42}}],meshes:[{primitives:[{attributes:{POSITION:0,TEXCOORD_0:1},material:0}]}],materials:[{pbrMetallicRoughness:{baseColorTexture:{index:0}}}],textures:[{source:0}],images:[{mimeType,bufferView:2}],buffers:[{byteLength:data.length}],bufferViews:[{buffer:0,byteLength:positions.byteLength},{buffer:0,byteOffset:positions.byteLength,byteLength:uv.byteLength},{buffer:0,byteOffset:positions.byteLength+uv.byteLength,byteLength:image.length}],accessors:[{bufferView:0,componentType:5126,count:3,type:'VEC3'},{bufferView:1,componentType:5126,count:3,type:'VEC2'}]};
   const text=new TextEncoder().encode(JSON.stringify(json));const textLength=Math.ceil(text.length/4)*4,binLength=Math.ceil(data.length/4)*4;const bytes=new Uint8Array(28+textLength+binLength);const view=new DataView(bytes.buffer);view.setUint32(0,0x46546c67,true);view.setUint32(4,2,true);view.setUint32(8,bytes.length,true);view.setUint32(12,textLength,true);view.setUint32(16,0x4e4f534a,true);bytes.fill(32,20,20+textLength);bytes.set(text,20);view.setUint32(20+textLength,binLength,true);view.setUint32(24+textLength,0x004e4942,true);bytes.set(data,28+textLength);return new File([bytes],'capture.glb');
 }
 class OpaqueCanvas {
@@ -72,4 +73,23 @@ it('#4380 a superseded pending image decode cannot replace the newer GLB or repo
     });
     const models=[...useViewerStore.getState().models.values()];assert.equal(models.length,1);assert.equal(models[0].loadState,'complete');assert.ok(models[0].geometryResult?.meshes[0].textureBitmap);assert.equal(useViewerStore.getState().error,null);assert.equal(closed,1,'only stale decoder result is closed');
   } finally {await act(async()=>root.unmount());host.remove();}
+});
+
+
+it('#4380 rejects a transparent PNG declared as JPEG before opacity fast-path or asset decode', async () => {
+  // Real one-pixel RGBA PNG with alpha=0; its GLB MIME intentionally lies.
+  const transparent = new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DAAAAEAQEARwbK3gAAAABJRU5ErkJggg==', 'base64'));
+  let decodes = 0;
+  Object.defineProperty(globalThis, 'createImageBitmap', { configurable: true, writable: true, value: async () => {
+    decodes++; return { width: 1, height: 1, close() {} };
+  } });
+  Object.defineProperty(globalThis, 'OffscreenCanvas', { configurable: true, writable: true, value: class {
+    constructor() { throw new Error('A forged JPEG currently skips opacity readback'); }
+  } });
+  const lease = modelAppearanceAssets.begin('forged-jpeg');
+  try {
+    await assert.rejects(prepareGlbViewerModel(await fixture('image/jpeg', transparent).arrayBuffer(),
+      archive => lease.decode(archive), () => false), /image.*signature.*MIME/i);
+    assert.equal(decodes, 0, 'Cache boundary rejects before image resource allocation');
+  } finally { lease.cancel(); }
 });

--- a/packages/cache/README.md
+++ b/packages/cache/README.md
@@ -149,7 +149,9 @@ texture references, node TRS/matrices and mirrored winding. UV vertices remain
 separate across seams. Node translation stays in the double-precision `origin`.
 Use `parseGLBImageResources(parsed.json, parsed.bin)` to obtain original encoded
 PNG/JPEG images keyed by each mesh's `textureRef.url`. Decode these at the host
-boundary; this package never allocates browser image objects.
+boundary; this package never allocates browser image objects. Embedded PNG/JPEG
+magic bytes must match the declared MIME type before geometry or resources are
+returned; MIME labels cannot bypass the host opacity checks.
 
 This is opaque captured-albedo import. Embedded base-colour PNG/JPEG images and
 repeat/clamp samplers are supported. External images/buffers, other UV sets,

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -6,11 +6,10 @@ import { parseGLBToMeshData } from './glb.js';
 import { parseGLBImageResources } from './glb-images.js';
 import type { GLTFDocument } from './glb-types.js';
 
-function capture(): { json: GLTFDocument; bin: Uint8Array } {
+function capture(png = new Uint8Array([137,80,78,71,13,10,26,10])): { json: GLTFDocument; bin: Uint8Array } {
   // Two triangles duplicate the shared geometric corner with distinct UVs: an atlas seam.
   const positions = new Float32Array([0,0,0, 1,0,0, 0,1,1, 0,0,0, 0,1,1, -1,0,0]);
   const uvs = new Float32Array([0,0, 0.5,0, 0.5,1, 1,0, 1,1, 0.5,0]);
-  const png = new Uint8Array([137,80,78,71,13,10,26,10]);
   const bin = new Uint8Array(positions.byteLength + uvs.byteLength + png.byteLength);
   bin.set(new Uint8Array(positions.buffer)); bin.set(new Uint8Array(uvs.buffer), positions.byteLength); bin.set(png, positions.byteLength + uvs.byteLength);
   return { bin, json: {
@@ -54,6 +53,27 @@ describe('captured GLB appearance #4380', () => {
     delete json.materials![0].alphaMode; json.samplers=[{wrapS:33648}];json.textures![0].sampler=0;expect(()=>parseGLBToMeshData(json,bin)).toThrow(/mirrored/);
     delete json.textures![0].sampler;json.extensionsRequired=['KHR_draco_mesh_compression'];expect(()=>parseGLBToMeshData(json,bin)).toThrow(/required extension/);
     delete json.extensionsRequired;json.bufferViews![2].byteLength=bin.length;expect(()=>parseGLBImageResources(json,bin)).toThrow(/exceeds/);
+  });
+  it('rejects mismatched MIME/signatures before geometry or resource copying', () => {
+    const png = new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DAAAAEAQEARwbK3gAAAABJRU5ErkJggg==', 'base64'));
+    const {json,bin} = capture(png);
+    expect(parseGLBImageResources(json,bin).get('textures/glb-image-0.png')).toEqual(png);
+    json.images![0].mimeType='image/jpeg';
+    expect(()=>parseGLBToMeshData(json,bin)).toThrow(/signature.*MIME/);
+    expect(()=>parseGLBImageResources(json,bin)).toThrow(/signature.*MIME/);
+    for (const bytes of [new Uint8Array([137,80,78]), new Uint8Array([255,216,0])]) {
+      const invalid=capture(bytes);
+      expect(()=>parseGLBImageResources(invalid.json,invalid.bin)).toThrow(/signature.*MIME/);
+    }
+  });
+  it('retains a genuine encoded JPEG and rejects it when declared PNG', () => {
+    const jpeg = new Uint8Array(Buffer.from('/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAIDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDx/9k=', 'base64'));
+    const {json,bin}=capture(jpeg); json.images![0].mimeType='image/jpeg';
+    const [mesh]=parseGLBToMeshData(json,bin);
+    expect(parseGLBImageResources(json,bin).get(mesh.textureRef!.url)).toEqual(jpeg);
+    expect(mesh.textureRef!.url).toMatch(/\.jpg$/);
+    json.images![0].mimeType='image/png';
+    expect(()=>parseGLBImageResources(json,bin)).toThrow(/signature.*MIME/);
   });
   it('bounds deep scene walks without consuming the call stack', () => {
     const {json,bin}=capture(); const leaf=json.nodes![0];json.nodes=Array.from({length:12000},(_,i)=>i===11999?leaf:{children:[i+1]});json.scenes=[{nodes:[0]}];

--- a/packages/cache/src/glb-images.ts
+++ b/packages/cache/src/glb-images.ts
@@ -29,6 +29,12 @@ function imageResources(gltf: GLTFDocument, bin: Uint8Array, copy: boolean): Map
     if (!view || view.buffer !== 0 || length === undefined || !Number.isSafeInteger(start) || !Number.isSafeInteger(length) || start < 0 || length <= 0 || start + length > bin.byteLength) {
       throw new Error('GLB: image buffer view exceeds the embedded buffer');
     }
+    // The host can skip alpha readback for JPEG paths only when the encoded
+    // payload really is JPEG. Do not derive that guarantee from untrusted MIME.
+    const signature = image.mimeType === 'image/png' ? [137,80,78,71,13,10,26,10] : [255,216,255];
+    if (length < signature.length || signature.some((value, offset) => bin[start + offset] !== value)) {
+      throw new Error('GLB: image signature does not match its declared MIME type');
+    }
     total += length;
     if (resources.size >= 256 || total > 256 * 1024 * 1024) throw new Error('GLB: embedded images exceed the 256-image / 256 MiB limit');
     resources.set(path, copy ? bin.slice(start, start + length) : bin.subarray(start, start + length));


### PR DESCRIPTION
Refs #4380

A GLB could label embedded transparent PNG bytes as `image/jpeg`. The cache then gave the resource a `.jpg` path, while the image inventory decoded its actual PNG bytes; the viewer's JPEG opacity fast path consequently skipped the alpha check. Reject PNG/JPEG signature and MIME mismatches at the headless cache boundary before resource copies or browser decoding. Legitimate JPEGs keep the existing fast path.

The regression passes a real one-pixel transparent PNG declared as JPEG through `prepareGlbViewerModel` and the actual image inventory. Before the fix the expected refusal was absent (two existing tests passed, the new test failed); after the fix all three pass with zero skips. Cache tests also check genuine JPEG byte retention, both mismatch directions and truncated signatures.

Validation: full root build (51 tasks), root typecheck (1894 test sources), cache suite (188 passed, one existing optional fixture skip), canonical viewer GLB tests (3 passed), documentation samples (383), API snapshot and changeset checks. Cache patch changeset and package documentation are included. Issue #4380 remains open for integrated capture acceptance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded GLB PNG and JPEG images are now validated against their declared MIME types.
  * Invalid, mismatched, or truncated image data is rejected before processing, preventing incorrect opacity handling.

* **Documentation**
  * Updated cache documentation to describe embedded image validation and supported encoded formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->