### PR TITLE
fix(viewer): complete the scan capture flow

### DIFF
--- a/.changeset/public-plums-start.md
+++ b/.changeset/public-plums-start.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Make scan capture discoverable with in-panel upload and blank IFC creation, preserve selected regions when adding a destination, and export the authored model by default.

--- a/.changeset/public-plums-start.md
+++ b/.changeset/public-plums-start.md
@@ -1,5 +1,5 @@
 ---
-"@ifc-lite/viewer": patch
+"@ifc-lite/viewer": minor
 ---
 
 Make scan capture discoverable with in-panel upload and blank IFC creation, preserve selected regions when adding a destination, and export the authored model by default.

--- a/apps/viewer/src/components/viewer/ExportDialog.default-model.test.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.default-model.test.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import '@/test/setup-dom.js';
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { useViewerStore } from '@/store';
+import { render, cleanup, click } from '@/test/render';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture';
+import { ExportDialog } from './ExportDialog';
+
+afterEach(cleanup);
+
+test('Export IFC opens on the active authored model, not the first loaded scan (#4477)', () => {
+  useViewerStore.setState({ ...fixtureModels(fixtureModel('scan.glb'), fixtureModel('captured.ifc')), activeModelId: 'captured.ifc', dirtyModels: new Set() });
+  const ui = render(<ExportDialog />);
+  click([...ui.querySelectorAll('button')].find(button => button.textContent?.includes('Export IFC'))!);
+  const choices = [...document.querySelectorAll('[role="combobox"]')].map(node => node.textContent ?? '');
+  assert.ok(choices.some(text => text.includes('captured.ifc')), `model selector shows the destination: ${JSON.stringify(choices)}`);
+  assert.ok(!choices.some(text => text.includes('scan.glb')), 'the source scan is not the default export');
+});

--- a/apps/viewer/src/components/viewer/ExportDialog.tsx
+++ b/apps/viewer/src/components/viewer/ExportDialog.tsx
@@ -68,6 +68,7 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import { spliceScheduleIntoExport } from '@/sdk/adapters/export-schedule-splice';
 import { downloadFile, sanitizeFilename } from '@/lib/export/download';
 import { ExtensionExportSlot } from '@/components/extensions/ExtensionExportSlot';
+import { preferredExportModelId } from './export-model-default';
 
 type ExportScope = 'single' | 'merged';
 type SchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
@@ -79,6 +80,7 @@ interface ExportDialogProps {
 
 export function ExportDialog({ trigger }: ExportDialogProps) {
   const models = useViewerStore((s) => s.models);
+  const activeModelId = useViewerStore((s) => s.activeModelId);
   const dirtyModels = useViewerStore((s) => s.dirtyModels);
   const getMutationView = useViewerStore((s) => s.getMutationView);
   const registerMutationView = useViewerStore((s) => s.registerMutationView);
@@ -172,12 +174,19 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
     return list;
   }, [models, dirtyModels, legacyIfcDataStore]);
 
