### PR TITLE
feat(appearance): opt in to occurrence-local mapped tessellation

### DIFF
--- a/.changeset/evaluated-occurrence-appearance.md
+++ b/.changeset/evaluated-occurrence-appearance.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Add an explicit evaluated-occurrence policy to native image and PDF appearance planning for supported, uniquely owned mapped bodies. Preserve product identity and shared type graphs, and return conversion provenance in the same atomic appearance plan.

--- a/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+import type { AppearancePlan, AppearanceRequest } from './planner-types.js';
+
+test('real WASM preserves mapped occurrences unless explicitly opted in and composes finite PDF appearance (#4404)', async t => {
+  const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  const sourceUrl = new URL('../../../../../tests/models/ara3d/AC20-FZK-Haus.ifc', import.meta.url);
+  try { await Promise.all([access(wasmUrl), access(sourceUrl)]); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    t.skip('Run pnpm fixtures and pnpm build:wasm for the real evaluated appearance contract'); return;
+  }
+  const source = await readFile(sourceUrl);
+  const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: await readFile(wasmUrl) });
+  const api = new IfcAPI();
+  const request: AppearanceRequest = { schema: 'IFC4', sourceRevision: 'AC20-wasm', nextExpressId: 100_000,
+    productIds: [35169], imageUri: 'textures/evaluated.png', repeatS: true, repeatT: true,
+    mapping: { kind: 'box', frame: 'world', origin: [0, 0, 0], metresPerTile: [1, 1, 1] } };
+  try {
+    const preserved = JSON.parse(new TextDecoder().decode(api.planAppearance(source, JSON.stringify(request)))) as AppearancePlan;
+    assert.equal(preserved.items.length, 0); assert.equal(preserved.created.length, 0);
+    request.representationPolicy = 'evaluatedOccurrence';
+    const result = JSON.parse(new TextDecoder().decode(api.planAppearance(source, JSON.stringify(request)))) as AppearancePlan;
+    assert.equal(result.items.length, 1); assert.deepEqual(result.exclusions, []);
+    assert.equal(result.conversions?.[0].productId, 35169);
+    assert.equal(result.conversions?.[0].sourceGeometryItemId, 35135);
+    assert.equal(result.conversions?.[0].sourceIndices.length, 36);
+    assert.ok(result.edits.every(edit => edit.expressId === 35155));
+    assert.equal(result.items[0].geometryItemId, result.conversions?.[0].geometryItemId);
+    assert.throws(() => api.planAppearance(source, JSON.stringify({ ...request, representationPolicy: 'silentlyFlatten' })), /unknown variant/);
+  } finally { api.free(); }
+  const { runPageAppearancePlanning } = await import('../../workers/appearance.worker.js');
+  const page = await runPageAppearancePlanning(source, {
+    appearance: { ...request, repeatS: false, repeatT: false,
+      mapping: { kind: 'planar', frame: 'world', origin: [1, 6, 3], axisU: [0, 1, 0], axisV: [0, 0, 1], metresPerTile: [2, 2] } },
+    page: { width: 1, height: 1, byteOffset: 0, byteLength: 4 }, sourceImages: [], texelsPerMetre: 32,
+  }, new Uint8Array([255, 0, 0, 255]));
+  assert.equal(page.plan.conversions?.length, 1); assert.ok(page.assets.length > 0);
+  assert.ok(page.plan.edits.every(edit => edit.expressId === 35155));
+});

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -18,6 +18,8 @@ export type AppearanceMapping =
       axisU: [number, number, number]; axisV: [number, number, number]; metresPerTile: [number, number] }
   | { kind: 'box'; frame: 'item' | 'world'; origin: [number, number, number]; metresPerTile: [number, number, number] };
 export interface AppearanceRequest {
+  /** Explicit conversion consent; omitted preserves the existing direct-only policy. */
+  representationPolicy?: 'preserve' | 'evaluatedOccurrence';
   schema: 'IFC4' | 'IFC4X3';
   sourceRevision: string;
   nextExpressId: number;
@@ -28,6 +30,9 @@ export interface AppearanceRequest {
   mapping: AppearanceMapping;
 }
 export interface AppearancePlan extends AppearanceEntityPlan {
+  /** Original renderer provenance for opted-in occurrence-local Body conversions. */
+  conversions?: Array<{ productId: number; representationId: number; sourceGeometryItemId: number;
+    geometryItemId: number; sourceIndices: number[] }>; 
   nextAvailableExpressId: number;
   items: Array<{
     productId: number;

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -32,7 +32,7 @@ export interface AppearanceRequest {
 export interface AppearancePlan extends AppearanceEntityPlan {
   /** Original renderer provenance for opted-in occurrence-local Body conversions. */
   conversions?: Array<{ productId: number; representationId: number; sourceGeometryItemId: number;
-    geometryItemId: number; sourceIndices: number[] }>; 
+    geometryItemId: number; sourceIndices: number[] }>;
   nextAvailableExpressId: number;
   items: Array<{
     productId: number;

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -32,7 +32,8 @@ into their creation records before returning the plan.
 Unsupported cases remain diagnostics: opening-bearing products (including voids
 propagated through aggregates), StandardCase subclasses, shared Body/PDS wrappers,
 shape aspects, styled presentation layers, additional renderable representations,
-multiple meshes or ambiguous/inherited styles, material-layer slicing, existing
+multiple meshes or ambiguous/inherited styles, mapped-chain and nested geometry
+style overrides (even with matching colour), material-layer slicing, existing
 textures, and ExistingUv conversion. No alternate visible Body is added. These
 are first-slice limits, not claims that IFC cannot represent the cases.
 

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -1,0 +1,52 @@
+# Evaluated occurrence appearance policy (F6, #4404)
+
+Image and finite-page requests keep `representationPolicy: "preserve"` by
+default. `"evaluatedOccurrence"` explicitly permits the supported occurrence's
+parametric Body to become evaluated tessellation. A viewer must explain this
+tradeoff and show the converted products before Apply. Discard publishes nothing;
+conversion and appearance belong to one mutation/history operation.
+
+The first supported path is a mapped `IfcElement` occurrence with a uniquely
+owned `IfcProductDefinitionShape` and one uniquely owned Body shape wrapper.
+The wrapper may have ordinary presentation-layer membership. Its Items and
+RepresentationType change in place; its identity, context, layer membership,
+product placement, product identity, properties and semantic relationships stay
+intact. Non-Body curve and bounding-box wrappers remain untouched. Shared mapped
+items, representation maps, type products, source styles and sibling occurrences
+are never edited. Retaining the occurrence wrapper avoids creating orphaned
+ProductDefinitionShapes or accidentally sharing shape wrappers contrary to
+IfcShapeModel.WR11.
+
+The canonical element-production funnel evaluates the original occurrence.
+The first slice requires one unambiguous mesh and one explicit source surface
+style. New tessellation coordinates use the inverse rigid product placement,
+restoring mesh origin and RTC once, in source length units. Canonical reopening
+must reproduce every oriented triangle corner exactly and retain the original
+colour/material before the requested appearance is applied. A bounded single
+IfcPresentationStyleAssignment wrapper can be flattened while keeping its
+surface-style definition. The native image/page planners consume this private
+typed source overlay and return one composite mutation plan, with original-item
+provenance in `conversions`. Edits targeting private newly created rows are folded
+into their creation records before returning the plan.
+
+Unsupported cases remain diagnostics: opening-bearing products (including voids
+propagated through aggregates), StandardCase subclasses, shared Body/PDS wrappers,
+shape aspects, styled presentation layers, additional renderable representations,
+multiple meshes or ambiguous/inherited styles, material-layer slicing, existing
+textures, and ExistingUv conversion. No alternate visible Body is added. These
+are first-slice limits, not claims that IFC cannot represent the cases.
+
+Opening conversion is deliberately not enabled by this policy. buildingSMART
+distinguishes subtractive opening Body geometry from Reference geometry accompanying
+an already-cut host. Our geometry path must honor that distinction before baked
+opening surfaces can be published while retaining the opening relationships.
+See [IfcOpeningElement semantics](https://standards.buildingsmart.org/IFC/RELEASE/IFC4_3/HTML/lexical/IfcOpeningElement.htm).
+
+The real IFC4 fixture is AC20-FZK-Haus from the fixture manifest, SHA-256
+`ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d`.
+Mapped IfcMember 35169 is one of 42 members sharing a type; its Body wrapper is
+35155 and evaluated source geometry item is 35135. Native tests compare all
+unselected meshes unchanged and the selected oriented world corners exactly,
+exercise finite-page composition, and refuse direct/inherited openings and shared
+wrappers. Independent IfcOpenShell checks compare new violations against the
+source's existing validation findings; the original model is not schema-clean.

--- a/docs/architecture/evidence/evaluated-occurrences/README.md
+++ b/docs/architecture/evidence/evaluated-occurrences/README.md
@@ -1,0 +1,32 @@
+# Mapped occurrence conversion evidence (#4404)
+
+The real IFC4 AC20-FZK-Haus fixture comes from `tests/models/manifest.json`.
+The test selects IfcMember 35169, one of 42 type-related members, and applies
+image appearance through the native evaluated-occurrence policy. The only
+changed pre-existing STEP entity is its occurrence Body wrapper 35155. All
+unselected canonical meshes compare exactly; the selected mesh retains every
+oriented world triangle corner and gains the new texture/UV mapping.
+
+`independent-reader.json` comes from IfcOpenShell 0.8.2 reopening the actual native
+plan export. There are zero new schema violations relative to the source's 170
+existing findings. Its 12 triangles and world vertices match the native source;
+the largest nearest-corner difference is below one micrometre. This is an IFC
+interchange/identity check, not a claim of viewer mouse-selection acceptance.
+
+Reproduce with the real fixture and generated native artifacts:
+
+```sh
+IFCLITE_EVALUATED_EVIDENCE_DIR=/tmp/evaluated-evidence cargo test -p ifc-lite-processing \
+  appearance::evaluated --lib
+cargo run -p ifc-lite-processing --example evaluated_policy_probe -- \
+  tests/models/ara3d/AC20-FZK-Haus.ifc 35169 59290 > /tmp/evaluated-evidence/native-original.json
+python3 docs/architecture/evidence/evaluated-occurrences/verify-native-plan.py \
+  tests/models/ara3d/AC20-FZK-Haus.ifc /tmp/evaluated-evidence/native-planned.ifc /tmp/evaluated-evidence
+```
+
+The native tests also cover finite PDF-page atlas composition, shared Body
+refusal, direct and aggregate-propagated opening refusal, and failure atomicity
+when normalization succeeds but subsequent image mapping fails. Opening-bearing
+conversion remains disabled; a prototype exposed representation semantics that
+must be resolved in a later slice. The current scope and constraints are in
+[the representation policy](../../appearance-evaluated-occurrences.md).

--- a/docs/architecture/evidence/evaluated-occurrences/independent-reader.json
+++ b/docs/architecture/evidence/evaluated-occurrences/independent-reader.json
@@ -1,0 +1,15 @@
+{
+  "reader": "IfcOpenShell",
+  "version": "0.8.2",
+  "sourceSchemaErrors": 170,
+  "targetSchemaErrors": 170,
+  "newSchemaViolations": [],
+  "changedExistingEntities": [
+    35155
+  ],
+  "triangles": 12,
+  "maxNativeCornerDistanceMetres": 6.16098448373493e-08,
+  "GlobalId": "0oTQ6V1VbChulreA_hfmUa",
+  "materialPolicy": "original style retained by internal normalization; final requested image replaces albedo",
+  "productIdentityPreserved": true
+}

--- a/docs/architecture/evidence/evaluated-occurrences/native-load.json
+++ b/docs/architecture/evidence/evaluated-occurrences/native-load.json
@@ -1,0 +1,189 @@
+{
+  "base": "8e8d5efa9",
+  "branch": "4e4b2f0d9",
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "method": "Prebuilt separate profiling targets; scripts/perf/probe.sh <fixture> --iters 5 --fingerprint --json in A/B/A/B order. Other agents paused heavy work; normal OS background processes remained. Native load only, not browser worker pool or conversion latency.",
+  "verdict": "No resolvable load regression at integer-millisecond phase precision; no speedup claim. All ordered mesh fingerprints and mesh/triangle counts identical.",
+  "runs": [
+    {
+      "variant": "base",
+      "sample": "a1",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 2.35,
+        "parseMs": 3,
+        "entityScanMs": 2,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          17,
+          11,
+          12,
+          8,
+          8
+        ],
+        "allWallMs": [
+          17.667084,
+          11.482584000000001,
+          12.653208000000001,
+          9.283167,
+          8.889083000000001
+        ],
+        "pointCacheHits": 51868,
+        "pointCacheMisses": 9132,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "branch",
+      "sample": "b1",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 2.39,
+        "parseMs": 3,
+        "entityScanMs": 2,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          16,
+          11,
+          10,
+          9,
+          8
+        ],
+        "allWallMs": [
+          16.653125000000003,
+          11.438042000000001,
+          10.661208,
+          9.534292,
+          9.090333000000001
+        ],
+        "pointCacheHits": 52092,
+        "pointCacheMisses": 9172,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "base",
+      "sample": "a2",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.8,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 4,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          13,
+          9,
+          9,
+          8,
+          8
+        ],
+        "allWallMs": [
+          14.382333000000001,
+          10.193249999999999,
+          9.484625,
+          8.923375,
+          8.626375000000001
+        ],
+        "pointCacheHits": 51996,
+        "pointCacheMisses": 9172,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "branch",
+      "sample": "b2",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.34,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 4,
+        "facetedBrepMs": 0,
+        "totalMs": 7,
+        "allTotalsMs": [
+          11,
+          9,
+          8,
+          8,
+          7
+        ],
+        "allWallMs": [
+          11.901917,
+          9.661207999999998,
+          8.949542,
+          8.558416,
+          8.166292
+        ],
+        "pointCacheHits": 52196,
+        "pointCacheMisses": 9236,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/architecture/evidence/evaluated-occurrences/verify-native-plan.py
+++ b/docs/architecture/evidence/evaluated-occurrences/verify-native-plan.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MPL-2.0
+"""Compare a real native appearance export with independent IfcOpenShell."""
+import sys
+import ifcopenshell,ifcopenshell.geom,ifcopenshell.validate,collections,json,numpy as np
+from pathlib import Path
+root=Path(sys.argv[3])
+original=ifcopenshell.open(sys.argv[1]);target=ifcopenshell.open(sys.argv[2])
+def problems(m):
+ l=ifcopenshell.validate.json_logger();ifcopenshell.validate.validate(m,l,express_rules=True)
+ return collections.Counter((s.get('attribute'),s['message']) for s in l.statements)
+a,b=problems(original),problems(target);new=list((b-a).elements());assert not new,new
+p=target.by_id(35169);shape=ifcopenshell.geom.create_shape(ifcopenshell.geom.settings(),p)
+mesh=next(m for m in json.load(open(root/'native-original.json')) if m['express_id']==35169)
+mat=np.asarray(shape.transformation.matrix).reshape(4,4).T
+v=np.asarray(shape.geometry.verts).reshape(-1,3);world=(mat@np.column_stack([v,np.ones(len(v))]).T).T[:,:3]
+native=np.asarray(mesh['positions']).reshape(-1,3)+mesh.get('origin',[0,0,0]);distance=max(min(np.linalg.norm(world-p,axis=1)) for p in native);assert distance<1e-6,distance
+assert len(shape.geometry.faces)==len(mesh['indices'])
+changed=[e.id() for e in original if str(e)!=str(target.by_id(e.id()))];assert changed==[35155],changed
+result=dict(reader='IfcOpenShell',version=ifcopenshell.version,sourceSchemaErrors=sum(a.values()),targetSchemaErrors=sum(b.values()),newSchemaViolations=new,changedExistingEntities=changed,triangles=len(shape.geometry.faces)//3,maxNativeCornerDistanceMetres=distance,GlobalId=p.GlobalId,materialPolicy='original style retained by internal normalization; final requested image replaces albedo',productIdentityPreserved=True)
+(root/'native-reader-result.json').write_text(json.dumps(result,indent=2)+'\n');print(json.dumps(result))

--- a/docs/guide/appearance.md
+++ b/docs/guide/appearance.md
@@ -150,3 +150,16 @@ Creation is available outside shared rooms; the saved IFC can then be shared.
 
 For implementation status, shared workflow boundaries and future scan/PDF options,
 see the [appearance roadmap](../architecture/appearance-roadmap.md).
+
+## Native evaluated-occurrence policy
+
+Native `planAppearance` and `planPageAppearance` requests accept
+`representationPolicy: "evaluatedOccurrence"` to convert supported mapped
+occurrences to tessellation as part of the same appearance plan. The omitted
+policy remains `"preserve"`. This backend option is not yet exposed by the
+Appearance panel. Hosts must explain the loss of parametric Body geometry before
+opting in and use the returned `conversions` provenance to bind the existing
+rendered occurrence to its new geometry item. Product identities, placements,
+properties and shared type graphs remain intact. Opening-bearing and ambiguous
+representation/material cases are still refused. See the
+[evaluated-occurrence contract](../architecture/appearance-evaluated-occurrences.md).

--- a/rust/processing/examples/evaluated_policy_probe.rs
+++ b/rust/processing/examples/evaluated_policy_probe.rs
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Read-only native geometry evidence for occurrence appearance conversion.
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    assert!(args.len() >= 3, "Usage: evaluated_policy_probe <ifc> <product-id>...");
+    let content = std::fs::read(&args[1]).expect("read IFC");
+    let ids: Vec<u32> = args[2..].iter().map(|s| s.parse().expect("product id")).collect();
+    let result = ifc_lite_processing::process_geometry(&content);
+    let meshes: Vec<_> = result.meshes.iter().filter(|mesh| ids.contains(&mesh.express_id)).collect();
+    println!("{}", serde_json::to_string(&meshes).expect("serialize meshes"));
+}

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -152,13 +152,11 @@ impl Normalized {
         }
         // The common wire contract edits existing rows. Fold edits of private
         // normalization rows into their creation records before publication.
-        let created:BTreeSet<_>=plan.created.iter().map(|entity|entity.express_id).collect();
+        let created:std::collections::BTreeMap<_,_>=plan.created.iter().enumerate().map(|(index,entity)|(entity.express_id,index)).collect();
         let edits=std::mem::take(&mut plan.edits);
         for edit in edits {
-            if created.contains(&edit.express_id) {
-                if let Some(entity)=plan.created.iter_mut().find(|entity|entity.express_id==edit.express_id) {
-                    entity.attributes[edit.index]=edit.value;
-                }
+            if let Some(&index)=created.get(&edit.express_id) {
+                plan.created[index].attributes[edit.index]=edit.value;
             } else { plan.edits.push(edit); }
         }
         plan.next_express_id=self.start;

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -67,6 +67,7 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
             let mesh=meshes.remove(0);
             if mesh.texture.is_some() || mesh.uvs.is_some() { return Err("Evaluated conversion of textured source surfaces is not supported yet".into()); }
             let old_item=mesh.geometry_item_id.ok_or("Missing evaluated source item provenance")?;
+            evaluated_source::validate_style_tree(source,&body,old_item)?;
             let surface=evaluated_source::surface_styles(source,old_item)?;
             if mesh.positions.len()%3!=0 || mesh.indices.len()%3!=0 || mesh.positions.is_empty()
                 || mesh.indices.is_empty() || mesh.positions.iter().chain(&mesh.normals).any(|n|!n.is_finite())

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -1,0 +1,171 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Private evaluated-occurrence normalization; publication is one appearance plan.
+use super::{evaluated_source, source::Source, *};
+use ifc_lite_core::{AttributeValue as A, DecodedEntity};
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+struct Conversion {
+    plan: AppearancePlan,
+    binding: AppearanceConversion,
+    styled_id: u32,
+}
+pub(super) struct Normalized {
+    request: AppearanceRequest,
+    conversions: Vec<Conversion>,
+    exclusions: Vec<Exclusion>,
+    start: u32,
+}
+fn list(ids: &[u32]) -> A { A::List(ids.iter().copied().map(A::EntityRef).collect()) }
+// Authored, fixed-depth schema values only; never recursively walk source data.
+fn wire(value: &A) -> Value {
+    match value {
+        A::EntityRef(id) => reference(*id), A::Null => Value::Null,
+        A::String(s) => json!(s), A::Enum(s) => json!(format!(".{s}.")),
+        A::Integer(n) => json!(n), A::Float(n) => json!(n),
+        A::List(items) => json!(items.iter().map(wire).collect::<Vec<_>>()),
+        _ => unreachable!("fixed authored values"),
+    }
+}
+fn authored(plan: &mut AppearancePlan, entities: &mut FxHashMap<u32, Arc<DecodedEntity>>,
+    ty: IfcType, attributes: Vec<A>) -> u32 {
+    let id = add(plan,ty.name(),attributes.iter().map(wire).collect());
+    entities.insert(id,Arc::new(DecodedEntity::new(id,ty,attributes))); id
+}
+
+pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut Source<'_>) -> Result<Normalized,String> {
+    if !matches!(request.schema.as_str(),"IFC4"|"IFC4X3") || request.product_ids.is_empty()
+        || request.product_ids.len()>10_000 || request.source_revision.len()>4096 {
+        return Err("Evaluated appearance requires a bounded IFC4/IFC4X3 scope".into());
+    }
+    validate_image_uri(&request.image_uri)?;
+    mapping::validate(&request.mapping)?;
+    texture_budget::preflight(source)?;
+    if request.next_express_id <= source.types.last_key_value().map_or(0,|(id,_)|*id) {
+        return Err("Stale allocator watermark overlaps effective IFC source".into());
+    }
+    let mut styles = page_source::appearance(bytes,source);
+    let textures = ifc_lite_geometry::build_texture_index(bytes,&mut source.decoder);
+    let mut normalized = Normalized { request:request.clone(), conversions:Vec::new(), exclusions:Vec::new(), start:request.next_express_id };
+    normalized.request.representation_policy=RepresentationPolicy::Preserve;
+    normalized.request.product_ids.clear();
+    let mut budget=budget::PlanBudget::default();
+    let mut seen=BTreeSet::new();
+    for &product_id in &request.product_ids {
+        if !seen.insert(product_id) { continue; }
+        if source.product_items(product_id).is_ok() {
+            normalized.request.product_ids.push(product_id); continue;
+        }
+        let candidate=(|| {
+            if styles.void_index.contains_key(&product_id) { return Err("Evaluated conversion of opening-bearing products is not supported yet".into()); }
+            if matches!(request.mapping,Mapping::ExistingUv {..}) { return Err("Evaluated occurrence conversion requires a new planar or box mapping".into()); }
+            let (product, body)=evaluated_source::body(source,product_id)?;
+            let mut meshes=canonical::produce(source,product_id,&textures,Some(&styles))?;
+            if meshes.len()!=1 { return Err("Evaluated appearance currently requires one unambiguous source surface".into()); }
+            let mesh=meshes.remove(0);
+            if mesh.texture.is_some() || mesh.uvs.is_some() { return Err("Evaluated conversion of textured source surfaces is not supported yet".into()); }
+            let old_item=mesh.geometry_item_id.ok_or("Missing evaluated source item provenance")?;
+            let surface=evaluated_source::surface_styles(source,old_item)?;
+            if mesh.positions.len()%3!=0 || mesh.indices.len()%3!=0 || mesh.positions.is_empty()
+                || mesh.indices.is_empty() || mesh.positions.iter().chain(&mesh.normals).any(|n|!n.is_finite())
+                || mesh.indices.iter().any(|&i|i as usize>=mesh.positions.len()/3) {
+                return Err("Canonical source geometry is invalid".into());
+            }
+            budget.reserve(mesh.positions.len()/3,mesh.indices.len()/3,0)?;
+            let points=evaluated_source::local_points(source,&product,&mesh)?;
+            Ok((body.clone(),points,mesh,old_item,surface,source::refs(body.get(3))?))
+        })();
+        let (mut body,points,mesh,old_item,surface,old_items)=match candidate {
+            Ok(value)=>value,
+            Err(reason)=> {
+                if budget.exhausted { return Err(budget::BUDGET_ERROR.into()); }
+                normalized.exclusions.push(Exclusion {product_id,reason}); continue;
+            }
+        };
+        if u64::from(normalized.request.next_express_id)+3>=u64::from(u32::MAX) || source.types.len()+3>200_000 {
+            return Err("Evaluated appearance entity capacity exceeded".into());
+        }
+        let mut plan=AppearancePlan {next_express_id:normalized.request.next_express_id,
+            next_available_express_id:normalized.request.next_express_id,..Default::default()};
+        let mut entities=FxHashMap::default();
+        let rows=A::List(points.into_iter().map(|p|A::List(p.into_iter().map(A::Float).collect())).collect());
+        let mut point_attributes=vec![rows];
+        if request.schema=="IFC4X3" {point_attributes.push(A::Null);}
+        let coordinates=authored(&mut plan,&mut entities,IfcType::IfcCartesianPointList3D,point_attributes);
+        let indices=A::List(mesh.indices.chunks_exact(3).map(|tri|A::List(tri.iter().map(|&i|A::Integer(i64::from(i)+1)).collect())).collect());
+        let item=authored(&mut plan,&mut entities,IfcType::IfcTriangulatedFaceSet,
+            vec![A::EntityRef(coordinates),A::Null,A::Null,indices,A::Null]);
+        let styled=authored(&mut plan,&mut entities,IfcType::IfcStyledItem,vec![A::EntityRef(item),list(&surface),A::Null]);
+        Arc::make_mut(&mut body.attributes)[2]=A::String("Tessellation".into()); Arc::make_mut(&mut body.attributes)[3]=list(&[item]);
+        plan.edits.extend([PositionalEdit {express_id:body.id,index:2,value:json!("Tessellation")},
+            PositionalEdit {express_id:body.id,index:3,value:json!([reference(item)])}]);
+        let body_id=body.id;
+        entities.insert(body.id,Arc::new(body));
+        source.decoder.inject_shared_cache(&entities);
+        for entity in &plan.created { source.types.insert(entity.express_id,entities[&entity.express_id].ifc_type); }
+        for old in old_items { if let Some(parents)=source.incoming.get_mut(&old) {parents.remove(&body_id);} }
+        source.incoming.insert(coordinates,BTreeSet::from([item]));
+        source.incoming.insert(item,BTreeSet::from([body_id,styled]));
+        source.styled_items.insert(item,vec![styled]);
+        let (_,style)=crate::prepass::surface_style_from_styled_item(&entities[&styled],&mut source.decoder)
+            .ok_or("Converted surface style failed canonical resolution")?;
+        styles.geometry_style_index.insert(item,style);
+        let target=canonical::produce(source,product_id,&textures,Some(&styles))?;
+        if target.len()!=1 { return Err("Evaluated replacement changed canonical submesh count".into()); }
+        let target=&target[0];
+        if mesh.indices.len()!=target.indices.len() || mesh.color!=target.color || mesh.material_name!=target.material_name {
+            return Err("Evaluated replacement changed source appearance or triangle count".into());
+        }
+        for (&a,&b) in mesh.indices.iter().zip(&target.indices) {
+            let before=canonical::corner_position(&mesh.positions,a)?;
+            let after=canonical::corner_position(&target.positions,b)?;
+            if (0..3).any(|axis|f64::from(before[axis])+mesh.origin[axis]!=f64::from(after[axis])+target.origin[axis]) {
+                return Err("Evaluated replacement cannot preserve canonical triangle corners exactly".into());
+            }
+        }
+        normalized.request.next_express_id=plan.next_available_express_id;
+        normalized.request.product_ids.push(product_id);
+        normalized.conversions.push(Conversion {plan,styled_id:styled,binding:AppearanceConversion {
+            product_id,representation_id:body_id,source_geometry_item_id:old_item,geometry_item_id:item,source_indices:mesh.indices }});
+    }
+    Ok(normalized)
+}
+impl Normalized {
+    pub(super) fn request(&self)->&AppearanceRequest {&self.request}
+    pub(super) fn patch_styles(&self, source:&mut Source<'_>, styles:&mut crate::prepass::ResolvedPrepass)->Result<(),String> {
+        for conversion in &self.conversions {
+            let styled=source.entity(conversion.styled_id)?;
+            let (_,style)=crate::prepass::surface_style_from_styled_item(&styled,&mut source.decoder).ok_or("Missing converted style")?;
+            styles.geometry_style_index.insert(conversion.binding.geometry_item_id,style);
+        }
+        Ok(())
+    }
+    pub(super) fn compose(self,mut plan:AppearancePlan)->AppearancePlan {
+        let accepted:BTreeSet<_>=plan.items.iter().map(|item|item.product_id).collect();
+        for conversion in self.conversions {
+            if accepted.contains(&conversion.binding.product_id) {
+                plan.created.extend(conversion.plan.created); plan.edits.extend(conversion.plan.edits);
+                plan.conversions.push(conversion.binding);
+            }
+        }
+        // The common wire contract edits existing rows. Fold edits of private
+        // normalization rows into their creation records before publication.
+        let created:BTreeSet<_>=plan.created.iter().map(|entity|entity.express_id).collect();
+        let edits=std::mem::take(&mut plan.edits);
+        for edit in edits {
+            if created.contains(&edit.express_id) {
+                if let Some(entity)=plan.created.iter_mut().find(|entity|entity.express_id==edit.express_id) {
+                    entity.attributes[edit.index]=edit.value;
+                }
+            } else { plan.edits.push(edit); }
+        }
+        plan.next_express_id=self.start;
+        plan.exclusions.extend(self.exclusions); plan
+    }
+}
+
+#[cfg(test)]
+#[path = "evaluated_tests.rs"]
+mod tests;

--- a/rust/processing/src/appearance/evaluated_source.rs
+++ b/rust/processing/src/appearance/evaluated_source.rs
@@ -36,6 +36,10 @@ pub(super) fn body(source: &mut Source<'_>, product_id: u32) -> Result<(DecodedE
         if rep.get_string(2) != Some("MappedRepresentation") {
             return Err("Evaluated appearance currently supports mapped occurrence bodies only".into());
         }
+        let items=refs(rep.get(3))?;
+        if items.len()!=1 || source.types.get(&items[0])!=Some(&IfcType::IfcMappedItem) {
+            return Err("Evaluated appearance requires one mapped occurrence item".into());
+        }
         found = Some(rep);
     }
     Ok((product, found.ok_or("No occurrence Body representation")?))

--- a/rust/processing/src/appearance/evaluated_source.rs
+++ b/rust/processing/src/appearance/evaluated_source.rs
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Eligibility for occurrence-local evaluated Body replacement (#4404).
+use super::{source::{refs, Source}, *};
+use ifc_lite_core::DecodedEntity;
+
+pub(super) fn body(source: &mut Source<'_>, product_id: u32) -> Result<(DecodedEntity, DecodedEntity), String> {
+    let product = source.entity(product_id)?;
+    if !product.ifc_type.is_subtype_of(IfcType::IfcElement)
+        || product.ifc_type.name().ends_with("StandardCase")
+        || product.ifc_type.is_subtype_of(IfcType::IfcFeatureElement) {
+        return Err("Evaluated appearance requires an element whose IFC class permits tessellation".into());
+    }
+    source.validate_world_placement(&product)?;
+    let pds_id = product.get_ref(6).ok_or("Product has no representation")?;
+    let pds = source.entity(pds_id)?;
+    if pds.ifc_type != IfcType::IfcProductDefinitionShape || !source.single_parent(pds_id, product_id) {
+        return Err("Evaluated appearance requires an occurrence-owned ProductDefinitionShape".into());
+    }
+    let mut found = None;
+    for id in refs(pds.get(2))? {
+        let rep = source.entity(id)?;
+        if rep.ifc_type != IfcType::IfcShapeRepresentation { return Err("Unsupported product representation".into()); }
+        if !rep.get_string(1).is_some_and(|s| s.eq_ignore_ascii_case("Body")) {
+            if !matches!(rep.get_string(2), Some("BoundingBox" | "Curve2D" | "Curve3D" | "GeometricCurveSet")) {
+                return Err("Additional renderable representations are unsupported for evaluated appearance".into());
+            }
+            continue;
+        }
+        if found.is_some() { return Err("Evaluated appearance requires exactly one Body representation".into()); }
+        if !source.incoming.get(&id).is_some_and(|incoming| incoming.contains(&pds_id)
+            && incoming.iter().all(|parent| *parent == pds_id || source.types.get(parent) == Some(&IfcType::IfcPresentationLayerAssignment))) {
+            return Err("Body is shared or has unsupported layer/aspect associations".into());
+        }
+        if rep.get_string(2) != Some("MappedRepresentation") {
+            return Err("Evaluated appearance currently supports mapped occurrence bodies only".into());
+        }
+        found = Some(rep);
+    }
+    Ok((product, found.ok_or("No occurrence Body representation")?))
+}
+
+/// Flatten only the schema's single assignment wrapper, never a recursive file
+/// graph. Preserve the existing surface style definition rather than its RGB.
+pub(super) fn surface_styles(source: &mut Source<'_>, item: u32) -> Result<Vec<u32>, String> {
+    let styled = source.styled_items.get(&item).cloned().unwrap_or_default();
+    if styled.len() != 1 { return Err("Evaluated appearance requires one explicit source surface style".into()); }
+    let entity = source.entity(styled[0])?;
+    let direct = refs(entity.get(1))?;
+    if direct.len() > 8 { return Err("Source style assignment exceeds its budget".into()); }
+    let mut result = Vec::new();
+    for id in direct {
+        let style = source.entity(id)?;
+        let ids = if source.style_assignments.contains(&id) { refs(style.get(0))? } else { vec![id] };
+        if ids.len() > 8 { return Err("Source style assignment exceeds its budget".into()); }
+        for id in ids {
+            if source.types.get(&id) != Some(&IfcType::IfcSurfaceStyle) { return Err("Source has unsupported non-surface styles".into()); }
+            result.push(id);
+        }
+    }
+    if result.len() != 1 { return Err("Multiple or missing source surface styles are unsupported".into()); }
+    let surface = source.entity(result[0])?;
+    let members=refs(surface.get(2))?;
+    if members.len()>5 { return Err("Surface style exceeds its schema budget".into()); }
+    for id in members {
+        if source.types.get(&id) == Some(&IfcType::IfcSurfaceStyleWithTextures) {
+            return Err("Evaluated conversion of existing texture coordinates is not supported".into());
+        }
+    }
+    Ok(result)
+}
+
+pub(super) fn local_points(source: &mut Source<'_>, product: &DecodedEntity,
+    mesh: &crate::types::mesh::MeshData) -> Result<Vec<[f64; 3]>, String> {
+    let scale = source.decoder.length_unit_scale();
+    let context = source.context.as_ref().ok_or("Missing canonical context")?;
+    // Resolve placement without RTC: mesh origin and context RTC are restored
+    // before applying the inverse product frame, in IFC metres exactly once.
+    let transform = ifc_lite_geometry::GeometryRouter::with_scale(scale)
+        .resolve_scaled_placement(product, &mut source.decoder).map_err(|e| e.to_string())?;
+    let columns: [[f64;3];3] = std::array::from_fn(|i| std::array::from_fn(|j| transform[i*4+j]));
+    let dot = |a:[f64;3], b:[f64;3]| a.iter().zip(b).map(|(a,b)| a*b).sum::<f64>();
+    if !scale.is_finite() || scale <= 0. || transform.iter().any(|v| !v.is_finite())
+        || (0..3).any(|i| (0..3).any(|j| (dot(columns[i], columns[j]) - if i==j {1.} else {0.}).abs()>1e-10)) {
+        return Err("Evaluated appearance requires a finite rigid product placement".into());
+    }
+    let rtc: [f64;3] = if context.meta.needs_shift { context.meta.rtc_offset.into() } else { [0.;3] };
+    mesh.positions.chunks_exact(3).map(|p| {
+        let delta = std::array::from_fn(|i| f64::from(p[i])+mesh.origin[i]+rtc[i]-transform[12+i]);
+        let point = columns.map(|axis| dot(axis,delta)/scale);
+        if point.iter().any(|v| !v.is_finite()) { Err("Evaluated coordinate exceeds numeric range".into()) } else { Ok(point) }
+    }).collect()
+}

--- a/rust/processing/src/appearance/evaluated_source.rs
+++ b/rust/processing/src/appearance/evaluated_source.rs
@@ -96,3 +96,37 @@ pub(super) fn local_points(source: &mut Source<'_>, product: &DecodedEntity,
         if point.iter().any(|v| !v.is_finite()) { Err("Evaluated coordinate exceeds numeric range".into()) } else { Ok(point) }
     }).collect()
 }
+
+/// Eligibility is a pure property of each reachable geometry node: a global
+/// visited set handles shared DAG nodes, with separate node/value work ceilings.
+/// Style definitions are inverse associations and are inspected, not traversed.
+pub(super) fn validate_style_tree(source:&mut Source<'_>, body:&DecodedEntity, leaf:u32)->Result<(),String> {
+    let mut pending=vec![body.id];
+    let mut visited=std::collections::BTreeSet::new();
+    let mut work=0usize;
+    while let Some(id)=pending.pop() {
+        if !visited.insert(id) {continue;}
+        if visited.len()>4096 {return Err("Evaluated style graph exceeds its node budget".into());}
+        if id!=leaf && source.styled_items.get(&id).is_some_and(|items|!items.is_empty()) {
+            return Err("Mapped-chain or nested geometry style overrides are unsupported for evaluated appearance".into());
+        }
+        if source.incoming.get(&id).is_some_and(|parents|parents.iter()
+            .any(|parent|source.types.get(parent)==Some(&IfcType::IfcPresentationLayerWithStyle))) {
+            return Err("Styled presentation layers on evaluated geometry are unsupported".into());
+        }
+        let entity=source.entity(id)?;
+        let mut values:Vec<&ifc_lite_core::AttributeValue>=if entity.ifc_type==IfcType::IfcShapeRepresentation {
+            entity.get(3).into_iter().collect()
+        } else {entity.attributes.iter().collect()};
+        while let Some(value)=values.pop() {
+            work+=1;
+            if work>65_536 {return Err("Evaluated style graph exceeds its reference budget".into());}
+            match value {
+                ifc_lite_core::AttributeValue::EntityRef(id)=>pending.push(*id),
+                ifc_lite_core::AttributeValue::List(items)=>values.extend(items),
+                _=>{},
+            }
+        }
+    }
+    Ok(())
+}

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -84,3 +84,11 @@ fn issue_4404_inherited_aggregate_voids_cannot_be_baked_as_uncut_geometry() {
     assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("opening-bearing"));
     assert!(plan.items.is_empty());assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
 }
+#[test]
+fn issue_4404_failed_image_mapping_never_publishes_its_successful_private_conversion() {
+    let Some(source)=real_source() else{return};let mut request=request();
+    request.mapping=Mapping::Box {frame:MappingFrame::World,origin:[0.;3],metres_per_tile:[f64::MIN_POSITIVE;3]};
+    let plan=plan_appearance(source.as_bytes(),&request).unwrap();
+    assert_eq!(plan.exclusions.len(),1);assert!(plan.items.is_empty());assert!(plan.created.is_empty());
+    assert!(plan.edits.is_empty());assert!(plan.conversions.is_empty());
+}

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -92,3 +92,33 @@ fn issue_4404_failed_image_mapping_never_publishes_its_successful_private_conver
     assert_eq!(plan.exclusions.len(),1);assert!(plan.items.is_empty());assert!(plan.created.is_empty());
     assert!(plan.edits.is_empty());assert!(plan.conversions.is_empty());
 }
+#[test]
+fn issue_4404_same_albedo_different_roughness_on_mapped_chain_is_not_silently_lost() {
+    let Some(source)=real_source() else{return};
+    // Same Kiefer name, colour, diffuse and specular as the source; only
+    // roughness differs. RGB/name comparison alone cannot detect this override.
+    let styles="#99990=IFCSURFACESTYLERENDERING(#17389,0.,IFCNORMALISEDRATIOMEASURE(0.74),$,$,$,IFCNORMALISEDRATIOMEASURE(0.1),IFCSPECULARROUGHNESS(0.01),.NOTDEFINED.);\n#99991=IFCSURFACESTYLE('Kiefer',.BOTH.,(#99990));\n";
+    for target in [35155,35153,35139] {
+        let changed=source.replace("#35155=",&format!("{styles}#99992=IFCSTYLEDITEM(#{target},(#99991),$);\n#35155="));
+        let plan=plan_appearance(changed.as_bytes(),&request()).unwrap();
+        assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("style overrides") || plan.exclusions[0].reason.contains("Body is shared"),"target {target}: {:?}",plan.exclusions);
+        assert!(plan.created.is_empty());assert!(plan.edits.is_empty());assert!(plan.conversions.is_empty());
+    }
+    for target in [35153,35135] {
+        let changed=source.replace("#35155=",&format!("{styles}#99992=IFCPRESENTATIONLAYERWITHSTYLE('Kiefer',$,(#{target}),$,.T.,.F.,.F.,(#99991));\n#35155="));
+        let plan=plan_appearance(changed.as_bytes(),&request()).unwrap();
+        assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("Styled presentation layers"));
+        assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
+    }
+}
+#[test]
+fn issue_4404_material_layer_slicing_refusal_precedes_mapped_evaluation() {
+    let Some(source)=real_source() else{return};
+    let layers="#99980=IFCMATERIAL('Finish',$,$);\n#99981=IFCMATERIALLAYER(#99980,0.05,$,$,$,$,$);\n#99982=IFCMATERIALLAYER(#99980,0.2,$,$,$,$,$);\n#99983=IFCMATERIALLAYERSET((#99981,#99982),$,$);\n#99984=IFCMATERIALLAYERSETUSAGE(#99983,.AXIS2.,.POSITIVE.,0.,$);\n#99985=IFCRELASSOCIATESMATERIAL('0Proxy000000000000000a',$,$,$,(#35169),#99984);\n";
+    let changed=source.replace("#35155=",&format!("{layers}#35155="));
+    let mut decoder=ifc_lite_core::EntityDecoder::new(changed.as_bytes());
+    assert!(ifc_lite_geometry::MaterialLayerIndex::from_content(changed.as_bytes(),&mut decoder).is_sliceable(35169));
+    let plan=plan_appearance(changed.as_bytes(),&request()).unwrap();
+    assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("Material-layer slicing"));
+    assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
+}

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::*;
+use crate::appearance::tests::apply;
+fn request() -> AppearanceRequest {
+    AppearanceRequest { representation_policy:RepresentationPolicy::EvaluatedOccurrence,
+        schema:"IFC4".into(),source_revision:"real-AC20".into(),next_express_id:100_000,product_ids:vec![35169],
+        image_uri:"textures/evaluated.png".into(),repeat_s:true,repeat_t:true,
+        mapping:Mapping::Box {frame:MappingFrame::World,origin:[0.;3],metres_per_tile:[1.;3]} }
+}
+fn real_source()->Option<String> {
+    let path=std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/models/ara3d/AC20-FZK-Haus.ifc");
+    match std::fs::read_to_string(path) {
+        Ok(source)=>Some(source),
+        Err(error) if error.kind()==std::io::ErrorKind::NotFound=>{eprintln!("skip real AC20 fixture; run pnpm fixtures");None},
+        Err(error)=>panic!("read fixture: {error}"),
+    }
+}
+fn corners(mesh:&crate::types::mesh::MeshData)->Vec<[f64;3]> {
+    mesh.indices.iter().map(|&i|std::array::from_fn(|axis|f64::from(mesh.positions[i as usize*3+axis])+mesh.origin[axis])).collect()
+}
+#[test]
+fn issue_4404_real_mapped_member_is_opt_in_and_preserves_every_sibling_and_world_corner() {
+    let Some(source)=real_source() else{return};
+    let mut request=request();request.representation_policy=RepresentationPolicy::Preserve;
+    let refused=plan_appearance(source.as_bytes(),&request).unwrap();
+    assert!(refused.items.is_empty());assert!(refused.conversions.is_empty());
+    request.representation_policy=RepresentationPolicy::EvaluatedOccurrence;
+    let plan=plan_appearance(source.as_bytes(),&request).unwrap();
+    assert!(plan.exclusions.is_empty(),"{:?}",plan.exclusions);
+    assert_eq!(plan.conversions.len(),1);assert_eq!(plan.items.len(),1);
+    assert_eq!(plan.conversions[0].representation_id,35155);
+    assert_eq!(plan.conversions[0].source_geometry_item_id,35135);
+    assert!(plan.edits.iter().all(|edit|edit.express_id==35155));
+    assert!(plan.removed.is_empty());
+    let output=apply(&source,&plan);
+    let before=crate::process_geometry(source.as_bytes());let after=crate::process_geometry(output.as_bytes());
+    assert_eq!(before.meshes.len(),after.meshes.len());
+    for mesh in &before.meshes {
+        let other=after.meshes.iter().find(|m|m.express_id==mesh.express_id && (m.express_id==35169 || m.geometry_item_id==mesh.geometry_item_id)).unwrap();
+        if mesh.express_id==35169 {
+            assert_eq!(corners(mesh),corners(other));assert!(other.uvs.is_some());assert!(other.texture.is_some());
+            assert_eq!(mesh.global_id,other.global_id);
+        } else { assert_eq!(serde_json::to_value(mesh).unwrap(),serde_json::to_value(other).unwrap()); }
+    }
+    if let Ok(directory)=std::env::var("IFCLITE_EVALUATED_EVIDENCE_DIR") {
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(std::path::Path::new(&directory).join("native-planned.ifc"),output).unwrap();
+        std::fs::write(std::path::Path::new(&directory).join("native-plan.json"),serde_json::to_vec_pretty(&plan).unwrap()).unwrap();
+    }
+}
+#[test]
+fn issue_4404_opening_hosts_and_shared_body_wrappers_never_receive_conversion_mutations() {
+    let Some(source)=real_source() else{return};let mut request=request();
+    request.product_ids=vec![59290,21966];
+    let plan=plan_appearance(source.as_bytes(),&request).unwrap();
+    assert_eq!(plan.exclusions.len(),2);assert!(plan.created.is_empty());assert!(plan.edits.is_empty());assert!(plan.conversions.is_empty());
+    let shared=source.replace("#35155=", "#99999=IFCREPRESENTATIONMAP(#5,#35155);\n#35155=");
+    request.product_ids=vec![35169];
+    let plan=plan_appearance(shared.as_bytes(),&request).unwrap();
+    assert_eq!(plan.exclusions.len(),1);assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
+}
+#[test]
+fn issue_4404_page_projection_composes_conversion_and_atlas_in_one_plan() {
+    let Some(source)=real_source() else{return};let mut appearance=request();
+    appearance.repeat_s=false;appearance.repeat_t=false;
+    appearance.mapping=Mapping::Planar {frame:MappingFrame::World,origin:[1.,6.,3.],axis_u:[0.,1.,0.],axis_v:[0.,0.,1.],metres_per_tile:[2.,2.]};
+    let request=PageAppearanceRequest {appearance,page:AppearanceRaster {width:1,height:1,byte_offset:0,byte_length:4},source_images:vec![],texels_per_metre:32.};
+    let result=plan_page_appearance(source.as_bytes(),&request,&[255,0,0,255]).unwrap();
+    assert_eq!(result.plan.conversions.len(),1);assert_eq!(result.item_images.len(),1);assert!(!result.assets.is_empty());
+    assert!(result.plan.edits.iter().all(|edit|edit.express_id==35155));
+    let output=apply(&source,&result.plan);
+    let reopened=crate::process_geometry(output.as_bytes());
+    let target=reopened.meshes.iter().find(|mesh|mesh.express_id==35169).unwrap();
+    assert!(target.uvs.is_some());assert!(target.texture.is_some());
+    assert_eq!(target.geometry_item_id,Some(result.plan.conversions[0].geometry_item_id));
+}
+#[test]
+fn issue_4404_inherited_aggregate_voids_cannot_be_baked_as_uncut_geometry() {
+    let Some(source)=real_source() else{return};
+    let inherited=source.replace("#35155=", "#99996=IFCRELVOIDSELEMENT('x',$,$,$,#99998,#59365);\n#99997=IFCRELAGGREGATES('y',$,$,$,#99998,(#35169));\n#99998=IFCELEMENTASSEMBLY('z',$,$,$,$,$,$,$,$,$);\n#35155=");
+    let plan=plan_appearance(inherited.as_bytes(),&request()).unwrap();
+    assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("opening-bearing"));
+    assert!(plan.items.is_empty());assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
+}

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -4,6 +4,8 @@
 //! Opt-in appearance authoring over an effective IFC snapshot. No load-time
 //! geometry changes. Plans are applied atomically by the host mutation editor.
 mod budget;
