### PR TITLE
feat(viewer): ingest local glTF scan bundles

### DIFF
--- a/.changeset/moody-adults-sing.md
+++ b/.changeset/moody-adults-sing.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Open glTF 2.0 scan bundles by selecting the .gltf document with its local .bin and PNG/JPEG resources. The bounded resolver rejects missing, remote, traversal, and ambiguous resources, then feeds a self-contained GLB through the existing model loader.

--- a/.changeset/moody-adults-sing.md
+++ b/.changeset/moody-adults-sing.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/viewer": patch
+"@ifc-lite/viewer": minor
 ---
 
 Open glTF 2.0 scan bundles by selecting the .gltf document with its local .bin and PNG/JPEG resources. The bounded resolver rejects missing, remote, traversal, and ambiguous resources, then feeds a self-contained GLB through the existing model loader.

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -40,13 +40,14 @@ import { isTypeVisible } from '@/store/typeVisibilityFilter';
 import type { AggregationRelationships } from '@/utils/aggregation';
 import { useIfc } from '@/hooks/useIfc';
 import { useWebGPU } from '@/hooks/useWebGPU';
-import { cacheFileBlobs, formatFileSize, getCachedFile, getRecentFiles, recordRecentFiles, type RecentFileEntry } from '@/lib/recent-files';
+import { formatFileSize, getCachedFile, type RecentFileEntry } from '@/lib/recent-files';
 import {
   supportsFileSystemAccess,
   openIfcFilesWithHandles,
   handlesFromDataTransfer,
 } from '@/services/file-system-access';
-import { FILE_ACCEPT, isSupportedModelFile } from '@/services/supported-model-files';
+import { FILE_ACCEPT, isGltfBundleFile, isSupportedModelFile } from '@/services/supported-model-files';
+import { usePreparedModelFileRoute } from '@/hooks/ingest/usePreparedModelFileRoute';
 import {
   SOURCE_DOWNLOAD_EVENT,
   type SourceDownloadEvent,
@@ -359,6 +360,8 @@ export function ViewportContainer() {
     }
   }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, hasModelsLoaded]);
 
+  const prepareAndRoute = usePreparedModelFileRoute(routeLoad, setRecentFiles);
+
   // Cloud source providers (Dalux Build, etc.) download bytes outside the
   // viewer and hand them off via this event rather than calling addModel()
   // directly — keeps the sources UI decoupled from viewer internals.
@@ -470,8 +473,8 @@ export function ViewportContainer() {
     if (dxfFiles.length > 0) void ingestDxfFiles(dxfFiles);
     if (allDropped.length === 0) return;
 
-    // Filter to supported files (IFC, IFCX, GLB, point clouds)
-    const supportedFiles = allDropped.filter(isSupportedFile);
+    // Keep glTF sidecars beside the document until they are packed into GLB.
+    const supportedFiles = allDropped.filter(file => isSupportedFile(file) || isGltfBundleFile(file));
 
     if (supportedFiles.length === 0) {
       // Tell the user *why* — common case is a Recap project / SketchUp
@@ -487,18 +490,14 @@ export function ViewportContainer() {
       // Prefer the handle-paired files (Chromium): each file + handle comes from
       // the same dropped item, so no filename matching is needed. Fall back to
       // the plain dropped files when no handles were captured (Firefox/Safari).
-      const supportedOpened = (opened ?? []).filter((o) => isSupportedFile(o.file));
+      const supportedOpened = (opened ?? []).filter((o) => isSupportedFile(o.file) || isGltfBundleFile(o.file));
       const useHandles = supportedOpened.length > 0;
       const files = useHandles ? supportedOpened.map((o) => o.file) : supportedFiles;
       const handles = useHandles ? supportedOpened.map((o) => o.handle) : undefined;
 
-      recordRecentFiles(files.map((file) => ({ name: file.name, size: file.size })));
-      void cacheFileBlobs(files);
-      setRecentFiles(getRecentFiles().slice(0, 3));
-
-      routeLoad(files, handles);
+      void prepareAndRoute(files, handles);
     });
-  }, [routeLoad, applyDragEvent, isSupportedFile, webgpu.supported]);
+  }, [prepareAndRoute, applyDragEvent, isSupportedFile, webgpu.supported]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     // Block file loading if WebGPU not supported
@@ -515,22 +514,18 @@ export function ViewportContainer() {
 
     // Filter to supported files (IFC, IFCX, GLB). The <input> path yields no
     // live handle, so these models are not refreshable.
-    const supportedFiles = modelFiles.filter(isSupportedFile);
+    const supportedFiles = modelFiles.filter(file => isSupportedFile(file) || isGltfBundleFile(file));
 
     if (supportedFiles.length === 0) {
       e.target.value = '';
       return;
     }
 
-    recordRecentFiles(supportedFiles.map((file) => ({ name: file.name, size: file.size })));
-    void cacheFileBlobs(supportedFiles);
-    setRecentFiles(getRecentFiles().slice(0, 3));
-
-    routeLoad(supportedFiles);
+    void prepareAndRoute(supportedFiles);
 
     // Reset input so same file can be selected again
     e.target.value = '';
-  }, [routeLoad, isSupportedFile, webgpu.supported]);
+  }, [prepareAndRoute, isSupportedFile, webgpu.supported]);
 
   // Preferred open path: the File System Access picker (Chromium) captures a
   // live handle per file so the model can be refreshed from disk. Falls back to
