### PR TITLE
ci: keep the bot workflows on GitHub-hosted runners

### DIFF
--- a/.github/workflows/base-freshness.yml
+++ b/.github/workflows/base-freshness.yml
@@ -52,7 +52,7 @@ concurrency:
 jobs:
   sweep:
     name: Base freshness
-    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -86,7 +86,7 @@ env:
 jobs:
   scan:
     name: Scan open PRs for CI-silent heads
-    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/issue-queue.yml
+++ b/.github/workflows/issue-queue.yml
@@ -111,7 +111,7 @@ jobs:
     # compute-bound. No poll, so no budget to measure -- unlike
     # pr-review-signal.yml this gate asks a question that is already answered
     # when the PR event fires, rather than waiting for other jobs to appear.
-    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -81,7 +81,7 @@ jobs:
     # question, and leaving it in would mean the rollup never reads as settled.
     name: PR review signal
     # Free runner: two API reads and a poll, not compute-bound.
-    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     # Above the poll budget below, so a run that exhausts the budget still gets
     # to PRINT its verdict rather than being killed mid-wait with no output.
     timeout-minutes: 45

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   review-posted:
     name: Review posted
-    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     # ABOVE the gate's poll budget (REVIEW_POSTED_POLL_SECONDS in
     # scripts/review-lane-budget.mjs), deliberately, so a run that exhausts
     # the budget still gets to PRINT its verdict rather than being killed


### PR DESCRIPTION
`pr-review-signal`, `issue-queue` and `review-posted` **poll the PR's other checks and wait** (`pr-review-signal` for up to 40 min). On the 6-runner fleet they occupy every runner while waiting for `Test` jobs queued behind them — a deadlock. Observed today: all six runners at 0.2% CPU holding `check-pr-review-signal.mjs --timeout-seconds 2400`, 94 runs queued.

On GitHub-hosted, parallelism is unbounded and the wait is harmless; these do seconds of API work. `dirty-pr-scan` and `base-freshness` are the same shape and go back too.

5 files, `runs-on` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflows to consistently run on standard hosted runners.
  - Removed conditional selection of self-hosted runners while preserving existing workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->