### PR TITLE
fix(cache): accept photogrammetry base-colour inputs

### DIFF
--- a/.changeset/hungry-bikes-stand.md
+++ b/.changeset/hungry-bikes-stand.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Load photogrammetry GLBs with usable base-colour textures even when they also carry auxiliary material maps, morph targets, vertex colours, alpha metadata, or alternate UV sets. Unsupported Draco compression now reports the uncompressed export workaround.

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -59,6 +59,12 @@ describe('captured GLB appearance #4380', () => {
     json.extensionsRequired=['KHR_materials_specular'];
     expect(parseGLBToMeshData(json,bin)[0].textureRef?.url).toBe('textures/glb-image-0.png');
   });
+  it('reports vertex-colour-only appearance as unavailable', () => {
+    const {json,bin}=capture();
+    delete json.materials![0].pbrMetallicRoughness!.baseColorTexture;
+    json.meshes![0].primitives[0].attributes.COLOR_0=5;
+    expect(()=>parseGLBToMeshData(json,bin)).toThrow(/vertex-colour-only appearance is unavailable.*base-colour texture/);
+  });
   it('reads the base colour texture coordinate set selected by the material', () => {
     const {json,bin}=capture();
     json.meshes![0].primitives[0].attributes.TEXCOORD_1=json.meshes![0].primitives[0].attributes.TEXCOORD_0;

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -71,6 +71,10 @@ describe('captured GLB appearance #4380', () => {
     delete json.textures![0].sampler;json.extensionsRequired=['KHR_draco_mesh_compression'];expect(()=>parseGLBToMeshData(json,bin)).toThrow(/Draco-compressed.*uncompressed/);
     delete json.extensionsRequired;json.bufferViews![2].byteLength=bin.length;expect(()=>parseGLBImageResources(json,bin)).toThrow(/exceeds/);
   });
+  it('rejects required legacy specular-glossiness instead of inventing a base colour', () => {
+    const {json,bin}=capture(); json.extensionsRequired=['KHR_materials_pbrSpecularGlossiness'];
+    expect(()=>parseGLBToMeshData(json,bin)).toThrow(/specular-glossiness.*base-colour/);
+  });
   it('rejects mismatched MIME/signatures before geometry or resource copying', () => {
     const png = new Uint8Array(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DAAAAEAQEARwbK3gAAAABJRU5ErkJggg==', 'base64'));
     const {json,bin} = capture(png);

--- a/packages/cache/src/glb-capture.test.ts
+++ b/packages/cache/src/glb-capture.test.ts
@@ -48,10 +48,27 @@ describe('captured GLB appearance #4380', () => {
     const {json,bin}=capture(); json.nodes![0].scale=[-1,1,1];
     const [mesh]=parseGLBToMeshData(json,bin); expect([...mesh.indices]).toEqual([0,2,1,3,5,4]); expect(mesh.uvs![6]).toBe(1);
   });
-  it('rejects unsupported alpha, wrap, required compression, and image ranges explicitly', () => {
-    const {json,bin}=capture(); json.materials![0].alphaMode='BLEND'; expect(()=>parseGLBToMeshData(json,bin)).toThrow(/MASK\/BLEND/);
-    delete json.materials![0].alphaMode; json.samplers=[{wrapS:33648}];json.textures![0].sampler=0;expect(()=>parseGLBToMeshData(json,bin)).toThrow(/mirrored/);
-    delete json.textures![0].sampler;json.extensionsRequired=['KHR_draco_mesh_compression'];expect(()=>parseGLBToMeshData(json,bin)).toThrow(/required extension/);
+  it('retains the supported base colour from a typical photogrammetry material', () => {
+    const {json,bin}=capture();
+    const material=json.materials![0];
+    material.alphaMode='BLEND'; material.normalTexture={index:1}; material.occlusionTexture={index:2};
+    material.emissiveTexture={index:3}; material.pbrMetallicRoughness!.metallicRoughnessTexture={index:4};
+    material.extensions={KHR_materials_specular:{specularFactor:0.5}};
+    json.meshes![0].primitives[0].targets=[{POSITION:4}];
+    json.meshes![0].primitives[0].attributes.COLOR_0=5;
+    json.extensionsRequired=['KHR_materials_specular'];
+    expect(parseGLBToMeshData(json,bin)[0].textureRef?.url).toBe('textures/glb-image-0.png');
+  });
+  it('reads the base colour texture coordinate set selected by the material', () => {
+    const {json,bin}=capture();
+    json.meshes![0].primitives[0].attributes.TEXCOORD_1=json.meshes![0].primitives[0].attributes.TEXCOORD_0;
+    delete json.meshes![0].primitives[0].attributes.TEXCOORD_0;
+    json.materials![0].pbrMetallicRoughness!.baseColorTexture!.texCoord=1;
+    expect([...parseGLBToMeshData(json,bin)[0].uvs!]).toEqual([0,0,0.5,0,0.5,1,1,0,1,1,0.5,0]);
+  });
+  it('rejects unsupported wrap, required compression, and image ranges explicitly', () => {
+    const {json,bin}=capture(); json.samplers=[{wrapS:33648}];json.textures![0].sampler=0;expect(()=>parseGLBToMeshData(json,bin)).toThrow(/mirrored/);
+    delete json.textures![0].sampler;json.extensionsRequired=['KHR_draco_mesh_compression'];expect(()=>parseGLBToMeshData(json,bin)).toThrow(/Draco-compressed.*uncompressed/);
     delete json.extensionsRequired;json.bufferViews![2].byteLength=bin.length;expect(()=>parseGLBImageResources(json,bin)).toThrow(/exceeds/);
   });
   it('rejects mismatched MIME/signatures before geometry or resource copying', () => {

--- a/packages/cache/src/glb-images.ts
+++ b/packages/cache/src/glb-images.ts
@@ -43,21 +43,16 @@ function imageResources(gltf: GLTFDocument, bin: Uint8Array, copy: boolean): Map
 }
 
 export function primitiveTexture(gltf: GLTFDocument, bin: Uint8Array, primitive: GLTFPrimitive, vertexCount: number): Pick<MeshData, 'uvs' | 'textureRef'> {
-  if (primitive.targets?.length || primitive.extensions?.KHR_draco_mesh_compression || primitive.attributes.COLOR_0 !== undefined) {
-    throw new Error('GLB: morph targets, Draco compression and vertex colours are not supported for capture appearance');
-  }
   const material = primitive.material === undefined ? undefined : gltf.materials?.[primitive.material];
   if (primitive.material !== undefined && !material) throw new Error('GLB: material index does not exist');
-  if (material?.normalTexture || material?.emissiveTexture || material?.occlusionTexture || material?.pbrMetallicRoughness?.metallicRoughnessTexture || Object.keys(material?.extensions ?? {}).some(key => key !== 'KHR_materials_unlit')) {
-    throw new Error('GLB: material maps/extensions beyond base colour are not supported for capture appearance');
-  }
   const reference = material?.pbrMetallicRoughness?.baseColorTexture;
   if (!reference) return {};
-  if (material?.alphaMode && material.alphaMode !== 'OPAQUE') throw new Error('GLB: textured MASK/BLEND materials are not supported');
   const transform = reference.extensions?.KHR_texture_transform;
-  if ((transform?.texCoord ?? reference.texCoord ?? 0) !== 0) throw new Error('GLB: only TEXCOORD_0 is supported');
-  const accessor = primitive.attributes.TEXCOORD_0;
-  if (accessor === undefined || gltf.accessors?.[accessor]?.type !== 'VEC2') throw new Error('GLB: textured primitive requires TEXCOORD_0 VEC2');
+  const texCoord = transform?.texCoord ?? reference.texCoord ?? 0;
+  if (!Number.isSafeInteger(texCoord) || texCoord < 0) throw new Error('GLB: invalid base-colour texture coordinate set');
+  const attribute = `TEXCOORD_${texCoord}`;
+  const accessor = primitive.attributes[attribute];
+  if (accessor === undefined || gltf.accessors?.[accessor]?.type !== 'VEC2') throw new Error(`GLB: textured primitive requires ${attribute} VEC2`);
   const raw = readAccessorData(gltf, bin, accessor);
   const declaration = gltf.accessors![accessor];
   const divisor = raw instanceof Float32Array ? 1 : declaration.normalized && raw instanceof Uint16Array ? 65535 : declaration.normalized && raw instanceof Uint8Array ? 255 : 0;

--- a/packages/cache/src/glb-images.ts
+++ b/packages/cache/src/glb-images.ts
@@ -46,7 +46,12 @@ export function primitiveTexture(gltf: GLTFDocument, bin: Uint8Array, primitive:
   const material = primitive.material === undefined ? undefined : gltf.materials?.[primitive.material];
   if (primitive.material !== undefined && !material) throw new Error('GLB: material index does not exist');
   const reference = material?.pbrMetallicRoughness?.baseColorTexture;
-  if (!reference) return {};
+  if (!reference) {
+    if (primitive.attributes.COLOR_0 !== undefined) {
+      throw new Error('GLB: vertex-colour-only appearance is unavailable; export a base-colour texture.');
+    }
+    return {};
+  }
   const transform = reference.extensions?.KHR_texture_transform;
   const texCoord = transform?.texCoord ?? reference.texCoord ?? 0;
   if (!Number.isSafeInteger(texCoord) || texCoord < 0) throw new Error('GLB: invalid base-colour texture coordinate set');

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -151,7 +151,8 @@ import { type Mat4, MAT4_IDENTITY, mat4Mul, nodeLocalMat4, linearIsIdentity, nor
 export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshData[] {
   const meshes: MeshData[] = [];
   for (const extension of gltf.extensionsRequired ?? []) {
-    if (!['KHR_texture_transform', 'KHR_materials_unlit'].includes(extension)) throw new Error(`GLB: unsupported required extension ${extension}`);
+    if (extension === 'KHR_draco_mesh_compression') throw new Error('GLB: Draco-compressed geometry is not yet supported; export an uncompressed GLB or glTF bundle.');
+    if (!extension.startsWith('KHR_materials_') && extension !== 'KHR_texture_transform') throw new Error(`GLB: unsupported required extension ${extension}`);
   }
   validateGLBImages(gltf, bin);
   const mapping = extractGLBMapping(gltf);

--- a/packages/cache/src/glb.ts
+++ b/packages/cache/src/glb.ts
@@ -152,6 +152,7 @@ export function parseGLBToMeshData(gltf: GLTFDocument, bin: Uint8Array): MeshDat
   const meshes: MeshData[] = [];
   for (const extension of gltf.extensionsRequired ?? []) {
     if (extension === 'KHR_draco_mesh_compression') throw new Error('GLB: Draco-compressed geometry is not yet supported; export an uncompressed GLB or glTF bundle.');
+    if (extension === 'KHR_materials_pbrSpecularGlossiness') throw new Error('GLB: required specular-glossiness materials do not expose a supported base-colour texture.');
     if (!extension.startsWith('KHR_materials_') && extension !== 'KHR_texture_transform') throw new Error(`GLB: unsupported required extension ${extension}`);
   }
   validateGLBImages(gltf, bin);


### PR DESCRIPTION
Closes #4475. Follow-up to #4381.

Real scan GLBs no longer lose an otherwise supported base-colour path merely because the material also carries normal/metallic-roughness/emissive/occlusion maps, standard material extensions, morph targets, vertex colours, alpha-mode metadata, or a nonzero UV set. The source image remains byte-identical.

Draco geometry is still not decoded in this synchronous package; it now fails with the precise uncompressed GLB/glTF export workaround instead of the misleading catch-all appearance error.

Evidence:
- `pnpm test` — 102/102 tasks green; viewer 7,777 passed, 13 skipped
- `pnpm typecheck` — 94/94 tasks; all 1,930 test files covered
- `pnpm lint` — 0 errors
- regression fixture models the material shape emitted by photogrammetry tools and asserts the base-colour texture survives

This PR changes only the first defect class. Bundled `.gltf` ingestion is #4476 and the panel/destination/export UX is #4477.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved photogrammetry GLB loading with support for auxiliary material data, morph targets, vertex colours, alpha metadata, and alternate UV sets.
  - Added support for selecting non-default texture-coordinate sets.
  - Improved compatibility with supported material extensions and non-opaque alpha modes.

- **Bug Fixes**
  - Unsupported legacy specular-glossiness materials are now explicitly rejected.
  - Draco-compressed GLB files now provide a clear unsupported-format error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->