### PR TITLE
fix(geometry): judge a room by a point that is in it, and cap free wall ends

### DIFF
--- a/rust/geometry/src/space_dcel/geom2d.rs
+++ b/rust/geometry/src/space_dcel/geom2d.rs
@@ -47,6 +47,87 @@ pub(super) fn point_in_quad(p: [f64; 2], quad: &[[f64; 2]; 4]) -> bool {
     inside
 }
 
+/// Ray-cast point-in-polygon for an arbitrary simple ring.
+pub(super) fn point_in_polygon(p: [f64; 2], poly: &[[f64; 2]]) -> bool {
+    let n = poly.len();
+    if n < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = (poly[i][0], poly[i][1]);
+        let (xj, yj) = (poly[j][0], poly[j][1]);
+        if ((yi > p[1]) != (yj > p[1])) && (p[0] < (xj - xi) * (p[1] - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+/// A point that is genuinely INSIDE `poly`.
+///
+/// Callers classify a whole face by testing one point of it, which is only
+/// sound if the point lies in the face. A centroid does not: for a concave
+/// ring it sits in the notch, so an L-shaped corridor gets classified by a
+/// point in the room next door, and a room with a stub wall in it by a point
+/// inside that stub. Both then read as "wall interior" and the room is lost.
+///
+/// The area centroid is still tried first — it is exact for every convex ring
+/// and cheap. Otherwise scan horizontal lines drawn BETWEEN adjacent vertex
+/// heights, where no vertex can lie on the line and the crossings therefore
+/// alternate outside/inside cleanly, and take the middle of the widest
+/// interior span. That span is maximally far from the ring, so the answer does
+/// not hinge on a tolerance.
+pub(super) fn representative_point(poly: &[[f64; 2]]) -> Option<[f64; 2]> {
+    if poly.len() < 3 {
+        return None;
+    }
+    let area = polygon_area(poly);
+    if area.abs() > EPS {
+        let (mut cx, mut cy) = (0.0, 0.0);
+        for i in 0..poly.len() {
+            let p = poly[i];
+            let q = poly[(i + 1) % poly.len()];
+            let cross = p[0] * q[1] - q[0] * p[1];
+            cx += (p[0] + q[0]) * cross;
+            cy += (p[1] + q[1]) * cross;
+        }
+        let c = [cx / (6.0 * area), cy / (6.0 * area)];
+        if c[0].is_finite() && c[1].is_finite() && point_in_polygon(c, poly) {
+            return Some(c);
+        }
+    }
+    let mut ys: Vec<f64> = poly.iter().map(|p| p[1]).collect();
+    ys.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    let mut best: Option<([f64; 2], f64)> = None;
+    for w in ys.windows(2) {
+        if w[1] - w[0] < EPS {
+            continue;
+        }
+        let y = 0.5 * (w[0] + w[1]);
+        let mut xs: Vec<f64> = Vec::new();
+        for i in 0..poly.len() {
+            let p = poly[i];
+            let q = poly[(i + 1) % poly.len()];
+            if (p[1] > y) != (q[1] > y) {
+                xs.push(p[0] + (y - p[1]) / (q[1] - p[1]) * (q[0] - p[0]));
+            }
+        }
+        xs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+        let mut k = 0;
+        while k + 1 < xs.len() {
+            let width = xs[k + 1] - xs[k];
+            if best.is_none_or(|(_, b)| width > b) {
+                best = Some(([0.5 * (xs[k] + xs[k + 1]), y], width));
+            }
+            k += 2;
+        }
+    }
+    best.map(|(p, _)| p)
+}
+
 /// Perpendicular distance of point `p` to the infinite line through `a` and `b`
 /// (degenerates to the point distance when `a == b`). Used to judge whether a
 /// degree-2 node is a redundant collinear point on its neighbours' chord.

--- a/rust/geometry/src/space_dcel/mod.rs
+++ b/rust/geometry/src/space_dcel/mod.rs
@@ -54,7 +54,9 @@ mod geom2d;
 mod tests;
 
 use arrangement::Arrangement;
-use geom2d::{is_simple_polygon, line_intersection, perp_distance, point_in_quad, polygon_area};
+use geom2d::{is_simple_polygon, line_intersection, perp_distance, point_in_quad, polygon_area, representative_point};
+#[cfg(test)]
+use geom2d::point_in_polygon;
 
 /// Stable handle to a vertex. Survives edits; never reused after tombstoning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -1073,13 +1075,20 @@ impl SpacePlate {
         if outline.len() < 3 {
             return false;
         }
-        let (mut cx, mut cy) = (0.0, 0.0);
-        for p in &outline {
-            cx += p[0];
-            cy += p[1];
-        }
-        let c = [cx / outline.len() as f64, cy / outline.len() as f64];
-        !self.wall_rects.iter().any(|r| point_in_quad(c, r))
+        // A face of this arrangement lies wholly inside one wall rectangle or
+        // wholly outside every one — the rectangle edges are all in the
+        // arrangement, so no face straddles a wall boundary. One point of the
+        // face therefore decides it, PROVIDED the point is in the face.
+        //
+        // It used to be the average of the corners, which is not. On a concave
+        // ring that average leaves the face: an L-shaped corridor was judged by
+        // a point in the wall capping its long arm, and a room with a stub wall
+        // standing in it by a point inside that stub. Both read as "wall
+        // interior", so the room was dropped and the plan came back missing it.
+        let Some(inside) = representative_point(&outline) else {
+            return false;
+        };
+        !self.wall_rects.iter().any(|r| point_in_quad(inside, r))
     }
 
     /// CCW outline of a face (no repeated closing vertex).
@@ -1141,19 +1150,44 @@ impl SpacePlate {
             // Inward normal of a CCW outline is to the left of a→b: (-uy, ux).
             lines.push(([a[0] - uy * off, a[1] + ux * off], [ux, uy]));
         }
-        let mut verts: Vec<[f64; 2]> = Vec::with_capacity(n);
+        /// Foot of the perpendicular from `q` onto the line `(p, d)` (`d` unit).
+        fn project(q: [f64; 2], p: [f64; 2], d: [f64; 2]) -> [f64; 2] {
+            let t = (q[0] - p[0]) * d[0] + (q[1] - p[1]) * d[1];
+            [p[0] + t * d[0], p[1] + t * d[1]]
+        }
+        let mut verts: Vec<[f64; 2]> = Vec::with_capacity(n + 2);
         for i in 0..n {
-            let (pp, pd) = lines[(i + n - 1) % n];
+            let pj = (i + n - 1) % n;
+            let (pp, pd) = lines[pj];
             let (cp, cd) = lines[i];
+            // A wall that ends free inside a room is a SPUR: the face walks out
+            // along its axis and back, so the two edges meeting at the tip are
+            // antiparallel and their offset lines are parallel — one on each
+            // flank, a wall thickness apart. There is no corner to intersect
+            // here; there is an END to cap, and it needs two vertices where
+            // every other corner needs one. Emitting one collapsed the tip onto
+            // a single flank and the outline cut diagonally across the wall
+            // from the far flank's base — the "diagonally sliced wall end".
+            //
+            // The cap sits at the wall's real end, `half` beyond the axis tip
+            // (the axis stops half a thickness short so the end squares off),
+            // which for the gross outline means half short of it instead —
+            // hence `sign`.
+            if pd[0] * cd[0] + pd[1] * cd[1] < -1.0 + 1e-9 {
+                let half = self.half_edges[cycle[pj].0 as usize]
+                    .half_thickness
+                    .max(self.half_edges[cycle[i].0 as usize].half_thickness);
+                let tip = [centre[i][0] + sign * half * pd[0], centre[i][1] + sign * half * pd[1]];
+                verts.push(project(tip, pp, pd));
+                verts.push(project(tip, cp, cd));
+                continue;
+            }
             let hit = line_intersection(pp, [pp[0] + pd[0], pp[1] + pd[1]], cp, [cp[0] + cd[0], cp[1] + cd[1]]);
             // Parallel offset lines (a collinear node, e.g. a mid-wall split, or
             // two edges of equal thickness in a straight run) don't intersect —
             // drop the corner onto the current offset line so it sits flush on
             // the inset boundary instead of poking back to the centreline.
-            verts.push(hit.unwrap_or_else(|| {
-                let t = (centre[i][0] - cp[0]) * cd[0] + (centre[i][1] - cp[1]) * cd[1];
-                [cp[0] + t * cd[0], cp[1] + t * cd[1]]
-            }));
+            verts.push(hit.unwrap_or_else(|| project(centre[i], cp, cd)));
         }
         if verts.iter().any(|v| !v[0].is_finite() || !v[1].is_finite()) {
             return centre;
@@ -1164,6 +1198,15 @@ impl SpacePlate {
         }
         if inset && got > polygon_area(&centre).abs() + 1e-6 {
             return centre; // the inset inverted the polygon — keep the centreline
+        }
+        // A ring that crosses itself passes every test above: it is finite, it
+        // has area, and folding one lobe back over another only makes that area
+        // SMALLER, so the inset guard reads it as a healthy shrink. It is not a
+        // polygon any consumer can use — an area, a bake, a fill all take it
+        // differently — so hand back the centreline rather than a shape whose
+        // meaning depends on who measures it.
+        if !is_simple_polygon(&verts) {
+            return centre;
         }
         verts
     }

--- a/rust/geometry/src/space_dcel/tests.rs
+++ b/rust/geometry/src/space_dcel/tests.rs
@@ -1182,3 +1182,104 @@
             );
         }
     }
