### PR TITLE
fix(appearance): finalize composite plans for atomic host allocation

### DIFF
--- a/.changeset/evaluated-composite-allocation.md
+++ b/.changeset/evaluated-composite-allocation.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Emit evaluated occurrence appearance creations in contiguous allocator order, including when a private conversion is excluded. Rebind generated IFC references and page image provenance together so atomic host application can accept the composite plan.

--- a/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
@@ -25,6 +25,7 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
     assert.equal(preserved.items.length, 0); assert.equal(preserved.created.length, 0);
     request.representationPolicy = 'evaluatedOccurrence';
     const result = JSON.parse(new TextDecoder().decode(api.planAppearance(source, JSON.stringify(request)))) as AppearancePlan;
+    assert.deepEqual(result.created.map(row => row.expressId), Array.from({ length: result.created.length }, (_, index) => result.nextExpressId + index));
     assert.equal(result.items.length, 1); assert.deepEqual(result.exclusions, []);
     assert.equal(result.conversions?.[0].productId, 35169);
     assert.equal(result.conversions?.[0].sourceGeometryItemId, 35135);
@@ -39,6 +40,8 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
       mapping: { kind: 'planar', frame: 'world', origin: [1, 6, 3], axisU: [0, 1, 0], axisV: [0, 0, 1], metresPerTile: [2, 2] } },
     page: { width: 1, height: 1, byteOffset: 0, byteLength: 4 }, sourceImages: [], texelsPerMetre: 32,
   }, new Uint8Array([255, 0, 0, 255]));
+  assert.deepEqual(page.plan.created.map(row => row.expressId), Array.from({ length: page.plan.created.length }, (_, index) => page.plan.nextExpressId + index));
+  assert.equal(page.itemImages[0].geometryItemId, page.plan.items[0].geometryItemId);
   assert.equal(page.plan.conversions?.length, 1); assert.ok(page.assets.length > 0);
   assert.ok(page.plan.edits.every(edit => edit.expressId === 35155));
 });

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -51,3 +51,9 @@ unselected meshes unchanged and the selected oriented world corners exactly,
 exercise finite-page composition, and refuse direct/inherited openings and shared
 wrappers. Independent IfcOpenShell checks compare new violations against the
 source's existing validation findings; the original model is not schema-clean.
+
+Composite output uses ascending, contiguous created IDs from `nextExpressId`.
+Private conversions rejected by the final appearance pass leave no allocator
+gaps. Generated references, replacement-item provenance and page image bindings
+are rebound together before the plan leaves Rust; host allocation checks remain
+strict.

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -57,3 +57,7 @@ Private conversions rejected by the final appearance pass leave no allocator
 gaps. Generated references, replacement-item provenance and page image bindings
 are rebound together before the plan leaves Rust; host allocation checks remain
 strict.
+
+Page material names beginning with `#` are refused explicitly: the current
+authoring wire cannot distinguish those literals from reference strings. They
+are never silently rewritten or exported as a Name reference.

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -58,6 +58,7 @@ gaps. Generated references, replacement-item provenance and page image bindings
 are rebound together before the plan leaves Rust; host allocation checks remain
 strict.
 
-Page material names beginning with `#` are refused explicitly: the current
-authoring wire cannot distinguish those literals from reference strings. They
-are never silently rewritten or exported as a Name reference.
+Page material names equal to reserved wire tokens after trimming (`#123`,
+`.ENUM.`, `$`, or `*`) are refused explicitly. The current authoring wire cannot
+distinguish those literals from references/enumerations/null/derived values.
+Other labels, including `#material` and `.surface`, remain literal strings.