-  // Select first model by default
-  useMemo(() => {
-    if (modelList.length > 0 && !selectedModelId) {
-      setSelectedModelId(modelList[0].id);
+  // Keep a removed selection from stranding the dialog. The open handler below
+  // deliberately re-seeds from the active model each time: authoring commands
+  // select their destination, so Export follows the object the user just made.
+  useEffect(() => {
+    if (selectedModelId && !modelList.some(model => model.id === selectedModelId)) {
+      setSelectedModelId(modelList[0]?.id ?? '');
     }
   }, [modelList, selectedModelId]);
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    if (next) setSelectedModelId(preferredExportModelId(modelList.map(model => model.id), activeModelId));
+    setOpen(next);
+  }, [modelList, activeModelId]);
 
   // Get selected model's data - supports both federated and legacy mode
   const selectedModel = useMemo(() => {
@@ -593,7 +602,7 @@ export function ExportDialog({ trigger }: ExportDialogProps) {
   }, [selectedModel, selectedModelId, schema, isIfc5, exportScope, includeGeometry, applyMutations, changesOnly, visibleOnly, unitReconciliation, onlyKnownProperties, getMutationView, getLocalHiddenIds, getLocalIsolatedIds, modifiedCount, models, extensionHost, outputInfo]);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         {trigger || (
           <Button variant="outline" size="sm">

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.flow.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.flow.test.tsx
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import 'fake-indexeddb/auto';
+import '@/test/setup-dom.js';
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act } from 'react';
+import { initSync } from '@ifc-lite/wasm';
+import { useViewerStore } from '@/store';
+import { render, cleanup, click, advance } from '@/test/render';
+import { emptyPlacementState } from '@/lib/model-placement/state';
+import { AppearanceCapturePanel } from './AppearanceCapturePanel';
+
+// A real 1x1 PNG: the GLB image reader verifies the encoded signature (#4397).
+const png = Uint8Array.from(Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLbtAAAAABJRU5ErkJggg==', 'base64'));
+
+/** One textured triangle as a photogrammetry export ships it: .gltf + .bin + texture. */
+function scanBundle(): File[] {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), uvs = new Float32Array([0, 0, 1, 0, 0, 1]);
+  const bin = new Uint8Array(positions.byteLength + uvs.byteLength);
+  bin.set(new Uint8Array(positions.buffer)); bin.set(new Uint8Array(uvs.buffer), positions.byteLength);
+  const json = {
+    asset: { version: '2.0' }, scene: 0, scenes: [{ nodes: [0] }], nodes: [{ mesh: 0, extras: { expressId: 42 } }],
+    buffers: [{ uri: 'scan.bin', byteLength: bin.byteLength }],
+    bufferViews: [{ buffer: 0, byteOffset: 0, byteLength: positions.byteLength }, { buffer: 0, byteOffset: positions.byteLength, byteLength: uvs.byteLength }],
+    accessors: [{ bufferView: 0, componentType: 5126, count: 3, type: 'VEC3' }, { bufferView: 1, componentType: 5126, count: 3, type: 'VEC2' }],
+    images: [{ uri: 'scan.png' }], textures: [{ source: 0 }], materials: [{ pbrMetallicRoughness: { baseColorTexture: { index: 0 } } }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, TEXCOORD_0: 1 }, material: 0 }] }],
+  };
+  return [new File([JSON.stringify(json)], 'scan.gltf'), new File([bin], 'scan.bin'), new File([png], 'scan.png', { type: 'image/png' })];
+}
+
+class OpaqueCanvas {
+  width = 1;
+  getContext() { return { clearRect() {}, drawImage() {}, getImageData() { return { data: new Uint8ClampedArray([255, 0, 0, 255]) }; } }; }
+}
+
+async function until(condition: () => boolean, what: string): Promise<void> {
+  for (let i = 0; i < 1500; i++) { if (condition()) return; await advance(10); }
+  assert.fail(`Timed out waiting for ${what}`);
+}
+
+// The blank IFC4 destination is parsed by the real engine. Under happy-dom the
+// bridge takes its browser path (`window` exists) and would fetch the binary
+// over file://, so pre-load the shared module from disk the way
+// `useClash.solid-inflight-invalidation.test.tsx` does; skip when it is absent.
+const wasmPath = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..', '..', '..', 'packages', 'wasm', 'pkg', 'ifc-lite_bg.wasm');
+
+const decoder = globalThis.createImageBitmap, canvas = globalThis.OffscreenCanvas;
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(globalThis, 'createImageBitmap', { value: decoder, configurable: true, writable: true });
+  Object.defineProperty(globalThis, 'OffscreenCanvas', { value: canvas, configurable: true, writable: true });
+  useViewerStore.getState().resetViewerState(); useViewerStore.getState().clearAllModels();
+});
+
+test('first-user path: a glTF scan bundle uploaded in the panel reaches the canonical loader, then a blank IFC4 destination is created in-flow without losing the region (#4477)', async t => {
+  if (!existsSync(wasmPath)) { t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first'); return; }
+  initSync({ module: readFileSync(wasmPath) });
+  Object.defineProperty(globalThis, 'createImageBitmap', { configurable: true, writable: true, value: async () => ({ width: 1, height: 1, close() {} }) });
+  Object.defineProperty(globalThis, 'OffscreenCanvas', { configurable: true, writable: true, value: OpaqueCanvas });
+  useViewerStore.getState().resetViewerState(); useViewerStore.getState().clearAllModels();
+  useViewerStore.setState({ selectedEntityId: null, modelPlacement: emptyPlacementState(), collabRoomId: null, mutationViews: new Map() });
+  const ui = render(<AppearanceCapturePanel />);
+  const source = ui.querySelector<HTMLSelectElement>('select[aria-label="Captured source surface"]')!;
+  assert.equal(source.options.length, 1, 'nothing to capture before a scan is loaded');
+
+  const picker = ui.querySelector<HTMLInputElement>('input[aria-label="Add scan files"]')!;
+  const transfer = new window.DataTransfer();
+  for (const file of scanBundle()) transfer.items.add(file);
+  Object.defineProperty(picker, 'files', { configurable: true, value: transfer.files });
+  await act(async () => picker.dispatchEvent(new window.Event('change', { bubbles: true })));
+  // The scan is listed the moment the loader publishes it; the region follows once its images settle.
+  await until(() => /1 triangles in this region/.test(ui.textContent ?? ''), 'the packed scan to load and its region to be prepared');
+  const [scan] = [...useViewerStore.getState().models.values()];
+  assert.equal(scan.name, 'scan.glb', 'the bundle was packed into one GLB and loaded as a model');
+  assert.equal(scan.loadState, 'complete');
+  assert.ok(scan.geometryResult?.meshes[0]?.textureRef, 'the loaded surface carries its base-colour texture');
+  assert.equal(source.value, `${scan.id}:0`);
+
+  const destination = ui.querySelector<HTMLSelectElement>('select[aria-label="Capture destination model"]')!;
+  assert.equal(destination.value, '', 'a scan is not an editable destination');
+  click([...ui.querySelectorAll('button')].find(button => button.textContent === 'New IFC4 model')!);
+  await until(() => destination.value !== '', 'the blank IFC4 model to be created and chosen as destination');
+  const created = useViewerStore.getState().models.get(destination.value);
+  assert.ok(created && created.id !== scan.id, 'the destination is the model created in-flow');
+  assert.equal(useViewerStore.getState().models.size, 2, 'the scan stays loaded beside its destination');
+  assert.equal(source.value, `${scan.id}:0`, 'the chosen source survives adding the destination');
+  assert.match(ui.textContent ?? '', /1 triangles in this region/);
+  assert.match(ui.textContent ?? '', /selected scan region is still ready/);
+});

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.flow.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.flow.test.tsx
@@ -75,7 +75,7 @@ test('first-user path: a glTF scan bundle uploaded in the panel reaches the cano
   Object.defineProperty(picker, 'files', { configurable: true, value: transfer.files });
   await act(async () => picker.dispatchEvent(new window.Event('change', { bubbles: true })));
   // The scan is listed the moment the loader publishes it; the region follows once its images settle.
-  await until(() => /1 triangles in this region/.test(ui.textContent ?? ''), 'the packed scan to load and its region to be prepared');
+  await until(() => /1 triangle in this region/.test(ui.textContent ?? ''), 'the packed scan to load and its region to be prepared');
   const [scan] = [...useViewerStore.getState().models.values()];
   assert.equal(scan.name, 'scan.glb', 'the bundle was packed into one GLB and loaded as a model');
   assert.equal(scan.loadState, 'complete');
@@ -90,6 +90,6 @@ test('first-user path: a glTF scan bundle uploaded in the panel reaches the cano
   assert.ok(created && created.id !== scan.id, 'the destination is the model created in-flow');
   assert.equal(useViewerStore.getState().models.size, 2, 'the scan stays loaded beside its destination');
   assert.equal(source.value, `${scan.id}:0`, 'the chosen source survives adding the destination');
-  assert.match(ui.textContent ?? '', /1 triangles in this region/);
+  assert.match(ui.textContent ?? '', /1 triangle in this region/);
   assert.match(ui.textContent ?? '', /selected scan region is still ready/);
 });

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.test.tsx
@@ -25,3 +25,17 @@ test('removing the pinned captured surface never silently substitutes another lo
   act(()=>{select.value='other:0';select.dispatchEvent(new window.Event('change',{bubbles:true}));});
   assert.equal(select.value,'other:0','another source requires an explicit choice');
 });
