### PR TITLE
refactor: extract canonical authored product context

### DIFF
--- a/.changeset/shared-authored-context.md
+++ b/.changeset/shared-authored-context.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Extract native product-authoring metadata, source context and placement preparation from the shared textured creator so additional geometry representations can reuse it. Existing creator APIs and output behavior remain unchanged.

--- a/docs/architecture/captured-mesh-authoring.md
+++ b/docs/architecture/captured-mesh-authoring.md
@@ -94,3 +94,9 @@ Actual WebGPU creation, original-image export, normal re-import, and picking are
 recorded in [captured UI acceptance](evidence/captured-ui/README.md).
 
 Destination eligibility is independent of load order or prior object selection: a loaded IFC4/IFC4X3 spatial model is offered even before its lazy mutation view exists. Creation initializes or reuses the canonical view, preserving prior edits. The created object activates its destination model so the shared Undo action targets that creation. Drawing-to-IfcAnnotation creation uses the same destination and selection helpers.
+
+The native shared creator obtains metadata validation, the effective source
+context, allocation preflight and container-relative placement from
+`appearance/authored.rs`. Texture-specific row construction and canonical mesh
+production remain in the existing annotation/captured planner. This extraction
+does not change the public creator APIs or enable additional representations.

--- a/docs/architecture/evidence/authored-context/README.md
+++ b/docs/architecture/evidence/authored-context/README.md
@@ -1,0 +1,21 @@
+# Shared authored context (#4406)
+
+This prerequisite extracts the existing source/metadata/placement setup and
+fixed-row author from the common annotation/captured-object planner. The public
+APIs, fixed entity layouts, texture construction and canonical mesh production
+stay in the existing creator path. Metadata validation still precedes image URI
+validation. It enables later geometry representations to reuse source context
+without supplying an image URI or adding another STEP writer.
+
+Two independently rebuilt WASM modules from exact base `c638bdca7` and branch
+`e81472165` produced byte-identical complete plan buffers for all 24 controls in
+`plan-identity.json`. The comparison includes ordered IFC rows, canonical mesh
+arrays, placement, UV seams and all sampler combinations, across IFC4/IFC4X3
+and metres/millimetres. Horizontal and vertical image annotation frames are
+covered. These are full buffer comparisons, not just mesh-count checks.
+
+Full native workspace and strict workspace/all-target clippy passed. Existing
+appearance tests passed, the root build passed, and actual WASM contracts
+passed with their existing optional fixture skips. A fresh independently
+installed PyO3 wheel matched all four committed quick-lane IFC references;
+the existing halfspace triangle-density advisory remains.

--- a/docs/architecture/evidence/authored-context/README.md
+++ b/docs/architecture/evidence/authored-context/README.md
@@ -19,3 +19,8 @@ appearance tests passed, the root build passed, and actual WASM contracts
 passed with their existing optional fixture skips. A fresh independently
 installed PyO3 wheel matched all four committed quick-lane IFC references;
 the existing halfspace triangle-density advisory remains.
+
+The exact-source native A/B/A/B normal-load probe in `native-load.json` resolved
+no difference at its timing precision; ordered mesh fingerprints and all counts
+matched. Each run uses five iterations, with probe timings reported as best of
+five. This does not measure browser worker performance or creation throughput.

