### PR TITLE
fix(geometry): close the vacuity gap in geometry_correctness_harness

### DIFF
--- a/rust/geometry/tests/geometry_correctness_harness.rs
+++ b/rust/geometry/tests/geometry_correctness_harness.rs
@@ -33,6 +33,18 @@
 //! belong in dedicated regression test files once their behaviour has
 //! been visually verified.
 //!
+//! That soft-pass is conditioned on `IFC_LITE_REQUIRE_FIXTURES` (see
+//! `tests/support::require_fixtures`): unset/`0` (local dev, fresh
+//! clone) skips a missing fixture exactly as before; `1` (the
+//! `csg-accept-gates` CI job) turns a missing fixture into a named
+//! `panic!` instead, so this 25-fixture census can't report `ok` having
+//! examined nothing — the failure mode issue #2802 named for the
+//! per-fixture skip-shaped tests applies just as much to a census that
+//! silently shrinks to zero. A non-`NotFound` I/O error (permission
+//! denied, a truncated download, …) always panics unconditionally,
+//! flag or not — that is a broken environment, not an absent optional
+//! download.
+//!
 //! **Snapshot baseline (insta):** every *present* fixture additionally
 //! pins its stable stats (mesh count, vertex/triangle totals, rounded
 //! bbox + surface area, per-type counts) as a named `insta` snapshot in
@@ -47,6 +59,8 @@
 //! Snapshots are pinned to the pure-Rust exact CSG kernel — the only
 //! kernel on every target since #1024, so they are asserted
 //! unconditionally.
+
+mod support;
 
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
 use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
@@ -387,13 +401,20 @@ fn run_fixture(fx: &Fixture) -> FixtureReport {
         ..Default::default()
     };
     let p = fixture_path(fx.path);
-    if !p.exists() {
-        return report;
-    }
-    report.fixture_found = true;
-    let Ok(content) = std::fs::read_to_string(&p) else {
-        return report;
+    let content = match std::fs::read_to_string(&p) {
+        Ok(content) => content,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            assert!(
+                !support::require_fixtures(),
+                "fixture missing and IFC_LITE_REQUIRE_FIXTURES=1: {} \
+                 — run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                p.display()
+            );
+            return report;
+        }
+        Err(err) => panic!("failed to read fixture {}: {err}", p.display()),
     };
+    report.fixture_found = true;
     let entity_index = build_entity_index(&content);
     let mut decoder = EntityDecoder::with_index(&content, entity_index);
     let router = GeometryRouter::with_units(&content, &mut decoder);


### PR DESCRIPTION
## Summary
- `geometry_correctness_harness` (the 25-fixture geometry census in `rust/geometry`) never consulted `IFC_LITE_REQUIRE_FIXTURES`. With zero fixtures found it printed `25 missing` in the summary and still reported `ok`, exactly the vacuous-pass shape #4365/#4395/#4398 have been closing elsewhere, even though `IFC_LITE_REQUIRE_FIXTURES=1` is set precisely to forbid it.
- Reuses `tests/support::require_fixtures()` (added by #4365 for this crate). Replaces the `Path::exists()`-then-`read_to_string` pair with a single read matched on `io::Error::kind()`: `NotFound` skips unless the flag is set, in which case it panics naming the missing path; any other I/O error panics unconditionally regardless of the flag.
- Everything else about the harness is untouched: the per-fixture soft-pass for a deliberately-partial corpus, the universal hard invariants (NaN/Inf, parse failures, empty-when-expected), and the insta snapshot baseline all behave exactly as before when fixtures are present.
- No changeset: #4365/#4395/#4398 shipped this change class without one, deliberately (test-only, no user-facing behavior).
- `unqueued`: found while auditing this harness for the same vacuous-pass pattern; not a `ready`-queue issue, no new issue opened per instructions.

## Test plan
- [x] RED (before fix, on `upstream/main`): moved `tests/models` away, ran with `IFC_LITE_REQUIRE_FIXTURES=1` — `summary: 25 fixtures, 25 missing, ...` then `test result: ok`.
- [x] GREEN (after fix): same setup now panics at the first missing fixture, naming its path, `test result: FAILED`.
- [x] Four combinations: present+flag → ok; present+unset → ok; absent+flag → panics naming the path; absent+unset → skips cleanly (`ok`, unchanged).
- [x] Mutation-marker: replaced the `assert!` guard with `eprintln!("MUTATION-MARKER: ...")`; confirmed it printed 25 times with `require_fixtures=true` while the suite still reported `ok`; restored the real guard.
- [x] Full `rust/geometry` crate regression against the complete 164-fixture corpus, both flag states, exit codes read unpiped: `1286 passed; 0 failed` for both `IFC_LITE_REQUIRE_FIXTURES` unset and `=1`.
- [x] `node scripts/check-module-size.mjs` (unpiped exit code): `check-module-size: OK (2635 files measured, 330 allowlisted, 0 new over 400)`, `EXIT=0`.
- [x] `cargo clippy -p ifc-lite-geometry --tests -- -D warnings`: clean, `EXIT=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)