--- a/docs/architecture/evidence/evaluated-occurrences/allocation-load.json
+++ b/docs/architecture/evidence/evaluated-occurrences/allocation-load.json
@@ -1,0 +1,185 @@
+{
+  "base": "e95350017 (merged by cd0e214cc)",
+  "branch": "3cf3f5237",
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "method": "Prebuilt source-specific profiling binaries, A/B/A/B with five iterations each. Other agents paused heavy work; normal OS processes and an unrelated filesystem search remained. Base is the immutable binary from the preceding F6 probe; branch runs scripts/perf/probe.sh. Native load only, not conversion or worker-pool latency.",
+  "verdict": "Identical phase timings in both pairs at integer-millisecond precision; no resolvable load regression or speedup claim. All mesh counts and ordered fingerprints match.",
+  "runs": [
+    {
+      "variant": "base",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.28,
+        "parseMs": 3,
+        "entityScanMs": 2,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          16,
+          9,
+          8,
+          8,
+          10
+        ],
+        "allWallMs": [
+          17.24,
+          9.80825,
+          9.336333,
+          8.850916,
+          10.547167
+        ],
+        "pointCacheHits": 51932,
+        "pointCacheMisses": 9164,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "branch",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.39,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          12,
+          8,
+          8,
+          8,
+          8
+        ],
+        "allWallMs": [
+          13.297458,
+          9.279292,
+          8.657292,
+          9.045292,
+          8.701375
+        ],
+        "pointCacheHits": 52244,
+        "pointCacheMisses": 9236,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "base",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.12,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 4,
+        "facetedBrepMs": 0,
+        "totalMs": 7,
+        "allTotalsMs": [
+          9,
+          8,
+          8,
+          8,
+          7
+        ],
+        "allWallMs": [
+          10.037707999999999,
+          8.594709,
+          8.592834,
+          8.514292,
+          8.129624999999999
+        ],
+        "pointCacheHits": 52268,
+        "pointCacheMisses": 9260,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    },
+    {
+      "variant": "branch",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.11,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 4,
+        "facetedBrepMs": 0,
+        "totalMs": 7,
+        "allTotalsMs": [
+          11,
+          8,
+          8,
+          7,
+          7
+        ],
+        "allWallMs": [
+          12.159334000000001,
+          8.5575,
+          8.701208,
+          8.233292,
+          8.143625
+        ],
+        "pointCacheHits": 51884,
+        "pointCacheMisses": 9140,
+        "csgFailures": 0,
+        "degenerateDropped": 0,
+        "meshFingerprintsFnv1a64": [
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00",
+          "25ac885b6ff4ad00"
+        ]
+      }
+    }
+  ]
+}

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -144,7 +144,7 @@ impl Normalized {
         }
         Ok(())
     }