--- a/docs/architecture/evidence/authored-context/native-load.json
+++ b/docs/architecture/evidence/authored-context/native-load.json
@@ -1,0 +1,106 @@
+{
+  "fixtureSha256": "ea6f04eaf92fac4d7ad0038bc3d2dfea4c094dd3f516ecc33c50bf1835ca108d",
+  "baseSource": "c638bdca7",
+  "branchSource": "e81472165",
+  "measurement": "Interleaved native five-iteration normal-load A/B/A/B on an explicitly idle machine. Probe parse/geometry/total values are best-of-five, not medians. Separate fingerprints are not timed evidence. No worker-pool or authoring throughput claim.",
+  "runs": [
+    {
+      "version": "base",
+      "parseMs": 3,
+      "geometryMs": 5,
+      "totalMs": 8,
+      "allTotalsMs": [
+        17,
+        11,
+        10,
+        9,
+        8
+      ],
+      "allWallMs": [
+        18.047291,
+        11.59575,
+        10.475375,
+        9.925542,
+        9.202416999999999
+      ]
+    },
+    {
+      "version": "branch",
+      "parseMs": 3,
+      "geometryMs": 5,
+      "totalMs": 8,
+      "allTotalsMs": [
+        17,
+        10,
+        9,
+        9,
+        8
+      ],
+      "allWallMs": [
+        17.483209,
+        11.244667,
+        10.158541999999999,
+        9.786,
+        9.251125
+      ]
+    },
+    {
+      "version": "base",
+      "parseMs": 2,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [
+        11,
+        8,
+        8,
+        8,
+        7
+      ],
+      "allWallMs": [
+        12.122291,
+        8.949542,
+        8.384959,
+        8.427999999999999,
+        8.146959
+      ]
+    },
+    {
+      "version": "branch",
+      "parseMs": 2,
+      "geometryMs": 4,
+      "totalMs": 7,
+      "allTotalsMs": [
+        9,
+        8,
+        8,
+        7,
+        7
+      ],
+      "allWallMs": [
+        9.374125000000001,
+        8.408040999999999,
+        8.36575,
+        8.225167,
+        8.056584
+      ]
+    }
+  ],
+  "identity": {
+    "base": {
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "meshFingerprintsFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    "branch": {
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "meshFingerprintsFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    }
+  }
+}

--- a/docs/architecture/evidence/authored-context/plan-identity.json
+++ b/docs/architecture/evidence/authored-context/plan-identity.json
@@ -1,0 +1,31 @@
+{
+  "baseSource": "c638bdca7",
+  "branchSource": "e81472165",
+  "measurement": "Exact full UTF8 JSON byte equality from independently built actual WASM modules; includes canonical meshes, IFC entity rows, texture/sampler metadata and placement.",
+  "results": [
+    {"schema":"IFC4","millimetres":false,"kind":"annotation","vertical":true,"bytes":2631,"sha256":"2a8dcb79f1f888397c79bfa59ecc4f65f3a3219f6de0ff692fc6581fcef9a699"},
+    {"schema":"IFC4","millimetres":false,"kind":"annotation","vertical":false,"bytes":2626,"sha256":"3a508e1fe7f8dc11530f77600734bc9318fd73c49dede99ad53a6250458ed3a2"},
+    {"schema":"IFC4","millimetres":false,"kind":"captured","repeatS":true,"repeatT":true,"bytes":2702,"sha256":"9d52268533bd0c931f69bdca1f8a54faeb05fa740a2ca2d173b4dbc972ca32a3"},
+    {"schema":"IFC4","millimetres":false,"kind":"captured","repeatS":true,"repeatT":false,"bytes":2703,"sha256":"ce23b824653ba5e8a8831dda819fb145c34a2dfa63027867d29679de587b0e8d"},
+    {"schema":"IFC4","millimetres":false,"kind":"captured","repeatS":false,"repeatT":true,"bytes":2703,"sha256":"2062831d6c86fab3403adad7ee8bd4628ba96aeba1cd923b1e0056e76eeae743"},
+    {"schema":"IFC4","millimetres":false,"kind":"captured","repeatS":false,"repeatT":false,"bytes":2704,"sha256":"09cea502cc0e102986debf9a354126d465d14564773c7edef8e8a423cb8d35ba"},
+    {"schema":"IFC4","millimetres":true,"kind":"annotation","vertical":true,"bytes":2652,"sha256":"19f0f4ed5644771a0c1e3e8785183a54f94dc30fe6dd850abfb9a02a5f963a07"},
+    {"schema":"IFC4","millimetres":true,"kind":"annotation","vertical":false,"bytes":2647,"sha256":"4801f30dc93d9e0264c42d3e79b829404595cdd85d3942f44fbf5890fab18100"},
+    {"schema":"IFC4","millimetres":true,"kind":"captured","repeatS":true,"repeatT":true,"bytes":2726,"sha256":"99ef6d35a30944cd2ed952dee0a1343ed22aa2acefe857d1511d6761e30c0cdd"},
+    {"schema":"IFC4","millimetres":true,"kind":"captured","repeatS":true,"repeatT":false,"bytes":2727,"sha256":"c298ed8fde9b937846a6e419a8db761e1462327a22ec23c70b6e864ea4e7d109"},
+    {"schema":"IFC4","millimetres":true,"kind":"captured","repeatS":false,"repeatT":true,"bytes":2727,"sha256":"56f9322b039793c35136484d736a9398f1a0530a274ecb19a5a5c7da48f1a0e2"},
+    {"schema":"IFC4","millimetres":true,"kind":"captured","repeatS":false,"repeatT":false,"bytes":2728,"sha256":"f922051b25dba216bc4080d79b64120bc615f38c24f3f5d2e6af01c06b24d751"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"annotation","vertical":true,"bytes":2652,"sha256":"f374fffb8b68585e8e9f517b1f0ff6ff17252a08cd7c8ab75f60d86da1ffd980"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"annotation","vertical":false,"bytes":2647,"sha256":"36f4e9844f4d4bd21dd93fb69de517e006d9301e4103ab48278becc53b7ffbd0"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"captured","repeatS":true,"repeatT":true,"bytes":2707,"sha256":"385a1a9c796eaeff8efee6ff5c17d7bf56dd810be41eda5bbc20eaf2b4fd9de8"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"captured","repeatS":true,"repeatT":false,"bytes":2708,"sha256":"4aee0558497c8d38af6ef3af00683698a168e84e3cc6bdb7de00bbe0f8eb7577"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"captured","repeatS":false,"repeatT":true,"bytes":2708,"sha256":"6714940aaad77887ba0409483373b676f3e2aeb82ab80f0d753826012aa83437"},
+    {"schema":"IFC4X3","millimetres":false,"kind":"captured","repeatS":false,"repeatT":false,"bytes":2709,"sha256":"73728b600fd6ed7579f89272bb05056d8bcaa3b66ca918479f4c78ed4df2e523"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"annotation","vertical":true,"bytes":2673,"sha256":"29427e3c7c29d5cbd84aa9fbfe1caca61d1b80baedf8e232b693af60a51f617c"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"annotation","vertical":false,"bytes":2668,"sha256":"eddf481ca6ce4eb9f0a73b9c532b34736d7ef29c7217fe2a2a9efc3906957398"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"captured","repeatS":true,"repeatT":true,"bytes":2731,"sha256":"bf9a78f6437802bb760a53e4aeac949a3c4064bdb3b15ba482192ec9b5e6725f"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"captured","repeatS":true,"repeatT":false,"bytes":2732,"sha256":"c11f2b8892234b21aeb8a3de7c76f02a6e62b2f7ad1225a1dd14c705afdaa025"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"captured","repeatS":false,"repeatT":true,"bytes":2732,"sha256":"966993d0fa64067ad1c39398e5651d676cd3f1b16611140e143ba09c85e5b8c5"},
+    {"schema":"IFC4X3","millimetres":true,"kind":"captured","repeatS":false,"repeatT":false,"bytes":2733,"sha256":"e861bc5582221d2d80c5e28d6b71bcad9a5cf040608dd80070ff289a5a2fc3d6"}
+  ]
+}

--- a/rust/processing/src/appearance/annotation.rs
+++ b/rust/processing/src/appearance/annotation.rs
@@ -1,41 +1,12 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
-use super::{annotation_types::*, canonical, mapping, reference, source::Source, validate_image_uri, AppearancePlan, Mapping, MappingFrame};
-use ifc_lite_core::{AttributeValue as A, DecodedEntity, IfcType};
+use super::{annotation_types::*, authored::{vector, refs}, canonical, validate_image_uri, AppearancePlan};
+use ifc_lite_core::{AttributeValue as A, IfcType};
 use ifc_lite_geometry::{ImageTextureRef, ResolvedTextureMap, TextureSource};
 use rustc_hash::FxHashMap;
-use serde_json::{json, Value};
-use std::sync::Arc;
-
-fn dot(a: [f64; 3], b: [f64; 3]) -> f64 { a.iter().zip(b).map(|(a,b)| a*b).sum() }
-fn cross(a: [f64;3], b: [f64;3]) -> [f64;3] { [a[1]*b[2]-a[2]*b[1], a[2]*b[0]-a[0]*b[2], a[0]*b[1]-a[1]*b[0]] }
-fn vector(v: [f64;3]) -> A { A::List(v.into_iter().map(A::Float).collect()) }
-fn refs(ids: &[u32]) -> A { A::List(ids.iter().copied().map(A::EntityRef).collect()) }
-fn valid_guid(value: &str) -> bool {
-    value.len()==22 && value.as_bytes()[0]<=b'3' && value.as_bytes()[0]>=b'0'
-        && value.bytes().all(|c| c.is_ascii_alphanumeric() || c==b'_' || c==b'$')
-}
-// Only our fixed authored schema rows reach this conversion: file-supplied
-// aggregate values are never recursively cloned or reinterpreted here.
-fn wire(value: &A) -> Value {
-    match value {
-        A::EntityRef(id) => reference(*id), A::Null => Value::Null,
-        A::Derived => json!("*"), A::Enum(s) => json!(format!(".{s}.")),
-        A::String(s) => json!(s), A::Integer(n) => json!(n), A::Float(n) => json!(n),
-        A::List(v) => json!(v.iter().map(wire).collect::<Vec<_>>()),
-    }
-}
-struct Author {
-    plan: AppearancePlan,
-    entities: FxHashMap<u32, Arc<DecodedEntity>>,
-}
-impl Author {
-    fn add(&mut self, ty: IfcType, attributes: Vec<A>) -> u32 {
-        let id = super::add(&mut self.plan, ty.name(), attributes.iter().map(wire).collect());
-        self.entities.insert(id, Arc::new(DecodedEntity::new(id, ty, attributes))); id
-    }
-}
+#[cfg(test)]
+use super::source::Source;
 
 pub(super) struct AuthoredProductPlan {
     pub plan: AppearancePlan,
@@ -46,68 +17,15 @@ pub(super) struct AuthoredProductPlan {
 }
 pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest, captured:Option<&super::captured_types::CapturedMesh>, repeat:[bool;2]) -> Result<AuthoredProductPlan,String> {
     let r=request;
-    if !matches!(r.schema.as_str(), "IFC4"|"IFC4X3") || r.source_revision.len()>4096 || r.name.len()>1024
-        || !valid_guid(&r.global_id) || !valid_guid(&r.containment_global_id) || r.global_id==r.containment_global_id {
-        return Err("Annotation needs IFC4/IFC4X3, bounded metadata and distinct valid IFC GlobalIds".into());
-    }
-    super::wire_text::validate(&r.name, "Authored product Name")?;
-    validate_image_uri(&r.image_uri)?;
     let f=&r.frame;
-    mapping::validate(&Mapping::Planar { frame: MappingFrame::World, origin:f.origin, axis_u:f.axis_u,
-        axis_v:f.axis_v, metres_per_tile:f.size_metres })?;
-    if (dot(f.axis_u,f.axis_u)-1.).abs()>1e-10 || (dot(f.axis_v,f.axis_v)-1.).abs()>1e-10 || dot(f.axis_u,f.axis_v).abs()>1e-10 {
-        return Err("Annotation image frame must have orthonormal axes".into());
-    }
-    let mut source=Source::new(bytes)?;
-    if source.types.len()+32>200_000 || r.next_express_id<=source.types.last_key_value().map_or(0,|(id,_)| *id)
-        || r.next_express_id.checked_add(32).is_none() {
-        return Err("Annotation allocator or entity budget is exhausted/stale".into());
-    }
-    let ids:Vec<_>=source.types.iter().filter(|(_,t)|t.is_subtype_of(IfcType::IfcRoot)).map(|(id,_)|*id).collect();
-    for id in ids {
-        let entity=source.entity(id)?;
-        if entity.get_string(0).is_some_and(|guid|guid==r.global_id || guid==r.containment_global_id) {
-            return Err("Annotation GlobalId already exists in the effective model".into());
-        }
-    }
-    let container=source.entity(r.container_id)?;
-    if !container.ifc_type.is_subtype_of(IfcType::IfcSpatialElement) {
-        return Err("Choose an effective IfcSpatialElement as annotation container".into());
-    }
-    source.validate_world_placement(&container)?;
-    let projects:Vec<_>=source.types.iter().filter(|(_,t)|**t==IfcType::IfcProject).map(|(id,_)|*id).collect();
-    if projects.len()!=1 { return Err("Annotation creation needs one unambiguous IfcProject".into()); }
-    let project=source.entity(projects[0])?;
-    let mut contexts=Vec::new();
-    for id in super::source::refs(project.get(7))? {
-        let context=source.entity(id)?;
-        if context.ifc_type==IfcType::IfcGeometricRepresentationContext && context.get(2).and_then(A::as_int)==Some(3) {
-            contexts.push(id);
-        }
-    }
-    if contexts.len()!=1 { return Err("Choose a model with one unambiguous root 3D representation context".into()); }
-    let scale=source.decoder.length_unit_scale();
-    if !scale.is_finite() || scale<=0. { return Err("Invalid model length unit".into()); }
-    let context=source.context.as_ref().ok_or("Missing canonical load context")?;
-    let rtc_offset=if context.meta.needs_shift { context.meta.rtc_offset.into() } else { [0.;3] };
-    let transform=context.router().resolve_scaled_placement(&container,&mut source.decoder).map_err(|e|e.to_string())?;
-    let columns:[[f64;3];3]=std::array::from_fn(|i|std::array::from_fn(|j|transform[i*4+j]));
-    if transform.iter().any(|v|!v.is_finite()) || (0..3).any(|i| (0..3).any(|j|
-        (dot(columns[i],columns[j])-if i==j {1.} else {0.}).abs()>1e-10)) || dot(cross(columns[0],columns[1]),columns[2])<0.999999 {
-        return Err("Annotation container placement must be a finite right-handed rigid frame".into());
-    }
-    let inverse=|v:[f64;3]|columns.map(|c|dot(c,v));
-    let origin=inverse(std::array::from_fn(|i|f.origin[i]-transform[12+i])).map(|v|v/scale);
-    let u=inverse(f.axis_u); let normal=inverse(cross(f.axis_u,f.axis_v));
+    let metadata=super::authored::Metadata {schema:&r.schema,source_revision:&r.source_revision,
+        next_express_id:r.next_express_id,container_id:r.container_id,global_id:&r.global_id,
+        containment_global_id:&r.containment_global_id,name:&r.name};
+    super::authored::validate_metadata(&metadata)?;
+    validate_image_uri(&r.image_uri)?;
+    let super::authored::Authoring {mut author,mut source,placement,context_id,owner,scale,rtc_offset} =
+        super::authored::prepare(bytes,&metadata,f,32)?;
     let size=f.size_metres.map(|v|v/scale);
-    if origin.iter().chain(&size).any(|v|!v.is_finite()) { return Err("Annotation placement exceeds numeric range".into()); }
-    let mut author=Author { plan:AppearancePlan { source_revision:r.source_revision.clone(), next_express_id:r.next_express_id,
-        next_available_express_id:r.next_express_id, ..Default::default() }, entities:FxHashMap::default() };
-    let point=author.add(IfcType::IfcCartesianPoint,vec![vector(origin)]);
-    let axis=author.add(IfcType::IfcDirection,vec![vector(normal)]);
-    let direction=author.add(IfcType::IfcDirection,vec![vector(u)]);
-    let axes=author.add(IfcType::IfcAxis2Placement3D,vec![A::EntityRef(point),A::EntityRef(axis),A::EntityRef(direction)]);
-    let placement=author.add(IfcType::IfcLocalPlacement,vec![container.get_ref(5).map_or(A::Null,A::EntityRef),A::EntityRef(axes)]);
     let vertices = captured.map_or_else(|| vec![[0.,0.,0.],[size[0],0.,0.],[size[0],size[1],0.],[0.,size[1],0.]], |m| m.positions.iter().map(|p| std::array::from_fn(|i| (p[i]-f.origin[i])/scale)).collect());
     let mut point_attributes=vec![A::List(vertices.into_iter().map(vector).collect())];
     if r.schema=="IFC4X3" { point_attributes.push(A::Null); } // TagList, IFC4X3 only.
@@ -125,9 +43,8 @@ pub(super) fn plan_textured_product(bytes:&[u8], request:&AnnotationPlaneRequest
     let texture=author.add(IfcType::IfcSurfaceStyleWithTextures,vec![refs(&[image])]);
     let style=author.add(IfcType::IfcSurfaceStyle,vec![A::String("Registered image".into()),A::Enum("BOTH".into()),refs(&[shading,texture])]);
     let styled=author.add(IfcType::IfcStyledItem,vec![A::EntityRef(item),refs(&[style]),A::Null]);
-    let shape=author.add(IfcType::IfcShapeRepresentation,vec![A::EntityRef(contexts[0]),A::String(if captured.is_some() {"Body"} else {"Annotation"}.into()),A::String("Tessellation".into()),refs(&[item])]);
+    let shape=author.add(IfcType::IfcShapeRepresentation,vec![A::EntityRef(context_id),A::String(if captured.is_some() {"Body"} else {"Annotation"}.into()),A::String("Tessellation".into()),refs(&[item])]);
     let product_shape=author.add(IfcType::IfcProductDefinitionShape,vec![A::Null,A::Null,refs(&[shape])]);
-    let owner=project.get_ref(1).map_or(A::Null,A::EntityRef);
     let mut annotation_attributes=vec![A::String(r.global_id.clone()),owner.clone(),A::String(r.name.clone()),A::Null,
         A::String(if captured.is_some() {"IfcLite:CapturedSurface"} else {"IfcLite:RegisteredImage"}.into()),A::EntityRef(placement),A::EntityRef(product_shape)];
     if captured.is_some() { annotation_attributes.extend([A::Null,A::Enum("USERDEFINED".into())]); }

--- a/rust/processing/src/appearance/authored.rs
+++ b/rust/processing/src/appearance/authored.rs
@@ -1,0 +1,255 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::{
+    annotation_types::AnnotationPlaneFrame, mapping, reference, source::Source, AppearancePlan,
+    Mapping, MappingFrame,
+};
+use ifc_lite_core::{AttributeValue as A, DecodedEntity, IfcType};
+use rustc_hash::FxHashMap;
+use serde_json::{json, Value};
+use std::sync::Arc;
+pub(super) fn vector(v: [f64; 3]) -> A {
+    A::List(v.into_iter().map(A::Float).collect())
+}
+pub(super) fn refs(ids: &[u32]) -> A {
+    A::List(ids.iter().copied().map(A::EntityRef).collect())
+}
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a.iter().zip(b).map(|(a, b)| a * b).sum()
+}
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+pub(super) struct Metadata<'a> {
+    pub schema: &'a str,
+    pub source_revision: &'a str,
+    pub next_express_id: u32,
+    pub container_id: u32,
+    pub global_id: &'a str,
+    pub containment_global_id: &'a str,
+    pub name: &'a str,
+}
+pub(super) struct Authoring<'a> {
+    pub author: Author,
+    pub source: Source<'a>,
+    pub placement: u32,
+    pub context_id: u32,
+    pub owner: A,
+    pub scale: f64,
+    pub rtc_offset: [f64; 3],
+}
+fn valid_guid(value: &str) -> bool {
+    value.len() == 22
+        && value.as_bytes()[0] <= b'3'
+        && value.as_bytes()[0] >= b'0'
+        && value
+            .bytes()
+            .all(|c| c.is_ascii_alphanumeric() || c == b'_' || c == b'$')
+}
+// Only our fixed authored schema rows reach this conversion: file-supplied
+// aggregate values are never recursively cloned or reinterpreted here.
+fn wire(value: &A) -> Value {
+    match value {
+        A::EntityRef(id) => reference(*id),
+        A::Null => Value::Null,
+        A::Derived => json!("*"),
+        A::Enum(s) => json!(format!(".{s}.")),
+        A::String(s) => json!(s),
+        A::Integer(n) => json!(n),
+        A::Float(n) => json!(n),
+        A::List(v) => json!(v.iter().map(wire).collect::<Vec<_>>()),
+    }
+}
+pub(super) struct Author {
+    pub plan: AppearancePlan,
+    pub entities: FxHashMap<u32, Arc<DecodedEntity>>,
+}
+impl Author {
+    pub fn add(&mut self, ty: IfcType, attributes: Vec<A>) -> u32 {
+        let id = super::add(
+            &mut self.plan,
+            ty.name(),
+            attributes.iter().map(wire).collect(),
+        );
+        self.entities
+            .insert(id, Arc::new(DecodedEntity::new(id, ty, attributes)));
+        id
+    }
+}
+
+pub(super) fn validate_metadata(r: &Metadata<'_>) -> Result<(),String> {
+    if !matches!(r.schema, "IFC4" | "IFC4X3")
+        || r.source_revision.len() > 4096
+        || r.name.len() > 1024
+        || !valid_guid(r.global_id)
+        || !valid_guid(r.containment_global_id)
+        || r.global_id == r.containment_global_id
+    {
+        return Err(
+            "Annotation needs IFC4/IFC4X3, bounded metadata and distinct valid IFC GlobalIds"
+                .into(),
+        );
+    }
+    super::wire_text::validate(r.name, "Authored product Name")?;
+    Ok(())
+}
+
+pub(super) fn prepare<'a>(
+    bytes: &'a [u8],
+    request: &Metadata<'_>,
+    frame: &AnnotationPlaneFrame,
+    reserve: usize,
+) -> Result<Authoring<'a>, String> {
+    let r = request;
+    validate_metadata(r)?;
+    let f = frame;
+    mapping::validate(&Mapping::Planar {
+        frame: MappingFrame::World,
+        origin: f.origin,
+        axis_u: f.axis_u,
+        axis_v: f.axis_v,
+        metres_per_tile: f.size_metres,
+    })?;
+    if (dot(f.axis_u, f.axis_u) - 1.).abs() > 1e-10
+        || (dot(f.axis_v, f.axis_v) - 1.).abs() > 1e-10
+        || dot(f.axis_u, f.axis_v).abs() > 1e-10
+    {
+        return Err("Annotation image frame must have orthonormal axes".into());
+    }
+    let mut source = Source::new(bytes)?;
+    if source
+        .types
+        .len()
+        .checked_add(reserve)
+        .is_none_or(|n| n > 200_000)
+        || r.next_express_id <= source.types.last_key_value().map_or(0, |(id, _)| *id)
+        || u32::try_from(reserve)
+            .ok()
+            .and_then(|n| r.next_express_id.checked_add(n))
+            .is_none()
+    {
+        return Err("Annotation allocator or entity budget is exhausted/stale".into());
+    }
+    let ids: Vec<_> = source
+        .types
+        .iter()
+        .filter(|(_, t)| t.is_subtype_of(IfcType::IfcRoot))
+        .map(|(id, _)| *id)
+        .collect();
+    for id in ids {
+        let entity = source.entity(id)?;
+        if entity
+            .get_string(0)
+            .is_some_and(|guid| guid == r.global_id || guid == r.containment_global_id)
+        {
+            return Err("Annotation GlobalId already exists in the effective model".into());
+        }
+    }
+    let container = source.entity(r.container_id)?;
+    if !container.ifc_type.is_subtype_of(IfcType::IfcSpatialElement) {
+        return Err("Choose an effective IfcSpatialElement as annotation container".into());
+    }
+    source.validate_world_placement(&container)?;
+    let projects: Vec<_> = source
+        .types
+        .iter()
+        .filter(|(_, t)| **t == IfcType::IfcProject)
+        .map(|(id, _)| *id)
+        .collect();
+    if projects.len() != 1 {
+        return Err("Annotation creation needs one unambiguous IfcProject".into());
+    }
+    let project = source.entity(projects[0])?;
+    let mut contexts = Vec::new();
+    for id in super::source::refs(project.get(7))? {
+        let context = source.entity(id)?;
+        if context.ifc_type == IfcType::IfcGeometricRepresentationContext
+            && context.get(2).and_then(A::as_int) == Some(3)
+        {
+            contexts.push(id);
+        }
+    }
+    if contexts.len() != 1 {
+        return Err("Choose a model with one unambiguous root 3D representation context".into());
+    }
+    let scale = source.decoder.length_unit_scale();
+    if !scale.is_finite() || scale <= 0. {
+        return Err("Invalid model length unit".into());
+    }
+    let context = source
+        .context
+        .as_ref()
+        .ok_or("Missing canonical load context")?;
+    let rtc_offset = if context.meta.needs_shift {
+        context.meta.rtc_offset.into()
+    } else {
+        [0.; 3]
+    };
+    let transform = context
+        .router()
+        .resolve_scaled_placement(&container, &mut source.decoder)
+        .map_err(|e| e.to_string())?;
+    let columns: [[f64; 3]; 3] =
+        std::array::from_fn(|i| std::array::from_fn(|j| transform[i * 4 + j]));
+    if transform.iter().any(|v| !v.is_finite())
+        || (0..3).any(|i| {
+            (0..3)
+                .any(|j| (dot(columns[i], columns[j]) - if i == j { 1. } else { 0. }).abs() > 1e-10)
+        })
+        || dot(cross(columns[0], columns[1]), columns[2]) < 0.999999
+    {
+        return Err(
+            "Annotation container placement must be a finite right-handed rigid frame".into(),
+        );
+    }
+    let inverse = |v: [f64; 3]| columns.map(|c| dot(c, v));
+    let origin =
+        inverse(std::array::from_fn(|i| f.origin[i] - transform[12 + i])).map(|v| v / scale);
+    let u = inverse(f.axis_u);
+    let normal = inverse(cross(f.axis_u, f.axis_v));
+    let size = f.size_metres.map(|v| v / scale);
+    if origin.iter().chain(&size).any(|v| !v.is_finite()) {
+        return Err("Annotation placement exceeds numeric range".into());
+    }
+    let mut author = Author {
+        plan: AppearancePlan {
+            source_revision: r.source_revision.to_owned(),
+            next_express_id: r.next_express_id,
+            next_available_express_id: r.next_express_id,
+            ..Default::default()
+        },
+        entities: FxHashMap::default(),
+    };
+    let point = author.add(IfcType::IfcCartesianPoint, vec![vector(origin)]);
+    let axis = author.add(IfcType::IfcDirection, vec![vector(normal)]);
+    let direction = author.add(IfcType::IfcDirection, vec![vector(u)]);
+    let axes = author.add(
+        IfcType::IfcAxis2Placement3D,
+        vec![
+            A::EntityRef(point),
+            A::EntityRef(axis),
+            A::EntityRef(direction),
+        ],
+    );
+    let placement = author.add(
+        IfcType::IfcLocalPlacement,
+        vec![
+            container.get_ref(5).map_or(A::Null, A::EntityRef),
+            A::EntityRef(axes),
+        ],
+    );
+    Ok(Authoring {
+        author,
+        source,
+        placement,
+        context_id: contexts[0],
+        owner: project.get_ref(1).map_or(A::Null, A::EntityRef),
+        scale,
+        rtc_offset,
+    })
+}

