### PR TITLE
docs: link out-of-tree tool sources by repo URL, not relative path

### DIFF
--- a/docs/architecture/evidence/appearance-query-scopes/README.md
+++ b/docs/architecture/evidence/appearance-query-scopes/README.md
@@ -21,7 +21,7 @@ verify the texture and occurrence ownership directly.
 
 [The evidence record](viewer-acceptance.json) pins source, runtime, fixture and
 asserted states. The manual harness is
-[`accept-query-scope.mjs`](../../../../tools/texture-authoring/accept-query-scope.mjs);
+[`accept-query-scope.mjs`](https://github.com/LTplus-AG/ifc-lite/blob/main/tools/texture-authoring/accept-query-scope.mjs);
 run it against an isolated local viewer with `EVALUATED_URL` and `EVALUATED_OUT`.
 It closes its browser in `finally`. This is behavior evidence, not a performance
 measurement or a new IFC export interoperability claim.

--- a/docs/architecture/evidence/pdf-vectors/README.md
+++ b/docs/architecture/evidence/pdf-vectors/README.md
@@ -32,7 +32,7 @@ vectors would be a distinct tracing/OCR operation.
 
 ## Controlled cases
 
-The [original CC0 generator](../../../../tools/texture-authoring/pdf-vector-controls.py)
+The [original CC0 generator](https://github.com/LTplus-AG/ifc-lite/blob/main/tools/texture-authoring/pdf-vector-controls.py)
 creates two pages, independently rendered below with Poppler's `-cropbox` option.
 Page one has a 72-native-unit line, one rectangle, one cubic curve, and a dashed
 line under translation, rotation and non-uniform scale. The page has a nonzero


### PR DESCRIPTION
Unblocks `Deploy Documentation / build` on `main` (red since before #4499).

mkdocs runs in **strict** mode. Two evidence READMEs link to `tools/texture-authoring/*` via `../../../../` — the files exist, but they live outside `docs/`, so mkdocs cannot resolve them and aborts with warnings.

Nothing else in `docs/` links out-of-tree, so there was no convention to follow. The mkdocs answer for a repo file is an absolute link through `repo_url` (already configured) — both links now point at `github.com/LTplus-AG/ifc-lite/blob/main/tools/texture-authoring/…`.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgMF3UZJUSZS7iGgNAWACw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated manual harness and controlled-case generator references to use canonical GitHub URLs.
  - Improved reliability of links when viewing the documentation outside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->