### PR TITLE
fix(viewer): send the OAuth scope BIMcollab requires

### DIFF
--- a/.changeset/fix-3900-bimcollab-oauth-scope.md
+++ b/.changeset/fix-3900-bimcollab-oauth-scope.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+BCF browser sign-in against a BIMcollab space now sends the OAuth scope BIMcollab requires (#3900).
+
+The `bimcollab` preset declared no `oauthScope`, and `createAuthorizationRequest` writes the parameter only when one is set, so the authorize URL carried no `scope` at all. BIMcollab's IdentityServer answers a scope-less authorize request with `invalid_request`, so sign-in could not start even with a valid client id. The preset now sends `openid offline_access bcf`, the value the BIMcollab Connection API implementation guide documents for both the playground and issued credentials.

--- a/apps/viewer/src/components/viewer/bcf/bcf-server-presets.test.ts
+++ b/apps/viewer/src/components/viewer/bcf/bcf-server-presets.test.ts
@@ -36,6 +36,19 @@ describe('BCF_SERVER_PRESETS invariants', () => {
     }
   });
 
+  it('BIMcollab carries the scope its IdentityServer requires', () => {
+    // createAuthorizationRequest writes `scope` only `if (config.scope)`, so a
+    // missing field and an empty string both send no scope at all, and
+    // BIMcollab answers a scope-less authorize request with `invalid_request`.
+    // Both halves are asserted because both are silent failures.
+    const bimcollab = findBcfServerPreset('bimcollab');
+    assert.ok(
+      bimcollab.oauthScope,
+      'bimcollab needs a truthy oauthScope; a missing or empty one omits the parameter',
+    );
+    assert.equal(bimcollab.oauthScope, 'openid offline_access bcf');
+  });
+
   it('resolves saved connections back to their preset, and unknown ones to custom', () => {
     assert.equal(presetForServerUrl('https://app.streambim.com/bcf').id, 'streambim');
     assert.equal(presetForServerUrl('https://my-own-server.example/bcf').id, CUSTOM_PRESET_ID);

--- a/apps/viewer/src/components/viewer/bcf/bcf-server-presets.ts
+++ b/apps/viewer/src/components/viewer/bcf/bcf-server-presets.ts
@@ -104,6 +104,11 @@ export const BCF_SERVER_PRESETS: readonly BcfServerPreset[] = [
     label: 'BIMcollab',
     baseUrl: '',
     authMethods: ['oauth', 'token'],
+    // BIMcollab's IdentityServer rejects a scope-less authorize request with
+    // `invalid_request`; measured on playground.bimcollab.com against a valid
+    // client, two requests differing only in this parameter. These three are
+    // what the Connection API implementation guide documents.
+    oauthScope: 'openid offline_access bcf',
     note: 'Your space URL, e.g. https://myspace.bimcollab.com. The same address you give Solibri or a BCF manager.',
   },
   {


### PR DESCRIPTION
Refs #3900.

The `bimcollab` preset sends no OAuth `scope`, and BIMcollab's IdentityServer rejects a scope-less authorize request. `packages/oauth-pkce` only writes the parameter `if (config.scope)`, so omitting the field omits it entirely.

## Measured against a real client, not inferred

Two requests differing only in that parameter, against `playground.bimcollab.com` using the shared Playground credentials the vendor publishes:

| probe | result |
|---|---|
| valid client + registered redirect + documented scope | **303 to the login page (accepted)** |
| valid client + registered redirect + **no scope** | `invalid_request` |

The string `openid offline_access bcf` is the vendor's, from the Connection API Implementation Guide 1.5, which documents it in two places and warns "do not deviate from the credentials provided to you". `offline_access` matters because `completeSignIn` persists `refresh_token`.

## What this does NOT fix

**It does not close #3900.** The reporter's error is `unauthorized_client`, which is BIMcollab rejecting the Client ID itself, and they cannot obtain one: BIMcollab issues them to vetted application vendors, not to space administrators. That is why other tools work where we do not. Louis has since been granted playground access, and production needs app-specific credentials.

So this is the half that is ours. It is deliberately `Refs`, not `Closes`: the issue stays open until credentials land and the flow is verified end to end, rather than asking the reporter to retest a build we have not confirmed.

A probe also rules out a theory worth not chasing: an unregistered redirect URI returns `invalid_request`, not `unauthorized_client`, so there is no `www.ifclite.com` mismatch.

No email/password method was added to the preset. BIMcollab's token endpoint returns `invalid_client` for the password grant without a registered client, so offering it would ship a sign-in path that always fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - BIMcollab OAuth authorization now requests the required `openid offline_access bcf` permissions, improving sign-in and BCF service connectivity.

- **Tests**
  - Added coverage to verify the BIMcollab OAuth scope configuration remains correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->