### PR TITLE
fix(ci): make the aggregate gate judge every job it depends on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,11 @@ jobs:
     # standard runner so routine CI remains within the Depot Developer tier.
     # See scripts/README-vercel-cost.md for the full runner-cost rationale.
     runs-on: ubuntu-latest
+    # A path filter over one checkout. Anything past a minute is a hung API call,
+    # not work. Capped because the default is SIX HOURS and a job killed by its own
+    # timeout does NOT cancel the run: the aggregate would still run, every lane
+    # would read `skipped`, and before the map entry above that was a green gate.
+    timeout-minutes: 5
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -1150,6 +1155,17 @@ jobs:
       # block / zero derived inputs must FAIL rather than report clean.
       - name: Check CI path-coverage gate regressions
         run: node --test scripts/check-ci-path-coverage.test.mjs
+      # The neighbouring class, and the one the comment above names in passing:
+      # a skipped job counts as success in the aggregate `test` gate, so a job
+      # that is in its `needs:` but MISSING from its results map is unjudged --
+      # its failure skips every dependent, every skip reads as a pass, and a
+      # required context on main reports green. `changes` was exactly that.
+      - name: Check the aggregate gate judges every job it depends on
+        run: node scripts/check-ci-aggregate-coverage.mjs
+      # Executable proof it cannot pass vacuously: an unfindable or empty
+      # `test:` job must FAIL rather than report "0 unjudged of 0".
+      - name: Check aggregate-coverage gate regressions
+        run: node --test scripts/check-ci-aggregate-coverage.test.mjs
       # Same class as the gate above (#3452), for a case it cannot see: its
       # own scan only recognises gates invoked as a literal `node
       # scripts/*.mjs` in a `run:` step, and sdk-canary.yml's job is `pnpm
