### PR TITLE
fix(viewer): one pending property edit no longer forces IDS validation onto the main thread

### DIFF
--- a/apps/viewer/src/hooks/ids/canUseIdsWorker.ts
+++ b/apps/viewer/src/hooks/ids/canUseIdsWorker.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { isIfcxDataStore } from '@/store';
+import { idsWorkerSupported } from './idsWorkerClient';
+
+/**
+ * Is this model's IDS run safe to hand to the validation worker?
+ *
+ * Preferred path: validate in a Web Worker so the whole run is off the main
+ * thread — the UI stays at full frame rate and progress actually paints. Every
+ * other heavy stage (parse, geometry) already runs in a worker; this brings
+ * validation in line. The caller falls back to in-process validation when this
+ * returns false: the worker is unavailable, the model has no source bytes for
+ * it to re-parse, or those bytes are not STEP.
+ *
+ * The IFCX exclusion is load-bearing, not defensive. An IFCX store's `source`
+ * is the IFCX **JSON** file (`buildIfcxDataStore`,
+ * hooks/ingest/viewerModelIngest.ts) and its byte index is empty, so
+ * `byteLength > 0` is true and the worker's `parseColumnar` happily parses JSON
+ * as STEP and yields a store with no properties, attributes or relationships.
+ * Before #3946 an IFCX model with pending edits was saved from that by the
+ * edits themselves, which forced the main thread; removing that fork without
+ * this term would convert a working validation into a silently empty one.
+ */
+export function canUseIdsWorker(dataStore: IfcDataStore): boolean {
+  return (
+    idsWorkerSupported()
+    && !isIfcxDataStore(dataStore)
+    && !!dataStore.source
+    && dataStore.source.byteLength > 0
+  );
+}

--- a/apps/viewer/src/hooks/ids/idsDataAccessor.ts
+++ b/apps/viewer/src/hooks/ids/idsDataAccessor.ts
@@ -19,84 +19,23 @@
  * accessor actually sees the correction instead of the pre-edit value.
  * Every other read (attributes, classifications, materials, partOf) is
  * untouched; only property reads consult the overlay.