-    pub(super) fn compose(self,mut plan:AppearancePlan)->(AppearancePlan,BTreeMap<u32,u32>) {
+    pub(super) fn compose(self,mut plan:AppearancePlan)->Result<(AppearancePlan,BTreeMap<u32,u32>),String> {
         let accepted:BTreeSet<_>=plan.items.iter().map(|item|item.product_id).collect();
         for conversion in self.conversions {
             if accepted.contains(&conversion.binding.product_id) {
@@ -163,8 +163,8 @@ impl Normalized {
         }
         plan.next_express_id=self.start;
         plan.exclusions.extend(self.exclusions);
-        let ids=super::evaluated_allocation::compact(&mut plan);
-        (plan,ids)
+        let ids=super::evaluated_allocation::compact(&mut plan)?;
+        Ok((plan,ids))
     }
 }
 

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //! Private evaluated-occurrence normalization; publication is one appearance plan.
+use std::collections::BTreeMap;
 use super::{evaluated_source, source::Source, *};
 use ifc_lite_core::{AttributeValue as A, DecodedEntity};
 use rustc_hash::FxHashMap;
@@ -143,7 +144,7 @@ impl Normalized {
         }
         Ok(())
     }
-    pub(super) fn compose(self,mut plan:AppearancePlan)->AppearancePlan {
+    pub(super) fn compose(self,mut plan:AppearancePlan)->(AppearancePlan,BTreeMap<u32,u32>) {
         let accepted:BTreeSet<_>=plan.items.iter().map(|item|item.product_id).collect();
         for conversion in self.conversions {
             if accepted.contains(&conversion.binding.product_id) {
@@ -161,7 +162,9 @@ impl Normalized {
             } else { plan.edits.push(edit); }
         }
         plan.next_express_id=self.start;
-        plan.exclusions.extend(self.exclusions); plan
+        plan.exclusions.extend(self.exclusions);
+        let ids=super::evaluated_allocation::compact(&mut plan);
+        (plan,ids)
     }
 }
 

--- a/rust/processing/src/appearance/evaluated_allocation.rs
+++ b/rust/processing/src/appearance/evaluated_allocation.rs
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Keep composite private plans compatible with sequential host allocation.
+use std::collections::BTreeMap;
+use super::*;
+
+pub(super) fn compact(plan: &mut AppearancePlan) -> BTreeMap<u32,u32> {
+    plan.created.sort_unstable_by_key(|entity|entity.express_id);
+    let ids:BTreeMap<_,_>=plan.created.iter().enumerate()
+        .map(|(index,entity)|(entity.express_id,plan.next_express_id+index as u32)).collect();
+    // These are generated, already-budgeted plan values, not source reference
+    // traversal. Iteration also avoids recursive allocation when rebinding arrays.
+    let mut values=Vec::new();
+    for entity in &mut plan.created {
+        entity.express_id=ids[&entity.express_id];
+        values.extend(entity.attributes.iter_mut());
+    }
+    for edit in &mut plan.edits { values.push(&mut edit.value); }
+    while let Some(value)=values.pop() {
+        match value {
+            Value::String(text)=> {
+                if let Some(id)=text.strip_prefix('#').and_then(|id|id.parse::<u32>().ok()).and_then(|id|ids.get(&id)) {
+                    *text=format!("#{id}");
+                }
+            },
+            Value::Array(items)=>values.extend(items.iter_mut()),
+            _=>{},
+        }
+    }
+    for item in &mut plan.items { if let Some(&id)=ids.get(&item.geometry_item_id) {item.geometry_item_id=id;} }
+    for item in &mut plan.conversions { if let Some(&id)=ids.get(&item.geometry_item_id) {item.geometry_item_id=id;} }
+    plan.next_available_express_id=plan.next_express_id+plan.created.len() as u32;
+    ids
+}

--- a/rust/processing/src/appearance/evaluated_allocation.rs
+++ b/rust/processing/src/appearance/evaluated_allocation.rs
@@ -5,18 +5,36 @@
 use std::collections::BTreeMap;
 use super::*;
 
-pub(super) fn compact(plan: &mut AppearancePlan) -> BTreeMap<u32,u32> {
+pub(super) fn compact(plan: &mut AppearancePlan) -> Result<BTreeMap<u32,u32>,String> {
     plan.created.sort_unstable_by_key(|entity|entity.express_id);
     let ids:BTreeMap<_,_>=plan.created.iter().enumerate()
         .map(|(index,entity)|(entity.express_id,plan.next_express_id+index as u32)).collect();
-    // These are generated, already-budgeted plan values, not source reference
-    // traversal. Iteration also avoids recursive allocation when rebinding arrays.
+    // The wire format uses strings for both references and labels. Visit only
+    // EXPRESS reference slots in the entity types this authoring path generates.
+    // A Name such as '#100001' is a literal, even when that ID is being compacted.
     let mut values=Vec::new();
     for entity in &mut plan.created {
         entity.express_id=ids[&entity.express_id];
-        values.extend(entity.attributes.iter_mut());
+        let slots:&[usize]=match entity.r#type.as_str() {
+            "IfcTriangulatedFaceSet"|"IfcSurfaceStyleShading"|"IfcSurfaceStyleWithTextures"=>&[0],
+            "IfcStyledItem"=>&[0,1], "IfcIndexedTriangleTextureMap"=>&[0,1,2],
+            "IfcSurfaceStyle"=>&[2], "IfcImageTexture"=>&[3],
+            "IfcSurfaceStyleRendering"=>&[0,2,3,4,5,6],
+            "IfcCartesianPointList3D"|"IfcTextureVertexList"|"IfcColourRgb"=>&[],
+            name=>return Err(format!("Unsupported generated appearance reference layout: {name}")),
+        };
+        values.extend(entity.attributes.iter_mut().enumerate().filter_map(|(index,value)|slots.contains(&index).then_some(value)));
     }
-    for edit in &mut plan.edits { values.push(&mut edit.value); }
+    for edit in &mut plan.edits {
+        let body=plan.conversions.iter().any(|conversion|conversion.representation_id==edit.express_id);
+        match (body,edit.index) {
+            (true,3)|(false,1)=>values.push(&mut edit.value),
+            (true,2)=>{},
+            _=>return Err("Unsupported evaluated appearance reference edit".into()),
+        }
+    }
+    // Only bounded generated plan arrays enter this iterative walk. Typed numeric
+    // SELECT objects have no reference-bearing slots and are intentionally opaque.
     while let Some(value)=values.pop() {
         match value {
             Value::String(text)=> {
@@ -31,5 +49,5 @@ pub(super) fn compact(plan: &mut AppearancePlan) -> BTreeMap<u32,u32> {
     for item in &mut plan.items { if let Some(&id)=ids.get(&item.geometry_item_id) {item.geometry_item_id=id;} }
     for item in &mut plan.conversions { if let Some(&id)=ids.get(&item.geometry_item_id) {item.geometry_item_id=id;} }
     plan.next_available_express_id=plan.next_express_id+plan.created.len() as u32;
-    ids
+    Ok(ids)
 }

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -156,12 +156,22 @@ fn issue_4404_filtered_private_conversion_prefix_compacts_to_host_allocation_ord
 #[test]
 fn issue_4404_real_page_material_name_that_looks_like_generated_reference_is_literal() {
     let Some(source)=real_source() else{return};
-    let ambiguous_source=source.replace("'Kiefer'","'#100001'");
     let mut appearance=request(); appearance.repeat_s=false;appearance.repeat_t=false;
     appearance.mapping=Mapping::Planar {frame:MappingFrame::World,origin:[1.,6.,3.],axis_u:[0.,1.,0.],axis_v:[0.,0.,1.],metres_per_tile:[2.,2.]};
     let request=PageAppearanceRequest {appearance,page:AppearanceRaster {width:1,height:1,byte_offset:0,byte_length:4},source_images:vec![],texels_per_metre:32.};
-    let error=plan_page_appearance(ambiguous_source.as_bytes(),&request,&[255,0,0,255]).unwrap_err();
-    assert!(error.contains("names beginning with '#'"),"{error}");
+    for name in ["#100001",".FOO.","*","$"," .T. "," #100001 "] {
+        let ambiguous_source=source.replace("'Kiefer'",&format!("'{name}'"));
+        let error=plan_page_appearance(ambiguous_source.as_bytes(),&request,&[255,0,0,255]).unwrap_err();
+        assert!(error.contains("reserved appearance wire token"),"{name}: {error}");
+    }
+    for name in ["#material",".surface","*label","$label","ordinary'quoted"] {
+        let named_source=source.replace("'Kiefer'",&format!("'{}'",name.replace('\'',"''")));
+        let result=plan_page_appearance(named_source.as_bytes(),&request,&[255,0,0,255]).unwrap();
+        let output=apply(&named_source,&result.plan);
+        let reopened=crate::process_geometry(output.as_bytes());
+        let target=reopened.meshes.iter().find(|mesh|mesh.express_id==35169).unwrap();
+        assert_eq!(target.material_name.as_deref(),Some(name));
+    }
     // The public path refuses the ambiguous Name instead of emitting invalid
     // STEP. Also protect the finalizer itself against treating literal slots as
     // references, independently of the page writer's current restriction.

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -29,6 +29,7 @@ fn issue_4404_real_mapped_member_is_opt_in_and_preserves_every_sibling_and_world
     request.representation_policy=RepresentationPolicy::EvaluatedOccurrence;
     let plan=plan_appearance(source.as_bytes(),&request).unwrap();
     assert!(plan.exclusions.is_empty(),"{:?}",plan.exclusions);
+    assert_eq!(plan.created.iter().map(|row|row.express_id).collect::<Vec<_>>(),(plan.next_express_id..plan.next_available_express_id).collect::<Vec<_>>());
     assert_eq!(plan.conversions.len(),1);assert_eq!(plan.items.len(),1);
     assert_eq!(plan.conversions[0].representation_id,35155);
     assert_eq!(plan.conversions[0].source_geometry_item_id,35135);
@@ -68,6 +69,8 @@ fn issue_4404_page_projection_composes_conversion_and_atlas_in_one_plan() {
     appearance.mapping=Mapping::Planar {frame:MappingFrame::World,origin:[1.,6.,3.],axis_u:[0.,1.,0.],axis_v:[0.,0.,1.],metres_per_tile:[2.,2.]};
     let request=PageAppearanceRequest {appearance,page:AppearanceRaster {width:1,height:1,byte_offset:0,byte_length:4},source_images:vec![],texels_per_metre:32.};
     let result=plan_page_appearance(source.as_bytes(),&request,&[255,0,0,255]).unwrap();
+    assert_eq!(result.plan.created.iter().map(|row|row.express_id).collect::<Vec<_>>(),(result.plan.next_express_id..result.plan.next_available_express_id).collect::<Vec<_>>());
+    assert_eq!(result.item_images[0].geometry_item_id,result.plan.items[0].geometry_item_id);
     assert_eq!(result.plan.conversions.len(),1);assert_eq!(result.item_images.len(),1);assert!(!result.assets.is_empty());
     assert!(result.plan.edits.iter().all(|edit|edit.express_id==35155));
     let output=apply(&source,&result.plan);
@@ -121,4 +124,31 @@ fn issue_4404_material_layer_slicing_refusal_precedes_mapped_evaluation() {
     let plan=plan_appearance(changed.as_bytes(),&request()).unwrap();
     assert_eq!(plan.exclusions.len(),1);assert!(plan.exclusions[0].reason.contains("Material-layer slicing"));
     assert!(plan.created.is_empty());assert!(plan.edits.is_empty());
+}
+
+#[test]
+fn issue_4404_filtered_private_conversion_prefix_compacts_to_host_allocation_order() {
+    let Some(text)=real_source() else{return};
+    let mut request=request(); request.product_ids=vec![35169,35304];
+    let mut source=Source::new(text.as_bytes()).unwrap();
+    let mut normalized=prepare(text.as_bytes(),&request,&mut source).unwrap();
+    assert_eq!(normalized.conversions.len(),2);
+    // The final appearance pass can exclude a normalized occurrence. Its unused
+    // private IDs must not leave a gap before the accepted occurrence's rows.
+    normalized.request.product_ids.retain(|id|*id==35304);
+    let mapped=super::super::plan_with_source(text.as_bytes(),&normalized.request,&mut source).unwrap();
+    let (plan,ids)=normalized.compose(mapped);
+    assert_eq!(plan.conversions.len(),1);
+    assert_eq!(plan.conversions[0].product_id,35304);
+    assert!(ids.iter().any(|(old,new)|old!=new));
+    assert_eq!(plan.created.iter().map(|row|row.express_id).collect::<Vec<_>>(),(plan.next_express_id..plan.next_available_express_id).collect::<Vec<_>>());
+    let output=apply(&text,&plan);
+    let before=crate::process_geometry(text.as_bytes()); let after=crate::process_geometry(output.as_bytes());
+    for id in [35169,35304] {
+        let original=before.meshes.iter().find(|m|m.express_id==id).unwrap();
+        let replacement=after.meshes.iter().find(|m|m.express_id==id).unwrap();
+        assert_eq!(corners(original),corners(replacement));
+        if id==35169 {assert_eq!(serde_json::to_value(original).unwrap(),serde_json::to_value(replacement).unwrap());}
+        else {assert_eq!(replacement.geometry_item_id,Some(plan.conversions[0].geometry_item_id));assert!(replacement.texture.is_some());}
+    }
 }

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -137,7 +137,7 @@ fn issue_4404_filtered_private_conversion_prefix_compacts_to_host_allocation_ord
     // private IDs must not leave a gap before the accepted occurrence's rows.
     normalized.request.product_ids.retain(|id|*id==35304);
     let mapped=super::super::plan_with_source(text.as_bytes(),&normalized.request,&mut source).unwrap();
-    let (plan,ids)=normalized.compose(mapped);
+    let (plan,ids)=normalized.compose(mapped).unwrap();
     assert_eq!(plan.conversions.len(),1);
     assert_eq!(plan.conversions[0].product_id,35304);
     assert!(ids.iter().any(|(old,new)|old!=new));
@@ -151,4 +151,32 @@ fn issue_4404_filtered_private_conversion_prefix_compacts_to_host_allocation_ord
         if id==35169 {assert_eq!(serde_json::to_value(original).unwrap(),serde_json::to_value(replacement).unwrap());}
         else {assert_eq!(replacement.geometry_item_id,Some(plan.conversions[0].geometry_item_id));assert!(replacement.texture.is_some());}
     }
+}
+
+#[test]
+fn issue_4404_real_page_material_name_that_looks_like_generated_reference_is_literal() {
+    let Some(source)=real_source() else{return};
+    let ambiguous_source=source.replace("'Kiefer'","'#100001'");
+    let mut appearance=request(); appearance.repeat_s=false;appearance.repeat_t=false;
+    appearance.mapping=Mapping::Planar {frame:MappingFrame::World,origin:[1.,6.,3.],axis_u:[0.,1.,0.],axis_v:[0.,0.,1.],metres_per_tile:[2.,2.]};
+    let request=PageAppearanceRequest {appearance,page:AppearanceRaster {width:1,height:1,byte_offset:0,byte_length:4},source_images:vec![],texels_per_metre:32.};
+    let error=plan_page_appearance(ambiguous_source.as_bytes(),&request,&[255,0,0,255]).unwrap_err();
+    assert!(error.contains("names beginning with '#'"),"{error}");
+    // The public path refuses the ambiguous Name instead of emitting invalid
+    // STEP. Also protect the finalizer itself against treating literal slots as
+    // references, independently of the page writer's current restriction.
+    let mut result=plan_page_appearance(source.as_bytes(),&request,&[255,0,0,255]).unwrap();
+    for row in &mut result.plan.created {
+        if row.r#type=="IfcSurfaceStyle" {row.attributes[0]=json!("#100001");}
+    }
+    let names=|plan:&AppearancePlan|plan.created.iter().filter(|row|row.r#type=="IfcSurfaceStyle")
+        .map(|row|row.attributes[0].clone()).collect::<Vec<_>>();
+    let original_names=names(&result.plan);assert!(original_names.contains(&json!("#100001")));
+    // Force the same remapping that an omitted private prefix requires, using
+    // the actual native page plan with its preserved exporter material label.
+    result.plan.next_express_id-=1;
+    let ids=super::super::evaluated_allocation::compact(&mut result.plan).unwrap();
+    assert_ne!(ids[&100001],100001);
+    assert_eq!(names(&result.plan),original_names);
+    assert_eq!(result.plan.created[0].express_id,result.plan.next_express_id);
 }

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -87,7 +87,7 @@ pub fn plan_appearance(
     if request.representation_policy==RepresentationPolicy::EvaluatedOccurrence {
         let normalized=evaluated::prepare(bytes,request,&mut source)?;
         let plan=plan_with_source(bytes,normalized.request(),&mut source)?;
-        return Ok(normalized.compose(plan).0);
+        return Ok(normalized.compose(plan)?.0);
     }
     plan_with_source(bytes,request,&mut source)
 }

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -6,6 +6,7 @@
 mod budget;
 mod evaluated;
 mod evaluated_source;
+mod evaluated_allocation;
 mod annotation;
 mod captured;
 mod captured_types;
@@ -86,7 +87,7 @@ pub fn plan_appearance(
     if request.representation_policy==RepresentationPolicy::EvaluatedOccurrence {
         let normalized=evaluated::prepare(bytes,request,&mut source)?;
         let plan=plan_with_source(bytes,normalized.request(),&mut source)?;
-        return Ok(normalized.compose(plan));
+        return Ok(normalized.compose(plan).0);
     }
     plan_with_source(bytes,request,&mut source)
 }

--- a/rust/processing/src/appearance/page.rs
+++ b/rust/processing/src/appearance/page.rs
@@ -103,7 +103,15 @@ pub fn plan_page_appearance(bytes: &[u8], request: &PageAppearanceRequest, rgba:
         start += count;
     }
     bind_images(&mut plan, &item_images, &mut source, &styles)?;
-    let plan=match normalization { Some(n)=>n.compose(plan),None=>plan };
+    let plan=match normalization {
+        Some(n)=> {
+            let (plan,ids)=n.compose(plan);
+            for image in &mut item_images {
+                if let Some(&id)=ids.get(&image.geometry_item_id) {image.geometry_item_id=id;}
+            }
+            plan
+        },None=>plan
+    };
     Ok(PageAppearancePlan { plan, item_images, assets, texels_per_metre: request.texels_per_metre })
 }
 fn encode_png(atlas: &page_atlas::Atlas, limit: usize) -> Result<Vec<u8>, String> {

--- a/rust/processing/src/appearance/page.rs
+++ b/rust/processing/src/appearance/page.rs
@@ -105,7 +105,7 @@ pub fn plan_page_appearance(bytes: &[u8], request: &PageAppearanceRequest, rgba:
     bind_images(&mut plan, &item_images, &mut source, &styles)?;
     let plan=match normalization {
         Some(n)=> {
-            let (plan,ids)=n.compose(plan);
+            let (plan,ids)=n.compose(plan)?;
             for image in &mut item_images {
                 if let Some(&id)=ids.get(&image.geometry_item_id) {image.geometry_item_id=id;}
             }

--- a/rust/processing/src/appearance/page_material.rs
+++ b/rust/processing/src/appearance/page_material.rs
@@ -58,11 +58,16 @@ pub(super) fn preserve(plan: &mut AppearancePlan, source: &mut Source<'_>, item:
     if original.get_string(0).is_some_and(|name| name.len() > 4096) {
         return Err("Source material name exceeds 4096-byte budget".into());
     }
-    // The current authoring wire encodes references as '#id' strings. A label
-    // beginning with '#' cannot be serialized unambiguously; refuse rather than
-    // publish a Name reference or silently alter the exporter's material label.
-    if original.get_string(0).is_some_and(|name|name.starts_with('#')) {
-        return Err("Page material names beginning with '#' cannot be preserved by the current appearance wire format".into());
+    // Match the generic wire writer's reserved tokens after whitespace trim.
+    // It cannot distinguish these free-text labels from null/derived/ref/enum
+    // values when serializing a newly created style, so refuse losslessly.
+    if original.get_string(0).is_some_and(|name| {
+        let token=name.trim();
+        matches!(token,"$"|"*")
+            || token.strip_prefix('#').is_some_and(|id|!id.is_empty() && id.bytes().all(|c|c.is_ascii_digit()))
+            || token.strip_prefix('.').and_then(|s|s.strip_suffix('.')).is_some_and(|s|!s.is_empty() && s.bytes().all(|c|c.is_ascii_alphanumeric() || c==b'_'))
+    }) {
+        return Err("Page material name is a reserved appearance wire token and cannot be preserved".into());
     }
     let members = original.get_list(2).ok_or("Missing source surface style elements")?;
     if members.len() > 5 { return Err("Source surface style exceeds five-element schema limit".into()); }

--- a/rust/processing/src/appearance/page_material.rs
+++ b/rust/processing/src/appearance/page_material.rs
@@ -58,6 +58,12 @@ pub(super) fn preserve(plan: &mut AppearancePlan, source: &mut Source<'_>, item:
     if original.get_string(0).is_some_and(|name| name.len() > 4096) {
         return Err("Source material name exceeds 4096-byte budget".into());
     }
+    // The current authoring wire encodes references as '#id' strings. A label
+    // beginning with '#' cannot be serialized unambiguously; refuse rather than
+    // publish a Name reference or silently alter the exporter's material label.
+    if original.get_string(0).is_some_and(|name|name.starts_with('#')) {
+        return Err("Page material names beginning with '#' cannot be preserved by the current appearance wire format".into());
+    }
     let members = original.get_list(2).ok_or("Missing source surface style elements")?;
     if members.len() > 5 { return Err("Source surface style exceeds five-element schema limit".into()); }
     let mut extras = Vec::new();

--- a/rust/processing/src/appearance/tests.rs
+++ b/rust/processing/src/appearance/tests.rs
@@ -85,7 +85,12 @@ fn step(value: &Value) -> String {
             "({})",
             values.iter().map(step).collect::<Vec<_>>().join(",")
         ),
-        Value::String(s) if s.starts_with('#') || s.starts_with('.') || s == "*" => s.clone(),
+        Value::String(s) if {
+            let token=s.trim();
+            matches!(token,"$"|"*")
+                || token.strip_prefix('#').is_some_and(|id|!id.is_empty() && id.bytes().all(|c|c.is_ascii_digit()))
+                || token.strip_prefix('.').and_then(|s|s.strip_suffix('.')).is_some_and(|s|!s.is_empty() && s.bytes().all(|c|c.is_ascii_alphanumeric() || c==b'_'))
+        } => s.trim().into(),
         Value::String(s) => format!("'{}'", s.replace('\'', "''")),
         other => other.to_string(),
     }

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1120,3 +1120,11 @@ This is native load evidence, not a worker-pool speedup or conversion-latency
 claim. Preserve the opt-in boundary and measure broad authoring separately when
 its host UI lands. [Raw samples and measurement limits](../../docs/architecture/evidence/evaluated-occurrences/native-load.json)
 record the comparison.
+
+The F6 composite-allocation follow-up keeps compaction inside authoring only.
+Repeated base/branch AC20 load probes retained identical phase timings at the
+probe's measurement precision and identical ordered mesh fingerprints. This
+supports no resolvable native-load regression, not an authoring or worker-pool
+speedup. Preserve literal-versus-reference schema slots when compacting plans;
+never trade semantic fidelity for convenient generic string rewriting.
+[Follow-up samples and limits](../../docs/architecture/evidence/evaluated-occurrences/allocation-load.json).


### PR DESCRIPTION
Evaluated occurrence plans appended their private conversion rows after the appearance rows. The host correctly rejected these plans because new IFC rows must follow its contiguous allocator order. Finalize the native composite in that order, close gaps left by rejected private conversions, and rebind generated references, conversion provenance and finite-page image bindings together.

Refs #4404 (ready, assigned to louistrue; remains open for the separately developed UI).

The finalizer visits only schema-known reference slots, so literal material labels cannot be rewritten as references. The existing generic authoring wire cannot encode a material Name equal to a trimmed reference, enumeration, null or derived token (`#123`, `.ENUM.`, `$`, `*`); page planning now refuses those names explicitly. Safe prefix labels and apostrophes retain their exact names after IFC serialization and native reopening.

Validation:

- Appearance native tests 72/72 pass, including real AC20 contiguous allocation, filtered private-prefix compaction, page image identity, reserved-name refusals and safe material-name roundtrips. Excluded siblings retain identical geometry and appearance.
- Full Rust workspace tests and all-target clippy with warnings denied pass; final WASM rebuilt without committed type drift.
- The developing mounted UI exposed the original failure. With the allocation fix, actual WASM single/federated image preview, Compare, Apply, one Undo/Redo, exact PNG export and untouched sibling assertions pass 2/2 with no skips. UI changes are not in this PR.
- Root independently reviewed the allocation and reference-slot policy. Final root typecheck covers all 1,901 test files; fresh actual WASM allocation/page-provenance test passes 1/1 with zero skips through root Turbo (44/44 tasks). Docs samples, reference-walk guard, Rust API snapshot and issue queue checks pass.

Performance: prebuilt A/B/A/B native AC20 probes, five iterations each, had identical parse/geometry/total phase timings in both pairs (3/5/8 ms and 3/4/7 ms). All retain 285 meshes, 19,456 triangles and ordered FNV `25ac885b6ff4ad00`. Other agents paused heavy work; normal OS activity and an unrelated filesystem search remained. No resolvable native-load regression at this precision, and no authoring or browser worker-pool speedup claim. Raw evidence and the perf ledger record the limits.