+
+    // ─── Concave faces and free wall ends ───
+
+    /// Wall rectangles (0.2 thick) enclosing an L-shaped corridor: a 40 m long
+    /// arm with a short stub at its left end.
+    fn l_corridor_rects() -> Vec<[[f64; 2]; 4]> {
+        vec![
+            [[-0.2, -0.2], [40.2, -0.2], [40.2, 0.0], [-0.2, 0.0]], // below the long arm
+            [[40.0, -0.2], [40.2, -0.2], [40.2, 1.2], [40.0, 1.2]], // the far end cap
+            [[1.0, 1.0], [40.2, 1.0], [40.2, 1.2], [1.0, 1.2]],     // over the long arm
+            [[1.0, 1.0], [1.2, 1.0], [1.2, 2.6], [1.0, 2.6]],       // beside the short arm
+            [[-0.2, 2.4], [1.2, 2.4], [1.2, 2.6], [-0.2, 2.6]],     // over the short arm
+            [[-0.2, -0.2], [0.0, -0.2], [0.0, 2.6], [-0.2, 2.6]],   // the outer end
+        ]
+    }
+
+    /// A 10×6 room with a 0.2 thick stub wall rising off the bottom wall to
+    /// y = 3 and stopping there, free, in the middle of the room.
+    fn free_end_rects() -> Vec<[[f64; 2]; 4]> {
+        vec![
+            [[-0.2, -0.2], [10.2, -0.2], [10.2, 0.0], [-0.2, 0.0]],
+            [[-0.2, 6.0], [10.2, 6.0], [10.2, 6.2], [-0.2, 6.2]],
+            [[-0.2, -0.2], [0.0, -0.2], [0.0, 6.2], [-0.2, 6.2]],
+            [[10.0, -0.2], [10.2, -0.2], [10.2, 6.2], [10.0, 6.2]],
+            [[4.9, 0.0], [5.1, 0.0], [5.1, 3.0], [4.9, 3.0]],
+        ]
+    }
+
+    /// The average of a ring's corners is not a point of the ring. Both fixtures
+    /// below are built so that it lands in a WALL, which is what made the room
+    /// vanish: the gap test read the wall's answer instead of the room's.
+    fn corner_average(pts: &[[f64; 2]]) -> [f64; 2] {
+        let n = pts.len() as f64;
+        let (mut x, mut y) = (0.0, 0.0);
+        for p in pts {
+            x += p[0];
+            y += p[1];
+        }
+        [x / n, y / n]
+    }
+
+    #[test]
+    fn representative_point_leaves_the_notch_of_a_concave_ring() {
+        // A U: the centroid sits in the gap between the prongs, outside the ring.
+        let u = [
+            [0.0, 0.0], [6.0, 0.0], [6.0, 6.0], [4.0, 6.0],
+            [4.0, 2.0], [2.0, 2.0], [2.0, 6.0], [0.0, 6.0],
+        ];
+        let p = representative_point(&u).expect("a ring with area has an interior point");
+        assert!(point_in_polygon(p, &u), "representative point {p:?} is outside the ring");
+    }
+
+    #[test]
+    fn an_l_shaped_corridor_is_detected_though_its_corner_average_lies_in_a_wall() {
+        let rects = l_corridor_rects();
+        let plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1, "the L-shaped corridor is one room");
+        let room = plate.rooms().next().unwrap();
+        // Guard the guard: if the fixture ever stops putting the corner average
+        // inside a wall, this test still passes but no longer bites, and the
+        // regression it exists for could come back unnoticed.
+        let avg = corner_average(&plate.face_outline(room));
+        assert!(
+            rects.iter().any(|r| point_in_quad(avg, r)),
+            "fixture no longer exercises the defect: corner average {avg:?} is in no wall",
+        );
+    }
+
+    #[test]
+    fn a_room_keeps_its_identity_when_a_stub_wall_stands_inside_it() {
+        let rects = free_end_rects();
+        let plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
+        assert_eq!(plate.room_count(), 1, "a stub wall divides nothing — the room is still one room");
+        let room = plate.rooms().next().unwrap();
+        let avg = corner_average(&plate.face_outline(room));
+        assert!(
+            rects.iter().any(|r| point_in_quad(avg, r)),
+            "fixture no longer exercises the defect: corner average {avg:?} is in no wall",
+        );
+    }
+
+    #[test]
+    fn a_free_wall_end_is_capped_square_rather_than_sliced_across() {
+        let plate = SpacePlate::build_from_wall_rects(&free_end_rects(), BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        let net = plate.net_outline(room, true);
+        assert!(is_simple_polygon(&net), "net outline crosses itself: {net:?}");
+        // 10×6 room less the 0.2×3 stub standing in it. The old outline ran
+        // diagonally from one flank's base to the other's tip and measured
+        // 59.71 — too much room, and through a wall.
+        let area = polygon_area(&net).abs();
+        assert!((area - 59.4).abs() < 1e-6, "net area {area}, want 59.4");
+        // Both flanks must reach the wall's REAL end at y = 3.0 (the axis stops
+        // half a thickness short of it, so the cap is what squares the end off).
+        for want in [[4.9, 3.0], [5.1, 3.0]] {
+            assert!(
+                net.iter().any(|p| (p[0] - want[0]).abs() < 1e-9 && (p[1] - want[1]).abs() < 1e-9),
+                "cap corner {want:?} missing from {net:?}",
+            );
+        }
+    }


### PR DESCRIPTION
Closes #4488.

## What this changes

Three files under `rust/geometry/src/space_dcel/`, no public API and no
TypeScript.

- `geom2d.rs` — new `point_in_polygon` and `representative_point`.
- `mod.rs` — `is_gap_face` judges at the representative point; `net_outline`
  caps an antiparallel corner with two vertices; a self-intersection guard on
  the offset ring.
- `tests.rs` — four cases, listed below.

## Why

**Rooms that vanish.** `is_gap_face` rests on a sound premise: the wall-rect
edges are all in the arrangement, so no face straddles a wall boundary and a
single point decides whether a face is a room. The precondition is that the
point is in the face. It was the average of the corners, which holds for every
convex ring and can fail on a concave one. On an L-shaped corridor that average
lands in the wall capping the long arm; with a stub wall protruding into a
room, inside the stub. Either way `point_in_quad` answers true, the face reads
as wall interior, and the whole room is dropped.

`representative_point` keeps the centroid where it is honest and otherwise
scans a horizontal line taken strictly between two adjacent vertex heights —
where no vertex can lie on the line, so the crossing parity is unambiguous —
and takes the midpoint of the widest interior span.

**Wall ends sliced across.** In `net_outline` a free wall end is a spur: the
face walks out along the axis and back, so the two edges at the tip are
antiparallel and their offset lines are parallel, one on each flank, a
thickness apart. `line_intersection` returns `None`, and the existing fallback
drops the corner onto the current offset line. That is correct for the case its
comment names — a collinear node, where the two lines are parallel *and
coincident*. At a spur tip they are a thickness apart, so the single vertex
lands on one flank and the outline runs diagonally to it, through the wall. A
free end is not a corner to intersect but an end to cap, and a cap needs two
vertices.

Both changes are local. `is_gap_face` runs once at build; the cap is one branch
ahead of the existing corner loop, so every corner that is a corner takes the
path it always took.

## One part is a net, not a fix

The self-intersection guard is included deliberately and I would rather label
it than let it look like part of the repair. A crossed ring passes every check
that was already there: it is finite, it has area, and folding one lobe back
over another only makes that area smaller, which the inset guard reads as a
healthy shrink. The crossings actually observed came from the missing cap and
disappear with it. Drop that hunk if you would rather not carry a guard without
a failing case behind it — the rest stands without it.

## Tests

Four, all self-contained in the module, no model needed:

- `representative_point_leaves_the_notch_of_a_concave_ring`
- `an_l_shaped_corridor_is_detected_though_its_corner_average_lies_in_a_wall`
- `a_room_keeps_its_identity_when_a_stub_wall_stands_inside_it`
- `a_free_wall_end_is_capped_square_rather_than_sliced_across`

## Verified, and not

Verified locally on the pinned toolchain (`nightly-2025-11-15`):

- `cargo test -p ifc-lite-geometry --lib` — 863 passed, 0 failed, 1 ignored.
  That is the whole crate, not only the new cases.
- `cargo clippy -p ifc-lite-geometry --lib --all-features` — no warnings from
  these files.

Not verified: this was found on a fork that tracks `main`, not on a fresh
upstream checkout, and the plan that showed it is not mine to share. The three
files were byte-identical to `upstream/main` before the change, and both chains
are readable from `mod.rs` alone, so the defect is upstream's rather than
something local. The room-count and area figures in the issue come from that
plan and are an indication of scale, not a reproducible measurement.

No changeset: nothing under `packages/*` is touched, matching how other
`rust/geometry` changes land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room detection for concave layouts, L-shaped corridors, and rooms with free-ended interior walls.
  - Improved wall-gap classification when polygon corners do not accurately represent the interior.
  - Prevented invalid self-intersecting net outlines and added safer handling for free wall ends.

- **Tests**
  - Added regression coverage for concave rooms, stub walls, representative interior points, and valid net-outline geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->