@@ -546,16 +541,12 @@ export function ViewportContainer() {
     // DXF reference underlays split off before model routing (issue #1782).
     const dxfPicked = opened.filter((o) => o.file.name.toLowerCase().endsWith('.dxf'));
     if (dxfPicked.length > 0) void ingestDxfFiles(dxfPicked.map((o) => o.file));
-    const supported = opened.filter((o) => isSupportedFile(o.file));
+    const supported = opened.filter((o) => isSupportedFile(o.file) || isGltfBundleFile(o.file));
     if (supported.length === 0) return;
 
     const files = supported.map((o) => o.file);
-    recordRecentFiles(files.map((f) => ({ name: f.name, size: f.size })));
-    void cacheFileBlobs(files);
-    setRecentFiles(getRecentFiles().slice(0, 3));
-
-    routeLoad(files, supported.map((o) => o.handle));
-  }, [routeLoad, isSupportedFile, webgpu.supported]);
+    prepareAndRoute(files, supported.map((o) => o.handle));
+  }, [prepareAndRoute, isSupportedFile, webgpu.supported]);
 
   const handleStartBlank = useCallback(async () => {
     if (!webgpu.supported) return;

--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -118,9 +118,6 @@ export function ViewportContainer() {
   } = viewportStoreState;
   const storeModels = models;
 
-  // Check if we have models loaded (for determining add vs replace behavior)
-  const hasModelsLoaded = models.size > 0 || (geometryResult?.meshes && geometryResult.meshes.length > 0);
-
   // Multi-model: create mapping from modelId to modelIndex (stable order)
   const modelIdToIndex = useMemo(() => modelIndices(storeModels), [storeModels]);
 
@@ -346,6 +343,11 @@ export function ViewportContainer() {
     files: File[],
     handles?: (FileSystemFileHandle | undefined)[],
   ) => {
+    // Read the loaded state now, not at render: bundle preparation awaits
+    // before routing, and a model that arrived meanwhile must be added to,
+    // not replaced (#4476 review).
+    const current = viewerStoreApi.getState();
+    const hasModelsLoaded = current.models.size > 0 || (current.geometryResult?.meshes?.length ?? 0) > 0;
     if (hasModelsLoaded) {
       // Models already loaded - add new files sequentially (federate).
       void loadFilesSequentially(files, handles);
@@ -358,7 +360,7 @@ export function ViewportContainer() {
       clearAllModels();
       void loadFilesSequentially(files, handles);
     }
-  }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, hasModelsLoaded]);
+  }, [loadFile, loadFilesSequentially, resetViewerState, clearAllModels, viewerStoreApi]);
 
   const prepareAndRoute = usePreparedModelFileRoute(routeLoad, setRecentFiles);
 

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -23,10 +23,11 @@ import {
 import { toast } from '@/components/ui/toast';
 import { isCollabEnabled } from '@/lib/collab/config';
 import { ingestDxfFiles, splitDxfFiles } from '@/hooks/ingest/dxfIngest';
+import { usePreparedModelFileRoute } from '@/hooks/ingest/usePreparedModelFileRoute';
 import { ShareDialog } from '../ShareDialog';
 import { FederationSetupControls } from '../FederationSetupControls';
 
-import { FILE_ACCEPT, isSupportedModelFile } from '@/services/supported-model-files';
+import { FILE_ACCEPT, isGltfBundleFile, isSupportedModelFile } from '@/services/supported-model-files';
 
 // FILE_ACCEPT offers `.dxf` while `isSupportedModelFile` rejects it: DXF
 // files are 2D reference underlays, not models, and split off to the DXF
@@ -139,6 +140,20 @@ export function useFileCommands(): FileCommands {
 
   const hasModelsLoaded = models.size > 0 || Boolean(geometryResult?.meshes && geometryResult.meshes.length > 0);
 
+  const routeOpenedFiles = useCallback((supportedFiles: File[], handles?: (FileSystemFileHandle | undefined)[]) => {
+    if (supportedFiles.length === 1) {
+      void loadFile(supportedFiles[0], { kind: 'primary' }, { sourceHandle: handles?.[0] });
+      return;
+    }
+    const allIfcx = supportedFiles.every(isIfcxModelFile);
+    resetViewerState();
+    clearAllModels();
+    if (allIfcx) void loadFederatedIfcx(supportedFiles);
+    else void loadFilesSequentially(supportedFiles, handles);
+  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+
+  const prepareAndOpen = usePreparedModelFileRoute(routeOpenedFiles);
+
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files || files.length === 0) return;
@@ -148,41 +163,18 @@ export function useFileCommands(): FileCommands {
     if (dxfFiles.length > 0) void ingestDxfFiles(dxfFiles);
 
     // Filter to supported files (IFC, IFCX, GLB, point clouds)
-    const supportedFiles = modelFiles.filter(isSupportedModelFile);
+    const supportedFiles = modelFiles.filter(file => isSupportedModelFile(file) || isGltfBundleFile(file));
 
     if (supportedFiles.length === 0) {
       e.target.value = '';
       return;
     }
 
-    // Track recently opened files (metadata + blob cache for instant reload)
-    recordRecentFiles(supportedFiles.map(f => ({ name: f.name, size: f.size })));
-    cacheFileBlobs(supportedFiles);
-
-    if (supportedFiles.length === 1) {
-      // Single file - use loadFile (simpler single-model path)
-      loadFile(supportedFiles[0]);
-    } else {
-      // Multiple files - check if ALL are IFCX (use federated loading for layer composition)
-      const allIfcx = supportedFiles.every(isIfcxModelFile);
-
-      resetViewerState();
-      clearAllModels();
-
-      if (allIfcx) {
-        // IFCX files use federated loading (layer composition - later files override earlier ones)
-        // This handles overlay files that add properties without geometry
-        console.log(`[toolbar] Loading ${supportedFiles.length} IFCX files with federated composition`);
-        loadFederatedIfcx(supportedFiles);
-      } else {
-        // Mixed or all IFC4/GLB files - load sequentially as independent models
-        loadFilesSequentially(supportedFiles);
-      }
-    }
+    prepareAndOpen(supportedFiles);
 
     // Reset input so same files can be selected again
     e.target.value = '';
-  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+  }, [prepareAndOpen]);
 
   // Shared Add-Model routing. `handles` is positionally aligned with
   // `supportedFiles`, carrying a live FS Access handle per file (Chromium) so
@@ -209,6 +201,8 @@ export function useFileCommands(): FileCommands {
     }
   }, [loadFilesSequentially, addIfcxOverlays, ifcDataStore]);
 
+  const prepareAndAdd = usePreparedModelFileRoute(addSupportedFiles);
+
   const handleAddModelSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files || files.length === 0) return;
@@ -216,11 +210,11 @@ export function useFileCommands(): FileCommands {
     const { dxfFiles, modelFiles } = splitDxfFiles(Array.from(files));
     if (dxfFiles.length > 0) void ingestDxfFiles(dxfFiles);
     // <input> yields no live handle, so models added this way aren't refreshable.
-    const supportedFiles = modelFiles.filter(isSupportedModelFile);
-    addSupportedFiles(supportedFiles);
+    const supportedFiles = modelFiles.filter(file => isSupportedModelFile(file) || isGltfBundleFile(file));
+    prepareAndAdd(supportedFiles);
     // Reset input so same files can be selected again
     e.target.value = '';
-  }, [addSupportedFiles]);
+  }, [prepareAndAdd]);
 
   // Preferred Add-Model path: the picker captures a handle per file so the
   // resulting federation can be refreshed. Falls back to the hidden <input>.
@@ -234,9 +228,9 @@ export function useFileCommands(): FileCommands {
     // DXF reference underlays split off before model routing (issue #1782).
     const dxfPicked = opened.filter(o => o.file.name.toLowerCase().endsWith('.dxf'));
     if (dxfPicked.length > 0) void ingestDxfFiles(dxfPicked.map(o => o.file));
-    const supported = opened.filter(o => isSupportedModelFile(o.file));
-    addSupportedFiles(supported.map(o => o.file), supported.map(o => o.handle));
-  }, [addSupportedFiles]);
+    const supported = opened.filter(o => isSupportedModelFile(o.file) || isGltfBundleFile(o.file));
+    prepareAndAdd(supported.map(o => o.file), supported.map(o => o.handle));
+  }, [prepareAndAdd]);
 
   // Open via the File System Access API when available (Chromium) so we capture
   // a live FileSystemFileHandle for each file — that handle is what lets the
@@ -254,30 +248,11 @@ export function useFileCommands(): FileCommands {
     if (dxfPicked.length > 0) void ingestDxfFiles(dxfPicked.map(o => o.file));
     // The picker keeps an "all files" option, so drop anything unsupported
     // before it reaches the load pipeline (matches the <input> + Add Model paths).
-    const opened = picked.filter(o => isSupportedModelFile(o.file));
+    const opened = picked.filter(o => isSupportedModelFile(o.file) || isGltfBundleFile(o.file));
     if (opened.length === 0) return;
 
-    const files = opened.map(o => o.file);
-    recordRecentFiles(files.map(f => ({ name: f.name, size: f.size })));
-    void cacheFileBlobs(files);
-
-    if (opened.length === 1) {
-      // Single model: keep the handle so Refresh can re-read it from disk.
-      void loadFile(opened[0].file, { kind: 'primary' }, { sourceHandle: opened[0].handle });
-    } else {
-      // Multiple files mirror handleFileSelect's branching.
-      const allIfcx = files.every(isIfcxModelFile);
-      resetViewerState();
-      clearAllModels();
-      if (allIfcx) {
-        // IFCX layers compose into one shared store — no per-file handle.
-        void loadFederatedIfcx(files);
-      } else {
-        // Carry each file's handle so the whole federation stays refreshable.
-        void loadFilesSequentially(files, opened.map(o => o.handle));
-      }
-    }
-  }, [loadFile, loadFilesSequentially, loadFederatedIfcx, resetViewerState, clearAllModels]);
+    prepareAndOpen(opened.map(o => o.file), opened.map(o => o.handle));
+  }, [prepareAndOpen]);
 
   // Refresh re-reads files from disk and re-parses them. Offered when EVERY
   // loaded model has a live FS Access handle (a single model, or a federation

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
@@ -49,4 +49,13 @@ describe('prepared model file routing #4476', () => {
     await next;
     assert.deepEqual(routed, ['model.ifc']);
   });