--- a/rust/processing/src/appearance/mod.rs
+++ b/rust/processing/src/appearance/mod.rs
@@ -8,6 +8,7 @@ mod evaluated;
 mod evaluated_source;
 mod evaluated_allocation;
 mod annotation;
+mod authored;
 mod captured;
 mod captured_types;
 pub use captured::plan_captured_mesh;

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1243,3 +1243,15 @@ worker-pool speedup claim; small overhead below run-to-run variation remains
 unresolved. [Exact revisions, probe results and limits](../../docs/architecture/evidence/evaluated-openings/reference-textures.json)
 are recorded with the fixture evidence. Do not infer that a nonempty void-index
 entry implies actual subtraction: the opening representation identifier matters.
+
+## Shared authored source context (#4406)
+
+Extracting common creator setup resolved no normal-load timing difference in
+interleaved exact-source native probes, with identical ordered mesh fingerprints
+and counts. Independently rebuilt WASM modules also returned byte-identical
+complete plans for the checked annotation/captured controls. This is a reuse
+prerequisite, not an optimization or an authoring-throughput claim. Reuse the
+canonical source, placement and row author when adding non-image geometry; do
+not introduce a dummy texture to access shared setup. See the [raw native
+measurements](../../docs/architecture/evidence/authored-context/native-load.json)
+and adjacent plan identity evidence.


