### PR TITLE
fix(core): compare the scanned IFCPROJECT keyword case-insensitively

### DIFF
--- a/.changeset/case-insensitive-ifcproject-unit-scale.md
+++ b/.changeset/case-insensitive-ifcproject-unit-scale.md
@@ -6,4 +6,8 @@ Fix `EntityDecoder::length_unit_scale`/`plane_angle_to_radians` (`rust/core/src/
 
 `georeferencing_candidate_type` (`rust/processing/src/georeferencing.rs`) had the same defect: it classified `IfcMapConversion`, `IfcProjectedCRS`, `IfcPropertySet` and `IfcSite` candidates with a case-sensitive `match`, so a lowercase- or CamelCase-keyword file reported no georeferencing at all despite carrying complete `IfcMapConversion` data. It is the gate for both the standalone extractor and the native geometry scan, so both paths were affected.
 
+`find_ifcproject_id` also stopped on the first `#<id>=IFCPROJECT(` it could backtrack to, including one written inside a STEP string literal, and returned that id — which then fails the resolver's own `IFCPROJECT` type check and restores the same silent 1.0 default. It now requires the `#` to actually start a record (preceded, across trivia, by `;` or the start of input). Matching the keyword case-insensitively widened this pre-existing hazard from uppercase decoys to ordinary lowercase prose in a description or comment, so it is fixed here.
+
+The same scan now prefilters on the keyword's `J` rather than its leading `I`: every IFC keyword starts with `I` and GUIDs are dense in `I`/`i`, so the lead-byte scan hit on nearly every record. On a 20 MB project-less file this measured 7.6-13.1 ms against 0.33-0.36 ms for the `J` prefilter (and 0.8-1.0 ms for the case-sensitive `memmem` it replaced).
+
 This is one part of a broader case-sensitivity class tracked in issue #4497; the remaining sites are enumerated in the PR.

--- a/.changeset/case-insensitive-ifcproject-unit-scale.md
+++ b/.changeset/case-insensitive-ifcproject-unit-scale.md
@@ -2,4 +2,8 @@
 "@ifc-lite/wasm": patch
 ---
 
-Fix `EntityDecoder::length_unit_scale`/`plane_angle_to_radians` (`rust/core/src/decoder.rs`) and their `find_ifcproject_id_inner` fallback (`rust/processing/src/prepass.rs`) comparing the scanned `IFCPROJECT` keyword case-sensitively. A file whose keywords are lowercase or CamelCase (STEP keyword case is not significant) silently defaulted the length-unit scale to `1.0` instead of the declared value — a 1000x error on a millimetre model feeding curve tessellation, appearance/texture mapping, and unit conversion. This is one instance of a broader case-sensitivity class tracked in issue #4497; the other three sites listed there are unchanged.
+Fix `EntityDecoder::length_unit_scale`/`plane_angle_to_radians` (`rust/core/src/decoder.rs`) and their `find_ifcproject_id_inner` fallback (`rust/processing/src/prepass.rs`) comparing the scanned `IFCPROJECT` keyword case-sensitively. A file whose keywords are lowercase or CamelCase (STEP keyword case is not significant) silently defaulted the length-unit scale to `1.0` instead of the declared value — a 1000x error on a millimetre model feeding curve tessellation, appearance/texture mapping, and unit conversion.
+
+`georeferencing_candidate_type` (`rust/processing/src/georeferencing.rs`) had the same defect: it classified `IfcMapConversion`, `IfcProjectedCRS`, `IfcPropertySet` and `IfcSite` candidates with a case-sensitive `match`, so a lowercase- or CamelCase-keyword file reported no georeferencing at all despite carrying complete `IfcMapConversion` data. It is the gate for both the standalone extractor and the native geometry scan, so both paths were affected.
+
+This is one part of a broader case-sensitivity class tracked in issue #4497; the remaining sites are enumerated in the PR.

--- a/.changeset/case-insensitive-ifcproject-unit-scale.md
+++ b/.changeset/case-insensitive-ifcproject-unit-scale.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix `EntityDecoder::length_unit_scale`/`plane_angle_to_radians` (`rust/core/src/decoder.rs`) and their `find_ifcproject_id_inner` fallback (`rust/processing/src/prepass.rs`) comparing the scanned `IFCPROJECT` keyword case-sensitively. A file whose keywords are lowercase or CamelCase (STEP keyword case is not significant) silently defaulted the length-unit scale to `1.0` instead of the declared value — a 1000x error on a millimetre model feeding curve tessellation, appearance/texture mapping, and unit conversion. This is one instance of a broader case-sensitivity class tracked in issue #4497; the other three sites listed there are unchanged.

--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -308,7 +308,14 @@ impl<'a> EntityDecoder<'a> {
         let mut scanner = crate::parser::EntityScanner::new(self.content);
         let mut project_id: Option<u32> = None;
         while let Some((id, type_name, _, _)) = scanner.next_entity() {
-            if type_name == "IFCPROJECT" {
+            // #4497: STEP keyword case is not significant (ISO 10303-21);
+            // `type_name` is the raw, unnormalised scanner slice, so compare
+            // ASCII-case-insensitively rather than requiring upstream
+            // uppercase. Zero-alloc: `eq_ignore_ascii_case` against a fixed
+            // literal, unlike `schema_helpers::normalise_uppercase` which
+            // allocates a canonical owned copy — not needed here since there
+            // is nothing downstream to reuse the normalised form for.
+            if type_name.eq_ignore_ascii_case("IFCPROJECT") {
                 project_id = Some(id);
                 break;
             }
@@ -338,7 +345,9 @@ impl<'a> EntityDecoder<'a> {
         let mut scanner = crate::parser::EntityScanner::new(self.content);
         let mut project_id: Option<u32> = None;
         while let Some((id, type_name, _, _)) = scanner.next_entity() {
-            if type_name == "IFCPROJECT" {
+            // #4497: see the matching comment in `plane_angle_to_radians`
+            // above — same case-insensitivity fix, same rationale.
+            if type_name.eq_ignore_ascii_case("IFCPROJECT") {
                 project_id = Some(id);
                 break;
             }

--- a/rust/core/src/decoder/decoder_tests.rs
+++ b/rust/core/src/decoder/decoder_tests.rs
@@ -502,3 +502,108 @@ fn get_face_bound_fast_refuses_oversized_loop_ref() {
     let mut decoder = EntityDecoder::new(content);
     assert_eq!(decoder.get_face_bound_fast(1), Some((u32::MAX, true, false)));
 }
+
+/// Issue #4497: `EntityScanner::next_entity` returns the STEP keyword as a
+/// raw, unnormalised slice, and `length_unit_scale`/`plane_angle_to_radians`
+/// compared it case-sensitively against `"IFCPROJECT"`. A file whose
+/// keywords are lowercase (a legal STEP file — case is not significant)
+/// silently defaulted to scale `1.0` instead of the declared `0.001`, a
+/// 1000x error feeding curve tessellation, appearance mapping and unit
+/// conversion.
+#[test]
+fn length_unit_scale_lowercase_keywords_repro() {
+    let content = r#"
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=ifcproject('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);
+#2=ifcunitassignment((#3));
+#3=ifcsiunit(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.length_unit_scale(), 0.001);
+}
+
+/// Control: uppercase keywords (the pre-existing, always-worked case) must
+/// keep resolving exactly as before the #4497 fix.
+#[test]
+fn length_unit_scale_uppercase_keywords_unchanged() {
+    let content = r#"
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.length_unit_scale(), 0.001);
+}
+
+/// The realistic case per #4497: some exporters emit CamelCase keywords
+/// (`IfcProject`, not all-lower or all-upper).
+#[test]
+fn length_unit_scale_mixed_case_keywords() {
+    let content = r#"
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IfcProject('0001projectaaaaaaaaaaa',$,'P',$,$,$,$,$,#2);
+#2=IfcUnitAssignment((#3));
+#3=IfcSiUnit(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.length_unit_scale(), 0.001);
+}
+
+/// `plane_angle_to_radians` has the same scanner-comparison bug — cover it
+/// separately rather than assuming the `length_unit_scale` fix carries over.
+/// DEGREE fixture per `units_tests::test_extract_plane_angle_degree`, with
+/// all keywords lowercased.
+#[test]
+fn plane_angle_to_radians_lowercase_keywords() {
+    let content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=ifcproject('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=ifcgeometricrepresentationcontext($,'Model',3,1.E-5,#4,$);
+#3=ifcunitassignment((#5,#10));
+#4=ifcaxis2placement3d(#7,$,$);
+#5=ifcsiunit(*,.LENGTHUNIT.,$,.METRE.);
+#7=ifccartesianpoint((0.,0.,0.));
+#8=ifcsiunit(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#9=ifcmeasurewithunit(ifcratiomeasure(0.0174532925199433),#8);
+#10=ifcconversionbasedunit(#11,.PLANEANGLEUNIT.,'DEGREE',#9);
+#11=ifcdimensionalexponents(0,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let mut decoder = EntityDecoder::new(content);
+    let scale = decoder.plane_angle_to_radians();
+    assert!(
+        (scale - 0.0174532925199433).abs() < 1e-9,
+        "expected 0.01745… for DEGREE, got {scale}"
+    );
+}

--- a/rust/processing/src/georeferencing.rs
+++ b/rust/processing/src/georeferencing.rs
@@ -140,16 +140,36 @@ pub fn extract_georeferencing_with_index(
 }
 
 /// Candidate classification shared by standalone extraction and the native
-/// geometry scan. Preserve raw-name matching and file order, including all sites.
+/// geometry scan. Preserves file order, including all sites.
+///
+/// `type_name` is the STEP keyword exactly as the scanner read it, and STEP
+/// keyword case is not significant (ISO 10303-21), so the comparison is
+/// case-insensitive. A case-sensitive match silently classified every entity in
+/// a lowercase- or CamelCase-keyword file as a non-candidate, and the model then
+/// reported no georeferencing at all despite carrying complete data (#4497).
+/// `eq_ignore_ascii_case` rather than an uppercase copy: this runs once per
+/// entity in the scan loop, and the comparison is against fixed literals, so
+/// there is nothing an allocated canonical form would be reused for — the same
+/// shape `processor::quick_metadata::is_quick_spatial_type_ci` uses.
 pub(crate) fn georeferencing_candidate_type(type_name: &str) -> Option<IfcType> {
-    match type_name {
-        // Scaled's first eight attributes have the base conversion layout.
-        "IFCMAPCONVERSION" | "IFCMAPCONVERSIONSCALED" => Some(IfcType::IfcMapConversion),
-        "IFCPROJECTEDCRS" => Some(IfcType::IfcProjectedCRS),
-        "IFCPROPERTYSET" => Some(IfcType::IfcPropertySet),
-        "IFCSITE" => Some(IfcType::IfcSite),
-        _ => None,
+    // Scaled's first eight attributes have the base conversion layout.
+    const MAP_CONVERSION: [&str; 2] = ["IFCMAPCONVERSION", "IFCMAPCONVERSIONSCALED"];
+    if MAP_CONVERSION
+        .iter()
+        .any(|candidate| type_name.eq_ignore_ascii_case(candidate))
+    {
+        return Some(IfcType::IfcMapConversion);
     }
+    if type_name.eq_ignore_ascii_case("IFCPROJECTEDCRS") {
+        return Some(IfcType::IfcProjectedCRS);
+    }
+    if type_name.eq_ignore_ascii_case("IFCPROPERTYSET") {
+        return Some(IfcType::IfcPropertySet);
+    }
+    if type_name.eq_ignore_ascii_case("IFCSITE") {
+        return Some(IfcType::IfcSite);
+    }
+    None
 }
 
 /// Reuse candidates from the geometry scan, avoiding the remaining whole-file

--- a/rust/processing/src/georeferencing_tests.rs
+++ b/rust/processing/src/georeferencing_tests.rs
@@ -580,3 +580,99 @@ fn reads_ifc4x3_scaled_map_conversion_as_a_map_conversion() {
     assert_eq!(scaled.source.as_deref(), Some("mapConversion"));
     assert_eq!(scaled.source, plain.source);
 }
+
+/// STEP keyword case is not significant (ISO 10303-21), but
+/// `EntityScanner::next_entity` hands the keyword back exactly as written.
+/// A case-sensitive candidate match therefore drops every candidate in a
+/// lowercase- or CamelCase-keyword file, and the model silently reports no
+/// georeferencing at all despite carrying a complete `IfcMapConversion`.
+#[test]
+fn candidate_classification_ignores_keyword_case() {
+    for (name, expected) in [
+        ("ifcmapconversion", Some(IfcType::IfcMapConversion)),
+        ("IfcMapConversionScaled", Some(IfcType::IfcMapConversion)),
+        ("ifcprojectedcrs", Some(IfcType::IfcProjectedCRS)),
+        ("IfcPropertySet", Some(IfcType::IfcPropertySet)),
+        ("ifcsite", Some(IfcType::IfcSite)),
+        ("IfcWall", None),
+        ("ifcsiteless", None),
+    ] {
+        assert_eq!(
+            georeferencing_candidate_type(name),
+            expected,
+            "candidate classification of {name}"
+        );
+    }
+}
+
+/// DRIFT GUARD. The native geometry scan evaluates
+/// `georeferencing_candidate_type` and `is_quick_spatial_type_ci` on the same
+/// scanner slice in the same loop, so the two must agree on `IFCSITE` for every
+/// spelling of it -- otherwise one feature sees the site and the other does not.
+#[test]
+fn site_candidacy_agrees_with_the_quick_spatial_gate_on_every_spelling() {
+    for name in ["IFCSITE", "ifcsite", "IfcSite", "iFcSiTe"] {
+        assert_eq!(
+            georeferencing_candidate_type(name),
+            Some(IfcType::IfcSite),
+            "{name} must be a georeferencing candidate"
+        );
+        assert!(
+            crate::is_quick_spatial_type_ci(name),
+            "{name} must be a quick-metadata spatial node"
+        );
+    }
+}
+
+/// End-to-end: the same model written with lowercase keywords must produce the
+/// same georeferencing as the uppercase original.
+#[test]
+fn extraction_survives_lowercase_keywords() {
+    let upper = extract_georeferencing(GEOREF_IFC).expect("uppercase georef");
+    let lowered = lowercase_step_keywords(GEOREF_IFC);
+    assert!(
+        lowered.contains("=ifcmapconversion("),
+        "fixture rewrite did not lowercase the keywords"
+    );
+    let lower = extract_georeferencing(&lowered).expect("lowercase georef");
+    assert_eq!(lower.crs_name, upper.crs_name);
+    assert_eq!(lower.geodetic_datum, upper.geodetic_datum);
+    assert_eq!(lower.map_projection, upper.map_projection);
+    assert_eq!(lower.eastings, upper.eastings);
+    assert_eq!(lower.northings, upper.northings);
+    assert_eq!(lower.orthogonal_height, upper.orthogonal_height);
+    assert_eq!(lower.rotation_degrees, upper.rotation_degrees);
+}
+
+/// The `IfcSite` lat/long fallback is a separate extraction path from
+/// `IfcMapConversion`, so it gets its own lowercase fixture rather than being
+/// assumed fixed by the map-conversion test.
+#[test]
+fn site_fallback_survives_lowercase_keywords() {
+    let lowered = lowercase_step_keywords(SITE_ONLY_IFC);
+    let geo = extract_georeferencing(&lowered).expect("lowercase site georef");
+    assert_eq!(geo.source.as_deref(), Some("siteLocation"));
+    assert!((geo.northings - 47.375).abs() < 1e-9, "lat {}", geo.northings);
+    assert!((geo.eastings - 8.5375).abs() < 1e-9, "long {}", geo.eastings);
+}
+
+/// Lowercase only the `#nn=IFCxxx` keyword tokens, leaving string literals and
+/// enumeration values (`.ELEMENT.`, `.METRE.`) untouched -- a blanket
+/// `to_lowercase()` would change the data the assertions read back.
+fn lowercase_step_keywords(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        match line.split_once('=') {
+            Some((lhs, rhs)) if lhs.starts_with('#') => {
+                let split = rhs.find('(').unwrap_or(rhs.len());
+                out.push_str(lhs);
+                out.push('=');
+                out.push_str(&rhs[..split].to_lowercase());
+                out.push_str(&rhs[split..]);
+            }
+            _ => out.push_str(line),
+        }
+        out.push('\n');
+    }
+    out
+}

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -374,6 +374,29 @@ pub fn find_ifcproject_id(content: &[u8]) -> Option<u32> {
     result
 }
 
+/// Case-insensitive byte-level search for the literal keyword `IFCPROJECT(`
+/// (issue #4497 — STEP keyword case is not significant, so a lowercase or
+/// CamelCase exporter's `ifcproject(`/`IfcProject(` must resolve exactly like
+/// the uppercase form). `memchr::memmem` has no case-insensitive mode, so
+/// this scans for the 'I'/'i' lead byte with `memchr::memchr2` (still
+/// SIMD-accelerated) and verifies the rest of the keyword with an explicit
+/// ASCII case-insensitive byte compare — the least invasive way to keep this
+/// hot path SIMD-driven without a new dependency or an allocating uppercase
+/// pass over the whole file.
+fn find_ifcproject_keyword(content: &[u8], from: usize) -> Option<usize> {
+    const KEYWORD: &[u8] = b"IFCPROJECT(";
+    let mut search_from = from;
+    while let Some(rel) = memchr::memchr2(b'I', b'i', &content[search_from..]) {
+        let candidate = search_from + rel;
+        let end = candidate + KEYWORD.len();
+        if end <= content.len() && content[candidate..end].eq_ignore_ascii_case(KEYWORD) {
+            return Some(candidate);
+        }
+        search_from = candidate + 1;
+    }
+    None
+}
+
 fn find_ifcproject_id_inner(content: &[u8], refused: &mut usize) -> Option<u32> {
     let mut from = 0usize;
     // Search for the keyword+paren only; the `=` and `#<id>` are reconstructed by
@@ -383,8 +406,7 @@ fn find_ifcproject_id_inner(content: &[u8], refused: &mut usize) -> Option<u32> 
     // on a mm model, plane-angle → radians on a degree model, making arched
     // openings render as full circles — issue #1367). `IFCPROJECT(` cannot
     // collide with `IFCPROJECTEDCRS(` because the `(` must immediately follow.
-    while let Some(rel) = memchr::memmem::find(&content[from..], b"IFCPROJECT(") {
-        let kw = from + rel;
+    while let Some(kw) = find_ifcproject_keyword(content, from) {
         // Backtrack over optional whitespace, then require '='.
         let mut i = kw;
         while i > 0 && content[i - 1].is_ascii_whitespace() {

--- a/rust/processing/src/prepass.rs
+++ b/rust/processing/src/prepass.rs
@@ -378,23 +378,41 @@ pub fn find_ifcproject_id(content: &[u8]) -> Option<u32> {
 /// (issue #4497 — STEP keyword case is not significant, so a lowercase or
 /// CamelCase exporter's `ifcproject(`/`IfcProject(` must resolve exactly like
 /// the uppercase form). `memchr::memmem` has no case-insensitive mode, so
-/// this scans for the 'I'/'i' lead byte with `memchr::memchr2` (still
-/// SIMD-accelerated) and verifies the rest of the keyword with an explicit
-/// ASCII case-insensitive byte compare — the least invasive way to keep this
-/// hot path SIMD-driven without a new dependency or an allocating uppercase
-/// pass over the whole file.
+/// this prefilters one byte of the keyword with `memchr::memchr2` (still
+/// SIMD-accelerated) and verifies the rest with an ASCII case-insensitive
+/// compare — no new dependency, and no allocating uppercase pass over the
+/// whole file.
+///
+/// The prefilter byte is `J`, not the lead `I`. `I` is the WORST choice in
+/// this alphabet: every IFC keyword starts with it and IFC GUIDs are full of
+/// `I`/`i`, so a 20 MB project-less file hits on nearly every record and the
+/// verify loop dominates — measured in release on such a file, leading on
+/// `I`/`i` costs 7.6–13.1 ms against 0.8–1.0 ms for the case-SENSITIVE
+/// `memmem` this replaced. `J` occurs in almost nothing else, which brings
+/// the same scan to 0.33–0.36 ms — below the `memmem` it replaces. `J` sits
+/// at `J_OFFSET` in the keyword, so a hit at `j` means a candidate start of
+/// `j - J_OFFSET`; a `J` in the first `J_OFFSET` bytes cannot start one.
 fn find_ifcproject_keyword(content: &[u8], from: usize) -> Option<usize> {
     const KEYWORD: &[u8] = b"IFCPROJECT(";
+    /// Index of `J` within `IFCPROJECT(`.
+    const J_OFFSET: usize = 6;
     let mut search_from = from;
-    while let Some(rel) = memchr::memchr2(b'I', b'i', &content[search_from..]) {
-        let candidate = search_from + rel;
+    loop {
+        let rel = memchr::memchr2(b'J', b'j', content.get(search_from..)?)?;
+        let j = search_from + rel;
+        search_from = j + 1;
+        // Below `J_OFFSET` bytes in, or behind `from`: either way this `J`
+        // cannot open a keyword at or after `from`. The second case matters
+        // because the caller resumes at `previous_hit + 1`, so without it the
+        // same hit would be returned forever.
+        let Some(candidate) = j.checked_sub(J_OFFSET).filter(|&c| c >= from) else {
+            continue;
+        };
         let end = candidate + KEYWORD.len();
         if end <= content.len() && content[candidate..end].eq_ignore_ascii_case(KEYWORD) {
             return Some(candidate);
         }
-        search_from = candidate + 1;
     }
-    None
 }
 
 fn find_ifcproject_id_inner(content: &[u8], refused: &mut usize) -> Option<u32> {
@@ -423,7 +441,8 @@ fn find_ifcproject_id_inner(content: &[u8], refused: &mut usize) -> Option<u32> 
             while i > 0 && content[i - 1].is_ascii_digit() {
                 i -= 1;
             }
-            if i > 0 && content[i - 1] == b'#' && i < digits_end {
+            if i > 0 && content[i - 1] == b'#' && i < digits_end && starts_a_record(content, i - 1)
+            {
                 // Refuse (not wrap) above u32::MAX (#3421); None here just
                 // keeps searching, same as the "not found" case below.
                 // Counted (issue #3752) so the caller can report it via the
@@ -434,11 +453,54 @@ fn find_ifcproject_id_inner(content: &[u8], refused: &mut usize) -> Option<u32> 
                 }
             }
         }
-        // `IFCPROJECT(` not preceded by `#<digits>=` (e.g. inside a string)
-        // — keep searching.
+        // `IFCPROJECT(` not preceded by a record-starting `#<digits>=` (e.g.
+        // the whole thing quoted inside a string) — keep searching.
         from = kw + 1;
     }
     None
+}
+
+/// Does the `#` at `hash` begin a record, rather than sit inside a quoted
+/// string or a comment?
+///
+/// 10303-21 terminates every entity instance with `;`, so a declaration's
+/// `#` is preceded — across trivia only — by that `;` or by the start of
+/// input. Without this check a description or comment containing a
+/// record-shaped decoy such as `'note: #9=ifcproject( …'` is accepted, and
+/// the scan returns a WRONG express id AND stops, so the real project is
+/// never reached: `extract_length_unit_scale` then rejects that id on its
+/// `IFCPROJECT` type guard and the caller's `unwrap_or(1.0)` restores the
+/// 1000×-oversized millimetre default issue #4497 exists to remove. The
+/// hazard predates case-insensitive matching, which only widens it from
+/// uppercase decoys to ordinary lowercase prose.
+///
+/// Validating instead that the id decodes to an `IFCPROJECT` would be
+/// stricter, but it needs an entity index per candidate — the
+/// O(file)-scan-per-decoder cost [`resolve_unit_scales`] exists to keep
+/// dead. This stays a single linear byte scan.
+///
+/// "Trivia", not whitespace: a `/* … */` comment is legal wherever
+/// whitespace is, so `#1=IFCWALL(…); /* note */ #7=IFCPROJECT(…)` is a real
+/// declaration and must not be refused (the entity scanner's `skip_step_trivia`
+/// makes the same allowance in the forward direction).
+fn starts_a_record(content: &[u8], hash: usize) -> bool {
+    let mut i = hash;
+    loop {
+        while i > 0 && content[i - 1].is_ascii_whitespace() {
+            i -= 1;
+        }
+        // A closing `*/` here means a comment sits between the boundary and
+        // the `#`; skip back over it and re-test. An unopened `*/` is not
+        // trivia, so refuse rather than loop.
+        if i >= 2 && content[i - 1] == b'/' && content[i - 2] == b'*' {
+            match memchr::memmem::rfind(&content[..i - 2], b"/*") {
+                Some(open) => i = open,
+                None => return false,
+            }
+            continue;
+        }
+        return i == 0 || content[i - 1] == b';';
+    }
 }
 
 /// Flat wire encodings of the resolved styles for the browser's

--- a/rust/processing/src/prepass_tests.rs
+++ b/rust/processing/src/prepass_tests.rs
@@ -269,3 +269,115 @@ END-ISO-10303-21;
     assert!((scales.length_unit_scale - 0.001).abs() < 1e-12);
     assert!((scales.plane_angle_to_radians - 0.017_453_292_519_943_295).abs() < 1e-12);
 }
+
+/// A `#<id>=IFCPROJECT(` sequence embedded in a STEP string literal is not a
+/// record definition, so the scan must not return its id and must not stop:
+/// the real project follows it. The old case-sensitive scan could only be
+/// fooled by an uppercase decoy; matching `ifcproject(` too widens the
+/// hazard to ordinary lowercase prose in a comment or a description.
+///
+/// The consequence of a false positive is the exact symptom issue #4497
+/// exists to remove: `extract_length_unit_scale` rejects the wrong id on its
+/// `IFCPROJECT` type guard and the caller's `unwrap_or(1.0)` defaults a
+/// millimetre model to metres.
+#[test]
+fn find_ifcproject_id_skips_a_full_record_decoy_inside_a_string() {
+    let ifc = b"DATA;\n#5=IFCWALL('note: #9=ifcproject( in the source',$);\n#7=IFCPROJECT('g',$);\n";
+    assert_eq!(find_ifcproject_id(ifc), Some(7));
+
+    let upper = b"DATA;\n#5=IFCWALL('note: #9=IFCPROJECT( in the source',$);\n#7=IFCPROJECT('g',$);\n";
+    assert_eq!(find_ifcproject_id(upper), Some(7));
+}
+
+/// The record-start guard must not refuse a real declaration that a
+/// 10303-21 comment separates from the previous record's `;` — a comment is
+/// legal wherever whitespace is, and the entity scanner accepts it (see
+/// `skip_step_trivia` in `rust/core/src/parser/lexical.rs`). A false
+/// negative here is the same silent 1.0 default as a miss.
+#[test]
+fn find_ifcproject_id_accepts_a_record_behind_a_step_comment() {
+    let ifc = b"DATA;\n#1=IFCWALL('x',$); /* was #9 */ #7=IFCPROJECT('g',$);\n";
+    assert_eq!(find_ifcproject_id(ifc), Some(7));
+
+    let two = b"DATA;\n#1=IFCWALL('x',$);/**//* b */#7=IFCPROJECT('g',$);\n";
+    assert_eq!(find_ifcproject_id(two), Some(7));
+}
+
+/// A project declared at byte 0, with no preceding `;` at all, is still a
+/// record start.
+#[test]
+fn find_ifcproject_id_accepts_a_record_at_the_start_of_input() {
+    assert_eq!(find_ifcproject_id(b"#7=IFCPROJECT('g',$);\n"), Some(7));
+}
+
+/// `find_ifcproject_keyword` prefilters on `J` rather than the lead `I` (a
+/// ~20x scan win on a project-less file, since every IFC keyword starts with
+/// `I`). The offset arithmetic that buys it — candidate start is `j - 6`,
+/// with the first six bytes and any hit behind `from` skipped — is exactly
+/// where such a rewrite goes wrong, so pin it against a naive reference over
+/// every offset of adversarial and pseudo-random buffers.
+#[test]
+fn find_ifcproject_keyword_matches_a_naive_reference_at_every_offset() {
+    const KEYWORD: &[u8] = b"IFCPROJECT(";
+    fn naive(content: &[u8], from: usize) -> Option<usize> {
+        if content.len() < KEYWORD.len() {
+            return None;
+        }
+        (from..=content.len() - KEYWORD.len())
+            .find(|&i| content[i..i + KEYWORD.len()].eq_ignore_ascii_case(KEYWORD))
+    }
+
+    let mut cases: Vec<Vec<u8>> = vec![
+        b"".to_vec(),
+        b"J".to_vec(),
+        b"j(".to_vec(),
+        b"IFCPROJECT(".to_vec(),
+        b"ifcproject(".to_vec(),
+        b"IfcProject(".to_vec(),
+        b"IFCPROJECTEDCRS(".to_vec(),
+        b"IFCPROJECT".to_vec(),
+        b"XXXXXXIFCPROJECT(".to_vec(),
+        b"IFCPROJECT(IFCPROJECT(".to_vec(),
+        b"ifcprojectIFCPROJECT(".to_vec(),
+        b"JIFCPROJECT(".to_vec(),
+        b"#9=ifcproject( #7=IFCPROJECT(".to_vec(),
+        b"AAJAA".to_vec(),
+    ];
+
+    // xorshift64 over an alphabet dense in the keyword's own bytes, so near
+    // misses are common rather than astronomically rare.
+    let alphabet = b"IiFfCcPpRrOoJjEeTt(#=; \n'";
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for _ in 0..400 {
+        let len = (next() % 48) as usize;
+        cases.push(
+            (0..len)
+                .map(|_| alphabet[(next() as usize) % alphabet.len()])
+                .collect(),
+        );
+    }
+
+    let mut checked = 0usize;
+    for case in &cases {
+        for from in 0..=case.len() {
+            assert_eq!(
+                find_ifcproject_keyword(case, from),
+                naive(case, from),
+                "from={from} in {:?}",
+                String::from_utf8_lossy(case)
+            );
+            checked += 1;
+        }
+    }
+    // Anti-vacuity: an empty or tiny case list would pass silently.
+    assert!(
+        checked > 5_000,
+        "only {checked} (buffer, offset) pairs checked"
+    );
+}

--- a/rust/processing/src/prepass_tests.rs
+++ b/rust/processing/src/prepass_tests.rs
@@ -59,6 +59,80 @@ fn find_ifcproject_id_accepts_a_ref_at_exactly_u32_max() {
     assert_eq!(find_ifcproject_id(ifc), Some(u32::MAX));
 }
 
+/// Issue #4497: `find_ifcproject_id_inner`'s `memchr::memmem::find` against
+/// the literal `b"IFCPROJECT("` was case-sensitive, so this — this exact
+/// resolver, the fallback `resolve_unit_scales` falls back to when no
+/// project-id hint is available — silently returned `None` on a lowercase
+/// STEP file, which is the exact "no project" branch that then defaults
+/// length/angle scale to 1.0.
+#[test]
+fn find_ifcproject_id_lowercase_keyword() {
+    let ifc = b"DATA;\n#1=ifcwall('x',$,$,$,$,$,$,$,$);\n#7=ifcproject('g',$,'P',$,$,$,$,$,$);\n";
+    assert_eq!(find_ifcproject_id(ifc), Some(7));
+}
+
+/// The realistic case per #4497: CamelCase keywords from some exporters.
+#[test]
+fn find_ifcproject_id_mixed_case_keyword() {
+    let ifc = b"DATA;\n#7=IfcProject('g',$,'P',$,$,$,$,$,$);\n";
+    assert_eq!(find_ifcproject_id(ifc), Some(7));
+}
+
+/// Lowercase must still respect whitespace-around-`=` and the
+/// IFCPROJECTEDCRS non-collision, exactly like the uppercase cases above.
+#[test]
+fn find_ifcproject_id_lowercase_handles_whitespace_and_crs_collision() {
+    let space_after = b"DATA;\n#1=ifcwall('x',$);\n#1593796= ifcproject('g',$,'P',$,$,$,$,$,$);\n";
+    assert_eq!(find_ifcproject_id(space_after), Some(1593796));
+
+    let crs_only = b"DATA;\n#9= ifcprojectedcrs('EPSG:32632',$,'WGS84',$,'UTM','32N',$);\n";
+    assert_eq!(find_ifcproject_id(crs_only), None);
+}
+
+/// End-to-end: `resolve_unit_scales` with no hint (forcing the
+/// `find_ifcproject_id` fallback path) resolves a lowercase-keyword,
+/// millimetre + degree file exactly like its uppercase equivalent
+/// (`resolve_unit_scales_resolves_degrees_and_millimetres` below).
+#[test]
+fn resolve_unit_scales_fallback_path_lowercase_keywords() {
+    const IFC: &[u8] = b"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=ifcproject('guid',$,'Test',$,$,$,$,(#2),#3);
+#2=ifcgeometricrepresentationcontext($,'Model',3,1.E-5,#4,$);
+#3=ifcunitassignment((#5,#10));
+#4=ifcaxis2placement3d(#7,$,$);
+#5=ifcsiunit(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#7=ifccartesianpoint((0.,0.,0.));
+#8=ifcsiunit(*,.PLANEANGLEUNIT.,$,.RADIAN.);
+#9=ifcmeasurewithunit(ifcratiomeasure(0.0174532925199433),#8);
+#10=ifcconversionbasedunit(#11,.PLANEANGLEUNIT.,'DEGREE',#9);
+#11=ifcdimensionalexponents(0,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+";
+    let index = ifc_lite_core::build_entity_index(IFC);
+    let mut decoder = EntityDecoder::with_index(IFC, index);
+
+    // No hint: forces resolve_unit_scales to call find_ifcproject_id.
+    let scales = resolve_unit_scales(IFC, None, &mut decoder);
+    assert_eq!(scales.project_id, Some(1));
+    assert!(
+        (scales.length_unit_scale - 0.001).abs() < 1e-12,
+        "expected 0.001 (mm), got {}",
+        scales.length_unit_scale
+    );
+    assert!(
+        (scales.plane_angle_to_radians - 0.0174532925199433).abs() < 1e-9,
+        "expected 0.01745… (degree), got {}",
+        scales.plane_angle_to_radians
+    );
+}
+
 /// RED for issue #3421: `find_ifcproject_id` used to accumulate the express
 /// id with `wrapping_mul`/`wrapping_add`, so `#4294967297=IFCPROJECT(...)`
 /// wrapped onto id 1 instead of refusing. A real `#1=IFCWALL(...)` earlier in


### PR DESCRIPTION
## Summary

`EntityScanner::next_entity()` returns the STEP keyword as a raw, unnormalised slice. STEP keyword case is not significant per ISO 10303-21, so every case-sensitive comparison against that slice is a silent wrong-answer bug. This PR fixes the two instances issue #4497 names as user-visible.

### 1. 1000x unit-scale error (`rust/core`)

`EntityDecoder::length_unit_scale()` and `plane_angle_to_radians()` (`rust/core/src/decoder.rs`) compared the slice against `"IFCPROJECT"` with `==`. A file whose keywords are lowercase or CamelCase never matched, so `project_id` stayed `None` and both resolvers silently defaulted to `1.0`. On a millimetre model this is a silent 1000x scale error feeding curve tessellation, appearance/texture mapping, and unit conversion.

`find_ifcproject_id_inner` (`rust/processing/src/prepass.rs`) — the fallback `resolve_unit_scales` uses when no project-id hint is available — had the same defect one level down: its `memchr::memmem::find` search for the literal byte string `b"IFCPROJECT("` was also case-sensitive. Both are fixed together, since fixing only the primary path would leave the fallback silently preserving the bug.

- `decoder.rs`'s two comparisons now use `type_name.eq_ignore_ascii_case("IFCPROJECT")` rather than `schema_helpers::normalise_uppercase`: the comparison is against one fixed literal, so there's nothing to reuse an allocated canonical form for, and `processor/quick_metadata.rs` already uses `eq_ignore_ascii_case` for exactly this shape of comparison.
- `prepass.rs`'s byte-level search can't use a string helper directly (it operates pre-UTF8-decode). It now prefilters one byte with `memchr::memchr2` (still SIMD-accelerated) and verifies the rest of the keyword with an explicit ASCII case-insensitive byte compare — no new dependency. The prefilter byte is `J`, not the leading `I`: see "Scan cost" below.

### 1b. A string-literal false positive returned a wrong id and stopped the search

Found in review of the round above, and fixed here because the case-insensitive match widens it. `find_ifcproject_id` backtracks from `IFCPROJECT(` to a `#<digits>=` prefix and accepted it wherever it found one — including inside a STEP string literal. On

```
DATA;
#5=IFCWALL('note: #9=ifcproject( in the source',$);
#7=IFCPROJECT('g',$);
```

it returned `Some(9)` **and returned early**, so the real `#7` was never reached. `extract_length_unit_scale` then rejects `#9` on its own `IFCPROJECT` type guard and `resolve_unit_scales`'s `unwrap_or(1.0)` fires — the exact silent 1000x default this PR exists to remove.

The hazard is pre-existing in kind (the code's own comment named the in-string case), but case-insensitivity widens it: before, only an *uppercase* `#N=IFCPROJECT(` inside a literal could fool the scan; now ordinary lowercase or CamelCase prose in a description or comment does.

The fix requires the `#` to actually start a record — preceded, across trivia, by `;` or the start of input, which ISO 10303-21 guarantees for every declaration. A `/* … */` comment is legal wherever whitespace is, so the backward walk skips one, mirroring `skip_step_trivia`'s forward allowance in the scanner; a real declaration behind a comment is not refused.

I chose this over the stricter alternative (validate that the found id decodes to an `IFCPROJECT`, and keep scanning if not). That one is more robust — it would also reject a decoy written as `'…;#9=ifcproject('` — but it costs an entity index per candidate, which is the O(file)-scan-per-decoder class `resolve_unit_scales`'s own doc comment exists to keep dead. This keeps the function a single linear byte pass.

### 1c. Scan cost: the case-insensitive match made the scan ~14x slower; fixed

`memchr2('I', 'i')` is the worst possible prefilter for this keyword: every IFC keyword starts with `I` and IFC GUIDs are dense in `I`/`i`, so a project-less file hits on nearly every record and the verify loop dominates. The worst case is reachable on exactly the files this PR targets — a lowercase file yields no project-id hint from `processor/mod.rs`, so this fallback runs, and IfcOpenShell emits `IFCPROJECT` near the END of the file.

Measured in release on a 20 MB synthetic file with no `IFCPROJECT` (7 runs, best-worst):

| scan | time |
|---|---|
| `memmem` (case-SENSITIVE — what this PR replaced) | 0.75-0.98 ms |
| `memchr2('I','i')` (previous head of this PR) | 7.56-13.08 ms |
| `memchr2('J','j')` + candidate at `j - 6` (this head) | 0.33-0.36 ms |

`J` occurs in almost nothing else in an IFC file. It sits at index 6 of `IFCPROJECT(`, so a hit at `j` means a candidate start of `j - 6`; a `J` in the first 6 bytes, or one whose candidate falls behind the caller's resume point, cannot open a match and is skipped.

### 2. Dropped georeferencing (`rust/processing`)

`georeferencing_candidate_type` (`rust/processing/src/georeferencing.rs`) classified candidates with a case-sensitive `match` on `"IFCMAPCONVERSION" | "IFCMAPCONVERSIONSCALED" | "IFCPROJECTEDCRS" | "IFCPROPERTYSET" | "IFCSITE"`. A lowercase- or CamelCase-keyword file therefore produced an **empty** candidate list and the model reported **no georeferencing at all**, despite carrying a complete `IfcMapConversion`. It gates both `extract_georeferencing_with_index` and the native geometry scan in `processor/mod.rs`, so both paths were affected.

The divergence was observable inside a single loop: in `processor/mod.rs`'s scan, `georeferencing_candidate_type("ifcsite")` returned `None` while its sibling `is_quick_spatial_type_ci("ifcsite")` returned `true` on the same slice. A drift guard test now pins those two to agree on every spelling of `IFCSITE`.

Fixed with `eq_ignore_ascii_case` against the fixed literals — no allocation on a per-entity hot path.

## Verification

**Unit scale (`rust/core` + `prepass.rs`), unchanged from the earlier review round:**
- Repro before the fix: a lowercase-keyword millimetre fixture made `length_unit_scale()` return `1.0` instead of `0.001`. RED → GREEN on the same fixture.
- Uppercase control unchanged; mixed case (`IfcProject`/`IfcUnitAssignment`/`IfcSiUnit`) resolves correctly.
- `find_ifcproject_id` tested directly with lowercase/mixed-case/whitespace/CRS-collision fixtures, plus an end-to-end `resolve_unit_scales(..., None, ...)` test that forces the no-hint fallback.
- `plane_angle_to_radians` covered separately with a lowercase DEGREE fixture.
- Each of the three sites individually mutated back to `==` with an `eprintln!` marker proving the mutated line ran; each reddened exactly its own tests.

**Record-start guard (1b), new in this round:** RED first — `find_ifcproject_id_skips_a_full_record_decoy_inside_a_string` returned `Some(9)` instead of `Some(7)` on the input above. GREEN after. Mutated the guard back out, replacing `starts_a_record(content, i - 1)` with `{ eprintln!("MUTATION PROBE: record-start guard bypassed"); true }`: the probe printed and the test reddened with `left: Some(9) right: Some(7)`. Two further tests pin the other direction, which is where such a guard goes wrong — a declaration behind a `/* … */` comment, and one at byte 0 with no preceding `;` — since a false negative here is the same silent `1.0` default as a miss.

**Scan equivalence (1c), new in this round:** `find_ifcproject_keyword_matches_a_naive_reference_at_every_offset` pins the `J` prefilter against a naive `eq_ignore_ascii_case` reference at **every** offset of 414 buffers — 14 hand-built adversarial cases (`"JIFCPROJECT("`, `"XXXXXXIFCPROJECT("`, `"IFCPROJECTEDCRS("`, `"ifcprojectIFCPROJECT("`, a bare `"J"`, …) plus 400 pseudo-random buffers over an alphabet dense in the keyword's own bytes — with an anti-vacuity assert on the pair count. Mutation: `J_OFFSET` 6 -> 5 reddens it (and 13 other prepass tests); dropping the `>= from` filter reddens it at `from=1 in "IFCPROJECT("`; an `eprintln!` probe inside the mutated expression proved the line ran. The same differential harness, run standalone against the previous `memchr2('I','i')` implementation as a third oracle, agreed on all 120,565 (buffer, offset) pairs.

**Georeferencing (new in this round):** four tests in `rust/processing/src/georeferencing_tests.rs`.

RED first, before the fix (`cargo test -p ifc-lite-processing --lib georeferencing`): `20 passed; 4 failed` —
```
candidate_classification_ignores_keyword_case
  left: None  right: Some(IfcMapConversion)  (candidate classification of ifcmapconversion)
site_candidacy_agrees_with_the_quick_spatial_gate_on_every_spelling
  left: None  right: Some(IfcSite)           (ifcsite must be a georeferencing candidate)
extraction_survives_lowercase_keywords        panicked: "lowercase georef"
site_fallback_survives_lowercase_keywords     panicked: "lowercase site georef"
```

GREEN after the fix: `cargo test -p ifc-lite-processing --lib` → **300 passed; 0 failed** (296 before, + the 4 new). With the four tests added for 1b/1c this head is at **304 passed; 0 failed**.

Mutation-tested per comparison, each with an `eprintln!` marker inside the mutated expression so a no-op mutation could not read as green:

| mutation (back to `==`) | marker prints | tests reddened |
|---|---|---|
| `IFCSITE` | 7 | `candidate_classification…`, `site_candidacy_agrees…`, `site_fallback_survives…` |
| `IFCMAPCONVERSION` / `…SCALED` | 33 | `candidate_classification…`, `extraction_survives…` |
| `IFCPROJECTEDCRS` | 15 | `candidate_classification…`, `extraction_survives…` |
| `IFCPROPERTYSET` | 1 | `candidate_classification…` |

The end-to-end lowercase fixtures rewrite only the `#nn=IFCxxx` keyword token, leaving string literals and enumeration values (`.ELEMENT.`, `.METRE.`) alone — a blanket `to_lowercase()` would have changed the data the assertions read back, which the assertion on the rewritten text guards.

**Gates run locally on this head:** `cargo clippy -p ifc-lite-processing --all-targets -- -D warnings` clean; `cargo test -p ifc-lite-processing` **496 passed; 0 failed**; `cargo test -p ifc-lite-core` **314 passed; 0 failed**; `cargo test -p ifc-lite-processing --test module_size_ratchet` 6/6 (`prepass.rs` 729 lines against its 781 budget); `node scripts/check-module-size.mjs` exit 0 (`2716 files measured, 329 allowlisted, 0 new over 400`). Changeset updated. No wasm-dependent JS test runs in this environment, so none are claimed.

## CI on this head (`c44373a30`)

All four required checks green: `Build + WASM + Rust + Node`, `Issue queue`, `PR review signal`, `parity (in-tree fixtures, committed reference)` — run `34590567856` (20 jobs) plus `34590447019`. `Benchmark` and `Content-matching fixture` show `cancelled`, which is supersession, not failure.

`Viewer E2E smoke` failed on the first attempt with the same `model-reposition.e2e.spec.ts:16` `page.waitForFunction: Timeout 120000ms exceeded` recorded below, in the same test (`reposition IFC and diagnostic scan, IFC first (#4226)`). It also failed that way on the previous head `5611fccca` — which already carried current `main`, and `main` is green — so I re-ran that job alone on this head rather than assert a cause: it **passed**, and the run is now `completed success`. Flaky, not caused here.

I did not take that on trust. The record-start guard is the one change on this branch that could plausibly refuse a real project and default the unit scale, so I swept every `.ifc` in the tree (**367 files, 177 of which resolve a project id**) comparing `find_ifcproject_id` with and without the guard: **0 files answer differently**. The e2e model (`tests/models/ara3d/AC20-FZK-Haus.ifc`) is downloaded in CI and so is not in that corpus; its keywords are uppercase, on which this branch's comparisons are byte-identical to the old ones.

## CI: the red checks on an earlier head were inherited, not caused here

The previous run (`34510706095`, head `4722551a`, created 2026-09-10T17:50Z) was based on `18c5aa18e`, and `main` itself was red at that commit. Per-check:

| Check | Verdict | Evidence |
|---|---|---|
| `Rust tests` | **stale** | `error: function 'oracle_fixture_present' is never used … rust/geometry/tests/triangulation_invariance.rs:2183` under `-D warnings`. This branch touches no file in `rust/geometry`. Fixed on `main` by #4499 (merged 2026-09-10T23:19Z), which added `#[allow(dead_code)]` there. |
| `CSG accept gates (feature builds)` | **stale** | Same error, same file, same line. |
| `Node tests` | **stale** | `check-sdk-canary-coverage`: `sdk-canary.yml` `paths:` covered 30 of 32 transitively-built packages, missing `packages/regex-guard` and `packages/wasm-lifecycle`. This branch touches neither, nor the workflow. Fixed on `main`; `.github/workflows/sdk-canary.yml` on `main` now lists both. |
| `Build + WASM + Rust + Node` | **stale** | 2s aggregator job; it needs `Rust tests` and `Node tests`, so it reported their failures rather than one of its own. |
| `Viewer E2E smoke` | **flaky; re-ran green on this head** | `TimeoutError: page.waitForFunction: Timeout 120000ms exceeded` in `e2e/model-reposition.e2e.ts` ("agnostic scan IFC first", #4226). The fixtures it loads use uppercase keywords, on which this branch's comparisons are byte-identical to the old ones, so there is no mechanism by which this change could alter that test. I could not attribute it to a specific `main` commit, so I am reporting it as unattributed rather than asserting it is stale — the re-run on the merged head is the check. |

This head merges current `upstream/main` (no rebase, so the maintainer's commits on the branch are preserved and nothing is force-pushed). `git diff upstream/main HEAD` touches only the 7 files this PR owns, so the merge reverted nothing from `main`.

## What a user actually gets after this PR

**A user loading a lowercase-keyword file gets correct units and still-wrong geometry.** This PR fixes the unit scale. It does not fix the scan arms that consume the same raw keyword, so openings are still never subtracted.

Measured against `rust/processing/tests/fixtures/issue_2019_wall_two_overlapping_openings.ifc` through `process_geometry`, with only the `#nn=IFCxxx` keyword tokens lowercased (string literals and enumerations left alone):

| input | meshes | triangles |
|---|---|---|
| as written (uppercase) | 4 | **230** |
| same file, lowercase keywords | 4 | **48** |

48 is four plain boxes: the wall renders solid, with all three `IfcRelVoidsElement` openings ignored, because `processor/mod.rs`'s scan arms are still case-sensitive — `type_name == "IFCRELVOIDSELEMENT"` at :698 among the block at :656-712.

This is worth stating plainly because this PR removes the 1000x symptom — the loud, obvious one that would have led a user to report the rest.

## The rest of the class, and the fix worth making

This bug class exists because the scanner hands out a raw slice; fixing call sites one at a time resets the clock rather than closing the hole. I swept `rust/` for every case-sensitive comparison against a value bound from `next_entity()` (script: walk each `next_entity()` loop body, flag `== "…"` / `!= "…"` / `match <var>` / `<var>.starts_with(` / `matches!(<var>` on the keyword binding). **At least 53 sites remain** after this PR.

**That number is a floor, not a total.** The heuristic structurally cannot see `ends_with`, nor any comparison that is not inside a `next_entity()` loop body. Review found four more that it missed, each verified here — see "Missed by the sweep" below. Treat 53 as "at least 53, from a heuristic that misses `ends_with` and any comparison outside a `next_entity()` loop".

Sites the sweep did find:

- `rust/processing/src/processor/mod.rs`: 656, 662, 668, 671, 674, 685, 689, 694 (`starts_with("IFCPROPERTY")`), 698, 700, 702, 708, 710, 712, 786, 805
- `rust/processing/src/appearance/context.rs`: 21, 24, 27 — and `appearance/page_source.rs`:14, `appearance/source.rs`:61
- `rust/processing/src/determinism.rs`:259, `prepass_type_material.rs`:89, `symbolic/color.rs`:28 & 43, `symbolic/mod.rs`:173
- `rust/core/src/model_bounds.rs`: 131, 208, 216, 222, 231; `rust/core/src/decoder/styled_items.rs`:41
- `rust/geometry/src/void_index.rs`: 94, 267; `material_layer_index.rs`:150; `processors/texture/mod.rs`:324; `profile_extractor.rs`:750; `router/mod.rs`:285
- `rust/wasm-bindings/src/api/styling/prepass.rs`: 49, 169, 252, 325; `gpu_meshes/prepass.rs`:335; `alignment_lines.rs`: 62, 80; `grid_lines.rs`:67; `api/mod.rs`:937
- `rust/export/src/model.rs`:172, `relationships.rs`:59, `merged/plan.rs`:67, `constructions.rs`:53, `dfjson/spatial.rs`: 90, 91

Plus three byte-level prefilters over the whole file, which fail the same way and silently skip a pass entirely: `rust/wasm-bindings/src/api/mod.rs`:926 (`b"IFCINDEXEDCOLOURMAP"`), `rust/wasm-bindings/src/api/gpu_meshes/prepass.rs`:746 (`b"IFCREPRESENTATIONMAP"`), `rust/geometry/src/processors/texture/mod.rs`:318 (`b"IFCINDEXEDTRIANGLETEXTUREMAP"`). And one transitive site: `merged/plan.rs` stores the raw keyword into `type_of`, which `merged/empty.rs`:286 and :296 then test with `starts_with("IFCREL")`.

### Missed by the sweep

Four sites the heuristic could not reach, each reproduced:

- **`rust/processing/src/shard_classes.rs`:153, `classify_type_name`** — a `match` on the keyword **outside** any `next_entity()` loop. Reproduced: `classify_type_name("IFCPROJECT") == 2`, `("IfcProject") == 0`, `("ifcproject") == 0`; `("IFCRELVOIDSELEMENT") == 8`, `("ifcrelvoidselement") == 0`. This is the **sharded browser prepass** (`scan_shard_classified`, consumed by `wasm-bindings/src/api/gpu_meshes/prepass_sharded.rs`), so on a lowercase file every named class collapses to `PREPASS_CLASS_NONE` and no project, site record, styled item, void rel, aggregate or layer set is discovered. Geometry survives because the flag bits go through `has_geometry_by_name`, which normalises — `classify_type_name("IfcSite")` returns 128, the geometry flag alone, against 3 for `"IFCSITE"`. Colours and openings do not survive.
- **`rust/core/src/schema_helpers.rs`:327, `type_product_ifc_type`** — short-circuits on `!type_name.ends_with("TYPE") && !type_name.ends_with("STYLE")` **before** the normalising `legacy_aware_ifc_type` call it then makes. Reproduced: `("IFCWALLTYPE") == Some(IfcWallType)`, `("IfcWallType") == None`, `("ifcwalltype") == None`. It sits beside the helpers listed under "Not affected, checked" below, which made the whole family look safe; it is not.
- **Two more whole-file byte prefilters** of the same shape as the three listed above: `rust/wasm-bindings/src/api/mod.rs`:758 (`memmem::find(content, b"IFCMATERIALLAYERSET")` — a miss caches an EMPTY `MaterialLayerIndex`, so layered walls are never sliced) and `rust/wasm-bindings/src/api/styling/prepass.rs`:154-155 (`windows(…).any(|w| w == b"IFCREPRESENTATIONMAP")` — a miss returns `Vec::new()` and skips the type-geometry pass entirely).

Not affected, checked: `IfcType::from_str`, `has_geometry_by_name`, `geometry_flags_by_name`, `is_representationless_spatial_container_by_name` and `legacy_aware_ifc_type` all normalise first, so call sites going through them are already case-correct. Comparisons against `IfcType::as_str()` or a decoded `profile.ifc_type` (e.g. `rust/geometry/src/processors/advanced_face/*`, which uppercases into a local first) are comparing canonical forms and are safe. `rust/geometry/src/router/content_hash.rs`:142 (`type_token_is(b, b"IFCFACETEDBREP")`) looks like a fourth byte prefilter but is **not** affected: `type_token_is` compares with `eq_ignore_ascii_case`. I did not audit `packages/` (TypeScript) for the same class, and I did not re-run the sweep script with `ends_with` added — the four above came from review, not from a second sweep, so there may be more.

**I deliberately did not hand-patch `processor/mod.rs` and `appearance/context.rs` here**, even though the edits are mechanical and provably no-op for uppercase input. They are 19 of 53 sites: patching them leaves 34 behind while inflating this PR's diff, and the next raw comparison someone writes reopens the hole.

**Proposal for the maintainer** (not undertaken in this PR): make the divergence impossible at the source. `next_entity()` returns `(u32, &str, usize, usize)` on a hot path where allocating an uppercase `String` per entity is not acceptable, so uppercasing in the scanner is out. The viable shape is a newtype — `StepKeyword<'a>(&'a str)` — that borrows exactly as today, exposes `eq_ignore_ascii_case`-backed `PartialEq<&str>` / an `is()` method / a `match`-friendly `as_canonical()`, and deliberately does **not** implement `Deref<Target = str>` or `PartialEq<str>`, so `type_name == "IFCSITE"` stops compiling and a `match` on it is a type error. That turns the sites that receive the keyword through `next_entity()`'s return type into compiler errors to be worked through once, with zero runtime cost and no way to regress.

**It would not close the whole class, and you should weigh it knowing that.** Neither `shard_classes.rs::classify_type_name` nor `schema_helpers.rs::type_product_ifc_type` takes the scanner slice through `next_entity()` — both take a plain `&str` from a caller — so both would keep compiling unchanged, and the whole-file byte prefilters (five of them now) are pre-decode and out of reach of any `&str` newtype. Those need either their own `&[u8]` helper or their signatures changed to take the newtype too. It is a wide mechanical change across five crates and touches the public signature of `EntityScanner::next_entity`, so it wants its own issue and your call on the API shape before anyone starts. Happy to take it if you want it.

Closes #4497


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of STEP files that use lowercase or mixed-case entity keywords.
  - Fixed length and angle unit detection, preventing incorrect scaling—such as millimetre models being interpreted with a 1000× error.
  - Restored georeferencing detection for files using varied capitalization, including project, site, coordinate reference, and property entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