+mod evaluated;
+mod evaluated_source;
 mod annotation;
 mod captured;
 mod captured_types;
@@ -75,17 +77,27 @@ pub fn plan_appearance(
     bytes: &[u8],
     request: &AppearanceRequest,
 ) -> Result<AppearancePlan, String> {
+    if request.product_ids.is_empty() { return Err("Appearance scope must contain 1..10000 products".into()); }
+    let mut source=Source::new(bytes)?;
+    if request.representation_policy==RepresentationPolicy::EvaluatedOccurrence {
+        let normalized=evaluated::prepare(bytes,request,&mut source)?;
+        let plan=plan_with_source(bytes,normalized.request(),&mut source)?;
+        return Ok(normalized.compose(plan));
+    }
+    plan_with_source(bytes,request,&mut source)
+}
+
+fn plan_with_source(bytes:&[u8], request:&AppearanceRequest, source:&mut Source<'_>) -> Result<AppearancePlan,String> {
     if request.schema != "IFC4" && request.schema != "IFC4X3" {
         return Err("Appearance authoring requires IFC4 or IFC4X3".into());
     }
-    if request.product_ids.is_empty() || request.product_ids.len() > 10_000 {
+    if request.product_ids.len() > 10_000 {
         return Err("Appearance scope must contain 1..10000 products".into());
     }
     let uri = &request.image_uri;
     validate_image_uri(uri)?;
     mapping::validate(&request.mapping)?;
-    let mut source = Source::new(bytes)?;
-    texture_budget::preflight(&mut source)?;
+    texture_budget::preflight(source)?;
     let textures = ifc_lite_geometry::build_texture_index(bytes, &mut source.decoder);
     let max_id = source
         .types
@@ -130,9 +142,9 @@ pub fn plan_appearance(
                         }
                     }
                 }