+
+  it('rejects sidecars picked without their .gltf by name instead of loading nothing', async () => {
+    // .bin and images pass the entry-point filters so they can travel beside a
+    // document; alone they used to resolve to [] and return silently.
+    let routed = false;
+    const sidecars = [new File([new Uint8Array(4)], 'scan.bin'), new File([new Uint8Array(8)], 'scan.png', { type: 'image/png' })];
+    await assert.rejects(prepareModelFiles(sidecars, undefined, () => { routed = true; }), /\.gltf document together with its \.bin and texture files/);
+    assert.equal(routed, false);
+  });
 });

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '../../test/setup-dom.js';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { prepareModelFiles } from './usePreparedModelFileRoute.js';
+
+/** A standalone glTF 2.0 document whose only buffer is embedded, so packing needs no sidecar. */
+function gltfDocument(name: string, Ctor: typeof File = File): File {
+  const json = { asset: { version: '2.0' }, buffers: [{ byteLength: 4, uri: 'data:application/octet-stream;base64,AAAAAA==' }] };
+  return new Ctor([JSON.stringify(json)], name, { type: 'model/gltf+json' });
+}
+
+/** Reads its JSON only after a delay, standing in for a large bundle on a slow disk. */
+class SlowFile extends File {
+  override text(): Promise<string> {
+    return new Promise(resolve => setTimeout(() => resolve(super.text()), 30));
+  }
+}
+
+const handle = (name: string): FileSystemFileHandle => ({ kind: 'file', name } as unknown as FileSystemFileHandle);
+
+describe('prepared model file routing #4476', () => {
+  it('routes picks in the order they were made even when an earlier bundle resolves later', async () => {
+    const routed: string[][] = [];
+    const route = (files: File[]) => { routed.push(files.map(file => file.name)); };
+    const slow = prepareModelFiles([gltfDocument('scan.gltf', SlowFile)], undefined, route);
+    const fast = prepareModelFiles([new File(['ISO-10303-21;'], 'model.ifc')], undefined, route);
+    await Promise.all([slow, fast]);
+    assert.deepEqual(routed, [['scan.glb'], ['model.ifc']]);
+  });
+
+  it('keeps each ordinary file beside its own handle in a mixed pick and gives the packed GLB none', async () => {
+    let routed: { files: File[]; handles?: (FileSystemFileHandle | undefined)[] } | undefined;
+    const ifc = new File(['ISO-10303-21;'], 'model.ifc'), ifcHandle = handle('model.ifc');
+    const picked = [gltfDocument('scan.gltf'), new File([new Uint8Array(4)], 'scan.bin'), ifc];
+    await prepareModelFiles(picked, [handle('scan.gltf'), handle('scan.bin'), ifcHandle], (files, handles) => { routed = { files, handles }; });
+    assert.deepEqual(routed?.files.map(file => file.name), ['model.ifc', 'scan.glb']);
+    assert.deepEqual(routed?.handles, [ifcHandle, undefined]);
+  });
+
+  it('reports a broken bundle to its own pick without stalling the next one', async () => {
+    const routed: string[] = [];
+    const broken = { asset: { version: '2.0' }, buffers: [{ byteLength: 4, uri: 'missing.bin' }] };
+    const failed = prepareModelFiles([new File([JSON.stringify(broken)], 'broken.gltf')], undefined, () => { routed.push('broken'); });
+    const next = prepareModelFiles([new File(['ISO-10303-21;'], 'model.ifc')], undefined, files => { routed.push(files[0].name); });
+    await assert.rejects(failed, /missing “missing\.bin”/);
+    await next;
+    assert.deepEqual(routed, ['model.ifc']);
+  });
+});

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.test.ts
@@ -1,6 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+// Routing caches the resolved blobs for the recent-files list; without an
+// IndexedDB the cache logs a ReferenceError that CI's observe-production lane
+// classifies as a load failure.
+import 'fake-indexeddb/auto';
 import '../../test/setup-dom.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
@@ -6,23 +6,42 @@ import { cacheFileBlobs, getRecentFiles, recordRecentFiles, type RecentFileEntry
 import { resolveGltfModelFiles } from '@/services/gltf-bundle';
 import { toast } from '@/components/ui/toast';
 
-type RouteFiles = (files: File[], handles?: (FileSystemFileHandle | undefined)[]) => void;
+type Handles = (FileSystemFileHandle | undefined)[];
+type RouteFiles = (files: File[], handles?: Handles) => void;
 
-/** Resolve compound inputs, then hand one ordinary file per model to the canonical loader. */
+// Packing a bundle reads its sidecars asynchronously, so two quick picks could
+// otherwise reach the loader out of order: a slow earlier Open replacing a
+// later one, or added models landing in the wrong sequence. One chain shared
+// by every entry point (Open, Add Model, drop) keeps routing in pick order.
+let queue: Promise<void> = Promise.resolve();
+
+/** Keep each original handle beside the same `File`; a packed GLB is synthetic and gets none. */
+function alignHandles(files: readonly File[], handles: Handles | undefined, resolved: readonly File[]): Handles | undefined {
+  if (!handles) return undefined;
+  const byFile = new Map<File, FileSystemFileHandle | undefined>();
+  files.forEach((file, index) => byFile.set(file, handles[index]));
+  return resolved.map(file => byFile.get(file));
+}
+
+/** Resolve compound inputs, then hand one ordinary file per model to `route`, in pick order. */
+export function prepareModelFiles(files: readonly File[], handles: Handles | undefined, route: RouteFiles, setRecentFiles?: (files: RecentFileEntry[]) => void): Promise<void> {
+  const turn = queue.then(async () => {
+    const resolved = await resolveGltfModelFiles(files);
+    if (!resolved.length) return;
+    recordRecentFiles(resolved.map(file => ({ name: file.name, size: file.size })));
+    void cacheFileBlobs(resolved);
+    setRecentFiles?.(getRecentFiles().slice(0, 3));
+    route(resolved, alignHandles(files, handles, resolved));
+  });
+  // A rejected bundle is reported to its own caller and must not stall later picks.
+  queue = turn.catch(() => undefined);
+  return turn;
+}
+
 export function usePreparedModelFileRoute(route: RouteFiles, setRecentFiles?: (files: RecentFileEntry[]) => void): RouteFiles {
   return useCallback((files, handles) => {
-    void (async () => {
-      try {
-        const resolved = await resolveGltfModelFiles(files);
-        if (!resolved.length) return;
-        recordRecentFiles(resolved.map(file => ({ name: file.name, size: file.size })));
-        void cacheFileBlobs(resolved);
-        setRecentFiles?.(getRecentFiles().slice(0, 3));
-        const unchanged = resolved.length === files.length && resolved.every((file, index) => file === files[index]);
-        route(resolved, unchanged ? handles : undefined);
-      } catch (error) {
-        toast.error(error instanceof Error ? error.message : String(error));
-      }
-    })();
+    prepareModelFiles(files, handles, route, setRecentFiles).catch((error: unknown) => {
+      toast.error(error instanceof Error ? error.message : String(error));
+    });
   }, [route, setRecentFiles]);
 }

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { useCallback } from 'react';
+import { cacheFileBlobs, getRecentFiles, recordRecentFiles, type RecentFileEntry } from '@/lib/recent-files';
+import { resolveGltfModelFiles } from '@/services/gltf-bundle';
+import { toast } from '@/components/ui/toast';
+
+type RouteFiles = (files: File[], handles?: (FileSystemFileHandle | undefined)[]) => void;
+
+/** Resolve compound inputs, then hand one ordinary file per model to the canonical loader. */
+export function usePreparedModelFileRoute(route: RouteFiles, setRecentFiles?: (files: RecentFileEntry[]) => void): RouteFiles {
+  return useCallback((files, handles) => {
+    void (async () => {
+      try {
+        const resolved = await resolveGltfModelFiles(files);
+        if (!resolved.length) return;
+        recordRecentFiles(resolved.map(file => ({ name: file.name, size: file.size })));
+        void cacheFileBlobs(resolved);
+        setRecentFiles?.(getRecentFiles().slice(0, 3));
+        const unchanged = resolved.length === files.length && resolved.every((file, index) => file === files[index]);
+        route(resolved, unchanged ? handles : undefined);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : String(error));
+      }
+    })();
+  }, [route, setRecentFiles]);
+}