### PR DESCRIPTION
## Change

Extract source context, metadata validation, allocation preflight, placement and fixed-row authoring from the existing shared textured creator. This lets the next PDF fill representation reuse canonical authoring without a dummy image URI or another STEP writer. Existing annotation/captured APIs, entity layouts, validation order and canonical mesh production remain unchanged.

Refs #4406 (stays open for vector planning/UI). Assigned to louistrue. This is the small prerequisite for the native fill-page stack.

## Evidence

- Exact independently built base/branch WASM: all 24 complete annotation/captured plan JSON buffers byte-identical, across IFC4/IFC4X3, metres/mm, horizontal/vertical frames, UV seams and all sampler flags. Committed evidence.
- Full Rust workspace, strict clippy, root build 51/51, focused appearance 86/86 passed. Actual WASM 88 passed, 3 existing optional skips. Fresh own wheel 4/4 committed parity MATCH, existing halfspace density advisory.
- No API or generated binding change. Patch WASM release note and architecture docs included.
- Exact-source idle native A/B/A/B (five iterations each): both first-pair parse/geometry/total = 3/5/8 ms, both second-pair = 2/4/7 ms. Counts (285 meshes, 35,940 vertices, 19,456 triangles) and ordered FNV fingerprint match. Raw evidence committed; no optimization, worker-speedup or creation-throughput claim.
