### PR TITLE
fix(viewer): keep large appearance scope review responsive

### DIFF
--- a/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.test.tsx
@@ -5,20 +5,21 @@ import '@/test/setup-dom.js';
 import { afterEach, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { useState } from 'react';
-import { render, click, cleanup } from '@/test/render.js';
+import { render, click, cleanup, type } from '@/test/render.js';
 import { DEFAULT_APPEARANCE_SETTINGS } from '@/lib/appearance/settings.js';
 import { resolveAppearanceAssignments } from '@/lib/appearance/assignments/resolve.js';
 import type { AppearanceAssignment } from '@/lib/appearance/assignments/types.js';
 import { AppearanceAssignmentList } from './AppearanceAssignmentList.js';
 afterEach(cleanup);
-function assignment(id: string): AppearanceAssignment {
+function assignment(id: string, count = 1): AppearanceAssignment {
   return { id, model: { slotId: 'model-slot', modelId: 'model', name: 'Building', sourceSha256: 'a'.repeat(64), revision: 'r' },
     source: { id: 'b'.repeat(64), name: id, width: 2, height: 2 }, settings: { ...DEFAULT_APPEARANCE_SETTINGS },
-    query: { kind: 'model' }, members: [{ expressId: 10, GlobalId: 'wall' }], excludedGlobalIds: [] };
+    query: { kind: 'model' }, members: Array.from({ length: count }, (_, i) => ({ expressId: 10 + i, GlobalId: `wall-${i}` })), excludedGlobalIds: [] };
 }
-function Harness({ disabled = false }: { disabled?: boolean }) {
-  const [assignments, setAssignments] = useState([assignment('Brick'), assignment('Paint')]);
-  return <AppearanceAssignmentList rows={resolveAppearanceAssignments(assignments)} disabled={disabled} objectName={() => 'East wall'}
+function Harness({ disabled = false, count = 1 }: { disabled?: boolean; count?: number }) {
+  const [assignments, setAssignments] = useState([assignment('Brick', count), assignment('Paint', count)]);
+  return <AppearanceAssignmentList rows={resolveAppearanceAssignments(assignments)} disabled={disabled}
+    objectName={(_, id) => id === 10009 ? 'Final wall' : `Wall ${id}`}
     onRemove={id => setAssignments(rows => rows.filter(row => row.id !== id))}
     onMove={(id, direction) => setAssignments(rows => { const next = [...rows], index = next.findIndex(row => row.id === id);
       [next[index], next[index + direction]] = [next[index + direction], next[index]]; return next; })}
@@ -29,16 +30,45 @@ it('mounted assignment order and explicit exceptions change the reviewed winner 
   const ui = render(<Harness />);
   const rows = () => [...ui.querySelectorAll('li')];
   assert.match(rows()[0].textContent!, /0 objects.*1 replaced/);
-  click(rows()[1].querySelector('input')!);
+  click(ui.querySelector('[aria-label="Review objects for assignment 2"]')!);
+  click(rows()[1].querySelector('input[type="checkbox"]')!);
   assert.match(rows()[0].textContent!, /1 objects/);
   assert.match(rows()[1].textContent!, /0 objects · 1 excluded/);
-  click(rows()[1].querySelector('input')!);
+  click(rows()[1].querySelector('input[type="checkbox"]')!);
   click(ui.querySelector('[aria-label="Move assignment 2 earlier"]')!);
   assert.match(rows()[0].textContent!, /Paint.*0 objects/);
   assert.match(rows()[1].textContent!, /Brick.*1 objects/);
   click(ui.querySelector('[aria-label="Remove assignment 2"]')!);
   assert.equal(rows().length, 1);
   assert.match(rows()[0].textContent!, /Paint.*1 objects/);
+});
+it('large assignment review mounts one bounded page and finds/excludes objects beyond it #4420', () => {
+  const ui = render(<Harness count={10000} />);
+  const checks = () => [...ui.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')];
+  assert.equal(checks().length, 0, 'closed scopes must not eagerly mount their members');
+  click(ui.querySelector('[aria-label="Review objects for assignment 1"]')!);
+  assert.equal(checks().length, 50);
+  assert.match(ui.textContent!, /1–50 of 10000/);
+  const viewport = ui.querySelector<HTMLElement>('[aria-label="Objects in this assignment"]')!;
+  viewport.scrollTop = 100;
+  click(ui.querySelector('[aria-label="Next objects"]')!);
+  assert.equal(viewport.scrollTop, 0, 'a new page begins at its first member');
+  assert.match(ui.textContent!, /51–100 of 10000/);
+  type(ui.querySelector<HTMLInputElement>('input[type="search"]')!, 'Final wall');
+  assert.equal(checks().length, 1);
+  assert.match(checks()[0].parentElement!.textContent!, /Final wall/);
+  click(checks()[0]);
+  assert.equal(checks()[0].checked, false);
+  assert.match(ui.querySelector('li')!.textContent!, /1 excluded/);
+  click(ui.querySelector('[aria-label="Review objects for assignment 2"]')!);
+  assert.equal(checks().length, 50, 'opening another scope unmounts the previous review');
+  click(ui.querySelector('[aria-label="Review objects for assignment 1"]')!);
+  type(ui.querySelector<HTMLInputElement>('input[type="search"]')!, 'wall-9999');
+  assert.equal(checks().length, 1, 'IFC GlobalId search also reaches the last object');
+  assert.equal(checks()[0].checked, false, 'exceptions survive paging and closing the review');
+  type(ui.querySelector<HTMLInputElement>('input[type="search"]')!, 'does not exist');
+  assert.equal(checks().length, 0);
+  assert.match(ui.textContent!, /No matching objects/);
 });
 it('mounted assignment review is locked during coordinated publication #4420', () => {
   const ui = render(<Harness disabled />);

--- a/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.tsx
@@ -1,9 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
+import { useId, useState } from 'react';
+import { ArrowDown, ArrowUp, ChevronRight, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { ResolvedAssignment } from '@/lib/appearance/assignments/types.js';
+import { AppearanceAssignmentMembers } from './AppearanceAssignmentMembers.js';
 
 export interface AppearanceAssignmentListProps {
   rows: readonly ResolvedAssignment[];
@@ -16,6 +18,8 @@ export interface AppearanceAssignmentListProps {
 
 /** Ordered recipe review; the controller alone prepares and publishes changes. */
 export function AppearanceAssignmentList(props: AppearanceAssignmentListProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const reviewId = useId();
   if (!props.rows.length) return null;
   return <section className="space-y-2" aria-label="Appearance assignments">
     <div><h3 className="text-xs font-semibold">Assignments</h3>
@@ -34,13 +38,14 @@ export function AppearanceAssignmentList(props: AppearanceAssignmentListProps) {
             aria-label={`Remove assignment ${index + 1}`} onClick={() => props.onRemove(item.id)}><Trash2 className="h-3 w-3" /></Button>
         </div>
         <p className="mt-1 text-[11px]">{row.productIds.length} objects · {row.excluded} excluded · {row.overridden} replaced by later assignments</p>
-        <details className="mt-1 text-[11px]"><summary className="cursor-pointer">Review objects and exceptions</summary>
-          <div className="mt-1 max-h-40 space-y-1 overflow-y-auto">{item.members.map(product => <label key={product.GlobalId} className="flex items-center gap-2">
-            <input type="checkbox" disabled={props.disabled} checked={!item.excludedGlobalIds.includes(product.GlobalId)}
-              onChange={event => props.onExclude(item.id, product.GlobalId, !event.currentTarget.checked)} />
-            <span className="truncate">{props.objectName(item.model.modelId, product.expressId)}</span>
-          </label>)}</div>
-        </details>
+        <Button type="button" variant="ghost" size="sm" className="mt-1 h-6 px-0 text-[11px]" disabled={props.disabled}
+          aria-label={`Review objects for assignment ${index + 1}`} aria-expanded={expandedId === item.id}
+          aria-controls={`${reviewId}-${index}`} onClick={() => setExpandedId(expandedId === item.id ? null : item.id)}>
+          <ChevronRight className={`h-3 w-3 ${expandedId === item.id ? 'rotate-90' : ''}`} />Review objects and exceptions
+        </Button>
+        <div id={`${reviewId}-${index}`}>
+          {expandedId === item.id && <AppearanceAssignmentMembers assignment={item} disabled={props.disabled} objectName={props.objectName} onExclude={props.onExclude} />}
+        </div>
       </li>;
     })}</ol>
   </section>;

--- a/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentMembers.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentMembers.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { AppearanceAssignment } from '@/lib/appearance/assignments/types.js';
+import type { AppearanceAssignmentListProps } from './AppearanceAssignmentList.js';
+
+const PAGE_SIZE = 50;
+
+/** Mount only for the expanded assignment. Scope size never becomes DOM size. */
+export function AppearanceAssignmentMembers({ assignment, disabled, objectName, onExclude }:
+  Pick<AppearanceAssignmentListProps, 'disabled' | 'objectName' | 'onExclude'> & { assignment: AppearanceAssignment }) {
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(0);
+  const search = useDeferredValue(query.trim().toLocaleLowerCase());
+  const { members, model, excludedGlobalIds } = assignment;
+  const matches = useMemo(() => search ? members.filter(product =>
+    product.GlobalId.toLocaleLowerCase().includes(search)
+      || objectName(model.modelId, product.expressId).toLocaleLowerCase().includes(search)) : members,
+  [members, model.modelId, objectName, search]);
+  const excluded = useMemo(() => new Set(excludedGlobalIds), [excludedGlobalIds]);
+  const lastPage = Math.max(0, Math.ceil(matches.length / PAGE_SIZE) - 1);
+  const currentPage = Math.min(page, lastPage);
+  const start = currentPage * PAGE_SIZE;
+  const visible = matches.slice(start, start + PAGE_SIZE);
+  const pending = search !== query.trim().toLocaleLowerCase();
+  const viewport = useRef<HTMLDivElement>(null);
+  useEffect(() => { if (viewport.current) viewport.current.scrollTop = 0; }, [currentPage, search]);
+
+  return <div className="mt-2 space-y-2 text-[11px]">
+    <label className="block space-y-1"><span>Find an object</span>
+      <Input type="search" className="h-7 text-xs" placeholder="Name or GlobalId" value={query} disabled={disabled}
+        onChange={event => { setQuery(event.currentTarget.value); setPage(0); }} />
+    </label>
+    <div ref={viewport} role="group" aria-label="Objects in this assignment" aria-busy={pending} className="max-h-48 space-y-1 overflow-y-auto">
+      {visible.map(product => <label key={product.GlobalId} className="flex items-start gap-2 rounded px-1 py-1 hover:bg-muted">
+        <input type="checkbox" className="mt-0.5" disabled={disabled || pending} checked={!excluded.has(product.GlobalId)}
+          onChange={event => onExclude(assignment.id, product.GlobalId, !event.currentTarget.checked)} />
+        <span className="min-w-0"><span className="block truncate">{objectName(model.modelId, product.expressId)}</span>
+          <span className="block truncate text-[10px] text-muted-foreground">{product.GlobalId}</span></span>
+      </label>)}
+    </div>
+    <div className="flex items-center justify-between gap-1">
+      <p role="status">{matches.length ? `${start + 1}–${start + visible.length} of ${matches.length}` : 'No matching objects'}</p>
+      {matches.length > PAGE_SIZE && <div className="flex gap-1">
+        <Button type="button" size="sm" variant="ghost" className="h-6 px-2 text-[11px]" aria-label="Previous objects"
+          disabled={disabled || pending || currentPage === 0} onClick={() => setPage(currentPage - 1)}>Previous</Button>
+        <Button type="button" size="sm" variant="ghost" className="h-6 px-2 text-[11px]" aria-label="Next objects"
+          disabled={disabled || pending || currentPage === lastPage} onClick={() => setPage(currentPage + 1)}>Next</Button>
+      </div>}
+    </div>
+  </div>;
+}

--- a/docs/architecture/appearance-assignments.md
+++ b/docs/architecture/appearance-assignments.md
@@ -22,6 +22,10 @@ Rows run in displayed order. A later included row replaces earlier assignments
 on overlapping objects in the same model. Excluding an object from a row exposes
 any earlier assignment for that object; exclusions do not affect another model.
 The review reports affected, excluded and overridden counts separately.
+Object review opens one assignment at a time and mounts at most 50 members.
+Search covers the full reviewed membership by display name or GlobalId; paging
+and closing the review do not discard exceptions. Closed scopes mount no object
+checkboxes, so a model-sized membership does not become a model-sized DOM tree.
 
 Saved recipes are bounded, versioned JSON. Restoring requires an explicitly
 chosen loaded model for each saved slot and the original source derivative.


### PR DESCRIPTION
Closed appearance assignment scopes eagerly mounted every member checkbox. Two 10,000-object scopes produced 20,000 controls before the user opened either row. The review now expands one assignment at a time, mounts at most 50 objects, and searches the complete membership by name or IFC GlobalId. Paging and closing preserve exclusions; a new page resets its scroll position.

This follows the #4420 foundation. Its controlled list is covered by mounted interaction tests; the coordinated workspace consumer and real multi-model browser acceptance remain in the next stack slice. [Review contract](https://github.com/LTplus-AG/ifc-lite/blob/59504dd53/docs/architecture/appearance-assignments.md).

Validation: the large-scope regression fails against the previous component with 20,000 checkboxes and passes after the fix. Final root Turbo viewer shard passes 3/3, including ordering/overlap exceptions and finding/excluding the last object by both name and GlobalId. Full root typecheck passes all 94 tasks and covers 1,911 test files; dependency/viewer builds, changed-file lint, module/license checks, generated docs, package READMEs and clean diff pass. Viewer-private UI only; no published package/API changes or package changeset.

Refs #4420; keep open for integrated multi-model acceptance.
