### PR TITLE
fix(parser): a STEP record missing its ';' no longer swallows the next one

### DIFF
--- a/.changeset/fix-4179-step-scanner-record-boundary.md
+++ b/.changeset/fix-4179-step-scanner-record-boundary.md
@@ -1,0 +1,12 @@
+---
+"@ifc-lite/parser": patch
+"@ifc-lite/wasm": patch
+---
+
+Fix the fast STEP entity scan swallowing the next record when one is missing its own `;`. `#2=IFCB(2)` with no terminator used to run on to the *next* record's `;`, so `#1=IFCA(1);\n#2=IFCB(2)\n#3=IFCC(3);\n#4=IFCD(4);` yielded `#1`, `#2` (with a byte span covering all of `#3`), and `#4`, with `#3` gone and `malformedRecordCount` still `0`. The same shape with a truncated last record absorbed the file's `ENDSEC;` footer into that record and still reported success.
+
+The scan is now bounded to the record's own body by two ISO 10303-21 grammar rules: the last significant byte before the terminator must be the `)` closing the parameter list, and no `=` may appear before it outside a string or comment (`=` occurs only in `entity_instance_name '=' record`). A record that fails either rule is dropped and reported, and the scan resumes at the `)` closing its own parameter list, so one bad record costs one record. Stopping instead would have cost far more: a shard whose scanner stops hands back no handoff, and the stitch then discards every later shard, turning one missing `;` into the loss of the whole tail of the model on the sharded viewer path (measured: 40 records in, 19 out). An unterminated string or comment still has nothing to resume from, so that case stops exactly as before.
+
+Applied to all three hand-duplicated copies of the scan: `tokenizer.ts`, the Web Worker's `scan-worker-source.ts`, and the Rust `EntityScanner` behind the wasm path, which is why `@ifc-lite/wasm` is bumped alongside the parser.
+
+A record with no closing `)` at all is dropped the same way rather than ending the scan: its literals and comments all closed, so the bytes after it are still readable and the scan re-hunts from past its `#`. Only a literal or comment that never closes leaves nothing to resume from, and that still stops the scan as before.

--- a/packages/parser/src/columnar-prescanned-columns.test.ts
+++ b/packages/parser/src/columnar-prescanned-columns.test.ts
@@ -113,7 +113,7 @@ describe('issue #3985 pre-scanned column preparation', () => {
     expect(result.oversizedIdCount).toBe(2);
     expect(result.malformedRecordCount).toBe(1);
     expect(diagnostics.some(message => message.includes('skipped 2 record(s)'))).toBe(true);
-    expect(diagnostics.some(message => message.includes('stopped early'))).toBe(true);
+    expect(diagnostics.some(message => message.includes('dropped a record'))).toBe(true);
     const unknown: string[] = [];
     await scanColumnarEntities(bytes.buffer, {
       preScannedEntityIndex: { ...columns(true), oversizedIdCount: undefined },

--- a/packages/parser/src/entity-scanner.malformed-record.test.ts
+++ b/packages/parser/src/entity-scanner.malformed-record.test.ts
@@ -60,7 +60,7 @@ describe('scanIfcEntities: unterminated string literal', () => {
     // #3 is not recovered — asserting that honestly, so a future resync
     // attempt has to update this test rather than silently regress it.
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early') && m.includes('a record had'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
   });
 
   it('does not report malformedRecordCount, or emit its diagnostic, for a well-formed file', async () => {
@@ -78,7 +78,7 @@ describe('scanIfcEntities: unterminated string literal', () => {
 
     expect(result.malformedRecordCount).toBe(0);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1, 2, 3]);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(false);
   });
 });
 
@@ -106,7 +106,7 @@ describe('scanIfcEntities: unterminated comment inside a record', () => {
     expect(result.scanPath).toBe('tokenizer');
     expect(result.malformedRecordCount).toBe(1);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early') && m.includes('a record had'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
   });
 });
 
@@ -131,11 +131,15 @@ describe('scanIfcEntities: unterminated comment before the record body opens', (
     expect(result.scanPath).toBe('tokenizer');
     expect(result.malformedRecordCount).toBe(1);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early') && m.includes('a record had'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
     // The message must not claim the construct was a string literal when it
     // was actually a comment -- the whole point of #3695's remaining
     // review finding.
-    expect(diagnostics.some((m) => m.includes('string literal or comment'))).toBe(true);
+    // Both shapes named, not just one. The wording moved with #4179 (the scan
+    // now DROPS the record and resumes rather than stopping), so this asserts
+    // the two nouns rather than the old phrase.
+    expect(diagnostics.some((m) => m.includes('quoted string'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('comment'))).toBe(true);
   });
 });
 
@@ -165,7 +169,7 @@ describe('scanIfcEntities: shapes the per-site increments missed (round 2)', () 
     expect(result.scanPath).toBe('tokenizer');
     expect(result.malformedRecordCount).toBe(1);
     expect(result.entityRefs).toEqual([]);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
   });
 
   it('reports malformedRecordCount for a stray unclosed comment between two DATA records', async () => {
@@ -181,7 +185,7 @@ describe('scanIfcEntities: shapes the per-site increments missed (round 2)', () 
     expect(result.scanPath).toBe('tokenizer');
     expect(result.malformedRecordCount).toBe(1);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
   });
 
   it.each([
@@ -201,7 +205,7 @@ describe('scanIfcEntities: shapes the per-site increments missed (round 2)', () 
     expect(result.scanPath).toBe('tokenizer');
     expect(result.malformedRecordCount).toBe(1);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
   });
 });
 
@@ -231,7 +235,7 @@ describe('scanIfcEntities: declOpen false positive from a reference inside an ab
     expect(result.oversizedIdCount).toBe(1);
     expect(result.malformedRecordCount).toBe(0);
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(false);
   });
 
   it('control: a declaration genuinely cut off at EOF still reports malformedRecordCount 1', async () => {

--- a/packages/parser/src/entity-scanner.prescanned-malformed.test.ts
+++ b/packages/parser/src/entity-scanner.prescanned-malformed.test.ts
@@ -71,7 +71,7 @@ describe('scanIfcEntities: a pre-scanned index that stopped at a malformed recor
     // issue is that the caller is TOLD, not that the record comes back.
     expect(result.entityRefs.map((r) => r.expressId)).toEqual([1]);
     expect(
-      diagnostics.some((m) => m.includes('stopped early') && m.includes('a record had')),
+      diagnostics.some((m) => m.includes('dropped a record')),
     ).toBe(true);
   });
 
@@ -88,7 +88,7 @@ describe('scanIfcEntities: a pre-scanned index that stopped at a malformed recor
     });
 
     expect(result.malformedRecordCount).toBe(0);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(false);
   });
 
   it('reports BOTH when the stop and an unreported refusal count apply', async () => {
@@ -105,7 +105,7 @@ describe('scanIfcEntities: a pre-scanned index that stopped at a malformed recor
       onDiagnostic: (m) => diagnostics.push(m),
     });
 
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(true);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(true);
     expect(diagnostics.some((m) => m.includes('does not report refused'))).toBe(true);
   });
 
@@ -130,6 +130,6 @@ describe('scanIfcEntities: a pre-scanned index that stopped at a malformed recor
     });
 
     expect(result.malformedRecordCount).toBe(0);
-    expect(diagnostics.some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics.some((m) => m.includes('dropped a record'))).toBe(false);
   });
 });