--- a/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
+++ b/apps/viewer/src/hooks/ingest/usePreparedModelFileRoute.ts
@@ -27,7 +27,12 @@ function alignHandles(files: readonly File[], handles: Handles | undefined, reso
 export function prepareModelFiles(files: readonly File[], handles: Handles | undefined, route: RouteFiles, setRecentFiles?: (files: RecentFileEntry[]) => void): Promise<void> {
   const turn = queue.then(async () => {
     const resolved = await resolveGltfModelFiles(files);
-    if (!resolved.length) return;
+    // Sidecars pass every entry-point filter so they can travel beside a .gltf;
+    // picked on their own they resolve to nothing, which must be said, not swallowed.
+    if (!resolved.length) {
+      if (files.length) throw new Error('Select the .gltf document together with its .bin and texture files.');
+      return;
+    }
     recordRecentFiles(resolved.map(file => ({ name: file.name, size: file.size })));
     void cacheFileBlobs(resolved);
     setRecentFiles?.(getRecentFiles().slice(0, 3));

--- a/apps/viewer/src/services/gltf-bundle.test.ts
+++ b/apps/viewer/src/services/gltf-bundle.test.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '../test/setup-dom.js';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseGLB, parseGLBImageResources, parseGLBToMeshData } from '@ifc-lite/cache';
+import { packGltfBundle, resolveGltfModelFiles } from './gltf-bundle.js';
+
+function scanBundle() {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const uvs = new Float32Array([0, 0, 1, 0, 0, 1]);
+  const geometry = new Uint8Array(positions.byteLength + uvs.byteLength);
+  geometry.set(new Uint8Array(positions.buffer)); geometry.set(new Uint8Array(uvs.buffer), positions.byteLength);
+  const texture = new Uint8Array([255, 216, 255]);
+  const document = {
+    asset: { version: '2.0' }, scene: 0, scenes: [{ nodes: [0] }], nodes: [{ mesh: 0 }],
+    buffers: [{ uri: 'boulder.bin', byteLength: geometry.byteLength }],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: positions.byteLength },
+      { buffer: 0, byteOffset: positions.byteLength, byteLength: uvs.byteLength },
+    ],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3' },
+      { bufferView: 1, componentType: 5126, count: 3, type: 'VEC2' },
+    ],
+    images: [{ uri: 'textures/boulder.jpg' }], textures: [{ source: 0 }],
+    materials: [{ pbrMetallicRoughness: { baseColorTexture: { index: 0 } } }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, TEXCOORD_0: 1 }, material: 0 }] }],
+  };
+  return {
+    document: new File([JSON.stringify(document)], 'boulder.gltf', { type: 'model/gltf+json' }),
+    geometry: new File([geometry], 'boulder.bin'), texture: new File([texture], 'boulder.jpg', { type: 'image/jpeg' }), textureBytes: texture,
+  };
+}
+
+describe('glTF bundle ingestion #4476', () => {
+  it('packs external geometry and a nested texture into the canonical GLB reader without changing image bytes', async () => {
+    const fixture = scanBundle();
+    const packed = await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture]);
+    assert.equal(packed.name, 'boulder.glb');
+    const { json, bin } = parseGLB(new Uint8Array(await packed.arrayBuffer()));
+    const [mesh] = parseGLBToMeshData(json, bin!);
+    assert.deepEqual([...mesh.positions], [0, 0, 0, 1, 0, 0, 0, 1, 0]);
+    assert.deepEqual(parseGLBImageResources(json, bin!).get(mesh.textureRef!.url), fixture.textureBytes);
+  });
+
+  it('reports missing, remote, traversal and ambiguous resources by name', async () => {
+    const fixture = scanBundle();
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.texture]), /missing “boulder\.bin”/);
+    for (const uri of ['https://example.com/model.bin', '../model.bin', '/model.bin', 'folder\\model.bin']) {
+      const json = JSON.parse(await fixture.document.text()); json.buffers[0].uri = uri;
+      await assert.rejects(packGltfBundle(new File([JSON.stringify(json)], 'unsafe.gltf'), []), /local relative file/);
+    }
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, new File(['other'], 'boulder.bin'), fixture.texture]), /more than one possible “boulder\.bin”/);
+  });
+
+  it('accepts data URI resources and removes selected sidecars from the model list', async () => {
+    const fixture = scanBundle(), json = JSON.parse(await fixture.document.text());
+    json.buffers[0].uri = `data:application/octet-stream;base64,${btoa(String.fromCharCode(...new Uint8Array(await fixture.geometry.arrayBuffer())))}`;
+    const standalone = new File([JSON.stringify(json)], 'standalone.gltf');
+    const resolved = await resolveGltfModelFiles([standalone, fixture.texture]);
+    assert.equal(resolved.length, 1); assert.equal(resolved[0].name, 'standalone.glb');
+  });
+});

--- a/apps/viewer/src/services/gltf-bundle.test.ts
+++ b/apps/viewer/src/services/gltf-bundle.test.ts
@@ -34,6 +34,23 @@ function scanBundle() {
   };
 }
 
+const pad4 = (value: number) => (value + 3) & ~3;
+
+/**
+ * The GLB the glTF 2.0 binary container spec says this bundle packs to, worked
+ * out from the fixture alone: a 28-byte frame (12-byte header + two 8-byte
+ * chunk headers), the rewritten JSON padded to 4 bytes, then one BIN chunk
+ * holding the geometry followed by the texture as an extra buffer view.
+ */
+async function expectedGlbSize(fixture: ReturnType<typeof scanBundle>): Promise<number> {
+  const json = JSON.parse(await fixture.document.text());
+  const binLength = pad4(fixture.geometry.size) + pad4(fixture.texture.size);
+  json.buffers = [{ byteLength: binLength }];
+  json.bufferViews.push({ buffer: 0, byteOffset: pad4(fixture.geometry.size), byteLength: fixture.texture.size });
+  json.images = [{ bufferView: 2, mimeType: 'image/jpeg' }];
+  return 28 + pad4(new TextEncoder().encode(JSON.stringify(json)).byteLength) + binLength;
+}
+
 describe('glTF bundle ingestion #4476', () => {
   it('packs external geometry and a nested texture into the canonical GLB reader without changing image bytes', async () => {
     const fixture = scanBundle();
@@ -71,16 +88,32 @@ describe('glTF bundle ingestion #4476', () => {
       override arrayBuffer(): Promise<ArrayBuffer> { return Promise.reject(new Error('texture was read after the budget was spent')); }
     }
     const texture = new UnreadableTexture([fixture.textureBytes], 'boulder.jpg', { type: 'image/jpeg' });
-    const exact = (await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture])).size;
+    const expected = await expectedGlbSize(fixture);
     // Before a read the budget is the 28-byte GLB frame + the document + what is packed so far (4-byte aligned):
     // geometry fills it exactly, so the texture would tip the total over and is never read.
-    const pad4 = (value: number) => (value + 3) & ~3;
     const limits = { ...DEFAULT_GLTF_BUNDLE_LIMITS, maxBundleBytes: 28 + pad4(fixture.document.size) + pad4(fixture.geometry.size) };
     await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, texture], limits), /limit at “textures\/boulder\.jpg”/);
     // The limit is the finished GLB size: one byte short is refused, exactly enough is packed.