-                items.push(mapping::map_item(&mut source, request, product, id, &mut budget)?);
+                items.push(mapping::map_item(source, request, product, id, &mut budget)?);
             }
-            canonical::align_source_corners(&mut source, product, &mut items, &textures, request)?;
+            canonical::align_source_corners(source, product, &mut items, &textures, request)?;
             Ok::<_, String>(items)
         })();
         // Resource refusal invalidates the whole command, never a partial success.

--- a/rust/processing/src/appearance/page.rs
+++ b/rust/processing/src/appearance/page.rs
@@ -26,11 +26,16 @@ pub fn plan_page_appearance(bytes: &[u8], request: &PageAppearanceRequest, rgba:
             return Err("Source rasters need distinct bounded IFC image URIs".into());
         }
     }
-    let mut plan = plan_appearance(bytes, spec)?;
     let mut source = Source::new(bytes)?;
+    let normalization=if spec.representation_policy==RepresentationPolicy::EvaluatedOccurrence {
+        Some(evaluated::prepare(bytes,spec,&mut source)?)
+    } else { None };
+    let spec=normalization.as_ref().map_or(spec,|n|n.request());
+    let mut plan = plan_with_source(bytes,spec,&mut source)?;
     texture_budget::preflight(&mut source)?;
     let textures = ifc_lite_geometry::build_texture_index(bytes, &mut source.decoder);
