### PR TITLE
fix: refuse ambiguous authored appearance wire strings

### DIFF
--- a/.changeset/authored-wire-tokens.md
+++ b/.changeset/authored-wire-tokens.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Refuse annotation/captured-object names and appearance image paths that the mutation STEP writer would reinterpret as structural tokens. Share the same guard with preserved page material names; ordinary names remain unchanged.

--- a/apps/viewer/src/lib/appearance/authored-wire-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/authored-wire-wasm.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '@/test/setup-dom.js';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { IfcParser } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from '@ifc-lite/export';
+import type { AnnotationPlanePlan, CapturedMeshPlan } from './planner-types';
+import { texturedProductSource as source } from '@/test/textured-product-fixture';
+
+test('native creators refuse wire tokens and preserve ordinary Names through StoreEditor STEP export (#4441)', async t => {
+  let wasm: Buffer;
+  try { wasm = await readFile(new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url)); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    t.skip('Build WASM with pnpm build:wasm'); return;
+  }
+  const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: wasm });
+  const api = new IfcAPI();
+  try {
+    for (const captured of [false, true]) {
+      const common = { schema: 'IFC4', sourceRevision: 'wire-test', containerId: 40,
+        GlobalId: '0aaaaaaaaaaaaaaaaaaaaa', containmentGlobalId: '0bbbbbbbbbbbbbbbbbbbbb',
+        imageUri: 'textures/image.png',
+        ...(captured ? { mesh: { positions: [[0,0,0],[1,0,0],[0,1,0]], triangles: [[0,1,2]],
+          uvs: [[0,0],[1,0],[0,1]], uvTriangles: [[0,1,2]] } }
+          : { frame: { origin: [2,3,4], axisU: [1,0,0], axisV: [0,0,1], sizeMetres: [2,1] } }) };
+      const plan = (input: object) => JSON.parse(new TextDecoder().decode(captured
+        ? api.planCapturedMesh(source, JSON.stringify(input))
+        : api.planAnnotationPlane(source, JSON.stringify(input)))) as AnnotationPlanePlan | CapturedMeshPlan;
+      for (const Name of ['*', '$', '#123', '.ENUM.', ' .lower_1. ', '\ufeff#123\ufeff']) {
+        assert.throws(() => plan({ ...common, nextExpressId: 100, Name }), /Authored product Name is a reserved appearance wire token/);
+      }
+      for (const imageUri of ['*', '$', '.ENUM.', ' .lower_1. ']) {
+        assert.throws(() => plan({ ...common, nextExpressId: 100, Name: 'Ordinary', imageUri }), /Image URI is a reserved appearance wire token/);
+      }
+      for (const Name of ['Ordinary name', "O'Brien – 墙", '#not_a_ref', '.not-an-enum.', '* label', '\u0085#123\u0085']) {
+        const data = await new IfcParser().parseColumnar(source.slice().buffer);
+        const view = new MutablePropertyView(data.properties, 'wire-test');
+        const editor = new StoreEditor(data, view);
+        const result = plan({ ...common, nextExpressId: view.peekNextExpressId(), Name });
+        for (const row of result.plan.created) assert.equal(editor.addEntity(row.type, row.attributes).expressId, row.expressId);
+        const exported = await new StepExporter(data, view).exportAsync({ schema: 'IFC4', applyMutations: true, includeGeometry: true });
+        const bytes = typeof exported.content === 'string' ? new TextEncoder().encode(exported.content) : exported.content;
+        const reopened = await new IfcParser().parseColumnar(bytes.slice().buffer);
+        const id = 'annotationId' in result ? result.annotationId : result.objectId;
+        assert.equal(reopened.entities.getName(id), Name);
+        assert.equal(reopened.entities.getTypeName(id), captured ? 'IfcBuildingElementProxy' : 'IfcAnnotation');
+      }
+    }
+  } finally { api.free(); }
+});

