### PR TITLE
fix(parser): say when IfcComplexProperty nesting is truncated instead of dropping it silently

### DIFF
--- a/.changeset/fix-3972-complex-property-truncation-marker.md
+++ b/.changeset/fix-3972-complex-property-truncation-marker.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Say when `IfcComplexProperty` nesting was cut short instead of stopping silently at the depth cap (issue #3972). A complex property nested deeper than 8 levels used to degrade to the bare `UsageName`, which is indistinguishable from a complex property that genuinely has no nested content; when the capped node had no `UsageName` the whole nested member vanished and its parent's own `UsageName` was shown in its place, so the reader saw a real value attributed to the wrong nesting level. The value now carries a `(truncated: nesting deeper than 8 levels)` suffix, byte-identical to the server's `resolve_complex_property_value`. The cap itself is unchanged — it is what makes a self-referencing `HasProperties` chain terminate.

--- a/apps/server/src/services/data_model/property_value.rs
+++ b/apps/server/src/services/data_model/property_value.rs
@@ -17,15 +17,41 @@ use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder};
 /// `IfcComplexProperty` at most a couple of levels deep.
 pub(super) const MAX_COMPLEX_PROPERTY_DEPTH: u8 = 8;
 
+/// The suffix minted into a complex property's display value when the depth
+/// cap stops the walk with `HasProperties` members still unread (issue
+/// #3972). Byte-identical to `complexPropertyTruncationMarker()` in
+/// `packages/parser/src/property-value-parser.ts` — the two paths feed the
+/// same property panel, CSV/parquet export and compare fingerprints, so a
+/// divergence here reads as a data difference between server and browser.
+///
+/// A suffix rather than a `truncated` flag on `Property`: a flag would have
+/// to be carried through the Rust struct + serde, the per-field parquet
+/// columns, the TS `Property` type, the `serverDataModel` adapter and the
+/// panel renderer, and is silently lost at any one of them — a signal that
+/// never fires, which is the same shape this issue is about. The value
+/// string reaches every reader by construction.
+fn complex_property_truncation_marker() -> String {
+    format!("(truncated: nesting deeper than {MAX_COMPLEX_PROPERTY_DEPTH} levels)")
+}
+
 /// Resolve an `IfcComplexProperty`'s nested `HasProperties` (EXPRESS:
 /// `[Name, Description, UsageName, HasProperties]`, index 3) into a display
 /// value plus a flat `values` candidate list, recursing into any further
 /// nested `IfcComplexProperty` — mirrors `resolveComplexPropertyValue`
 /// (`packages/parser/src/property-value-parser.ts`) member-for-member:
 ///
-/// - Not a list, or the depth cap is hit: return the bare `UsageName` (or the
-///   "null" kind when it's absent/empty) with NO truncation flag — the TS
-///   side is silent about hitting the cap too, it just stops recursing.
+/// - Not a list, or an empty list: return the bare `UsageName` (or the "null"
+///   kind when it's absent/empty) — there was nothing nested to lose.
+/// - The depth cap is hit with a NON-EMPTY `HasProperties` still unread:
+///   return `UsageName` suffixed with
+///   `complex_property_truncation_marker()`, or the bare marker when there is
+///   no `UsageName`. Never the bare `UsageName`: that is a plausible,
+///   well-formed value indistinguishable from a complex property that
+///   genuinely has no nested content (issue #3972). The empty-`UsageName`
+///   case matters most — before #3972 it produced an empty display, the
+///   parent `continue`d past it, and the whole nested member vanished while
+///   the parent fell back to showing its OWN `UsageName`, so the reader saw
+///   a real value attributed to the wrong nesting level.
 /// - Each nested member that resolves to a non-empty display becomes one
 ///   `"Name: value"` part (or bare `value` when the nested member has no
 ///   Name); a member that fails to resolve, or resolves to an empty display,