+
+test('capture panel exposes source upload and blank destination actions in the flow (#4477)', () => {
+  useViewerStore.setState({models:new Map(),selectedEntityId:null,activeModelId:null,
+    modelPlacement:emptyPlacementState(),collabRoomId:null,mutationViews:new Map()});
+  const ui=render(<AppearanceCapturePanel/>);
+  assert.match(ui.textContent ?? '', /1\. Choose a source/);
+  assert.match(ui.textContent ?? '', /2\. Choose a destination/);
+  assert.match(ui.textContent ?? '', /3\. Create the IFC object/);
+  assert.ok([...ui.querySelectorAll('button')].some(button => button.textContent === 'Add scan'));
+  assert.ok([...ui.querySelectorAll('button')].some(button => button.textContent === 'New IFC4 model'));
+  assert.equal(ui.querySelector<HTMLInputElement>('input[aria-label="Add scan files"]')?.accept,
+    '.glb,.gltf,.bin,.png,.jpg,.jpeg,.ifc,.ifczip');
+  assert.match(ui.textContent ?? '', /glTF bundle/);
+});

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { selectCreatedAppearanceObject } from './select-created-object';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { prepareCapturedRegion } from '@/lib/appearance/capture/source';
@@ -12,15 +12,24 @@ import { AppearanceMeshPreview } from './AppearanceMeshPreview';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { appearanceSelectClass } from './AppearanceSourceFields';
+import { useIfc } from '@/hooks/useIfc';
+import { createBlankIfcFile } from '@/utils/createBlankIfc';
+import { usePreparedModelFileRoute } from '@/hooks/ingest/usePreparedModelFileRoute';
+
+const MAX_CAPTURE_ROWS = 200_000;
+const CAPTURE_ACCEPT = '.glb,.gltf,.bin,.png,.jpg,.jpeg,.ifc,.ifczip';
 
 export function AppearanceCapturePanel() {
   const models = useViewerStore(state => state.models), selected = useViewerStore(state => state.selectedEntityId);
   const room = useViewerStore(state => state.collabRoomId);
-  const placement = useViewerStore(state => state.modelPlacement), mutationVersion = useViewerStore(state => state.mutationVersion);
+  const placement = useViewerStore(state => state.modelPlacement);
+  const { addModel, loadFile, loadFilesSequentially, loading } = useIfc();
   const target = useIfcAuthoringTarget();
   const candidates = useMemo(() => [...models.values()].flatMap(model => (model.geometryResult?.meshes ?? [])
     .flatMap((mesh, index) => mesh.textureRef ? [{ id: `${model.id}:${index}`, modelId: model.id, mesh,
       label: `${model.name} · Surface ${index + 1} · ${(mesh.indices.length / 3).toLocaleString()} triangles` }] : [])), [models]);
+  const excludedSurfaces = useMemo(() => [...models.values()].reduce((count, model) => count
+    + (model.geometryResult?.meshes ?? []).filter(mesh => !mesh.textureRef).length, 0), [models]);
   const [chosen, setChosen] = useState('');
   const candidate = chosen ? candidates.find(item => item.id === chosen)
     : candidates.find(item => item.mesh.expressId === selected) ?? candidates[0];
@@ -32,15 +41,24 @@ export function AppearanceCapturePanel() {
   const [ready, setReady] = useState(false), [busy, setBusy] = useState(false);
   const [message, setMessage] = useState(''), [error, setError] = useState(false);
   const operation = useRef<AbortController | null>(null);
+  const scanInput = useRef<HTMLInputElement>(null);
+  const routeScanFiles = useCallback((files: File[]) => {
+    setMessage('Loading scan source…'); setError(false);
+    if (models.size === 0 && files.length === 1) void loadFile(files[0]);
+    else void loadFilesSequentially(files);
+  }, [models.size, loadFile, loadFilesSequentially]);
+  const prepareAndLoadScan = usePreparedModelFileRoute(routeScanFiles);
   useEffect(() => () => { operation.current?.abort(); operation.current = null; }, []);
   useEffect(() => {
     operation.current?.abort(); setReady(false); setPrepared(null); setAssetId(null); setMessage(''); setError(false);
     if (!candidate) { setTriangles([]); return; }
     setChosen(candidate.id);
-    if (candidate.mesh.indices.length / 3 > 200_000) { setError(true); setMessage('Choose a source surface with at most 200000 triangles.'); setTriangles([]); return; }
     try {
       const first = prepareCapturedRegion(candidate.modelId, candidate.mesh, [0]);
-      setAssetId(first.assetId); setTriangles(Array.from({ length: candidate.mesh.indices.length / 3 }, (_, i) => i));
+      const count = candidate.mesh.indices.length / 3;
+      setAssetId(first.assetId);
+      setTriangles(count <= MAX_CAPTURE_ROWS ? Array.from({ length: count }, (_, i) => i) : [0]);
+      if (count > MAX_CAPTURE_ROWS) setMessage(`This surface has ${count.toLocaleString()} triangles. Select a region with at most 200,000 triangles and vertices.`);
     } catch (failure) { setTriangles([]); setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); }
   }, [candidate?.modelId, candidate?.mesh]);
   useEffect(() => { setCreated(false); }, [candidate?.mesh, triangles]);
@@ -49,9 +67,20 @@ export function AppearanceCapturePanel() {
     setPrepared(null); if (!candidate || !assetId) return;
     if (placement.preview) { setMessage('Finish repositioning the model to create this region.'); return; }
     if (!triangles.length) { setMessage('The rectangle contains no triangle centres. Choose another region or Entire surface.'); return; }
-    try { setPrepared(prepareCapturedRegion(candidate.modelId,candidate.mesh,triangles)); setError(false); setMessage('Review the textured region, then choose where to create it.'); }
+    try { setPrepared(prepareCapturedRegion(candidate.modelId,candidate.mesh,triangles)); setError(false); setMessage(candidate.mesh.indices.length / 3 > MAX_CAPTURE_ROWS && triangles.length === 1
+      ? `This surface is larger than the capture limit. Use Select region to keep at most 200,000 triangles and vertices.`
+      : 'Review the textured region, then choose where to create it.'); }
     catch (failure) { setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); }
-  }, [candidate?.modelId, candidate?.mesh, assetId, triangles, placement, mutationVersion, created]);
+  }, [candidate?.modelId, candidate?.mesh, assetId, triangles, placement, created]);
+  async function createDestination() {
+    if (loading || busy) return;
+    setMessage('Creating an editable IFC4 model…'); setError(false);
+    try {
+      const modelId = await addModel(createBlankIfcFile({ projectName: 'Captured Surfaces' }));
+      if (modelId) { target.setChosenModel(modelId); target.setChosenContainer(undefined); setMessage('Editable IFC4 destination created. Your selected scan region is still ready.'); }
+      else { setError(true); setMessage('The editable IFC4 model could not be created.'); }
+    } catch (failure) { setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); }
+  }
   async function create() {
     const renderer = getGlobalRenderer();
     if (!prepared || !ready || !renderer || !target.modelId || target.containerId === undefined || operation.current || room) return;
@@ -65,17 +94,29 @@ export function AppearanceCapturePanel() {
     } catch (failure) { if (!controller.signal.aborted) { setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); } }
     finally { if (operation.current === controller) { operation.current = null; setBusy(false); } }
   }