--- a/docs/architecture/evidence/authored-wire-tokens/README.md
+++ b/docs/architecture/evidence/authored-wire-tokens/README.md
@@ -1,0 +1,27 @@
+# Authored wire-token refusal (#4441)
+
+`authored-wire-wasm.test.ts` exercises the rebuilt native annotation and captured
+creators through real StoreEditor rows, StepExporter and parser reopen. Both
+creators refuse reserved structural Names and image URIs before returning a
+plan. Six ordinary/near-token Names per creator retain their exact decoded
+text, including apostrophes, Unicode and U+0085 surrounding a reference-like
+substring. ECMAScript trims U+FEFF but not U+0085; the native guard matches that
+boundary. This is explicit refusal of previously misserialized input, not an
+unqualified literal-string extension to the mutation wire protocol.
+
+Validation at `aad7def981713dd299bf2d3db152f9a2b8f1fe2a`: root build and typecheck
+passed; actual host roundtrip had no skips; native workspace passed (3,025 tests,
+37 ignored); strict workspace/all-target clippy passed. Four final issue
+regressions include source material-name preservation. Existing actual-WASM
+contracts passed with only their three pre-existing optional fixture skips.
+A freshly rebuilt and independently installed PyO3 wheel matched all four
+committed IFC quick-lane references, retaining the existing halfspace triangle
+density advisory. No geometry algorithm or public API changed.
+
+`native-load.json` records source-matched, interleaved five-iteration native
+normal-load probes on the public AC20 fixture, with all other agents explicitly
+idle. Fingerprints were collected separately. Normal-load total and geometry
+best-of-five values matched, with a quantized parse-only variation in the first
+pair. All mesh counts and fingerprints matched. This supports no detected
+normal-load regression in this bounded probe; it does not measure authoring
+throughput or establish a worker-pool speedup.