@@ -2081,6 +2097,12 @@ jobs:
       - name: Gate on dependencies
         run: |
           declare -A results=(
+            # `changes` is judged like any other lane, and it matters most: every
+            # other job here `needs` it, so if it fails they all SKIP, and `skipped`
+            # counts as a pass below. Unjudged, one failure took the whole matrix
+            # green on a required context. scripts/check-ci-aggregate-coverage.mjs
+            # keeps this map and the `needs:` list above in step.
+            [changes]="${{ needs.changes.result }}"
             [build]="${{ needs.build.result }}"
             [revert-oracle]="${{ needs.revert-oracle.result }}"
             [typecheck]="${{ needs.typecheck.result }}"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:snap-edges": "node scripts/test-snap-edges.mjs",
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
     "check:ci-path-coverage": "node scripts/check-ci-path-coverage.mjs",
+    "check:ci-aggregate-coverage": "node scripts/check-ci-aggregate-coverage.mjs",
     "check:test-glob-coverage": "node scripts/check-test-glob-coverage.mjs",
     "check:source-text-assertions": "node scripts/check-source-text-assertions.mjs",
     "check:rust-source-text-assertions": "node scripts/check-rust-source-text-assertions.mjs",

--- a/scripts/check-ci-aggregate-coverage.mjs
+++ b/scripts/check-ci-aggregate-coverage.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Ratchet: every job the aggregate gate DEPENDS ON must appear in the map it
+ * JUDGES.
+ *
+ * THE DEFECT CLASS. `test.yml`'s `test` job is the required context that guards
+ * `main`. It runs `if: always()` and decides pass/fail by walking a hand-written
+ * `results` map of `needs.<job>.result`. `needs:` and that map are two lists of
+ * the same thing, written in two places, and nothing kept them in step. A job
+ * present in `needs:` but absent from the map is UNJUDGED: its failure cannot
+ * raise `fail`, so the aggregate exits 0.
+ *
+ * That is worse than an unwatched job, because of how `needs:` propagates. When
+ * a dependency fails, every job that needs it is SKIPPED, and `skipped` counts
+ * as a pass here (`case "$r" in success|skipped)`) for the good reason that path
+ * filters skip most lanes on most PRs. So an unjudged job failing does not just
+ * hide its own result: it skips its dependents, every skip reads as success, the
+ * fail count is zero, and a required context reports green having run almost
+ * nothing.
+ *
+ * THE INSTANCE THIS WAS WRITTEN FOR. `changes` (Detect changes) was in `needs:`
+ * and not in the map. It is the path-filter job every other lane depends on, so
+ * it is the single worst job to leave unjudged: if it fails, all thirteen lanes
+ * skip, the map reads all-skipped, and `Build + WASM + Rust + Node` goes green.
+ *
+ * NEVER OBSERVED, AND SAID PLAINLY. Sampling 24 recent `test.yml` runs,
+ * `Detect changes` came back 19 success, 3 cancelled, 2 queued and zero
+ * failures, and in the cancelled runs the aggregate correctly reported
+ * `failure` -- workflow-level cancellation from a force-push cancels the
+ * aggregate too, and `if: always()` does not rescue a job from that. So this
+ * closes a latent path, not an incident. The live routes to it are a step
+ * FAILURE (a paths-filter API error, a checkout failure) and a job-level
+ * TIMEOUT, which does not cancel the run. `changes` carried no
+ * `timeout-minutes` and inherited the six-hour default; that is fixed in the
+ * same commit.
+ *
+ * WHY A SCRIPT AND NOT A COMMENT. The pairing is the kind that drifts silently:
+ * adding a lane means editing `needs:` and the map, and forgetting the second
+ * costs nothing at author time and everything later. `scripts/check-ci-path-coverage.mjs`
+ * exists for the neighbouring class ("a gate may not read a path that cannot
+ * trigger it") and its header already names this one in passing -- "the
+ * aggregate `test` gate reports success because a skipped job counts as
+ * success". This makes that observation enforceable.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = join(ROOT, '.github/workflows/test.yml');
+
+/**
+ * Pull the aggregate job's `needs:` list and the job names its `results` map
+ * judges.
+ *
+ * Deliberately regex over the raw text rather than a YAML parse: the map lives
+ * inside a `run:` block-scalar, so a YAML parser hands back one opaque string
+ * and the keys still need extracting by regex. Parsing the whole file to then
+ * regex a string buys nothing and adds a dependency.
+ */
+export function readAggregate(text, jobName = 'test') {
+  // `(?![\\s\\S])` and not `$`: under the `m` flag `$` matches at the end of EVERY
+  // line, so a lazy body stops at the first newline and the job reads as empty.
+  // That produced a "needs: []" verdict on a job with fourteen of them.
+  const job = new RegExp(`^  ${jobName}:\\n([\\s\\S]*?)(?=\\n  \\S|(?![\\s\\S]))`, 'm').exec(text);
+  if (!job) return null;
+  const body = job[1];
+
+  const needsLine = /^\s*needs:\s*\[([^\]]*)\]/m.exec(body);
+  const needs = needsLine
+    ? needsLine[1].split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  // BOTH halves of `[job]="${{ needs.job.result }}"`, and they must agree. The
+  // bracket key is what the bash loop iterates and what gets reported; the
+  // interpolation is what is actually READ. Checking only the key misses the
+  // likeliest way to add a lane wrong: copy the row above, edit the bracket,
+  // forget the right-hand side. That yields `[new]="${{ needs.build.result }}"`,
+  // which judges `build` twice and leaves `new` unjudged while this gate reports
+  // full coverage — the same fail-open one level in.
+  //
+  // Either quote: `[job]='${{ ... }}'` is valid bash and valid interpolation, and
+  // requiring `"` made a legal map parse as zero entries. Fail-closed, but the
+  // remedy text sent you hunting a coverage hole that was not there.
+  const rows = [...body.matchAll(
+    /^\s*\[([A-Za-z0-9_-]+)\]=["']\$\{\{\s*needs\.([A-Za-z0-9_-]+)\.result/gm
+  )].map((m) => ({ key: m[1], reads: m[2] }));
+
+  const judged = rows.map((r) => r.key);
+  const mismatched = rows.filter((r) => r.key !== r.reads);
+  const seen = new Set();
+  const duplicated = judged.filter((k) => (seen.has(k) ? true : (seen.add(k), false)));
+
+  return { needs, judged: [...new Set(judged)], mismatched, duplicated };
+}
+
+/** Jobs that are depended on but never judged. */
+export function unjudged({ needs, judged }) {
+  const seen = new Set(judged);
+  return needs.filter((n) => !seen.has(n));
+}
+
+/** Jobs judged but not depended on: the map would read an empty result forever. */
+export function unreachable({ needs, judged }) {
+  const seen = new Set(needs);
+  return judged.filter((j) => !seen.has(j));
+}
+
+/**
+ * Jobs that run on a `pull_request` yet are deliberately NOT judged by the
+ * aggregate. Each needs a reason, because the default has to be "blocking" for
+ * the gate to mean anything, and an exemption is a decision rather than an
+ * oversight.
+ *
+ * Keep this list SHORT and ratchet it down. An entry here is a lane whose
+ * failure cannot stop a merge.
+ */
+export const UNJUDGED_BY_DESIGN = {
+  'csg-accept-gates':
+    'Advisory. Runs only when geometry changed and reports accept-gate deltas; ' +
+    'it is not in the branch ruleset either. Whether it SHOULD block is an open ' +
+    'question, tracked separately rather than decided by this gate.',
+};
+
+/**
+ * Every job in the `jobs:` block that a `pull_request` can reach.
+ *
+ * Scoped to the `jobs:` section on purpose: a naive `^  name:$` sweep of the
+ * whole file also matches `push:` and `pull_request:` under the top-level `on:`
+ * trigger, which is how an earlier ad-hoc probe reported a job that does not
+ * exist.
+ */
+export function prJobs(text) {
+  const jobsAt = text.indexOf('\njobs:\n');
+  if (jobsAt < 0) return [];
+  const section = text.slice(jobsAt);
+  const names = [...section.matchAll(/^  ([A-Za-z0-9_-]+):$/gm)].map((m) => m[1]);
+  return names.filter((n) => {
+    const body = new RegExp(`^  ${n}:\\n([\\s\\S]*?)(?=\\n  \\S|(?![\\s\\S]))`, 'm').exec(section);
+    if (!body) return false;
+    // A job gated to a non-PR event cannot block a PR, so it is not in scope.
+    return !/if:.*github\.event_name\s*(!=\s*'pull_request'|==\s*'push')/.test(body[1]);
+  });
+}
+
+/** PR-reachable jobs the aggregate neither depends on nor exempts. */
+export function unwatched(text, { needs }) {
+  const judged = new Set(needs);
+  return prJobs(text).filter(
+    (j) => j !== 'test' && !judged.has(j) && !(j in UNJUDGED_BY_DESIGN)
+  );
+}
+
+function main() {
+  const text = readFileSync(WORKFLOW, 'utf8');
+  const agg = readAggregate(text);
+
+  if (!agg) {
+    console.error(
+      '❌ AGGREGATE_JOB_NOT_FOUND: no `test:` job in .github/workflows/test.yml.\n' +
+        '   This gate reads that job by name. If it was renamed, rename it here too —\n' +
+        '   a gate that cannot find its subject must fail, not pass quietly.'
+    );
+    process.exit(1);
+  }
+  if (agg.needs.length === 0) {
+    console.error(
+      '❌ AGGREGATE_NEEDS_EMPTY: the `test:` job declares no `needs:` list.\n' +
+        '   Either the job changed shape or this parser broke. Failing rather than\n' +
+        '   reporting "0 unjudged of 0", which is the vacuous pass this file exists to stop.'
+    );
+    process.exit(1);
+  }
+
+  const missing = unjudged(agg);
+  const extra = unreachable(agg);
+  const loose = unwatched(text, agg);
+  const { mismatched = [], duplicated = [] } = agg;
+
+  console.log(`aggregate \`test\`: ${agg.needs.length} needs, ${agg.judged.length} judged`);
+
+  if (mismatched.length > 0) {
+    console.error(
+      `\n❌ MAP_KEY_MISMATCH: ${mismatched.length} row(s) judge a different job than they name:\n` +
+        mismatched.map((m) => `      - [${m.key}] reads needs.${m.reads}.result`).join('\n') +
+        '\n   The bash loop reports the bracket key, so this reads as coverage while the\n' +
+        '   named lane is never judged and another is judged twice.\n' +
+        '   REMEDY: make both halves the same job name.'
+    );
+  }
+  if (duplicated.length > 0) {
+    console.error(
+      `\n❌ DUPLICATE_MAP_KEY: ${duplicated.length} job(s) appear twice in the map:\n` +
+        duplicated.map((m) => `      - ${m}`).join('\n') +
+        '\n   bash keeps the LAST assignment, so the earlier row is dead and the count\n' +
+        '   above overstates coverage.\n' +
+        '   REMEDY: delete the duplicate row.'
+    );
+  }
+  if (loose.length > 0) {
+    console.error(
+      `\n❌ UNWATCHED_JOB: ${loose.length} job(s) run on a pull_request but the aggregate ` +
+        'neither depends on them nor exempts them:\n' +
+        loose.map((m) => `      - ${m}`).join('\n') +
+        '\n   Their failure cannot stop a merge, and unlike an unjudged dependency this\n' +
+        '   one is invisible from the `needs:` list alone.\n' +
+        '   REMEDY: add the job to `needs:` AND to the results map to make it blocking,\n' +
+        '   or add it to UNJUDGED_BY_DESIGN in this file with the reason it is advisory.'
+    );
+  }
+  if (missing.length === 0 && extra.length === 0 && mismatched.length === 0 && duplicated.length === 0 && loose.length === 0) {
+    console.log('✔ every dependency of the aggregate gate is judged by it');
+    return;
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      `\n❌ UNJUDGED_DEPENDENCY: ${missing.length} job(s) the aggregate depends on are ` +
+        'absent from its `results` map, so their failure cannot fail the gate:\n' +
+        missing.map((m) => `      - ${m}`).join('\n') +
+        '\n   A failed job also SKIPS everything that needs it, and `skipped` counts as a\n' +
+        '   pass here, so an unjudged failure can take the whole matrix green.\n' +
+        '   REMEDY: add `[<job>]="${{ needs.<job>.result }}"` to the map in test.yml.'
+    );
+  }
+  if (extra.length > 0) {
+    console.error(
+      `\n❌ UNREACHABLE_JUDGEMENT: ${extra.length} entr(y|ies) in the \`results\` map name a ` +
+        'job the aggregate does not depend on:\n' +
+        extra.map((m) => `      - ${m}`).join('\n') +
+        '\n   `needs.<absent>.result` interpolates to the empty string, which is neither\n' +
+        '   `success` nor `skipped`, so this fails the gate on every run — or, if the\n' +
+        '   case arms change, silently stops meaning anything.\n' +
+        '   REMEDY: add the job to `needs:`, or drop the map entry.'
+    );
+  }
+  process.exit(1);
+}
+
+// `pathToFileURL`, not `file://${argv[1]}`: `import.meta.url` percent-encodes a
+// space, `#`, `?` or any non-ASCII byte in the path and `process.argv[1]` does
+// not, so the string compare is false and `main()` never runs. The CI step then
+// exits 0 having read nothing -- a gate that cannot find its subject passing
+// quietly, which is the thing this file refuses to do everywhere else.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-ci-aggregate-coverage.mjs
+++ b/scripts/check-ci-aggregate-coverage.mjs
@@ -223,6 +223,9 @@ function main() {
         missing.map((m) => `      - ${m}`).join('\n') +
         '\n   A failed job also SKIPS everything that needs it, and `skipped` counts as a\n' +
         '   pass here, so an unjudged failure can take the whole matrix green.\n' +
+        // A literal GitHub Actions expression for the user to paste, not JS
+        // interpolation.
+        // eslint-disable-next-line no-template-curly-in-string
         '   REMEDY: add `[<job>]="${{ needs.<job>.result }}"` to the map in test.yml.'
     );
   }