@@ -42,21 +68,32 @@ pub(super) fn resolve_complex_property_value(
     depth: u8,
 ) -> (String, String, Option<String>, Option<Vec<String>>) {
     let usage_name = entity.get_string(2).map(|s| s.to_string());
-    let has_properties_list = if depth < MAX_COMPLEX_PROPERTY_DEPTH {
-        entity.get_list(3)
-    } else {
-        None
+    let bare = |usage_name: Option<String>| match usage_name {
+        Some(u) if !u.is_empty() => (u, "string".to_string(), None, None),
+        _ => (String::new(), "null".to_string(), None, None),
     };
 
-    let refs: Vec<u32> = match has_properties_list {
-        Some(list) => list.iter().filter_map(|v| v.as_entity_ref()).collect(),
-        None => {
-            return match usage_name {
-                Some(u) if !u.is_empty() => (u, "string".into(), None, None),
-                _ => (String::new(), "null".into(), None, None),
-            };
-        }
+    let has_properties = match entity.get_list(3) {
+        Some(list) if !list.is_empty() => list,
+        // Absent, not a list, or empty: nothing nested exists, so stopping
+        // here loses nothing and must NOT be marked as a truncation.
+        _ => return bare(usage_name),
     };
+
+    if depth >= MAX_COMPLEX_PROPERTY_DEPTH {
+        // Members were present and we declined to read them. Say so.
+        let marker = complex_property_truncation_marker();
+        let value = match usage_name {
+            Some(u) if !u.is_empty() => format!("{u} {marker}"),
+            _ => marker,
+        };
+        return (value, "string".into(), None, None);
+    }
+
+    let refs: Vec<u32> = has_properties
+        .iter()
+        .filter_map(|v| v.as_entity_ref())
+        .collect();
 
     let mut parts: Vec<String> = Vec::new();
     let mut values: Vec<String> = Vec::new();

--- a/apps/server/src/services/data_model/tests.rs
+++ b/apps/server/src/services/data_model/tests.rs
@@ -1641,3 +1641,116 @@ fn unknown_type_metadata_falls_back_to_ifcelement_layout_positions() {
     assert_eq!(e.object_type.as_deref(), Some("ObjType95"));
     assert_eq!(e.tag.as_deref(), Some("Tag95"));
 }
+
+/// Issue #3972: `IfcComplexProperty` nesting past `MAX_COMPLEX_PROPERTY_DEPTH`
+/// (8) used to stop silently, so a truncated value was indistinguishable from
+/// a complete one. Four members on one wall, each probing a different shape:
+///
+/// - `C0`: a 9-level chain (`C0`..`C8`) whose deepest node carries a
+///   `UsageName` and one unread `Leaf` sub-property.
+/// - `D0`: the same 9-level chain but with the deepest node's `UsageName`
+///   absent (`$`) — the worse pre-fix shape, where the whole `D8` member
+///   vanished and `D7`'s own `UsageName` was shown in its place.
+/// - `Cyc`: a self-referencing complex property; the cap is what makes this
+///   terminate at all, which is why the fix marks the cut instead of
+///   removing the cap.
+/// - `E0`: an 8-level control (`E0`..`E7`, deepest at depth 7) whose `Leaf`
+///   IS read — the marker must not fire one level early.
+const COMPLEX_PROPERTY_DEPTH_CAP_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000003972',$,'P',$,$,$,$,$,$);
+#28=IFCWALL('Wall0000000000000003972',$,'W',$,$,$,$,$,$);
+#200=IFCPROPERTYSINGLEVALUE('Leaf',$,IFCLABEL('LeafVal'),$);
+#209=IFCCOMPLEXPROPERTY('C8',$,'U8',(#200));
+#208=IFCCOMPLEXPROPERTY('C7',$,'U7',(#209));
+#207=IFCCOMPLEXPROPERTY('C6',$,'U6',(#208));
+#206=IFCCOMPLEXPROPERTY('C5',$,'U5',(#207));
+#205=IFCCOMPLEXPROPERTY('C4',$,'U4',(#206));
+#204=IFCCOMPLEXPROPERTY('C3',$,'U3',(#205));
+#203=IFCCOMPLEXPROPERTY('C2',$,'U2',(#204));
+#202=IFCCOMPLEXPROPERTY('C1',$,'U1',(#203));
+#201=IFCCOMPLEXPROPERTY('C0',$,'U0',(#202));
+#219=IFCCOMPLEXPROPERTY('D8',$,$,(#200));
+#218=IFCCOMPLEXPROPERTY('D7',$,'V7',(#219));
+#217=IFCCOMPLEXPROPERTY('D6',$,'V6',(#218));
+#216=IFCCOMPLEXPROPERTY('D5',$,'V5',(#217));
+#215=IFCCOMPLEXPROPERTY('D4',$,'V4',(#216));
+#214=IFCCOMPLEXPROPERTY('D3',$,'V3',(#215));
+#213=IFCCOMPLEXPROPERTY('D2',$,'V2',(#214));
+#212=IFCCOMPLEXPROPERTY('D1',$,'V1',(#213));
+#211=IFCCOMPLEXPROPERTY('D0',$,'V0',(#212));
+#220=IFCCOMPLEXPROPERTY('Cyc',$,'CycUsage',(#220));
+#228=IFCCOMPLEXPROPERTY('E7',$,'W7',(#200));
+#227=IFCCOMPLEXPROPERTY('E6',$,'W6',(#228));
+#226=IFCCOMPLEXPROPERTY('E5',$,'W5',(#227));
+#225=IFCCOMPLEXPROPERTY('E4',$,'W4',(#226));
+#224=IFCCOMPLEXPROPERTY('E3',$,'W3',(#225));
+#223=IFCCOMPLEXPROPERTY('E2',$,'W2',(#224));
+#222=IFCCOMPLEXPROPERTY('E1',$,'W1',(#223));
+#221=IFCCOMPLEXPROPERTY('E0',$,'W0',(#222));
+#229=IFCCOMPLEXPROPERTY('Empty',$,'EmptyUsage',());
+#230=IFCPROPERTYSET('Pst0000000000000003972',$,'Pset_Deep',$,(#201,#211,#220,#221,#229));
+#231=IFCRELDEFINESBYPROPERTIES('Rel0000000000000003972',$,$,$,(#28),#230);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn depth_cap_property_value(dm: &DataModel, name: &str) -> String {
+    dm.property_sets
+        .iter()
+        .find(|p| p.pset_id == 230)
+        .expect("Pset_Deep must be extracted")
+        .properties
+        .iter()
+        .find(|p| p.property_name == name)
+        .unwrap_or_else(|| panic!("{name} entry missing"))
+        .property_value
+        .clone()
+}
+
+#[test]
+fn complex_property_nesting_past_the_depth_cap_says_it_was_truncated() {
+    let dm = extract_data_model(COMPLEX_PROPERTY_DEPTH_CAP_IFC);
+
+    // Pre-#3972 this was "C1: C2: C3: C4: C5: C6: C7: C8: U8" — the unread
+    // "Leaf: LeafVal" gone with no trace, and "U8" reading as C8's content.
+    assert_eq!(
+        depth_cap_property_value(&dm, "C0"),
+        "C1: C2: C3: C4: C5: C6: C7: C8: U8 (truncated: nesting deeper than 8 levels)"
+    );
+
+    // Pre-#3972 this was "D1: D2: D3: D4: D5: D6: D7: V7": D8's empty display
+    // made the parent skip it entirely, so D7 fell back to its OWN UsageName
+    // and the reader saw a genuine value at the wrong nesting level. The
+    // marker is non-empty, so D8 now survives as a member.
+    assert_eq!(
+        depth_cap_property_value(&dm, "D0"),
+        "D1: D2: D3: D4: D5: D6: D7: D8: (truncated: nesting deeper than 8 levels)"
+    );
+
+    // The cap is load-bearing: without it this self-reference never returns.
+    // Keeping it and marking the cut is the fix, not raising it.
+    assert_eq!(
+        depth_cap_property_value(&dm, "Cyc"),
+        "Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: CycUsage (truncated: nesting deeper than 8 levels)"
+    );
+}
+
+#[test]
+fn complex_property_nesting_within_the_depth_cap_is_not_marked_truncated() {
+    let dm = extract_data_model(COMPLEX_PROPERTY_DEPTH_CAP_IFC);
+
+    // E7 sits at depth 7, one below the cap, so its Leaf IS read. The marker
+    // must not fire one level early.
+    assert_eq!(
+        depth_cap_property_value(&dm, "E0"),
+        "E1: E2: E3: E4: E5: E6: E7: Leaf: LeafVal"
+    );
+
+    // An EMPTY HasProperties is a genuinely empty complex property, not a
+    // truncation — it keeps its bare UsageName at any depth.
+    assert_eq!(depth_cap_property_value(&dm, "Empty"), "EmptyUsage");
+}

--- a/packages/parser/src/property-value-parser.ts
+++ b/packages/parser/src/property-value-parser.ts
@@ -235,6 +235,26 @@ export function extractNumericValue(attr: unknown): number | null {
 const MAX_COMPLEX_PROPERTY_DEPTH = 8;
 
 /**
+ * The suffix minted into a complex property's display value when
+ * {@link MAX_COMPLEX_PROPERTY_DEPTH} stops the walk with `HasProperties`
+ * members still unread (issue #3972). Byte-identical to
+ * `complex_property_truncation_marker()` in
+ * `apps/server/src/services/data_model/property_value.rs` — the two paths
+ * feed the same property panel, CSV/parquet export and compare fingerprints,
+ * so a divergence here reads as a data difference between browser and server.
+ *
+ * A suffix rather than a `truncated` flag on `Property`: a flag would have to
+ * be carried through the `Property` type, the `serverDataModel` adapter, the
+ * Rust struct + serde, the per-field parquet columns and the panel renderer,
+ * and is silently lost at any one of them — the same "a signal that never
+ * fires" shape this issue is about. The value string reaches every reader by
+ * construction.
+ */
+function complexPropertyTruncationMarker(): string {
+    return `(truncated: nesting deeper than ${MAX_COMPLEX_PROPERTY_DEPTH} levels)`;
+}
+
+/**
  * Resolve an `IfcComplexProperty`'s nested `HasProperties` (EXPRESS:
  * `[Name, Description, UsageName, HasProperties]`, index 3) into a display
  * value plus a flat `values` candidate list, recursing into any further
@@ -242,6 +262,16 @@ const MAX_COMPLEX_PROPERTY_DEPTH = 8;
  * default branch reads attribute index 2 as if it were a `NominalValue`,
  * which for `IfcComplexProperty` is `UsageName` — a label, not a value — and
  * every nested property silently vanishes from the panel/query output.
+ *
+ * Hitting {@link MAX_COMPLEX_PROPERTY_DEPTH} with a non-empty `HasProperties`
+ * still unread appends {@link complexPropertyTruncationMarker}; a bare
+ * `UsageName` there is a plausible, well-formed value indistinguishable from
+ * a complex property that genuinely has no nested content (issue #3972). The
+ * empty-`UsageName` case matters most — before #3972 it produced an empty
+ * display, the caller loop `continue`d past it, and the whole nested member
+ * vanished while its parent fell back to showing its OWN `UsageName`, so the
+ * reader saw a real value attributed to the wrong nesting level. An absent or
+ * empty `HasProperties` is NOT a truncation and keeps the bare `UsageName`.
  */
 export function resolveComplexPropertyValue(
     store: IfcDataStore,
@@ -253,8 +283,19 @@ export function resolveComplexPropertyValue(
     const usageName = typeof attrs[2] === 'string' ? attrs[2] : '';
     const hasProperties = attrs[3];
 
-    if (!Array.isArray(hasProperties) || depth >= MAX_COMPLEX_PROPERTY_DEPTH) {
+    if (!Array.isArray(hasProperties) || hasProperties.length === 0) {
+        // Nothing nested exists, so stopping here loses nothing and must NOT
+        // be marked as a truncation.
         return { type: PropertyValueType.String, value: usageName || null };
+    }
+
+    if (depth >= MAX_COMPLEX_PROPERTY_DEPTH) {
+        // Members were present and we declined to read them. Say so.
+        const marker = complexPropertyTruncationMarker();
+        return {
+            type: PropertyValueType.String,
+            value: usageName ? `${usageName} ${marker}` : marker,
+        };
     }
 
     const parts: string[] = [];

--- a/packages/parser/test/complex-property-depth-cap.test.ts
+++ b/packages/parser/test/complex-property-depth-cap.test.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser, extractPropertiesOnDemand } from '../src/columnar-parser.js';
+
+/**
+ * Issue #3972: `IfcComplexProperty` nesting past `MAX_COMPLEX_PROPERTY_DEPTH`
+ * (8) used to stop silently, so a truncated value was indistinguishable from
+ * a complete one. Five members on one wall, each probing a different shape:
+ *
+ * - `C0`: a 9-level chain (`C0`..`C8`) whose deepest node carries a
+ *   `UsageName` and one unread `Leaf` sub-property.
+ * - `D0`: the same chain with the deepest node's `UsageName` absent (`$`) —
+ *   the worse pre-fix shape, where the whole `D8` member vanished and `D7`'s
+ *   own `UsageName` was shown in its place.
+ * - `Cyc`: a self-referencing complex property; the cap is what makes this
+ *   terminate at all, which is why the fix marks the cut rather than removing
+ *   the cap.
+ * - `E0`: an 8-level control (deepest at depth 7) whose `Leaf` IS read.
+ * - `Empty`: an empty `HasProperties` — genuinely empty, not truncated.
+ *
+ * The expected strings are byte-identical to the Rust assertions in
+ * `apps/server/src/services/data_model/tests.rs`
+ * (`complex_property_nesting_past_the_depth_cap_says_it_was_truncated`).
+ */
+const DEPTH_CAP_IFC = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#200=IFCPROPERTYSINGLEVALUE('Leaf',$,IFCLABEL('LeafVal'),$);
+#209=IFCCOMPLEXPROPERTY('C8',$,'U8',(#200));
+#208=IFCCOMPLEXPROPERTY('C7',$,'U7',(#209));
+#207=IFCCOMPLEXPROPERTY('C6',$,'U6',(#208));
+#206=IFCCOMPLEXPROPERTY('C5',$,'U5',(#207));
+#205=IFCCOMPLEXPROPERTY('C4',$,'U4',(#206));
+#204=IFCCOMPLEXPROPERTY('C3',$,'U3',(#205));
+#203=IFCCOMPLEXPROPERTY('C2',$,'U2',(#204));
+#202=IFCCOMPLEXPROPERTY('C1',$,'U1',(#203));
+#201=IFCCOMPLEXPROPERTY('C0',$,'U0',(#202));
+#219=IFCCOMPLEXPROPERTY('D8',$,$,(#200));
+#218=IFCCOMPLEXPROPERTY('D7',$,'V7',(#219));
+#217=IFCCOMPLEXPROPERTY('D6',$,'V6',(#218));
+#216=IFCCOMPLEXPROPERTY('D5',$,'V5',(#217));
+#215=IFCCOMPLEXPROPERTY('D4',$,'V4',(#216));
+#214=IFCCOMPLEXPROPERTY('D3',$,'V3',(#215));
+#213=IFCCOMPLEXPROPERTY('D2',$,'V2',(#214));
+#212=IFCCOMPLEXPROPERTY('D1',$,'V1',(#213));
+#211=IFCCOMPLEXPROPERTY('D0',$,'V0',(#212));
+#220=IFCCOMPLEXPROPERTY('Cyc',$,'CycUsage',(#220));
+#228=IFCCOMPLEXPROPERTY('E7',$,'W7',(#200));
+#227=IFCCOMPLEXPROPERTY('E6',$,'W6',(#228));
+#226=IFCCOMPLEXPROPERTY('E5',$,'W5',(#227));
+#225=IFCCOMPLEXPROPERTY('E4',$,'W4',(#226));
+#224=IFCCOMPLEXPROPERTY('E3',$,'W3',(#225));
+#223=IFCCOMPLEXPROPERTY('E2',$,'W2',(#224));
+#222=IFCCOMPLEXPROPERTY('E1',$,'W1',(#223));
+#221=IFCCOMPLEXPROPERTY('E0',$,'W0',(#222));
+#229=IFCCOMPLEXPROPERTY('Empty',$,'EmptyUsage',());
+#230=IFCPROPERTYSET('pset-guid',#1,'Pset_Deep',$,(#201,#211,#220,#221,#229));
+#231=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#230);`;
+
+async function depthCapValues(): Promise<Map<string, string>> {
+  const source = new TextEncoder().encode(DEPTH_CAP_IFC);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  const store = await parser.parseLite(source.buffer.slice(0), entityRefs, {});
+  const psets = extractPropertiesOnDemand(store, 10);
+  expect(psets).toHaveLength(1);
+  return new Map(psets[0].properties.map(p => [p.name, String(p.value)]));
+}
+
+describe('IfcComplexProperty depth cap (issue #3972)', () => {
+  it('says the value was truncated instead of stopping silently', async () => {
+    const values = await depthCapValues();
+
+    // Pre-#3972 this was "C1: C2: C3: C4: C5: C6: C7: C8: U8" — the unread
+    // "Leaf: LeafVal" gone with no trace, and "U8" reading as C8's content.
+    expect(values.get('C0')).toBe(
+      'C1: C2: C3: C4: C5: C6: C7: C8: U8 (truncated: nesting deeper than 8 levels)'
+    );
+
+    // Pre-#3972 this was "D1: D2: D3: D4: D5: D6: D7: V7": D8's empty display
+    // made the caller skip it entirely, so D7 fell back to its OWN UsageName
+    // and the reader saw a genuine value at the wrong nesting level. The
+    // marker is non-empty, so D8 now survives as a member.
+    expect(values.get('D0')).toBe(
+      'D1: D2: D3: D4: D5: D6: D7: D8: (truncated: nesting deeper than 8 levels)'
+    );
+
+    // The cap is load-bearing: without it this self-reference never returns.
+    // Keeping it and marking the cut is the fix, not raising it.
+    expect(values.get('Cyc')).toBe(
+      'Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: CycUsage (truncated: nesting deeper than 8 levels)'
+    );
+  });
+
+  it('does not mark nesting that stayed within the cap', async () => {
+    const values = await depthCapValues();
+
+    // E7 sits at depth 7, one below the cap, so its Leaf IS read. The marker
+    // must not fire one level early.
+    expect(values.get('E0')).toBe('E1: E2: E3: E4: E5: E6: E7: Leaf: LeafVal');
+
+    // An EMPTY HasProperties is a genuinely empty complex property, not a
+    // truncation — it keeps its bare UsageName at any depth.
+    expect(values.get('Empty')).toBe('EmptyUsage');
+  });
+});


### PR DESCRIPTION
Closes #3972.

## The current behaviour, measured before changing anything

A 9-level chain, the same chain with the deepest `UsageName` empty, a self-referencing chain, and an 8-level control, through both extractors:

```
C0  "C1: C2: C3: C4: C5: C6: C7: C8: U8"
D0  "D1: D2: D3: D4: D5: D6: D7: V7"
Cyc "Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: Cyc: CycUsage"
E0  "E1: E2: E3: E4: E5: E6: E7: Leaf: LeafVal"
```

Rust and TypeScript byte-identical.

- `C0` loses the leaf under C8 with no trace, and `U8` reads as C8's content.
- `D0` is worse: D8's empty display made the parent skip it, so the member vanished **and** `V7`, which is D7's own `UsageName`, is presented as D7's content. A real value at the wrong nesting level.
- `Cyc` terminates at 8. **The cap is load-bearing.**

## Why surface it rather than raise the cap

The `Cyc` probe is exactly what the cap bounds. Raising or removing it trades a visible truncation for an unbounded walk.

A `truncated` flag on `Property` was rejected too: it would have to survive the Rust struct, serde, the per-field parquet columns, the TS type, the adapter and the renderer, and being silently dropped at any one of them is the same never-fires shape the issue is about. The value string has two homes and reaches every reader by construction.

So the capped node's value carries `(truncated: nesting deeper than 8 levels)`. Because the marker is non-empty, the `D0` shape cannot recur. An absent or empty `HasProperties` is not a truncation and keeps its bare `UsageName`. Both sides derive the number from their own copy of the cap constant, so they cannot disagree about what they print.

## Left undone, deliberately

No cross-language gate pins the marker text. The repo has precedent (`check:csv-escapers`, `check:step-escapers`), but adding one is a new CI script and outside this issue. The two sites cite each other and both tests assert the identical literal, so a drift breaks a test rather than passing silently. Worth its own issue if you want it enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9