### PR TITLE
feat(appearance): provide canonical occurrence source geometry for preview

### DIFF
--- a/.changeset/evaluated-native-source-mesh.md
+++ b/.changeset/evaluated-native-source-mesh.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Include the bounded canonical source mesh and RTC frame in opted-in occurrence appearance plans so renderer integrations can materialize individual instances without inferring IFC geometry from rounded GPU transforms.

--- a/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
@@ -20,6 +20,7 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
   const request: AppearanceRequest = { schema: 'IFC4', sourceRevision: 'AC20-wasm', nextExpressId: 100_000,
     productIds: [35169], imageUri: 'textures/evaluated.png', repeatS: true, repeatT: true,
     mapping: { kind: 'box', frame: 'world', origin: [0, 0, 0], metresPerTile: [1, 1, 1] } };
+  let original: NonNullable<AppearancePlan['conversions']>[number] | undefined;
   try {
     const preserved = JSON.parse(new TextDecoder().decode(api.planAppearance(source, JSON.stringify(request)))) as AppearancePlan;
     assert.equal(preserved.items.length, 0); assert.equal(preserved.created.length, 0);
@@ -30,6 +31,14 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
     assert.equal(result.conversions?.[0].productId, 35169);
     assert.equal(result.conversions?.[0].sourceGeometryItemId, 35135);
     assert.equal(result.conversions?.[0].sourceIndices.length, 36);
+    original = result.conversions![0];
+    assert.ok(original.sourcePositions?.length && original.sourceNormals?.length);
+    assert.equal(original.sourcePositions.length, original.sourceNormals.length);
+    assert.ok(original.sourceIndices.every(index => index < original!.sourcePositions!.length / 3));
+    for (const values of [original.sourcePositions, original.sourceNormals, original.sourceOrigin, original.sourceColor, original.rtcOffset]) {
+      assert.ok(values?.length); assert.ok(values.every(value => typeof value === 'number' && Number.isFinite(value)));
+    }
+    assert.deepEqual(original.rtcOffset, [0, 0, 0]);
     assert.ok(result.edits.every(edit => edit.expressId === 35155));
     assert.equal(result.items[0].geometryItemId, result.conversions?.[0].geometryItemId);
     assert.throws(() => api.planAppearance(source, JSON.stringify({ ...request, representationPolicy: 'silentlyFlatten' })), /unknown variant/);
@@ -44,4 +53,9 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
   assert.equal(page.itemImages[0].geometryItemId, page.plan.items[0].geometryItemId);
   assert.equal(page.plan.conversions?.length, 1); assert.ok(page.assets.length > 0);
   assert.ok(page.plan.edits.every(edit => edit.expressId === 35155));
+  assert.ok(original);
+  const converted = page.plan.conversions![0];
+  for (const field of ['sourcePositions', 'sourceNormals', 'sourceOrigin', 'sourceColor', 'rtcOffset'] as const) {
+    assert.deepEqual(converted[field], original[field], 'image and page reuse the same canonical original');
+  }
 });

