### PR TITLE
fix(viewer): remove obsolete layer-stack teardown exemption

### DIFF
--- a/apps/viewer/src/store/teardown-exemptions.ts
+++ b/apps/viewer/src/store/teardown-exemptions.ts
@@ -103,18 +103,6 @@ export const TEARDOWN_EXEMPTIONS: Readonly<Record<string, string>> = {
     'WebHID device connection state and sensitivity — no field references a modelId or ' +
     'expressId.',
 
-  layerStackSlice:
-    'The IFCX layer composition (layerStack / layerStackPathToId / layerStackDiff) is only ' +
-    'ever populated by a full federated (re-)load, which always calls `setLayerStack(...)` ' +
-    'right after `clearAllModels()` in the same synchronous flow, and a non-federated load ' +
-    'calls `clearLayerStack()` explicitly (`useIfcLoader.ts`). KNOWN GAP, not covered by this ' +
-    'exemption\'s reasoning: `useFileCommands.tsx`\'s multi-file, non-all-IFCX branch calls ' +
-    '`clearAllModels()` then `loadFilesSequentially()` without ever touching layerStack, so a ' +
-    'PRIOR IFCX composition\'s entries can survive into a session that loaded plain IFC files ' +
-    '— `LayersPanel.tsx` renders `layerStack` with no membership guard. Left for a follow-up ' +
-    '(same shape as the splitToolSlice fix this branch makes, but in call-site wiring, not ' +
-    'the teardown seam) rather than fixed here to keep this PR scoped to the registration gap.',
-
   appearanceSlice:
     'Verified 2026-09-09 field by field against `AppearanceDraftRecipe` (lib/appearance/draft-' +
     'types.ts): `sourceId`, `settings` and `previewEnabled` name no modelId or expressId; only ' +


### PR DESCRIPTION
The layer-stack teardown added for #4309 is registered, but the old exemption still claims that the slice has no teardown. Remove that obsolete entry so the registry has one consistent lifecycle declaration. The actual teardown handler is unchanged.

Closes #4424.

Validation on Node 22.23.2 through root Turbo: current main registry test fails 5/6 with layerStackSlice both registered and exempt; the fixed branch passes 6/6. Existing layer-stack lifecycle tests pass 4/4. Full root typecheck covers 1,903 test files, and module-size, license and diff checks pass. This removes stale internal metadata only; no public API, guide or changeset change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated teardown handling so the layer stack follows the standard teardown coverage rules.
  * No user-facing functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->