### PR TITLE
ci(review-signal): 900 s poll budget, 20 min cap, no re-run on edited

### DIFF
--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -43,20 +43,33 @@ name: PR review signal
 #    still becomes an enforced gate the moment the PR is retargeted to main,
 #    same as before.
 #
-# `edited` IS THE POINT OF THE TYPES LIST. GitHub's default `pull_request`
-# activity types are opened/synchronize/reopened. Retargeting a PR's base branch
-# fires `edited` and nothing else. Before this job ran on all bases, that meant
-# `edited` did not re-fire the workflows that a `branches: [main]` filter had
-# excluded while the PR pointed at a feature branch -- the deterministic,
-# reproducible mechanism behind #3294 merging with 8 checks and leaving main's
-# module-size gate red. Kept now for the same retarget transition, and because
-# this job derives its required-lane list from test.yml at read time regardless
-# of which event fired it.
+# `edited` IS DELIBERATELY NOT IN THE TYPES LIST (CI redesign, step 3). It was
+# once, for the retarget transition: retargeting a PR's base fires `edited` and
+# nothing else, and before this job ran on all bases that was the mechanism
+# behind #3294 merging with 8 checks. Two things changed the trade:
 #
-# `ready_for_review` covers the draft->ready transition for the same reason.
+#   1. This job has run on EVERY base since #3429, so a stacked PR already
+#      carries a red MISSING_LANES verdict before it is retargeted. Dropping
+#      `edited` leaves that verdict standing until the next push or a manual
+#      re-run -- fail-closed, and the author sees a red row, not a green one.
+#   2. The cost was measured: 116 runs/day of this workflow at 5.2 min average
+#      (max 21.7), ~10 runner-slot-hours a day, and 40% of all Test runs were
+#      same-SHA re-runs from `edited` waves (title/body edits, the changesets
+#      release PR rewriting its body after every merge). Every one of those
+#      re-polled a head that already had a verdict.
+#
+# Why not keep the type and skip the job on a non-retarget edit? A skipped run
+# publishes a `skipped` check run, and GitHub's required-check evaluation takes
+# the LATEST run per check name and reads `skipped` as a pass -- so a body edit
+# on a red PR would turn this required check green. No run at all leaves the
+# previous verdict in place, which is the only safe shape.
+#
+# `ready_for_review` covers the draft->ready transition, and this job derives
+# its required-lane list from test.yml at read time regardless of which event
+# fired it.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -84,7 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     # Above the poll budget below, so a run that exhausts the budget still gets
     # to PRINT its verdict rather than being killed mid-wait with no output.
-    timeout-minutes: 45
+    # 20 min against a 900 s budget leaves the >= 300 s of slack the budget
+    # tests in scripts/lib/pr-review-signal.test.mjs require.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -116,12 +131,19 @@ jobs:
       #      main's ruleset, so branch protection already blocks on it, and the
       #      #3294 total-absence shape still fails under this config naming all
       #      fifteen lanes.
-      #   2. 2400 s, and THIS NUMBER HAS MOVED TWICE. Excluding the aggregate
-      #      is not enough on its own: the last non-aggregate lane appeared at
-      #      min 161 / median 190 / p95 522 / max 845 s over those 68 runs, so
-      #      420 s would still have false-failed 8 of them. 900 s covered all
-      #      68 -- at a tail margin of 900/845 = 1.07x, which this comment
-      #      called thin, and on 2026-08-31 it broke.
+      #   2. 900 s, and THIS NUMBER HAS MOVED THREE TIMES. Excluding the
+      #      aggregate is not enough on its own: the last non-aggregate lane
+      #      appeared at min 161 / median 190 / p95 522 / max 845 s over those
+      #      68 runs, so 420 s would still have false-failed 8 of them. 900 s
+      #      covered all 68 -- at a tail margin of 900/845 = 1.07x -- and on
+      #      2026-08-31 it broke, which moved the budget to 2400 s. It is back
+      #      at 900 s (CI redesign, step 3) because of what a breach now
+      #      MEANS: since #3810 a breach while the rollup is still moving is
+      #      the LANE_PUBLICATION_TIMEOUT advisory below, not a MISSING_LANES
+      #      failure, so the only thing the extra 1500 s bought was a runner
+      #      slot held for 25 more minutes per busy-day run. At 116 runs a day
+      #      this workflow was ~10 slot-hours/day of polling; a job that gives
+      #      up early and says so costs a re-run on the tail, not a verdict.
       #
       #      THE 2026-08-31 POPULATION, ITS BREACH COUNT AND ITS MARGIN ARE
       #      NOT RESTATED HERE -- they live once, in the budget tests in