--- a/scripts/check-ci-aggregate-coverage.test.mjs
+++ b/scripts/check-ci-aggregate-coverage.test.mjs
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * The gate is only worth having if it goes RED on the shape it exists to catch,
+ * so every case here is a positive control: a synthetic workflow carrying the
+ * defect, asserted to be reported. The last case pins the real file.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { readAggregate, unjudged, unreachable, prJobs, unwatched, UNJUDGED_BY_DESIGN } from './check-ci-aggregate-coverage.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const workflow = (needs, judged) => `on: [push]
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+  test:
+    name: Build + WASM + Rust + Node
+    needs: [${needs.join(', ')}]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate on dependencies
+        run: |
+          declare -A results=(
+${judged.map((j) => `            [${j}]="\${{ needs.${j}.result }}"`).join('\n')}
+          )
+          exit $fail
+`;
+
+test('RED: a job in needs but absent from the map is reported unjudged', () => {
+  const agg = readAggregate(workflow(['changes', 'build'], ['build']));
+  assert.deepEqual(unjudged(agg), ['changes']);
+});
+
+test('RED: this is the exact #4144 shape — changes unjudged while every lane needs it', () => {
+  const agg = readAggregate(workflow(['changes', 'build', 'lint'], ['build', 'lint']));
+  assert.ok(unjudged(agg).includes('changes'));
+});
+
+test('RED: a map entry naming a job not in needs is reported unreachable', () => {
+  const agg = readAggregate(workflow(['build'], ['build', 'ghost']));
+  assert.deepEqual(unreachable(agg), ['ghost']);
+});
+
+test('GREEN: a fully covered aggregate reports nothing', () => {
+  const agg = readAggregate(workflow(['changes', 'build'], ['changes', 'build']));
+  assert.deepEqual(unjudged(agg), []);
+  assert.deepEqual(unreachable(agg), []);
+});
+
+test('the parser survives `$` under the m flag, which truncated the body to one line', () => {
+  // The first draft used `(?=\n  \S|$)`. With /m, `$` matches at every line end,
+  // so the lazy body stopped after `name:` and a job with fourteen dependencies
+  // reported `needs: []` — a vacuous pass dressed as a parse.
+  const agg = readAggregate(workflow(['a', 'b', 'c'], ['a']));
+  assert.equal(agg.needs.length, 3, 'body must span past the first newline');
+});
+
+test('RED: a row whose bracket key and interpolation disagree is reported', () => {
+  // The likeliest way to add a lane wrong: copy the row above, edit the bracket,
+  // forget the right-hand side. Checking only the key called this full coverage.
+  const text = workflow(['changes', 'build'], ['changes', 'build']).replace(
+    '[build]="${{ needs.build.result }}"',
+    '[build]="${{ needs.changes.result }}"'
+  );
+  const agg = readAggregate(text);
+  assert.deepEqual(agg.mismatched, [{ key: 'build', reads: 'changes' }]);
+});
+
+test('RED: a duplicated bracket key is reported, not deduped away', () => {
+  // bash keeps the LAST assignment, so an earlier duplicate row is dead code and
+  // the "N judged" count overstates coverage.
+  const text = workflow(['changes', 'build'], ['changes', 'build', 'build']);
+  const agg = readAggregate(text);
+  assert.deepEqual(agg.duplicated, ['build']);
+});
+
+test('a single-quoted map value is accepted, not read as zero coverage', () => {
+  // `[job]='${{ ... }}'` is valid bash and valid interpolation. Requiring `"`
+  // made a legal map parse as no entries: fail-closed, but the remedy text sent
+  // you hunting a coverage hole that did not exist.
+  const text = workflow(['build'], ['build']).replace(
+    '[build]="${{ needs.build.result }}"',
+    "[build]='${{ needs.build.result }}'"
+  );
+  const agg = readAggregate(text);
+  assert.deepEqual(agg.judged, ['build']);
+  assert.deepEqual(unjudged(agg), []);
+});
+
+test('RED: a PR-reachable job outside needs and outside the exemptions is reported', () => {
+  const text = `on: [pull_request]
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+  stray:
+    name: Stray lane
+    needs: changes
+    runs-on: ubuntu-latest
+  test:
+    needs: [changes]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          declare -A results=(
+            [changes]="\${{ needs.changes.result }}"
+          )
+`;
+  assert.deepEqual(unwatched(text, readAggregate(text)), ['stray']);
+});
+
+test('prJobs reads the jobs: block only, not the on: trigger keys', () => {
+  // A naive `^  name:$` sweep of the whole file also matches `push:` and
+  // `pull_request:` under the top-level `on:`, which made an ad-hoc probe
+  // report a job that does not exist.
+  const text = `on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  real:
+    runs-on: ubuntu-latest
+`;
+  assert.deepEqual(prJobs(text), ['real']);
+});
+
+test('every exemption carries a stated reason', () => {
+  // An exemption is a decision. One with no reason is an oversight wearing a
+  // decision's clothes, and this list is meant to ratchet down.
+  for (const [job, reason] of Object.entries(UNJUDGED_BY_DESIGN)) {
+    assert.ok(typeof reason === 'string' && reason.length > 40, `${job} needs a real reason`);
+  }
+});
+
+test('the real test.yml aggregate is fully covered', () => {
+  const text = readFileSync(join(ROOT, '.github/workflows/test.yml'), 'utf8');
+  const agg = readAggregate(text);
+  assert.ok(agg, 'the `test:` job must be findable by name');
+  assert.ok(agg.needs.length > 5, `expected a real needs list, got ${agg.needs.length}`);
+  assert.ok(agg.needs.includes('changes'), 'the path-filter job must be a dependency');
+  assert.deepEqual(unjudged(agg), [], 'every dependency must be judged');
+  assert.deepEqual(unreachable(agg), [], 'every judgement must name a dependency');
+  assert.deepEqual(agg.mismatched, [], 'every row must judge the job it names');
+  assert.deepEqual(agg.duplicated, [], 'no job may be judged twice');
+});

