### PR TITLE
test: fix two hosted-runner flakes (export timestamp byte-compare, 65536-name prescan timeout)

### DIFF
--- a/apps/viewer/src/lib/appearance/command.test.ts
+++ b/apps/viewer/src/lib/appearance/command.test.ts
@@ -160,7 +160,10 @@ END-ISO-10303-21;`);
   const sourceCheckpoint = captureAppearanceSource(view);
   const preview = new AppearancePreviewSession(renderer);
   preview.stage(groups);
-  const exported = () => new StepExporter(data, view).export({ schema: 'IFC4', applyMutations: true }).content;
+  // Pin the FILE_NAME timestamp: two snapshots taken across a wall-clock
+  // second boundary otherwise differ by one header digit and fail the
+  // byte-equality assertions below (seen on loaded CI runners).
+  const exported = () => new StepExporter(data, view).export({ schema: 'IFC4', applyMutations: true, timeStamp: '20260101T000000' }).content;
   const assertUncommitted = (initial: ReturnType<typeof snapshot>) => {
     assert.deepEqual(snapshot(), initial);
     assert.strictEqual(useViewerStore.getState().models.get(MODEL)?.geometryResult, geometry);

--- a/packages/parser/src/columnar-prescanned-columns.test.ts
+++ b/packages/parser/src/columnar-prescanned-columns.test.ts
@@ -137,7 +137,7 @@ describe('issue #3985 pre-scanned column preparation', () => {
     const prepared = await prepareColumnarEntities(scanned, false, async () => {});
     expect(prepared.geometryRefs.map(ref => [ref.expressId, ref.type])).toEqual([[65537, 'IFCWALL']]);
     expect(prepared.byType.get('IFCWALL')).toEqual([65537]);
-  });
+  }, 30_000); // 65536-name fixture: ~5 s on a loaded CI runner, past vitest's 5 s default
 
   it('retains empty pre-pass fallback and complete tokenizer reference access', async () => {
     const store = await new IfcParser().parseColumnar(bytes.buffer, {


### PR DESCRIPTION
Two tests that fail only on loaded hosted runners, seen across unrelated PRs today.

**1. `apps/viewer/src/lib/appearance/command.test.ts`** byte-compares `StepExporter` output taken at different moments (`assert.deepEqual(f.snapshot().exported, before.exported)`). The STEP `FILE_NAME` header carries the export instant, so any two snapshots that straddle a wall-clock second differ by exactly one digit:

```
Expected values to be strictly deep-equal:
  exported: Uint8Array(1138) [ ... 53, + 50, - 49, 39, ...
```

Seen on `Viewer tests (shard 3)` of #4347, #4472, #4495 and #4503 (a different subtest each time), while main's own runs passed. `StepExportOptions.timeStamp` exists precisely for byte-identical exports; the test now pins it. The atomicity assertions are unchanged.

**2. `packages/parser/src/columnar-prescanned-columns.test.ts › does not lose a recognized type after 65536 distinct file-supplied names`** builds and parses a 65536-name fixture; on a loaded runner that took 5.3 s and tripped vitest's 5 s default (`Node tests` on #4338 and #4512). Explicit 30 s timeout — still a hang guard, no longer a load guard.

No production changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Stabilized STEP export test results by using a fixed timestamp.
  - Increased the timeout for a large fixture test to reduce failures from slow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->