@@ -185,5 +207,5 @@ jobs:
           node scripts/check-pr-review-signal.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --self-name 'PR review signal' \
-            --timeout-seconds 2400 \
+            --timeout-seconds 900 \
             --poll-seconds 30

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -508,7 +508,36 @@ test('the gate workflow carries NO `paths:` filter, so its own config cannot dod
   // same defect one level up.
   const own = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
   assert.ok(!/^\s*paths(-ignore)?:/m.test(own), 'pr-review-signal.yml must have no path filter');
-  assert.match(own, /types:\s*\[[^\]]*edited/, 'it must fire on `edited`, which is the retarget event');
+});
+
+test('the gate workflow does NOT fire on `edited`: no run beats a skipped run, and a re-poll beats nothing', () => {
+  // This used to assert the opposite -- `edited` is the retarget event, and
+  // before #3429 it was the only way a PR moved onto `main` re-fired this
+  // gate. Since #3429 the gate runs on every base, so a stacked PR is already
+  // red (MISSING_LANES) before it is retargeted, and dropping `edited` leaves
+  // that fail-closed verdict standing until the next push or a manual re-run.
+  //
+  // What it buys (CI redesign, step 3): 40% of Test runs were same-SHA
+  // re-runs from `edited` waves, and this workflow was 116 runs/day at 5.2 min
+  // average, re-polling heads that already had a verdict.
+  //
+  // What it must NOT become: an `if:` that skips the job on a non-retarget
+  // edit. A skipped job still publishes a check run, GitHub's required-check
+  // evaluation takes the LATEST run per name, and `skipped` reads as a pass --
+  // a body edit on a red PR would go green. The type has to be absent.
+  const own = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
+  const types = /^\s{4}types:\s*\[([^\]]*)\]/m.exec(own);
+  assert.ok(types, 'the workflow must declare explicit `pull_request` activity types');
+  const declared = types[1].split(',').map((t) => t.trim());
+  assert.ok(!declared.includes('edited'), `\`edited\` must not be a trigger; declared: ${declared.join(', ')}`);
+  for (const t of ['opened', 'synchronize', 'reopened', 'ready_for_review']) {
+    assert.ok(declared.includes(t), `the gate must still fire on \`${t}\`; declared: ${declared.join(', ')}`);
+  }
+  const code = own.split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
+  assert.ok(
+    !/github\.event\.action\s*[!=]=\s*'edited'|github\.event\.changes\.base/.test(code),
+    'no job may gate on the edited action or changes.base: the skipped run would report as a pass',
+  );
 });
 
 test('test.yml fires on `edited` too, so a retargeted PR gets the lanes this gate requires', () => {

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -604,8 +604,17 @@ test('the poll treats an EMPTY rollup as "nothing has appeared yet", never as se
  * re-measure does NOT read it -- it is a different population and carries its
  * own array, which is the whole reason the two disagree about 900 s.
  */
-/** The budget the workflow ships; asserted against the YAML below, not restated. */
-const BUDGET_SECONDS = 2400;
+/**
+ * The budget the workflow ships; asserted against the YAML below, not restated.
+ *
+ * 900 s AGAIN, after 2400 s (CI redesign, step 3). The 2026-08-31 re-measure
+ * below still stands -- eight of 56 runs breach 900 s -- but what a breach
+ * MEANS changed with #3810: a deadline that expires while the rollup is still
+ * moving is the LANE_PUBLICATION_TIMEOUT advisory (`ok` stays true), not a
+ * MISSING_LANES failure. So the extra 1500 s bought no verdict, only a runner
+ * slot held for 25 more minutes on every busy-day run, at 116 runs a day.
+ */
+const BUDGET_SECONDS = 900;
 
 const LANE_APPEARED_SECONDS = [
   161, 162, 162, 162, 163, 164, 164, 165, 165, 165, 166, 166, 167, 167, 167, 167, 167, 169, 169,
@@ -650,7 +659,7 @@ test('MEASURED on 2026-08-25/26: 900 s covered every lane APPEARANCE in THAT pop
   assert.equal(Number((900 / max).toFixed(2)), 1.07, 'tail margin, stated honestly');
 });
 
-test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () => {
+test('RE-MEASURED 2026-08-31: 900 s BREACHED, and a breach is an advisory, not a verdict', () => {
   // A 1.07x margin is one busy afternoon from being wrong, and this was that
   // afternoon.
   //
@@ -688,26 +697,30 @@ test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () 
   // their last lane may yet appear later; so far they stand at 304..1145 s, and
   // the budget would have to be wrong by more than 1255 s for one to breach.
   const STILL_QUEUED_SO_FAR = [304, 306, 324, 374, 378, 397, 435, 446, 467, 485, 1102, 1145];
-  assert.ok(Math.max(...STILL_QUEUED_SO_FAR) < BUDGET_SECONDS, 'none of the unmeasurable runs is near the cap');
+  assert.ok(Math.max(...STILL_QUEUED_SO_FAR) < 2400, 'none of the unmeasurable runs was near the 2400 s cap');
+  // Under the shipped 900 s two of them had ALREADY crossed the budget while
+  // still queued; both are the advisory timeout shape below, not a failure.
+  assert.deepEqual(STILL_QUEUED_SO_FAR.filter((t) => t > BUDGET_SECONDS), [1102, 1145]);
 
   // EIGHT breach 900 s, not the seven an earlier censored draft claimed.
-  assert.deepEqual(
-    RE_MEASURED.filter((t) => t > 900),
-    [906, 1172, 1276, 1387, 1503, 1527, 1786, 2028],
-    '900 s breaches eight of 56',
-  );
+  const BREACHES = [906, 1172, 1276, 1387, 1503, 1527, 1786, 2028];
+  assert.deepEqual(RE_MEASURED.filter((t) => t > 900), BREACHES, '900 s breaches eight of 56');
   assert.deepEqual(RE_MEASURED.filter((t) => t > 1800), [2028], '1800 s still breaches the max');
-  assert.deepEqual(RE_MEASURED.filter((t) => t > BUDGET_SECONDS), [], 'the shipped budget covers all 56');
+  // 2400 s covered all 56; that is the budget this file shipped between
+  // 2026-08-31 and the CI redesign, and it is kept as a measured fact.
+  assert.deepEqual(RE_MEASURED.filter((t) => t > 2400), [], '2400 s covered all 56');
 
-  // THE COVERING DIRECTION.
+  // THE SHIPPED BUDGET IS 900 s AND THOSE EIGHT RUNS TIME OUT UNDER IT. This is
+  // asserted, not hidden, because the reason it is acceptable is a property of
+  // the VERDICT and not of the number: at the deadline the rollup is still
+  // moving, and `evaluate` (check-pr-review-signal.test.mjs, the
+  // LANE_PUBLICATION_TIMEOUT case) reports that as an advisory with `ok: true`
+  // and a re-run remedy. What the eight runs cost under 2400 s was a runner
+  // slot held for up to 25 more minutes each; what they cost under 900 s is a
+  // re-run on the tail. The 48 that fit still get an immediate answer.
   for (const t of RE_MEASURED) {
-    assert.equal(poll(driver(completesAt(t * 1000)), { deadline: BUDGET_SECONDS * 1000 }).timedOut, false, `${t}s`);
-  }
-  // THE FAILING DIRECTION, because a budget that covers everything proves
-  // nothing on its own: the two superseded budgets genuinely time out on the
-  // runs they are claimed to.
-  for (const t of [906, 2028]) {
-    assert.equal(poll(driver(completesAt(t * 1000)), { deadline: 900_000 }).timedOut, true, `${t}s vs 900 s`);
+    const r = poll(driver(completesAt(t * 1000)), { deadline: BUDGET_SECONDS * 1000 });
+    assert.equal(r.timedOut, t > BUDGET_SECONDS, `${t}s vs the shipped ${BUDGET_SECONDS} s`);
   }
   assert.equal(poll(driver(completesAt(2028_000)), { deadline: 1800_000 }).timedOut, true, '2028s vs 1800 s');
 });
@@ -735,12 +748,14 @@ test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () 
  * exist -- correct, because nothing failed.
  */
 test('the budget the WORKFLOW ships is the budget this file tested', () => {
-  // WITHOUT THIS, REVERTING THE SHIPPED VALUE LEAVES THE SUITE GREEN. Measured:
-  // putting `--timeout-seconds 900` and `timeout-minutes: 20` back -- the exact
-  // regression this work exists to fix -- passed the whole suite, because the only
-  // budget any test named was a literal inside itself. Third instance today of
-  // the same shape: a value tested in one place and shipped from another. See
-  // the WIRING test in check-pr-review-signal.test.mjs.
+  // WITHOUT THIS, CHANGING THE SHIPPED VALUE LEAVES THE SUITE GREEN. Measured
+  // when the budget first moved to 2400 s: putting `--timeout-seconds 900` and
+  // `timeout-minutes: 20` back passed the whole suite, because the only budget
+  // any test named was a literal inside itself. Third instance that day of the
+  // same shape: a value tested in one place and shipped from another. See the
+  // WIRING test in check-pr-review-signal.test.mjs. (The budget has since gone
+  // back to 900 s deliberately -- see BUDGET_SECONDS -- and this pin is what
+  // makes that a one-line, reviewable change rather than a silent one.)
   const wf = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
   // ANCHORED, and that is load-bearing rather than tidy. Unanchored, these
   // matched the FIRST occurrence anywhere in a comment-dense file whose comments
@@ -785,14 +800,12 @@ test('the budget the WORKFLOW ships is the budget this file tested', () => {
 });
 
 test('MEASURED: excluding the aggregate matters more than any budget, and 420 s false-failed 8', () => {
-  // THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN ANY BUDGET EVER WAS, and
-  // the 900 s figure below no longer argues that, because 900 s is not the
-  // budget any more: at 2400 s, 0 of those 68 would breach and the evidence
-  // would be vacuous. Re-measured on the same 56 runs of 2026-08-31 as the
-  // budget above, the aggregate appeared at min 213 / median 1175 / MAX 3364 s,
-  // with TWELVE past 2400 s. So the exclusion still carries the fix at the
-  // budget actually in force, and the 68-run figure below is kept as the
-  // original finding rather than restated as a current one.
+  // THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN ANY BUDGET EVER WAS.
+  // Re-measured on the same 56 runs of 2026-08-31 as the budget above, the
+  // aggregate appeared at min 213 / median 1175 / MAX 3364 s, with TWELVE
+  // past 2400 s and 33 past 900 s. So the exclusion carries the fix at the
+  // budget actually in force (900 s again), and the 68-run figure below is
+  // kept as the original finding rather than restated as a current one.
   //
   // Same 68 runs, when `Build + WASM + Rust + Node` itself appeared: min 509,
   // median 894, max 2067 s. Requiring it would false-fail 33 of the 68 at a


### PR DESCRIPTION
CI redesign, step 3 (first half): the `PR review signal` bot stops re-polling heads that already have a verdict, and gives up early when the rollup is still moving.

## What changed

- `.github/workflows/pr-review-signal.yml`
  - `--timeout-seconds 2400` -> `900`, `timeout-minutes: 45` -> `20` (the >= 300 s slack the budget tests require is kept: 1200 - 900 = 300).
  - `edited` removed from the `pull_request` activity types.
- `scripts/lib/pr-review-signal.test.mjs`: `BUDGET_SECONDS` pinned back to 900 against the YAML; the 2026-08-31 re-measure is kept as a measured fact (eight of 56 runs breach 900 s) and now asserts that those eight time out under the shipped budget instead of asserting the budget covers them.
- `scripts/check-pr-review-signal.test.mjs`: the test that required `edited` in the types list now requires its absence, and pins that no job may gate on `github.event.action == 'edited'` / `changes.base` either.

## Why (plan evidence)

- 40% of `Test` runs (158/400 over 38 h) were same-SHA re-runs from `edited` waves; every one re-fired this workflow too.
- This workflow ran 116 times/day at 5.2 min average (max 21.7 min), about 10 runner-slot-hours a day, almost all of it polling for lanes to appear.
- The 2400 s budget bought no verdict: since #3810 a breach while the rollup is still unsettled is the `LANE_PUBLICATION_TIMEOUT` advisory (`ok: true`, remedy = re-run), not `MISSING_LANES`. The extra 1500 s only held a slot for up to 25 more minutes per busy-day run.

## Guards preserved

- The check keeps its name (`PR review signal`) and stays required. MISSING_LANES, NO_VERDICT, stale-review and fork handling are untouched; only the poll ceiling moves.
- Dropping `edited` is fail-closed: on a retarget the previous verdict stands (a stacked PR is already red with MISSING_LANES since #3429) until the next push or a manual re-run. It is NOT implemented as an `if:` skip, because a skipped run publishes a `skipped` check run that GitHub's required-check evaluation reads as a pass, which would turn a red PR green on a body edit. The new test pins that shape out.
- `scripts/check-swallowed-push.mjs`, `check-ci-path-coverage.mjs`, `check-ci-aggregate-coverage.mjs`, `check-test-wiring.mjs` all pass locally.

## Assumption noted

Retargeting a PR onto `main` no longer re-runs this gate by itself. Step 6 of the plan (re-trigger on `workflow_run: [Test] completed`) is the designed replacement; until then the author re-runs the check or pushes.

## Revert

`git revert` of this single commit restores the 2400 s budget, the 45 min cap and the `edited` trigger; the two test files revert with it. Workflow-only, no changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Updates**
  - Pull request review signaling now runs for newly opened, synchronized, reopened, and ready-for-review pull requests.
  - Review signal monitoring now uses a 20-minute polling window.
  - Timeout conditions are reported as advisories while review lanes continue progressing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->