--- a/scripts/check-ci-aggregate-coverage.test.mjs
+++ b/scripts/check-ci-aggregate-coverage.test.mjs
@@ -6,6 +6,9 @@
  * so every case here is a positive control: a synthetic workflow carrying the
  * defect, asserted to be reported. The last case pins the real file.
  */
+/* eslint-disable no-template-curly-in-string -- the strings under test ARE
+ * GitHub Actions expressions (`${{ needs.<job>.result }}`); they must stay
+ * literal, and a template literal would interpolate them away. */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';


### PR DESCRIPTION
Refs #4219.

`test.yml`'s `test` job is the required context on `main`. It runs `if: always()` and decides pass/fail by walking a hand-written `results` map. `needs:` and that map are two lists of the same thing, written in two places, and nothing kept them in step.

`changes` was in the first and not the second. That is the worst job to leave unjudged: every other lane depends on it, so if it fails they all SKIP, and `skipped` counts as a pass here for the good reason that path filters skip most lanes on most PRs. The failure does not merely hide itself, it skips all thirteen dependents, every skip reads as success, and a required context reports green having run almost nothing.

## Never observed, and worth saying so

Across 24 recent `test.yml` runs, `Detect changes` came back 19 success, 3 cancelled, 2 queued, **zero failures**, and in the cancelled runs the aggregate correctly reported `failure` (workflow-level cancellation kills the aggregate too; `if: always()` does not rescue a job from that). This closes a latent path, not an incident. The live routes are a step FAILURE and a job-level TIMEOUT, which does not cancel the run, so the missing `timeout-minutes` is half the fix rather than a tidy-up.

## The gate, and two holes it had itself

`scripts/check-ci-aggregate-coverage.mjs` compares the two sets. `/code-review` then found two fail-opens inside it, both fixed:

- The map regex read the bracket key but never checked the interpolation, so `[new-lane]="${{ needs.build.result }}"` (the natural copy-paste error) reported full coverage while the lane went unjudged. **The same hole, one level in.**
- `import.meta.url === \`file://${argv[1]}\`` is false on any path Node percent-encodes, so on a directory with a space the gate exited 0 having read nothing.

Every test but the last is a positive control: a synthetic workflow carrying the defect, asserted to be reported. It also refuses to pass vacuously, failing when the `test:` job cannot be found or declares no dependencies.

Writing it produced one instance of that shape: the first parser used `(?=\n  \S|$)`, and under `/m` `$` matches every line end, so a job with fourteen dependencies parsed as `needs: []`. Pinned by its own test.

## The second hole it found, which is NOT fixed here

`csg-accept-gates` runs on geometry PRs, is not in `needs:`, and is not a required context, so a geometry PR whose accept gates fail can merge. Making an advisory lane blocking is a policy call, so it is #4219 and the gate carries it in `UNJUDGED_BY_DESIGN` with a stated reason. A test asserts every exemption has a real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9