--- a/packages/parser/src/entity-scanner.ts
+++ b/packages/parser/src/entity-scanner.ts
@@ -241,8 +241,13 @@ async function scanEntities(
   // Before this diagnostic existed, that stop was entirely silent: fewer
   // entities came back, and nothing said the file might be incomplete.
   //
-  // Deliberately singular and generic, not "N record(s)": the scan always
-  // stops at the first one it hits (there is no reliable place to resume),
+  // Deliberately generic: the flag covers three shapes collapsed into one, so a
+  // message naming only one of them would misdescribe the others. It no longer
+  // says the scan STOPS: since #4179 a record missing its ';' is DROPPED and the
+  // scan resumes at the balancing ')', so the common case loses one record from a
+  // file otherwise read to completion. The Rust twin
+  // (rust/core/src/parser/malformed_records.rs:34) carries the same wording and
+  // these two halves must not diverge.
   // so malformedRecordCount is 0 or 1, never a density, and it covers three
   // shapes -- an unterminated string, an unterminated comment, and a
   // declaration cut off before its own '(' -- collapsed into one flag, so a
@@ -250,9 +255,9 @@ async function scanEntities(
   // time it fires.
   if (malformedRecordCount > 0) {
     const message =
-      'scan: stopped early, a record had a string literal or comment that never closed, or ' +
-      'was cut off, before end of input, so scanning could not continue past it; the entities ' +
-      'returned may be an incomplete view of this file';
+      "scan: dropped a record with no terminating ';' (an unterminated quoted string, " +
+      'comment, or truncated file); the entities returned may be an incomplete view of ' +
+      'this file (#3695)';
     console.warn(`[IfcParser] ${message}`);
     options.onDiagnostic?.(message);
   }

--- a/packages/parser/src/parser-worker-malformed-handoff.test.ts
+++ b/packages/parser/src/parser-worker-malformed-handoff.test.ts
@@ -180,7 +180,7 @@ describe('parser.worker.ts and the #3790 set-entity-index handoff', () => {
     await settle();
 
     assertParsed();
-    expect(diagnostics().some((m) => m.includes('stopped early'))).toBe(true);
+    expect(diagnostics().some((m) => m.includes('dropped a record'))).toBe(true);
   }, 30_000);
 
   it('stays silent when the host reported no stop', async () => {
@@ -196,7 +196,7 @@ describe('parser.worker.ts and the #3790 set-entity-index handoff', () => {
     await settle();
 
     assertParsed();
-    expect(diagnostics().some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics().some((m) => m.includes('dropped a record'))).toBe(false);
   }, 30_000);
 
   it('stays silent when the host sent no such field at all', async () => {
@@ -211,7 +211,7 @@ describe('parser.worker.ts and the #3790 set-entity-index handoff', () => {
     await settle();
 
     assertParsed();
-    expect(diagnostics().some((m) => m.includes('stopped early'))).toBe(false);
+    expect(diagnostics().some((m) => m.includes('dropped a record'))).toBe(false);
   }, 30_000);
 });
 

--- a/packages/parser/src/scan-entities-balanced.ts
+++ b/packages/parser/src/scan-entities-balanced.ts
@@ -19,11 +19,11 @@ import { safeUtf8Decode } from '@ifc-lite/data';
 import { isIndexableExpressId } from './express-id.js';
 import {
   countNewlines,
-  findEntityLength,
   opensLiteralOrComment,
   skipLexical,
   skipTrivia,
 } from './step-lexing.js';
+import { findEntityLength } from './step-record-boundary.js';
 
 export interface ScannedEntityRef {
   expressId: number;
@@ -164,11 +164,12 @@ export class BalancedEntityScan {
             line: startLine,
           };
         } else {
-          // 0 means findEntityLength ran off the end of the buffer without
-          // ever balancing the '(' -- an unterminated literal or comment
-          // inside the argument list, or no closing ')' at all. Its own loop
-          // has no other exit, so this is always the EOF case, never a
-          // mid-file syntax choice to resume past.
+          // Either classified failure (UNBALANCED_RECORD / UNREADABLE_RECORD)
+          // means findEntityLength ran off the end of the buffer without ever
+          // balancing the '('. Its own loop has no other exit, so this is
+          // always the EOF case, never a mid-file syntax choice to resume
+          // past; this scan stops on both, unlike scanEntitiesFast, which
+          // resumes past an unbalanced record (#4179).
           stopped = true;
           break;
         }

--- a/packages/parser/src/scan-worker-lexing.ts
+++ b/packages/parser/src/scan-worker-lexing.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The scan worker's lexing helpers, as a string.
+ *
+ * `step-lexing.ts` is to `tokenizer.ts` what this file is to
+ * `scan-worker-source.ts`: the STEP lexical rules, separated from the scan
+ * loop that walks them. The worker's copy has to be a string and has to be
+ * hand-duplicated because a Blob worker cannot import at runtime -- that is a
+ * transport constraint, never a licence for the rules themselves to drift.
+ * Each function below names the `step-lexing.ts` function it mirrors.
+ *
+ * Interpolated into `WORKER_CODE`, which supplies `buf`, `len` and `line`.
+ */
+export const WORKER_LEXING = `
+  // The STEP whitespace set: space, tab, CR, LF, form feed, vertical tab.
+  // The matched half is the now-exported isSpaceByte in step-lexing.ts; a
+  // member going missing from one copy is what #3733 was.
+  function isSpaceByteAt(p) {
+    var t = buf[p];
+    return t === 0x20 || t === 0x09 || t === 0x0A || t === 0x0D || t === 0x0C || t === 0x0B;
+  }
+
+  // Whether a STEP comment opens at p.
+  function opensCommentAt(p) {
+    return p + 1 < len && buf[p] === 0x2F && buf[p + 1] === 0x2A;
+  }
+
+  // Index just past the '*/' closing the comment at p, or -1 when it never
+  // closes. Counts the newlines it crosses so line numbers stay in step.
+  //
+  // Kept behaviourally identical to skipComment/skipTrivia in step-lexing.ts,
+  // which this cannot import: the worker source is a string, so this copy of
+  // the rule has to live here. Comments do not nest, per ISO 10303-21.
+  function skipCommentAt(p) {
+    var q = p + 2;
+    while (q + 1 < len) {
+      if (buf[q] === 0x2A && buf[q + 1] === 0x2F) return q + 2;
+      if (buf[q] === 0x0A) line++;
+      q++;
+    }
+    return -1;
+  }
+
+  // Skip whitespace, comments, and any run of the two -- 10303-21 allows a
+  // comment wherever whitespace is allowed, INCLUDING inside a record.
+  // Returns -1 when a comment opens and never closes: everything from there on
+  // is inside it, so there is nothing left to find.
+  //
+  // The whitespace byte set (space, tab, CR, LF, form feed, vertical tab) is
+  // kept byte-for-byte in sync with isSpaceByte in step-lexing.ts and its
+  // three inline twins in tokenizer.ts's scanEntitiesFast -- this file is a
+  // string because a Blob worker cannot import at runtime, not a reason for
+  // the rule itself to drift.
+  function skipTriviaAt(p) {
+    for (;;) {
+      while (p < len) {
+        var t = buf[p];
+        if (t === 0x20 || t === 0x09 || t === 0x0D || t === 0x0C || t === 0x0B) { p++; }
+        else if (t === 0x0A) { line++; p++; }
+        else break;
+      }
+      if (!opensCommentAt(p)) return p;
+      var e = skipCommentAt(p);
+      if (e < 0) return -1;
+      p = e;
+    }
+  }
+
+  // Byte length from startOffset through the ')' balancing the '(' at p, or a
+  // CLASSIFIED failure: -1 unbalanced but readable, -2 a literal or comment
+  // that never closed. The RECOVERY point for a record with no ';' of its own
+  // (#4179), and the exact answer for whether a ';' is the record's own.
+  // Mirrors findEntityLength in step-record-boundary.ts; a literal is jumped
+  // whole and a comment after it, in that order, so a paren inside either is
+  // text. NOTE: skipCommentAt advances the line counter, so a caller that
+  // re-walks the record must save and restore it.
+  function findEntityLengthAt(p, startOffset) {
+    var d = 0;
+    while (p < len) {
+      var b = buf[p];
+      if (b === 0x27) {
+        p++;
+        for (;;) {
+          if (p >= len) return -2;
+          if (buf[p] === 0x27) { if (buf[p + 1] === 0x27) { p += 2; continue; } p++; break; }
+          p++;
+        }
+      } else if (opensCommentAt(p)) {
+        var q = skipCommentAt(p);
+        if (q < 0) return -2;
+        p = q;
+      } else if (b === 0x28) { d++; p++; }
+      else if (b === 0x29) { if (d === 0) return -1; d--; p++; if (d === 0) return p - startOffset; }
+      else { p++; }
+    }
+    return -1;
+  }
+`;

--- a/packages/parser/src/scan-worker-source.malformed-record.test.ts
+++ b/packages/parser/src/scan-worker-source.malformed-record.test.ts
@@ -15,10 +15,21 @@
 
 import { describe, expect, it } from 'vitest';
 import { WORKER_CODE } from './scan-worker-source.js';
+import {
+  LEGAL_BODIES,
+  LINE_NUMBER_CASE,
+  SWALLOW_CASES,
+  UNBALANCED_CASE,
+  UNRESUMABLE_BODIES,
+  type ScanDriver,
+} from './step-record-boundary.vectors.js';
 import { MAX_EXPRESS_ID } from './express-id.js';
 
 interface WorkerScanMessage {
   ids: ArrayBuffer;
+  offsets: ArrayBuffer;
+  lengths: ArrayBuffer;
+  lines: ArrayBuffer;
   count: number;
   oversizedIds: number;
   malformedRecords: number;
@@ -165,5 +176,65 @@ describe('scan-worker-source WORKER_CODE: unterminated string literal', () => {
     const result = runWorkerCode(text);
     expect(result.malformedRecords).toBe(1);
     expect(result.count).toBe(1);
+  });
+});
+
+
+describe('scan-worker-source WORKER_CODE: record-boundary guards (#4179)', () => {
+  const scan: ScanDriver = (text) => (() => {
+    const result = runWorkerCode(text);
+    const ids = new Uint32Array(result.ids);
+    const offsets = new Uint32Array(result.offsets);
+    const lengths = new Uint32Array(result.lengths);
+    const spans: (readonly [number, string])[] = [];
+    for (let i = 0; i < result.count; i++) {
+      spans.push([ids[i], text.slice(offsets[i], offsets[i] + lengths[i])] as const);
+    }
+    return { spans, malformed: result.malformedRecords };
+  })();
+
+  it.each(SWALLOW_CASES.map((c) => [c[0], c[1], c[2]] as const))(
+    '%s',
+    (_label, text, expected) => {
+      const { spans, malformed } = scan(text);
+      expect(spans).toEqual(expected);
+      expect(malformed).toBe(1);
+    },
+  );
+
+  it('does not inflate line numbers when the cold check re-walks the record', () => {
+    // skipCommentAt advances the worker's line counter as a side effect, so
+    // balancing the record again to settle the ')' rule used to count the
+    // interior comment's newlines twice. tokenizer.ts is unaffected because
+    // its findEntityLength is pure, which makes it the oracle here.
+    const result = runWorkerCode(LINE_NUMBER_CASE.text);
+    expect(Array.from(new Uint32Array(result.lines)).slice(0, result.count))
+      .toEqual([...LINE_NUMBER_CASE.lines]);
+  });
+
+  it('drops ONE record, not the tail, when a record has no closing ")"', () => {
+    const { spans, malformed } = scan(UNBALANCED_CASE.text);
+    expect(spans).toEqual(UNBALANCED_CASE.spans);
+    expect(malformed).toBe(1);
+  });
+
+  it('stops instead of resuming when there is no balancing ")" to resume at', () => {
+    // Recovery is bounded by the SAME "no resume point" rule the #3695 cluster
+    // set: the balance walks strings and comments whole, so an unterminated one
+    // leaves no ')' and the scan still stops there.
+    for (const body of UNRESUMABLE_BODIES) {
+      const { spans, malformed } = scan(`#1=IFCA(1);\n#2=${body}\n#3=IFCC(3);\n`);
+      expect(spans, body).toEqual([[1, '#1=IFCA(1);']]);
+      expect(malformed, body).toBe(1);
+    }
+  });
+
+  it('never falsely refuses a legal record', () => {
+    for (const body of LEGAL_BODIES) {
+      const text = `#1=${body}\n#2=IFCDOOR($);\n`;
+      const { spans, malformed } = scan(text);
+      expect(spans, body).toEqual([[1, `#1=${body}`], [2, '#2=IFCDOOR($);']]);
+      expect(malformed, body).toBe(0);
+    }
   });
 });

--- a/packages/parser/src/scan-worker-source.ts
+++ b/packages/parser/src/scan-worker-source.ts
@@ -13,6 +13,7 @@
  */
 
 import { MAX_EXPRESS_ID } from './express-id.js';
+import { WORKER_LEXING } from './scan-worker-lexing.js';
 
 /**
  * Self-contained entity scanner code (runs inside Web Worker).
@@ -39,51 +40,7 @@ self.onmessage = function(e) {
   // (#3395). The worker runs from a Blob URL and cannot import at runtime, so
   // the bound below is interpolated from express-id.ts when this template is
   // evaluated -- one home for the number, not a copy that can drift.
-  // Whether a STEP comment opens at p.
-  function opensCommentAt(p) {
-    return p + 1 < len && buf[p] === 0x2F && buf[p + 1] === 0x2A;
-  }
-
-  // Index just past the '*/' closing the comment at p, or -1 when it never
-  // closes. Counts the newlines it crosses so line numbers stay in step.
-  //
-  // Kept behaviourally identical to skipComment/skipTrivia in step-lexing.ts,
-  // which this cannot import: the worker source is a string, so this copy of
-  // the rule has to live here. Comments do not nest, per ISO 10303-21.
-  function skipCommentAt(p) {
-    var q = p + 2;
-    while (q + 1 < len) {
-      if (buf[q] === 0x2A && buf[q + 1] === 0x2F) return q + 2;
-      if (buf[q] === 0x0A) line++;
-      q++;
-    }
-    return -1;
-  }
-
-  // Skip whitespace, comments, and any run of the two -- 10303-21 allows a
-  // comment wherever whitespace is allowed, INCLUDING inside a record.
-  // Returns -1 when a comment opens and never closes: everything from there on
-  // is inside it, so there is nothing left to find.
-  //
-  // The whitespace byte set (space, tab, CR, LF, form feed, vertical tab) is
-  // kept byte-for-byte in sync with isSpaceByte in step-lexing.ts and its
-  // three inline twins in tokenizer.ts's scanEntitiesFast -- this file is a
-  // string because a Blob worker cannot import at runtime, not a reason for
-  // the rule itself to drift.
-  function skipTriviaAt(p) {
-    for (;;) {
-      while (p < len) {
-        var t = buf[p];
-        if (t === 0x20 || t === 0x09 || t === 0x0D || t === 0x0C || t === 0x0B) { p++; }
-        else if (t === 0x0A) { line++; p++; }
-        else break;
-      }
-      if (!opensCommentAt(p)) return p;
-      var e = skipCommentAt(p);
-      if (e < 0) return -1;
-      p = e;
-    }
-  }
+${WORKER_LEXING}
 
   var ids = new Uint32Array(estimatedCount);
   var offsets = new Uint32Array(estimatedCount);
@@ -257,9 +214,22 @@ self.onmessage = function(e) {
       if (buf[pos] !== 0x28) { declOpen = false; continue; }
       declOpen = false; // Header complete: '(' found.
 
-      // Skip to semicolon (handling strings)
+      // Skip to semicolon (handling strings), bounded to THIS record's own
+      // body so a record missing its ';' cannot latch onto a later one and
+      // swallow what lies between (#4179): the ';' must be preceded, modulo
+      // trivia, by the ')' closing the parameter list, and no '=' may come
+      // before it outside a string or comment. On either failure the record is
+      // DROPPED and the scan resumes at that ')' rather than abandoning the
+      // file's tail. close_step_record in rust/core/src/parser/lexical.rs
+      // argues both rules and the recovery; this is a hand-duplicated copy
+      // because a Blob worker cannot import at runtime. Change them together.
+      var parenPos = pos;
       var inString = false;
       var foundTerminator = false;
+      // Memoised across the exact ';' check and the recovery below, which
+      // would otherwise balance the same record twice. -3 = not computed;
+      // -1 = unbalanced but readable; -2 = a literal/comment never closed.
+      var recordClose = -3;
       while (pos < len) {
         var c6 = buf[pos];
         if (c6 === 0x27) { // quote
@@ -274,15 +244,26 @@ self.onmessage = function(e) {
           // and parens inside it text -- the other direction of the rule the
           // quote branch above gives for a '/*' inside a literal.
           var ce = skipCommentAt(pos);
-          if (ce < 0) {
-            // Unterminated: this record has no terminator, and neither has
-            // anything after it. Drop it and stop.
-            pos = len;
-            break;
-          }
+          if (ce < 0) break; // Unterminated: recovery below finds no ')'.
           pos = ce;
           continue;
         } else if (c6 === 0x3B && !inString) { // semicolon
+          // ')' modulo whitespace settles it for every record a real file
+          // holds. Anything else -- including the '/' of a trailing '*/',
+          // which a backwards walk cannot see through -- goes to the cold,
+          // exact balance-and-skip-trivia check.
+          var w = pos;
+          while (w > parenPos && isSpaceByteAt(w - 1)) w--;
+          if (buf[w - 1] !== 0x29) {
+            var savedBalLine = line;
+            recordClose = findEntityLengthAt(parenPos, startOffset);
+            line = savedBalLine;
+            if (recordClose <= 0) break;
+            recordClose += startOffset;
+            var after = skipTriviaAt(recordClose);
+            line = savedBalLine;
+            if (after < 0 || after !== pos) break;
+          }
           var entityLength = pos - startOffset + 1;
 
           // Grow if needed
@@ -298,19 +279,40 @@ self.onmessage = function(e) {
           pos++;
           foundTerminator = true;
           break;
+        } else if (c6 === 0x3D && !inString) {
+          break; // '=': the NEXT declaration already started.
         } else if (c6 === 0x0A) {
           line++;
         }
         pos++;
       }
 
-      // Ran off the end without an unquoted ';' -- usually an unescaped
-      // quote left open, or the unterminated-comment break above (mirrors
-      // tokenizer.ts's scanEntitiesFast). Not resynced: with no known
-      // terminator, guessing a resume point risks fabricating entities from
-      // misaligned bytes. Recorded in 'stopped', not incremented here -- see
-      // the post-loop check below.
-      if (!foundTerminator) { stopped = true; }
+      // No ';' of this record's own. EVERY such exit lands here, so the
+      // recovery lives here once rather than at each break -- mirrors
+      // tokenizer.ts's scanEntitiesFast. Resume at the ')' balancing this
+      // record's own '(' when there is one, dropping just this record;
+      // otherwise run to len, ending the scan un-resynced rather than guessing
+      // a resume point from misaligned bytes.
+      if (!foundTerminator) {
+        stopped = true;
+        if (recordClose === -3) {
+          var savedRecLine = line;
+          recordClose = findEntityLengthAt(parenPos, startOffset);
+          line = savedRecLine;
+          if (recordClose > 0) recordClose += startOffset;
+        }
+        if (recordClose > 0) {
+          pos = recordClose;
+          line = startLine;
+          for (var q = startOffset; q < pos; q++) if (buf[q] === 0x0A) line++;
+        } else if (recordClose === -1) {
+          // Unbalanced but readable: re-hunt from past this record's '#'.
+          pos = startOffset + 1;
+          line = startLine;
+        } else {
+          pos = len; // Nothing to resume from (#3695).
+        }
+      }
     } else if (ch === 0x0A) {
       line++;
       pos++;

--- a/packages/parser/src/step-lexing.ts
+++ b/packages/parser/src/step-lexing.ts
@@ -21,8 +21,6 @@ const SLASH = 0x2f; // '/'
 const STAR = 0x2a; // '*'
 const NEWLINE = 0x0a; // '\n'
 const QUOTE = 0x27; // '\''
-const LPAREN = 0x28; // '('
-const RPAREN = 0x29; // ')'
 
 // Whether a comment opens at `pos`.
 export function opensComment(buf: Uint8Array, pos: number, len: number): boolean {
@@ -136,7 +134,7 @@ export function opensLiteralOrComment(buf: Uint8Array, pos: number, len: number)
 // definition and excludes vertical tab, so reaching for it on either side
 // reintroduces the exact FF/VT divergence issue #3733 reported (dropped
 // entity on a leading form feed) rather than closing it.
-function isSpaceByte(b: number): boolean {
+export function isSpaceByte(b: number): boolean {
   return (
     b === 0x20 || b === 0x09 || b === 0x0d || b === NEWLINE || b === 0x0c || b === 0x0b
   );
@@ -187,56 +185,6 @@ export function countNewlines(buf: Uint8Array, from: number, to: number): number
     if (buf[p] === NEWLINE) n++;
   }
   return n;
-}
-
-// Byte length of the record that starts at `startOffset` and whose argument
-// list opens at `pos`: the span up to and including the ')' balancing that '(',
-// or 0 when the input runs out first.
-//
-// A string literal is jumped over by skipStringLiteral above rather than
-// counted, so the '(' in 'Storey (Level 1)' is text and not depth, and STEP's
-// doubled-quote escape ('') stays inside the literal instead of closing it.
-// Sharing that helper is what keeps the escape rule in one place: an
-// open-coded `inString` flag here would be a second copy of it, free to drift
-// from the one every other scanner in this file uses.
-//
-// A comment is jumped over for the same reason, in the same order: the literal
-// test comes first, so a '/*' inside a value is text; the comment is then taken
-// whole, so a '(' or a quote inside it is text. Without that, the comment in
-// `#1=IFCWALL('a', /* see IFCWALL( */ $);` opened a paren depth that never
-// closed and the record came back with length 0.
-export function findEntityLength(buf: Uint8Array, pos: number, startOffset: number): number {
-  const len = buf.length;
-  let depth = 0;
-
-  while (pos < len) {
-    const char = buf[pos];
-
-    if (char === QUOTE) {
-      // Returns `-1` on an unterminated literal (see skipStringLiteral's own
-      // doc): no balancing ')' can follow, same 0 as running off the end.
-      const next = skipStringLiteral(buf, pos, len);
-      if (next < 0) return 0;
-      pos = next;
-    } else if (opensComment(buf, pos, len)) {
-      const end = skipComment(buf, pos, len);
-      // Unterminated: the rest of the input is inside the comment, so no
-      // balancing ')' can follow. Same 0 as running off the end.
-      if (end < 0) return 0;
-      pos = end;
-    } else if (char === LPAREN) {
-      depth++;
-      pos++;
-    } else if (char === RPAREN) {
-      depth--;
-      pos++;
-      if (depth === 0) return pos - startOffset;
-    } else {
-      pos++;
-    }
-  }
-
-  return 0; // no matching ')'
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/parser/src/step-record-boundary.ts
+++ b/packages/parser/src/step-record-boundary.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Where one STEP record ends, and whether a given `;` is its own (#4179).
+ *
+ * The TypeScript half of the rule argued in `close_step_record` in
+ * rust/core/src/parser/lexical.rs. Rust is the source of truth
+ * per AGENTS.md; read the two rules, the general property they approximate,
+ * and why a refusal recovers rather than stops, THERE, and change the halves
+ * together. `StepTokenizer.scanEntitiesFast` (tokenizer.ts) calls into here;
+ * `WORKER_CODE` (scan-worker-source.ts) hand-duplicates it because a Blob
+ * worker cannot import at runtime.
+ */
+
+import { opensComment, skipComment, skipStringLiteral, skipTrivia } from './step-lexing.js';
+
+const QUOTE = 0x27; // '\''
+const LPAREN = 0x28; // '('
+const RPAREN = 0x29; // ')'
+
+// Byte length of the record starting at `startOffset` whose argument list
+// opens at `pos`: up to and including the ')' balancing that '('.
+//
+// A failure is CLASSIFIED, because the two kinds call for opposite answers
+// from a scan that wants to recover (#4179). UNBALANCED_RECORD: every literal
+// and comment closed, so bytes after this record are readable and a caller may
+// resume there. UNREADABLE_RECORD: one never closed, so everything to end of
+// input is inside it and nothing can be resumed.
+//
+// A string literal is jumped over by skipStringLiteral rather than counted, so
+// the '(' in 'Storey (Level 1)' is text and not depth, and STEP's doubled-quote
+// escape ('') stays inside the literal instead of closing it. Sharing that
+// helper keeps the escape rule in one place: an open-coded `inString` flag here
+// would be a second copy, free to drift from the one every other scanner uses.
+//
+// A comment is jumped over for the same reason, in the same order: the literal
+// test comes first, so a '/*' inside a value is text; the comment is then taken
+// whole, so a '(' or a quote inside it is text. Without that, the comment in
+// `#1=IFCWALL('a', /* see IFCWALL( */ $);` opened a depth that never closed.
+export const UNBALANCED_RECORD = -1;
+export const UNREADABLE_RECORD = -2;
+export function findEntityLength(buf: Uint8Array, pos: number, startOffset: number): number {
+  const len = buf.length;
+  let depth = 0;
+
+  while (pos < len) {
+    const char = buf[pos];
+
+    if (char === QUOTE) {
+      // Returns `-1` on an unterminated literal (see skipStringLiteral's own
+      // doc): nothing after it is readable.
+      const next = skipStringLiteral(buf, pos, len);
+      if (next < 0) return UNREADABLE_RECORD;
+      pos = next;
+    } else if (opensComment(buf, pos, len)) {
+      const end = skipComment(buf, pos, len);
+      // Unterminated: the rest of the input is inside the comment.
+      if (end < 0) return UNREADABLE_RECORD;
+      pos = end;
+    } else if (char === LPAREN) {
+      depth++;
+      pos++;
+    } else if (char === RPAREN) {
+      depth--;
+      pos++;
+      if (depth === 0) return pos - startOffset;
+    } else {
+      pos++;
+    }
+  }
+
+  return UNBALANCED_RECORD; // ran out of input with the '(' still open
+}
+
+/**
+ * Offset just past the `)` balancing the record's own `(`, or one of
+ * `UNBALANCED_RECORD` / `UNREADABLE_RECORD`.
+ *
+ * The byte a scan resumes at after dropping a record it refused, and the two
+ * failures a caller must tell apart to know whether it may resume at all.
+ */
+export function recordCloseOffset(
+  buf: Uint8Array,
+  parenPos: number,
+  startOffset: number,
+): number {
+  const length = findEntityLength(buf, parenPos, startOffset);
+  return length > 0 ? startOffset + length : length;
+}
+
+/**
+ * Whether the `;` at `semi` terminates the record that closes at `close` (from
+ * `recordCloseOffset`).
+ *
+ * Only for the case a caller's backwards whitespace walk could not settle: on
+ * a record with a trailing comment before its `;` the walk lands on the last
+ * byte of the comment close, and it cannot see through a comment (searching
+ * back for the opener would find one written inside a string literal).
+ * Skipping the trivia after
+ * the closing `)` answers it exactly, for any run of comments, and runs only
+ * here -- never on a record whose `)` sits directly before its `;`.
+ *
+ * Takes `close` rather than recomputing it so the caller, which needs the same
+ * offset to resume from when this returns false, balances the record once.
+ */
+export function semicolonClosesRecord(
+  buf: Uint8Array,
+  close: number,
+  semi: number,
+): boolean {
+  if (close <= 0) return false;
+  const after = skipTrivia(buf, close, buf.length);
+  return !after.stop && after.next === semi;
+}

--- a/packages/parser/src/step-record-boundary.vectors.ts
+++ b/packages/parser/src/step-record-boundary.vectors.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared #4179 record-boundary cases for the two TypeScript scan copies.
+ *
+ * The SCANNERS are hand-duplicated because a Blob worker cannot import at
+ * runtime. A test file is an ordinary module and has no such excuse, so the
+ * vectors live here once and `tokenizer.test.ts` and
+ * `scan-worker-source.malformed-record.test.ts` supply only their own driver.
+ * They were copies for one commit and had already drifted inside it.
+ */
+
+/** What a scan returned: each record as `[expressId, source text]`. */
+export type ScanSpans = { spans: (readonly [number, string])[]; malformed: number };
+
+/** Drives one scan implementation over `text`. */
+export type ScanDriver = (text: string) => ScanSpans;
+
+/**
+ * Records that must be ACCEPTED, i.e. the false-positive direction.
+ *
+ * Every shape is hand-constructed because a 487-file, 14,282,864-record sweep
+ * of this repo's IFC corpus contains NONE of them: zero records with a comment
+ * between the ')' and the ';', and zero with any whitespace there either. A
+ * clean sweep over a population without the case is not evidence about the
+ * case. What the corpus DOES carry, and so does attest: 6,816,392 records
+ * ending in a nested '))', 234,391 spanning several lines, and 15,111 with an
+ * '=' inside a string or comment, all accepted.
+ */
+export const LEGAL_BODIES: readonly string[] = [
+  "IFCWALL('a=b',$);",
+  'IFCWALL($ /* a=b */);',
+  "IFCDOCUMENTREFERENCE('http://h/q?a=b&c=d',$);",
+  'IFCWALL($)/* trailing */;',
+  'IFCWALL($)/* one *//* two */;',
+  'IFCWALL($) /* spaced */ \t /* twice */ ;',
+  'IFCWALL($)/* multi\nline */;',
+  "IFCWALL(('a'),(1.,2.));",
+  "IFCWALL(\n  'a',\n  $\n);",
+  // isSpaceByte includes vertical tab and form feed; a form feed silently
+  // dropping an entity is exactly what #3733 was.
+  ...[' ', '\t', '\r', '\n', '\v', '\f'].flatMap((sp) => [
+    `IFCWALL($)${sp};`,
+    `IFCWALL($)${sp}/* c */${sp};`,
+  ]),
+];
+
+/**
+ * A record with no closing ')' at all costs ONE record, not the tail.
+ *
+ * `close_step_record`'s two failures are not interchangeable: this one leaves
+ * every literal and comment closed, so the bytes after are readable and the
+ * scan re-hunts from past the record's '#'. Collapsing it with the
+ * unreadable case below took `[1]` from an input the parent scanner read as
+ * `[1, 2, 3, 4]`, which is the amplification #4179 exists to remove.
+ */
+export const UNBALANCED_CASE = {
+  text: '#1=IFCA(1);\n#2=IFCB(2;\n#3=IFCC(3);\n#4=IFCD(4);\n',
+  spans: [[1, '#1=IFCA(1);'], [3, '#3=IFCC(3);'], [4, '#4=IFCD(4);']] as const,
+};
+
+/** Bodies with no ';' of their own AND no balancing ')' to resume at. */
+export const UNRESUMABLE_BODIES: readonly string[] = [
+  "IFCWALL('never closes,$)",
+  'IFCWALL(/* never closes $)',
+];
+
+/** The two shapes #4179 is about, as `[label, text, expected spans]`. */
+/**
+ * Records whose LINE numbers a cold re-walk must not disturb.
+ *
+ * The worker's comment skip advances its line counter as a side effect, so a
+ * caller that balances the record again to settle the ')' rule inflates every
+ * later line unless it saves and restores. `#2` here landed on line 4 in the
+ * worker and line 3 in the tokenizer for the same bytes.
+ */
+export const LINE_NUMBER_CASE = {
+  text: '#1=IFCWALL(/* a\nb */$)/* c */;\n#2=IFCDOOR($);\n',
+  lines: [1, 3] as const,
+};
+
+export const SWALLOW_CASES: readonly (readonly [string, string, (readonly [number, string])[]])[] = [
+  [
+    // Pre-fix: [#1, #2, #4] -- #3 gone, #2's span covering #3's whole record,
+    // and no diagnostic. The broken record is DROPPED, not the tail: #3 and #4
+    // both survive, because the scan resumes at the ')' balancing #2's own '('.
+    'a record missing its own ";" does not swallow the next record',
+    '#1=IFCA(1);\n#2=IFCB(2)\n#3=IFCC(3);\n#4=IFCD(4);\n',
+    [[1, '#1=IFCA(1);'], [3, '#3=IFCC(3);'], [4, '#4=IFCD(4);']],
+  ],
+  [
+    // Pre-fix: #2's span absorbed "ENDSEC;" and nothing was reported, so the
+    // file read as fully successful having lost a structural marker.
+    'a truncated last record does not swallow the footer',
+    "#1=IFCPROJECT('a');\n#2=IFCWALL('b')\nENDSEC;\nEND-ISO-10303-21;\n",
+    [[1, "#1=IFCPROJECT('a');"]],
+  ],
+];

--- a/packages/parser/src/tokenizer.test.ts
+++ b/packages/parser/src/tokenizer.test.ts
@@ -4,6 +4,14 @@
 
 import { describe, expect, it } from 'vitest';
 import { StepTokenizer } from './tokenizer.js';
+import {
+  LEGAL_BODIES,
+  LINE_NUMBER_CASE,
+  SWALLOW_CASES,
+  UNBALANCED_CASE,
+  UNRESUMABLE_BODIES,
+  type ScanDriver,
+} from './step-record-boundary.vectors.js';
 
 describe('StepTokenizer.scanEntitiesFast', () => {
   it('finds entities and reports correct expressId/type/line', () => {
@@ -168,5 +176,57 @@ describe('StepTokenizer.scanEntities (balanced-parenthesis path)', () => {
 
     expect(tokenizer.malformedRecordCount).toBe(1);
     expect(refs.map((r) => r.expressId)).toEqual([1]);
+  });
+});
+
+
+describe('StepTokenizer.scanEntitiesFast: record-boundary guards (#4179)', () => {
+  const scan: ScanDriver = (text) => (() => {
+    const tokenizer = new StepTokenizer(new TextEncoder().encode(text));
+    const spans = Array.from(tokenizer.scanEntitiesFast()).map(
+      (r) => [r.expressId, text.slice(r.offset, r.offset + r.length)] as const,
+    );
+    return { spans, malformed: tokenizer.malformedRecordCount };
+  })();
+
+  it.each(SWALLOW_CASES.map((c) => [c[0], c[1], c[2]] as const))(
+    '%s',
+    (_label, text, expected) => {
+      const { spans, malformed } = scan(text);
+      expect(spans).toEqual(expected);
+      expect(malformed).toBe(1);
+    },
+  );
+
+  it('reports the line numbers the worker copy must match', () => {
+    const tokenizer = new StepTokenizer(new TextEncoder().encode(LINE_NUMBER_CASE.text));
+    expect(Array.from(tokenizer.scanEntitiesFast()).map((r) => r.line))
+      .toEqual([...LINE_NUMBER_CASE.lines]);
+  });
+
+  it('drops ONE record, not the tail, when a record has no closing ")"', () => {
+    const { spans, malformed } = scan(UNBALANCED_CASE.text);
+    expect(spans).toEqual(UNBALANCED_CASE.spans);
+    expect(malformed).toBe(1);
+  });
+
+  it('stops instead of resuming when there is no balancing ")" to resume at', () => {
+    // Recovery is bounded by the SAME "no resume point" rule the #3695 cluster
+    // set: the balance walks strings and comments whole, so an unterminated one
+    // leaves no ')' and the scan still stops there.
+    for (const body of UNRESUMABLE_BODIES) {
+      const { spans, malformed } = scan(`#1=IFCA(1);\n#2=${body}\n#3=IFCC(3);\n`);
+      expect(spans, body).toEqual([[1, '#1=IFCA(1);']]);
+      expect(malformed, body).toBe(1);
+    }
+  });
+
+  it('never falsely refuses a legal record', () => {
+    for (const body of LEGAL_BODIES) {
+      const text = `#1=${body}\n#2=IFCDOOR($);\n`;
+      const { spans, malformed } = scan(text);
+      expect(spans, body).toEqual([[1, `#1=${body}`], [2, '#2=IFCDOOR($);']]);
+      expect(malformed, body).toBe(0);
+    }
   });
 });

--- a/packages/parser/src/tokenizer.ts
+++ b/packages/parser/src/tokenizer.ts
@@ -11,12 +11,21 @@ import { isIndexableExpressId } from './express-id.js';
 import { BalancedEntityScan, type ScannedEntityRef } from './scan-entities-balanced.js';
 import {
   countNewlines,
+  isSpaceByte,
   opensComment,
   opensLiteralOrComment,
   skipComment,
   skipLexical,
   skipTrivia,
 } from './step-lexing.js';
+import {
+  recordCloseOffset,
+  semicolonClosesRecord,
+  UNBALANCED_RECORD,
+} from './step-record-boundary.js';
+
+/** `recordClose` before anything has computed it (both real failures are negative). */
+const NOT_COMPUTED = -3;
 
 export class StepTokenizer {
   private buffer: Uint8Array;
@@ -31,11 +40,17 @@ export class StepTokenizer {
    *  (express-id.ts, #3395). Reset per scan; the caller reports it. */
   get oversizedIdCount(): number { return this.oversizedIds; }
 
-  /** 0 or 1: whether the last `scanEntitiesFast`/`scanEntities` run stopped
-   *  early on an unclosed `'` string, an unclosed block comment, or a
-   *  declaration cut off before its own '(' -- never a count of how many,
-   *  since the scan has no reliable way to resume past the first one it
-   *  hits. Reset at the start of every scan; the caller reports it. */
+  /** 0 or 1: whether the last run DROPPED a record for having no terminator
+   *  of its own. Never a count of how many: the first is reported and later
+   *  ones are not accumulated. Nor does it say the scan STOPPED.
+   *
+   *  The two scans DISAGREE about which records exist, and this is where that
+   *  shows. `scanEntitiesFast` applies the #4179 record-boundary rules, so
+   *  `#1=IFCA(1);\n#2=IFCB(2)\n#3=IFCC(3);` gives ids [1, 3] and a count of
+   *  1: it drops the unterminated #2 and recovers. `scanEntities`
+   *  (BalancedEntityScan) closes every record on the ')' balancing its '(' and
+   *  never looks at the ';' at all, so the same input gives [1, 2, 3] and a
+   *  count of 0. Reset at the start of every scan; the caller reports it. */
   get malformedRecordCount(): number { return this.malformedRecords; }
 
   /**
@@ -71,6 +86,7 @@ export class StepTokenizer {
     const HASH = 0x23;      // '#'
     const EQUALS = 0x3D;    // '='
     const LPAREN = 0x28;    // '('
+    const RPAREN = 0x29;    // ')'
     const SEMICOLON = 0x3B; // ';'
     const QUOTE = 0x27;     // '\''
     const NEWLINE = 0x0A;   // '\n'
@@ -253,9 +269,21 @@ export class StepTokenizer {
         if (buf[pos] !== LPAREN) { declOpen = false; continue; }
         declOpen = false; // Header complete: '(' found.
 
-        // FAST: Skip to semicolon (handling strings)
+        // FAST: Skip to semicolon (handling strings), bounded to THIS
+        // record's own body so one missing its ';' cannot latch onto a later
+        // one and swallow what lies between (#4179). close_step_record in
+        // rust/core/src/parser/lexical.rs argues both rules and the
+        // recovery; step-record-boundary.ts is this file's TS half of them.
+        // Only the hot part is inline here, because it must be:
+        // '=' is one more test on a branch chain this loop already walks, and
+        // the ')' rule is settled ONCE per record, at the ';'.
+        const parenPos = pos;
         let inString = false;
         let foundTerminator = false;
+        // Memoised across the two places that need the record's own close: the
+        // exact ';' check and the recovery below would otherwise balance the
+        // same record twice.
+        let recordClose = NOT_COMPUTED;
         while (pos < len) {
           const c = buf[pos];
           if (c === QUOTE) {
@@ -270,22 +298,27 @@ export class StepTokenizer {
             // quotes and parens inside it text, the other half of the rule the
             // literal skip above provides in the opposite direction.
             const end = skipComment(buf, pos, len);
-            if (end < 0) {
-              // Unterminated: this record has no terminator, and neither has
-              // anything after it. Drop it and stop, which is the None Rust's
-              // find_entity_end returns on the same input.
-              pos = len;
-              break;
-            }
+            if (end < 0) break; // Unterminated: recovery below finds no ')'.
             line += countNewlines(buf, pos, end);
             pos = end;
             continue;
           } else if (c === SEMICOLON && !inString) {
+            // ')' modulo whitespace settles it for every record a real file
+            // holds; anything else defers to the cold, exact check.
+            let i = pos;
+            while (i > parenPos && isSpaceByte(buf[i - 1])) i--;
+            if (buf[i - 1] !== RPAREN) {
+              recordClose = recordCloseOffset(buf, parenPos, startOffset);
+              if (!semicolonClosesRecord(buf, recordClose, pos)) break;
+            }
             // Found end of entity
             const entityLength = pos - startOffset + 1; // Include semicolon
             yield { expressId, type, offset: startOffset, length: entityLength, line: startLine };
             pos++;
             foundTerminator = true;
+            break;
+          } else if (c === EQUALS && !inString) {
+            // The next declaration started before this record was terminated.
             break;
           } else if (c === NEWLINE) {
             line++;
@@ -293,13 +326,35 @@ export class StepTokenizer {
           pos++;
         }
 
-        // Ran off the end without an unquoted ';' — usually an unescaped `'`
-        // left open, or the unterminated-comment break above; `pos` is
-        // already `len`, ending the scan here. Not resynced: with no known
-        // terminator, guessing a resume point risks fabricating entities from
-        // misaligned bytes. Recorded in `stopped`, not incremented here --
-        // see the post-loop check below.
-        if (!foundTerminator) stopped = true;
+        // No ';' of this record's own -- it ran off the end (an unescaped `'`
+        // left open, an unterminated comment), or one of the two #4179
+        // boundary rules refused the ';' it found. EVERY such exit lands here,
+        // so the recovery lives here once rather than at each `break`.
+        //
+        // Resume at the ')' balancing this record's own '(' when there is one,
+        // dropping just this record; otherwise run to `len`, ending the scan
+        // un-resynced rather than guessing a resume point from misaligned
+        // bytes. The pre-existing exits reach the second case, which is the
+        // `pos = len` they used to set for themselves.
+        if (!foundTerminator) {
+          stopped = true;
+          if (recordClose === NOT_COMPUTED) {
+            recordClose = recordCloseOffset(buf, parenPos, startOffset);
+          }
+          if (recordClose > 0) {
+            pos = recordClose;
+            line = startLine + countNewlines(buf, startOffset, pos);
+          } else if (recordClose === UNBALANCED_RECORD) {
+            // No balancing ')', but the bytes after are readable: re-hunt from
+            // past this record's '#' so the NEXT declaration is still found.
+            pos = startOffset + 1;
+            line = startLine;
+          } else {
+            // UNREADABLE_RECORD: a literal or comment swallowed the rest of
+            // the input, so there is nothing to resume from (#3695).
+            pos = len;
+          }
+        }
       } else if (char === NEWLINE) {
         line++;
         pos++;

--- a/rust/core/src/parser/lexical.rs
+++ b/rust/core/src/parser/lexical.rs
@@ -105,6 +105,142 @@ pub fn is_step_space(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
 }
 
+/// Where a refused record ends, and whether anything after it can be read.
+///
+/// The two failures are separate because they call for opposite answers. A
+/// record whose parens never balance (`#2=IFCB(2;`) still leaves the rest of
+/// the file readable, so a scan drops that ONE record and hunts on; one whose
+/// literal or comment never closes puts everything to end of input inside it,
+/// so there is nothing to resume from and the scan stops (#3695). Collapsing
+/// them cost the whole tail of the file for a missing `)`, which is the same
+/// amplification #4179 is about.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RecordClose {
+    /// Offset just past the `)` balancing the record's `(`.
+    At(usize),
+    /// No balancing `)`, but every literal and comment closed.
+    Unbalanced,
+    /// A literal or comment opened and never closed.
+    Unreadable,
+}
+
+/// Whether the last significant byte of `plain` is `')'`, or `carried` when
+/// `plain` holds nothing but STEP whitespace (so the answer stands from before
+/// it). The cheap half of the record-boundary rule argued on
+/// [`close_step_record`]; walks backwards, stopping on the first byte for
+/// every real record.
+#[inline]
+pub fn closes_with_paren(plain: &[u8], carried: bool) -> bool {
+    match plain.iter().rev().find(|b| !is_step_space(**b)) {
+        Some(&b) => b == b')',
+        None => carried,
+    }
+}
+
+/// Offset just past the `)` that balances the first `(` in `bytes`, or `None`
+/// when the input runs out, a comment or literal never closes, or a `)`
+/// arrives before any `(`.
+///
+/// # Where a STEP record ends, and whether a `;` is its own (#4179)
+///
+/// This doc is the one argument for a rule four scans implement:
+/// [`EntityScanner::find_entity_end`](super::scanner) and this function in
+/// Rust, `StepTokenizer.scanEntitiesFast` (`packages/parser/src/tokenizer.ts`)
+/// with `packages/parser/src/step-record-boundary.ts` in TypeScript, and
+/// `WORKER_CODE` (`packages/parser/src/scan-worker-source.ts`), which
+/// hand-duplicates it because a Blob worker cannot import at runtime. Rust is
+/// the source of truth per AGENTS.md; the halves are changed together.
+///
+/// ## The two rules
+///
+/// A "skip to the next unquoted `;`" scan is bounded only by end-of-buffer, so
+/// a record missing its own `;` takes the first `;` it can reach — the NEXT
+/// record's, or the footer's — reporting success while swallowing whatever lay
+/// between. Two rules read off the ISO 10303-21 grammar bound it to the
+/// record's own body:
+///
+///   * `simple_record` is `keyword '(' [parameter_list] ')'`, so the last
+///     significant byte before the terminator is always `')'`. A `;` preceded
+///     by anything else, as in `#2=IFCWALL('b')\nENDSEC;`, is the footer's.
+///   * `'='` appears in the exchange structure only in
+///     `entity_instance_name '=' record`, never inside a parameter list, so
+///     one before the terminator, as in `#2=IFCB(2)\n#3=IFCC(3);`, means the
+///     scan walked into the NEXT declaration.
+///
+/// Both are judged only on bytes outside strings and comments: an `=` in
+/// either is text, and a comment between the `)` and the `;` is trivia.
+///
+/// The two are a cheap approximation of one general property — *the `;` is the
+/// first non-trivia byte after the `)` balancing the record's own `(`* — which
+/// is what THIS function computes exactly. The approximation is deliberate:
+/// the exact rule costs a full paren balance per record on the hottest
+/// structural path, so it runs only where a byte test already refused. It is
+/// strictly weaker, and admits shapes the exact rule rejects, `#2=IFCB(2) (3);`
+/// among them.
+///
+/// ## Why a refusal RECOVERS instead of stopping
+///
+/// 10303-21 closes every record's parameter list, so the `)` this function
+/// finds is a real grammar boundary even when the `;` after it is missing.
+/// That lets the scan drop the ONE broken record and carry on. The rest of the
+/// file is not the malformed record's to take: a shard whose scanner stops
+/// hands back no handoff, and both stitches — `stitchShards`
+/// (`packages/geometry/src/shard-stitch.ts`) and the native
+/// `parallel_scan::stitch` — read that as "no more real entities" and discard
+/// every LATER shard, including bytes those shards already scanned cleanly.
+/// Measured on a 40-record file whose #20 lost its `;`, at four shards: 40
+/// records in, 19 out. An unterminated string or comment has no such `)`,
+/// nothing to resume from, so that case still stops as #3695 set it.
+///
+/// A string literal is jumped whole and a `/* … */` comment after it, in that
+/// order, so a `(` or `)` inside either is text; the same rule and the same
+/// order the scanner's own body walk uses. The matched TypeScript half is
+/// `findEntityLength` in `packages/parser/src/step-lexing.ts`.
+pub fn close_step_record(bytes: &[u8]) -> RecordClose {
+    let mut pos = 0;
+    let mut depth = 0u32;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\'' => {
+                pos += 1;
+                loop {
+                    match memchr::memchr(b'\'', &bytes[pos..]) {
+                        Some(off) => pos += off + 1,
+                        None => return RecordClose::Unreadable,
+                    }
+                    // A doubled '' is an escaped quote: still inside.
+                    if bytes.get(pos) != Some(&b'\'') {
+                        break;
+                    }
+                    pos += 1;
+                }
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'*') => match skip_step_comment(bytes, pos) {
+                Some(next) => pos = next,
+                None => return RecordClose::Unreadable,
+            },
+            b'(' => {
+                depth += 1;
+                pos += 1;
+            }
+            b')' => {
+                match depth.checked_sub(1) {
+                    Some(d) => depth = d,
+                    // A ')' before any '(' is not this record's close, but it
+                    // closed nothing either, so the bytes after are readable.
+                    None => return RecordClose::Unbalanced,
+                }
+                pos += 1;
+                if depth == 0 {
+                    return RecordClose::At(pos);
+                }
+            }
+            _ => pos += 1,
+        }
+    }
+    RecordClose::Unbalanced
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,6 +294,25 @@ mod tests {
         assert_eq!(skip_step_comment(b"/* never closes", 0), None);
         assert_eq!(skip_step_comment(b"/*", 0), None);
         assert_eq!(skip_step_comment(b"/* trailing star *", 0), None);
+    }
+
+    #[test]
+    fn close_step_record_finds_the_balancing_paren() {
+        // Offset is just PAST the ')', which is where a scan resumes.
+        assert_eq!(close_step_record(b"IFCWALL($);rest"), RecordClose::At(10));
+        assert_eq!(close_step_record(b"IFCWALL(('a'),(1.,2.))\ntail"), RecordClose::At(22));
+        // A paren inside a literal or a comment is text, not depth.
+        assert_eq!(close_step_record(b"IFCWALL('a)b');"), RecordClose::At(14));
+        assert_eq!(close_step_record(b"IFCWALL('a''(b');"), RecordClose::At(16));
+        assert_eq!(close_step_record(b"IFCWALL(/* ) ( */$);"), RecordClose::At(19));
+        // Nothing to resume from: the stop the #3695 cluster relies on.
+        assert_eq!(close_step_record(b"IFCWALL('never closes"), RecordClose::Unreadable);
+        assert_eq!(close_step_record(b"IFCWALL(/* never closes"), RecordClose::Unreadable);
+        // Readable, just never balanced: a scan may drop the record and hunt on.
+        assert_eq!(close_step_record(b"IFCWALL($"), RecordClose::Unbalanced);
+        assert_eq!(close_step_record(b"IFCWALL(2;#3=IFCC(3);"), RecordClose::Unbalanced);
+        // A ')' before any '(' must not underflow.
+        assert_eq!(close_step_record(b")))"), RecordClose::Unbalanced);
     }
 
     #[test]

--- a/rust/core/src/parser/malformed_records.rs
+++ b/rust/core/src/parser/malformed_records.rs
@@ -6,20 +6,21 @@
 //! terminator - the Rust twin of the TS fix on `EntityScanResult.malformedRecordCount`
 //! (`packages/parser/src/entity-scanner.ts`, #3695).
 //!
-//! [`EntityScanner`](super::EntityScanner) stops the whole scan the moment a
-//! record opens a `'` string, a `/* ... */` comment, or simply runs to end of
-//! input with none of them ever closing - [`EntityScanner::find_entity_end`]
-//! has no byte to resume from once that happens (unlike the oversized-id
-//! refusal in [`super::oversized_ids`], which SKIPS the one record and keeps
-//! scanning). A model that comes back with its tail silently missing reads
-//! exactly like a complete one, so this module is the other half: the caller
-//! reports it rather than staying quiet.
+//! [`EntityScanner`](super::EntityScanner) drops any record
+//! [`EntityScanner::find_entity_end`] refuses. Most are recoverable: a record
+//! missing its `;` costs that one record and the scan carries on at the `)`
+//! closing its parameter list (#4179), exactly as the oversized-id refusal in
+//! [`super::oversized_ids`] does. It stops the whole scan only when there is
+//! nothing to resume from, which is a `'` string or a `/* ... */` comment that
+//! never closes. Either way a model that comes back short reads exactly like a
+//! complete one, so this module is the other half: the caller reports it
+//! rather than staying quiet.
 //!
 //! Modelled directly on [`super::oversized_ids`] - same "one home, not one
 //! call site" reasoning, same host-installed sink (shared with it via
 //! [`super::report_sink`], not a second `OnceLock`) - but the count this
-//! reports is always 0 or 1: once a scan stops here it never resumes, so
-//! there is nothing left to accumulate a second refusal from.
+//! reports is always 0 or 1: it answers "was anything dropped", which is what
+//! a user needs in order to distrust the result, not how many.
 //!
 //! One constant message, not a builder like [`super::oversized_id_report`]:
 //! the oversized-id report names a count, so it has to allocate a formatted
@@ -30,9 +31,9 @@
 /// The one-line report for a scan that stopped because of a malformed
 /// record.
 const MALFORMED_RECORD_MESSAGE: &str =
-    "scan: stopped early - a record had no terminating ';' before end of input \
-     (an unterminated quoted string, comment, or truncated file); the entities \
-     returned may be an incomplete view of this file (#3695)";
+    "scan: dropped a record with no terminating ';' (an unterminated quoted \
+     string, comment, or truncated file); the entities returned may be an \
+     incomplete view of this file (#3695)";
 
 /// Emit [`MALFORMED_RECORD_MESSAGE`] to the installed sink (stderr by
 /// default; see [`super::set_report_sink`]).

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -11,6 +11,15 @@
 mod scanner_header;
 use scanner_header::data_section_start;
 
+// `has_non_null_attribute` lives next door, per this file's own split pattern
+// (see `scanner_attributes.rs`'s doc comment).
+#[path = "scanner_attributes.rs"]
+mod scanner_attributes;
+
+// The refusal/drop reporting surface, likewise (see its doc comment).
+#[path = "scanner_diagnostics.rs"]
+mod scanner_diagnostics;
+
 /// Fast entity scanner over raw IFC bytes without full parsing.
 /// O(n) performance for finding entities by type
 /// Uses memchr for SIMD-accelerated byte searching
@@ -24,8 +33,8 @@ pub struct EntityScanner<'a> {
     /// [`Self::skipped_oversized_id_starts`]. It never allocates on a file
     /// with nothing to refuse, which is every real file.
     skipped_oversized_id_starts: Vec<usize>,
-    /// See [`Self::malformed_record_start`] for what this points at.
-    malformed_record_start: Option<usize>,
+    /// See [`Self::malformed_record_starts`] for what these point at.
+    malformed_record_starts: Vec<usize>,
 }
 
 impl<'a> EntityScanner<'a> {
@@ -44,7 +53,7 @@ impl<'a> EntityScanner<'a> {
             bytes,
             position: data_section_start(bytes),
             skipped_oversized_id_starts: Vec::new(),
-            malformed_record_start: None,
+            malformed_record_starts: Vec::new(),
         }
     }
 
@@ -68,7 +77,7 @@ impl<'a> EntityScanner<'a> {
             bytes,
             position: clamped,
             skipped_oversized_id_starts: Vec::new(),
-            malformed_record_start: None,
+            malformed_record_starts: Vec::new(),
         }
     }
 
@@ -77,50 +86,11 @@ impl<'a> EntityScanner<'a> {
         self.position
     }
 
-    /// How many records this scanner has skipped because their instance name
-    /// does not fit `u32` (issue #3395).
-    ///
-    /// ISO 10303-21 puts no upper bound on `#<digits>`, but every express-id
-    /// column in this workspace is `u32` (`ColumnarIndex::ids`,
-    /// `MeshData::express_id`, the wasm `express_ids` buffers), so a wider id
-    /// cannot be represented — it used to wrap, making `#4294967297`
-    /// indistinguishable from `#1`. The record is dropped instead, and this
-    /// counter is the other half of that guard: callers report it rather than
-    /// letting the model come back quietly short.
-    pub fn skipped_oversized_ids(&self) -> usize {
-        self.skipped_oversized_id_starts.len()
-    }
-
-    /// The `line_start` byte offset of every record this scanner refused,
-    /// strictly increasing.
-    ///
-    /// A whole-file scan only needs the count above. A SHARDED scan needs the
-    /// offsets, and the difference is not cosmetic: shard `i > 0` starts at an
-    /// arbitrary byte, so it can begin inside a quoted value and parse a
-    /// string literal such as `'…#4294967297=IFCWALL(…'` as a record — and
-    /// refuse it. That refusal is an artefact of where the shard started, not
-    /// a record the file declares, so a count alone would let a file with
-    /// NOTHING oversized in it be reported as incomplete. The offset lets the
-    /// stitch keep only the refusals inside the byte region it actually
-    /// retained from that shard (issue #3395/#3430).
-    pub fn skipped_oversized_id_starts(&self) -> &[usize] {
-        &self.skipped_oversized_id_starts
-    }
-
-    /// The byte offset that stopped this scan because no terminator was
-    /// found, or `None` otherwise: a record's `line_start` (its `#`) when
-    /// [`find_entity_end`](Self::find_entity_end) fails, or the `/` of an
-    /// unterminated comment found BETWEEN records (no record to name yet).
-    /// A whole-file scan needs only `is_some()`; a SHARDED scan needs the
-    /// offset, for the reason [`Self::skipped_oversized_id_starts`] does.
-    pub fn malformed_record_start(&self) -> Option<usize> {
-        self.malformed_record_start
-    }
-
-    /// Record `at` as this scan's stop point, the first time only.
+    /// Record `at` as a dropped record. Offsets only advance, so the list
+    /// stays strictly increasing.
     fn mark_malformed(&mut self, at: usize) {
-        if self.malformed_record_start.is_none() {
-            self.malformed_record_start = Some(at);
+        if self.malformed_record_starts.last() != Some(&at) {
+            self.malformed_record_starts.push(at);
         }
     }
 
@@ -227,10 +197,23 @@ impl<'a> EntityScanner<'a> {
             let end_offset = match self.find_entity_end(line_content) {
                 Some(o) => o,
                 None => {
-                    // No terminator found (see `find_entity_end`'s doc
-                    // comment) — record and stop, per `tokenizer.ts`.
+                    // Report it, then drop just THIS record rather than the
+                    // rest of the file: the `)` balancing its `(` is a real
+                    // 10303-21 boundary (#4179), the same per-record skip the
+                    // oversized id below takes. An unterminated string or
+                    // comment has no balancing `)` either, so #3695's
+                    // "nothing to resume from" stop is unchanged.
                     self.mark_malformed(line_start);
-                    return None;
+                    self.position = match super::lexical::close_step_record(line_content) {
+                        super::lexical::RecordClose::At(o) => body_start + o,
+                        // No balancing ')', but the bytes after are readable:
+                        // re-hunt from past this record's '#' so the NEXT
+                        // declaration is still found. Stopping here cost the
+                        // whole tail for a missing ')' (#4179 review).
+                        super::lexical::RecordClose::Unbalanced => line_start + 1,
+                        super::lexical::RecordClose::Unreadable => return None,
+                    };
+                    continue;
                 }
             };
             let line_end = body_start + end_offset + 1;
@@ -288,59 +271,71 @@ impl<'a> EntityScanner<'a> {
         }
     }
 
-    /// Find the terminating semicolon of an entity, skipping over quoted strings.
-    /// IFC strings are enclosed in single quotes ('...') and can contain semicolons.
-    /// Returns the offset of the semicolon from the start of the slice.
+    /// Offset of the record's terminating `;` from the start of the slice.
     ///
-    /// A `/* ... */` comment is skipped whole, so a `;` written inside one does
-    /// not end the record — `#1=IFCWALL('a', /* pending; revise */ $);` is
-    /// legal 10303-21 and used to come back truncated at that inner `;`. The
-    /// two skips compose in one direction only, and the order below is what
-    /// fixes it: a quote is tested first, so a `/*` inside a string literal is
-    /// text; the comment is then consumed as a region, so a quote inside a
-    /// comment is text and cannot open a literal.
+    /// `memchr3` jumps straight to the next quote, comment opener or
+    /// semicolon, so a string-free geometry primitive
+    /// (`#7=IFCCARTESIANPOINT((1.,2.,3.));`), the overwhelming majority of
+    /// records, resolves in one vectorized hop rather than a per-byte loop.
+    /// A quote is tested before a comment opener and a comment is then
+    /// consumed whole, which is what makes a `/*` inside a literal text and a
+    /// `;` or quote inside a comment text: `#1=IFCWALL('a', /* p; q */ $);` is
+    /// legal 10303-21 and used to come back truncated at that inner `;`.
     ///
-    /// SIMD scan: instead of inspecting every byte, `memchr3` jumps straight to
-    /// the next quote, comment opener or semicolon. The overwhelming majority
-    /// of records are string-free geometry primitives
-    /// (`#7=IFCCARTESIANPOINT((1.,2.,3.));`), so the common case resolves the
-    /// terminator in a single vectorized hop rather than a per-byte loop.
-    /// Widening `memchr2` to `memchr3` costs one more comparison per SIMD
-    /// block; on a comment-free file the only extra work beyond that is one
-    /// byte test per `'/'` that is not followed by `'*'` (STEP division), which
-    /// records essentially never contain. Semantics are otherwise unchanged:
-    /// the first `;` outside a quoted string and outside a comment, with
-    /// doubled `''` treated as an escaped in-string quote per STEP
-    /// (ISO 10303-21). This is the single hottest structural-scan function and
-    /// runs on every entity of every model (native and wasm), through both
-    /// `build_entity_index` and the processor scan loop, which share this
-    /// scanner.
+    /// Returns the first `;` outside a string and outside a comment, doubled
+    /// `''` being an escaped in-string quote per STEP (ISO 10303-21), and
+    /// `None` unless that `;` is preceded by the `)` closing the parameter
+    /// list with no `=` before it, which bounds the search to the record's OWN
+    /// body (#4179). [`close_step_record`](super::lexical::close_step_record)
+    /// argues both rules, the general property they approximate, and why a
+    /// refusal recovers rather than stops; the TypeScript halves are
+    /// `step-record-boundary.ts` and `scan-worker-source.ts`. This is the
+    /// single hottest structural-scan function: every entity of every model,
+    /// native and wasm, through `build_entity_index` and the processor scan
+    /// loop alike.
     #[inline]
     fn find_entity_end(&self, content: &[u8]) -> Option<usize> {
         let mut pos = 0;
+        // Only the two arms that can make it true compute it (#4179).
+        let mut closes_paren = false;
 
         loop {
             // Outside a quoted string: jump to the next quote, comment opener
-            // or terminating semicolon in one SIMD pass.
-            pos += memchr::memchr3(b'\'', b';', b'/', &content[pos..])?;
-            if content[pos] == b';' {
-                return Some(pos);
+            // or terminating semicolon in one SIMD pass. Slicing `rest` once
+            // spares the arms below a repeated bounds check on `content[pos]`.
+            let rest = &content[pos..];
+            let hit = memchr::memchr3(b'\'', b';', b'/', rest)?;
+            let plain = &rest[..hit];
+            // An '=' out here is the NEXT declaration's: this record never ended.
+            if memchr::memchr(b'=', plain).is_some() {
+                return None;
             }
-            if content[pos] == b'/' {
+            let found = rest[hit];
+            pos += hit;
+
+            if found == b';' {
+                // A ';' closing nothing belongs to what FOLLOWS the record.
+                return super::lexical::closes_with_paren(plain, closes_paren).then_some(pos);
+            }
+            if found == b'/' {
                 if content.get(pos + 1) == Some(&b'*') {
+                    // A comment is trivia, so a ')' before it still counts:
+                    // `#1=IFCWALL($) /* c */ ;` closes at that ')'.
+                    closes_paren = super::lexical::closes_with_paren(plain, closes_paren);
                     // Unterminated: the rest of the input is inside the
                     // comment, so this record has no terminator. `None` drops
                     // it and ends the scan rather than inventing an end.
                     pos = super::lexical::skip_step_comment(content, pos)?;
                 } else {
                     // A lone '/' is STEP division inside a value list.
+                    closes_paren = false;
                     pos += 1;
                 }
                 continue;
             }
 
-            // content[pos] == b'\'' : entered a quoted string. Scan to the
-            // closing quote, treating a doubled '' as an escaped quote.
+            // found == b'\'' : entered a quoted string. Scan to the closing
+            // quote, treating a doubled '' as an escaped quote.
             pos += 1;
             loop {
                 pos += memchr::memchr(b'\'', &content[pos..])?;
@@ -353,6 +348,7 @@ impl<'a> EntityScanner<'a> {
                 pos += 1;
                 break;
             }
+            closes_paren = false; // A literal is a parameter, not a close.
         }
     }
 
@@ -401,117 +397,7 @@ impl<'a> EntityScanner<'a> {
     pub fn reset(&mut self) {
         self.position = data_section_start(self.bytes);
         self.skipped_oversized_id_starts.clear();
-        self.malformed_record_start = None;
-    }
-
-    /// Fast check if attribute at given index is non-null (not '$')
-    /// This is used to filter building elements that don't have representation
-    /// without full entity decode. Index 0 is first attribute after '('.
-    ///
-    /// Returns true if attribute exists and is not '$', false otherwise.
-    #[inline]
-    pub fn has_non_null_attribute(&self, start: usize, end: usize, attr_index: usize) -> bool {
-        let content = &self.bytes[start..end];
-
-        // Find the opening parenthesis
-        let paren_pos = match memchr::memchr(b'(', content) {
-            Some(p) => p + 1,
-            None => return false,
-        };
-
-        let mut pos = paren_pos;
-        let mut current_attr = 0;
-        let mut depth = 0; // Track nested parentheses
-        let mut in_string = false;
-
-        // Helper to check if we're at target attribute and return result
-        let check_target = |pos: usize, current_attr: usize, depth: usize| -> Option<bool> {
-            if current_attr == attr_index && depth == 0 {
-                // Skip whitespace AND comments (`skip_step_trivia`, shared with
-                // the scanner's other trivia points): `/* c1 */ $` is still the
-                // null slot, not a non-null value starting with '/'. An
-                // unterminated comment leaves nothing certain after it, so
-                // treat the slot as absent rather than reading into the void.
-                return Some(match super::lexical::skip_step_trivia(content, pos) {
-                    Some(p) if p < content.len() => content[p] != b'$',
-                    _ => false,
-                });
-            }
-            None
-        };
-
-        // Check if target is first attribute (index 0)
-        if let Some(result) = check_target(pos, current_attr, depth) {
-            return result;
-        }
-
-        while pos < content.len() {
-            let b = content[pos];
-
-            if in_string {
-                if b == b'\'' {
-                    // Check for escaped quote ('')
-                    if pos + 1 < content.len() && content[pos + 1] == b'\'' {
-                        pos += 2;
-                        continue;
-                    }
-                    in_string = false;
-                }
-                pos += 1;
-                continue;
-            }
-
-            match b {
-                b'\'' => {
-                    in_string = true;
-                    pos += 1;
-                }
-                b'/' if content.get(pos + 1) == Some(&b'*') => {
-                    // A comment is consumed as a region -- the other half of
-                    // the rule the quote branch above gives in the opposite
-                    // direction. A ',', '(' or ')' inside it must not move
-                    // current_attr or depth, or `#1=IFCWALL($, /* a, b */ 'x');`
-                    // would count the comment's comma as an attribute
-                    // separator. Unterminated: nothing after it is certain, so
-                    // give up rather than guess.
-                    match super::lexical::skip_step_comment(content, pos) {
-                        Some(next) => pos = next,
-                        None => return false,
-                    }
-                }
-                b'(' => {
-                    depth += 1;
-                    pos += 1;
-                }
-                b')' => {
-                    if depth == 0 {
-                        // End of entity - attribute not found
-                        return false;
-                    }
-                    depth -= 1;
-                    pos += 1;
-                }
-                b',' if depth == 0 => {
-                    current_attr += 1;
-                    pos += 1;
-                    // Skip whitespace and comments after the comma (same rule
-                    // as check_target's leading skip).
-                    match super::lexical::skip_step_trivia(content, pos) {
-                        Some(p) => pos = p,
-                        None => return false,
-                    }
-                    // Check if we're now at target attribute
-                    if let Some(result) = check_target(pos, current_attr, depth) {
-                        return result;
-                    }
-                }
-                _ => {
-                    pos += 1;
-                }
-            }
-        }
-
-        false
+        self.malformed_record_starts.clear();
     }
 }
 

--- a/rust/core/src/parser/scanner_attributes.rs
+++ b/rust/core/src/parser/scanner_attributes.rs
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `EntityScanner::has_non_null_attribute`, the scanner's one per-ATTRIBUTE
+//! read.
+//!
+//! A sibling file for the same reason `scanner_header.rs` and
+//! `scanner_tests.rs` are: `scanner.rs` is at its `module_size_ratchet`
+//! budget, and this method shares no state or control flow with the record
+//! scan it sat next to — it walks one already-located span, comma by comma,
+//! rather than hunting the next record. Splitting it is what bought
+//! `find_entity_end` room to document the #4179 record-boundary rules.
+
+impl<'a> super::EntityScanner<'a> {
+    /// Fast check if attribute at given index is non-null (not '$')
+    /// This is used to filter building elements that don't have representation
+    /// without full entity decode. Index 0 is first attribute after '('.
+    ///
+    /// Returns true if attribute exists and is not '$', false otherwise.
+    #[inline]
+    pub fn has_non_null_attribute(&self, start: usize, end: usize, attr_index: usize) -> bool {
+        let content = &self.bytes[start..end];
+
+        // Find the opening parenthesis
+        let paren_pos = match memchr::memchr(b'(', content) {
+            Some(p) => p + 1,
+            None => return false,
+        };
+
+        let mut pos = paren_pos;
+        let mut current_attr = 0;
+        let mut depth = 0; // Track nested parentheses
+        let mut in_string = false;
+
+        // Helper to check if we're at target attribute and return result
+        let check_target = |pos: usize, current_attr: usize, depth: usize| -> Option<bool> {
+            if current_attr == attr_index && depth == 0 {
+                // Skip whitespace AND comments (`skip_step_trivia`, shared with
+                // the scanner's other trivia points): `/* c1 */ $` is still the
+                // null slot, not a non-null value starting with '/'. An
+                // unterminated comment leaves nothing certain after it, so
+                // treat the slot as absent rather than reading into the void.
+                return Some(match crate::parser::lexical::skip_step_trivia(content, pos) {
+                    Some(p) if p < content.len() => content[p] != b'$',
+                    _ => false,
+                });
+            }
+            None
+        };
+
+        // Check if target is first attribute (index 0)
+        if let Some(result) = check_target(pos, current_attr, depth) {
+            return result;
+        }
+
+        while pos < content.len() {
+            let b = content[pos];
+
+            if in_string {
+                if b == b'\'' {
+                    // Check for escaped quote ('')
+                    if pos + 1 < content.len() && content[pos + 1] == b'\'' {
+                        pos += 2;
+                        continue;
+                    }
+                    in_string = false;
+                }
+                pos += 1;
+                continue;
+            }
+
+            match b {
+                b'\'' => {
+                    in_string = true;
+                    pos += 1;
+                }
+                b'/' if content.get(pos + 1) == Some(&b'*') => {
+                    // A comment is consumed as a region -- the other half of
+                    // the rule the quote branch above gives in the opposite
+                    // direction. A ',', '(' or ')' inside it must not move
+                    // current_attr or depth, or `#1=IFCWALL($, /* a, b */ 'x');`
+                    // would count the comment's comma as an attribute
+                    // separator. Unterminated: nothing after it is certain, so
+                    // give up rather than guess.
+                    match crate::parser::lexical::skip_step_comment(content, pos) {
+                        Some(next) => pos = next,
+                        None => return false,
+                    }
+                }
+                b'(' => {
+                    depth += 1;
+                    pos += 1;
+                }
+                b')' => {
+                    if depth == 0 {
+                        // End of entity - attribute not found
+                        return false;
+                    }
+                    depth -= 1;
+                    pos += 1;
+                }
+                b',' if depth == 0 => {
+                    current_attr += 1;
+                    pos += 1;
+                    // Skip whitespace and comments after the comma (same rule
+                    // as check_target's leading skip).
+                    match crate::parser::lexical::skip_step_trivia(content, pos) {
+                        Some(p) => pos = p,
+                        None => return false,
+                    }
+                    // Check if we're now at target attribute
+                    if let Some(result) = check_target(pos, current_attr, depth) {
+                        return result;
+                    }
+                }
+                _ => {
+                    pos += 1;
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/rust/core/src/parser/scanner_diagnostics.rs
+++ b/rust/core/src/parser/scanner_diagnostics.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! What an [`EntityScanner`](super::EntityScanner) scan DROPPED, and why.
+//!
+//! A sibling file for the same reason `scanner_header.rs` and
+//! `scanner_attributes.rs` are: `scanner.rs` is at its `module_size_ratchet`
+//! budget, and these four accessors share no control flow with the record
+//! hunt. They are the reporting surface, and the reasoning they carry (why
+//! each is a `Vec` of offsets rather than a count, and why a SHARDED caller
+//! needs the offsets) is the same argument twice, so it belongs in one place.
+
+impl<'a> super::EntityScanner<'a> {
+    /// How many records this scanner has skipped because their instance name
+    /// does not fit `u32` (issue #3395).
+    ///
+    /// ISO 10303-21 puts no upper bound on `#<digits>`, but every express-id
+    /// column in this workspace is `u32` (`ColumnarIndex::ids`,
+    /// `MeshData::express_id`, the wasm `express_ids` buffers), so a wider id
+    /// cannot be represented — it used to wrap, making `#4294967297`
+    /// indistinguishable from `#1`. The record is dropped instead, and this
+    /// counter is the other half of that guard: callers report it rather than
+    /// letting the model come back quietly short.
+    pub fn skipped_oversized_ids(&self) -> usize {
+        self.skipped_oversized_id_starts.len()
+    }
+
+    /// The `line_start` byte offset of every record this scanner refused,
+    /// strictly increasing.
+    ///
+    /// A whole-file scan only needs the count above. A SHARDED scan needs the
+    /// offsets, and the difference is not cosmetic: shard `i > 0` starts at an
+    /// arbitrary byte, so it can begin inside a quoted value and parse a
+    /// string literal such as `'…#4294967297=IFCWALL(…'` as a record — and
+    /// refuse it. That refusal is an artefact of where the shard started, not
+    /// a record the file declares, so a count alone would let a file with
+    /// NOTHING oversized in it be reported as incomplete. The offset lets the
+    /// stitch keep only the refusals inside the byte region it actually
+    /// retained from that shard (issue #3395/#3430).
+    pub fn skipped_oversized_id_starts(&self) -> &[usize] {
+        &self.skipped_oversized_id_starts
+    }
+
+    /// The first record this scan dropped for having no terminator of its own,
+    /// or `None`. See [`Self::malformed_record_starts`].
+    pub fn malformed_record_start(&self) -> Option<usize> {
+        self.malformed_record_starts.first().copied()
+    }
+
+    /// The `line_start` of EVERY record this scan dropped for having no
+    /// terminator of its own, strictly increasing.
+    ///
+    /// A REPORT, not a stop signal: a record merely missing its `;` is dropped
+    /// and the scan CONTINUES past the `)` closing its parameter list (#4179).
+    /// Ask [`position`](Self::position), not this, whether a scan finished.
+    ///
+    /// A `Vec` for the reason
+    /// [`skipped_oversized_id_starts`](Self::skipped_oversized_id_starts) is
+    /// one, which recovery made load-bearing: a SHARDED scan can now hit a
+    /// speculative drop inside a quoted value AND a real one after it, and
+    /// keeping only the first made the stitch's "inside my retained region"
+    /// filter test the speculative offset and discard the real report with it.
+    pub fn malformed_record_starts(&self) -> &[usize] {
+        &self.malformed_record_starts
+    }
+}

--- a/rust/core/src/parser/scanner_tests.rs
+++ b/rust/core/src/parser/scanner_tests.rs
@@ -253,6 +253,18 @@ fn scan_spans(content: &str) -> Vec<(u32, String, String)> {
     out
 }
 
+/// `scan_spans` without the type name, plus where the scan stopped. Separate
+/// only because the #4179 tests assert on spans and the stop TOGETHER, and
+/// borrowing `&str` out of `content` keeps their expectations literal.
+fn scan_spans_and_stop(content: &str) -> (Vec<(u32, &str)>, Option<usize>) {
+    let mut scanner = EntityScanner::new(content);
+    let mut spans = Vec::new();
+    while let Some((id, _type_name, start, end)) = scanner.next_entity() {
+        spans.push((id, &content[start..end]));
+    }
+    (spans, scanner.malformed_record_start())
+}
+
 const DATA_PREAMBLE: &str = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n";
 
 fn data_file(records: &[&str]) -> String {
@@ -645,4 +657,100 @@ fn fused_id_prefix_retains_refusal_and_malformed_order_3987() {
     let mut scanner = EntityScanner::new(source);
     assert_eq!(scanner.next_entity().map(|x| x.0), Some(8));
     assert!(scanner.skipped_oversized_id_starts().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// #4179: a record with no `;` of its own must not latch onto a LATER `;`.
+// The already-fixed cluster above covers "nothing left to find at all"; these
+// cover the opposite case, where something IS left to find and the scan runs
+// past its own record boundary to reach it — swallowing the next record and
+// reporting success.
+// ---------------------------------------------------------------------------
+
+/// RED, pre-fix: `[1, 2, 4]` — #3 is gone, #2's span covers #3's bytes, and
+/// `malformed_record_start()` is `None`.
+///
+/// The broken record is DROPPED, not the rest of the file: #3 and #4 both
+/// survive. `close_step_record` (parser::lexical) argues why recovery beats
+/// stopping; `missing_terminator_does_not_cost_the_sharded_scan_its_tail_4179`
+/// is the measurement.
+#[test]
+fn unterminated_record_does_not_swallow_the_next_record_4179() {
+    let content = "#1=IFCA(1);\n#2=IFCB(2)\n#3=IFCC(3);\n#4=IFCD(4);\n";
+    let (spans, stop) = scan_spans_and_stop(content);
+    assert_eq!(spans, vec![(1, "#1=IFCA(1);"), (3, "#3=IFCC(3);"), (4, "#4=IFCD(4);")]);
+    assert_eq!(
+        stop,
+        content.find("#2"),
+        "a record whose own ';' is missing must be reported, not completed \
+         with the next record's ';'"
+    );
+}
+
+/// RED, pre-fix: #2's span swallows `ENDSEC;` and nothing is reported — the
+/// file parses as fully successful having lost the footer's structural marker.
+#[test]
+fn unterminated_last_record_does_not_swallow_the_footer_4179() {
+    let content = "#1=IFCPROJECT('a');\n#2=IFCWALL('b')\nENDSEC;\nEND-ISO-10303-21;\n";
+    let (spans, stop) = scan_spans_and_stop(content);
+    assert_eq!(spans, vec![(1, "#1=IFCPROJECT('a');")]);
+    assert_eq!(stop, content.find("#2"));
+}
+
+/// Recovery is bounded by the SAME "no resume point" rule the #3695 cluster
+/// set: `close_step_record` walks strings and comments whole, so an
+/// unterminated one leaves no balancing `)` to resume at and the scan still
+/// stops there. Without this the recovery would quietly widen #3695's
+/// contract while every one of its own tests stayed green.
+#[test]
+fn recovery_does_not_resume_past_an_unclosed_string_or_comment_4179() {
+    for body in ["IFCWALL('never closes,$)", "IFCWALL(/* never closes $)"] {
+        let content = format!("#1=IFCA(1);\n#2={body}\n#3=IFCC(3);\n");
+        let (spans, stop) = scan_spans_and_stop(&content);
+        assert_eq!(spans, vec![(1, "#1=IFCA(1);")], "body: {body}");
+        assert_eq!(stop, content.find("#2"), "body: {body}");
+    }
+}
+
+/// The guards must not FALSELY refuse a legal record — the direction a
+/// per-guard mutation check cannot answer, and the dangerous one, since a
+/// refusal now drops a record.
+///
+/// Every shape here is hand-constructed because a sweep of this repo's IFC
+/// corpus contains NONE of them, so a clean sweep over it is not evidence
+/// about these cases. `LEGAL_BODIES` in
+/// `packages/parser/src/step-record-boundary.vectors.ts` carries the counts
+/// and holds the matching TypeScript vectors.
+#[test]
+fn record_boundary_guards_accept_legal_records_4179() {
+    let mut bodies = vec![
+        // '=' outside a declaration, in every place it can legally appear.
+        "IFCWALL('a=b',$);".to_string(),
+        "IFCWALL($ /* a=b */);".to_string(),
+        "IFCDOCUMENTREFERENCE('http://h/q?a=b&c=d',$);".to_string(),
+        // Trivia between the closing ')' and the ';'.
+        "IFCWALL($)/* trailing */;".to_string(),
+        "IFCWALL($)/* one *//* two */;".to_string(),
+        "IFCWALL($) /* spaced */ \t /* twice */ ;".to_string(),
+        "IFCWALL($)/* multi\nline */;".to_string(),
+        // Shapes the corpus does cover, kept as the control.
+        "IFCWALL(('a'),(1.,2.));".to_string(),
+        "IFCWALL(\n  'a',\n  $\n);".to_string(),
+        "(IFCA(1)IFCB(2));".to_string(),
+    ];
+    // Each STEP space byte on its own: `is_step_space` includes vertical tab
+    // and form feed, and a form feed silently dropping an entity is exactly
+    // what #3733 was.
+    for space in [" ", "\t", "\r", "\n", "\x0b", "\x0c"] {
+        bodies.push(format!("IFCWALL($){space};"));
+        bodies.push(format!("IFCWALL($){space}/* c */{space};"));
+    }
+    for body in &bodies {
+        let body = body.as_str();
+        let content = format!("#1={body}\n#2=IFCDOOR($);\n");
+        let (spans, stop) = scan_spans_and_stop(&content);
+        let record = format!("#1={body}");
+        assert_eq!(spans, vec![(1, record.as_str()), (2, "#2=IFCDOOR($);")], "body: {body}");
+        assert_eq!(stop, None, "body: {body}");
+    }
 }

--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -93,7 +93,7 @@ pub fn scan_shard_with_refusals(
     range_start: usize,
     range_end: usize,
 ) -> (ShardRecords, Option<usize>, ShardRefusals) {
-    let (records, handoff, refusals, _malformed_start) =
+    let (records, handoff, refusals, _malformed_starts) =
         scan_shard_with_diagnostics(content, range_start, range_end);
     (records, handoff, refusals)
 }
@@ -134,18 +134,20 @@ pub fn scan_shard_with_refusals(
 /// counts. Only the stitch knows which bytes of a shard were kept, so only the
 /// stitch can attribute a refusal — see [`native::stitch`].
 ///
-/// The malformed-record stop offset is the byte offset of the record — if
-/// any — that made [`ifc_lite_core::EntityScanner::find_entity_end`] fail
-/// (an unterminated `'` string or `/* … */` comment). Unlike an oversized-id
-/// refusal, the scanner STOPS ENTIRELY when this happens, so `records`/
-/// `handoff` above already reflect it; this offset is only the "why", for
-/// [`native::stitch`] to attribute — same speculative-prefix caveat as a
-/// refusal, so it is not reported here either.
+/// The malformed-record offsets are the `line_start` of every record
+/// [`ifc_lite_core::EntityScanner::find_entity_end`] refused. Most are
+/// RECOVERABLE: a record missing its `;` is dropped and the scan carries on
+/// (#4179), so `records`/`handoff` above continue past it. Only a record with
+/// nothing to resume from stops the scan, and that shows in `handoff` being
+/// `None` before `range_end`. All of them, not just the first: a shard can
+/// hold a speculative drop inside a quoted value AND a real one after it, and
+/// [`native::stitch`] must be able to find the real one. Same
+/// speculative-prefix caveat as a refusal, so it is not reported here either.
 pub fn scan_shard_with_diagnostics(
     content: &[u8],
     range_start: usize,
     range_end: usize,
-) -> (ShardRecords, Option<usize>, ShardRefusals, Option<usize>) {
+) -> (ShardRecords, Option<usize>, ShardRefusals, Vec<usize>) {
     // Deliberately NOT delegating to `scan_shard_classified`: index-only
     // callers (native exporters / georeferencing via
     // `build_entity_index_parallel`) would pay a per-entity keyword
@@ -169,7 +171,7 @@ pub fn scan_shard_with_diagnostics(
         records,
         handoff,
         scanner.skipped_oversized_id_starts().to_vec(),
-        scanner.malformed_record_start(),
+        scanner.malformed_record_starts().to_vec(),
     )
 }
 

--- a/rust/processing/src/parallel_scan/native.rs
+++ b/rust/processing/src/parallel_scan/native.rs
@@ -60,9 +60,9 @@ struct ChunkScan {
     /// Every refusal this chunk's scan produced, real or speculative. The
     /// stitch decides which; the chunk cannot.
     refusals: super::ShardRefusals,
-    /// Where this chunk's scan stopped on a malformed record, real or
+    /// Where this chunk's scan dropped a malformed record, real or
     /// speculative — same caveat as `refusals`.
-    malformed_start: Option<usize>,
+    malformed_starts: Vec<usize>,
 }
 
 #[inline]
@@ -81,13 +81,13 @@ fn scan_chunk(content: &[u8], i: usize, n_chunks: usize) -> ChunkScan {
     // semantics (`scan_shard` selects it on `range_start == 0`); every other
     // chunk starts speculatively at its byte offset. Same shard primitive the
     // wasm sharded pre-pass calls per worker, so the merge cannot drift.
-    let (records, handoff, refusals, malformed_start) =
+    let (records, handoff, refusals, malformed_starts) =
         super::scan_shard_with_diagnostics(content, start, end);
     ChunkScan {
         records,
         handoff,
         refusals,
-        malformed_start,
+        malformed_starts,
     }
 }
 
@@ -170,20 +170,25 @@ pub(super) fn with_chunks_counted(content: &[u8], n_chunks: usize) -> StitchResu
 /// serial path, which is the target — not immunity to mis-parsing, which
 /// would mean giving the scanner quote context (#3395/#3430).
 ///
-/// ## The malformed-record stop (#3695) is not "one more refusal count"
+/// ## The malformed-record report is a REPORT, never a control signal
 ///
-/// An oversized-id refusal SKIPS one record and scanning continues. A
-/// malformed record (unterminated `'` string / `/* … */` comment) has no
-/// byte to resume from, so the SERIAL scanner stops PERMANENTLY — nothing
-/// past that byte is ever in the serial index. Byte-identity means the
-/// parallel path must match: the first chunk (file order) whose
-/// ATTRIBUTED region contains a malformed stop drops every chunk after
-/// it, the same way `expected_start: None` already does when a chunk runs
-/// out of real entities. The returned bool is `true` in exactly that
-/// case; callers report it once, stitched, never per shard.
+/// A malformed record comes in two shapes and only one of them stops the
+/// scan (see `close_step_record` in ifc_lite_core's parser::lexical).
+/// `malformed_start` is set for BOTH, so it cannot say which happened, and
+/// this stitch used to read it as if it always meant the permanent one,
+/// dropping every chunk after it. Once a missing `;` became recoverable that
+/// turned one lost record into the whole tail of the file.
+///
+/// `handoff` is the signal that actually distinguishes them, and it always
+/// did: a chunk whose scanner stopped runs out of records before
+/// `range_end` and hands back `None`, which the `expected_start: None`
+/// break below already drops every later chunk on. So byte-identity with
+/// the serial scan is carried by the handoff alone, and `malformed_start`
+/// is only ever accumulated into the returned bool, which callers report
+/// once, stitched, never per shard.
 ///
 /// "Attributed" carries the same speculative-prefix caveat as a refusal —
-/// `chunk.malformed_start >= target` is that filter, mirroring the `<
+/// `chunk.malformed_starts` filtered by `>= target` is that, mirroring the `<
 /// target` split `refusals.partition_point` already makes.
 fn stitch(content: &[u8], chunks: &[ChunkScan], n_chunks: usize) -> StitchResult {
     let len = content.len();
@@ -199,63 +204,61 @@ fn stitch(content: &[u8], chunks: &[ChunkScan], n_chunks: usize) -> StitchResult
     }
     let mut expected_start = chunks[0].handoff;
     let mut refused = chunks[0].refusals.len();
-    let mut malformed = chunks[0].malformed_start.is_some();
+    let mut malformed = !chunks[0].malformed_starts.is_empty();
 
-    if !malformed {
-        for (i, chunk) in chunks.iter().enumerate().skip(1) {
-            // `expected_start` is the real entity start where chunk `i`
-            // begins, validated by chunk `i-1`. `None` => no more real
-            // entities, so every later chunk is speculative from end to
-            // end — records and refusals alike are dropped by breaking
-            // here.
-            let target = match expected_start {
-                Some(t) => t,
-                None => break,
-            };
-            let end = range_end(i, n_chunks, len);
-            let recs = &chunk.records;
-            // `records` is strictly increasing in `start`, so a binary
-            // search locates the real boundary (or proves the chunk
-            // never re-synced).
-            match recs.binary_search_by(|&(_, start, _)| start.cmp(&target)) {
-                Ok(p) => {
-                    for &(id, start, e) in &recs[p..] {
-                        index.insert(id, (start, e));
-                    }
-                    // `refusals` is strictly increasing, so the split
-                    // point is the first refusal inside the retained
-                    // region.
-                    let from = chunk.refusals.partition_point(|&o| o < target);
-                    refused += chunk.refusals.len() - from;
-                    // A malformed stop at/after `target` sits inside the
-                    // region this chunk just proved it resynchronised
-                    // over, so it is real — the same filter the refusal
-                    // count above just applied. Before `target` it is an
-                    // artefact of the discarded speculative prefix.
-                    if chunk.malformed_start.is_some_and(|m| m >= target) {
-                        malformed = true;
-                        break;
-                    }
-                    expected_start = chunk.handoff;
+    for (i, chunk) in chunks.iter().enumerate().skip(1) {
+        // `expected_start` is the real entity start where chunk `i`
+        // begins, validated by chunk `i-1`. `None` => no more real
+        // entities, so every later chunk is speculative from end to
+        // end — records and refusals alike are dropped by breaking
+        // here.
+        let target = match expected_start {
+            Some(t) => t,
+            None => break,
+        };
+        let end = range_end(i, n_chunks, len);
+        let recs = &chunk.records;
+        // `records` is strictly increasing in `start`, so a binary
+        // search locates the real boundary (or proves the chunk
+        // never re-synced).
+        match recs.binary_search_by(|&(_, start, _)| start.cmp(&target)) {
+            Ok(p) => {
+                for &(id, start, e) in &recs[p..] {
+                    index.insert(id, (start, e));
                 }
-                Err(_) => {
-                    // Rare: the speculative scan overshot the real boundary, or a
-                    // single record spans the whole chunk. Serially rescan this
-                    // range from the known-real `target` — byte-identical to the
-                    // serial builder for these bytes — and recompute the handoff.
-                    // The chunk's own refusals go with its records: unusable.
-                    //
-                    // This rescan starts at a validated real boundary, not
-                    // speculatively, so ANY malformed stop it hits is real —
-                    // no `>= target` filter needed, unlike the `Ok` arm.
-                    let rescanned = rescan_range(content, target, end, &mut index);
-                    refused += rescanned.refused;
-                    if rescanned.malformed_start.is_some() {
-                        malformed = true;
-                        break;
-                    }
-                    expected_start = rescanned.handoff;
-                }
+                // `refusals` is strictly increasing, so the split
+                // point is the first refusal inside the retained
+                // region.
+                let from = chunk.refusals.partition_point(|&o| o < target);
+                refused += chunk.refusals.len() - from;
+                // A drop at/after `target` sits inside the region this
+                // chunk just proved it resynchronised over, so it is
+                // real — the same filter the refusal count above just
+                // applied. Before `target` it is an artefact of the
+                // discarded speculative prefix. ALL of the offsets are
+                // tested, not just the first: a chunk can carry both.
+                //
+                // NOT `break`: a dropped record is not a stopped scan.
+                // A chunk that really stopped has no handoff, which the
+                // `None` arm above breaks on at the next iteration.
+                malformed |= chunk.malformed_starts.iter().any(|&m| m >= target);
+                expected_start = chunk.handoff;
+            }
+            Err(_) => {
+                // Rare: the speculative scan overshot the real boundary, or a
+                // single record spans the whole chunk. Serially rescan this
+                // range from the known-real `target` — byte-identical to the
+                // serial builder for these bytes — and recompute the handoff.
+                // The chunk's own refusals go with its records: unusable.
+                //
+                // This rescan starts at a validated real boundary, not
+                // speculatively, so ANY drop it hits is real — no
+                // `>= target` filter needed, unlike the `Ok` arm.
+                let rescanned = rescan_range(content, target, end, &mut index);
+                refused += rescanned.refused;
+                // Report, don't stop — see the `Ok` arm's note.
+                malformed |= !rescanned.malformed_starts.is_empty();
+                expected_start = rescanned.handoff;
             }
         }
     }
@@ -273,7 +276,7 @@ fn stitch(content: &[u8], chunks: &[ChunkScan], n_chunks: usize) -> StitchResult
 struct RescanResult {
     handoff: Option<usize>,
     refused: usize,
-    malformed_start: Option<usize>,
+    malformed_starts: Vec<usize>,
 }
 
 /// Serial rescan from a known-real entity start `target` up to `end`,
@@ -294,7 +297,7 @@ fn rescan_range(
             return RescanResult {
                 handoff: Some(start),
                 refused: scanner.skipped_oversized_ids(),
-                malformed_start: scanner.malformed_record_start(),
+                malformed_starts: scanner.malformed_record_starts().to_vec(),
             };
         }
         index.insert(id, (start, entity_end));
@@ -302,6 +305,6 @@ fn rescan_range(
     RescanResult {
         handoff: None,
         refused: scanner.skipped_oversized_ids(),
-        malformed_start: scanner.malformed_record_start(),
+        malformed_starts: scanner.malformed_record_starts().to_vec(),
     }
 }

--- a/rust/processing/src/parallel_scan_tests.rs
+++ b/rust/processing/src/parallel_scan_tests.rs
@@ -15,9 +15,28 @@ use ifc_lite_core::{build_entity_index, EntityScanner};
 /// This is the number the sharded path must reproduce: the target is
 /// parity with the serial scanner, not immunity to mis-parsing.
 fn serial_refusals(content: &[u8]) -> usize {
+    serial_diagnostics(content).0
+}
+
+/// Whether a SERIAL whole-file scan stops early on a malformed record.
+/// The sharded path must reproduce this too — for the same reason as
+/// `serial_refusals`, and for both directions: a fixture the serial scan
+/// clears must not acquire a stop from how the boundaries fell, and one it
+/// refuses must not lose it to a discarded speculative prefix.
+fn serial_malformed(content: &[u8]) -> bool {
+    serial_diagnostics(content).1
+}
+
+/// One serial drain, both diagnostics: `assert_parallel_matches_serial` wants
+/// each fixture's refusal count AND its malformed flag, and scanning twice for
+/// them made every fixture in this file cost two whole-file walks.
+fn serial_diagnostics(content: &[u8]) -> (usize, bool) {
     let mut scanner = EntityScanner::new(content);
     while scanner.next_entity().is_some() {}
-    scanner.skipped_oversized_ids()
+    (
+        scanner.skipped_oversized_ids(),
+        scanner.malformed_record_start().is_some(),
+    )
 }
 
 /// Assert `with_chunks_counted(content, n)` equals the serial index —
@@ -26,7 +45,7 @@ fn serial_refusals(content: &[u8]) -> usize {
 /// inside strings/comments/records across the sweep.
 fn assert_parallel_matches_serial(content: &[u8], label: &str) {
     let serial = build_entity_index(content);
-    let serial_refused = serial_refusals(content);
+    let (serial_refused, serial_stopped) = serial_diagnostics(content);
     for n in [1usize, 2, 3, 4, 5, 7, 8, 11, 16, 32, 64] {
         let stitched = with_chunks_counted(content, n);
         let (par, refused, malformed) = (stitched.index, stitched.refused, stitched.malformed);
@@ -38,10 +57,10 @@ fn assert_parallel_matches_serial(content: &[u8], label: &str) {
             refused, serial_refused,
             "attributed refusals (n_chunks={n}) != serial ({serial_refused}) for {label}"
         );
-        assert!(
-            !malformed,
-            "n_chunks={n}: {label} must not report a malformed-record stop — none of \
-             this file's `assert_parallel_matches_serial` fixtures declare one"
+        assert_eq!(
+            malformed, serial_stopped,
+            "attributed malformed-record stop (n_chunks={n}) != serial \
+             ({serial_stopped}) for {label}"
         );
     }
 }
@@ -95,11 +114,18 @@ fn duplicate_ids_last_wins() {
 /// and fake `#N=IFCWALL(...)` records. A chunk boundary inside the string
 /// makes the speculative scanner emit garbage until it re-syncs; the stitch
 /// (incl. the fallback) must still reproduce the serial index exactly.
+///
+/// The fake records must be COMPLETE — `)` before the `;` — or they are not
+/// garbage the scanner will emit at all: #4179's record-boundary rules refuse
+/// a `;` that closes nothing, so the half-record `IFCWALL(fake ;` this fixture
+/// used to spell produced zero in-string records and left the sentence above
+/// describing something that no longer happened. `saw_in_string_garbage`
+/// below is the guard that makes that failure loud instead of silent.
 #[test]
 fn chunk_boundary_inside_quoted_string() {
     let mut fake = String::new();
     for k in 0..400 {
-        fake.push_str(&format!(";\\n#{}=IFCWALL(fake ; still in string ", 90000 + k));
+        fake.push_str(&format!(";\\n#{}=IFCWALL(fake); still in string ", 90000 + k));
     }
     let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
     content.push_str("#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n");
@@ -108,7 +134,27 @@ fn chunk_boundary_inside_quoted_string() {
         content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
     }
     content.push_str("ENDSEC;\n");
-    assert_parallel_matches_serial(content.as_bytes(), "in-string-boundary");
+    let bytes = content.as_bytes();
+
+    // The premise, asserted rather than assumed: a shard starting inside the
+    // quoted value really does emit records the file never declared.
+    let string_body = content.find("#2=IFCWALL('").unwrap() + 12;
+    let string_end = content[string_body..].find("',$,").unwrap() + string_body;
+    let saw_in_string_garbage = [2usize, 3, 4, 5, 7, 8, 11, 16, 32, 64].iter().any(|&n| {
+        (0..n).any(|i| {
+            let start = i * bytes.len() / n;
+            super::scan_shard(bytes, start, range_end(i, n, bytes.len()))
+                .0
+                .iter()
+                .any(|&(_, s, _)| s > string_body && s < string_end)
+        })
+    });
+    assert!(
+        saw_in_string_garbage,
+        "no shard ever mis-parsed the quoted value — this fixture cannot \
+         exercise the stitch's speculative-prefix drop"
+    );
+    assert_parallel_matches_serial(bytes, "in-string-boundary");
 }
 
 /// Build a file with NOTHING oversized in it whose one long quoted
@@ -124,8 +170,11 @@ fn chunk_boundary_inside_quoted_string() {
 fn clean_file_with_oversized_shaped_text_in_a_string() -> String {
     let mut fake = String::new();
     for k in 0..400 {
+        // A COMPLETE record shape, `)` and all: the scanner's record-boundary
+        // guards (#4179) reject a `;` that closes nothing, so half a record no
+        // longer fools a speculative shard into refusing anything at all.
         fake.push_str(&format!(
-            "#4294967297=IFCWALL(fake {k} ; still in string "
+            "#4294967297=IFCWALL(fake {k}); still in string "
         ));
     }
     let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
@@ -343,7 +392,12 @@ fn an_oversized_id_in_a_rescanned_range_that_hits_eof_counts_once() {
 fn a_real_oversized_id_behind_an_adversarial_string_counts_once() {
     let mut fake = String::new();
     for k in 0..400 {
-        fake.push_str(&format!("#4294967297=IFCWALL(fake {k} ; still in string "));
+        // COMPLETE record shape, `)` and all: #4179's record-boundary rules
+        // refuse a `;` that closes nothing, so the half-record this used to
+        // spell made the speculative scan refuse NOTHING — leaving the
+        // assertion below with no false refusals to exclude. Measured: 0 with
+        // the old shape, 22975 across the sweep with this one.
+        fake.push_str(&format!("#4294967297=IFCWALL(fake {k}); still in string "));
     }
     let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
     content.push_str("#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n");
@@ -357,6 +411,26 @@ fn a_real_oversized_id_behind_an_adversarial_string_counts_once() {
     let bytes = content.as_bytes();
 
     assert_eq!(serial_refusals(bytes), 1, "one real oversized declaration");
+    // Guard against the loop below being vacuous: "none of the in-string ones"
+    // says nothing unless the shards actually made some. The sibling
+    // `clean_file_with_an_oversized_shaped_string_reports_no_refusal` has had
+    // this guard from the start and failed loudly when #4179 killed its
+    // fixture; this test had none and went quietly vacuous instead.
+    let n = 8usize;
+    let speculative: usize = (0..n)
+        .map(|i| {
+            let start = i * bytes.len() / n;
+            super::scan_shard_with_refusals(bytes, start, range_end(i, n, bytes.len()))
+                .2
+                .len()
+        })
+        .sum();
+    assert!(
+        speculative > 1,
+        "the quoted value made the shards refuse {speculative} record(s); with \
+         nothing false to exclude, the assertion below cannot discriminate the \
+         fix from the bug"
+    );
     for n in [1usize, 2, 3, 4, 5, 7, 8, 11, 16, 32, 64] {
         assert_eq!(
             with_chunks_counted(bytes, n).refused,
@@ -511,4 +585,136 @@ fn fixtures_byte_identical() {
             "public build_entity_index_parallel != serial for {rel}"
         );
     }
+}
+
+/// #4179: one record missing its `;` must not cost a SHARDED scan the whole
+/// tail of the file.
+///
+/// This is the measurement `close_step_record` (ifc_lite_core parser::lexical)
+/// cites for why a refusal recovers instead of stopping: a stopped shard hands
+/// back `handoff = None`, the stitch reads that as "no more real entities",
+/// and every LATER shard is dropped. Asserted through the real stitch, not the
+/// scanner alone, because the scanner alone cannot show the amplification.
+#[test]
+fn missing_terminator_does_not_cost_the_sharded_scan_its_tail_4179() {
+    let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    for id in 1..=40u32 {
+        // #20 loses its ';'; every other record is well-formed.
+        let terminator = if id == 20 { "" } else { ";" };
+        content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$){terminator}\n"));
+    }
+    content.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    let bytes = content.as_bytes();
+
+    // Serial ground truth: exactly #20 is lost, and the stop is reported.
+    let serial = build_entity_index(bytes);
+    assert_eq!(serial.len(), 39, "serial scan must drop only the broken record");
+    assert!(!serial.contains_key(&20));
+    assert!(serial.contains_key(&40), "the tail must survive a serial scan");
+    assert!(serial_malformed(bytes), "the broken record must still be reported");
+
+    // And the sharded path must match it at every chunk count. Before the
+    // recovery, n_chunks=4 came back with 19 of the 40.
+    assert_parallel_matches_serial(bytes, "missing-terminator-mid-file");
+}
+
+/// #4179 review, finding 2: a shard can now hold BOTH a speculative malformed
+/// record and a real one, and only the real one must be reported.
+///
+/// Before recovery this could not happen: a malformed record stopped the scan,
+/// so a shard had at most one. Now the speculative prefix hits one, recovers,
+/// and carries on into the record the file really declares. `mark_malformed`
+/// kept only the FIRST, so the stitch's `>= target` filter tested the
+/// speculative offset, rejected it, and reported nothing for a file the serial
+/// scan flags.
+#[test]
+fn a_speculative_stop_does_not_mask_a_real_one_4179() {
+    let mut fake = String::new();
+    for k in 0..400 {
+        // Unbalanced, so a shard starting mid-string marks it malformed and
+        // then RECOVERS, which is what lets a second one follow.
+        // Balanced, so a shard starting mid-string RECOVERS from each of
+        // these and carries on: that is what lets it reach a second, real
+        // drop. The trailing `x` before the `;` is what makes each one a drop
+        // rather than an accepted record.
+        fake.push_str(&format!("#9000{k}=IFCWALL(fake {k}) x; still in string "));
+    }
+    let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    content.push_str("#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n");
+    content.push_str(&format!("#2=IFCWALL('{fake}',$,$,$,$,$,$,$);\n"));
+    for id in 3..=60u32 {
+        content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
+    }
+    // The real one: no terminator of its own, well after the quoted value.
+    content.push_str("#900=IFCWALL('real',$,$,$,$,$,$,$)\n");
+    for id in 61..=120u32 {
+        content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
+    }
+    content.push_str("ENDSEC;\n");
+    let bytes = content.as_bytes();
+
+    assert!(serial_malformed(bytes), "the fixture must declare a real stop");
+    for n in [1usize, 2, 3, 4, 5, 7, 8, 11, 16, 32, 64] {
+        assert!(
+            with_chunks_counted(bytes, n).malformed,
+            "n_chunks={n}: the real malformed record went unreported"
+        );
+    }
+}
+
+/// #4179 review finding 2: a shard must report EVERY record it dropped, not
+/// just the first.
+///
+/// Recovery made a shard able to hold two: a speculative drop parsed out of a
+/// quoted value it started inside, and a real one after it resynchronised.
+/// While the scanner kept only the first, a shard whose retained region held
+/// the real record reported the speculative offset instead, and the stitch's
+/// "is it inside my region" filter then discarded the real record's report
+/// with it. Measured before the fix at four chunks: the shard covering the
+/// real malformed record at 19443 reported 16191.
+#[test]
+fn a_shard_reports_every_record_it_dropped_not_just_the_first_4179() {
+    let mut fake = String::new();
+    for k in 0..400 {
+        // Balanced, so a shard starting mid-string RECOVERS from each of
+        // these and carries on: that is what lets it reach a second, real
+        // drop. The trailing `x` before the `;` is what makes each one a drop
+        // rather than an accepted record.
+        fake.push_str(&format!("#9000{k}=IFCWALL(fake {k}) x; still in string "));
+    }
+    let mut content = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    content.push_str("#1=IFCPROJECT('guid',$,$,$,$,$,$,$,$);\n");
+    content.push_str(&format!("#2=IFCWALL('{fake}',$,$,$,$,$,$,$);\n"));
+    for id in 3..=60u32 {
+        content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
+    }
+    let real = content.len();
+    content.push_str("#900=IFCWALL('real',$,$,$,$,$,$,$)\n");
+    for id in 61..=120u32 {
+        content.push_str(&format!("#{id}=IFCDOOR('g{id}',$,$,$,$,$,$,$);\n"));
+    }
+    content.push_str("ENDSEC;\n");
+    let bytes = content.as_bytes();
+    assert!(serial_malformed(bytes), "the fixture must declare a real drop");
+
+    // Every shard whose range covers the real record must report THAT offset,
+    // whatever its speculative prefix also found on the way in.
+    let mut checked = 0usize;
+    for n in [2usize, 4, 8, 16] {
+        for i in 0..n {
+            let start = i * bytes.len() / n;
+            let end = range_end(i, n, bytes.len());
+            if !(start <= real && real < end) {
+                continue;
+            }
+            let (_records, _handoff, _refusals, malformed) =
+                super::scan_shard_with_diagnostics(bytes, start, end);
+            assert!(
+                malformed.contains(&real),
+                "n_chunks={n} shard {i} covers the real drop at {real} but reported {malformed:?}"
+            );
+            checked += 1;
+        }
+    }
+    assert!(checked >= 4, "fixture never put the real drop inside a shard");
 }

--- a/rust/processing/tests/issue_3395_oversized_id_report.rs
+++ b/rust/processing/tests/issue_3395_oversized_id_report.rs
@@ -72,7 +72,10 @@ fn clean_file_with_oversized_shaped_string(pad_records: u32, repeats: usize) -> 
     let string_starts_at = content.len();
     let mut fake = String::new();
     for k in 0..repeats {
-        fake.push_str(&format!("#4294967297=IFCWALL(fake {k} ; still in string "));
+        // A COMPLETE record shape, `)` and all: the scanner's record-boundary
+        // guards (#4179) reject a `;` that closes nothing, so half a record no
+        // longer fools a speculative shard into refusing anything at all.
+        fake.push_str(&format!("#4294967297=IFCWALL(fake {k}); still in string "));
     }
     content.push_str(&format!(
         "#{}=IFCWALL('{fake}',$,$,$,$,$,$,$);\n",
@@ -328,8 +331,8 @@ fn parallel_index_and_processor_scan_report_the_refusal() {
         "exactly one report for the malformed stop, got {reports:?}"
     );
     assert!(
-        reports[0].contains("stopped early"),
-        "the report must name the malformed-record stop: {}",
+        reports[0].contains("dropped a record with no terminating"),
+        "the report must name the dropped record: {}",
         reports[0]
     );
 }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -20,7 +20,17 @@
 # bring this file back under budget after a merge combined two independent
 # feature additions to it (#3673's four-scanner comment-trivia work and
 # #3699's unterminated-record reporting) past the recorded 601; 606 -> 557.
-     557 rust/core/src/parser/scanner.rs
+# -105: same move again for the same reason. has_non_null_attribute (one
+# per-ATTRIBUTE walk over an already-located span, sharing no state with the
+# record scan) split out to scanner_attributes.rs (125 lines, under budget, no
+# row) to make room for #4179's record-boundary rules and their recovery;
+# 557 -> 453.
+# -31: and once more. The four refusal/drop accessors, which are a reporting
+# surface with no control flow shared with the record hunt, split out to
+# scanner_diagnostics.rs (67 lines, under budget, no row) to make room for
+# #4179 review finding 2, which needed every dropped offset kept rather than
+# only the first; 453 -> 422.
+     422 rust/core/src/parser/scanner.rs
 # +3: Arc<Vec<AttributeValue>> so DecodedEntity clone is a refcount bump not a deep attribute-tree clone (perf/decode-churn).
     553 rust/core/src/schema_gen.rs
 # schema_helpers.rs row removed: the merged upstream #1969 split its tests into

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -57,7 +57,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// would rewrite the digest and fail CI for no reason.
 const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 4114979320796990468),
-    ("rust/core", 218310759456605933),
+    ("rust/core", 5128986816533797052),
     ("rust/export", 15791359419451037914),
     ("rust/geometry", 17164311728163718683),
     ("rust/processing", 7633784028779437211),


### PR DESCRIPTION
Closes #4179.

A record with no terminating `;` latched onto a later one and swallowed everything between. Two guards read off the ISO 10303-21 grammar, applied to all three scanner implementations (`rust/core` `scanner.rs`, `packages/parser` `tokenizer.ts`, and the worker's standalone copy).

## The regression this fix originally introduced

The first version turned a lost record into a truncated file. Measured on the real chain rather than reasoned about: 40 records in, **19 out**, 21 lost including shards that had scanned cleanly.

Now the record is dropped and the scan resumes at the `)` balancing its own `(`. An unterminated string or comment still has no balancing `)`, so #3695's stop is bit-identical.

The native stitch also had the assumption hard-coded: `malformed_start.is_some()` gated the whole merge loop, so recovery alone still truncated. It is now a report, never a control signal.

## Corpus evidence, stated honestly

487 files, 958 MB, **14,282,864 records, 0 refusals**. That number is only half a result:

- **The `=` guard's population cannot discriminate.** The corpus contains **zero** records with a plain-run `=`, so the zero is not evidence. What it does attest is the exclusion half: **15,111** records carry an `=` inside a string or comment and none were refused.
- **The `)` guard is partly discriminating.** 6,816,392 records end in a nested `))` and 234,391 span several lines, all accepted. Zero have a comment or whitespace between `)` and `;`, so those are hand-constructed.

Both facts are in the test comments so the next reader does not mistake the N for cover.

## Perf: UNMEASURED, not zero

`find_entity_end` is the hottest structural-scan function and this adds a `memchr` pass plus a backwards walk. `ab.sh` could not size it: it reported **+23.5% comparing a commit against itself**. Filed as #4221; #4288 has since fixed the ordering half. The cost is real and unsized, and says so rather than claiming zero.

## Message parity

The diagnostic said "stopped early ... could not continue past it". After this change the common case loses one record from a file read to completion, so that overstated the damage. It now matches the Rust twin, and the tests pinning the old phrase were retargeted while keeping their intent: the message must still name both the string and comment shapes, which is #3695's finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved STEP/IFC scanning when records are missing terminators, allowing processing to continue safely when boundaries can be recovered.
  - Prevented malformed records from consuming subsequent valid records or file footer data.
  - Added clearer diagnostics identifying dropped records and possible unterminated strings, comments, or truncated input.
  - Preserved scan-stopping behavior for unreadable content such as unterminated strings and comments.
  - Improved consistency of malformed-record reporting across standard, worker, WebAssembly, and parallel scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->