### PR TITLE
fix(ci): unbreak the export schema-conformance lane and let it see what breaks it

### DIFF
--- a/.github/workflows/export-schema-conformance.yml
+++ b/.github/workflows/export-schema-conformance.yml
@@ -48,6 +48,19 @@ on:
     paths:
       - "packages/export/**"
       - "packages/parser/**"
+      # The rest of the suite's workspace import closure, each one aliased to
+      # src in packages/export/vitest.config.ts because this job runs vitest
+      # with nothing built. Without these the lane cannot see the change that
+      # breaks it: `@ifc-lite/regex-guard` was added under `mutations`, and the
+      # resulting resolve failure only surfaced on the weekly cron, on a
+      # non-required check, detached from the PR that caused it.
+      - "packages/codegen/**"
+      - "packages/data/**"
+      - "packages/encoding/**"
+      - "packages/ifcx/**"
+      - "packages/mutations/**"
+      - "packages/pointcloud/**"
+      - "packages/regex-guard/**"
       - "tools/ifcopenshell_reference/validate_export.py"
       - "tools/ifcopenshell_reference/test_validate_export.py"
       - "tools/ifcopenshell_reference/requirements.lock"

--- a/.github/workflows/export-schema-conformance.yml
+++ b/.github/workflows/export-schema-conformance.yml
@@ -48,13 +48,14 @@ on:
     paths:
       - "packages/export/**"
       - "packages/parser/**"
-      # The rest of the suite's workspace import closure, each one aliased to
-      # src in packages/export/vitest.config.ts because this job runs vitest
-      # with nothing built. Without these the lane cannot see the change that
-      # breaks it: `@ifc-lite/regex-guard` was added under `mutations`, and the
-      # resulting resolve failure only surfaced on the weekly cron, on a
-      # non-required check, detached from the PR that caused it.
-      - "packages/codegen/**"
+      # The rest of the workspace closure of the ONE file this job runs,
+      # src/ifcopenshell-schema-conformance.test.ts — measured, not the full
+      # alias list in packages/export/vitest.config.ts (which also carries
+      # codegen and geometry for the rest of the export suite, neither
+      # reachable from this test). Without these the lane cannot see the
+      # change that breaks it: `@ifc-lite/regex-guard` was added under
+      # `mutations`, and the resulting resolve failure surfaced only on the
+      # weekly cron, on a non-required check, detached from its own PR.
       - "packages/data/**"
       - "packages/encoding/**"
       - "packages/ifcx/**"

--- a/packages/export/vitest.config.ts
+++ b/packages/export/vitest.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
       '@ifc-lite/ifcx': path.resolve(__dirname, '../ifcx/src/index.ts'),
       '@ifc-lite/mutations': path.resolve(__dirname, '../mutations/src/index.ts'),
       '@ifc-lite/parser': path.resolve(__dirname, '../parser/src/index.ts'),
+      // `@ifc-lite/mutations` imports this; it publishes only `./dist`, and the
+      // schema-conformance workflow runs this suite straight after
+      // `pnpm install --ignore-scripts` with nothing built, so the bare
+      // specifier fails to resolve there. Dependency-free, so src is safe.
+      '@ifc-lite/regex-guard': path.resolve(__dirname, '../regex-guard/src/index.ts'),
       // ifcx's entity-extractor imports @ifc-lite/pointcloud; alias it to src so
       // the suite resolves on a clean checkout without built dists. pointcloud's
       // src pulls in no further workspace deps (only laz-perf + node builtins).

--- a/packages/export/vitest.config.ts
+++ b/packages/export/vitest.config.ts
@@ -23,15 +23,15 @@ export default defineConfig({
       '@ifc-lite/ifcx': path.resolve(__dirname, '../ifcx/src/index.ts'),
       '@ifc-lite/mutations': path.resolve(__dirname, '../mutations/src/index.ts'),
       '@ifc-lite/parser': path.resolve(__dirname, '../parser/src/index.ts'),
+      // ifcx's entity-extractor imports @ifc-lite/pointcloud; alias it to src so
+      // the suite resolves on a clean checkout without built dists. pointcloud's
+      // src pulls in no further workspace deps (only laz-perf + node builtins).
+      '@ifc-lite/pointcloud': path.resolve(__dirname, '../pointcloud/src/index.ts'),
       // `@ifc-lite/mutations` imports this; it publishes only `./dist`, and the
       // schema-conformance workflow runs this suite straight after
       // `pnpm install --ignore-scripts` with nothing built, so the bare
       // specifier fails to resolve there. Dependency-free, so src is safe.
       '@ifc-lite/regex-guard': path.resolve(__dirname, '../regex-guard/src/index.ts'),
-      // ifcx's entity-extractor imports @ifc-lite/pointcloud; alias it to src so
-      // the suite resolves on a clean checkout without built dists. pointcloud's
-      // src pulls in no further workspace deps (only laz-perf + node builtins).
-      '@ifc-lite/pointcloud': path.resolve(__dirname, '../pointcloud/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## What was red

`Export schema conformance` has been failing on `main` and on every export/parser PR since `@ifc-lite/mutations` started importing `@ifc-lite/regex-guard`:

```
Error: Failed to resolve entry for package "@ifc-lite/regex-guard".
  ❯ ../mutations/src/bulk-query-engine.ts:14:1
  ❯ ../mutations/src/index.ts:24:1
```

`1 failed (0 test)` — the suite never reached a single assertion. The job runs `pnpm install --frozen-lockfile --ignore-scripts` and then vitest with nothing built, and `regex-guard` publishes only `./dist`.

## The fix

One alias in `packages/export/vitest.config.ts`, matching what the file already does for `@ifc-lite/pointcloud` and every other workspace dep, with the same reason. `regex-guard` has no `dependencies` at all, so pointing at src is safe.

Verified in a clean worktree (`pnpm install --ignore-scripts`, nothing built), both directions: without the alias the resolve error appears once; with it, zero, and the suite loads. Its two tests skip locally only because the fixtures and `ifcopenshell` are absent — on CI they run.

## Why the lane could not catch this itself

The `paths:` filter watched `packages/export/**` and `packages/parser/**`. `regex-guard` was added as a dependency of `mutations` — a package the filter did not watch — so the break never ran on the PR that introduced it and only appeared later on the Monday `23 4 * * 1` cron, on a non-required check, detached from its cause.

Widened the filter to the measured workspace closure of the one file this job runs: `data`, `encoding`, `ifcx`, `mutations`, `pointcloud`, `regex-guard`. Measured over the last 300 commits on `main` that is 59 → 76 matching commits.

## Deferred, on the record

Nothing ties the alias list to the test's actual import graph, so the list can go stale again. A check that resolves the closure and diffs it against the alias keys would make that fail loud and attributable. That is its own change, not a widening of a CI fix.

## Pre-flight

`/simplify` and `/code-review` both ran against this branch. Applied: alias ordering (it broke the file's alphabetical convention), and the `paths:` comment stating a rule the list did not follow (`codegen` is aliased but unreachable from this test; dropped it and named the real rule). Deferred: the sync gate above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9