### PR TITLE
docs: record nearest-band transfer capacity refusal

### DIFF
--- a/docs/architecture/evidence/mesh-transfer-capacity/README.md
+++ b/docs/architecture/evidence/mesh-transfer-capacity/README.md
@@ -86,3 +86,35 @@ ephemeral loopback port, accepts only fixed resource routes, creates fresh brows
 contexts, terminates every worker and closes its own browser/server handles.
 Input reads are bounded. The recorded payload hash distinguishes this full-model
 fixture from another generated capture. No large scan/IFC inputs are committed.
+
+## Nearest-first traversal follow-up
+
+A separate [unmerged nearest-band experiment](https://github.com/LTplus-AG/ifc-lite/commit/e74b81ee6)
+tried a different mechanism: visit the nearer BVH child first, shrink the search
+radius after each exact primitive distance, and retain all candidates inside
+the final nearest-distance plus ambiguity band in that same traversal. Exact
+point/normal memoization is capped at 1,024 entries. It preserves nearest-surface
+selection before normal checks and does not increase the aggregate work limit.
+
+The full selected 40,087-triangle boulder target against all 66,122 source
+triangles still returns `BVH query work budget exhausted`; no applicable plan is
+produced. [Pinned input hashes and refusal](nearest-band.json) identify the
+control. Native tests cover thin opposite faces, overlapping/UV-seam ambiguity,
+unknown albedo and emitted texel applicability, plus independent nearest/band
+point-distance checks and explicit budget failures. This is a capacity refusal,
+not a performance improvement or full-model acceptance. Timing was deliberately
+not compared while other builds were active. No nearest-query or memo-cache code
+from this experiment is merged into the product.
+
+For native reproduction, use the existing input generator above, split its
+`source`, `request`, and base64-decoded `rgba` into `source.ifc`, `request.json`,
+and `rgba.bin`, then run from the pinned experimental checkout:
+
+```sh
+cargo run -p ifc-lite-processing --example transfer_nearest_probe \
+  --profile server-release -- /path/to/input-directory
+```
+
+The example only reports planner metadata or refusal; it never publishes a
+mutation. The selected product is #65, whose geometry item #54 retains all
+40,087 triangles. Other products in the IFC are outside this explicit target.

--- a/docs/architecture/evidence/mesh-transfer-capacity/nearest-band.json
+++ b/docs/architecture/evidence/mesh-transfer-capacity/nearest-band.json
@@ -1,0 +1,34 @@
+{
+  "experimentCommit": "e74b81ee6",
+  "baseCommit": "6b1baee3e1bf34e397ae90f40c740c5399a7ad10",
+  "runtimeMerged": false,
+  "workLimit": 64000000,
+  "sourceTriangles": 66122,
+  "selectedProductIds": [
+    65
+  ],
+  "targetGeometryItemId": 54,
+  "targetTriangles": 40087,
+  "refusal": "BVH query work budget exhausted",
+  "applicablePlanProduced": false,
+  "inputs": {
+    "source.ifc": {
+      "bytes": 5664029,
+      "sha256": "0efc7987670ddb1287cb88fe1b9a239da754f41170e9420bf04293c0c54f34e3"
+    },
+    "request.json": {
+      "bytes": 8645275,
+      "sha256": "f7c131751a6b8f819a04c3d437cdc5171a1c264d14389c69183db5a62fa853ff"
+    },
+    "rgba.bin": {
+      "bytes": 4194304,
+      "sha256": "2c2dc5a76bc993bfc7bb86a4ddef95baecbc46161467fd45b7f8ccf1cc6077f1"
+    }
+  },
+  "validation": {
+    "transferTestsPassed": 9,
+    "nearestQueryTestsPassed": 2,
+    "strictWorkspaceClippy": "passed"
+  },
+  "timing": "Not reported: concurrent builds, no end-to-end worker-pool comparison."
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1179,3 +1179,12 @@ proxy, without authorizing a larger quota or producing an applicable plan.
 Do not repeat those cache mechanisms unchanged or infer broad capacity from a
 small target prefix. [Recorded experiments and worker evidence](../../docs/architecture/evidence/mesh-transfer-capacity/README.md)
 state the remaining gate and the limits of the measurement.
+
+
+The follow-up nearest-first BVH experiment shrank an exact per-sample search
+bound, retained the near-tie band in one traversal, and combined it with bounded
+exact observation memoization. It still refused the full selected boulder under
+the existing work cap, so the runtime experiment remains unmerged. A tighter
+candidate search alone did not establish complete-target capacity; do not
+reintroduce this variant as a shipped optimization without new end-to-end
+acceptance. [Reproducible refusal](../../docs/architecture/evidence/mesh-transfer-capacity/README.md#nearest-first-traversal-follow-up).


### PR DESCRIPTION
Records a bounded follow-up to the existing full-boulder transfer investigation. Nearest-first BVH traversal, a shrinking exact distance/ambiguity band and bounded exact observation memoization still exhaust the unchanged 64-million work limit for the complete selected 40,087-triangle target against 66,122 source triangles. No applicable plan is produced.

The runtime experiment is pinned on an unmerged spike commit; this PR only adds the refusal, exact input hashes, reproduction instructions and the performance-ledger lesson. Nine native transfer controls, two independent nearest-band query controls and strict workspace Clippy pass for the pinned experiment. No timing improvement is claimed, no runtime code or quota change is merged, and no package changeset is needed.

Validation: generated documentation, package READMEs and diff checks pass. Refs #4381, which remains open for broader scan-transfer acceptance and RGB-point support.