--- a/apps/viewer/src/lib/appearance/planner-types.ts
+++ b/apps/viewer/src/lib/appearance/planner-types.ts
@@ -34,7 +34,11 @@ export interface AppearanceRequest {
 export interface AppearancePlan extends AppearanceEntityPlan {
   /** Original renderer provenance for opted-in occurrence-local Body conversions. */
   conversions?: Array<{ productId: number; representationId: number; sourceGeometryItemId: number;
-    geometryItemId: number; sourceIndices: number[] }>;
+    geometryItemId: number; sourceIndices: number[];
+    /** Native canonical Z-up source mesh; older runtimes cannot materialize instances. */
+    sourcePositions?: number[]; sourceNormals?: number[];
+    sourceOrigin?: [number, number, number]; sourceColor?: [number, number, number, number];
+    rtcOffset?: [number, number, number] }>;
   nextAvailableExpressId: number;
   items: Array<{
     productId: number;

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -62,3 +62,13 @@ Page material names equal to reserved wire tokens after trimming (`#123`,
 `.ENUM.`, `$`, or `*`) are refused explicitly. The current authoring wire cannot
 distinguish those literals from references/enumerations/null/derived values.
 Other labels, including `#material` and `.surface`, remain literal strings.
+
+For occurrence materialization, each conversion also carries the original canonical
+`sourcePositions`, `sourceNormals`, `sourceOrigin`, `sourceColor`, and `rtcOffset`.
+`sourceIndices` indexes these positions. Values use IFC Z-up metres: add the f64
+source origin and the f64 RTC offset exactly once around local f32 vertices.
+These are moved from the same bounded evaluated mesh already checked against the
+replacement, not reconstructed from the renderer's rounded instance matrices.
+The existing aggregate plan geometry budget also bounds these retained arrays.
+The host must resolve the model index and registered placement frame explicitly;
+this payload does not make renderer instance expansion canonical UV provenance.

--- a/docs/architecture/evidence/evaluated-occurrences/source-mesh-load.json
+++ b/docs/architecture/evidence/evaluated-occurrences/source-mesh-load.json
@@ -1,0 +1,158 @@
+{
+  "base": "22f3f0d0d6e5088908107a183a883b87c35c4ddf",
+  "branch": "aca75527cbff93799b40f0c67f515825e735c1e1",
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "method": "Exact-source immutable profiling binaries, A/B/A/B with five iterations each on an otherwise-idle machine. Other agents paused builds/browser runs. Same perf_probe executable as scripts/perf/probe.sh. Native ordinary load only, not authoring or browser worker-pool latency.",
+  "identity": "Every run has identical mesh, vertex and triangle counts. The timed probe did not request optional ordered payload fingerprints.",
+  "verdict": "All four probes report parse 3ms, geometry 5ms and total 8ms at integer-millisecond precision. No resolvable ordinary-load regression or speedup.",
+  "runs": [
+    {
+      "variant": "base",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 2.49,
+        "parseMs": 3,
+        "entityScanMs": 2,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          16,
+          13,
+          9,
+          9,
+          8
+        ],
+        "allWallMs": [
+          17.368000000000002,
+          13.75575,
+          10.243749999999999,
+          9.571584,
+          8.979
+        ],
+        "pointCacheHits": 51972,
+        "pointCacheMisses": 9148,
+        "csgFailures": 0,
+        "degenerateDropped": 0
+      }
+    },
+    {
+      "variant": "branch",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.17,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          12,
+          8,
+          10,
+          8,
+          8
+        ],
+        "allWallMs": [
+          13.012958,
+          8.731124999999999,
+          10.616875,
+          8.685583,
+          8.80125
+        ],
+        "pointCacheHits": 52044,
+        "pointCacheMisses": 9196,
+        "csgFailures": 0,
+        "degenerateDropped": 0
+      }
+    },
+    {
+      "variant": "base",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.08,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          9,
+          8,
+          8,
+          8,
+          8
+        ],
+        "allWallMs": [
+          9.779917000000001,
+          8.631625,
+          8.4945,
+          8.687292,
+          8.421875
+        ],
+        "pointCacheHits": 52116,
+        "pointCacheMisses": 9220,
+        "csgFailures": 0,
+        "degenerateDropped": 0
+      }
+    },
+    {
+      "variant": "branch",
+      "probe": {
+        "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+        "fileMb": 2.41,
+        "entities": 44249,
+        "meshes": 285,
+        "vertices": 35940,
+        "triangles": 19456,
+        "indexBuildMs": 1.09,
+        "parseMs": 3,
+        "entityScanMs": 1,
+        "lookupMs": 0,
+        "preprocessMs": 0,
+        "geometryMs": 5,
+        "facetedBrepMs": 0,
+        "totalMs": 8,
+        "allTotalsMs": [
+          9,
+          8,
+          8,
+          9,
+          8
+        ],
+        "allWallMs": [
+          9.939625000000001,
+          8.527667,
+          8.701583000000001,
+          9.499,
+          8.654250000000001
+        ],
+        "pointCacheHits": 51724,
+        "pointCacheMisses": 9084,
+        "csgFailures": 0,
+        "degenerateDropped": 0
+      }
+    }
+  ]
+}