-  return <section className="mt-4 space-y-3" aria-label="Create from scan" aria-busy={busy}>
-    <h2 className="text-sm font-semibold">Create from scan</h2>
-    <p className="text-[11px] text-muted-foreground">Turn a selected scan surface into a textured IFC object. Open or add a textured GLB to begin.</p>
-    <label className="block text-[11px]">Source surface<select className={appearanceSelectClass} aria-label="Captured source surface" value={candidate?.id ?? ''} disabled={busy}
+  return <section className="mt-4 space-y-3" aria-label="Create from scan" aria-busy={busy || loading}>
+    <div><h2 className="text-sm font-semibold">Create from scan</h2>
+      <p className="mt-1 text-[11px] text-muted-foreground">Turn a textured scan or IFC surface into an editable IFC object.</p></div>
+    <div className="space-y-2 rounded-md border bg-muted/20 p-3">
+      <div className="flex items-center justify-between gap-2"><h3 className="text-xs font-medium">1. Choose a source</h3>
+        <Button type="button" size="sm" variant="outline" disabled={busy || loading} onClick={() => scanInput.current?.click()}>Add scan</Button></div>
+      <input ref={scanInput} type="file" multiple accept={CAPTURE_ACCEPT} className="hidden" aria-label="Add scan files" onChange={event => {
+        const files = Array.from(event.target.files ?? []); if (files.length) prepareAndLoadScan(files); event.target.value = '';
+      }}/>
+    <label className="block text-[11px]">Source surface<select className={appearanceSelectClass} aria-label="Captured source surface" value={candidate?.id ?? ''} disabled={busy || loading}
       onChange={event => setChosen(event.target.value)}>{!candidate && <option value="">{candidates.length ? 'Choose a source surface' : 'Open or add a textured model'}</option>}
       {candidates.map(item => <option key={item.id} value={item.id}>{item.label}</option>)}
     </select></label>
-    {candidate && assetId && <AppearanceMeshPreview key={candidate.id} mesh={candidate.mesh} assetId={assetId} triangles={triangles} disabled={busy}
-      onRegion={setTriangles} onReady={value => { setReady(value); if (value) { setError(false); setMessage('Review the textured region, then choose where to create it.'); } }} onError={text => { setReady(false); setError(true); setMessage(text); }} />}
+    {!candidate && <p className="text-[11px] text-muted-foreground">Choose a GLB, a glTF bundle (.gltf + .bin + textures), or an IFC with a supported base-colour texture.</p>}
+    {!candidate && excludedSurfaces > 0 && <p className="text-[11px] text-muted-foreground">{excludedSurfaces.toLocaleString()} loaded {excludedSurfaces === 1 ? 'surface is' : 'surfaces are'} unavailable because no supported base-colour texture and UV mapping was found.</p>}
+    {candidate && assetId && <AppearanceMeshPreview key={candidate.id} mesh={candidate.mesh} assetId={assetId} triangles={triangles} disabled={busy || loading}
+      onRegion={ids => { if (ids.length > MAX_CAPTURE_ROWS) { setError(true); setMessage('Select a smaller region with at most 200,000 triangles and vertices.'); return; } setTriangles(ids); }}
+      onReady={value => { setReady(value); if (value && !message) { setError(false); setMessage('Review the textured region, then choose where to create it.'); } }} onError={text => { setReady(false); setError(true); setMessage(text); }} />}
     {!!assetId && <p className="text-[11px]" role="status">{triangles.length.toLocaleString()} triangles in this region</p>}
-    <fieldset disabled={busy || !!room} className="space-y-2">
+    </div>
+    <fieldset disabled={busy || loading || !!room} className="space-y-2 rounded-md border bg-muted/20 p-3">
+      <div className="flex items-center justify-between gap-2"><h3 className="text-xs font-medium">2. Choose a destination</h3>
+        <Button type="button" size="sm" variant="outline" disabled={busy || loading || !!room} onClick={() => { void createDestination(); }}>New IFC4 model</Button></div>
       <label className="block text-[11px]">Destination model<select aria-label="Capture destination model" className={appearanceSelectClass} value={target.modelId}
         onChange={event => { target.setChosenModel(event.target.value); target.setChosenContainer(undefined); }}>
         {!target.eligible.length && <option value="">Add an editable IFC4 model</option>}
