### PR TITLE
feat(renderer): retain reversible occurrence appearance resources

### DIFF
--- a/.changeset/retained-instance-appearance.md
+++ b/.changeset/retained-instance-appearance.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add reversible, model-owned instance retention for occurrence appearance replacement. Suppressed originals retain their shared geometry and selection state while CPU geometry enumeration and picking exclude them; releasing the lease restores ordinary visibility.

--- a/docs/guide/appearance.md
+++ b/docs/guide/appearance.md
@@ -171,3 +171,17 @@ rendered occurrence to its new geometry item. Product identities, placements,
 properties and shared type graphs remain intact. Opening-bearing and ambiguous
 representation/material cases are still refused. See the
 [evaluated-occurrence contract](../architecture/appearance-evaluated-occurrences.md).
+
+Renderer integrations preparing an occurrence replacement can call
+`scene.retainInstancedOccurrence(globalId, modelIndex)` after geometry is resident.
+The returned lease has `valid`, `setSuppressed(boolean)`, and `release()` members.
+Suppression removes that occurrence from drawing, picking, and CPU instance
+geometry enumeration while retaining its shared template, current placement,
+selection, and colour override state. Releasing it restores the current user
+hide/isolate state. Model removal or a scene reset invalidates the lease.
+Retained leases prevent CPU geometry release until history releases them.
+
+This resource operation does not create IFC geometry or canonical UV provenance.
+An appearance integration must separately validate the native evaluated mesh and
+its model frame, publish a replacement, and retain the lease for Undo. It must
+release the lease if preparation fails or the preview is discarded.

--- a/packages/renderer/src/scene-instance-materialization.ts
+++ b/packages/renderer/src/scene-instance-materialization.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { MeshData } from '@ifc-lite/geometry';
+interface Occurrence { templateIndex: number; byteOffset: number; originalColor: [number, number, number, number]; itemId?: number }
+interface Template { positions: Float32Array; normals: Float32Array; indices: Uint32Array; instanceData: ArrayBuffer }
+/** CPU display expansion only: f32 instance transforms are not canonical IFC provenance. */
+export function materializeInstances(expressId: number, occ: readonly Occurrence[], templates: readonly (Template | undefined)[]): MeshData[] | undefined {
+    const out: MeshData[] = [];
+    for (const o of occ) {
+      const tpl = templates[o.templateIndex];
+      if (!tpl || tpl.positions.length === 0) continue;
+      const dv = new DataView(tpl.instanceData);
+      const b = o.byteOffset;
+      const m0 = dv.getFloat32(b + 0, true), m1 = dv.getFloat32(b + 4, true), m2 = dv.getFloat32(b + 8, true);
+      const m4 = dv.getFloat32(b + 16, true), m5 = dv.getFloat32(b + 20, true), m6 = dv.getFloat32(b + 24, true);
+      const m8 = dv.getFloat32(b + 32, true), m9 = dv.getFloat32(b + 36, true), m10 = dv.getFloat32(b + 40, true);
+      const m12 = dv.getFloat32(b + 48, true), m13 = dv.getFloat32(b + 52, true), m14 = dv.getFloat32(b + 56, true);
+      const n = tpl.positions.length;
+      const positions = new Float32Array(n);
+      const normals = new Float32Array(tpl.normals.length);
+      for (let i = 0; i < n; i += 3) {
+        const x = tpl.positions[i], y = tpl.positions[i + 1], z = tpl.positions[i + 2];
+        positions[i] = m0 * x + m4 * y + m8 * z + m12;
+        positions[i + 1] = m1 * x + m5 * y + m9 * z + m13;
+        positions[i + 2] = m2 * x + m6 * y + m10 * z + m14;
+        if (i + 2 < tpl.normals.length) {
+          // Rotate normals by the upper-3×3 (instancing transforms are rigid +
+          // uniform scale, so this is correct up to a renormalize).
+          const nx = tpl.normals[i], ny = tpl.normals[i + 1], nz = tpl.normals[i + 2];
+          let rx = m0 * nx + m4 * ny + m8 * nz;
+          let ry = m1 * nx + m5 * ny + m9 * nz;
+          let rz = m2 * nx + m6 * ny + m10 * nz;
+          const len = Math.hypot(rx, ry, rz) || 1;
+          rx /= len; ry /= len; rz /= len;
+          normals[i] = rx; normals[i + 1] = ry; normals[i + 2] = rz;
+        }
+      }
+      const color: [number, number, number, number] = [...o.originalColor];
+      // Per-occurrence key so CPU caches that would otherwise key on `expressId`
+      // alone (measure-snap geometry cache) don't collide across occurrences of
+      // this instanced entity, which share `expressId` but hold distinct
+      // world-space positions (issue #1405). templateIndex+byteOffset uniquely
+      // and stably identifies an occurrence within the instance buffers.
+      const occurrenceKey = `${expressId}:inst:${o.templateIndex}:${o.byteOffset}`;
+      // #2985: the same drill-to-source id a flat mesh carries, so a consumer of
+      // these pieces is not worse off for the geometry having been instanced.
+      const item = o.itemId !== undefined ? { geometryItemId: o.itemId } : {};
+      out.push({ expressId, positions, normals, indices: tpl.indices, color, occurrenceKey, ...item });
+    }
+    return out.length > 0 ? out : undefined;
+}