--- a/docs/guide/appearance.md
+++ b/docs/guide/appearance.md
@@ -185,3 +185,11 @@ This resource operation does not create IFC geometry or canonical UV provenance.
 An appearance integration must separately validate the native evaluated mesh and
 its model frame, publish a replacement, and retain the lease for Undo. It must
 release the lease if preparation fails or the preview is discarded.
+
+Opted-in native occurrence plans include canonical `sourcePositions`,
+`sourceNormals`, `sourceOrigin`, `sourceColor`, and `rtcOffset` alongside
+`sourceIndices` in each `conversions` entry. Renderer integrations use that bounded
+IFC Z-up snapshot to prepare one occurrence; reconstructing a GPU instance does
+not supply equivalent source provenance. See the
+[evaluated occurrence contract](../architecture/appearance-evaluated-occurrences.md)
+for units, frame restoration, and eligibility limits.

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -71,7 +71,8 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
             evaluated_source::validate_style_tree(source,&body,old_item)?;
             let surface=evaluated_source::surface_styles(source,old_item)?;
             if mesh.positions.len()%3!=0 || mesh.normals.len()!=mesh.positions.len() || mesh.indices.len()%3!=0 || mesh.positions.is_empty()
-                || mesh.indices.is_empty() || mesh.positions.iter().chain(&mesh.normals).any(|n|!n.is_finite())
+                || mesh.indices.is_empty() || mesh.positions.iter().chain(&mesh.normals).chain(&mesh.color).any(|n|!n.is_finite())
+                || mesh.origin.iter().any(|n|!n.is_finite())
                 || mesh.indices.iter().any(|&i|i as usize>=mesh.positions.len()/3) {
                 return Err("Canonical source geometry is invalid".into());
             }
@@ -130,7 +131,8 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
         normalized.request.next_express_id=plan.next_available_express_id;
         normalized.request.product_ids.push(product_id);
         let context=source.context.as_ref().ok_or("Missing canonical source frame")?;
-        let rtc_offset=if context.meta.needs_shift {context.meta.rtc_offset.into()} else {[0.;3]};
+        let rtc_offset: [f64;3]=if context.meta.needs_shift {context.meta.rtc_offset.into()} else {[0.;3]};
+        if rtc_offset.iter().any(|value|!value.is_finite()) {return Err("Invalid canonical source RTC frame".into());}
         normalized.conversions.push(Conversion {plan,styled_id:styled,binding:AppearanceConversion {
             product_id,representation_id:body_id,source_geometry_item_id:old_item,geometry_item_id:item,
             source_indices:mesh.indices,source_positions:mesh.positions,source_normals:mesh.normals,

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -70,7 +70,7 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
             let old_item=mesh.geometry_item_id.ok_or("Missing evaluated source item provenance")?;
             evaluated_source::validate_style_tree(source,&body,old_item)?;
             let surface=evaluated_source::surface_styles(source,old_item)?;
-            if mesh.positions.len()%3!=0 || mesh.indices.len()%3!=0 || mesh.positions.is_empty()
+            if mesh.positions.len()%3!=0 || mesh.normals.len()!=mesh.positions.len() || mesh.indices.len()%3!=0 || mesh.positions.is_empty()
                 || mesh.indices.is_empty() || mesh.positions.iter().chain(&mesh.normals).any(|n|!n.is_finite())
                 || mesh.indices.iter().any(|&i|i as usize>=mesh.positions.len()/3) {
                 return Err("Canonical source geometry is invalid".into());
@@ -129,8 +129,12 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
         }
         normalized.request.next_express_id=plan.next_available_express_id;
         normalized.request.product_ids.push(product_id);
+        let context=source.context.as_ref().ok_or("Missing canonical source frame")?;
+        let rtc_offset=if context.meta.needs_shift {context.meta.rtc_offset.into()} else {[0.;3]};
         normalized.conversions.push(Conversion {plan,styled_id:styled,binding:AppearanceConversion {
-            product_id,representation_id:body_id,source_geometry_item_id:old_item,geometry_item_id:item,source_indices:mesh.indices }});
+            product_id,representation_id:body_id,source_geometry_item_id:old_item,geometry_item_id:item,
+            source_indices:mesh.indices,source_positions:mesh.positions,source_normals:mesh.normals,
+            source_origin:mesh.origin,source_color:mesh.color,rtc_offset }});
     }
     Ok(normalized)
 }

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -231,4 +231,7 @@ fn issue_4404_materialization_payload_restores_georeferenced_native_frame_once()
     assert!(max_error<1e-6,"restored native world error: {max_error}");
     let json=serde_json::to_value(&plan).unwrap();
     assert_eq!(json["conversions"][0]["rtcOffset"],serde_json::json!(binding.rtc_offset));
