### PR TITLE
fix(viewer): search Space Sketch in the model's own frame, not the survey one

### DIFF
--- a/apps/viewer/src/hooks/useConstructionUnderlay.ts
+++ b/apps/viewer/src/hooks/useConstructionUnderlay.ts
@@ -9,10 +9,17 @@
  * while editing rooms.
  *
  * The construction projection (the same one the sections canvas uses) runs on
- * render-frame meshes (Y-up, RTC-shifted). For a plan (down = `'y'`) cut,
- * `projectTo2D` yields `(renderX, renderZ)`, and `renderX = ifcX − rtc.x +
- * shift.x`, `renderZ = −ifcY + rtc.y + shift.z`. We invert that back to the
- * room frame `(ifcX, ifcY)` so the underlay overlays the rooms directly.
+ * render-frame meshes (Y-up). For a plan (down = `'y'`) cut, `projectTo2D`
+ * yields `(renderX, renderZ)`, and `renderX = ifcX + shift.x`,
+ * `renderZ = −ifcY + shift.z`. We invert that back to the room frame
+ * `(ifcX, ifcY)` so the underlay overlays the rooms directly.
+ *
+ * The room frame is the model's OWN IFC frame, not the georeferenced one: a
+ * `wasmRtcOffset` term here put the cut plane 381 m below a georeferenced
+ * building, so the underlay came back empty on every storey — and an empty
+ * underlay is indistinguishable from a storey that genuinely has no walls.
+ * See the frame note in `lib/wall-rects-from-meshes.ts`, which this must stay
+ * in step with or the underlay slides off the rooms it is drawn under.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -49,13 +56,12 @@ export function useConstructionUnderlay(
     setLoading(true);
 
     const coord = geometryResult?.coordinateInfo as CoordinateInfo | undefined;
-    const rtc = coord?.wasmRtcOffset ?? { x: 0, y: 0, z: 0 };
     const shift = coord?.originShift ?? { x: 0, y: 0, z: 0 };
     // Plan cut at floor + 1.2 m, in render-frame Y.
-    const cutY = floorElevation + 1.2 - rtc.z + shift.y;
+    const cutY = floorElevation + 1.2 + shift.y;
     // Inverse of the plan projection → room (ifcX, ifcY) frame.
-    const cx = rtc.x - shift.x;
-    const cy = rtc.y + shift.z;
+    const cx = -shift.x;
+    const cy = shift.z;
 
     const config = createSectionConfig('y', cutY, {
       projectionDepth: 1.5,

--- a/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.test.ts
@@ -10,21 +10,15 @@ import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 type Pt = [number, number];
 const near = (a: number, b: number, eps = 1e-6) => Math.abs(a - b) < eps;
 
-// Canonical render→IFC reconstruction, independent of the code under test:
-// coordinate-handler `toWorld` (mirrored in PropertiesPanel + lib/geo
-// `totalYupOffset`). worldYup = renderLocal + originShift + rtcYup, with
-// rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y }; then ifcX = worldYup.x,
+// Render→IFC reconstruction for the model's OWN frame, independent of the code
+// under test: coordinate-handler `toWorld` with no survey anchor in play.
+// worldYup = renderLocal + originShift; then ifcX = worldYup.x,
 // ifcY = -worldYup.z, ifcZ = worldYup.y.
-function canonicalIfc(
+function localIfc(
   rx: number, ry: number, rz: number,
   shift: { x: number; y: number; z: number },
-  rtc: { x: number; y: number; z: number },
 ): { ifcX: number; ifcY: number; ifcZ: number } {
-  const rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y };
-  const wx = rx + shift.x + rtcYup.x;
-  const wy = ry + shift.y + rtcYup.y;
-  const wz = rz + shift.z + rtcYup.z;
-  return { ifcX: wx, ifcY: -wz, ifcZ: wy };
+  return { ifcX: rx + shift.x, ifcY: -(rz + shift.z), ifcZ: ry + shift.y };
 }
 
 // A render-frame box for one wall: plan footprint is XZ, height is Y. A wall
@@ -109,15 +103,13 @@ describe('wallRectsFromMeshes', () => {
     assert.strictEqual(rects.length, 1);
   });
 
-  it('reconstructs the footprint + elevation under a NON-ZERO originShift/rtc, matching the canonical handler', () => {
-    // Georeferenced model: non-zero originShift (viewer Y-up frame) AND
-    // wasmRtcOffset (IFC Z-up). Regression guard for the inverted shift signs —
-    // with a zero shift this test would pass even with the old (wrong) code.
+  it('reconstructs the footprint + elevation under a NON-ZERO originShift', () => {
+    // The room frame is the model's OWN IFC frame: render + originShift, with
+    // the Y-up→Z-up swap. Regression guard for the inverted shift signs — with
+    // a zero shift this test would pass even with the old (wrong) code.
     const shift = { x: 100, y: 5, z: 20 };
-    const rtc = { x: 1000, y: 2000, z: 3000 };
     const coord = {
       originShift: shift,
-      wasmRtcOffset: rtc,
       hasLargeCoordinates: true,
       // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
       // invariant); wallRectsFromMeshes never reads either bounds field, but
@@ -127,44 +119,63 @@ describe('wallRectsFromMeshes', () => {
     } as unknown as CoordinateInfo;
 
     // Wall render box: renderX[0..4], renderZ[0..0.8], renderY[0..3].
-    // Its render-Y band maps to ifcZ = renderY + shift.y + rtc.z = renderY + 3005,
-    // so the wall occupies ifcZ ∈ [3005, 3008]. Storey band [3005, 3008].
-    const floorElevation = 3005;
-    const floorToFloor = 3;
-    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, floorElevation, floorToFloor);
+    // ifcZ = renderY + shift.y, so the wall occupies ifcZ ∈ [5, 8].
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 5, 3);
     assert.strictEqual(rects.length, 1, 'wall should fall on the shifted storey band');
     assert.ok(near(rects[0].thickness, 0.8, 1e-3), `thickness ${rects[0].thickness}`);
 
-    // The centreline runs along X at mid-thickness (renderZ = 0.4). Compare the
-    // wall-rects output to the canonical reconstruction of that render point.
+    // The centreline runs along X at mid-thickness (renderZ = 0.4).
     const [a, b] = rects[0].centreline;
-    const endA = canonicalIfc(0, 1.5, 0.4, shift, rtc); // renderX 0
-    const endB = canonicalIfc(4, 1.5, 0.4, shift, rtc); // renderX 4
+    const endA = localIfc(0, 1.5, 0.4, shift); // renderX 0
+    const endB = localIfc(4, 1.5, 0.4, shift); // renderX 4
     // endpoints may be in either order — match as an unordered pair
     const matches =
       (near(a[0], endA.ifcX, 1e-3) && near(a[1], endA.ifcY, 1e-3) && near(b[0], endB.ifcX, 1e-3) && near(b[1], endB.ifcY, 1e-3)) ||
       (near(a[0], endB.ifcX, 1e-3) && near(a[1], endB.ifcY, 1e-3) && near(b[0], endA.ifcX, 1e-3) && near(b[1], endA.ifcY, 1e-3));
-    assert.ok(matches, `centreline ${JSON.stringify([a, b])} vs canonical A=${JSON.stringify(endA)} B=${JSON.stringify(endB)}`);
-    // Concretely: cx = rtc.x + shift.x = 1100, cy = rtc.y - shift.z = 1980,
-    // mid-thickness ifcY = 1980 - 0.4 = 1979.6.
-    assert.ok(near(a[1], 1979.6, 1e-3) && near(b[1], 1979.6, 1e-3), `centreline y ${a[1]},${b[1]}`);
+    assert.ok(matches, `centreline ${JSON.stringify([a, b])} vs local A=${JSON.stringify(endA)} B=${JSON.stringify(endB)}`);
+    // Concretely: cx = shift.x = 100, cy = -shift.z = -20,
+    // mid-thickness ifcY = -20 - 0.4 = -20.4.
+    assert.ok(near(a[1], -20.4, 1e-3) && near(b[1], -20.4, 1e-3), `centreline y ${a[1]},${b[1]}`);
   });
 
   it('excludes a wall whose SHIFTED elevation leaves the storey band', () => {
-    // Same shift/rtc, but a storey band that (after the shift) the wall misses.
     const coord = {
       originShift: { x: 100, y: 5, z: 20 },
-      wasmRtcOffset: { x: 1000, y: 2000, z: 3000 },
       hasLargeCoordinates: true,
-      // shiftedBounds = originalBounds - originShift (createCoordinateInfo's
-      // invariant); wallRectsFromMeshes never reads either bounds field, but
-      // a fixture no producer could emit is still worth avoiding.
       originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
       shiftedBounds: { min: { x: -100, y: -5, z: -20 }, max: { x: -100, y: -5, z: -20 } },
     } as unknown as CoordinateInfo;
-    // Wall ifcZ ∈ [3005, 3008]; a band at ifcZ [0, 3] does NOT overlap it.
-    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 0, 3);
+    // Wall ifcZ ∈ [5, 8]; a band at ifcZ [20, 23] does NOT overlap it.
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 20, 3);
     assert.strictEqual(rects.length, 0);
+  });
+
+  it('IGNORES wasmRtcOffset — a georeferenced model reads like an unplaced one', () => {
+    // The defect this file exists to prevent, from a real 6-storey LV95 model.
+    // `wasmRtcOffset` is what the WASM subtracted to undo a site placement that
+    // anchors the building to the survey grid; it is NOT part of the frame the
+    // storey elevation, `addSpace` or the 3D ghost speak. Folding it in put the
+    // band 381 m below the building — every storey reported "no walls found" —
+    // and adding it to the corners wrote baked rooms 2.66 million metres out.
+    const rtc = { x: 2665510.36, y: 1259339.34, z: 381.3 };
+    const coord = {
+      originShift: { x: 0, y: 0, z: 0 },
+      wasmRtcOffset: rtc,
+      hasLargeCoordinates: false,
+      originalBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+      shiftedBounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } },
+    } as unknown as CoordinateInfo;
+    // Storey elevation as IfcBuildingStorey carries it: local, 0 for the lowest
+    // floor — NOT 381.3. The wall stands on it, render-Y [0..3].
+    const rects = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], coord, 0, 3);
+    assert.strictEqual(rects.length, 1, 'the storey band must not be displaced by rtc');
+    // Corners stay local: an rtc-tainted frame would put them at ~2.67e6.
+    for (const [x, y] of rects[0].corners) {
+      assert.ok(Math.abs(x) < 1e3 && Math.abs(y) < 1e3, `corner (${x}, ${y}) carries the survey offset`);
+    }
+    // Same wall, same answer, with rtc absent entirely.
+    const bare = wallRectsFromMeshes([wallBox(1, 0, 4, 0, 0.8, 0, 3)], undefined, 0, 3);
+    assert.deepEqual(rects[0].corners, bare[0].corners);
   });
 
   it('ignores non-wall meshes', () => {

--- a/apps/viewer/src/lib/wall-rects-from-meshes.ts
+++ b/apps/viewer/src/lib/wall-rects-from-meshes.ts
@@ -20,12 +20,27 @@
  *
  * Frame: the rendered meshes are WebGL Y-up (`world = origin + position`). The
  * plan footprint is render XZ; we map it to the same "room frame" the underlay
- * uses (`useConstructionUnderlay`): `ifcX = renderX + cx`, `ifcY = cy − renderZ`,
- * with `cx = rtc.x + shift.x`, `cy = rtc.y − shift.z` — the canonical
- * `toWorld`/`totalYupOffset` sign convention. For models with no large
- * coordinate shift (rtc = shift = 0) this is `(renderX, −renderZ)` — identity to
- * IFC X/Y. Storey scoping is a render-Y (height) band overlap, so a full-height
- * wall correctly bounds rooms on every storey it passes through.
+ * uses (`useConstructionUnderlay`), which is the model's OWN IFC frame —
+ * `ifcX = renderX + shift.x`, `ifcY = −renderZ − shift.z`.
+ *
+ * NOT the georeferenced world frame. `wasmRtcOffset` is the offset the WASM
+ * mesh path subtracted when it resolved a site placement that anchors the
+ * building to a survey grid; adding it back here yields survey coordinates,
+ * and those are wrong for every consumer downstream. `addSpace` writes the
+ * outline into a storey whose placement chain ALREADY carries that anchor, so
+ * survey coordinates get the offset applied twice; the 3D ghost
+ * (`buildElementMesh`) reads render-frame corners; and the storey band below
+ * compares against render-frame mesh heights. Measured on a 6-storey LV95
+ * model (rtc = 2665510 / 1259339 / 381.3 m, geometry local to ~360 m): the
+ * band landed 381 m under the building so NO storey found a wall, and once it
+ * did, the baked rooms were written 2.66 million metres off. rtc is null for
+ * any model within 10 km of the origin, which is why neither showed up until
+ * a georeferenced file arrived.
+ *
+ * Storey scoping is a render-Y (height) band overlap, so a full-height wall
+ * correctly bounds rooms on every storey it passes through. `floorElevation`
+ * is the storey's own `IfcBuildingStorey.Elevation` — local to the building,
+ * the same frame the rendered geometry is in.
  */
 
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
@@ -127,21 +142,15 @@ export function wallRectsFromMeshes(
   floorElevation: number,
   floorToFloor: number,
 ): WallRect[] {
-  const rtc = coord?.wasmRtcOffset ?? { x: 0, y: 0, z: 0 };
   const shift = coord?.originShift ?? { x: 0, y: 0, z: 0 };
-  // Canonical reconstruction (coordinate-handler `toWorld`, mirrored in
-  // PropertiesPanel + lib/geo `totalYupOffset`): worldYup = renderLocal + shift
-  // + rtcYup, with rtcYup = { x: rtc.x, y: rtc.z, z: -rtc.y }; then
-  // ifcX = worldYup.x, ifcY = -worldYup.z, ifcZ = worldYup.y. Solving:
-  //   ifcX = renderX + (rtc.x + shift.x)   → cx = rtc.x + shift.x
-  //   ifcY = (rtc.y - shift.z) - renderZ   → cy = rtc.y - shift.z
-  // The shift terms were previously inverted (worked only because shift is
-  // usually 0 for non-georeferenced models).
-  const cx = rtc.x + shift.x;
-  const cy = rtc.y - shift.z;
-  // Storey band in render-Y (height). renderY = ifcZ − rtc.z − shift.y.
-  const lo = floorElevation - rtc.z - shift.y;
-  const hi = floorElevation + floorToFloor - rtc.z - shift.y;
+  // Render → the model's own IFC frame: ifcLocal = renderLocal + shift, with
+  // the Y-up→Z-up swap (ifcX = x, ifcY = -z, ifcZ = y). The rtc term is
+  // deliberately absent — see the frame note in the module docstring.
+  const cx = shift.x;
+  const cy = -shift.z;
+  // Storey band in render-Y (height). renderY = ifcZ − shift.y.
+  const lo = floorElevation - shift.y;
+  const hi = floorElevation + floorToFloor - shift.y;
 
   const walls = new Map<number, { pts: Pt[]; ymin: number; ymax: number }>();
   for (const m of meshes) {


### PR DESCRIPTION
Closes #4486.

## What this changes

`wasmRtcOffset` is dropped in the four places Space Sketch used it, across two
files:

- `apps/viewer/src/lib/wall-rects-from-meshes.ts` — both ends of the storey
  band and the two horizontal offsets.
- `apps/viewer/src/hooks/useConstructionUnderlay.ts` — the plan cut height and
  the inverse projection.

Nothing else moves. The `originShift` terms keep the signs they had.

## Why

The term is the offset the WASM mesh path subtracted when it resolved a site
placement anchoring a building to a survey grid. Adding it back yields survey
coordinates, and the storey band is then compared against render-frame mesh
heights that never carried it. On a model anchored to a national grid the band
lands a few hundred metres below the geometry, the intersection is empty on
every storey, and `SpaceSketchOverlay` reports it as "no walls found on this
storey" — which reads as a statement about the model rather than about the
search window.

The premise behind the term is what does not hold: Space Sketch's room frame is
not the world frame. `addSpace(modelId, storeyExpressId, …)` writes the outline
into a storey whose placement chain already carries the site anchor, so survey
coordinates would have the offset applied twice; the 3D ghost reads
render-frame corners; and the band is render-frame. Three consumers, one frame,
and it is the model's own.

The underlay carried the same term and fails silently there — an empty underlay
looks exactly like a storey with no walls.

`wasmRtcOffset` is null for any model within ~10 km of the origin, so all four
expressions collapse to the correct answer on a file without a distant site
placement. That is why this needed a surveyed file to show up at all.

## The two tests are a contract change, on purpose

`wall-rects-from-meshes.test.ts:112` and `:153` construct their own non-zero
`rtc` and assert the **world-frame** reconstruction, matching the coordinate
handler's `toWorld` and `lib/geo`'s `totalYupOffset`. The arithmetic there is
right; it is the frame the room path wants that is different. Under this change
they assert the opposite and say so in their names and comments: a non-zero
`wasmRtcOffset` makes no difference to the result, while a non-zero
`originShift` still does.

Worth deciding rather than merging on autopilot. **If you would rather keep the
room frame as the world frame**, the fix belongs on the consumer side instead —
but the band still needs `rtc.z` removed either way, because it is compared
against render-frame heights. I am happy to redo it in that shape.

## Verified, and not

Verified: `wall-rects-from-meshes.test.ts` passes with the rewritten
expectations (11 tests), and the viewer typechecks clean.

Not verified: this was found on a fork that tracks `main`, not on a fresh
upstream checkout, and the model that showed it is not mine to share. The
**band** half — no walls found — is readable from the file alone and is what
the tests now pin. The **horizontal** half — that derived rectangles and baked
rooms land at survey coordinates — I observed after forcing the band open, in a
tree whose overlay and bake modules carry local changes, so treat that half as
a strong reading of the code rather than a clean upstream observation.

I also did not touch the disagreement between the two files on the sign of
`originShift`. Only `wall-rects` is pinned by a test, so it is probably the
right one, but `shift` was zero everywhere this could be reproduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewer underlay and wall-rectangle calculations to use the model’s local IFC frame consistently.
  * Improved plan-cut and storey band positioning so underlays and wall outlines align correctly with the building model.
  * Corrected handling of shifted models, which helps prevent empty or misplaced underlays when viewing georeferenced data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->