--- a/packages/renderer/src/scene-instance-suppression.test.ts
+++ b/packages/renderer/src/scene-instance-suppression.test.ts
@@ -10,7 +10,7 @@ import { INSTANCE_COLOR_OFFSET, INSTANCE_FLAGS_OFFSET, INSTANCE_FLAG_HIDDEN, INS
 
 function fixture(modelIndex = 3) {
   const buffers = new WeakMap<GPUBuffer, ArrayBuffer>();
-  let failNext = false;
+  let failAfter = -1;
   const device = {
     limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
     createBuffer: (desc: GPUBufferDescriptor) => {
@@ -19,7 +19,8 @@ function fixture(modelIndex = 3) {
       buffers.set(buffer, data); return buffer;
     },
     queue: { writeBuffer: (buffer: GPUBuffer, offset: number, data: ArrayBufferView) => {
-      if (failNext) { failNext = false; throw new Error('simulated GPU upload failure'); }
+      if (failAfter === 0) { failAfter = -1; throw new Error('simulated GPU upload failure'); }
+      if (failAfter > 0) failAfter--;
       new Uint8Array(buffers.get(buffer)!, offset, data.byteLength).set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
     } },
   } as unknown as GPUDevice;
@@ -34,7 +35,7 @@ function fixture(modelIndex = 3) {
   const gpu = scene.getInstancedTemplates()[0];
   const flags = (index: number) => new DataView(buffers.get(gpu.instanceBuffer)!).getUint32(index * INSTANCE_STRIDE_BYTES + INSTANCE_FLAGS_OFFSET, true);
   const color = (index: number) => Array.from(new Float32Array(buffers.get(gpu.instanceBuffer)!, index * INSTANCE_STRIDE_BYTES + INSTANCE_COLOR_OFFSET, 4));
-  return { scene, gpu, flags, color, fail: () => { failNext = true; } };
+  return { scene, gpu, flags, color, shard, device, fail: (after = 0) => { failAfter = after; } };
 }
 
 describe('occurrence appearance resource lifetime (#4404)', () => {
@@ -88,6 +89,33 @@ describe('occurrence appearance resource lifetime (#4404)', () => {
     lease.release();
     const after = scene.getInstancedMeshDataPieces(41)![0].positions;
     for (let i = 0; i < before.length; i++) assert.equal(after[i], before[i] + (i % 3 === 0 ? 5 : 0));
+  });
+
+  for (const failedWrite of [0, 1]) it(`rolls back reset at GPU write ${failedWrite} and permits retry`, () => {
+    const { scene, flags, fail } = fixture();
+    const leases = [41, 42].map(id => scene.retainInstancedOccurrence(id, 3));
+    for (const lease of leases) lease.setSuppressed(true);
+    fail(failedWrite);
+    assert.throws(() => scene.clearFlatGeometry(), /GPU upload failure/);
+    assert.ok(leases.every(lease => lease.valid));
+    assert.deepEqual(scene.getAllInstancedMeshData(), []);
+    assert.deepEqual([flags(0), flags(1)], [INSTANCE_FLAG_HIDDEN, INSTANCE_FLAG_HIDDEN]);
+    scene.clearFlatGeometry();
+    assert.ok(leases.every(lease => !lease.valid));
+    assert.deepEqual([flags(0), flags(1)], [0, 0]);
+    assert.deepEqual([...scene.getInstancedEntityIds()], [41, 42]);
+  });
+
+  it('refuses a late shard changing a retained owner before upload, and permits unrelated owners', () => {
+    const { scene, device, shard, flags } = fixture();
+    const lease = scene.retainInstancedOccurrence(41, 3); lease.setSuppressed(true);
+    assert.throws(() => scene.addInstancedShard(device, shard, 3), /Cannot append/);
+    assert.equal(scene.getInstancedTemplates().length, 1);
+    assert.equal(lease.valid, true); assert.equal(flags(0), INSTANCE_FLAG_HIDDEN);
+    scene.addInstancedShard(device, { ...shard, instances: [{ ...shard.instances[0], entityId: 43 }] }, 3);
+    assert.deepEqual([...scene.getInstancedEntityIds()], [42, 43]);
+    assert.equal(lease.valid, true); lease.release();
+    assert.equal(scene.getInstancedMeshDataPieces(41)!.length, 1);
   });
 
   it('rejects another model and invalidates retained originals on removal or scene reset', () => {

--- a/packages/renderer/src/scene-instance-suppression.test.ts
+++ b/packages/renderer/src/scene-instance-suppression.test.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { DecodedInstancedShard } from '@ifc-lite/geometry';
+import { Scene } from './scene.js';
+import { INSTANCE_COLOR_OFFSET, INSTANCE_FLAGS_OFFSET, INSTANCE_FLAG_HIDDEN, INSTANCE_FLAG_SELECTED, INSTANCE_STRIDE_BYTES } from './instanced-render.js';
+(globalThis as Record<string, unknown>).GPUBufferUsage = { COPY_DST: 8, INDEX: 16, VERTEX: 32 };
+
+function fixture(modelIndex = 3) {
+  const buffers = new WeakMap<GPUBuffer, ArrayBuffer>();
+  let failNext = false;
+  const device = {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: (desc: GPUBufferDescriptor) => {
+      const data = new ArrayBuffer(desc.size);
+      const buffer = { size: desc.size, getMappedRange: () => data, unmap() {}, destroy() {} } as unknown as GPUBuffer;
+      buffers.set(buffer, data); return buffer;
+    },
+    queue: { writeBuffer: (buffer: GPUBuffer, offset: number, data: ArrayBufferView) => {
+      if (failNext) { failNext = false; throw new Error('simulated GPU upload failure'); }
+      new Uint8Array(buffers.get(buffer)!, offset, data.byteLength).set(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+    } },
+  } as unknown as GPUDevice;
+  const shard: DecodedInstancedShard = {
+    carriesItemIds: false,
+    templates: [{ positions: new Float32Array([-1, 0, -1, 1, 0, -1, 0, 0, 1]),
+      normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0]), indices: new Uint32Array([0, 1, 2]), origin: [0, 0, 0] }],
+    instances: [41, 42].map((entityId, index) => ({ templateIndex: 0, entityId,
+      color: [0.4, 0.5, 0.6, 1], transform: new Float32Array([1, 0, 0, index * 5, 0, 1, 0, 5, 0, 0, 1, 0, 0, 0, 0, 1]) })),
+  };
+  const scene = new Scene(); scene.addInstancedShard(device, shard, modelIndex);
+  const gpu = scene.getInstancedTemplates()[0];
+  const flags = (index: number) => new DataView(buffers.get(gpu.instanceBuffer)!).getUint32(index * INSTANCE_STRIDE_BYTES + INSTANCE_FLAGS_OFFSET, true);
+  const color = (index: number) => Array.from(new Float32Array(buffers.get(gpu.instanceBuffer)!, index * INSTANCE_STRIDE_BYTES + INSTANCE_COLOR_OFFSET, 4));
+  return { scene, gpu, flags, color, fail: () => { failNext = true; } };
+}
+
+describe('occurrence appearance resource lifetime (#4404)', () => {
+  it('suppresses only the retained occurrence through selection and hide/isolate updates', () => {
+    const { scene, gpu, flags, color } = fixture();
+    const sibling = scene.getInstancedMeshDataPieces(42)![0];
+    scene.setInstancedSelection(new Set([41]));
+    const lease = scene.retainInstancedOccurrence(41, 3);
+    assert.throws(() => scene.retainInstancedOccurrence(41, 3), /already retains/);
+    lease.setSuppressed(true);
+    assert.equal(flags(0), INSTANCE_FLAG_SELECTED | INSTANCE_FLAG_HIDDEN);
+    assert.equal(flags(1), 0);
+    assert.equal(gpu.selectedCount, 1);
+    assert.deepEqual([...scene.getInstancedEntityIds()], [42]);
+    assert.equal(scene.getInstancedMeshDataPieces(41), undefined);
+    assert.deepEqual(scene.getAllInstancedMeshData().map(p => p.expressId), [42]);
+    assert.equal(scene.raycast({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: -1 }), null);
+    scene.setInstancedVisibility(null, new Set([41]));
+    scene.setInstancedSelection(new Set([42]));
+    scene.setInstancedVisibility(null, null);
+    assert.equal(flags(0), INSTANCE_FLAG_HIDDEN);
+    assert.equal(flags(1), INSTANCE_FLAG_SELECTED);
+    assert.equal(gpu.selectedCount, 1);
+    assert.deepEqual(scene.getInstancedMeshDataPieces(42)![0].positions, sibling.positions);
+    scene.setInstancedVisibility(new Set([41]), null);
+    scene.setInstancedColorOverrides(new Map([[41, [1, 0, 0, 1]]]));
+    lease.release();
+    assert.deepEqual(color(0), [1, 0, 0, 1], 'release keeps the current colour override');
+    assert.equal(lease.valid, false);
+    assert.equal(flags(0), INSTANCE_FLAG_HIDDEN, 'release retains ordinary user hiding');
+    scene.setInstancedVisibility(null, null);
+    assert.equal(flags(0), 0);
+    assert.equal(scene.raycast({ x: 0, y: 0, z: 0 }, { x: 0, y: 0, z: -1 })?.expressId, 41);
+    assert.throws(() => lease.setSuppressed(true), /stale/);
+  });
+
+  it('retains translations and rolls back failed GPU suppression without consuming ownership', () => {
+    const { scene, flags, fail } = fixture();
+    const before = scene.getInstancedMeshDataPieces(41)![0].positions;
+    const lease = scene.retainInstancedOccurrence(41, 3);
+    fail(); assert.throws(() => lease.setSuppressed(true), /GPU upload failure/);
+    assert.equal(flags(0), 0); assert.equal(lease.valid, true);
+    assert.ok(scene.getInstancedMeshDataPieces(41));
+    lease.setSuppressed(true);
+    fail(); assert.throws(() => lease.release(), /GPU upload failure/);
+    assert.equal(lease.valid, true); assert.equal(flags(0), INSTANCE_FLAG_HIDDEN);
+    scene.translateInstancedEntity(41, [2, 0, 0]);
+    scene.setModelTranslation(3, [3, 0, 0]);
+    assert.equal(scene.getEntityBoundingBox(41), null);
+    assert.deepEqual(scene.getAllMeshDataExpressIds(), [42]);
+    lease.release();
+    const after = scene.getInstancedMeshDataPieces(41)![0].positions;
+    for (let i = 0; i < before.length; i++) assert.equal(after[i], before[i] + (i % 3 === 0 ? 5 : 0));
+  });
+
+  it('rejects another model and invalidates retained originals on removal or scene reset', () => {
+    const { scene } = fixture();
+    assert.throws(() => scene.retainInstancedOccurrence(41, 0), /specified model/);
+    const lease = scene.retainInstancedOccurrence(41, 3); lease.setSuppressed(true);
+    scene.removeInstancedTemplatesForModel(3);
+    assert.equal(lease.valid, false); lease.release();
+    assert.equal(scene.getAllInstancedMeshData().length, 0);
+    const other = fixture(); const retained = other.scene.retainInstancedOccurrence(41, 3);
+    retained.setSuppressed(true); other.scene.clearFlatGeometry();
+    assert.equal(retained.valid, false);
+    assert.equal(other.flags(0), 0);
+    assert.equal(other.scene.getAllInstancedMeshData().length, 2);
+    const deleted = other.scene.retainInstancedOccurrence(41, 3);
+    deleted.setSuppressed(true); other.scene.removeMeshesForEntity(41);
+    assert.equal(deleted.valid, false);
+    assert.deepEqual([...other.scene.getInstancedEntityIds()], [42]);
+    other.scene.clear();
+  });
+});

--- a/packages/renderer/src/scene-instance-suppression.ts
+++ b/packages/renderer/src/scene-instance-suppression.ts
@@ -17,6 +17,7 @@ export class InstanceSuppression {
   *suppressedIds(): IterableIterator<number> {
     for (const [id, entry] of this.entries) if (entry.suppressed) yield id;
   }
+  owns(id: number): boolean { return this.entries.has(id); }
   get retained(): boolean { return this.entries.size > 0; }
   has(id: number): boolean { return this.entries.get(id)?.suppressed === true; }
   acquire(expressId: number, modelIndex: number): InstanceLease {
@@ -46,9 +47,19 @@ export class InstanceSuppression {
     });
   }
   restore(): void {
-    const hidden = [...this.entries].filter(([, entry]) => entry.suppressed).map(([id]) => id);
+    const hidden = [...this.entries].filter(([, entry]) => entry.suppressed);
+    for (const [, entry] of hidden) entry.suppressed = false;
+    try { for (const [id] of hidden) this.changed(id); }
+    catch (error) {
+      for (const [, entry] of hidden) entry.suppressed = true;
+      const failures: unknown[] = [error];
+      for (const [id] of hidden) {
+        try { this.changed(id); } catch (rollbackError) { failures.push(rollbackError); }
+      }
+      if (failures.length > 1) throw new AggregateError(failures, 'Occurrence restoration and rollback failed');
+      throw error;
+    }
     this.entries.clear();
-    for (const id of hidden) this.changed(id);
   }
   forget(id?: number): void {
     if (id === undefined) this.entries.clear();

--- a/packages/renderer/src/scene-instance-suppression.ts
+++ b/packages/renderer/src/scene-instance-suppression.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Retains occurrence records while a replacement owns their visible geometry. */
+export interface InstanceLease {
+  readonly expressId: number;
+  readonly modelIndex: number;
+  readonly valid: boolean;
+  setSuppressed(value: boolean): void;
+  release(): void;
+}
+interface Entry { suppressed: boolean; modelIndex: number }
+export class InstanceSuppression {
+  private entries = new Map<number, Entry>();
+  constructor(private readonly changed: (id: number) => void) {}
+  *suppressedIds(): IterableIterator<number> {
+    for (const [id, entry] of this.entries) if (entry.suppressed) yield id;
+  }
+  get retained(): boolean { return this.entries.size > 0; }
+  has(id: number): boolean { return this.entries.get(id)?.suppressed === true; }
+  acquire(expressId: number, modelIndex: number): InstanceLease {
+    if (this.entries.has(expressId)) throw new Error('An appearance operation already retains this occurrence');
+    const entry: Entry = { suppressed: false, modelIndex };
+    this.entries.set(expressId, entry);
+    const valid = () => this.entries.get(expressId) === entry;
+    return Object.freeze({
+      expressId, modelIndex,
+      get valid() { return valid(); },
+      setSuppressed: (value: boolean) => {
+        if (!valid()) throw new Error('The retained occurrence is stale');
+        if (entry.suppressed === value) return;
+        entry.suppressed = value;
+        try { this.changed(expressId); }
+        catch (error) { entry.suppressed = !value; this.changed(expressId); throw error; }
+      },
+      release: () => {
+        if (!valid()) return;
+        if (entry.suppressed) {
+          entry.suppressed = false;
+          try { this.changed(expressId); }
+          catch (error) { entry.suppressed = true; this.changed(expressId); throw error; }
+        }
+        this.entries.delete(expressId);
+      },
+    });
+  }
+  restore(): void {
+    const hidden = [...this.entries].filter(([, entry]) => entry.suppressed).map(([id]) => id);
+    this.entries.clear();
+    for (const id of hidden) this.changed(id);
+  }
+  forget(id?: number): void {
+    if (id === undefined) this.entries.clear();
+    else this.entries.delete(id);
+  }
+  forgetModel(modelIndex: number): void {
+    for (const [id, entry] of this.entries) if (entry.modelIndex === modelIndex) this.entries.delete(id);
+  }
+}

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3810,8 +3810,8 @@ export class Scene {
    * picking and sections cannot see a removed flat contribution (#4226).
    */
   clearFlatGeometry(): void {
-    this.appearanceController?.forget();
     this.instanceSuppression.restore();
+    this.appearanceController?.forget();
     for (const mesh of this.meshes) destroyGpuResources(mesh);
     for (const batch of this.batchedMeshes) destroyGpuResources(batch);
     for (const tm of this.texturedMeshes) {

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -6,6 +6,8 @@
  * Scene graph and mesh management
  */
 
+import { materializeInstances } from './scene-instance-materialization.js';
+import { InstanceSuppression } from './scene-instance-suppression.js';
 import { createSceneBatch } from './scene-batch-upload.js';
 import { createSceneAppearancePreview } from './scene-appearance-preview.js';
 import { interleaveTexturedVertices } from './textured-vertices.js';
@@ -317,6 +319,12 @@ export class Scene {
   private instancedTemplateCpu: (InstancedTemplateCpu | undefined)[] = [];
   private instancedDevice?: GPUDevice;                              // cached for per-instance flag/colour writeBuffer updates
   private instancedSelected: Set<number> = new Set();              // currently flag-selected instanced express_ids
+  private readonly instanceSuppression = new InstanceSuppression((id) => {
+    if (this.instancedDevice) this.writeInstanceFlags(this.instancedDevice, id);
+    this.boundingBoxes.delete(id);
+    if (!this.instanceSuppression.has(id)) this.recomputeInstancedBounds(id);
+    this.evictHighlightMeshes(id);
+  });
   private instancedHidden: Set<number> = new Set();               // currently hidden instanced express_ids (hide/isolate)
   private instancedOverridden: Set<number> = new Set();            // currently colour-overridden instanced express_ids
   private instancedGhosted: Set<number> = new Set();               // currently X-Ray ghosted instanced express_ids
@@ -1435,6 +1443,7 @@ export class Scene {
     if (this.instancedSelected.has(expressId)) {
       this.bumpTemplateSelectedCount(expressId, -1);
     }
+    this.instanceSuppression.forget(expressId);
     this.instancedEntityMap.delete(expressId);
     this.instancedSelected.delete(expressId);
     this.instancedHidden.delete(expressId);
@@ -1683,6 +1692,7 @@ export class Scene {
       const template = this.instancedTemplates[occ.templateIndex];
       if (template) foldOccurrenceWorldBox(template, w);
     }
+    if (this.instanceSuppression.has(expressId)) this.boundingBoxes.delete(expressId);
   }
 
   /** Drop the per-entity selection-highlight meshes for `expressId` (frozen
@@ -1705,13 +1715,15 @@ export class Scene {
   setModelTranslation(modelIndex: number, translation: readonly [number, number, number]): boolean {
     const batches = this.finalizeInProgress ? [...new Set([...this.batchedMeshes,
       ...[...this.buckets.values()].flatMap((bucket) => bucket.batchedMesh ? [bucket.batchedMesh] : [])])] : this.batchedMeshes;
-    return translateSceneModel({ translations: this.modelTranslations, pieces: this.meshDataMap,
+    const changed = translateSceneModel({ translations: this.modelTranslations, pieces: this.meshDataMap,
       bounds: this.boundingBoxes, batches, meshes: this.meshes, overrides: this.overrideBatches, textured: this.texturedMeshes,
       templates: this.instancedTemplates, cpu: this.instancedTemplateCpu, occurrences: this.instancedEntityMap,
       device: this.instancedDevice, evictHighlight: (id) => this.evictHighlightMeshes(id, true),
       clearPartial: () => this.dropAllPartialCaches(),
       unionBounds: (id, view, offset, min, max) => this.unionInstancedWorldAabb(id, view, offset, ...min, ...max),
     }, modelIndex, translation);
+    for (const id of this.instanceSuppression.suppressedIds()) if (!this.meshDataMap.has(id)) this.boundingBoxes.delete(id);
+    return changed;
   }
 
   /** Bulk variant of `translateMeshesForEntity`. */
@@ -2348,6 +2360,10 @@ export class Scene {
    */
   releaseGeometryData(): void {
     if (this.geometryReleased) return;
+    if (this.instanceSuppression.retained) {
+      console.warn('[Appearance] Retained occurrence history still needs CPU geometry');
+      return;
+    }
 
     // Guard: releasing while async batch work is in-flight would corrupt GPU state
     if (this.pendingBatchKeys.size > 0 || this.streamingFragments.length > 0) {
@@ -2978,6 +2994,7 @@ export class Scene {
    * no-op).
    */
   removeInstancedTemplatesForModel(modelIndex: number): number {
+    this.instanceSuppression.forgetModel(modelIndex);
     const freed = new Set<number>();
     for (let i = 0; i < this.instancedTemplates.length; i++) {
       const t = this.instancedTemplates[i];
@@ -3293,10 +3310,22 @@ export class Scene {
     return this.instancedEntityMap.has(expressId);
   }
 
+  /** Retain one model-owned occurrence for reversible appearance replacement. */
+  retainInstancedOccurrence(expressId: number, modelIndex: number) {
+    const occurrences = this.instancedEntityMap.get(expressId);
+    if (this.geometryReleased || this.finalizeInProgress || this.streamingFragments.length
+      || this.pendingBatchKeys.size || !occurrences?.length
+      || occurrences.some(o => this.instancedTemplates[o.templateIndex]?.modelIndex !== modelIndex
+        || !this.instancedTemplateCpu[o.templateIndex]?.positions.length)) {
+      throw new Error('Appearance requires resident instances owned by the specified model');
+    }
+    return this.instanceSuppression.acquire(expressId, modelIndex);
+  }
+
   /** All instanced occurrence express_ids (for CPU consumers that enumerate geometry,
    *  e.g. the raycast-engine and exporters). */
-  getInstancedEntityIds(): IterableIterator<number> {
-    return this.instancedEntityMap.keys();
+  *getInstancedEntityIds(): IterableIterator<number> {
+    for (const id of this.instancedEntityMap.keys()) if (!this.instanceSuppression.has(id)) yield id;
   }
 
   /** Number of distinct GPU-instanced entities. O(1) — for size heuristics
@@ -3322,7 +3351,7 @@ export class Scene {
   /** World-space AABB for an instanced occurrence (union over its occurrences),
    *  or null if not instanced. Populated at upload time, so this is O(1). */
   getInstancedEntityBounds(expressId: number): BoundingBox | null {
-    if (!this.instancedEntityMap.has(expressId)) return null;
+    if (!this.instancedEntityMap.has(expressId) || this.instanceSuppression.has(expressId)) return null;
     return this.boundingBoxes.get(expressId) ?? null;
   }
 
@@ -3332,50 +3361,8 @@ export class Scene {
    *  export). Returns undefined if the id is not instanced. */
   getInstancedMeshDataPieces(expressId: number): MeshData[] | undefined {
     const occ = this.instancedEntityMap.get(expressId);
-    if (!occ || occ.length === 0) return undefined;
-    const out: MeshData[] = [];
-    for (const o of occ) {
-      const tpl = this.instancedTemplateCpu[o.templateIndex];
-      if (!tpl || tpl.positions.length === 0) continue;
-      const dv = new DataView(tpl.instanceData);
-      const b = o.byteOffset;
-      const m0 = dv.getFloat32(b + 0, true), m1 = dv.getFloat32(b + 4, true), m2 = dv.getFloat32(b + 8, true);
-      const m4 = dv.getFloat32(b + 16, true), m5 = dv.getFloat32(b + 20, true), m6 = dv.getFloat32(b + 24, true);
-      const m8 = dv.getFloat32(b + 32, true), m9 = dv.getFloat32(b + 36, true), m10 = dv.getFloat32(b + 40, true);
-      const m12 = dv.getFloat32(b + 48, true), m13 = dv.getFloat32(b + 52, true), m14 = dv.getFloat32(b + 56, true);
-      const n = tpl.positions.length;
-      const positions = new Float32Array(n);
-      const normals = new Float32Array(tpl.normals.length);
-      for (let i = 0; i < n; i += 3) {
-        const x = tpl.positions[i], y = tpl.positions[i + 1], z = tpl.positions[i + 2];
-        positions[i] = m0 * x + m4 * y + m8 * z + m12;
-        positions[i + 1] = m1 * x + m5 * y + m9 * z + m13;
-        positions[i + 2] = m2 * x + m6 * y + m10 * z + m14;
-        if (i + 2 < tpl.normals.length) {
-          // Rotate normals by the upper-3×3 (instancing transforms are rigid +
-          // uniform scale, so this is correct up to a renormalize).
-          const nx = tpl.normals[i], ny = tpl.normals[i + 1], nz = tpl.normals[i + 2];
-          let rx = m0 * nx + m4 * ny + m8 * nz;
-          let ry = m1 * nx + m5 * ny + m9 * nz;
-          let rz = m2 * nx + m6 * ny + m10 * nz;
-          const len = Math.hypot(rx, ry, rz) || 1;
-          rx /= len; ry /= len; rz /= len;
-          normals[i] = rx; normals[i + 1] = ry; normals[i + 2] = rz;
-        }
-      }
-      const color: [number, number, number, number] = [...o.originalColor];
-      // Per-occurrence key so CPU caches that would otherwise key on `expressId`
-      // alone (measure-snap geometry cache) don't collide across occurrences of
-      // this instanced entity, which share `expressId` but hold distinct
-      // world-space positions (issue #1405). templateIndex+byteOffset uniquely
-      // and stably identifies an occurrence within the instance buffers.
-      const occurrenceKey = `${expressId}:inst:${o.templateIndex}:${o.byteOffset}`;
-      // #2985: the same drill-to-source id a flat mesh carries, so a consumer of
-      // these pieces is not worse off for the geometry having been instanced.
-      const item = o.itemId !== undefined ? { geometryItemId: o.itemId } : {};
-      out.push({ expressId, positions, normals, indices: tpl.indices, color, occurrenceKey, ...item });
-    }
-    return out.length > 0 ? out : undefined;
+    if (!occ || occ.length === 0 || this.instanceSuppression.has(expressId)) return undefined;
+    return materializeInstances(expressId, occ, this.instancedTemplateCpu);
   }
 
   /**
@@ -3598,7 +3585,7 @@ export class Scene {
     if (!locs) return;
     const flags =
       (this.instancedSelected.has(eid) ? INSTANCE_FLAG_SELECTED : 0) |
-      (this.instancedHidden.has(eid) ? INSTANCE_FLAG_HIDDEN : 0);
+      (this.instancedHidden.has(eid) || this.instanceSuppression.has(eid) ? INSTANCE_FLAG_HIDDEN : 0);
     const data = new Uint32Array([flags >>> 0]);
     for (const loc of locs) {
       const buf = this.instancedTemplates[loc.templateIndex]?.instanceBuffer;
@@ -3786,6 +3773,7 @@ export class Scene {
     this.instancedTemplates = [];
     this.liveInstancedTemplates = [];
     this.instancedTemplateCpu = [];
+    this.instanceSuppression.forget();
     this.instancedEntityMap.clear();
     this.instancedSelected.clear();
     this.instancedHidden.clear();
@@ -3820,6 +3808,7 @@ export class Scene {
    */
   clearFlatGeometry(): void {
     this.appearanceController?.forget();
+    this.instanceSuppression.restore();
     for (const mesh of this.meshes) destroyGpuResources(mesh);
     for (const batch of this.batchedMeshes) destroyGpuResources(batch);
     for (const tm of this.texturedMeshes) {
@@ -3946,7 +3935,7 @@ export class Scene {
     // enumerating geometry see them too. IDs only — no geometry materialized.
     // (#1238 review)
     const ids = new Set<number>(this.meshDataMap.keys());
-    for (const eid of this.instancedEntityMap.keys()) ids.add(eid);
+    for (const eid of this.getInstancedEntityIds()) ids.add(eid);
     return Array.from(ids);
   }
 
@@ -3957,6 +3946,7 @@ export class Scene {
    * @returns Bounding box with min/max corners, or null if no mesh data exists
    */
   getEntityBoundingBox(expressId: number): BoundingBox | null {
+    if (this.instanceSuppression.has(expressId) && !this.meshDataMap.has(expressId)) return null;
     return cachedWorldAabb(expressId, this.meshDataMap.get(expressId), this.boundingBoxes);
   }
 

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3099,6 +3099,9 @@ export class Scene {
    * GPU upload.
    */
   addInstancedShard(device: GPUDevice, shard: DecodedInstancedShard, modelIndex = 0): void {
+    if (shard.instances.some(instance => this.instanceSuppression.owns(instance.entityId))) {
+      throw new Error('Cannot append geometry to a retained appearance occurrence');
+    }
     this.instancedDevice = device; // cached for per-instance selection/overlay writeBuffer
     const prepared = prepareInstancedRender(shard);
     // Selected ids whose occurrences arrived in THIS shard (selection recorded


### PR DESCRIPTION
Repeated IFC occurrences can live only in GPU instance templates, so an appearance replacement needs to retain the original occurrence while temporarily suppressing its drawing and picking. Add a model-owned Scene lease that keeps selection, colour overrides and placement updates intact, excludes suppressed originals from CPU geometry enumeration, and restores ordinary hide/isolate state on release. Shared sibling instances remain unchanged.

This is the renderer resource prerequisite for #4404. It does not yet enable the mapped-occurrence texture UI; canonical native geometry binding and the complete Apply/Undo journey remain in that open, assigned issue.

Validation:
- Real Scene tests with two shared occurrences cover hide/isolate, selection/overrides, CPU raycast/enumeration, translation, model/entity deletion, reset, failed suppression/release, first/later reset-write rollback and retry, and late-shard refusal before upload.
- Root Turbo renderer suite: 1,456 passed, one existing opt-in 340 MB test skipped. Full root typecheck on this isolated main-based branch: 1,903 test files covered; root lint: zero errors. Renderer tests also passed on this isolated main-based branch (same counts).
- Renderer build, module-size gate, enforcing issue-queue check (maintainer exemption) and API snapshot regeneration passed; snapshot unchanged. Includes renderer minor changeset and guide contract.

The existing CPU instance expansion was extracted without changing its geometry math to stay below the Scene module-size budget. It remains display geometry, not canonical IFC UV provenance. No Rust or geometry-worker load path changes.