-    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: exact - 1 }), /limit at “boulder\.gltf”/);
-    const packed = await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: exact });
-    assert.equal(packed.size, exact);
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: expected - 1 }), /limit at “boulder\.gltf”/);
+    const packed = await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: expected });
+    assert.equal(packed.size, expected);
+  });
+
+  it('rejects a buffer view that reaches past its buffer instead of rebasing it onto the next resource', async () => {
+    const fixture = scanBundle();
+    for (const view of [{ buffer: 0, byteOffset: fixture.geometry.size - 4, byteLength: 24 }, { buffer: 0, byteOffset: -4, byteLength: 24 }, { buffer: 0, byteOffset: 0, byteLength: 1.5 }]) {
+      const json = JSON.parse(await fixture.document.text()); json.bufferViews[1] = view;
+      await assert.rejects(packGltfBundle(new File([JSON.stringify(json)], 'boulder.gltf'), [fixture.geometry, fixture.texture]), /buffer view 1 lies outside buffer 0/);
+    }
+  });
+
+  it('decodes a percent-encoded data URI as octets rather than as UTF-8 text', async () => {
+    const document = { asset: { version: '2.0' }, buffers: [{ uri: 'data:application/octet-stream,%00%FF%01A', byteLength: 4 }] };
+    const packed = await packGltfBundle(new File([JSON.stringify(document)], 'octets.gltf'), []);
+    const { bin } = parseGLB(new Uint8Array(await packed.arrayBuffer()));
+    assert.deepEqual([...bin!.subarray(0, 4)], [0x00, 0xff, 0x01, 0x41]);
+    const malformed = { ...document, buffers: [{ uri: 'data:application/octet-stream,%0', byteLength: 1 }] };
+    await assert.rejects(packGltfBundle(new File([JSON.stringify(malformed)], 'octets.gltf'), []), /invalid escaping/);
   });
 
   it('accepts data URI resources and removes selected sidecars from the model list', async () => {

--- a/apps/viewer/src/services/gltf-bundle.test.ts
+++ b/apps/viewer/src/services/gltf-bundle.test.ts
@@ -5,7 +5,7 @@ import '../test/setup-dom.js';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { parseGLB, parseGLBImageResources, parseGLBToMeshData } from '@ifc-lite/cache';
-import { packGltfBundle, resolveGltfModelFiles } from './gltf-bundle.js';
+import { DEFAULT_GLTF_BUNDLE_LIMITS, packGltfBundle, resolveGltfModelFiles } from './gltf-bundle.js';
 
 function scanBundle() {
   const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
@@ -53,6 +53,34 @@ describe('glTF bundle ingestion #4476', () => {
       await assert.rejects(packGltfBundle(new File([JSON.stringify(json)], 'unsafe.gltf'), []), /local relative file/);
     }
     await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, new File(['other'], 'boulder.bin'), fixture.texture]), /more than one possible “boulder\.bin”/);
+  });
+
+  it('refuses an oversized sidecar by its size alone, before reading it', async () => {
+    const fixture = scanBundle();
+    class UnreadableHugeFile extends File {
+      override get size(): number { return DEFAULT_GLTF_BUNDLE_LIMITS.maxBundleBytes + 1; }
+      override arrayBuffer(): Promise<ArrayBuffer> { return Promise.reject(new Error('oversized sidecar was read into memory')); }
+    }
+    const huge = new UnreadableHugeFile([new Uint8Array(36)], 'boulder.bin');
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, huge, fixture.texture]), /exceeds the 512 MiB limit at “boulder\.bin”/);
+  });
+
+  it('applies one cumulative limit across the document, geometry and textures', async () => {
+    const fixture = scanBundle();
+    class UnreadableTexture extends File {
+      override arrayBuffer(): Promise<ArrayBuffer> { return Promise.reject(new Error('texture was read after the budget was spent')); }
+    }
+    const texture = new UnreadableTexture([fixture.textureBytes], 'boulder.jpg', { type: 'image/jpeg' });
+    const exact = (await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture])).size;
+    // Before a read the budget is the 28-byte GLB frame + the document + what is packed so far (4-byte aligned):
+    // geometry fills it exactly, so the texture would tip the total over and is never read.
+    const pad4 = (value: number) => (value + 3) & ~3;
+    const limits = { ...DEFAULT_GLTF_BUNDLE_LIMITS, maxBundleBytes: 28 + pad4(fixture.document.size) + pad4(fixture.geometry.size) };
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, texture], limits), /limit at “textures\/boulder\.jpg”/);
+    // The limit is the finished GLB size: one byte short is refused, exactly enough is packed.
+    await assert.rejects(packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: exact - 1 }), /limit at “boulder\.gltf”/);
+    const packed = await packGltfBundle(fixture.document, [fixture.document, fixture.geometry, fixture.texture], { ...limits, maxBundleBytes: exact });
+    assert.equal(packed.size, exact);
   });
 
   it('accepts data URI resources and removes selected sidecars from the model list', async () => {

--- a/apps/viewer/src/services/gltf-bundle.ts
+++ b/apps/viewer/src/services/gltf-bundle.ts
@@ -2,8 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-const MAX_RESOURCE_COUNT = 256;
-const MAX_BUNDLE_BYTES = 512 * 1024 * 1024;
+/** 12-byte GLB header plus the JSON and BIN chunk headers. */
+const GLB_FRAME_BYTES = 28;
+
+/** Bounds for one packed bundle; the viewer ships the defaults. */
+export interface GltfBundleLimits {
+  readonly maxResourceCount: number;
+  /** Cap on the finished GLB, so also on every byte read to build it. */
+  readonly maxBundleBytes: number;
+}
+
+export const DEFAULT_GLTF_BUNDLE_LIMITS: GltfBundleLimits = { maxResourceCount: 256, maxBundleBytes: 512 * 1024 * 1024 };
 
 interface GltfBuffer { byteLength: number; uri?: string }
 interface GltfBufferView { buffer: number; byteOffset?: number; byteLength: number }
@@ -17,6 +26,10 @@ interface GltfDocument {
 }
 
 function pad4(value: number): number { return (value + 3) & ~3; }
+
+function formatLimit(bytes: number): string {
+  return bytes % (1024 * 1024) === 0 ? `${bytes / (1024 * 1024)} MiB` : `${bytes} bytes`;
+}
 
 function safeUriPath(uri: string): string {
   let decoded: string;
@@ -58,14 +71,41 @@ function resourceIndex(files: readonly File[]): Map<string, File[]> {
   return index;
 }
 
-async function externalBytes(uri: string, files: Map<string, File[]>): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+/**
+ * Cumulative size guard over the GLB being built. `reserve` runs before a
+ * sidecar is read, so an oversized file is refused by its `size` alone and
+ * never reaches memory; the JSON chunk is estimated from the document file
+ * until the exact chunk exists.
+ */
+class BundleBudget {
+  private packed = 0;
+  constructor(private readonly limit: number, private readonly documentBytes: number) {}
+  reserve(bytes: number, what: string): void {
+    if (GLB_FRAME_BYTES + pad4(this.documentBytes) + this.packed + pad4(bytes) > this.limit) {
+      throw new Error(`glTF bundle exceeds the ${formatLimit(this.limit)} limit at “${what}”.`);
+    }
+  }
+  /** Record appended BIN bytes and return their padded offset. */
+  commit(bytes: number): number {
+    const offset = this.packed;
+    this.packed = pad4(offset + bytes);
+    return offset;
+  }
+  /** Padded length of everything committed so far: the BIN chunk length. */
+  get length(): number { return this.packed; }
+  fitsExactly(glbBytes: number): boolean { return glbBytes <= this.limit; }
+}
+
+async function externalBytes(uri: string, files: Map<string, File[]>, budget: BundleBudget): Promise<{ bytes: Uint8Array; mimeType?: string }> {
   const embedded = decodeDataUri(uri);
-  if (embedded) return embedded;
+  if (embedded) { budget.reserve(embedded.bytes.byteLength, uri.slice(0, 32)); return embedded; }
   const path = safeUriPath(uri), exact = files.get(path);
   const matches = exact?.length ? exact : files.get(path.split('/').pop() ?? '');
   if (!matches?.length) throw new Error(`glTF bundle is missing “${path}”. Select the .gltf, .bin and texture files together.`);
   if (matches.length !== 1) throw new Error(`glTF bundle contains more than one possible “${path}” resource.`);
-  return { bytes: new Uint8Array(await matches[0].arrayBuffer()), mimeType: matches[0].type || undefined };
+  const [match] = matches;
+  budget.reserve(match.size, path);
+  return { bytes: new Uint8Array(await match.arrayBuffer()), mimeType: match.type || undefined };
 }
 
 function imageMime(image: GltfImage, uri: string, supplied?: string): string {
@@ -75,28 +115,23 @@ function imageMime(image: GltfImage, uri: string, supplied?: string): string {
 }
 
 /** Resolve a user-selected .gltf + local resources into the GLB consumed by the canonical loader. */
-export async function packGltfBundle(documentFile: File, selectedFiles: readonly File[]): Promise<File> {
-  if (documentFile.size > MAX_BUNDLE_BYTES) throw new Error('glTF document exceeds the 512 MiB bundle limit.');
+export async function packGltfBundle(documentFile: File, selectedFiles: readonly File[], limits: GltfBundleLimits = DEFAULT_GLTF_BUNDLE_LIMITS): Promise<File> {
+  const budget = new BundleBudget(limits.maxBundleBytes, documentFile.size);
+  budget.reserve(0, documentFile.name);
   let document: GltfDocument;
   try { document = JSON.parse(await documentFile.text()) as GltfDocument; } catch { throw new Error(`${documentFile.name}: invalid glTF JSON.`); }
   if (document.asset?.version !== '2.0') throw new Error(`${documentFile.name}: only glTF 2.0 is supported.`);
   const buffers = document.buffers ?? [];
   const images = document.images ?? [];
-  if (buffers.length + images.filter(image => image.uri).length > MAX_RESOURCE_COUNT) throw new Error('glTF bundle exceeds the 256-resource limit.');
+  if (buffers.length + images.filter(image => image.uri).length > limits.maxResourceCount) throw new Error(`glTF bundle exceeds the ${limits.maxResourceCount}-resource limit.`);
   const files = resourceIndex(selectedFiles.filter(file => file !== documentFile));
   const chunks: Uint8Array[] = [];
-  let byteLength = 0;
-  const append = (bytes: Uint8Array): number => {
-    const offset = byteLength;
-    byteLength = pad4(byteLength + bytes.byteLength);
-    if (byteLength > MAX_BUNDLE_BYTES) throw new Error('glTF bundle exceeds the 512 MiB limit.');
-    chunks.push(bytes); return offset;
-  };
+  const append = (bytes: Uint8Array): number => { chunks.push(bytes); return budget.commit(bytes.byteLength); };
   const bufferOffsets: number[] = [];
   for (let index = 0; index < buffers.length; index++) {
     const buffer = buffers[index];
     if (!Number.isSafeInteger(buffer.byteLength) || buffer.byteLength < 0 || !buffer.uri) throw new Error(`glTF buffer ${index} must name a bounded local or data URI resource.`);
-    const { bytes } = await externalBytes(buffer.uri, files);
+    const { bytes } = await externalBytes(buffer.uri, files, budget);
     if (bytes.byteLength < buffer.byteLength) throw new Error(`glTF buffer “${buffer.uri}” is shorter than its declared byteLength.`);
     bufferOffsets[index] = append(bytes.subarray(0, buffer.byteLength));
   }
@@ -107,21 +142,24 @@ export async function packGltfBundle(documentFile: File, selectedFiles: readonly
   }
   for (const image of images) {
     if (!image.uri) continue;
-    const uri = image.uri, resource = await externalBytes(uri, files);
+    const uri = image.uri, resource = await externalBytes(uri, files, budget);
     image.bufferView = bufferViews.length;
     image.mimeType = imageMime(image, uri, resource.mimeType);
     bufferViews.push({ buffer: 0, byteOffset: append(resource.bytes), byteLength: resource.bytes.byteLength });
     delete image.uri;
   }
-  const bin = new Uint8Array(byteLength);
-  let cursor = 0;
-  for (const chunk of chunks) { bin.set(chunk, cursor); cursor = pad4(cursor + chunk.byteLength); }
-  document.buffers = [{ byteLength: bin.byteLength }]; document.bufferViews = bufferViews;
+  const binLength = budget.length;
+  document.buffers = [{ byteLength: binLength }]; document.bufferViews = bufferViews;
   const json = new TextEncoder().encode(JSON.stringify(document)), jsonLength = pad4(json.byteLength);
-  const output = new Uint8Array(28 + jsonLength + bin.byteLength), view = new DataView(output.buffer);
-  view.setUint32(0, 0x46546c67, true); view.setUint32(4, 2, true); view.setUint32(8, output.byteLength, true);
+  const glbLength = GLB_FRAME_BYTES + jsonLength + binLength;
+  // The rewritten JSON can outgrow the document it was estimated from; settle the exact size before allocating.
+  if (!budget.fitsExactly(glbLength)) throw new Error(`glTF bundle exceeds the ${formatLimit(limits.maxBundleBytes)} limit at “${documentFile.name}”.`);
+  const output = new Uint8Array(glbLength), view = new DataView(output.buffer);
+  view.setUint32(0, 0x46546c67, true); view.setUint32(4, 2, true); view.setUint32(8, glbLength, true);
   view.setUint32(12, jsonLength, true); view.setUint32(16, 0x4e4f534a, true); output.fill(0x20, 20, 20 + jsonLength); output.set(json, 20);
-  view.setUint32(20 + jsonLength, bin.byteLength, true); view.setUint32(24 + jsonLength, 0x004e4942, true); output.set(bin, 28 + jsonLength);
+  view.setUint32(20 + jsonLength, binLength, true); view.setUint32(24 + jsonLength, 0x004e4942, true);
+  let cursor = GLB_FRAME_BYTES + jsonLength;
+  for (const chunk of chunks) { output.set(chunk, cursor); cursor = pad4(cursor + chunk.byteLength); }
   return new File([output], documentFile.name.replace(/\.gltf$/i, '.glb'), { type: 'model/gltf-binary', lastModified: documentFile.lastModified });
 }
 

--- a/apps/viewer/src/services/gltf-bundle.ts
+++ b/apps/viewer/src/services/gltf-bundle.ts
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+const MAX_RESOURCE_COUNT = 256;
+const MAX_BUNDLE_BYTES = 512 * 1024 * 1024;
+
+interface GltfBuffer { byteLength: number; uri?: string }
+interface GltfBufferView { buffer: number; byteOffset?: number; byteLength: number }
+interface GltfImage { uri?: string; bufferView?: number; mimeType?: string }
+interface GltfDocument {
+  asset?: { version?: string };
+  buffers?: GltfBuffer[];
+  bufferViews?: GltfBufferView[];
+  images?: GltfImage[];
+  [key: string]: unknown;
+}
+
+function pad4(value: number): number { return (value + 3) & ~3; }
+
+function safeUriPath(uri: string): string {
+  let decoded: string;
+  try { decoded = decodeURIComponent(uri); } catch { throw new Error(`glTF resource has invalid escaping: ${uri}`); }
+  if (!decoded || decoded.includes('\\') || decoded.startsWith('/') || decoded.split('/').includes('..') || /^[a-z][a-z0-9+.-]*:/i.test(decoded)) {
+    throw new Error(`glTF resource must be a local relative file: ${uri}`);
+  }
+  return decoded.replace(/^\.\//, '');
+}
+
+function decodeDataUri(uri: string): { bytes: Uint8Array; mimeType?: string } | null {
+  if (!uri.startsWith('data:')) return null;
+  const comma = uri.indexOf(',');
+  if (comma < 5) throw new Error('glTF data URI is malformed');
+  const header = uri.slice(5, comma), payload = uri.slice(comma + 1);
+  const parts = header.split(';'), mimeType = parts[0] || undefined;
+  let bytes: Uint8Array;
+  if (parts.includes('base64')) {
+    let binary: string;
+    try { binary = atob(payload); } catch { throw new Error('glTF data URI contains invalid base64'); }
+    bytes = Uint8Array.from(binary, character => character.charCodeAt(0));
+  } else {
+    let text: string;
+    try { text = decodeURIComponent(payload); } catch { throw new Error('glTF data URI contains invalid escaping'); }
+    bytes = new TextEncoder().encode(text);
+  }
+  return { bytes, mimeType };
+}
+
+function resourceIndex(files: readonly File[]): Map<string, File[]> {
+  const index = new Map<string, File[]>();
+  for (const file of files) {
+    const relative = (file.webkitRelativePath || '').replace(/^\.\//, '');
+    for (const key of new Set([file.name, relative, relative.split('/').pop() ?? ''].filter(Boolean))) {
+      const matches = index.get(key) ?? [];
+      matches.push(file); index.set(key, matches);
+    }
+  }
+  return index;
+}
+
+async function externalBytes(uri: string, files: Map<string, File[]>): Promise<{ bytes: Uint8Array; mimeType?: string }> {
+  const embedded = decodeDataUri(uri);
+  if (embedded) return embedded;
+  const path = safeUriPath(uri), exact = files.get(path);
+  const matches = exact?.length ? exact : files.get(path.split('/').pop() ?? '');
+  if (!matches?.length) throw new Error(`glTF bundle is missing “${path}”. Select the .gltf, .bin and texture files together.`);
+  if (matches.length !== 1) throw new Error(`glTF bundle contains more than one possible “${path}” resource.`);
+  return { bytes: new Uint8Array(await matches[0].arrayBuffer()), mimeType: matches[0].type || undefined };
+}
+
+function imageMime(image: GltfImage, uri: string, supplied?: string): string {
+  const mime = image.mimeType || supplied || (/\.png(?:$|[?#])/i.test(uri) ? 'image/png' : /\.jpe?g(?:$|[?#])/i.test(uri) ? 'image/jpeg' : '');
+  if (mime !== 'image/png' && mime !== 'image/jpeg') throw new Error(`glTF texture “${uri}” must be PNG or JPEG.`);
+  return mime;
+}
+
+/** Resolve a user-selected .gltf + local resources into the GLB consumed by the canonical loader. */
+export async function packGltfBundle(documentFile: File, selectedFiles: readonly File[]): Promise<File> {
+  if (documentFile.size > MAX_BUNDLE_BYTES) throw new Error('glTF document exceeds the 512 MiB bundle limit.');
+  let document: GltfDocument;
+  try { document = JSON.parse(await documentFile.text()) as GltfDocument; } catch { throw new Error(`${documentFile.name}: invalid glTF JSON.`); }
+  if (document.asset?.version !== '2.0') throw new Error(`${documentFile.name}: only glTF 2.0 is supported.`);
+  const buffers = document.buffers ?? [];
+  const images = document.images ?? [];
+  if (buffers.length + images.filter(image => image.uri).length > MAX_RESOURCE_COUNT) throw new Error('glTF bundle exceeds the 256-resource limit.');
+  const files = resourceIndex(selectedFiles.filter(file => file !== documentFile));
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  const append = (bytes: Uint8Array): number => {
+    const offset = byteLength;
+    byteLength = pad4(byteLength + bytes.byteLength);
+    if (byteLength > MAX_BUNDLE_BYTES) throw new Error('glTF bundle exceeds the 512 MiB limit.');
+    chunks.push(bytes); return offset;
+  };
+  const bufferOffsets: number[] = [];
+  for (let index = 0; index < buffers.length; index++) {
+    const buffer = buffers[index];
+    if (!Number.isSafeInteger(buffer.byteLength) || buffer.byteLength < 0 || !buffer.uri) throw new Error(`glTF buffer ${index} must name a bounded local or data URI resource.`);
+    const { bytes } = await externalBytes(buffer.uri, files);
+    if (bytes.byteLength < buffer.byteLength) throw new Error(`glTF buffer “${buffer.uri}” is shorter than its declared byteLength.`);
+    bufferOffsets[index] = append(bytes.subarray(0, buffer.byteLength));
+  }
+  const bufferViews = document.bufferViews ?? [];
+  for (const view of bufferViews) {
+    if (!Number.isSafeInteger(view.buffer) || bufferOffsets[view.buffer] === undefined) throw new Error('glTF buffer view references a missing buffer.');
+    view.byteOffset = bufferOffsets[view.buffer] + (view.byteOffset ?? 0); view.buffer = 0;
+  }
+  for (const image of images) {
+    if (!image.uri) continue;
+    const uri = image.uri, resource = await externalBytes(uri, files);
+    image.bufferView = bufferViews.length;
+    image.mimeType = imageMime(image, uri, resource.mimeType);
+    bufferViews.push({ buffer: 0, byteOffset: append(resource.bytes), byteLength: resource.bytes.byteLength });
+    delete image.uri;
+  }
+  const bin = new Uint8Array(byteLength);
+  let cursor = 0;
+  for (const chunk of chunks) { bin.set(chunk, cursor); cursor = pad4(cursor + chunk.byteLength); }
+  document.buffers = [{ byteLength: bin.byteLength }]; document.bufferViews = bufferViews;
+  const json = new TextEncoder().encode(JSON.stringify(document)), jsonLength = pad4(json.byteLength);
+  const output = new Uint8Array(28 + jsonLength + bin.byteLength), view = new DataView(output.buffer);
+  view.setUint32(0, 0x46546c67, true); view.setUint32(4, 2, true); view.setUint32(8, output.byteLength, true);
+  view.setUint32(12, jsonLength, true); view.setUint32(16, 0x4e4f534a, true); output.fill(0x20, 20, 20 + jsonLength); output.set(json, 20);
+  view.setUint32(20 + jsonLength, bin.byteLength, true); view.setUint32(24 + jsonLength, 0x004e4942, true); output.set(bin, 28 + jsonLength);
+  return new File([output], documentFile.name.replace(/\.gltf$/i, '.glb'), { type: 'model/gltf-binary', lastModified: documentFile.lastModified });
+}
+
+export async function resolveGltfModelFiles(files: readonly File[]): Promise<File[]> {
+  const documents = files.filter(file => /\.gltf$/i.test(file.name));
+  const ordinary = files.filter(file => !/\.gltf$/i.test(file.name) && !/\.(?:bin|png|jpe?g)$/i.test(file.name));
+  return [...ordinary, ...await Promise.all(documents.map(file => packGltfBundle(file, files)))];
+}

--- a/apps/viewer/src/services/gltf-bundle.ts
+++ b/apps/viewer/src/services/gltf-bundle.ts
@@ -52,11 +52,21 @@ function decodeDataUri(uri: string): { bytes: Uint8Array; mimeType?: string } | 
     try { binary = atob(payload); } catch { throw new Error('glTF data URI contains invalid base64'); }
     bytes = Uint8Array.from(binary, character => character.charCodeAt(0));
   } else {
-    let text: string;
-    try { text = decodeURIComponent(payload); } catch { throw new Error('glTF data URI contains invalid escaping'); }
-    bytes = new TextEncoder().encode(text);
+    bytes = percentDecodedBytes(payload);
   }
   return { bytes, mimeType };
+}
+
+/** RFC 2397 payload without base64: every `%XX` is one octet, so `%00%FF` must not go through a UTF-8 round trip. */
+function percentDecodedBytes(payload: string): Uint8Array {
+  const encoder = new TextEncoder(), characters = Array.from(payload), bytes: number[] = [];
+  for (let index = 0; index < characters.length; index++) {
+    if (characters[index] !== '%') { bytes.push(...encoder.encode(characters[index])); continue; }
+    const octet = `${characters[index + 1] ?? ''}${characters[index + 2] ?? ''}`;
+    if (!/^[0-9a-f]{2}$/i.test(octet)) throw new Error('glTF data URI contains invalid escaping');
+    bytes.push(parseInt(octet, 16)); index += 2;
+  }
+  return Uint8Array.from(bytes);
 }
 
 function resourceIndex(files: readonly File[]): Map<string, File[]> {
@@ -136,10 +146,15 @@ export async function packGltfBundle(documentFile: File, selectedFiles: readonly
     bufferOffsets[index] = append(bytes.subarray(0, buffer.byteLength));
   }
   const bufferViews = document.bufferViews ?? [];
-  for (const view of bufferViews) {
-    if (!Number.isSafeInteger(view.buffer) || bufferOffsets[view.buffer] === undefined) throw new Error('glTF buffer view references a missing buffer.');
-    view.byteOffset = bufferOffsets[view.buffer] + (view.byteOffset ?? 0); view.buffer = 0;
-  }
+  bufferViews.forEach((view, index) => {
+    if (!Number.isSafeInteger(view.buffer) || bufferOffsets[view.buffer] === undefined) throw new Error(`glTF buffer view ${index} references a missing buffer.`);
+    // Rebasing moves every view into one BIN chunk, so a view that overran its own buffer would land in the next resource's bytes.
+    const offset = view.byteOffset ?? 0;
+    if (!Number.isSafeInteger(offset) || offset < 0 || !Number.isSafeInteger(view.byteLength) || view.byteLength < 0 || offset + view.byteLength > buffers[view.buffer].byteLength) {
+      throw new Error(`glTF buffer view ${index} lies outside buffer ${view.buffer}.`);
+    }
+    view.byteOffset = bufferOffsets[view.buffer] + offset; view.buffer = 0;
+  });
   for (const image of images) {
     if (!image.uri) continue;
     const uri = image.uri, resource = await externalBytes(uri, files, budget);

--- a/apps/viewer/src/services/supported-model-files.ts
+++ b/apps/viewer/src/services/supported-model-files.ts
@@ -21,6 +21,7 @@ export const MODEL_FILE_EXTENSIONS = [
   '.ifcx',
   '.ifczip',
   '.glb',
+  '.gltf',
   '.las',
   '.laz',
   '.ply',
@@ -41,6 +42,7 @@ export const REFERENCE_FILE_EXTENSIONS = ['.dxf'] as const;
 export const PICKER_FILE_EXTENSIONS: readonly string[] = [
   ...MODEL_FILE_EXTENSIONS,
   ...REFERENCE_FILE_EXTENSIONS,
+  '.bin', '.png', '.jpg', '.jpeg',
 ];
 
 /** `accept` attribute for the hidden `<input type="file">` elements. */
@@ -50,4 +52,9 @@ export const FILE_ACCEPT = PICKER_FILE_EXTENSIONS.join(',');
 export function isSupportedModelFile(f: File): boolean {
   const n = f.name.toLowerCase();
   return MODEL_FILE_EXTENSIONS.some((ext) => n.endsWith(ext));
+}
+
+/** Files retained alongside a `.gltf` document until its local bundle is packed. */
+export function isGltfBundleFile(f: File): boolean {
+  return /\.(?:gltf|bin|png|jpe?g)$/i.test(f.name);
 }


### PR DESCRIPTION
Closes #4476

## What changed
- Accepts a `.gltf` document together with its local `.bin` / PNG / JPEG resources in the landing page, drag/drop, Open and Add Model flows (`isGltfBundleFile` beside `isSupportedModelFile`).
- `packGltfBundle` validates every resource URI (rejects remote, path-traversal, ambiguous and malformed references; names missing resources), enforces one cumulative byte budget (`GltfBundleLimits`, default 256 resources / 512 MiB) that is reserved *before* each sidecar is read and settled exactly before the output GLB is allocated, and writes the chunks straight into the GLB.
- `prepareModelFiles` / `usePreparedModelFileRoute` runs every pick through one module-wide chain so routing stays in pick order across Open, Add Model and drop; a failed bundle rejects its own pick without stalling the next; file handles stay aligned per `File` (an IFC picked beside a `.gltf` keeps its `FileSystemFileHandle`, the packed GLB gets none); sidecars picked without their `.gltf` are rejected by name instead of loading nothing.
- The packed GLB enters the existing `useIfcLoader.loadFile` / `addModel` path only — no second ingest path. `ViewportContainer.routeLoad` reads the loaded-model state from the store at routing time, after the bundle await.
- Standalone data-URI glTF documents pack without sidecars.

## Why / root cause
Photogrammetry tools ship `.gltf + .bin + textures`; the viewer advertised only `.glb`, forcing users to repack outside the product. Bundle packing is asynchronous, so the naive version had ordering, handle-alignment and unbounded-read holes (see Review).

## Evidence
Run on this branch at its final base (origin/main `531194cdc`), Windows 11 / Git Bash, node:test via tsx:
- `apps/viewer`: `gltf-bundle.test.ts` + `usePreparedModelFileRoute.test.ts` — 11/11 pass (success, missing/unsafe/ambiguous/remote resources, oversized sidecar refused with an `arrayBuffer()` that throws if called, cumulative limit against an expected GLB size worked out from the fixture, out-of-range / negative / fractional buffer views rejected, percent-encoded data-URI octets, pick order with a slow bundle, mixed-selection handle alignment, failed pick does not stall, sidecars-only pick rejected by name).
- `pnpm --filter viewer typecheck`: exit 0.
- `node scripts/check-module-size.mjs`, `check-test-wiring.mjs`, `check-changeset-bump.mjs`, `check-test-glob-coverage.mjs`: exit 0. `check-source-text-assertions.mjs` could not be evaluated on this host (its merge-base comparison reported 114 files this PR does not touch); it is left to the PR checks.
- `pnpm exec oxlint` on every changed file: exit 0.
- On the previous base (`2f6ba4a45`, same code apart from the sidecar fix): 123/123 across the viewer test files around the touched modules, `pnpm --filter @ifc-lite/cache test` 192 passed / 1 skipped, and the full viewer package (818 files, 7,843 tests) with 51 failures all in files this PR does not touch — 41 are `api.<name> is not a function` from the host's prebuilt `packages/wasm/pkg` runtime being older than the committed `ifc-lite.d.ts`, the rest are Windows path / locale artefacts. CI builds its own wasm, so those are expected green here.

NOT run on this host: root `pnpm lint` (`check-changesets.mjs` / `check-unused-locals.mjs` spawn `pnpm` without a shell and fail with ENOENT on Windows), repo-wide `pnpm test` / `pnpm typecheck`, Rust lanes (no Rust change), and any browser / visual QA of the picker and drop flows.

## Review
CodeRabbit (first round; all five confirmed against the rebased code and fixed):
1. `.changeset/moody-adults-sing.md` — `patch` to `minor` (new capability).
2. `ViewportContainer.tsx` — add-vs-replace was decided from a render-time `hasModelsLoaded` captured before the bundle await; `routeLoad` now reads `models` / `geometryResult` from the store at routing time.
3. `usePreparedModelFileRoute.ts` — `unchanged` was all-or-nothing, so a mixed pick dropped every handle; handles are now aligned per `File`.
4. same file — picks were not serialised; one module-wide chain now keeps routing in pick order (chosen over discarding stale results, because an Add Model pick must never be dropped and the loader's stale-session guard already makes the last Open win).
5. `gltf-bundle.ts` — each resource was read before its size was checked and the limits were independent; a single cumulative budget is reserved before every read and settled before allocation.

Internal review (second round): a pick of sidecars only (`scan.bin` + `scan.png`, no `.gltf`) passed every entry-point filter and resolved to nothing silently — now rejected with "Select the .gltf document together with its .bin and texture files." (regression test added).

CodeRabbit (second round on `90dc93888`; all three fixed):
6. `gltf-bundle.ts` — buffer views were only checked for a valid buffer index, so a view overrunning its buffer would, once rebased into the single BIN chunk, read the next resource's bytes; views now need safe non-negative offset/length within their buffer's declared `byteLength`.
7. `gltf-bundle.ts` — non-base64 data URIs went through `decodeURIComponent` + `TextEncoder`, so `%00%FF` threw; each `%XX` is now one octet.
8. `gltf-bundle.test.ts` — the cumulative-limit test took its expected GLB size from the packer itself; it is now computed from the fixture and the GLB container layout.

CI: the "Changed tests observe production" lane judged the first push BASELINE-BROKEN because the route test logged `ReferenceError: indexedDB is not defined` from the recent-files cache; the test now installs `fake-indexeddb` like its siblings. Nothing rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg
