### PR TITLE
docs: put the nine un-navigated architecture docs in the nav, declare evidence/ as not_in_nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,12 @@ validation:
   nav:
     omitted_files: warn
 
+# architecture/evidence/** are the supporting artifacts (fixtures, screenshots,
+# method notes) behind the design docs above them, not pages in their own right.
+# Declaring them here keeps `omitted_files: warn` meaningful for everything else.
+not_in_nav: |
+  architecture/evidence/**
+
 theme:
   name: material
   custom_dir: docs/overrides
@@ -176,6 +182,16 @@ nav:
     - N-ary Union Repair: architecture/nary-union-repair.md
     - WASM Wide Arithmetic: architecture/wasm-wide-arithmetic.md
     - Plato Code Generation: architecture/plato-codegen.md
+    - Appearance:
+        - Roadmap: architecture/appearance-roadmap.md
+        - Coordinated Assignments: architecture/appearance-assignments.md
+        - Cooperative Apply: architecture/appearance-cooperative-apply.md
+        - Evaluated Occurrences: architecture/appearance-evaluated-occurrences.md
+        - Registered Drawing References: architecture/appearance-references.md
+        - Workspace Integration: architecture/appearance-workspace.md
+    - Captured Mesh Authoring: architecture/captured-mesh-authoring.md
+    - PDF Vector Annotations: architecture/pdf-vector-annotations.md
+    - Scan Alignment Workbench: architecture/scan-alignment-workbench.md
     - Extension System:
         - Extension Model: architecture/ai-customization/01-extension-model.md
         - Security Model: architecture/ai-customization/02-security.md


### PR DESCRIPTION
Keeps `Deploy Documentation / build` green on `main` after #4502.

mkdocs runs strict with `validation.nav.omitted_files: warn` — a deliberate gate, left as-is — and 53 pages were outside the nav:

| | pages | fix |
|---|---|---|
| `architecture/evidence/**` READMEs | 44 | `not_in_nav` — mkdocs' own mechanism for intentionally-unlisted supporting material |
| Real design docs added without a nav entry (`appearance-*`, `captured-mesh-authoring`, `pdf-vector-annotations`, `scan-alignment-workbench`) | 9 | added under **Architecture** with concise nav labels in the style of the existing entries (e.g. "Plato Code Generation"), grouped under an Appearance sub-section |

Verified: `mkdocs build --strict` → *Documentation built*, zero warnings.