### PR TITLE
fix(codegen): stop EXPRESS element qualifiers leaking into generated types

### DIFF
--- a/.changeset/fix-4212-express-element-qualifiers.md
+++ b/.changeset/fix-4212-express-element-qualifiers.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/codegen': patch
+---
+
+express-parser: strip an EXPRESS element qualifier from every aggregate shape, not only the numerically bounded one (#4212).
+
+`UNIQUE` and `OPTIONAL` in front of an aggregate's element type (`LIST [1:?] OF UNIQUE IfcGridAxis`) constrain the elements; they are not part of the element type name and have no TypeScript equivalent. #3565 dropped them in `parseNestedCollection`, but `parseAttribute` only reached that function when the aggregate carried numeric bounds. A symbolic bound (`LIST [1:Dim] OF UNIQUE X`), no bound at all (`LIST OF UNIQUE X`), or an `OPTIONAL UNIQUE` element qualifier fell to a string-replace fallback that carried the qualifier into `attr.type` verbatim, so the emitter wrote `UNIQUE X[]` into the entity interface and `type: 'UNIQUE X'` into `schema-registry.ts`, where it sits inside a string literal that no typecheck reads. Aggregate bounds are now matched loosely and only become `arrayBounds` when both ends are numeric, and every element type goes through `parseNestedCollection`.
+
+The three schemas committed in this package (IFC2X3_TC1, IFC4_ADD2_TC1, IFC4X3) use numeric bounds for all 36 of their `OF UNIQUE` occurrences (12, 11 and 13), so their regenerated output is byte identical. The fix matters for any other `.exp` fed to the CLI.

--- a/packages/codegen/src/express-parser.ts
+++ b/packages/codegen/src/express-parser.ts
@@ -227,49 +227,13 @@ function parseAttribute(name: string, typeStr: string, optional: boolean): Attri
   // Also handle nested collections: LIST [2:?] OF LIST [2:?] OF IfcCartesianPoint
   if (typeStr.includes('LIST')) {
     attr.isList = true;
-    const listMatch = typeStr.match(/LIST\s+\[(\d+|\?):(\d+|\?)\]\s+OF\s+(.*)/);
-    if (listMatch) {
-      attr.arrayBounds = [
-        listMatch[1] === '?' ? Infinity : parseInt(listMatch[1]),
-        listMatch[2] === '?' ? Infinity : parseInt(listMatch[2])
-      ];
-      const innerType = listMatch[3].trim();
-      // Recursively parse nested collection
-      attr.type = parseNestedCollection(innerType);
-    } else {
-      // Fallback if regex doesn't match
-      attr.type = typeStr.replace(/LIST\s+\[.*?\]\s+OF\s+/, '').trim();
-    }
+    applyAggregate(attr, typeStr, 'LIST');
   } else if (typeStr.includes('ARRAY')) {
     attr.isArray = true;
-    const arrayMatch = typeStr.match(/ARRAY\s+\[(\d+|\?):(\d+|\?)\]\s+OF\s+(.*)/);
-    if (arrayMatch) {
-      attr.arrayBounds = [
-        arrayMatch[1] === '?' ? Infinity : parseInt(arrayMatch[1]),
-        arrayMatch[2] === '?' ? Infinity : parseInt(arrayMatch[2])
-      ];
-      const innerType = arrayMatch[3].trim();
-      // Recursively parse nested collection
-      attr.type = parseNestedCollection(innerType);
-    } else {
-      // Fallback if regex doesn't match
-      attr.type = typeStr.replace(/ARRAY\s+\[.*?\]\s+OF\s+/, '').trim();
-    }
+    applyAggregate(attr, typeStr, 'ARRAY');
   } else if (typeStr.includes('SET')) {
     attr.isSet = true;
-    const setMatch = typeStr.match(/SET\s+\[(\d+|\?):(\d+|\?)\]\s+OF\s+(.*)/);
-    if (setMatch) {
-      attr.arrayBounds = [
-        setMatch[1] === '?' ? Infinity : parseInt(setMatch[1]),
-        setMatch[2] === '?' ? Infinity : parseInt(setMatch[2])
-      ];
-      const innerType = setMatch[3].trim();
-      // Recursively parse nested collection
-      attr.type = parseNestedCollection(innerType);
-    } else {
-      // Fallback if regex doesn't match
-      attr.type = typeStr.replace(/SET\s+\[.*?\]\s+OF\s+/, '').trim();
-    }
+    applyAggregate(attr, typeStr, 'SET');
   } else {
     attr.type = typeStr;
   }
@@ -277,20 +241,56 @@ function parseAttribute(name: string, typeStr: string, optional: boolean): Attri
   return attr;
 }
 