+    for key in ["sourcePositions","sourceNormals","sourceOrigin","sourceColor","rtcOffset"] {
+        assert!(json["conversions"][0][key].as_array().unwrap().iter().all(|v|v.as_f64().is_some_and(f64::is_finite)), "{key}");
+    }
 }

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -42,6 +42,13 @@ fn issue_4404_real_mapped_member_is_opt_in_and_preserves_every_sibling_and_world
         let other=after.meshes.iter().find(|m|m.express_id==mesh.express_id && (m.express_id==35169 || m.geometry_item_id==mesh.geometry_item_id)).unwrap();
         if mesh.express_id==35169 {
             assert_eq!(corners(mesh),corners(other));assert!(other.uvs.is_some());assert!(other.texture.is_some());
+            let binding=&plan.conversions[0];
+            assert_eq!(binding.source_positions,mesh.positions);
+            assert_eq!(binding.source_normals,mesh.normals);
+            assert_eq!(binding.source_indices,mesh.indices);
+            assert_eq!(binding.source_origin,mesh.origin);
+            assert_eq!(binding.source_color,mesh.color);
+            assert_eq!(binding.rtc_offset,[0.;3]);
             assert_eq!(mesh.global_id,other.global_id);
         } else { assert_eq!(serde_json::to_value(mesh).unwrap(),serde_json::to_value(other).unwrap()); }
     }
@@ -189,4 +196,39 @@ fn issue_4404_real_page_material_name_that_looks_like_generated_reference_is_lit
     assert_ne!(ids[&100001],100001);
     assert_eq!(names(&result.plan),original_names);
     assert_eq!(result.plan.created[0].express_id,result.plan.next_express_id);
+}
+
+#[test]
+fn issue_4404_materialization_payload_restores_georeferenced_native_frame_once() {
+    let Some(source)=real_source() else{return};
+    let source=source.replace("#112= IFCCARTESIANPOINT((0.,0.,0.));", "#112= IFCCARTESIANPOINT((1000000.,2000000.,0.));");
+    let plan=plan_appearance(source.as_bytes(),&request()).unwrap();
+    assert!(plan.exclusions.is_empty(),"{:?}",plan.exclusions);
+    let binding=&plan.conversions[0];
+    assert!(binding.rtc_offset.iter().any(|v|v.abs()>10_000.));
+    let mut effective=source::Source::new(source.as_bytes()).unwrap();
+    let context=context::Context::new(source.as_bytes(),&mut effective.decoder);
+    effective.context=Some(context);
+    let styles=page_source::appearance(source.as_bytes(),&mut effective);
+    let textures=ifc_lite_geometry::build_texture_index(source.as_bytes(),&mut effective.decoder);
+    let meshes=canonical::produce(&mut effective,35169,&textures,Some(&styles)).unwrap();
+    let mesh=&meshes[0];
+    assert_eq!(binding.source_positions,mesh.positions);
+    assert_eq!(binding.source_normals,mesh.normals);
+    assert_eq!(binding.source_origin,mesh.origin);
+    let output=apply(&source,&plan);
+    let reopened=crate::process_geometry(output.as_bytes());
+    let target=reopened.meshes.iter().find(|m|m.express_id==35169).unwrap();
+    // Full native loads choose a site-local frame; the planner uses detected RTC.
+    // Restore both in f64 before comparing their independently rounded f32 vertices.
+    let mut max_error=0.0_f64;
+    for (before,after) in corners(mesh).iter().zip(corners(target)) {
+        for axis in 0..3 {
+            max_error=max_error.max((before[axis]+binding.rtc_offset[axis]
+                -after[axis]-reopened.metadata.coordinate_info.origin_shift[axis]).abs());
+        }
+    }
+    assert!(max_error<1e-6,"restored native world error: {max_error}");
+    let json=serde_json::to_value(&plan).unwrap();
+    assert_eq!(json["conversions"][0]["rtcOffset"],serde_json::json!(binding.rtc_offset));
 }

