### PR TITLE
docs(appearance): close completed image workflow acceptance

### DIFF
--- a/docs/architecture/appearance-workspace.md
+++ b/docs/architecture/appearance-workspace.md
@@ -31,7 +31,7 @@ IFCZIP. The export dialog reports **IFC + images** when resources are present.
 Appearance editing in an active room remains unavailable until collaborative
 compound authoring is supported; users can share a completed model for viewing.
 
-## Evidence and remaining acceptance
+## Acceptance and limitations
 
 The real WebGPU viewer has exercised the initially untextured IFCOpenShell wall
 and public Convento model through preview, Apply, Undo/Redo, normal IFCZIP
@@ -49,8 +49,18 @@ edits invalidate cached scopes even without a viewer revision increment. Tests
 cover retyping, stale catalog responses and cancellation without allocator or
 history changes.
 
-Remaining follow-ups: Apply has a measured main-thread stall; transaction and
-dependency optimizations reduce it, while cooperative preparation continues
-separately. Fresh room viewing preserves appearance; the offered IFCX
-export/reopen texture defect is tracked in #4325. These limitations do not block
-shipping the image authoring workflow.
+The [trusted-input acceptance](evidence/appearance/apply-responsiveness/README.md)
+completes #4336: cooperative preparation lets input and Discard run during Apply,
+with unchanged geometry/history behavior. The final synchronous transaction fence
+still pauses rendering; this is not a claim of uninterrupted frame delivery.
+
+[Fresh-room and IFCX acceptance](evidence/ifcx-texture-roundtrip/README.md)
+completes #4325. The authored Convento model survives normal Share, fresh join,
+fresh rejoin, room export, ordinary IFCX import and viewport picking with matched
+owner/triangle/UV/image associations. Room transport preserves decoded image
+pixels; it does not promise the original compressed image bytes.
+
+This completes the scoped direct-tessellated image workflow in #4243. Evaluated
+surfaces and mapped occurrences remain in #4404; coordinated multi-model
+assignment and history remain in #4420. The scoped image workflow does not imply
+those later capabilities are available.


### PR DESCRIPTION
The image workspace document still describes #4336 and #4325 as pending, although their interaction and fresh-room/IFCX acceptance are merged. Link the recorded real Convento evidence, retain the synchronous transaction and decoded-image transport limitations, and separate completed direct-tessellated image authoring from open F6/F7 work.

Closes #4243. Its implemented scope is documented in the workspace guide: original source ownership, frozen model/selection/class/type scope, native mapping plans, Compare/Discard/Apply/Undo, normal IFCZIP export/reopen and selection. Existing mounted tests cover cancellation, stale revisions, scope identities and publication/resource failures; the linked real browser and independent artifacts cover ordinary authoring and transport. This PR updates acceptance status only, without claiming new behavior.

Validation: all four generated documentation regions, all45 package READMEs and diff check pass. No API change or changeset required.