-    let styles = page_source::appearance(bytes, &mut source);
+    let mut styles = page_source::appearance(bytes, &mut source);
+    if let Some(normalized)=&normalization { normalized.patch_styles(&mut source,&mut styles)?; }
     let scale = source.decoder.length_unit_scale();
     let extra = plan.items.len().checked_mul(4).ok_or("Page entity capacity overflow")?;
     if u64::from(plan.next_available_express_id) + extra as u64 >= u64::from(u32::MAX) {
@@ -97,6 +102,7 @@ pub fn plan_page_appearance(bytes: &[u8], request: &PageAppearanceRequest, rgba:
         start += count;
     }
     bind_images(&mut plan, &item_images, &mut source, &styles)?;
+    let plan=match normalization { Some(n)=>n.compose(plan),None=>plan };
     Ok(PageAppearancePlan { plan, item_images, assets, texels_per_metre: request.texels_per_metre })
 }
 fn encode_png(atlas: &page_atlas::Atlas, limit: usize) -> Result<Vec<u8>, String> {

--- a/rust/processing/src/appearance/page.rs
+++ b/rust/processing/src/appearance/page.rs
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 /// positions/triangles. Input/output/work limits refuse rather than downsample.
 pub fn plan_page_appearance(bytes: &[u8], request: &PageAppearanceRequest, rgba: &[u8]) -> Result<PageAppearancePlan, String> {
     let spec = &request.appearance;
+    if spec.product_ids.is_empty() { return Err("Appearance scope must contain 1..10000 products".into()); }
     if !matches!(spec.mapping, Mapping::Planar { .. }) || spec.repeat_s || spec.repeat_t {
         return Err("Page appearance requires non-repeating planar mapping".into());
     }

--- a/rust/processing/src/appearance/page_source.rs
+++ b/rust/processing/src/appearance/page_source.rs
@@ -13,6 +13,9 @@ pub(super) fn appearance(bytes: &[u8], source: &mut Source<'_>) -> ResolvedPrepa
     while let Some((id, name, start, end)) = scan.next_entity() {
         let target = match name {
             "IFCSTYLEDITEM" => &mut spans.styled_items,
+            "IFCRELVOIDSELEMENT" => &mut spans.void_rels,
+            "IFCRELFILLSELEMENT" => &mut spans.fills_rels,
+            "IFCRELAGGREGATES" => &mut spans.aggregate_rels,
             "IFCINDEXEDCOLOURMAP" => &mut spans.indexed_colour_maps,
             "IFCMATERIALDEFINITIONREPRESENTATION" => &mut spans.material_def_reprs,
             "IFCRELASSOCIATESMATERIAL" => &mut spans.rel_associates_material,

--- a/rust/processing/src/appearance/page_tests.rs
+++ b/rust/processing/src/appearance/page_tests.rs
@@ -10,7 +10,7 @@ fn fixture() -> (PageAppearanceRequest, Vec<u8>) {
     let mut rgba = page;
     rgba.extend([20, 80, 160, 255, 80, 160, 240, 255, 160, 40, 80, 255, 240, 80, 20, 255]);
     (PageAppearanceRequest {
-        appearance: AppearanceRequest { schema: "IFC4".into(), source_revision: "page-fixture".into(),
+        appearance: AppearanceRequest { representation_policy: RepresentationPolicy::Preserve, schema: "IFC4".into(), source_revision: "page-fixture".into(),
             next_express_id: 100, product_ids: vec![10, 30], image_uri: "appearance/page.png".into(),
             repeat_s: false, repeat_t: false, mapping: Mapping::Planar { frame: MappingFrame::World,
                 origin: [0.2, 0.2, 0.], axis_u: [1., 0., 0.], axis_v: [0., 1., 0.], metres_per_tile: [0.4, 0.4] } },

--- a/rust/processing/src/appearance/source.rs
+++ b/rust/processing/src/appearance/source.rs
@@ -13,6 +13,7 @@ pub(super) struct Source<'a> {
     pub texture_maps: BTreeMap<u32, Vec<u32>>,
     pub styled_items: BTreeMap<u32, Vec<u32>>,
     pub voided: BTreeSet<u32>,
+    pub style_assignments: BTreeSet<u32>,
 }
 impl<'a> Source<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self, String> {
@@ -27,10 +28,11 @@ impl<'a> Source<'a> {
             texture_maps: BTreeMap::new(),
             styled_items: BTreeMap::new(),
             voided: BTreeSet::new(),
+            style_assignments: BTreeSet::new(),
         };
         let mut scanner = EntityScanner::new(bytes);
         let mut work = 0;
-        while let Some((id, _, start, end)) = scanner.next_entity() {
+        while let Some((id, name, start, end)) = scanner.next_entity() {
             if source.types.len() >= 200_000 {
                 return Err("Appearance entity budget exceeded".into());
             }
@@ -56,6 +58,7 @@ impl<'a> Source<'a> {
                     _ => {}
                 }
             }
+            if name == "IFCPRESENTATIONSTYLEASSIGNMENT" { source.style_assignments.insert(id); }
             match entity.ifc_type {
                 IfcType::IfcIndexedTriangleTextureMap => {
                     if let Some(item) = entity.get_ref(1) {

--- a/rust/processing/src/appearance/tests.rs
+++ b/rust/processing/src/appearance/tests.rs
@@ -45,6 +45,7 @@ END-ISO-10303-21;
 
 fn request(products: Vec<u32>) -> AppearanceRequest {
     AppearanceRequest {
+        representation_policy: RepresentationPolicy::Preserve,
         schema: "IFC4".into(),
         source_revision: "revision-1".into(),
         next_express_id: 100,

--- a/rust/processing/src/appearance/types.rs
+++ b/rust/processing/src/appearance/types.rs
@@ -4,9 +4,20 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RepresentationPolicy {
+    #[default]
+    Preserve,
+    EvaluatedOccurrence,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AppearanceRequest {
+    /// Parametric conversion is never implicit.
+    #[serde(default)]
+    pub representation_policy: RepresentationPolicy,
     pub schema: String,
     pub source_revision: String,
     pub next_express_id: u32,
@@ -94,6 +105,8 @@ pub struct Exclusion {
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppearancePlan {
+    /// Explicit occurrence-local conversions, with original renderer provenance.
+    pub conversions: Vec<AppearanceConversion>,
     pub source_revision: String,
     pub next_express_id: u32,
     pub next_available_express_id: u32,
@@ -102,4 +115,14 @@ pub struct AppearancePlan {
     pub removed: Vec<u32>,
     pub items: Vec<AppearanceItem>,
     pub exclusions: Vec<Exclusion>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppearanceConversion {
+    pub product_id: u32,
+    pub representation_id: u32,
+    pub source_geometry_item_id: u32,
+    pub geometry_item_id: u32,
+    pub source_indices: Vec<u32>,
 }

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1091,3 +1091,14 @@ transaction fence is unchanged and still blocks. Identical runtime and canonical
 owner/mesh output were verified across paired runs; cancellation published no IFC
 or history changes. Raw evidence, memory caveats and methodology live in
 `docs/architecture/evidence/appearance/apply-responsiveness/README.md`.
+
+### Opt-in evaluated occurrence appearance (#4404)
+
+Occurrence-local normalization runs only during an explicit appearance plan;
+ordinary loading keeps its existing pipeline. Interleaved AC20 base/branch native
+load probes found no resolvable regression at the probe's integer-millisecond
+phase precision, with identical ordered mesh fingerprints and geometry counts.
+This is native load evidence, not a worker-pool speedup or conversion-latency
+claim. Preserve the opt-in boundary and measure broad authoring separately when
+its host UI lands. [Raw samples and measurement limits](../../docs/architecture/evidence/evaluated-occurrences/native-load.json)
+record the comparison.


### PR DESCRIPTION
Opt-in image and finite-page appearance can now convert a supported mapped occurrence to a textured tessellation in one native mutation plan. The real AC20 member #35169 keeps its GlobalId, semantic relationships, unique Body wrapper and original surface style; all sibling occurrences and shared type geometry remain unchanged. Default requests retain the existing direct-tessellation-only behavior.

Refs #4404 (ready, assigned to louistrue; remains open for host/UI and later evaluated cases).

The narrow policy requires a uniquely owned product representation and Body with one mapped item, one explicit surface style, and canonical geometry that survives replacement exactly. It refuses opening-bearing hosts, StandardCase subtypes, shared/aspect wrappers, styled layers, mapped-chain style overrides, material-layer slicing, multiple meshes, existing textures and ExistingUv conversion. Preview provenance accompanies the composite plan. The viewer has the typed contract but does not expose opt-in conversion yet.

Validation:

- Real AC20 native image and page plans reopen with equivalent oriented geometry; unselected canonical meshes are unchanged. Failed mapping and unsupported cases publish no conversion rows.
- Independent IfcOpenShell 0.8.2 validates the actual native output: 170 existing source findings remain 170, with zero new violations; only existing Body #35155 changes. Evidence and reproducible reader are in `docs/architecture/evidence/evaluated-occurrences/`.
- Full Rust workspace tests passed; final appearance tests 59/59 and workspace all-target clippy with warnings denied passed. Same-colour/different-roughness overrides and a verified sliceable material-layer fixture refuse atomically.
- Fresh WASM image and worker-page contract passed 1/1 with no skips. Root Turbo build 51/51, typecheck including 1,899 test files, lint, API snapshots, docs samples/generated/readmes and reference-walk/module/source-assertion guards passed.
- Root independent review cleared the native policy and the follow-up eligibility guard.

Performance: prebuilt source-specific native probes ran A/B/A/B, five iterations per sample, with other agents idle. Parse/geometry/total were 3/5/8 ms for both first samples; second samples were 3/4/8 vs 3/4/7 ms. Integer-millisecond precision does not resolve a meaningful change. All runs retain 285 meshes, 19,456 triangles and ordered FNV `25ac885b6ff4ad00`. This is native load evidence, not a browser worker-pool or conversion-latency claim. The perf ledger records the limitation.
