### PR TITLE
fix(viewer): match the singular "1 object" the assignment list now renders

### DIFF
--- a/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceAssignmentList.test.tsx
@@ -32,15 +32,15 @@ it('mounted assignment order and explicit exceptions change the reviewed winner 
   assert.match(rows()[0].textContent!, /0 objects.*1 replaced/);
   click(ui.querySelector('[aria-label="Review objects for assignment 2"]')!);
   click(rows()[1].querySelector('input[type="checkbox"]')!);
-  assert.match(rows()[0].textContent!, /1 objects/);
+  assert.match(rows()[0].textContent!, /1 object\b/);
   assert.match(rows()[1].textContent!, /0 objects · 1 excluded/);
   click(rows()[1].querySelector('input[type="checkbox"]')!);
   click(ui.querySelector('[aria-label="Move assignment 2 earlier"]')!);
   assert.match(rows()[0].textContent!, /Paint.*0 objects/);
-  assert.match(rows()[1].textContent!, /Brick.*1 objects/);
+  assert.match(rows()[1].textContent!, /Brick.*1 object\b/);
   click(ui.querySelector('[aria-label="Remove assignment 2"]')!);
   assert.equal(rows().length, 1);
-  assert.match(rows()[0].textContent!, /Paint.*1 objects/);
+  assert.match(rows()[0].textContent!, /Paint.*1 object\b/);
 });
 it('large assignment review mounts one bounded page and finds/excludes objects beyond it #4420', () => {
   const ui = render(<Harness count={10000} />);


### PR DESCRIPTION
## main is red

The viewer suite has been **7776 pass / 1 fail** since #4447 merged at 03:46 today. That PR taught `AppearanceAssignmentList.tsx` to pluralize:

```diff
-  {row.productIds.length} objects · …
+  {row.productIds.length} {row.productIds.length === 1 ? 'object' : 'objects'} · …
```

and left three assertions in `AppearanceAssignmentList.test.tsx` matching `/1 objects/`, a string that no longer appears anywhere:

```
The input did not match the regular expression /1 objects/. Input:
'1. BrickBuilding1 object · 0 excluded · 0 replaced by later assignments'
```

## Why all three

Only the first is visible in a run — `assert.match` throws at line 35 and lines 40 and 43 never execute. Fixing one would just move the failure down.

`/1 object\b/` is anchored so it cannot start matching `objects` again: in `"1 objects"` the position after `object` sits between `t` and `s`, both word characters, so `\b` fails and the literal has nowhere else to anchor.

The component is right and the test was pinned to the old copy, so the fix belongs in the assertions.

## Verified

3/3 pass on this branch; 1 fail on plain `origin/main`. I also reproduced the failure from a branch touching only `scripts/` and `.github/`, which is what ruled out my own work as the cause.

Confirmed independently by the other session working this repo tonight, which has no competing branch in `appearance/`.

## Why it matters beyond CI

`deploy-nightly.yml` promotes `production` with `require_green=true`, so it deploys the newest commit whose CI gate passed rather than the tip. With the viewer suite red since 03:46, tonight's tick walks back past it and everything after that point stays off ifclite.com. `production` is already 261 commits behind at `ed4770e4e`.

## Pre-flight

`/simplify` and `/code-review` both ran against this commit. The reviewer confirmed the `\b` semantics by running the tests in both directions, grepped the rest of `appearance/` for other assertions pinned to a stale plural (none — the only other count assertion is `/12 objects affected/`, correctly plural), and raised one style nit on record: matching the literal separator (`/1 object ·/`) would read more directly than relying on word-boundary semantics. Left as is, since the anchor is verified correct and main is red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193douQ6sTYHE65DJmyAei9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated assignment-list tests to accept singular “object” wording when exactly one object remains.
  * Preserved coverage for ordering, exclusions, and removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->