### PR TITLE
fix: preserve textured hosts with Reference-only openings

### DIFF
--- a/.changeset/reference-opening-host-textures.md
+++ b/.changeset/reference-opening-host-textures.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Preserve host image textures and UV coordinates when retained openings have only non-subtractive Reference representations. Mixed Body/Reference openings continue through canonical subtraction.

--- a/docs/architecture/evidence/evaluated-openings/README.md
+++ b/docs/architecture/evidence/evaluated-openings/README.md
@@ -79,3 +79,13 @@ with 32 triangles and finite coordinates. Run `node docs/architecture/evidence/e
 [Controlled native performance](performance.json) compares exact source revisions
 on AC20 and ISSUE_129; no material normal-load regression was resolved. These
 numbers do not claim browser worker-pool performance.
+
+## Textured Reference host routing
+
+Reference-only openings also leave the host on the canonical textured submesh
+path. A retained void relationship alone must not select the untextured cutter
+path. `GeometryRouter::opening_requires_subtraction` conservatively inspects the
+opening's bounded representation list using the shared element-aware policy;
+unknown or malformed data retains ordinary cutter/error handling. Mixed
+Body/Reference openings still subtract their Body geometry. This loader behavior
+does not itself enable post-opening appearance conversion.

--- a/docs/architecture/evidence/evaluated-openings/README.md
+++ b/docs/architecture/evidence/evaluated-openings/README.md
@@ -89,3 +89,10 @@ opening's bounded representation list using the shared element-aware policy;
 unknown or malformed data retains ordinary cutter/error handling. Mixed
 Body/Reference openings still subtract their Body geometry. This loader behavior
 does not itself enable post-opening appearance conversion.
+
+[Reference host texture evidence](reference-textures.json) records the exact
+source revisions, fresh native/WASM contracts, and controlled normal-load probes.
+The [buildingSMART opening definition](https://ifc43-docs.standards.buildingsmart.org/IFC/RELEASE/IFC4x3/HTML/lexical/IfcOpeningElement.htm)
+specifies that Reference geometry accompanies an existing hole without another
+subtraction. The native and WASM regressions use a closed textured cube, including
+Reference plus BoundingBox, mixed Body/Reference, and malformed-list controls.

--- a/docs/architecture/evidence/evaluated-openings/reference-textures.json
+++ b/docs/architecture/evidence/evaluated-openings/reference-textures.json
@@ -1,0 +1,309 @@
+{
+  "issue": 4440,
+  "baseSource": "f55a14ec0",
+  "branchProductionSource": "297c38f00",
+  "command": "perf_probe <fixture> --iters 5 --json (same profiling executable/arguments as scripts/perf/probe.sh; immutable copies avoid cross-worktree artifact replacement)",
+  "measurement": "Two interleaved A/B pairs per fixture, after all four agents explicitly confirmed idle; native only, no browser worker-pool claim.",
+  "baseBinarySha256": "e2257ce4f72fbd335b138394dcfe646eae99d63fd2aab554924d89a63a16e8ac",
+  "branchBinarySha256": "4928f688c485d39f617000eed33403bebbbbf3573267306a63fe01295c53c8aa",
+  "wasmSha256": "199072d1394911ecc10bc16fadfa629f67e260a5953108f9b8e4d05760998f56",
+  "identity": "Mesh/vertex/triangle counts, CSG failures and dropped-degenerate counts match on both fixtures; full output byte identity was not measured. Controlled Reference-only host regression requires exact MeshData equality.",
+  "verdict": "No consistent material normal-load regression resolved. First AC20 pair varies by one millisecond in reported total; second matches. ISSUE129 total varies below one percent. Small overhead below run-to-run variation is not ruled out.",
+  "measurements": {
+    "ac20": [
+      {
+        "base": {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.15,
+          "parseMs": 2,
+          "entityScanMs": 1,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 4,
+          "facetedBrepMs": 0,
+          "totalMs": 7,
+          "allTotalsMs": [
+            10,
+            9,
+            8,
+            7,
+            7
+          ],
+          "allWallMs": [
+            11.028666,
+            9.866542,
+            8.678875000000001,
+            8.285334,
+            8.076
+          ],
+          "pointCacheHits": 51916,
+          "pointCacheMisses": 9180,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        },
+        "branch": {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 2.15,
+          "parseMs": 3,
+          "entityScanMs": 2,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 5,
+          "facetedBrepMs": 0,
+          "totalMs": 8,
+          "allTotalsMs": [
+            16,
+            11,
+            10,
+            9,
+            8
+          ],
+          "allWallMs": [
+            17.144292,
+            11.4555,
+            10.478916,
+            9.905292,
+            9.315791
+          ],
+          "pointCacheHits": 52292,
+          "pointCacheMisses": 9332,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      },
+      {
+        "base": {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.19,
+          "parseMs": 2,
+          "entityScanMs": 1,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 4,
+          "facetedBrepMs": 0,
+          "totalMs": 7,
+          "allTotalsMs": [
+            9,
+            8,
+            7,
+            7,
+            7
+          ],
+          "allWallMs": [
+            10.292124999999999,
+            8.572375000000001,
+            8.035542,
+            8.209583,
+            8.095209
+          ],
+          "pointCacheHits": 52060,
+          "pointCacheMisses": 9180,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        },
+        "branch": {
+          "path": "tests/models/ara3d/AC20-FZK-Haus.ifc",
+          "fileMb": 2.41,
+          "entities": 44249,
+          "meshes": 285,
+          "vertices": 35940,
+          "triangles": 19456,
+          "indexBuildMs": 1.0,
+          "parseMs": 2,
+          "entityScanMs": 1,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 4,
+          "facetedBrepMs": 0,
+          "totalMs": 7,
+          "allTotalsMs": [
+            9,
+            9,
+            8,
+            7,
+            8
+          ],
+          "allWallMs": [
+            9.4785,
+            9.787625,
+            8.801,
+            7.972333,
+            8.425042000000001
+          ],
+          "pointCacheHits": 51724,
+          "pointCacheMisses": 9084,
+          "csgFailures": 0,
+          "degenerateDropped": 0
+        }
+      }
+    ],
+    "issue129": [
+      {
+        "base": {
+          "path": "tests/models/ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc",
+          "fileMb": 11.473,
+          "entities": 202661,
+          "meshes": 1402,
+          "vertices": 218255,
+          "triangles": 132674,
+          "indexBuildMs": 4.57,
+          "parseMs": 8,
+          "entityScanMs": 8,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 562,
+          "facetedBrepMs": 0,
+          "totalMs": 570,
+          "allTotalsMs": [
+            594,
+            592,
+            570,
+            605,
+            583
+          ],
+          "allWallMs": [
+            598.8243749999999,
+            597.023583,
+            575.884584,
+            610.13175,
+            588.391209
+          ],
+          "pointCacheHits": 222724,
+          "pointCacheMisses": 27874,
+          "csgFailures": 43,
+          "degenerateDropped": 6
+        },
+        "branch": {
+          "path": "tests/models/ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc",
+          "fileMb": 11.473,
+          "entities": 202661,
+          "meshes": 1402,
+          "vertices": 218255,
+          "triangles": 132674,
+          "indexBuildMs": 4.62,
+          "parseMs": 8,
+          "entityScanMs": 8,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 566,
+          "facetedBrepMs": 0,
+          "totalMs": 575,
+          "allTotalsMs": [
+            580,
+            596,
+            575,
+            594,
+            578
+          ],
+          "allWallMs": [
+            584.8243749999999,
+            600.8173340000001,
+            579.655041,
+            599.4123340000001,
+            583.210375
+          ],
+          "pointCacheHits": 222726,
+          "pointCacheMisses": 27872,
+          "csgFailures": 43,
+          "degenerateDropped": 6
+        }
+      },
+      {
+        "base": {
+          "path": "tests/models/ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc",
+          "fileMb": 11.473,
+          "entities": 202661,
+          "meshes": 1402,
+          "vertices": 218255,
+          "triangles": 132674,
+          "indexBuildMs": 4.59,
+          "parseMs": 8,
+          "entityScanMs": 8,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 570,
+          "facetedBrepMs": 0,
+          "totalMs": 578,
+          "allTotalsMs": [
+            589,
+            586,
+            578,
+            582,
+            580
+          ],
+          "allWallMs": [
+            594.842958,
+            590.964459,
+            583.547,
+            587.124958,
+            585.048208
+          ],
+          "pointCacheHits": 222724,
+          "pointCacheMisses": 27874,
+          "csgFailures": 43,
+          "degenerateDropped": 6
+        },
+        "branch": {
+          "path": "tests/models/ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc",
+          "fileMb": 11.473,
+          "entities": 202661,
+          "meshes": 1402,
+          "vertices": 218255,
+          "triangles": 132674,
+          "indexBuildMs": 4.6,
+          "parseMs": 8,
+          "entityScanMs": 8,
+          "lookupMs": 0,
+          "preprocessMs": 0,
+          "geometryMs": 570,
+          "facetedBrepMs": 0,
+          "totalMs": 579,
+          "allTotalsMs": [
+            587,
+            586,
+            587,
+            583,
+            579
+          ],
+          "allWallMs": [
+            591.5821249999999,
+            591.5433340000001,
+            592.111625,
+            587.642667,
+            584.031541
+          ],
+          "pointCacheHits": 222725,
+          "pointCacheMisses": 27873,
+          "csgFailures": 43,
+          "degenerateDropped": 6
+        }
+      }
+    ]
+  },
+  "checks": {
+    "nativeReferenceTests": 2,
+    "wasmContractsPassed": 90,
+    "wasmContractsFailed": 0,
+    "wasmContractsSkipped": 1,
+    "wasmSkip": "optional historical baseline",
+    "rustWorkspace": "passed",
+    "clippyWorkspaceAllTargetsDenyWarnings": "passed",
+    "freshWheelHarnessTests": 15,
+    "freshWheelCommittedReferenceComparisons": 4
+  }
+}

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -19,8 +19,8 @@ pub(crate) mod geom;
 mod malformed_opening_repair;
 pub(crate) mod prism_cut;
 mod probe;
+mod representation;
 mod synthesis;
-
 pub use bool2d_path::take_bool2d_stats;
 pub use prism_cut::{take_prism_defers, take_prism_stats};
 #[cfg(test)]

--- a/rust/geometry/src/router/voids/representation.rs
+++ b/rust/geometry/src/router/voids/representation.rs
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! Conservative, geometry-free routing for documented Reference openings.
+use crate::GeometryRouter;
+use ifc_lite_core::{EntityDecoder, IfcType};
+
+impl GeometryRouter {
+    /// Whether an opening must retain the canonical cutter path. Only a proven
+    /// Reference-only opening (optionally with BoundingBox) returns false.
+    /// Unknown, malformed, empty and over-budget representation data returns true
+    /// so ordinary cutter/error handling remains authoritative (#4440).
+    pub fn opening_requires_subtraction(&self, id:u32, decoder:&mut EntityDecoder<'_>)->bool {
+        let reference_only=(|| {
+            let opening=decoder.decode_by_id(id).ok()?;
+            if !opening.ifc_type.is_subtype_of(IfcType::IfcOpeningElement) {return None;}
+            let pds=decoder.decode_by_id(opening.get_ref(6)?).ok()?;
+            if pds.ifc_type!=IfcType::IfcProductDefinitionShape {return None;}
+            let representations=pds.get_list(2)?;
+            if representations.is_empty() || representations.len()>64 {return None;}
+            let mut reference=false;
+            for value in representations {
+                let representation=decoder.decode_by_id(value.as_entity_ref()?).ok()?;
+                if representation.ifc_type!=IfcType::IfcShapeRepresentation {return None;}
+                match crate::router::effective_element_rep_type(&opening,&representation) {
+                    Some("Reference")=>reference=true,
+                    Some("BoundingBox")=>{},
+                    _=>return None,
+                }
+            }
+            Some(reference)
+        })();
+        reference_only!=Some(true)
+    }
+}

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -332,7 +332,7 @@ fn produce_inner(
     let has_openings = ctx
         .void_index
         .get(&job.id)
-        .is_some_and(|openings| !openings.is_empty());
+        .is_some_and(|openings| openings.iter().any(|&id| router.opening_requires_subtraction(id, decoder)));
 
     // Material-layer wall: tag its per-layer slices GEOM_CLASS_LAYER_SLICE so the
     // 2D/section cut can split the cut into per-layer fills (one sub-mesh = one

--- a/rust/processing/src/element_reference_opening_tests.rs
+++ b/rust/processing/src/element_reference_opening_tests.rs
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//! #4440: a retained semantic opening must not strip the host image/UVs.
+const IFC:&str=r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Reference texture regression'),'2;1');
+FILE_NAME('reference.ifc','2026-09-10T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0000000000000000000001',$,'P',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCBUILDINGELEMENTPROXY('0000000000000000000002',$,'Host',$,$,#11,#12,$,$);
+#11=IFCLOCALPLACEMENT($,#5);
+#12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
+#13=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#14));
+#14=IFCTRIANGULATEDFACESET(#15,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
+#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#20=IFCIMAGETEXTURE(.T.,.F.,$,$,$,'textures/rock.png');
+#21=IFCTEXTUREVERTEXLIST(((0.,0.),(1.,0.),(0.,1.),(1.,1.)));
+#22=IFCINDEXEDTRIANGLETEXTUREMAP((#20),#14,#21,$);
+#23=IFCSTYLEDITEM(#14,(#24),$);
+#24=IFCSURFACESTYLE('Rock',.BOTH.,(#25,#26));
+#25=IFCSURFACESTYLERENDERING(#27,0.,$,$,$,$,$,$,.NOTDEFINED.);
+#26=IFCSURFACESTYLEWITHTEXTURES((#20));
+#27=IFCCOLOURRGB($,0.5,0.4,0.3);
+#80=IFCOPENINGELEMENT('0000000000000000000003',$,$,$,$,#11,#81,$,.OPENING.);
+#81=IFCPRODUCTDEFINITIONSHAPE($,$,(#82));
+#82=IFCSHAPEREPRESENTATION(#2,'Reference','CSG',(#84));
+#83=IFCRELVOIDSELEMENT('0000000000000000000004',$,$,$,#10,#80);
+#84=IFCBLOCK(#5,0.2,0.2,0.2);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+fn host(source:&str)->crate::MeshData {
+    crate::process_geometry(source.as_bytes()).meshes.into_iter().find(|mesh|mesh.express_id==10).unwrap()
+}
+#[test]
+fn issue_4440_reference_only_opening_keeps_exact_host_texture_and_triangle_binding() {
+    let control=host(&IFC.replace("#83=IFCRELVOIDSELEMENT('0000000000000000000004',$,$,$,#10,#80);", ""));
+    assert!(control.texture.is_some());assert!(control.uvs.is_some());
+    let reference=host(IFC);
+    assert_eq!(serde_json::to_value(&reference).unwrap(),serde_json::to_value(&control).unwrap());
+    let mixed=IFC.replace("(#82));","(#82,#85));").replace("#83=", "#85=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#84));\n#83=");
+    let body=host(&IFC.replace("'Reference'","'Body'"));
+    let mixed=host(&mixed);
+    assert_eq!(serde_json::to_value(&body).unwrap(),serde_json::to_value(&mixed).unwrap());
+    assert_ne!(body.indices.len(),reference.indices.len(),"mixed Body must still cut the host");
+    if let Ok(directory)=std::env::var("IFCLITE_REFERENCE_TEXTURE_EVIDENCE_DIR") {
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(std::path::Path::new(&directory).join("textured-reference.ifc"),IFC).unwrap();
+    }
+}
+#[test]
+fn issue_4440_unknown_and_over_budget_openings_retain_cutter_routing() {
+    let router=ifc_lite_geometry::GeometryRouter::new();
+    for source in [IFC.replace("'Reference'","'Unknown'"),IFC.replace("(#82));","(#9999));"),
+        IFC.replace("(#82));", &format!("({}));",vec!["#82";65].join(","))),
+        IFC.replace("IFCOPENINGELEMENT(","IFCBUILDINGELEMENTPROXY(")] {
+        let mut decoder=ifc_lite_core::EntityDecoder::new(source.as_bytes());
+        assert!(router.opening_requires_subtraction(80,&mut decoder));
+    }
+    let mut decoder=ifc_lite_core::EntityDecoder::new(IFC.as_bytes());
+    assert!(!router.opening_requires_subtraction(80,&mut decoder));
+    assert!(router.opening_requires_subtraction(9999,&mut decoder));
+}

--- a/rust/processing/src/element_reference_opening_tests.rs
+++ b/rust/processing/src/element_reference_opening_tests.rs
@@ -19,10 +19,10 @@ DATA;
 #11=IFCLOCALPLACEMENT($,#5);
 #12=IFCPRODUCTDEFINITIONSHAPE($,$,(#13));
 #13=IFCSHAPEREPRESENTATION(#2,'Body','Tessellation',(#14));
-#14=IFCTRIANGULATEDFACESET(#15,$,.T.,((1,2,3),(1,2,4),(1,4,3),(2,3,4)),$);
-#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(0.,1.,0.),(0.,0.,1.)));
+#14=IFCTRIANGULATEDFACESET(#15,$,.T.,((1,3,2),(1,4,3),(5,6,7),(5,7,8),(1,2,6),(1,6,5),(2,3,7),(2,7,6),(3,4,8),(3,8,7),(4,1,5),(4,5,8)),$);
+#15=IFCCARTESIANPOINTLIST3D(((0.,0.,0.),(1.,0.,0.),(1.,1.,0.),(0.,1.,0.),(0.,0.,1.),(1.,0.,1.),(1.,1.,1.),(0.,1.,1.)));
 #20=IFCIMAGETEXTURE(.T.,.F.,$,$,$,'textures/rock.png');
-#21=IFCTEXTUREVERTEXLIST(((0.,0.),(1.,0.),(0.,1.),(1.,1.)));
+#21=IFCTEXTUREVERTEXLIST(((0.,0.),(1.,0.),(1.,1.),(0.,1.),(0.,0.),(1.,0.),(1.,1.),(0.,1.)));
 #22=IFCINDEXEDTRIANGLETEXTUREMAP((#20),#14,#21,$);
 #23=IFCSTYLEDITEM(#14,(#24),$);
 #24=IFCSURFACESTYLE('Rock',.BOTH.,(#25,#26));
@@ -46,6 +46,8 @@ fn issue_4440_reference_only_opening_keeps_exact_host_texture_and_triangle_bindi
     assert!(control.texture.is_some());assert!(control.uvs.is_some());
     let reference=host(IFC);
     assert_eq!(serde_json::to_value(&reference).unwrap(),serde_json::to_value(&control).unwrap());
+    let with_box=IFC.replace("(#82));","(#82,#86));").replace("#83=", "#86=IFCSHAPEREPRESENTATION(#2,'Box','BoundingBox',(#87));\n#87=IFCBOUNDINGBOX(#4,1.,1.,1.);\n#83=");
+    assert_eq!(serde_json::to_value(host(&with_box)).unwrap(),serde_json::to_value(&control).unwrap());
     let mixed=IFC.replace("(#82));","(#82,#85));").replace("#83=", "#85=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#84));\n#83=");
     let body=host(&IFC.replace("'Reference'","'Body'"));
     let mixed=host(&mixed);
@@ -59,7 +61,7 @@ fn issue_4440_reference_only_opening_keeps_exact_host_texture_and_triangle_bindi
 #[test]
 fn issue_4440_unknown_and_over_budget_openings_retain_cutter_routing() {
     let router=ifc_lite_geometry::GeometryRouter::new();
-    for source in [IFC.replace("'Reference'","'Unknown'"),IFC.replace("(#82));","(#9999));"),
+    for source in [IFC.replace("(#82));","());"),IFC.replace("'Reference'","'Unknown'"),IFC.replace("(#82));","(#9999));"),
         IFC.replace("(#82));", &format!("({}));",vec!["#82";65].join(","))),
         IFC.replace("IFCOPENINGELEMENT(","IFCBUILDINGELEMENTPROXY(")] {
         let mut decoder=ifc_lite_core::EntityDecoder::new(source.as_bytes());

--- a/rust/processing/src/element_tests.rs
+++ b/rust/processing/src/element_tests.rs
@@ -423,3 +423,6 @@ fn a_shared_item_resolves_via_the_shallow_branch() {
         "the shallow branch reaches the styled leaf well inside the cap"
     );
 }
+
+#[path = "element_reference_opening_tests.rs"]
+mod reference_openings;

--- a/scripts/lib/wasm-appearance-contracts.mjs
+++ b/scripts/lib/wasm-appearance-contracts.mjs
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /** Register actual-WASM appearance and annotation acceptance contracts. */
+import { checkReferenceOpeningContract } from './wasm-reference-opening-contract.mjs';
 import { checkPdfVectorContract } from './wasm-pdf-vector-contract.mjs';
 import { checkAnnotationFillContract } from './wasm-annotation-fill-contract.mjs';
 import { checkMeshTransferContract } from './wasm-mesh-transfer-contract.mjs';
 import { checkScanRegistrationContract } from './wasm-scan-registration-contract.mjs';
 
 export function runAppearanceContracts(IfcAPI, test) {
+  test('Reference-only openings preserve exact host image/UV binding (#4440)', () => checkReferenceOpeningContract(IfcAPI));
   test('PDF vector state preserves calibrated stroke transforms and explicit blockers (#4406)', () => checkPdfVectorContract(IfcAPI));
   test('annotation fills preserve holes, units and solid colour (#4406)', () => checkAnnotationFillContract(IfcAPI));
   test('registered mesh transfer reports unknown coverage and binds prepared assets (#4381)', () => checkMeshTransferContract(IfcAPI));

--- a/scripts/lib/wasm-reference-opening-contract.mjs
+++ b/scripts/lib/wasm-reference-opening-contract.mjs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import assert from 'node:assert/strict';
+import { transferIfc } from './wasm-mesh-transfer-contract.mjs';
+
+const source=transferIfc.replace('((1,2,3))','((1,3,2),(1,4,3),(5,6,7),(5,7,8),(1,2,6),(1,6,5),(2,3,7),(2,7,6),(3,4,8),(3,8,7),(4,1,5),(4,5,8))')
+  .replace('((0.,0.,0.),(1.,0.,0.),(0.,1.,0.))','((0.,0.,0.),(1.,0.,0.),(1.,1.,0.),(0.,1.,0.),(0.,0.,1.),(1.,0.,1.),(1.,1.,1.),(0.,1.,1.))')
+  .replace('$,.F.,((1,3,2)','$,.T.,((1,3,2)')
+  .replace('(#22));','(#22,#32));')
+  .replace('ENDSEC;\nEND-ISO-10303-21;', `
+#30=IFCIMAGETEXTURE(.T.,.F.,$,$,$,'textures/rock.png');
+#31=IFCTEXTUREVERTEXLIST(((0.,0.),(1.,0.),(1.,1.),(0.,1.),(0.,0.),(1.,0.),(1.,1.),(0.,1.)));
+#32=IFCSURFACESTYLEWITHTEXTURES((#30));
+#33=IFCINDEXEDTRIANGLETEXTUREMAP((#30),#14,#31,$);
+#80=IFCOPENINGELEMENT('0000000000000000000003',$,$,$,$,#11,#81,$,.OPENING.);
+#81=IFCPRODUCTDEFINITIONSHAPE($,$,(#82));
+#82=IFCSHAPEREPRESENTATION(#2,'Reference','CSG',(#84));
+#83=IFCRELVOIDSELEMENT('0000000000000000000004',$,$,$,#10,#80);
+#84=IFCBLOCK(#5,0.2,0.2,0.2);
+ENDSEC;END-ISO-10303-21;`);
+
+export function checkReferenceOpeningContract(IfcAPI) {
+  const host=(text)=> {
+    const api=new IfcAPI();let collection;
+    try {
+      const bytes=new TextEncoder().encode(text), pre=api.buildPrePassOnce(bytes);
+      collection=api.processGeometryBatch(bytes,pre.jobs,pre.unitScale,...pre.rtcOffset,pre.needsShift,
+        pre.voidKeys,pre.voidCounts,pre.voidValues,pre.styleIds,pre.styleColors);
+      let result;
+      for(let i=0;i<collection.length;i++) {
+        const mesh=collection.get(i);
+        try {
+          if(mesh.expressId===10) result={positions:Array.from(mesh.positions),indices:Array.from(mesh.indices),
+            normals:Array.from(mesh.normals),origin:Array.from(mesh.origin),uvs:Array.from(mesh.uvs),
+            textureUrl:mesh.textureUrl,repeatS:mesh.textureRepeatS,repeatT:mesh.textureRepeatT};
+        } finally {mesh.free();}
+      }
+      assert.ok(result,'host is present');return result;
+    } finally {collection?.free();api.clearPrePassCache();api.free();}
+  };
+  const control=host(source.replace("#83=IFCRELVOIDSELEMENT('0000000000000000000004',$,$,$,#10,#80);",''));
+  assert.equal(control.textureUrl,'textures/rock.png');assert.ok(control.uvs.length>0);
+  assert.deepEqual(host(source),control,'Reference relationship preserves exact canonical host texture binding');
+  const body=host(source.replace("'Reference'","'Body'"));
+  const mixed=host(source.replace('(#82));','(#82,#85));').replace('#83=',"#85=IFCSHAPEREPRESENTATION(#2,'Body','CSG',(#84));\n#83="));
+  assert.deepEqual(body,mixed,'mixed Body/Reference retains the same actual cut');
+  assert.notEqual(body.indices.length,control.indices.length,'Body still subtracts');
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1219,3 +1219,16 @@ The lesson is to preserve the existing type-based rendering predicate for
 ordinary products while applying opening-specific semantics consistently to
 mesh production and fast void probes. Numeric evidence and source revisions are
 in `docs/architecture/evidence/evaluated-openings/performance.json`.
+
+### Reference-only opening host routing (#4440)
+
+A retained Reference-only opening must keep its host on the textured submesh
+path. The new predicate inspects representation membership without producing
+cutter meshes; unknown or over-budget data retains the existing cutter path.
+Two interleaved base/branch native probe pairs on AC20 and ISSUE_129 resolved no
+consistent material normal-load regression, with unchanged mesh/vertex/triangle
+counts and existing CSG diagnostics. This is a correctness fix, not a browser
+worker-pool speedup claim; small overhead below run-to-run variation remains
+unresolved. [Exact revisions, probe results and limits](../../docs/architecture/evidence/evaluated-openings/reference-textures.json)
+are recorded with the fixture evidence. Do not infer that a nonempty void-index
+entry implies actual subtraction: the opening representation identifier matters.


### PR DESCRIPTION
A textured host with a retained Reference-only opening lost its image and UVs because a nonempty void-index entry selected the untextured cutter path. The canonical native/browser element funnel now uses a bounded, geometry-free representation check: Reference-only openings preserve the textured host, while mixed Body/Reference and unrecognized data retain cutter handling.

Closes #4440. Prerequisite for #4404; post-opening authoring remains separate.

Validation:

- Native regression requires exact host MeshData equality with the no-opening control, including image/UV binding; mixed Body equals Body-only actual cut. Reference + BoundingBox and malformed/empty/over-budget controls pass. Previous routing fails the regression.
- Full Rust workspace tests and `cargo clippy --workspace --all-targets -- -D warnings` passed. Fresh WASM contracts: 90 passed, 0 failed, 1 optional historical-baseline skip; new Reference contract executes without a skip. Mixed cube cuts report zero CSG failures.
- Fresh Python wheel: 15 harness tests and all 4 committed-reference comparisons passed. Renderer dependency build, module/refwalk/license/wiring/source-assertion checks and changed-script lint passed. WASM type surface is unchanged; patch changeset included.
- Controlled native A/B/A/B (five iterations per run): AC20 parse/geometry/total 2/4/7 → 3/5/8 ms, then 2/4/7 → 2/4/7. ISSUE129 8/562/570 → 8/566/575 ms, then 8/570/578 → 8/570/579. Mesh/vertex/triangle and CSG diagnostic counts match. No consistent material normal-load regression resolved; no browser speedup or full-byte-identity claim.

[Exact source/runtime fingerprints, results and limits](https://github.com/LTplus-AG/ifc-lite/blob/651d4bd4a28722cfcb6051ef83c6a0314fa6d07e/docs/architecture/evidence/evaluated-openings/reference-textures.json). Required cloud checks may still be queued; the local runs above are the reported evidence.