+ *
+ * The view -> `PropertyOverride[]` projection itself lives in
+ * `@/lib/ids/property-overlay-snapshot`, not here, because the IDS worker
+ * needs the same projection and cannot import a `MutablePropertyView`
+ * (#3946). This accessor and the worker's accessor are handed resolvers
+ * built by the same function from the same snapshot, so they cannot drift.
  */
 
 import type { IFCDataAccessor } from '@ifc-lite/ids';
-import {
-  createDataAccessor as createBridgeAccessor,
-  type PropertyOverride,
-} from '@ifc-lite/ids/bridge';
+import { createDataAccessor as createBridgeAccessor } from '@ifc-lite/ids/bridge';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 
-/**
- * Build the bridge's property-overlay resolver from a `MutablePropertyView`.
- * Only property mutations with a scalar value are projected — list/array
- * property values aren't part of this overlay's contract and are skipped
- * rather than mis-rendered.
- *
- * `getMutationsForEntity()` (`mutationHistory`) is used ONLY to enumerate
- * WHICH (psetName, propName) pairs this entity has ever touched — history is
- * append-only (undo re-applies the inverse mutation with `skipHistory=true`
- * "to avoid polluting mutation history", `mutationSlice.ts`, so it never
- * pops), but the identity of a touched key never becomes wrong, only stale.
- * The actual current state/value for each key comes from
- * `MutablePropertyView.getPropertyMutation()` — the live overlay map
- * (`propertyMutations`), same source `hasChanges()` / `getModifiedEntityCount()`
- * read instead of history, for the same reason. Reading `mutation.newValue`
- * straight from history here was the bug: after an undo, the live overlay
- * had reverted but this resolver still reported the pre-undo (corrected)
- * value as an active override, so IDS re-validation kept reporting PASS on
- * data that had actually reverted to failing.
- */
-function buildOverlayResolver(mutationView: MutablePropertyView) {
-  return (expressId: number): PropertyOverride[] | undefined => {
-    const mutations = mutationView.getMutationsForEntity(expressId);
-    if (mutations.length === 0) return undefined;
-
-    const seen = new Set<string>();
-    const overrides: PropertyOverride[] = [];
-    for (const mutation of mutations) {
-      if (!mutation.psetName || !mutation.propName) continue;
-      const dedupeKey = JSON.stringify([mutation.psetName, mutation.propName]);
-      if (seen.has(dedupeKey)) continue;
-      seen.add(dedupeKey);
-
-      // The live, current state of this key — never the (possibly stale)
-      // `mutation` object itself. `undefined` means an undo unwound this key
-      // back to "no override at all" (see `deleteProperty`'s
-      // `deletePropertyMutation` branch): skip it so the read falls through
-      // to the base value, exactly as if it had never been touched.
-      const live = mutationView.getPropertyMutation(expressId, mutation.psetName, mutation.propName);
-      if (!live) continue;
-
-      if (live.operation === 'DELETE') {
-        overrides.push({ psetName: mutation.psetName, propName: mutation.propName, value: null, deleted: true });
-        continue;
-      }
-
-      const value = live.value ?? null;
-      if (value !== null && typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
-        // Array/list values aren't part of the overlay contract — skip
-        // rather than write a shape the bridge doesn't expect.
-        continue;
-      }
-      // `live.dataType` is set only when the writer knew one (currently
-      // the IDS correction dialog, #3929/#3943) — it lets the bridge's
-      // "no existing entry" branch (a PROPERTY_MISSING correction that
-      // CREATES a property) scale through `toBaseSI` the same way the
-      // "existing entry" branch already does. Absent for every other
-      // writer, which keeps their overrides behaving exactly as before.
-      overrides.push({
-        psetName: mutation.psetName,
-        propName: mutation.propName,
-        value,
-        dataType: live.dataType,
-      });
-    }
-    return overrides.length > 0 ? overrides : undefined;
-  };
-}
+import {
+  snapshotPropertyOverlay,
+  overlayResolverFromSnapshot,
+} from '@/lib/ids/property-overlay-snapshot';
 
 export function createDataAccessor(
   dataStore: IfcDataStore,
@@ -105,6 +44,8 @@ export function createDataAccessor(
 ): IFCDataAccessor {
   return createBridgeAccessor(
     dataStore,
-    mutationView ? buildOverlayResolver(mutationView) : undefined
+    mutationView
+      ? overlayResolverFromSnapshot(snapshotPropertyOverlay(mutationView))
+      : undefined
   );
 }

--- a/apps/viewer/src/hooks/ids/idsWorkerClient.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.ts
@@ -19,6 +19,8 @@ import type {
 } from '@ifc-lite/ids';
 import type { IfcSourceTransfer } from '@ifc-lite/parser';
 
+import type { PropertyOverlaySnapshot } from '@/lib/ids/property-overlay-snapshot';
+
 import type {
   IdsWorkerRequest,
   IdsWorkerResponse,
@@ -51,6 +53,16 @@ export interface RunInWorkerArgs {
   modelId: string;
   locale: 'en' | 'de' | 'fr';
   includePassingEntities: boolean;
+  /**
+   * The model's pending property edits as plain, clonable data (#3946).
+   *
+   * The worker validates the RE-PARSED source bytes, which do not carry
+   * in-memory corrections, so without this a model with edits pending had
+   * to be validated on the main thread instead. Snapshotting is
+   * O(pending edits); a model with none passes `undefined` and takes the
+   * unchanged no-overlay path.
+   */
+  propertyOverlay?: PropertyOverlaySnapshot;
   onProgress?: (progress: ValidationProgress) => void;
 }
 
@@ -123,6 +135,7 @@ export function runValidationInWorker(
       modelId: args.modelId,
       locale: args.locale,
       includePassingEntities: args.includePassingEntities,
+      propertyOverlay: args.propertyOverlay,
     };
     try {
       worker.postMessage(request);

--- a/apps/viewer/src/hooks/useIDS.pending-edit-worker-routing.test.tsx
+++ b/apps/viewer/src/hooks/useIDS.pending-edit-worker-routing.test.tsx
@@ -1,0 +1,339 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * One pending property edit must not drag a whole model's IDS validation
+ * onto the main thread (#3946).
+ *
+ * `runValidation()` used to compute
+ * `canUseWorker = !hasPendingPropertyEdits && ...`, so a SINGLE edited
+ * property made every subsequent validation of that model run in-process,
+ * at a cost of O(entities x specifications) and identical for one edit or
+ * a thousand — measured at ~500ms for a 250k-entity model, re-charged on
+ * every re-run until the edits were exported or cleared.
+ *
+ * The fix hands the worker the edits instead, as a `PropertyOverlaySnapshot`
+ * costing O(pending edits). These tests pin the ROUTING half of that (does
+ * the run reach the worker, and does it carry the overlay);
+ * `workers/idsValidation.worker.test.ts` pins the half that matters for
+ * correctness — that the worker actually applies what it is handed.
+ *
+ * Under happy-dom `typeof Worker === 'undefined'`, so a `FakeWorker` is
+ * installed on `globalThis`: without it `idsWorkerSupported()` is false and
+ * every case here would take the fallback for the wrong reason.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { parseIDS, type IDSValidationReport } from '@ifc-lite/ids';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+import type { GeometryResult } from '@ifc-lite/geometry';
+import { useViewerStore, type FederatedModel } from '@/store';
+import type { PropertyOverlaySnapshot } from '@/lib/ids/property-overlay-snapshot';
+import { useIDS } from './useIDS.js';
+
+// ─── Fake worker ──────────────────────────────────────────────────────────
+
+interface PostedRequest {
+  type: string;
+  id: number;
+  propertyOverlay?: PropertyOverlaySnapshot;
+  [key: string]: unknown;
+}
+
+const instances: FakeWorker[] = [];
+
+/**
+ * Replies `complete` as soon as it is posted to, so `runValidation` settles
+ * without the test having to drive the message pump by hand.
+ */
+class FakeWorker {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  readonly posted: PostedRequest[] = [];
+
+  constructor() {
+    instances.push(this);
+  }
+
+  postMessage(message: PostedRequest): void {
+    this.posted.push(message);
+    queueMicrotask(() => {
+      this.onmessage?.({
+        data: { type: 'complete', id: message.id, report: WORKER_REPORT },
+      });
+    });
+  }
+
+  terminate(): void {}
+}
+
+/** Distinguishable from anything the in-process validator would produce. */
+const WORKER_REPORT = {
+  summary: {
+    totalSpecifications: 1,
+    passedSpecifications: 1,
+    failedSpecifications: 0,
+    totalEntitiesChecked: 1,
+    totalEntitiesPassed: 1,
+    overallPassRate: 100,
+  },
+  specificationResults: [],
+  document: { specifications: [] },
+  timestamp: new Date(0),
+  modelInfo: { modelId: 'from-the-worker', schemaVersion: 'IFC4', entityCount: 1 },
+} as unknown as IDSValidationReport;
+
+// ─── Fixture ──────────────────────────────────────────────────────────────
+
+const WALL_ID = 1;
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+async function parseWalls(): Promise<IfcDataStore> {
+  const body = [
+    `#${WALL_ID}=IFCWALL('0aaaaaaaaaaaaaaaaaaaaa',$,'Wall A',$,$,$,$,$,.STANDARD.);`,
+    `#2=IFCWALL('0bbbbbbbbbbbbbbbbbbbbb',$,'Wall B',$,$,$,$,$,.STANDARD.);`,
+  ].join('\n');
+  const bytes = new TextEncoder().encode(ifc4(body));
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+const IDS_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ids:ids xmlns:ids="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+  <ids:info><ids:title>#3946 routing fixture</ids:title></ids:info>
+  <ids:specifications>
+    <ids:specification name="Wall with fire rating" ifcVersion="IFC4">
+      <ids:applicability minOccurs="0" maxOccurs="unbounded">
+        <ids:entity><ids:name><ids:simpleValue>IFCWALL</ids:simpleValue></ids:name></ids:entity>
+      </ids:applicability>
+      <ids:requirements>
+        <ids:property dataType="IFCLABEL">
+          <ids:propertySet><ids:simpleValue>Pset_WallCommon</ids:simpleValue></ids:propertySet>
+          <ids:baseName><ids:simpleValue>FireRating</ids:simpleValue></ids:baseName>
+        </ids:property>
+      </ids:requirements>
+    </ids:specification>
+  </ids:specifications>
+</ids:ids>`;
+
+function model(id: string, store: IfcDataStore): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: store,
+    geometryResult: { meshes: [] } as unknown as GeometryResult,
+    visible: true,
+    collapsed: false,
+    schemaVersion: store.schemaVersion,
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 2,
+  } as unknown as FederatedModel;
+}
+
+// ─── Harness ──────────────────────────────────────────────────────────────
+
+type IdsApi = ReturnType<typeof useIDS>;
+let api: IdsApi | null = null;
+let root: Root | null = null;
+
+function Probe(): null {
+  api = useIDS();
+  return null;
+}
+
+interface SeedOptions {
+  /** Register a mutation view carrying one pending property edit. */
+  withPendingEdit: boolean;
+  /** Label the store IFC5, which is how an IFCX store is recognised. */
+  asIfcx?: boolean;
+}
+
+async function seed(opts: SeedOptions): Promise<void> {
+  const store = await parseWalls();
+  if (opts.asIfcx) {
+    // `isIfcxDataStore` keys off `schemaVersion` alone, so this exercises the
+    // exact predicate `canUseWorker` consults. A real IFCX store additionally
+    // carries IFCX JSON in `source` (`buildIfcxDataStore`) — that is what makes
+    // a worker re-parse produce an empty store, and what this guard exists to
+    // avoid; reproducing it here would only test the parser.
+    (store as { schemaVersion: string }).schemaVersion = 'IFC5';
+  }
+
+  const mutationViews = new Map<string, MutablePropertyView>();
+  if (opts.withPendingEdit) {
+    const view = new MutablePropertyView(null, 'M');
+    view.setProperty(WALL_ID, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+    assert.equal(view.hasPendingChanges(), true, 'fixture must actually carry an edit');
+    mutationViews.set('M', view);
+  }
+
+  useViewerStore.setState({
+    models: new Map<string, FederatedModel>([['M', model('M', store)]]),
+    activeModelId: 'M',
+    mutationViews,
+    idsDocument: parseIDS(IDS_XML),
+    idsValidationReport: null,
+    idsError: null,
+    idsLoading: false,
+    idsProgress: null,
+  });
+
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  root = createRoot(el);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'useIDS must be mounted');
+}
+
+beforeEach(() => {
+  api = null;
+  instances.length = 0;
+  (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+});
+
+afterEach(async () => {
+  delete (globalThis as { Worker?: unknown }).Worker;
+  useViewerStore.setState({ mutationViews: new Map(), models: new Map(), activeModelId: null });
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('useIDS worker routing with pending property edits (#3946)', () => {
+  it('a model with NO pending edits reaches the worker (control: the fixture can route)', async () => {
+    await seed({ withPendingEdit: false });
+
+    const run: { report: IDSValidationReport | null } = { report: null };
+    await act(async () => {
+      run.report = await api!.runValidation('M');
+    });
+
+    assert.equal(instances.length, 1, 'the unedited path has always used the worker');
+    assert.equal(
+      run.report?.modelInfo.modelId,
+      'from-the-worker',
+      'the report must be the one the worker returned, not an in-process run'
+    );
+    assert.equal(
+      instances[0].posted[0].propertyOverlay,
+      undefined,
+      'no edits means no overlay — the byte-identical pre-#3946 payload'
+    );
+  });
+
+  // THE regression. Before #3946 this asserted zero worker instances, because
+  // one edit set `canUseWorker` to false and the whole model was validated on
+  // the main thread.
+  it('a model with ONE pending property edit still reaches the worker', async () => {
+    await seed({ withPendingEdit: true });
+
+    const run: { report: IDSValidationReport | null } = { report: null };
+    await act(async () => {
+      run.report = await api!.runValidation('M');
+    });
+
+    assert.equal(
+      instances.length,
+      1,
+      'one edited property must not move the whole validation onto the main thread'
+    );
+    assert.equal(run.report?.modelInfo.modelId, 'from-the-worker');
+  });
+
+  it('the edit crosses to the worker as an overlay entry, so it is not silently dropped', async () => {
+    await seed({ withPendingEdit: true });
+    await act(async () => {
+      await api!.runValidation('M');
+    });
+
+    const overlay = instances[0].posted[0].propertyOverlay;
+    assert.ok(overlay, 'routing to the worker without the overlay would validate the STALE value');
+    assert.deepEqual(overlay, [
+      [WALL_ID, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: 'F90', dataType: undefined }]],
+    ]);
+  });
+
+  it('the overlay is O(edits): an untouched entity contributes no entry', async () => {
+    await seed({ withPendingEdit: true });
+    await act(async () => {
+      await api!.runValidation('M');
+    });
+
+    const overlay = instances[0].posted[0].propertyOverlay!;
+    assert.equal(overlay.length, 1, 'the model has two walls; only the edited one may appear');
+    assert.equal(
+      overlay.some(([expressId]) => expressId === 2),
+      false
+    );
+  });
+
+  it('the overlay survives structured clone, which is how it actually reaches the worker', async () => {
+    await seed({ withPendingEdit: true });
+    await act(async () => {
+      await api!.runValidation('M');
+    });
+
+    const overlay = instances[0].posted[0].propertyOverlay!;
+    // postMessage throws DataCloneError on a non-clonable payload, and the
+    // client turns that into a rejected run — a `MutablePropertyView` (class,
+    // Maps of class instances, injected extractor FUNCTIONS) would do exactly
+    // that. This asserts the snapshot is plain data instead.
+    assert.deepEqual(structuredClone(overlay), overlay);
+  });
+
+  // The edit-fork was accidentally protecting IFCX. An IFCX store's `source` is
+  // the IFCX JSON file, so the worker's `parseColumnar` would parse JSON as
+  // STEP and validate an empty store. Dropping the fork without this guard
+  // would turn a correct main-thread validation into a silently empty one.
+  it('an IFCX (IFC5) model with a pending edit still validates in-process', async () => {
+    await seed({ withPendingEdit: true, asIfcx: true });
+
+    const run: { report: IDSValidationReport | null } = { report: null };
+    await act(async () => {
+      run.report = await api!.runValidation('M');
+    });
+
+    assert.equal(instances.length, 0, 'the worker cannot re-parse IFCX JSON as STEP');
+    assert.notEqual(
+      run.report?.modelInfo.modelId,
+      'from-the-worker',
+      'the report must come from the in-process validator'
+    );
+  });
+
+  it('an IFCX model with NO pending edits also stays in-process', async () => {
+    await seed({ withPendingEdit: false, asIfcx: true });
+    await act(async () => {
+      await api!.runValidation('M');
+    });
+    assert.equal(instances.length, 0);
+  });
+});

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useMemo, useEffect, useRef, useState } from 'react';
-import { useViewerStore } from '@/store';
+import { useViewerStore, isIfcxDataStore } from '@/store';
 import type {
   IDSAuditReport,
   IDSDocument,
@@ -36,6 +36,7 @@ import type { IDSBCFExportSettings, IDSExportProgress } from '@/components/viewe
 import { runIdsBcfExport } from './ids/idsBcfExport';
 
 import { createDataAccessor } from './ids/idsDataAccessor';
+import { snapshotPropertyOverlay } from '@/lib/ids/property-overlay-snapshot';
 import { resolveValidationTarget } from './ids/resolveValidationTarget';
 import { runValidationInWorker, idsWorkerSupported } from './ids/idsWorkerClient';
 import {
@@ -463,24 +464,43 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
 
       // A model with in-memory property edits (e.g. an IDS correction
       // applied through MutablePropertyView, #3929) must validate against
-      // THOSE edits, not the original parsed bytes. The worker only ever
-      // sees the raw source buffer, so it can't reflect an overlay that
-      // hasn't been exported/baked yet — force main-thread validation
-      // (which threads the mutation view into the data accessor below)
-      // whenever the target model has pending property mutations.
+      // THOSE edits, not the original parsed bytes. The worker re-parses
+      // the raw source buffer, so it cannot see them on its own — it is
+      // handed them, as a snapshot of the same `PropertyOverride[]`
+      // projection the main-thread accessor applies (#3946).
+      //
+      // This used to be a fork instead: ANY pending edit made
+      // `canUseWorker` false and dropped the whole run onto the main
+      // thread. That cost O(entities x specifications) — measured at
+      // ~500ms for a 250k-entity model, and identical for one edit or a
+      // thousand — and it was re-charged on every subsequent run until the
+      // edits were exported or cleared. Snapshotting instead costs
+      // O(pending edits).
       const mutationView = getMutationView(modelId);
-      const hasPendingPropertyEdits = !!mutationView?.hasPendingChanges();
+      const propertyOverlay = mutationView?.hasPendingChanges()
+        ? snapshotPropertyOverlay(mutationView)
+        : undefined;
 
       // Preferred path: validate in a Web Worker so the whole run is off
       // the main thread — the UI stays at full frame rate and progress
       // actually paints. Every other heavy stage (parse, geometry)
       // already runs in a worker; this brings validation in line. Falls
-      // back to in-process validation if the worker is unavailable, the
-      // model has no source bytes, or (see above) it carries edits the
-      // worker can't see.
+      // back to in-process validation when the worker is unavailable, the
+      // model has no source bytes for it to re-parse, or those bytes are
+      // not STEP.
+      //
+      // The IFCX exclusion is load-bearing, not defensive. An IFCX store's
+      // `source` is the IFCX **JSON** file (`buildIfcxDataStore`,
+      // hooks/ingest/viewerModelIngest.ts) and its byte index is empty, so
+      // `byteLength > 0` is true and the worker's `parseColumnar` happily
+      // parses JSON as STEP and yields a store with no properties,
+      // attributes or relationships. Before #3946 an IFCX model with
+      // pending edits was saved from that by the edits themselves, which
+      // forced the main thread; removing that fork without this term would
+      // convert a working validation into a silently empty one.
       const canUseWorker =
-        !hasPendingPropertyEdits
-        && idsWorkerSupported()
+        idsWorkerSupported()
+        && !isIfcxDataStore(dataStore)
         && !!dataStore.source
         && dataStore.source.byteLength > 0;
       if (canUseWorker) {
@@ -493,6 +513,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
             modelId,
             locale,
             includePassingEntities: true,
+            propertyOverlay,
             onProgress,
           });
         } catch (workerErr) {

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -14,7 +14,7 @@
  */
 
 import { useCallback, useMemo, useEffect, useRef, useState } from 'react';
-import { useViewerStore, isIfcxDataStore } from '@/store';
+import { useViewerStore } from '@/store';
 import type {
   IDSAuditReport,
   IDSDocument,
@@ -37,8 +37,9 @@ import { runIdsBcfExport } from './ids/idsBcfExport';
 
 import { createDataAccessor } from './ids/idsDataAccessor';
 import { snapshotPropertyOverlay } from '@/lib/ids/property-overlay-snapshot';
+import { canUseIdsWorker } from './ids/canUseIdsWorker';
 import { resolveValidationTarget } from './ids/resolveValidationTarget';
-import { runValidationInWorker, idsWorkerSupported } from './ids/idsWorkerClient';
+import { runValidationInWorker } from './ids/idsWorkerClient';
 import {
   DEFAULT_FAILED_COLOR,
   DEFAULT_PASSED_COLOR,
@@ -467,43 +468,18 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       // THOSE edits, not the original parsed bytes. The worker re-parses
       // the raw source buffer, so it cannot see them on its own — it is
       // handed them, as a snapshot of the same `PropertyOverride[]`
-      // projection the main-thread accessor applies (#3946).
-      //
-      // This used to be a fork instead: ANY pending edit made
-      // `canUseWorker` false and dropped the whole run onto the main
-      // thread. That cost O(entities x specifications) — measured at
-      // ~500ms for a 250k-entity model, and identical for one edit or a
-      // thousand — and it was re-charged on every subsequent run until the
-      // edits were exported or cleared. Snapshotting instead costs
-      // O(pending edits).
+      // projection the main-thread accessor applies (#3946). This used to
+      // be a fork instead: any pending edit dropped the whole run onto the
+      // main thread at O(entities x specifications), ~500ms for a
+      // 250k-entity model whether one property was edited or a thousand.
       const mutationView = getMutationView(modelId);
       const propertyOverlay = mutationView?.hasPendingChanges()
         ? snapshotPropertyOverlay(mutationView)
         : undefined;
 
-      // Preferred path: validate in a Web Worker so the whole run is off
-      // the main thread — the UI stays at full frame rate and progress
-      // actually paints. Every other heavy stage (parse, geometry)
-      // already runs in a worker; this brings validation in line. Falls
-      // back to in-process validation when the worker is unavailable, the
-      // model has no source bytes for it to re-parse, or those bytes are
-      // not STEP.
-      //
-      // The IFCX exclusion is load-bearing, not defensive. An IFCX store's
-      // `source` is the IFCX **JSON** file (`buildIfcxDataStore`,
-      // hooks/ingest/viewerModelIngest.ts) and its byte index is empty, so
-      // `byteLength > 0` is true and the worker's `parseColumnar` happily
-      // parses JSON as STEP and yields a store with no properties,
-      // attributes or relationships. Before #3946 an IFCX model with
-      // pending edits was saved from that by the edits themselves, which
-      // forced the main thread; removing that fork without this term would
-      // convert a working validation into a silently empty one.
-      const canUseWorker =
-        idsWorkerSupported()
-        && !isIfcxDataStore(dataStore)
-        && !!dataStore.source
-        && dataStore.source.byteLength > 0;
-      if (canUseWorker) {
+      // See canUseIdsWorker for what disqualifies a model, and why IFCX is
+      // excluded by store kind rather than by its source bytes.
+      if (canUseIdsWorker(dataStore)) {
         try {
           validationReport = await runValidationInWorker({
             // Whole-file consumer: the IDS worker re-parses the source.

--- a/apps/viewer/src/lib/ids/property-overlay-snapshot.test.ts
+++ b/apps/viewer/src/lib/ids/property-overlay-snapshot.test.ts
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The overlay snapshot that lets the IDS worker see pending property edits
+ * (#3946).
+ *
+ * Two properties matter, and neither is safe to take on trust:
+ *
+ * 1. **It carries the LIVE overlay, not the mutation history.** History is
+ *    append-only and undo does not pop it (`mutationSlice.ts` re-applies the
+ *    inverse with `skipHistory=true`), so a snapshot built from history would
+ *    ship a reverted correction to the worker as if it were still active —
+ *    the #3929 bug, reintroduced in a realm where it is harder to see.
+ *
+ * 2. **It carries ONLY property overrides.** That is what makes routing an
+ *    edited model to the worker equivalent to validating it on the main
+ *    thread rather than merely similar: the bridge accessor consults the
+ *    overlay in `getPropertyValue`/`getPropertySets` and nowhere else, so the
+ *    other ten kinds of state `hasPendingChanges()` reports (attribute edits,
+ *    retypes, quantities, tombstones, ...) were never visible to IDS
+ *    validation on EITHER path. If a snapshot silently started carrying them
+ *    the two realms would still agree, but the claim in this file's callers
+ *    would stop being the reason why.
+ *
+ * Expectations here are written out literally rather than derived from the
+ * functions under test, so a defect in the projection cannot also move the
+ * oracle.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+
+import {
+  snapshotPropertyOverlay,
+  overlayResolverFromSnapshot,
+} from './property-overlay-snapshot.js';
+
+function view(): MutablePropertyView {
+  return new MutablePropertyView(null, 'model-1');
+}
+
+describe('snapshotPropertyOverlay', () => {
+  it('is empty for a view with no edits', () => {
+    assert.deepEqual(snapshotPropertyOverlay(view()), []);
+  });
+
+  it('projects a scalar correction as one PropertyOverride', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+
+    assert.deepEqual(snapshotPropertyOverlay(v), [
+      [7, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: 'F90', dataType: undefined }]],
+    ]);
+  });
+
+  it('groups several edits on one entity into a single entry', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+    v.setProperty(7, 'Pset_WallCommon', 'IsExternal', true, PropertyValueType.Boolean);
+
+    const snapshot = snapshotPropertyOverlay(v);
+    assert.equal(snapshot.length, 1);
+    assert.equal(snapshot[0][0], 7);
+    assert.deepEqual(
+      snapshot[0][1].map((o) => [o.propName, o.value]),
+      [['FireRating', 'F90'], ['IsExternal', true]]
+    );
+  });
+
+  it('is O(edits): entities that were never touched contribute nothing', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+
+    const snapshot = snapshotPropertyOverlay(v);
+    assert.equal(snapshot.length, 1, 'a 250k-entity model with one edit must ship one entry');
+    assert.equal(overlayResolverFromSnapshot(snapshot)!(999), undefined);
+  });
+
+  // The #3929 regression, moved into a new realm. History keeps the SET row
+  // after the delete unwinds it, so a history-derived snapshot would ship the
+  // stale 'F90' and the worker would report PASS on data that reverted.
+  it('does NOT report a correction that has since been unwound', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+    v.deleteProperty(7, 'Pset_WallCommon', 'FireRating');
+
+    assert.equal(
+      v.getPropertyMutation(7, 'Pset_WallCommon', 'FireRating'),
+      undefined,
+      'oracle: the LIVE overlay no longer holds this key'
+    );
+    assert.ok(
+      v.getMutations().some((m) => m.propName === 'FireRating'),
+      'oracle: history still does, which is what makes this test worth having'
+    );
+    assert.deepEqual(snapshotPropertyOverlay(v), []);
+  });
+
+  it('skips a list/array value rather than shipping a shape the bridge cannot apply', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'Tags', ['a', 'b'] as unknown as string, PropertyValueType.String);
+
+    assert.deepEqual(snapshotPropertyOverlay(v), []);
+  });
+
+  // Property edits are the ONLY thing the accessor ever reflected — see the
+  // module doc. If any of these started appearing, the equivalence argument
+  // for routing edited models to the worker would need re-deriving.
+  it('carries no entry for mutations the IDS accessor never consulted', () => {
+    const v = view();
+    v.setAttribute(7, 'Name', 'Renamed Wall');
+    v.setQuantity(7, 'Qto_WallBaseQuantities', 'NetSideArea', 12.5);
+    v.setEntityType(7, 'IfcWall', 'IfcWallStandardCase');
+
+    assert.equal(v.hasPendingChanges(), true, 'the view really does carry pending state');
+    assert.deepEqual(
+      snapshotPropertyOverlay(v),
+      [],
+      'none of these were ever visible to IDS validation, on either path'
+    );
+  });
+
+  // A timing assertion would be flaky; this pins the SHAPE instead.
+  // `getMutationsForEntity` is a `filter` over the whole history, so one call
+  // per edited entity is O(edits^2) — measured at 174ms for 10k pending edits
+  // against 3.9ms for the single grouping pass. That is a main-thread stall
+  // put back by a different door.
+  it('walks the mutation history once, not once per edited entity', () => {
+    const v = view();
+    for (let i = 1; i <= 50; i += 1) {
+      v.setProperty(i, 'Pset_WallCommon', 'FireRating', `F${i}`, PropertyValueType.String);
+    }
+
+    let perEntityScans = 0;
+    const realPerEntity = v.getMutationsForEntity.bind(v);
+    v.getMutationsForEntity = (entityId: number) => {
+      perEntityScans += 1;
+      return realPerEntity(entityId);
+    };
+
+    const snapshot = snapshotPropertyOverlay(v);
+
+    assert.equal(snapshot.length, 50, 'sanity: every edit is still projected');
+    assert.equal(perEntityScans, 0, 'a per-entity history filter makes this quadratic');
+  });
+
+  it('is structured-clone safe, which is how it reaches the worker', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+    v.setProperty(8, 'Pset_WallCommon', 'IsExternal', false, PropertyValueType.Boolean);
+
+    const snapshot = snapshotPropertyOverlay(v);
+    // A `MutablePropertyView` would throw DataCloneError here: it holds Maps of
+    // class instances and injected extractor FUNCTIONS. Plain pairs do not.
+    assert.deepEqual(structuredClone(snapshot), snapshot);
+  });
+});
+
+describe('overlayResolverFromSnapshot', () => {
+  it('returns undefined for an absent or empty snapshot, so the caller takes the no-overlay path', () => {
+    assert.equal(overlayResolverFromSnapshot(undefined), undefined);
+    assert.equal(overlayResolverFromSnapshot([]), undefined);
+  });
+
+  it('round-trips a snapshot back to per-entity overrides', () => {
+    const v = view();
+    v.setProperty(7, 'Pset_WallCommon', 'FireRating', 'F90', PropertyValueType.String);
+    v.setProperty(8, 'Pset_WallCommon', 'FireRating', 'F30', PropertyValueType.String);
+
+    // Through structuredClone, because a resolver rebuilt in the worker is
+    // rebuilt from the CLONE, never from the object the main thread holds.
+    const resolver = overlayResolverFromSnapshot(structuredClone(snapshotPropertyOverlay(v)))!;
+
+    assert.equal(resolver(7)?.[0].value, 'F90');
+    assert.equal(resolver(8)?.[0].value, 'F30');
+    assert.equal(resolver(9), undefined);
+  });
+});

--- a/apps/viewer/src/lib/ids/property-overlay-snapshot.ts
+++ b/apps/viewer/src/lib/ids/property-overlay-snapshot.ts
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The IDS property overlay, split into a main-thread half and a
+ * realm-neutral half (#3946).
+ *
+ * ## Why this file exists
+ *
+ * `MutablePropertyView` is a live main-thread object: it holds closures
+ * (the on-demand property/attribute extractors), a base `PropertyTable`
+ * and the whole mutation history, none of which survives structured
+ * clone. That is the entire reason the IDS worker could not see pending
+ * property edits, and the reason `useIDS` used to answer "there are
+ * edits" by dropping the WHOLE validation run onto the main thread —
+ * unbounded by model size, and identical in cost for one edit or a
+ * thousand (#3946).
+ *
+ * What the bridge actually consumes is far smaller: a
+ * `PropertyOverlayResolver`, i.e. `expressId -> PropertyOverride[]`, where
+ * a `PropertyOverride` is plain scalar data. That IS clonable. So the
+ * overlay crosses to the worker as a snapshot of that projection —
+ * O(pending edits), not O(model size).
+ *
+ * ## The equivalence this file is shaped to guarantee
+ *
+ * Both realms must apply the SAME overrides, or the worker would answer a
+ * different question from the main thread and the fallback would stop
+ * being a fallback. Rather than assert that in a comment, there is
+ * exactly ONE projection function here — {@link overridesForEntity} —
+ * and both realms reach the bridge through it:
+ *
+ *   main thread:  overlayResolverFromSnapshot(snapshotPropertyOverlay(view))
+ *   worker:       overlayResolverFromSnapshot(snapshot posted to it)
+ *
+ * `snapshotPropertyOverlay` is nothing but `overridesForEntity` evaluated
+ * eagerly over every entity the overlay could possibly answer for, so the
+ * snapshot resolver and a lazy resolver over the same view are equal on
+ * every express id by construction, not by inspection.
+ *
+ * ## What the overlay does NOT carry, and why that is not a regression
+ *
+ * `MutablePropertyView.hasPendingChanges()` is true for eleven kinds of
+ * overlay state (quantity edits, attribute edits, positional attribute
+ * edits, retypes, pset/qset creates and deletes, overlay-created entities,
+ * tombstones, as well as property edits). This snapshot carries only the
+ * scalar property overrides.
+ *
+ * That matches what the accessor could ever have reflected. The bridge's
+ * `createDataAccessor(store, overlay)` consults the overlay in exactly two
+ * methods — `getPropertyValue` and `getPropertySets`; every other read
+ * (attributes, classifications, materials, partOf, predefined types,
+ * entity type) goes straight to the `IfcDataStore`, which the mutation
+ * overlay never writes into. So the pre-#3946 main-thread path did not
+ * reflect the other ten kinds either: routing a retype or a tombstone to
+ * the main thread bought nothing it could show. Only property edits were
+ * ever visible, and property edits are exactly what crosses here.
+ */
+
+import type {
+  PropertyOverride,
+  PropertyOverlayResolver,
+} from '@ifc-lite/ids/bridge';
+import type { Mutation, MutablePropertyView } from '@ifc-lite/mutations';
+
+/**
+ * The overlay reduced to structured-clone-safe plain data: one entry per
+ * entity that currently carries at least one property override.
+ *
+ * An array of pairs rather than a `Map` so the payload is also plain JSON
+ * — the worker request is posted with no transfer list, and a test can
+ * compare two snapshots with a deep-equal.
+ */
+export type PropertyOverlaySnapshot = Array<[expressId: number, overrides: PropertyOverride[]]>;
+
+/**
+ * The pending property overrides for ONE entity, or `undefined` when it
+ * has none. The single projection both realms use (see the module doc).
+ *
+ * `mutations` is this entity's slice of `mutationHistory`, and is used ONLY
+ * to enumerate WHICH (psetName, propName) pairs it has ever touched — history is
+ * append-only (undo re-applies the inverse mutation with `skipHistory=true`
+ * "to avoid polluting mutation history", `mutationSlice.ts`, so it never
+ * pops), but the identity of a touched key never becomes wrong, only stale.
+ * The actual current state/value for each key comes from
+ * `MutablePropertyView.getPropertyMutation()` — the live overlay map
+ * (`propertyMutations`), same source `hasChanges()` / `getModifiedEntityCount()`
+ * read instead of history, for the same reason. Reading `mutation.newValue`
+ * straight from history here was the bug (#3929): after an undo, the live
+ * overlay had reverted but this projection still reported the pre-undo
+ * (corrected) value as an active override, so IDS re-validation kept
+ * reporting PASS on data that had actually reverted to failing.
+ *
+ * Only property mutations with a scalar value are projected — list/array
+ * property values aren't part of this overlay's contract and are skipped
+ * rather than mis-rendered.
+ */
+function overridesForEntity(
+  view: MutablePropertyView,
+  expressId: number,
+  mutations: readonly Mutation[]
+): PropertyOverride[] | undefined {
+  if (mutations.length === 0) return undefined;
+
+  const seen = new Set<string>();
+  const overrides: PropertyOverride[] = [];
+  for (const mutation of mutations) {
+    if (!mutation.psetName || !mutation.propName) continue;
+    const dedupeKey = JSON.stringify([mutation.psetName, mutation.propName]);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    // The live, current state of this key — never the (possibly stale)
+    // `mutation` object itself. `undefined` means an undo unwound this key
+    // back to "no override at all" (see `deleteProperty`'s
+    // `deletePropertyMutation` branch): skip it so the read falls through
+    // to the base value, exactly as if it had never been touched.
+    const live = view.getPropertyMutation(expressId, mutation.psetName, mutation.propName);
+    if (!live) continue;
+
+    if (live.operation === 'DELETE') {
+      overrides.push({ psetName: mutation.psetName, propName: mutation.propName, value: null, deleted: true });
+      continue;
+    }
+
+    const value = live.value ?? null;
+    if (value !== null && typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+      // Array/list values aren't part of the overlay contract — skip
+      // rather than write a shape the bridge doesn't expect.
+      continue;
+    }
+    // `live.dataType` is set only when the writer knew one (currently
+    // the IDS correction dialog, #3929/#3943) — it lets the bridge's
+    // "no existing entry" branch (a PROPERTY_MISSING correction that
+    // CREATES a property) scale through `toBaseSI` the same way the
+    // "existing entry" branch already does. Absent for every other
+    // writer, which keeps their overrides behaving exactly as before.
+    overrides.push({
+      psetName: mutation.psetName,
+      propName: mutation.propName,
+      value,
+      dataType: live.dataType,
+    });
+  }
+  return overrides.length > 0 ? overrides : undefined;
+}
+
+/**
+ * Freeze the view's pending property overrides into plain, clonable data.
+ * Main-thread only — it needs the live `MutablePropertyView`.
+ *
+ * The candidate express ids come from `getMutations()`, the SAME
+ * append-only `mutationHistory` that `getMutationsForEntity()` filters, so
+ * the id set enumerated here is exactly the id set for which
+ * {@link overridesForEntity} can return anything but `undefined`. History
+ * over-reports (an undone edit keeps its row), which only costs a
+ * `getPropertyMutation` lookup that returns `undefined` and contributes no
+ * entry — the same conservative direction `hasPendingChanges()` documents.
+ * Under-reporting would be the dangerous direction and history cannot
+ * under-report: it never shrinks.
+ *
+ * Cost is O(mutation history), i.e. O(edits the user actually made) — NOT
+ * O(model size), which is the whole point of #3946.
+ */
+export function snapshotPropertyOverlay(view: MutablePropertyView): PropertyOverlaySnapshot {
+  // Group in ONE pass. `getMutationsForEntity()` is a `filter` over the whole
+  // history, so calling it per entity would make this O(edits^2): measured at
+  // 174ms for 10k pending edits, which would put a main-thread stall straight
+  // back — bounded by edit count rather than model size, but a stall. One pass
+  // plus a per-entity projection is O(history).
+  const byEntity = new Map<number, Mutation[]>();
+  for (const mutation of view.getMutations()) {
+    const bucket = byEntity.get(mutation.entityId);
+    if (bucket) bucket.push(mutation);
+    else byEntity.set(mutation.entityId, [mutation]);
+  }
+
+  const snapshot: PropertyOverlaySnapshot = [];
+  for (const [expressId, mutations] of byEntity) {
+    const overrides = overridesForEntity(view, expressId, mutations);
+    if (overrides) snapshot.push([expressId, overrides]);
+  }
+  return snapshot;
+}
+
+/**
+ * Rebuild the bridge's per-entity resolver from a snapshot. Realm-neutral:
+ * plain data in, closure out, no `MutablePropertyView` at runtime (the
+ * import above is type-only and erases), so the worker can call it.
+ *
+ * Returns `undefined` for an absent or empty snapshot so the caller hands
+ * the bridge no overlay at all, which is the byte-identical no-overlay
+ * path rather than an overlay that always answers `undefined`.
+ */
+export function overlayResolverFromSnapshot(
+  snapshot: PropertyOverlaySnapshot | undefined
+): PropertyOverlayResolver | undefined {
+  if (!snapshot || snapshot.length === 0) return undefined;
+  const byEntity = new Map<number, PropertyOverride[]>(snapshot);
+  return (expressId: number) => byEntity.get(expressId);
+}

--- a/apps/viewer/src/workers/idsValidation.worker.test.ts
+++ b/apps/viewer/src/workers/idsValidation.worker.test.ts
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The IDS worker must validate the model as the user currently sees it, not
+ * as it was written to disk (#3946).
+ *
+ * The worker re-parses `source`, so an in-memory property correction is
+ * invisible to it unless it is handed one. That was the whole reason
+ * `useIDS` used to refuse the worker for any model with pending edits, at a
+ * cost of O(entities x specifications) on the main thread. Routing such a
+ * model to the worker is only correct if the worker APPLIES what it is
+ * handed — a request that carries the overlay and an accessor that ignores
+ * it would silently validate the stale value and report a failure the user
+ * has already fixed.
+ *
+ * The fixture is built so the two answers differ: `FireRating` is `NONE` in
+ * the bytes and the specification requires `F90`, so the same source
+ * validates FAIL with no overlay and PASS with one. A fixture that passed
+ * either way could not observe this.
+ *
+ * `self` is stubbed before import because the module registers
+ * `self.onmessage` at evaluation time; under Node there is no worker scope.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { contiguousSourceBytes } from '@ifc-lite/parser';
+import { parseIDS, type IDSValidationReport } from '@ifc-lite/ids';
+
+import type { PropertyOverlaySnapshot } from '@/lib/ids/property-overlay-snapshot';
+import type { IdsWorkerRequest, IdsWorkerResponse } from './idsValidation.worker.js';
+
+const WALL_ID = 100;
+
+/** One IfcWall carrying Pset_WallCommon.FireRating = 'NONE'. */
+const IFC = [
+  'ISO-10303-21;',
+  'HEADER;',
+  "FILE_DESCRIPTION((''),'2;1');",
+  "FILE_NAME('3946.ifc','',(''),(''),'','','');",
+  "FILE_SCHEMA(('IFC4'));",
+  'ENDSEC;',
+  'DATA;',
+  "#1=IFCPROJECT('0project0000000000000a',$,'P',$,$,$,$,$,#9);",
+  '#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);',
+  '#9=IFCUNITASSIGNMENT((#2));',
+  `#${WALL_ID}=IFCWALL('0wall00000000000000000',$,'Wall A',$,$,$,$,$,.STANDARD.);`,
+  "#101=IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('NONE'),$);",
+  "#102=IFCPROPERTYSET('0pset00000000000000000',$,'Pset_WallCommon',$,(#101));",
+  `#103=IFCRELDEFINESBYPROPERTIES('0rel000000000000000000',$,$,$,(#${WALL_ID}),#102);`,
+  'ENDSEC;',
+  'END-ISO-10303-21;',
+  '',
+].join('\n');
+
+const IDS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ids xmlns="http://standards.buildingsmart.org/IDS" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd">
+  <info><title>#3946 worker overlay fixture</title></info>
+  <specifications>
+    <specification name="Walls are F90" ifcVersion="IFC4">
+      <applicability minOccurs="0" maxOccurs="unbounded">
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet><simpleValue>Pset_WallCommon</simpleValue></propertySet>
+          <baseName><simpleValue>FireRating</simpleValue></baseName>
+          <value><simpleValue>F90</simpleValue></value>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
+/**
+ * Requires only that `FireRating` EXISTS, which the on-disk `NONE` already
+ * satisfies. The value-constrained document above cannot observe a DELETE —
+ * the wall fails it either way — so a delete case written against it would
+ * pass with the overlay wired up or not.
+ */
+const IDS_XML_EXISTENCE = IDS_XML
+  .replace('<value><simpleValue>F90</simpleValue></value>', '')
+  .replace('#3946 worker overlay fixture', '#3946 worker overlay fixture (existence only)');
+
+const posted: IdsWorkerResponse[] = [];
+let onmessage: ((event: MessageEvent<IdsWorkerRequest>) => Promise<void>) | null = null;
+
+beforeEach(async () => {
+  posted.length = 0;
+  (globalThis as { self?: unknown }).self = {
+    postMessage: (msg: IdsWorkerResponse) => {
+      posted.push(msg);
+    },
+  };
+  // Cache-busted so each case gets a module instance whose `self` is the stub
+  // installed above rather than a previous case's.
+  await import(`./idsValidation.worker.js?t=${Date.now()}${Math.random()}`);
+  onmessage = (globalThis as { self?: { onmessage?: typeof onmessage } }).self!.onmessage!;
+});
+
+afterEach(() => {
+  onmessage = null;
+  delete (globalThis as { self?: unknown }).self;
+});
+
+async function validate(
+  propertyOverlay?: PropertyOverlaySnapshot,
+  idsXml: string = IDS_XML
+): Promise<IDSValidationReport> {
+  const request: IdsWorkerRequest = {
+    type: 'validate',
+    id: 42,
+    source: contiguousSourceBytes(new TextEncoder().encode(IFC)).toTransferable(),
+    document: parseIDS(idsXml),
+    schemaVersion: 'IFC4',
+    modelId: 'M',
+    locale: 'en',
+    includePassingEntities: true,
+    propertyOverlay,
+  };
+  await onmessage!({ data: request } as MessageEvent<IdsWorkerRequest>);
+
+  const terminal = posted.filter((m) => m.type !== 'progress');
+  assert.equal(terminal.length, 1, `expected exactly one terminal reply, got ${JSON.stringify(terminal)}`);
+  const reply = terminal[0];
+  assert.equal(reply.type, 'complete', reply.type === 'error' ? reply.message : '');
+  assert.equal(reply.id, 42, 'the reply must carry the request id');
+  return (reply as Extract<IdsWorkerResponse, { type: 'complete' }>).report;
+}
+
+describe('IDS worker property overlay (#3946)', () => {
+  // The control. Without it, a "passes with the overlay" assertion could not
+  // tell a working overlay apart from a fixture that passes regardless.
+  it('without an overlay, the on-disk FireRating=NONE fails the F90 requirement', async () => {
+    const report = await validate(undefined);
+    assert.equal(report.summary.totalEntitiesChecked, 1, 'the wall must be applicable');
+    assert.equal(report.summary.failedSpecifications, 1);
+    assert.equal(report.summary.totalEntitiesPassed, 0);
+  });
+
+  // THE regression: before #3946 the worker built its accessor with
+  // `createDataAccessor(store)` and had no way to receive this at all, so a
+  // corrected model routed here would have reported the stale failure.
+  it('an overlay correcting FireRating to F90 makes the same source PASS', async () => {
+    const report = await validate([
+      [WALL_ID, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: 'F90' }]],
+    ]);
+    assert.equal(report.summary.totalEntitiesChecked, 1);
+    assert.equal(report.summary.passedSpecifications, 1);
+    assert.equal(report.summary.totalEntitiesPassed, 1);
+    assert.equal(report.summary.failedSpecifications, 0);
+  });
+
+  it('an overlay entry for a DIFFERENT entity does not leak onto the wall', async () => {
+    const report = await validate([
+      [WALL_ID + 999, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: 'F90' }]],
+    ]);
+    assert.equal(report.summary.failedSpecifications, 1, 'the wall itself was never corrected');
+  });
+
+  it('an empty overlay behaves exactly like no overlay at all', async () => {
+    const report = await validate([]);
+    assert.equal(report.summary.failedSpecifications, 1);
+    assert.equal(report.summary.totalEntitiesChecked, 1);
+  });
+
+  it('the on-disk model PASSES the existence-only document (control for the delete case)', async () => {
+    const report = await validate(undefined, IDS_XML_EXISTENCE);
+    assert.equal(report.summary.totalEntitiesChecked, 1);
+    assert.equal(report.summary.totalEntitiesPassed, 1);
+    assert.equal(report.summary.passedSpecifications, 1);
+  });
+
+  // The overlay's other operation, measured where it can actually be seen:
+  // against a requirement the bytes already satisfy, so a worker that ignored
+  // the overlay would report the PASS above instead.
+  it('a DELETE override removes the property, turning that PASS into a failure', async () => {
+    const report = await validate(
+      [[WALL_ID, [{ psetName: 'Pset_WallCommon', propName: 'FireRating', value: null, deleted: true }]]],
+      IDS_XML_EXISTENCE
+    );
+    assert.equal(report.summary.totalEntitiesChecked, 1);
+    assert.equal(report.summary.totalEntitiesPassed, 0);
+    assert.equal(report.summary.failedSpecifications, 1);
+  });
+});

--- a/apps/viewer/src/workers/idsValidation.worker.ts
+++ b/apps/viewer/src/workers/idsValidation.worker.ts
@@ -30,6 +30,11 @@ import {
 } from '@ifc-lite/ids';
 import { createDataAccessor } from '@ifc-lite/ids/bridge';
 
+import {
+  overlayResolverFromSnapshot,
+  type PropertyOverlaySnapshot,
+} from '@/lib/ids/property-overlay-snapshot';
+
 export interface IdsWorkerRequest {
   type: 'validate';
   id: number;
@@ -41,6 +46,21 @@ export interface IdsWorkerRequest {
   modelId: string;
   locale: 'en' | 'de' | 'fr';
   includePassingEntities: boolean;
+  /**
+   * The model's pending, not-yet-exported property edits, as plain clonable
+   * data (#3946).
+   *
+   * The worker re-parses `source`, so it sees the model as it was written
+   * to disk. Before this field existed, a model with ANY pending edit was
+   * refused the worker entirely and validated on the main thread — a cost
+   * of O(entities x specifications) charged for a single corrected
+   * property, and charged again on every re-run until the edits were
+   * exported or cleared.
+   *
+   * Absent/empty means "no overlay", which is the byte-identical
+   * no-overlay path this worker always took.
+   */
+  propertyOverlay?: PropertyOverlaySnapshot;
 }
 
 export type IdsWorkerResponse =
@@ -75,7 +95,16 @@ self.onmessage = async (event: MessageEvent<IdsWorkerRequest>) => {
     store.schemaVersion =
       (req.schemaVersion as typeof store.schemaVersion) || store.schemaVersion;
 
-    const accessor = createDataAccessor(store);
+    // The SAME resolver the main-thread fallback builds, from the SAME
+    // snapshot — see `@/lib/ids/property-overlay-snapshot` (#3946). The two
+    // realms therefore apply identical overrides on top of identical
+    // parsed bytes, which is what makes routing an edited model here
+    // equivalent to validating it on the main thread rather than merely
+    // similar.
+    const accessor = createDataAccessor(
+      store,
+      overlayResolverFromSnapshot(req.propertyOverlay)
+    );
     const translator = createTranslationService(req.locale);
 
     const report = await validateIDS(


### PR DESCRIPTION
Closes #3946.

Not a cache key or a dependency array: a boolean fork at `useIDS.ts:481`. `hasPendingPropertyEdits` is true for eleven kinds of overlay state, and any one of them dropped the entire validation in-process.

Root cause: `MutablePropertyView` is a live main-thread object (base table, history, injected extractor closures) that structured clone cannot carry, so the worker could not see edits.

## Measured, both sides

Main-thread `validateIDS`, synthetic IFC4 models:

| entities | 1 pending edit | 1000 pending edits |
|---|---|---|
| 5,007 | 9 ms | 10 ms |
| 100,007 | 192 ms | 206 ms |
| 250,007 | **497 ms** | 473 ms |

Edit count does not move it; model size is the whole of it. After: snapshot plus structured clone, 0.006 ms at 1 edit, 8.5 ms at 10,000.

**Total CPU is not reduced.** The validation moves to the worker, where unedited models already ran. The win is main-thread time.

## Correctness argument

Not "results cannot have changed" but the same function of the same data. One projection in `property-overlay-snapshot.ts`; both realms build their resolver from it. The overlay funnels through `getPropertyValue` and `getPropertySets` and nowhere else, so the other ten mutation kinds were never visible on the main-thread path either.

## An accident was load-bearing

IFCX stores put IFCX **JSON** in `source` with `byteLength > 0`, so the worker would parse JSON as STEP into an empty store. Pending edits were accidentally protecting edited IFCX models. Removing the fork alone would have turned a correct validation into a silently empty one. Guarded with the existing `isIfcxDataStore` predicate.

## My own first cut was O(edits squared)

The after-measurement caught it: `getMutationsForEntity` re-filters the whole history per entity, 174 ms at 10k edits. One grouping pass, 3.9 ms, pinned by a structural test.

One weak test found en route: the DELETE case passed with the defect present, because deleting an already-failing property still fails. Rewritten against an existence-only IDS the bytes already satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - IDS validation now supports pending property edits when running in a worker.
  - Edited model data is validated consistently across worker and in-process workflows.
  - IFCX models continue to use in-process validation.

- **Bug Fixes**
  - Improved handling of edited, deleted, and reverted property values during validation.
  - Unchanged entities are excluded from transferred edit data for more efficient validation.

- **Tests**
  - Added coverage for worker routing, property overlays, entity isolation, and deletion overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->