### PR TITLE
fix(geometry): close the Path::exists()-gated vacuous-skip variant in rust/geometry tests

### DIFF
--- a/rust/geometry/tests/cdt_volume_watertight_verify.rs
+++ b/rust/geometry/tests/cdt_volume_watertight_verify.rs
@@ -13,6 +13,8 @@
 // box-minus-opening volume, and the #1112 roof host against a self-consistency
 // volume + watertight + rim-tear check.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
@@ -35,12 +37,30 @@ fn build_void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
     void_index
 }
 
-fn process(path: &str, host_id: u32) -> Option<Mesh> {
-    if !std::path::Path::new(path).exists() {
-        eprintln!("skipping: fixture {path} not present");
-        return None;
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally.
+fn read_fixture(path: &str) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {path} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            eprintln!("skipping: fixture {path} not present");
+            None
+        }
+        Err(e) => panic!("fixture {path} exists but could not be read: {e}"),
     }
-    let content = std::fs::read_to_string(path).ok()?;
+}
+
+fn process(path: &str, host_id: u32) -> Option<Mesh> {
+    let content = read_fixture(path)?;
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
     let router = GeometryRouter::with_units(&content, &mut decoder);

--- a/rust/geometry/tests/door_window_calibration_regression.rs
+++ b/rust/geometry/tests/door_window_calibration_regression.rs
@@ -31,8 +31,33 @@
 //! This test pins both halves of the finding so any future regression of
 //! the unit-scale pathway or the per-element placement chain is caught.
 
+mod support;
+
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
+
+/// `true` when the fixture at `path` is readable; `false` only for a
+/// genuinely absent file (`NotFound`), which is a legitimate skip unless
+/// `IFC_LITE_REQUIRE_FIXTURES=1`, in which case it panics naming the path.
+/// Any other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally. This attempts the read (rather than
+/// `Path::exists()`) because `exists()` collapses a permission error into
+/// `false` just like a genuinely absent file, and is a TOCTOU check besides
+/// — each caller performs the real read moments later.
+fn fixture_present(path: &str) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {path} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            false
+        }
+        Err(e) => panic!("fixture {path} exists but could not be read: {e}"),
+    }
+}
 
 fn bbox(positions: &[f32]) -> Option<((f32, f32, f32), (f32, f32, f32))> {
     if positions.is_empty() {
@@ -64,7 +89,7 @@ fn approx(a: f32, b: f32, tol: f32) -> bool {
 #[test]
 fn advanced_model_door_world_bbox_matches_ios_in_metres() {
     let path = "../../tests/models/ara3d/advanced_model.ifc";
-    if !std::path::Path::new(path).exists() {
+    if !fixture_present(path) {
         eprintln!("skipping: fixture missing at {path}");
         return;
     }
@@ -110,7 +135,7 @@ fn advanced_model_door_world_bbox_matches_ios_in_metres() {
 #[test]
 fn duplex_m_fixed_window_world_bbox_matches_ios() {
     let path = "../../tests/models/ara3d/duplex.ifc";
-    if !std::path::Path::new(path).exists() {
+    if !fixture_present(path) {
         eprintln!("skipping: fixture missing at {path}");
         return;
     }

--- a/rust/geometry/tests/issue_604_door_regression.rs
+++ b/rust/geometry/tests/issue_604_door_regression.rs
@@ -25,7 +25,6 @@ mod voids_common;
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::GeometryRouter;
 use rustc_hash::FxHashMap;
-use std::path::Path;
 use voids_common::production::fold_origin;
 
 const FIXTURE: &str = "../../tests/models/various/issue-604-door.ifc";
@@ -44,20 +43,32 @@ const WALL_ID: u32 = 55;
 const OPENING_ID: u32 = 2438;
 const DOOR_ID: u32 = 2390;
 
+/// Load the fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path. Any other `io::Error` (permission denied, corrupt read, ...)
+/// means the environment is broken rather than merely missing an optional
+/// download, so it panics unconditionally. This attempts the read directly
+/// (rather than checking `Path::exists()` first) because `exists()`
+/// collapses a permission error into `false` just like a genuinely absent
+/// file, and a separate check-then-read is a TOCTOU race besides.
 fn read_fixture() -> Option<String> {
-    if !Path::new(FIXTURE).exists() {
-        assert!(
-            !support::require_fixtures(),
-            "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
-             run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
-        );
-        eprintln!(
-            "skipping issue-604 regression: fixture missing at {FIXTURE} — \
-             run `pnpm fixtures` from the repo root to download it",
-        );
-        return None;
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1 -- \
+                 run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            eprintln!(
+                "skipping issue-604 regression: fixture missing at {FIXTURE} — \
+                 run `pnpm fixtures` from the repo root to download it",
+            );
+            None
+        }
+        Err(e) => panic!("fixture {FIXTURE} exists but could not be read: {e}"),
     }
-    std::fs::read_to_string(FIXTURE).ok()
 }
 
 /// Half (b) + (c) of #604 — verify door handle (`IfcSurfaceOfRevolution` +

--- a/rust/geometry/tests/mesh_welding_calibration.rs
+++ b/rust/geometry/tests/mesh_welding_calibration.rs
@@ -18,17 +18,37 @@
 //!      triangle-soup output existing GPU consumers expect — welding is
 //!      opt-in, never automatic.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::{GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 
 const DUPLEX: &str = "../../tests/models/ara3d/duplex.ifc";
 
-fn process(path: &str, element_id: u32) -> Option<Mesh> {
-    if !std::path::Path::new(path).exists() {
-        return None;
+/// Load a fixture, distinguishing a genuinely absent file from a broken
+/// read. `NotFound` is the fresh-clone case (`pnpm fixtures` not run yet):
+/// skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case panic naming
+/// the path, matching every other skip-on-missing test in this crate. Any
+/// other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally.
+fn read_fixture(path: &str) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(content) => Some(content),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {path} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            None
+        }
+        Err(e) => panic!("fixture {path} exists but could not be read: {e}"),
     }
-    let content = std::fs::read_to_string(path).ok()?;
+}
+
+fn process(path: &str, element_id: u32) -> Option<Mesh> {
+    let content = read_fixture(path)?;
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
     let router = GeometryRouter::with_units(&content, &mut decoder);

--- a/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
+++ b/rust/geometry/tests/polygonal_bounded_half_space_side_regression.rs
@@ -18,11 +18,36 @@
 //! 0.493 m bulk. IfcOpenShell (pip 0.8.2, use-world-coords) keeps the bulk:
 //! extent (4.201, 0.493, 2.795). Pin that.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder};
 use ifc_lite_geometry::{GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
 
 const FIXTURE: &str = "../../tests/models/ara3d/duplex.ifc";
+
+/// `true` when the fixture is readable; `false` only for a genuinely absent
+/// file (`NotFound`), which is a legitimate skip unless
+/// `IFC_LITE_REQUIRE_FIXTURES=1`, in which case it panics naming the path.
+/// Any other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally. This attempts the read (rather than
+/// `Path::exists()`) because `exists()` collapses a permission error into
+/// `false` just like a genuinely absent file, and is a TOCTOU check besides
+/// — `process` below performs the real read moments later.
+fn fixture_present() -> bool {
+    match std::fs::read_to_string(FIXTURE) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {FIXTURE} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
+            false
+        }
+        Err(e) => panic!("fixture {FIXTURE} exists but could not be read: {e}"),
+    }
+}
 
 fn bbox_extent(p: &[f32]) -> (f32, f32, f32) {
     let mut mn = (f32::INFINITY, f32::INFINITY, f32::INFINITY);
@@ -58,7 +83,7 @@ fn process(id: u32) -> Mesh {
 
 #[test]
 fn party_wall_polygonal_clip_keeps_material_side() {
-    if !std::path::Path::new(FIXTURE).exists() {
+    if !fixture_present() {
         eprintln!("skipping: fixture {FIXTURE} not present — run `pnpm fixtures` to download");
         return;
     }

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -127,6 +127,8 @@ mod census_golden;
 #[path = "census_rtc/mod.rs"]
 mod census_rtc;
 
+mod support;
+
 use census_golden::{is_closed_solid, totals, Delta, HostRow, PreVoid};
 use census_rtc::ModelFrame;
 use ifc_lite_core::{EntityDecoder, EntityScanner};
@@ -2169,6 +2171,30 @@ fn the_heavy_golden_pins_the_known_3435_tear_population() {
     }
 }
 
+/// `true` when the fixture at `path` is readable; `false` only for a
+/// genuinely absent file (`NotFound`), which is a legitimate skip unless
+/// `IFC_LITE_REQUIRE_FIXTURES=1`, in which case it panics naming the path.
+/// Any other `io::Error` (permission denied, corrupt read, ...) means the
+/// environment is broken rather than merely missing an optional download,
+/// so it panics unconditionally. This attempts the read (rather than
+/// `Path::exists()`) because `exists()` collapses a permission error into
+/// `false` just like a genuinely absent file, and is a TOCTOU check besides
+/// — each caller performs the real read moments later.
+fn oracle_fixture_present(path: &std::path::Path) -> bool {
+    match std::fs::read_to_string(path) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                path.display()
+            );
+            false
+        }
+        Err(e) => panic!("fixture {} exists but could not be read: {e}", path.display()),
+    }
+}
+
 // #3925: independent IfcOpenShell 0.8.2 volume is 0.03938 m³. The old
 // unre-based census collapsed corners and pinned approximately 0.03844 m³.
 #[cfg(not(any(feature = "csg_topology_gate", feature = "csg_manifold_gate")))]
@@ -2177,7 +2203,7 @@ fn census_rebases_real_covering_before_f32_geometry_3925() {
     let _serial = CENSUS_SWEEP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     set_alt(false);
     let path = crate_dir().join("../../tests/models/various/rvt01.ifc");
-    if !path.exists() {
+    if !oracle_fixture_present(&path) {
         eprintln!("Skipping #3925 covering oracle: run pnpm fixtures");
         return;
     }
@@ -2198,7 +2224,7 @@ fn repaired_office_covering_matches_independent_solid_3925() {
     let _serial = CENSUS_SWEEP_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     set_alt(false);
     let path = crate_dir().join("../../tests/models/ara3d/S_Office_Integrated Design Archi.ifc");
-    if !path.exists() {
+    if !oracle_fixture_present(&path) {
         eprintln!("Skipping #3925 office oracle: run pnpm fixtures");
         return;
     }

--- a/rust/geometry/tests/wall_opening_cut_regression.rs
+++ b/rust/geometry/tests/wall_opening_cut_regression.rs
@@ -25,6 +25,8 @@
 //! once each defect is fixed its `#[ignore]` should be removed and the
 //! assertions tightened to match IOS.
 
+mod support;
+
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
 use rustc_hash::FxHashMap;
@@ -119,6 +121,10 @@ fn fixture_present() -> bool {
     match std::path::Path::new(FIXTURE).try_exists() {
         Ok(true) => true,
         Ok(false) => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture {FIXTURE} not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)"
+            );
             eprintln!(
                 "skipping: fixture {} not present — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
                 FIXTURE,


### PR DESCRIPTION
## Summary

#4365 made `IFC_LITE_REQUIRE_FIXTURES` load-bearing for 19 `rust/geometry` tests whose skip-on-missing branch matched a `NotFound` `match` arm. #4395 closed a second shape — a `.ok()`-collapsing helper that folded every `io::Error` (not just `NotFound`) into a silent skip. #4395's PR body named five `Path::exists()`-gated files as a candidate follow-up it deliberately left unfixed, to keep its own diff mechanical. This PR closes that third shape.

## Enumeration

I re-derived the file list by grepping `rust/geometry/tests` for `.exists()` / `try_exists()` and checking each call site (15 files matched), then classifying each:

**Fixed (7 files, all now vacuous-proof):**
- `mesh_welding_calibration.rs`, `cdt_volume_watertight_verify.rs`, `polygonal_bounded_half_space_side_regression.rs` — bare `Path::exists()` gate, no `IFC_LITE_REQUIRE_FIXTURES` check at all.
- `door_window_calibration_regression.rs` (2 tests), `triangulation_invariance.rs` (2 tests) — same bare-`exists()`-no-flag shape.
- `wall_opening_cut_regression.rs` — already used `try_exists()` with a correct `NotFound`-vs-other split, but never checked the flag at all (an absent fixture skipped silently even with `IFC_LITE_REQUIRE_FIXTURES=1`).
- `issue_604_door_regression.rs` — already fixed by #4365 for the `NotFound` branch (asserts `!support::require_fixtures()`), but the `Ok`/non-`NotFound` path fell through to a bare `std::fs::read_to_string(FIXTURE).ok()`, which still silently skips on a broken read (e.g. permission error, corrupt file) regardless of the flag. This is exactly the #4395 defect class, just reached through an `exists()`-shaped guard instead of a `.ok()`-shaped helper.

**Named by #4395 but not applicable:**
- `rect_param_census.rs` was named in #4395's list, but its only non-`#[ignore]`d test, `parametric_rect_census`, is itself `#[ignore = "phase-0 census -- run explicitly with MEASURE_FIXTURE"]` — excluded from the default run by construction, same category #4365 already carved out. Left unchanged. (`rect_param_parity.rs` and `rect_param_production.rs`, the same file's siblings by shape, are `#[ignore]`d the same way.)

**Found, but a different gap — not fixed here (kept the diff mechanical, matching #4395's own restraint):**
- `issue_068_void_ordering_probe.rs`, `issue_3435_classify_probe.rs` — already use `try_exists()` with a correct `NotFound`-vs-other-`io::Error` split (their own doc comments spell out the same "exists() collapses a permission error into false" reasoning this PR uses). Their gap is different: neither ever checks `IFC_LITE_REQUIRE_FIXTURES`, so a missing fixture always skips regardless of the flag. That's a deliberate design choice per their doc comment ("An absent fixture must SKIP, never panic (AGENTS.md)"), not an unsound gate — opting them into the strict-CI flag is a policy decision, not a mechanical fix of the class this PR targets.
- `geometry_correctness_harness.rs` — a different shape entirely: an N-fixture census harness with a documented per-fixture soft-pass contract ("Missing fixtures are skipped — no snapshot is asserted for them... in CI the full manifest set is vendored"). If every fixture in `FIXTURES` were absent, its aggregate invariants would trivially pass. Fixing this requires a harness-level design decision (per-fixture panic vs. an aggregate "N missing under the flag" check), not the single-test-skip mechanical fix applied elsewhere. Flagging as a follow-up.
- `clash_intersection_real_model.rs`'s `model_path()` uses `.find(|p| p.exists())` over two candidate paths, but the test itself is `#[ignore]`d (excluded from the default run by construction).
- `issue_1007_real_opening_no_bridge.rs` is in #4395's own diff (open) — not touched here to avoid overlap.

## The fix

Each fixed helper now attempts the read directly and matches on `io::Error::kind()`, reusing `rust/geometry/tests/support::require_fixtures()` (already present, used by #4395):
- `NotFound`: skip unless `IFC_LITE_REQUIRE_FIXTURES=1`, in which case `assert!(!support::require_fixtures(), ...)` panics naming the path — #4365's convention.
- any other `io::Error` (permission denied, corrupt read, `IsADirectory`, ...): panics unconditionally, **regardless of the flag** — #4395's established split. A fixture that exists but can't be read means the environment is broken, not that an optional download was skipped.

This also closes the TOCTOU window a separate `exists()`-then-`read` gate leaves open (the file can vanish or change between the check and the read) — the fix attempts the read once and classifies the result, rather than checking presence and reading again.

## Verification

All against a scratch worktree cloned fresh from `LTplus-AG/ifc-lite` (`origin`, not a fork), rebased onto `upstream/main` immediately before pushing, with the real fixture corpus available via a local, read-only reference (not committed) and a private `CARGO_TARGET_DIR`.

**RED/GREEN per file** (fixture hidden via a per-file symlink farm — the real corpus was never mutated, verified with `ls -la` on the real path after every hide), `IFC_LITE_REQUIRE_FIXTURES=1`:

- `mesh_welding_calibration.rs` — RED: `test result: ok. 3 passed; 0 failed`. GREEN: all 3 panic — `fixture ../../tests/models/ara3d/duplex.ifc not present and IFC_LITE_REQUIRE_FIXTURES=1 -- run \`pnpm fixtures\` to download`.
- `cdt_volume_watertight_verify.rs` — RED: `2 passed; 0 failed`. GREEN: `box_opening_wall_555082_volume_and_watertight` panics naming `advanced_model.ifc`; `roof_1112_...` (different fixture, still present) stays `ok`.
- `polygonal_bounded_half_space_side_regression.rs` — RED: `1 passed; 0 failed`. GREEN: panics naming `duplex.ifc`.
- `door_window_calibration_regression.rs` — RED: `2 passed; 0 failed` (both `advanced_model.ifc` and `duplex.ifc` hidden). GREEN: both panic, each naming its own path.
- `triangulation_invariance.rs` — RED: `2 passed; 0 failed` (`rvt01.ifc` and `S_Office_Integrated Design Archi.ifc` hidden). GREEN: both panic, each naming its own path.
- `wall_opening_cut_regression.rs` — RED: `7 passed; 0 failed`. GREEN: all 7 panic naming `advanced_model.ifc`.
- `issue_604_door_regression.rs` — the `NotFound` branch was unchanged (already correct from #4365; reconfirmed: `absent+flag` panics, `absent+unset` skips). The **fixed** gap: with the fixture path replaced by a directory (`Is a directory (os error 21)`) and the flag **unset**, the pre-fix code (bare `.ok()` after the `exists()` check) reported `ok. 3 passed; 0 failed`; the fixed code panics on all 3 — `fixture .../issue-604-door.ifc exists but could not be read: Is a directory (os error 21)`.

**Four combinations**, all 7 files, run together (`--no-fail-fast`):
- present + flag set → 20/20 tests pass.
- present + flag unset → 20/20 tests pass.
- **absent + flag set → all 6 binaries `FAILED`** (17 tests fail, each panic naming the missing path; `cdt_volume_watertight_verify`'s unrelated `roof_1112` test, whose own fixture stayed present, is the one pass in that binary).
- absent + flag unset → all 6 binaries report `ok`, no `FAILED`, unchanged fresh-clone skip behaviour.

**Non-`NotFound` I/O error**: demonstrated on `issue_604_door_regression.rs` by replacing the fixture path with a directory (see above) — confirmed pre-fix silent `ok`, post-fix unconditional panic, independent of the flag.

**Mutation test** (`mesh_welding_calibration.rs`): replaced the `assert!(!support::require_fixtures(), ...)` guard with `if support::require_fixtures() { eprintln!("MUTATION-MARKER: guard removed, this line ran"); }`. With `duplex.ifc` hidden and the flag set: `MUTATION-MARKER: guard removed, this line ran` printed 3 times (once per test) and the suite still reported `ok. 3 passed; 0 failed` — confirming both that the guard is load-bearing and that the mutated branch actually executed. Reverted before committing (diffed clean against the committed version).

**Full-crate regression**, `rust/geometry`, both before and after rebasing onto a freshly-fetched `main`:
- `IFC_LITE_REQUIRE_FIXTURES=1`, full fixture corpus: **1286 passed, 0 failed**.
- unset, full fixture corpus: **1286 passed, 0 failed**.

Identical to each other and to #4365/#4395's own recorded baseline — confirms no assertion changed, only the enforcement path.

**Clippy** (`cargo clippy -p ifc-lite-geometry --tests --all-targets -- -D warnings`): clean.

**Module-size gate** (unpiped): `node scripts/check-module-size.mjs > /tmp/ms.txt 2>&1; echo "EXIT=$?"` → `EXIT=0`, `check-module-size: OK (2631 files measured, 330 allowlisted, 0 new over 400)`.

**Rust ratchet** (`cargo test -p ifc-lite-processing --test module_size_ratchet`): `6 passed; 0 failed` — confirmed rather than assumed that the touched `tests/*.rs` files are exempt by the gate's own rule.

## Not changed

- `rect_param_census.rs` (named by #4395, but `#[ignore]`d — not applicable).
- `issue_068_void_ordering_probe.rs`, `issue_3435_classify_probe.rs` — already correct `NotFound`-vs-other split via `try_exists()`; missing only the optional strict-CI flag, a policy question rather than an unsound gate. Flagging as a candidate follow-up, the same restraint #4395 exercised on this PR's own targets.
- `geometry_correctness_harness.rs` — a differently-shaped N-fixture soft-pass harness; needs a harness-level design decision, not this PR's mechanical fix. Flagging as a candidate follow-up.
- `clash_intersection_real_model.rs` — `#[ignore]`d, excluded from the default run by construction.
- `issue_1007_real_opening_no_bridge.rs` — touched by the still-open #4395; left alone to avoid overlap.

## Changeset

Not added. #4365 and #4395 — the direct predecessors for this exact class of change (`rust/geometry` test-file-only, no package version implication) — both shipped without one, and this PR follows that established precedent.

unqueued