--- a/docs/architecture/evidence/authored-wire-tokens/native-load.json
+++ b/docs/architecture/evidence/authored-wire-tokens/native-load.json
@@ -1,0 +1,58 @@
+{
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "baseSource": "f55a14ec02d5a08e22bbd06dd960edc057aa9877",
+  "branchSource": "aad7def981713dd299bf2d3db152f9a2b8f1fe2a",
+  "measurement": "Interleaved native five-iteration normal-load A/B/A/B on an explicitly idle machine. Probe parse/geometry/total values are best-of-five, not medians. Separate fingerprints are not timed evidence. No worker-pool or authoring throughput claim.",
+  "runs": [
+    {
+      "version": "base",
+      "parseMs": 2,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [9, 8, 8, 8, 7],
+      "allWallMs": [10.095, 8.962417, 8.488334, 8.507000000000001, 8.00325]
+    },
+    {
+      "version": "branch",
+      "parseMs": 3,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [11, 9, 9, 8, 7],
+      "allWallMs": [12.47125, 9.501707999999999, 9.907582999999999, 8.867917, 8.093]
+    },
+    {
+      "version": "base",
+      "parseMs": 3,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [9, 7, 7, 7, 7],
+      "allWallMs": [9.391791, 8.137375, 7.989916, 8.24675, 8.203999999999999]
+    },
+    {
+      "version": "branch",
+      "parseMs": 3,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [9, 8, 8, 7, 7],
+      "allWallMs": [9.404124999999999, 8.408291, 8.354208, 8.25775, 8.214625]
+    }
+  ],
+  "identity": {
+    "base": {
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "meshFingerprintsFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    "branch": {
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "meshFingerprintsFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    }
+  }
+}

--- a/docs/guide/appearance.md
+++ b/docs/guide/appearance.md
@@ -230,3 +230,10 @@ full loaded source geometry before disposing GPU buffers. Pass hidden models in
 that source inventory to retain their appearance history across hide/show.
 Changed or removed owners lose their old instance lease; ordinary
 `clearFlatGeometry()` and full scene reset still invalidate all such leases.
+
+Authored annotation/captured-object `Name` values and appearance image paths
+must not consist of a reserved mutation wire token (`$`, `*`, `#123`, or
+`.ENUM.`, including surrounding whitespace). Native planners refuse these
+values before returning a plan because the current STEP mutation protocol has
+no unqualified literal-string marker. Ordinary names, including Unicode and
+punctuation, remain unchanged. Preserved page material names use the same rule.

--- a/rust/processing/src/appearance/annotation.rs
+++ b/rust/processing/src/appearance/annotation.rs
@@ -50,6 +50,7 @@ pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest
         || !valid_guid(&r.global_id) || !valid_guid(&r.containment_global_id) || r.global_id==r.containment_global_id {
         return Err("Annotation needs IFC4/IFC4X3, bounded metadata and distinct valid IFC GlobalIds".into());
     }
+    super::wire_text::validate(&r.name, "Authored product Name")?;
     validate_image_uri(&r.image_uri)?;
     let f=&r.frame;
     mapping::validate(&Mapping::Planar { frame: MappingFrame::World, origin:f.origin, axis_u:f.axis_u,

--- a/rust/processing/src/appearance/annotation_tests.rs
+++ b/rust/processing/src/appearance/annotation_tests.rs
@@ -128,3 +128,21 @@ fn issue_4308_ifc4x3_emits_predefined_type_and_point_tag_slots() {
     assert_eq!(mesh.positions,result.mesh.positions);
     assert_eq!(mesh.uvs,result.mesh.uvs);
 }
+
+#[test]
+fn issue_4441_authored_metadata_refuses_wire_tokens_and_preserves_ordinary_names() {
+    let (source, mut request) = fixture();
+    for token in ["*", "$", "#123", ".ENUM.", " .lower_1. ", "\u{feff}#123\u{feff}"] {
+        request.name = token.into();
+        assert!(plan_annotation_plane(source.as_bytes(), &request).unwrap_err().contains("Authored product Name is a reserved appearance wire token"));
+    }
+    for name in ["Ordinary name", "O'Brien – 墙", "#not_a_ref", ".not-an-enum.", "* label", "\u{85}#123\u{85}"] {
+        request.name = name.into();
+        let result = plan_annotation_plane(source.as_bytes(), &request).unwrap();
+        assert_eq!(result.plan.created.iter().find(|e| e.express_id == result.annotation_id).unwrap().attributes[2], serde_json::json!(name));
+    }
+    for token in ["*", "$", ".ENUM.", " .lower_1. "] {
+        request.image_uri = token.into();
+        assert!(plan_annotation_plane(source.as_bytes(), &request).unwrap_err().contains("Image URI is a reserved appearance wire token"));
+    }
+}

--- a/rust/processing/src/appearance/captured_tests.rs
+++ b/rust/processing/src/appearance/captured_tests.rs
@@ -126,3 +126,21 @@ fn issue_4380_capture_retains_each_original_sampler_combination_on_reimport() {
         assert_eq!(mesh.uvs,plan.mesh.uvs);
     } }
 }
+
+#[test]
+fn issue_4441_authored_metadata_refuses_wire_tokens_and_preserves_ordinary_names() {
+    let (source, mut request) = fixture();
+    for token in ["*", "$", "#123", ".ENUM.", " .lower_1. ", "\u{feff}#123\u{feff}"] {
+        request.name = token.into();
+        assert!(plan_captured_mesh(source.as_bytes(), &request).unwrap_err().contains("Authored product Name is a reserved appearance wire token"));
+    }
+    for name in ["Ordinary name", "O'Brien – 墙", "#not_a_ref", ".not-an-enum.", "* label", "\u{85}#123\u{85}"] {
+        request.name = name.into();
+        let result = plan_captured_mesh(source.as_bytes(), &request).unwrap();
+        assert_eq!(result.plan.created.iter().find(|e| e.express_id == result.object_id).unwrap().attributes[2], serde_json::json!(name));
+    }
+    for token in ["*", "$", ".ENUM.", " .lower_1. "] {
+        request.image_uri = token.into();
+        assert!(plan_captured_mesh(source.as_bytes(), &request).unwrap_err().contains("Image URI is a reserved appearance wire token"));
+    }
+}

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -67,7 +67,10 @@ fn add(plan: &mut AppearancePlan, name: &str, attributes: Vec<Value>) -> u32 {
     id
 }
 
+mod wire_text;
+
 fn validate_image_uri(uri: &str) -> Result<(), String> {
+    wire_text::validate(uri, "Image URI")?;
     if uri.is_empty()
         || uri.len() > 240
         || !uri.is_ascii()

--- a/rust/processing/src/appearance/page_material.rs
+++ b/rust/processing/src/appearance/page_material.rs
@@ -58,16 +58,8 @@ pub(super) fn preserve(plan: &mut AppearancePlan, source: &mut Source<'_>, item:
     if original.get_string(0).is_some_and(|name| name.len() > 4096) {
         return Err("Source material name exceeds 4096-byte budget".into());
     }
-    // Match the generic wire writer's reserved tokens after whitespace trim.
-    // It cannot distinguish these free-text labels from null/derived/ref/enum
-    // values when serializing a newly created style, so refuse losslessly.
-    if original.get_string(0).is_some_and(|name| {
-        let token=name.trim();
-        matches!(token,"$"|"*")
-            || token.strip_prefix('#').is_some_and(|id|!id.is_empty() && id.bytes().all(|c|c.is_ascii_digit()))
-            || token.strip_prefix('.').and_then(|s|s.strip_suffix('.')).is_some_and(|s|!s.is_empty() && s.bytes().all(|c|c.is_ascii_alphanumeric() || c==b'_'))
-    }) {
-        return Err("Page material name is a reserved appearance wire token and cannot be preserved".into());
+    if let Some(name) = original.get_string(0) {
+        super::wire_text::validate(name, "Page material name")?;
     }
     let members = original.get_list(2).ok_or("Missing source surface style elements")?;
     if members.len() > 5 { return Err("Source surface style exceeds five-element schema limit".into()); }

--- a/rust/processing/src/appearance/page_tests.rs
+++ b/rust/processing/src/appearance/page_tests.rs
@@ -242,3 +242,13 @@ fn png_budget_refuses_truncated_final_chunk_4260() {
     decoder.next_frame(&mut pixels).unwrap();
     assert_eq!(pixels, atlas.rgba);
 }
+
+#[test]
+fn issue_4441_page_style_preservation_uses_shared_exact_wire_token_guard() {
+    let (request, rgba) = fixture();
+    for name in ["*", "$", "#123", ".ENUM.", "\u{feff}#123\u{feff}"] {
+        let source = CONTROLLED_IFC.replace("'Wood'", &format!("'{name}'"));
+        assert!(plan_page_appearance(source.as_bytes(), &request, &rgba).unwrap_err()
+            .contains("Page material name is a reserved appearance wire token"));
+    }
+}

--- a/rust/processing/src/appearance/tests.rs
+++ b/rust/processing/src/appearance/tests.rs
@@ -607,3 +607,13 @@ fn issue_4243_target_vertex_pool_can_exceed_surviving_triangle_corner_count() {
     assert_eq!(item.target_indices, mesh.indices);
     assert!(item.target_indices.iter().all(|&i| (i as usize) < item.target_vertex_count));
 }
+
+#[test]
+fn issue_4441_image_appearance_refuses_structural_image_uri_tokens() {
+    for token in ["*", "$", "#123", ".ENUM.", " .lower_1. "] {
+        let mut request = request(vec![10]);
+        request.image_uri = token.into();
+        assert!(plan_appearance(CONTROLLED_IFC.as_bytes(), &request).unwrap_err()
+            .contains("Image URI is a reserved appearance wire token"));
+    }
+}

--- a/rust/processing/src/appearance/wire_text.rs
+++ b/rust/processing/src/appearance/wire_text.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// StoreEditor has no unqualified literal-string marker. Its STEP writer
+/// interprets these exact trimmed spellings as structural tokens (#4441).
+/// Refuse before authoring; do not change ordinary strings or add quotes that
+/// would themselves become label content. Match ECMAScript String.trim (not
+/// Rust's broader Unicode White_Space predicate, which differs at U+0085).
+pub(super) fn validate(value: &str, label: &str) -> Result<(), String> {
+    let token = value.trim_matches(|c| matches!(c,
+        '\u{0009}'..='\u{000d}' | ' ' | '\u{00a0}' | '\u{1680}' |
+        '\u{2000}'..='\u{200a}' | '\u{2028}' | '\u{2029}' | '\u{202f}' |
+        '\u{205f}' | '\u{3000}' | '\u{feff}'));
+    let reserved = matches!(token, "$" | "*")
+        || token.strip_prefix('#').is_some_and(|id|
+            !id.is_empty() && id.bytes().all(|c| c.is_ascii_digit()))
+        || token.strip_prefix('.').and_then(|s| s.strip_suffix('.')).is_some_and(|s|
+            !s.is_empty() && s.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_'));
+    if reserved {
+        return Err(format!("{label} is a reserved appearance wire token and cannot be preserved"));
+    }
+    Ok(())
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -46,6 +46,17 @@ a baseline first-load viewport initialization race. Those failed samples were
 retained and excluded, not treated as successful loads. The lesson is to name
 and qualify the measured boundary before interpreting small load-time deltas.
 
+## Authored metadata wire validation (#4441)
+
+A shared early authoring guard now refuses free-text spellings that the host
+mutation writer interprets as structural tokens. The source-matched idle native
+AC20 A/B/A/B probe found matching normal-load geometry/total values and mesh
+fingerprints, with quantized parse variation. This is a correctness fix, not a
+worker-pool optimization. The lesson is to validate text at the shared authored
+boundary using the consumer's exact whitespace/token rules; broad trimming can
+both miss reserved inputs and reject ordinary Unicode names.
+Evidence: `docs/architecture/evidence/authored-wire-tokens/native-load.json`.
+
 ## Manual scan registration foundation (#4381)
 
 The correspondence solver is opt-in, bounded to 256 fitting and 256 held-out


### PR DESCRIPTION
## Problem and change

Native annotation/captured-object Names such as `#123`, `*` or `.ENUM.` were accepted as text but reinterpreted as structural STEP tokens during mutation export. Refuse these previously misserialized values before producing a plan. One shared guard also covers appearance image paths and preserved page material names, matching the host writer’s exact ECMAScript trim/token rules. Ordinary Unicode, punctuation and near-token names remain unchanged; this does not add arbitrary literal-string support to the wire protocol.

Closes #4441. Assigned to louistrue.

## Validation

- Real rebuilt native WASM → StoreEditor → StepExporter → parser acceptance passed for both annotation and captured-object creators: reserved-token refusals and six ordinary/near-token Names each, no skipped assertions.
- Root build 51/51 and root typecheck 94/94 passed. Actual WASM contracts 87 passed, 3 existing optional skips.
- Full Rust workspace: 3,025 passed, 37 ignored across 212 suites (no baseline CSG failure this run); strict workspace/all-target clippy passed. Final four #4441 regressions passed, including preserved page styles. Fresh own PyO3 wheel: all four committed quick-lane parity fixtures MATCH; existing halfspace triangle-density advisory only.
- API snapshots unchanged; patch WASM changeset, guide, license/module/reference-walk/source-assertion checks included.
- Perf: source-matched idle AC20 A/B/A/B (5 iterations each), base→branch parse/geometry/total 2/4/7→3/4/7 ms, then 3/4/7→3/4/7 ms. Identical 285 meshes / 35,940 vertices / 19,456 triangles and FNV `25ac885b6ff4ad00`. Quantized parse variation; no detected geometry/total regression in this probe, no worker speedup claim. Raw run arrays and lesson committed in evidence/ledger.