+type AggregateKeyword = 'LIST' | 'ARRAY' | 'SET';
+
+/**
+ * The tail of an EXPRESS aggregate declaration: optional bounds, then OF and
+ * the element type. Bounds may be absent ("LIST OF UNIQUE IfcGridAxis") and
+ * need not be numeric ("ARRAY [0:UUpper] OF ..."), so they are matched loosely
+ * and only become arrayBounds when both ends turn out to be numeric. One
+ * pattern shared by every caller, so no aggregate shape can reach the element
+ * type by a route that skips parseNestedCollection, where qualifiers drop.
+ */
+const AGGREGATE_TAIL = String.raw`\s*(?:\[([^\]]*)\])?\s+OF\s+([\s\S]*)`;
+const AGGREGATE_RE: Record<AggregateKeyword, RegExp> = {
+  LIST: new RegExp(`LIST${AGGREGATE_TAIL}`),
+  ARRAY: new RegExp(`ARRAY${AGGREGATE_TAIL}`),
+  SET: new RegExp(`SET${AGGREGATE_TAIL}`),
+};
+const NESTED_AGGREGATE_RE = new RegExp(`^(?:LIST|ARRAY|SET)${AGGREGATE_TAIL}`);
+const NUMERIC_BOUNDS = /^\s*(\d+|\?)\s*:\s*(\d+|\?)\s*$/;
+
+/** Record an aggregate's bounds and element type on `attr`. */
+function applyAggregate(attr: AttributeDefinition, typeStr: string, keyword: AggregateKeyword): void {
+  const match = typeStr.match(AGGREGATE_RE[keyword]);
+  if (!match) {
+    // Not an aggregate declaration despite containing the keyword.
+    attr.type = typeStr;
+    return;
+  }
+
+  const numeric = match[1]?.match(NUMERIC_BOUNDS);
+  if (numeric) {
+    attr.arrayBounds = [
+      numeric[1] === '?' ? Infinity : parseInt(numeric[1]),
+      numeric[2] === '?' ? Infinity : parseInt(numeric[2]),
+    ];
+  }
+  attr.type = parseNestedCollection(match[2].trim());
+}
+
 /**
  * Parse nested collection types, e.g. "LIST [2:?] OF IfcCartesianPoint" ->
- * "IfcCartesianPoint[]". A leading "UNIQUE" (e.g. "LIST [1:?] OF UNIQUE
- * IfcGridAxis") constrains the elements, not the element type — strip it.
+ * "IfcCartesianPoint[]". A leading "OPTIONAL" and/or "UNIQUE" (e.g. "LIST [1:?]
+ * OF UNIQUE IfcGridAxis") qualifies the elements, it is not part of the element
+ * type name, so strip it. Neither has a TypeScript type equivalent.
  */
 function parseNestedCollection(typeStr: string): string {
-  const stripped = typeStr.replace(/^UNIQUE\s+/, '');
+  const stripped = typeStr.replace(/^(?:OPTIONAL\s+)?(?:UNIQUE\s+)?/, '');
   // Check if this is another collection: LIST|ARRAY|SET [min:max] OF <innerType>
-  if (stripped.match(/^(LIST|ARRAY|SET)\s+\[/)) {
-    const match = stripped.match(/^(?:LIST|ARRAY|SET)\s+\[(?:\d+|\?):(?:\d+|\?)\]\s+OF\s+(.*)/);
-    if (match) {
-      const innerType = match[1].trim();
-      return `${parseNestedCollection(innerType)}[]`; // recursively parse and wrap in array
-    }
+  const match = stripped.match(NESTED_AGGREGATE_RE);
+  if (match) {
+    return `${parseNestedCollection(match[2].trim())}[]`; // recursively parse and wrap in array
   }
 
   // Base case: return the type as-is

--- a/packages/codegen/test/express-parser.test.ts
+++ b/packages/codegen/test/express-parser.test.ts
@@ -466,6 +466,78 @@ describe('EXPRESS Parser', () => {
       expect(locations.type).toBe('IfcLengthMeasure[]');
       expect(locations.type).not.toContain('UNIQUE');
     });
+
+    /**
+     * The three cases above all carry numeric aggregate bounds, which is the
+     * only shape the committed IFC4/IFC4X3 schemas use. EXPRESS (ISO 10303-11)
+     * also allows a symbolic bound, no bound at all, and an OPTIONAL qualifier
+     * in front of UNIQUE. Those forms miss the numeric bounds pattern, so the
+     * element type never reached the code that strips UNIQUE and the qualifier
+     * was carried into attr.type verbatim.
+     */
+    it('strips UNIQUE when the aggregate bound is symbolic', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY EntSymbolicBound
+          SUBTYPE OF (IfcRoot);
+          Axes : LIST [1:Dim] OF UNIQUE IfcGridAxis;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(
+        schema.entities.find(e => e.name === 'EntSymbolicBound')!,
+        schema
+      );
+      const axes = attrs.find(a => a.name === 'Axes')!;
+      expect(axes.type).toBe('IfcGridAxis');
+      expect(axes.type).not.toContain('UNIQUE');
+    });
+
+    it('strips UNIQUE when the aggregate has no bounds', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY EntUnbounded
+          SUBTYPE OF (IfcRoot);
+          Axes : LIST OF UNIQUE IfcGridAxis;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(
+        schema.entities.find(e => e.name === 'EntUnbounded')!,
+        schema
+      );
+      const axes = attrs.find(a => a.name === 'Axes')!;
+      expect(axes.type).toBe('IfcGridAxis');
+      expect(axes.type).not.toContain('UNIQUE');
+    });
+
+    it('strips an OPTIONAL UNIQUE element qualifier from an ARRAY', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY EntOptionalUnique
+          SUBTYPE OF (IfcRoot);
+          Axes : ARRAY [1:3] OF OPTIONAL UNIQUE IfcGridAxis;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(
+        schema.entities.find(e => e.name === 'EntOptionalUnique')!,
+        schema
+      );
+      const axes = attrs.find(a => a.name === 'Axes')!;
+      expect(axes.type).toBe('IfcGridAxis');
+      expect(axes.type).not.toContain('UNIQUE');
+      expect(axes.type).not.toContain('OPTIONAL');
+    });
   });
 
   describe('Real IFC schema parsing', () => {

--- a/packages/codegen/test/typescript-generator.test.ts
+++ b/packages/codegen/test/typescript-generator.test.ts
@@ -46,6 +46,35 @@ describe('TypeScript Generator', () => {
       expect(code.entities).toMatch(/[^\n]\n$/);
     });
 
+    /**
+     * attr.type reaches two emitters: the interface property type, where tsc
+     * would reject a stray `UNIQUE`, and schema-registry.ts, where it is
+     * emitted inside a string literal that no typecheck can ever look at.
+     * Assert both, so a leak cannot hide in the quiet channel.
+     */
+    it('never emits an EXPRESS element qualifier into a type or the registry', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY EntQualified;
+          SymbolicBound : LIST [1:Dim] OF UNIQUE IfcGridAxis;
+          Unbounded : LIST OF UNIQUE IfcGridAxis;
+          OptionalUnique : ARRAY [1:3] OF OPTIONAL UNIQUE IfcGridAxis;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const code = generateTypeScript(schema);
+
+      expect(code.entities).not.toMatch(/\bUNIQUE\b/);
+      expect(code.entities).toContain('SymbolicBound: IfcGridAxis[];');
+      expect(code.schemaRegistry).not.toMatch(/\bUNIQUE\b/);
+      // Paired with the negative above so an empty or attribute-less registry
+      // cannot satisfy it by having nothing to leak.
+      expect(code.schemaRegistry).toContain("name: 'SymbolicBound',\n          type: 'IfcGridAxis',");
+    });
+
     it('should generate interface with inheritance', () => {
       const schema = parseExpressSchema(`
         SCHEMA TEST;


### PR DESCRIPTION
Closes #4212.

On main the emitter really does write:

```
SymbolicBound: UNIQUE IfcGridAxis[];
Unbounded:     LIST OF UNIQUE IfcGridAxis[];
OptionalUnique: OPTIONAL UNIQUE IfcGridAxis[];
```

`UNIQUE` is an EXPRESS element qualifier, not a type. Fixed at the parser rather than the emitter: the qualifier is consumed where the aggregate is read, so nothing downstream has to know about it.

## Byte-identity measured, not asserted

I regenerated all three committed schemas with the rebuilt CLI and `git status --porcelain generated/` is empty. So the fix changes what the parser ACCEPTS without changing a byte of what currently ships.

The reason is in the changeset: all three committed schemas (IFC2X3_TC1, IFC4_ADD2_TC1, IFC4X3) use numerically-bounded aggregates for all 36 of their `OF UNIQUE` occurrences (12, 11 and 13), and the old `NUMERIC_BOUNDS` pattern already handled those. The unbounded form is what leaked, and no committed schema uses it.

That count was wrong in the first draft of the changeset (it said "two schemas" and "24") and is corrected here, because that text ships in the published CHANGELOG.

## Scope

Only `UNIQUE`. The review asked whether the sibling clauses (`WHERE`, `INVERSE`, `DERIVE`, SUBTYPE constraints) leak the same way; they are a separate class handled elsewhere in the grammar and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9