@@ -87,6 +128,7 @@ export function AppearanceCapturePanel() {
         {target.containers.map(node => <option key={node.expressId} value={node.expressId}>{node.name || `#${node.expressId}`}</option>)}
       </select></label>
       <label className="block text-[11px]">Name<Input aria-label="Captured object Name" value={Name} onChange={event => setName(event.target.value)} /></label>
+      <h3 className="pt-1 text-xs font-medium">3. Create the IFC object</h3>
       <Button type="button" className="w-full" disabled={!ready || !prepared || !!placement.preview || !target.modelId || target.containerId === undefined || !Name.trim()}
         onClick={() => { void create(); }}>Create IFC object</Button>
     </fieldset>

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
@@ -35,6 +35,8 @@ export function AppearanceCapturePanel() {
   const candidate = chosen ? candidates.find(item => item.id === chosen)
     : candidates.find(item => item.mesh.expressId === selected) ?? candidates[0];
   const [triangles, setTriangles] = useState<number[]>([]);
+  // An over-limit surface starts with a single placeholder triangle; a user's own one-triangle region looks the same by length.
+  const [placeholder, setPlaceholder] = useState(false);
   const [prepared, setPrepared] = useState<CapturedMeshSource | null>(null);
   const [assetId, setAssetId] = useState<string | null>(null);
   const [Name, setName] = useState('Captured surface');
@@ -55,6 +57,7 @@ export function AppearanceCapturePanel() {
   const [imagesSettled, setImagesSettled] = useState(0);
   useEffect(() => {
     operation.current?.abort(); setReady(false); setPrepared(null); setAssetId(null); setMessage(''); setError(false);
+    setPlaceholder(false);
     if (!candidate) { setTriangles([]); return; }
     setChosen(candidate.id);
     try {
@@ -62,6 +65,7 @@ export function AppearanceCapturePanel() {
       const count = candidate.mesh.indices.length / 3;
       setAssetId(first.assetId);
       setTriangles(count <= MAX_CAPTURE_ROWS ? Array.from({ length: count }, (_, i) => i) : [0]);
+      setPlaceholder(count > MAX_CAPTURE_ROWS);
       if (count > MAX_CAPTURE_ROWS) setMessage(`This surface has ${count.toLocaleString()} triangles. Select a region with at most 200,000 triangles and vertices.`);
     } catch (failure) {
       setTriangles([]); setMessage(failure instanceof Error ? failure.message : String(failure));
@@ -80,11 +84,11 @@ export function AppearanceCapturePanel() {
     setPrepared(null); if (!candidate || !assetId) return;
     if (placement.preview) { setMessage('Finish repositioning the model to create this region.'); return; }
     if (!triangles.length) { setMessage('The rectangle contains no triangle centres. Choose another region or Entire surface.'); return; }
-    try { setPrepared(prepareCapturedRegion(candidate.modelId,candidate.mesh,triangles)); setError(false); setMessage(candidate.mesh.indices.length / 3 > MAX_CAPTURE_ROWS && triangles.length === 1
-      ? `This surface is larger than the capture limit. Use Select region to keep at most 200,000 triangles and vertices.`
+    try { setPrepared(prepareCapturedRegion(candidate.modelId,candidate.mesh,triangles)); setError(false); setMessage(placeholder
+      ? 'This surface is larger than the capture limit. Use Select region to keep at most 200,000 triangles and vertices.'
       : 'Review the textured region, then choose where to create it.'); }
     catch (failure) { setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); }
-  }, [candidate?.modelId, candidate?.mesh, assetId, triangles, placement, created]);
+  }, [candidate?.modelId, candidate?.mesh, assetId, triangles, placeholder, placement, created]);
   async function createDestination() {
     if (loading || busy) return;
     setMessage('Creating an editable IFC4 model…'); setError(false);
@@ -121,11 +125,11 @@ export function AppearanceCapturePanel() {
       {candidates.map(item => <option key={item.id} value={item.id}>{item.label}</option>)}
     </select></label>
     {!candidate && <p className="text-[11px] text-muted-foreground">Choose a GLB, a glTF bundle (.gltf + .bin + textures), or an IFC with a supported base-colour texture.</p>}
-    {!candidate && excludedSurfaces > 0 && <p className="text-[11px] text-muted-foreground">{excludedSurfaces.toLocaleString()} loaded {excludedSurfaces === 1 ? 'surface is' : 'surfaces are'} unavailable because no supported base-colour texture and UV mapping was found.</p>}
+    {!candidate && excludedSurfaces > 0 && <p className="text-[11px] text-muted-foreground">None of the {excludedSurfaces.toLocaleString()} loaded {excludedSurfaces === 1 ? 'surface has' : 'surfaces have'} a supported base-colour texture with UV mapping.</p>}
     {candidate && assetId && <AppearanceMeshPreview key={candidate.id} mesh={candidate.mesh} assetId={assetId} triangles={triangles} disabled={busy || loading}
-      onRegion={ids => { if (ids.length > MAX_CAPTURE_ROWS) { setError(true); setMessage('Select a smaller region with at most 200,000 triangles and vertices.'); return; } setTriangles(ids); }}
+      onRegion={ids => { if (ids.length > MAX_CAPTURE_ROWS) { setError(true); setMessage('Select a smaller region with at most 200,000 triangles and vertices.'); return; } setPlaceholder(false); setTriangles(ids); }}
       onReady={value => { setReady(value); if (value && !message) { setError(false); setMessage('Review the textured region, then choose where to create it.'); } }} onError={text => { setReady(false); setError(true); setMessage(text); }} />}
-    {!!assetId && <p className="text-[11px]" role="status">{triangles.length.toLocaleString()} triangles in this region</p>}
+    {!!assetId && <p className="text-[11px]" role="status">{triangles.length.toLocaleString()} {triangles.length === 1 ? 'triangle' : 'triangles'} in this region</p>}
     </div>
     <fieldset disabled={busy || loading || !!room} className="space-y-2 rounded-md border bg-muted/20 p-3">
       <div className="flex items-center justify-between gap-2"><h3 className="text-xs font-medium">2. Choose a destination</h3>

--- a/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceCapturePanel.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useViewerStore } from '@/store';
 import { getGlobalRenderer } from '@/hooks/useBCF';
 import { prepareCapturedRegion } from '@/lib/appearance/capture/source';
+import { modelAppearanceAssets } from '@/lib/appearance/model-assets';
 import { createIfcFromCapturedMesh, type CapturedMeshSource } from '@/lib/appearance/create-captured-mesh';
 import { useIfcAuthoringTarget } from './useIfcAuthoringTarget';
 import { AppearanceMeshPreview } from './AppearanceMeshPreview';
@@ -44,11 +45,14 @@ export function AppearanceCapturePanel() {
   const scanInput = useRef<HTMLInputElement>(null);
   const routeScanFiles = useCallback((files: File[]) => {
     setMessage('Loading scan source…'); setError(false);
-    if (models.size === 0 && files.length === 1) void loadFile(files[0]);
+    // Bundle preparation awaits before routing, so decide from the store now:
+    // a model loaded meanwhile is added to, not replaced.
+    if (useViewerStore.getState().models.size === 0 && files.length === 1) void loadFile(files[0]);
     else void loadFilesSequentially(files);
-  }, [models.size, loadFile, loadFilesSequentially]);
+  }, [loadFile, loadFilesSequentially]);
   const prepareAndLoadScan = usePreparedModelFileRoute(routeScanFiles);
   useEffect(() => () => { operation.current?.abort(); operation.current = null; }, []);
+  const [imagesSettled, setImagesSettled] = useState(0);
   useEffect(() => {
     operation.current?.abort(); setReady(false); setPrepared(null); setAssetId(null); setMessage(''); setError(false);
     if (!candidate) { setTriangles([]); return; }
@@ -59,8 +63,17 @@ export function AppearanceCapturePanel() {
       setAssetId(first.assetId);
       setTriangles(count <= MAX_CAPTURE_ROWS ? Array.from({ length: count }, (_, i) => i) : [0]);
       if (count > MAX_CAPTURE_ROWS) setMessage(`This surface has ${count.toLocaleString()} triangles. Select a region with at most 200,000 triangles and vertices.`);
-    } catch (failure) { setTriangles([]); setError(true); setMessage(failure instanceof Error ? failure.message : String(failure)); }
-  }, [candidate?.modelId, candidate?.mesh]);
+    } catch (failure) {
+      setTriangles([]); setMessage(failure instanceof Error ? failure.message : String(failure));
+      // A freshly loaded scan is listed before its images settle: wait for them and prepare again.
+      const decoding = modelAppearanceAssets.pendingDecode(candidate.modelId);
+      setError(!decoding);
+      if (!decoding) return;
+      let live = true;
+      void decoding.then(() => { if (live) setImagesSettled(count => count + 1); });
+      return () => { live = false; };
+    }
+  }, [candidate?.modelId, candidate?.mesh, imagesSettled]);
   useEffect(() => { setCreated(false); }, [candidate?.mesh, triangles]);
   useEffect(() => {
     if (operation.current || created) return;

--- a/apps/viewer/src/components/viewer/export-model-default.test.ts
+++ b/apps/viewer/src/components/viewer/export-model-default.test.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { preferredExportModelId } from './export-model-default.js';
+
+test('Export IFC follows the active destination instead of the first loaded scan (#4477)', () => {
+  assert.equal(preferredExportModelId(['scan.glb', 'authored.ifc'], 'authored.ifc'), 'authored.ifc');
+  assert.equal(preferredExportModelId(['scan.glb', 'authored.ifc'], 'missing'), 'scan.glb');
+  assert.equal(preferredExportModelId([], null), '');
+});

--- a/apps/viewer/src/components/viewer/export-model-default.ts
+++ b/apps/viewer/src/components/viewer/export-model-default.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Prefer the active (usually just-authored) model, with a stable first-model fallback. */
+export function preferredExportModelId(modelIds: readonly string[], activeModelId: string | null): string {
+  return activeModelId && modelIds.includes(activeModelId) ? activeModelId : modelIds[0] ?? '';
+}

--- a/apps/viewer/src/hooks/ingest/unsupportedFormat.bcf.test.ts
+++ b/apps/viewer/src/hooks/ingest/unsupportedFormat.bcf.test.ts
@@ -38,3 +38,9 @@ describe('describeUnsupportedFormat for BCF archives (#4099)', () => {
     assert.doesNotMatch(message!, /extract first/i);
   });
 });
+
+it('scan archives explain the supported extraction/export path (#4477)', () => {
+  assert.match(describeUnsupportedFormat('capture.blend.zip')!, /Blender archive/);
+  assert.match(describeUnsupportedFormat('capture.blend.zip')!, /GLB|\.gltf/);
+  assert.match(describeUnsupportedFormat('capture.zip')!, /glTF bundles/);
+});

--- a/apps/viewer/src/hooks/ingest/unsupportedFormat.bcf.test.ts
+++ b/apps/viewer/src/hooks/ingest/unsupportedFormat.bcf.test.ts
@@ -39,8 +39,8 @@ describe('describeUnsupportedFormat for BCF archives (#4099)', () => {
   });
 });
 