--- a/rust/processing/src/appearance/types.rs
+++ b/rust/processing/src/appearance/types.rs
@@ -125,4 +125,11 @@ pub struct AppearanceConversion {
     pub source_geometry_item_id: u32,
     pub geometry_item_id: u32,
     pub source_indices: Vec<u32>,
+    /// Canonical evaluated IFC Z-up geometry, before any appearance replacement.
+    /// Coordinates are local f32 values plus source_origin and rtc_offset in metres.
+    pub source_positions: Vec<f32>,
+    pub source_normals: Vec<f32>,
+    pub source_origin: [f64; 3],
+    pub source_color: [f32; 4],
+    pub rtc_offset: [f64; 3],
 }

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1150,3 +1150,13 @@ conservative candidate reuse across target triangles/tiles, retaining nearest
 surface refusal and one atomic result, rather than enlarging the work ceiling.
 [Real-surface coverage and refusal evidence](../../docs/architecture/evidence/mesh-transfer/README.md#real-boulder-geometry-conservative-coverage-and-capacity)
 keeps that limitation separate from the ordinary-load measurements.
+
+Canonical occurrence source snapshots reuse the mesh already evaluated by the
+opt-in appearance planner. Moving its bounded vectors into the plan avoids
+reconstructing IFC geometry from GPU instance transforms. Interleaved exact-base
+native AC20 probes found no resolvable ordinary-load change and identical geometry
+counts. This establishes load-path isolation, not a browser worker-pool speedup
+or conversion throughput claim; the additional authored payload remains governed
+by the existing aggregate geometry budget.
+[Source-mesh payload probe](../../docs/architecture/evidence/evaluated-occurrences/source-mesh-load.json)
+records source heads, precision limits and the unchanged census.


### PR DESCRIPTION
GPU-instanced IFC occurrences have no retained canonical flat mesh for appearance binding. Include the original canonical positions, normals, origin, colour and RTC frame in opted-in appearance conversion records, reusing the mesh already evaluated and checked against the replacement. This lets the upcoming occurrence preview use native source geometry instead of inferring IFC UV provenance from rounded GPU instance transforms.

Part of #4404, which stays open and assigned until the full mapped-occurrence Apply/Undo/export journey is complete. This PR adds the native payload prerequisite; it does not enable the UI by itself. Default preserve behavior is unchanged.

Validation:
- Real AC20 mapped-member tests compare the payload directly with canonical native geometry, preserve siblings, exercise both image and finite-page planners, and verify a georeferenced frame is restored once. Planner and full-loader f32 frames agree below 1µm after their respective offsets are restored.
- Full Rust workspace tests and `cargo clippy --workspace --all-targets -- -D warnings` passed; final targeted native suite 10/10 passed. Fresh WASM build preserved current main's planMeshTransfer binding; actual WASM contract 1/1 passed with no skips and finite source numeric arrays on both planners. Committed WASM types do not drift.
- Full root typecheck covers 1,904 test files. Refwalk, Rust API surface, module-size and diff checks pass. Guide, architecture contract, wasm minor changeset and performance ledger included. Native tests/WASM/typecheck ran in the built integration tree with the same native source changes; this branch isolates the prerequisite onto main.
- Performance: base 22f3f0d0d vs branch aca75527c, A/B/A/B × 5 iterations on idle machine. Every run reports parse 3 ms / geometry 5 ms / total 8 ms at integer-millisecond precision, with 285 meshes/35,940 vertices/19,456 triangles. No resolvable native ordinary-load regression; no browser worker-pool or authoring speed claim. Raw probes and unchanged census are committed.