-it('scan archives explain the supported extraction/export path (#4477)', () => {
-  assert.match(describeUnsupportedFormat('capture.blend.zip')!, /Blender archive/);
-  assert.match(describeUnsupportedFormat('capture.blend.zip')!, /GLB|\.gltf/);
+it('scan sources explain the supported export/extraction path (#4477)', () => {
+  assert.match(describeUnsupportedFormat('capture.blend')!, /Blender scene/);
+  assert.match(describeUnsupportedFormat('capture.blend')!, /GLB|\.gltf/);
   assert.match(describeUnsupportedFormat('capture.zip')!, /glTF bundles/);
 });

--- a/apps/viewer/src/hooks/ingest/unsupportedFormat.ts
+++ b/apps/viewer/src/hooks/ingest/unsupportedFormat.ts
@@ -15,8 +15,11 @@
  */
 export function describeUnsupportedFormat(fileName: string): string | null {
   const lower = fileName.toLowerCase();
+  if (lower.endsWith('.blend.zip')) {
+    return 'Blender archive — extract it, then export a GLB or select the .gltf, .bin and texture files together.';
+  }
   if (lower.endsWith('.zip')) {
-    return 'ZIP archive — please extract first. .ply / .las / .laz / .e57 files inside will load.';
+    return 'ZIP archive — please extract first. GLB, glTF bundles, PLY, LAS, LAZ and E57 files inside can load.';
   }
   if (
     lower.endsWith('.rwp') || lower.endsWith('.rwi')

--- a/apps/viewer/src/hooks/ingest/unsupportedFormat.ts
+++ b/apps/viewer/src/hooks/ingest/unsupportedFormat.ts
@@ -15,8 +15,8 @@
  */
 export function describeUnsupportedFormat(fileName: string): string | null {
   const lower = fileName.toLowerCase();
-  if (lower.endsWith('.blend.zip')) {
-    return 'Blender archive — extract it, then export a GLB or select the .gltf, .bin and texture files together.';
+  if (lower.endsWith('.blend')) {
+    return 'Blender scene — export a GLB from Blender, or select the exported .gltf, .bin and texture files together.';
   }
   if (lower.endsWith('.zip')) {
     return 'ZIP archive — please extract first. GLB, glTF bundles, PLY, LAS, LAZ and E57 files inside can load.';

--- a/apps/viewer/src/lib/appearance/capture/region.test.ts
+++ b/apps/viewer/src/lib/appearance/capture/region.test.ts
@@ -53,6 +53,15 @@ test('capture registration uses stable federation anchor, independent of active 
   assert.deepEqual(after, before);
 });
 
+test('adding an editable destination does not invalidate a prepared scan region (#4477)', () => {
+  const f = fixture(), registration = captureRegistration('capture', f.mesh, f.getState);
+  const first = f.getState(), destination = fixtureModel('destination');
+  f.update({ ...first, models: new Map([...first.models, ['destination', destination]]),
+    mutationVersion: first.mutationVersion + 1 });
+  assert.doesNotThrow(() => registration.validate());
+  assert.equal(captureRegion(f.mesh, [0], registration).mesh.triangles.length, 1);
+});
+
 test('capture refuses placement copies and stale sources or workspace movement (#4380)', () => {
   const f = fixture();
   assert.throws(() => captureRegistration('capture', { ...f.mesh }, f.getState), /raw loaded/);
@@ -90,7 +99,7 @@ test('capture bounds compact output rows while allowing a small region of a larg
   f.mesh.indices = Uint32Array.from({ length: count }, (_, i) => i);
   const registration = captureRegistration('capture', f.mesh, f.getState);
   assert.equal(captureRegion(f.mesh, [0], registration).mesh.positions.length, 3);
-  assert.throws(() => captureRegion(f.mesh, Array.from({ length: count / 3 }, (_, i) => i), registration), /200000 position/);
+  assert.throws(() => captureRegion(f.mesh, Array.from({ length: count / 3 }, (_, i) => i), registration), /200,000 vertices/);
 });
 
 

--- a/apps/viewer/src/lib/appearance/capture/region.ts
+++ b/apps/viewer/src/lib/appearance/capture/region.ts
@@ -36,7 +36,7 @@ export function captureRegistration(modelId: string, mesh: MeshData,
     const state = getState(), current = state.models.get(modelId);
     const offset = totalYupOffset(placementFrameCoordinateInfo(state));
     if (current !== model || current?.geometryResult !== geometry || !geometry.meshes.includes(mesh)
-      || state.mutationVersion !== initial.mutationVersion || state.modelPlacement.preview
+      || state.modelPlacement.preview
       || placementFrameKey(state) !== frameKey
       || !placementFor(state.modelPlacement, modelId).translation.every((v, i) => v === modelTranslationIfc[i])
       || offset.x !== renderOffset.x || offset.y !== renderOffset.y || offset.z !== renderOffset.z
@@ -62,7 +62,7 @@ export function captureRegion(mesh: MeshData, triangleIds: readonly number[], re
   if (!mesh.textureRef || mesh.texture) throw new Error('The captured surface needs one external image texture.');
   if (mesh.color.some(value => Math.fround(value) !== 1)) throw new Error('Bake the material tint and opacity into the image before IFC capture.');
   if ((mesh.geometryClass ?? 0) === 2 || mesh.entityIds) throw new Error('Choose one concrete surface occurrence.');
-  if (triangleIds.length === 0 || triangleIds.length > MAX_ROWS) throw new Error('Choose 1..200000 captured triangles.');
+  if (triangleIds.length === 0 || triangleIds.length > MAX_ROWS) throw new Error('Select a smaller region with 1–200,000 triangles.');
   const vertexCount = mesh.positions.length / 3;
   if (!Number.isInteger(vertexCount) || mesh.indices.length % 3 || mesh.uvs?.length !== vertexCount * 2) {
     throw new Error('Captured geometry needs complete positions, triangles and per-vertex image coordinates.');
@@ -74,7 +74,7 @@ export function captureRegion(mesh: MeshData, triangleIds: readonly number[], re
   const vertex = (id: number): number => {
     if (!Number.isInteger(id) || id < 0 || id >= vertexCount) throw new Error('Captured triangle vertex is out of bounds.');
     const prior = remap.get(id); if (prior !== undefined) return prior;
-    if (positions.length >= MAX_ROWS) throw new Error('Captured region exceeds 200000 position or UV rows.');
+    if (positions.length >= MAX_ROWS) throw new Error('Select a smaller region with at most 200,000 vertices.');
     const p = fromRenderTranslation({ x: mesh.positions[id * 3] + origin[0] + offset.x,
       y: mesh.positions[id * 3 + 1] + origin[1] + offset.y, z: mesh.positions[id * 3 + 2] + origin[2] + offset.z });
     const world: [number, number, number] = [p[0] + registration.modelTranslationIfc[0],

--- a/apps/viewer/src/lib/appearance/model-assets.test.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.test.ts
@@ -345,3 +345,26 @@ it('resolves capture originals across URI spelling and rejects ambiguous or remo
   assert.throws(() => models.resolveImageAsset('capture', 'wood.png'), /missing/);
   assert.equal(inventory.get(id), undefined);
 });
+
+// #4477: the loader publishes a model before its images settle; a panel that
+// saw "still loading" needs a moment to retry rather than staying stuck.
+it('pendingDecode resolves when the source decode finishes or is cancelled, and is absent when idle', async () => {
+  const inventory = new AppearanceAssetInventory({ decode: async () => image() });
+  const models = new ModelAppearanceAssets(inventory);
+  assert.equal(models.pendingDecode('idle'), undefined);
+  const load = models.begin('capture');
+  let settled = false;
+  const waiting = models.pendingDecode('capture')!.then(() => { settled = true; });
+  await load.decode(archive());
+  assert.equal(settled, false, 'decoding alone does not settle the lease');
+  load.finish(true);
+  await waiting;
+  assert.equal(models.pendingDecode('capture'), undefined);
+  assert.doesNotThrow(() => models.resolveImageAsset('capture', 'wood.png'));
+  const replaced = models.begin('capture');
+  const cancelled = models.pendingDecode('capture')!;
+  models.remove('capture');
+  await cancelled;
+  assert.equal(models.pendingDecode('capture'), undefined);
+  replaced.finish(true);
+});

--- a/apps/viewer/src/lib/appearance/model-assets.ts
+++ b/apps/viewer/src/lib/appearance/model-assets.ts
@@ -31,7 +31,22 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
     (modelId, commandId) => [...this.authored.get(modelId)?.get(commandId) ?? []].map(id => this.getAuthoredUri(modelId, id)),
   );
   private pending = new Map<string, { cancel(): void }>();
+  private settling = new Map<string, Array<() => void>>();
   constructor(readonly inventory: AppearanceAssetInventory<B>) {}
+
+  /**
+   * The in-flight source decode for a model, if any: resolves once it finishes
+   * or is cancelled. The loader publishes a model before its images settle, so
+   * a panel that saw "still loading" can retry instead of staying stuck (#4477).
+   */
+  pendingDecode(modelId: string): Promise<void> | undefined {
+    if (!this.pending.has(modelId)) return undefined;
+    return new Promise(resolve => {
+      const waiters = this.settling.get(modelId) ?? [];
+      waiters.push(resolve);
+      this.settling.set(modelId, waiters);
+    });
+  }
 
   /** Begin before decode so model removal can cancel a late decoder. */
   begin(modelId: string) {
@@ -46,7 +61,12 @@ export class ModelAppearanceAssets<B extends AppearanceBitmap = ImageBitmap> {
       finished = true;
       controller.abort();
       this.inventory.releaseOwner(owner);
-      if (this.pending.get(modelId) === lease) this.pending.delete(modelId);
+      if (this.pending.get(modelId) === lease) {
+        this.pending.delete(modelId);
+        const waiters = this.settling.get(modelId) ?? [];
+        this.settling.delete(modelId);
+        for (const resolve of waiters) resolve();
+      }
     };
     const lease = {
       cancel,


### PR DESCRIPTION
Closes #4477

Stacked on #4479 (`feat/gltf-bundles-4476`). It stays targeted at that branch and will be retargeted to `main` once #4479 merges; until then the required "PR review signal" lane is red by design (it only runs for base = `main`).

## What changed
- Restructures Create from scan into three steps (source, destination, create) that match the rest of the Appearance workspace.
- Adds an in-panel "Add scan" picker (GLB, glTF bundle, IFC) that routes through `usePreparedModelFileRoute` into `useIfc().loadFile` / `loadFilesSequentially` — the canonical loader — deciding open-vs-add from the store at routing time.
- "New IFC4 model" creates a blank editable destination in-flow via `addModel(createBlankIfcFile(...))` and selects it.
- A prepared source region survives adding the destination (`captureRegistration.validate` no longer keys on `mutationVersion`; stale geometry / placement checks are retained and still tested under #4380).
- A scan listed before its texture images settle is re-prepared once `ModelAppearanceAssets.pendingDecode(modelId)` resolves instead of sticking on "Texture images are still loading."; genuine failures still error.
- Export IFC re-seeds its model choice from `activeModelId` on open, so the authored destination is selected after creation.
- Eligibility copy names GLB / glTF bundle / textured IFC sources and explains why untextured surfaces are excluded; capacity messages point at region selection with formatted limits; the over-limit placeholder region is tracked explicitly; the region count is pluralised.
- `describeUnsupportedFormat` explains a dropped Blender `.blend` scene and generic archives.

## Why / root cause
The capture capability worked end to end but a first-time user fell out of the panel: no way to open the scan there, an absent destination shown as an instruction instead of an action, destination creation invalidating the prepared region, export defaulting to the scan, no reason for excluded sources, and capacity errors with no recovery path.

## Evidence
Run on this branch at its final base (#4479 head `70740f225` on origin/main `531194cdc`), Windows 11 / Git Bash, node:test via tsx:
- Nine-file targeted set (`AppearanceCapturePanel.flow.test.tsx`, `AppearanceCapturePanel.test.tsx`, `ExportDialog.default-model.test.tsx`, `export-model-default.test.ts`, `model-assets.test.ts`, `capture/region.test.ts`, `unsupportedFormat.bcf.test.ts`, `gltf-bundle.test.ts`, `usePreparedModelFileRoute.test.ts`): 43/43 pass. The mounted flow test executed (not skipped) against `packages/wasm/pkg`: it uploads a real `.gltf + .bin + .png` bundle through the panel's own picker, waits for the packed scan to load through the canonical loader, clicks "New IFC4 model" (real engine parse) and asserts the destination is selected, the scan stays loaded and the region is intact.
- `pnpm --filter viewer typecheck`: exit 0.
- `node scripts/check-module-size.mjs`, `check-test-wiring.mjs`, `check-changeset-bump.mjs`, `check-test-glob-coverage.mjs`: exit 0. `check-source-text-assertions.mjs` could not be evaluated on this host (its merge-base comparison reported files this PR does not touch); left to the PR checks.
- `pnpm exec oxlint` on every changed file: exit 0.
- On the previous base: full viewer package (818 files, 7,843 tests) with 51 failures all in files neither PR touches — 41 `api.<name> is not a function` from the host's prebuilt wasm runtime being older than the committed bindings, the rest Windows path / locale artefacts. CI builds its own wasm.

NOT run on this host: root `pnpm lint`, repo-wide `pnpm test` / `pnpm typecheck`, Rust lanes (no Rust change), and any browser / visual QA — nobody has yet pushed an actual photogrammetry export from a real tool through this panel in a browser; the mounted test is the evidence for the user-visible flow.

## Review
CodeRabbit was rate-limited on the first round; the repo's Claude review found nothing. Internal review:
- Self-review against the acceptance list found the panel stuck on "Texture images are still loading." when open during a scan load (the loader publishes the model one await before its asset lease finishes) — fixed with `pendingDecode` plus a retry, kept rather than reordering the loader because asset retention must follow store registration.
- `routeScanFiles` decided open-vs-add from render-time `models.size` — now reads the store at routing time.
- Second round (nits, all applied): the over-limit notice was keyed on `triangles.length === 1`, indistinguishable from a deliberate one-triangle region, so the placeholder is now an explicit flag; the exclusion notice is reworded so an ordinary IFC does not read as a fault report; "1 triangles" is pluralised; the speculative `.blend.zip` branch is replaced by `.blend`.
- Not changed on purpose: the capacity strings keep a literal `200,000` while counts use `toLocaleString()`, so the tests stay locale-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg
