### PR TITLE
ci(revert-oracle): judge type-only production diffs with tsc, not a test run

### DIFF
--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -92,6 +92,7 @@ import { isCommentOnlyDiff } from './lib/revert-oracle-comment-only.mjs';
 import { requiredFeaturePlanOrDie, EXIT_UNHANDLED_CFG_SHAPE } from './lib/revert-oracle-rust-features.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 import { planRuns } from './lib/revert-oracle-plan-runs.mjs';
+import { loadTypeScript, typeOnlyProduction, typecheckPlans, runTypecheckPlan, gitShow } from './lib/revert-oracle-type-only.mjs';
 
 const SELF_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const rootFlag = process.argv.indexOf('--root');
@@ -191,6 +192,16 @@ function resolveBin(bin, pkgDir) {
 }
 
 function runPlan(plan, label) {
+  const started = Date.now();
+  // #4472: a type-only branch is judged by tsc, not by running tests. Same
+  // result shape, same aggregate/verdict path -- see revert-oracle-type-only.mjs.
+  if (plan.typecheck) {
+    const parsed = runTypecheckPlan(plan, ROOT, label);
+    parsed.durationMs = Date.now() - started;
+    parsed.tail = parsed.evidence.join('\n');
+    logRun(plan, label, parsed, parsed.kind === 'runner-missing' ? '?' : parsed.kind === 'pass' ? 0 : 1);
+    return parsed;
+  }
   const cwd = plan.crate ? ROOT : plan.dir;
   const binPath = resolveBin(plan.runner.bin, plan.dir);
   if (!binPath) {
@@ -202,7 +213,6 @@ function runPlan(plan, label) {
       evidence: [`runner binary "${plan.runner.bin}" not found from ${relative(ROOT, plan.dir) || '.'} — run pnpm install`],
     };
   }
-  const started = Date.now();
   const r = spawnSync(binPath, plan.runner.args, {
     cwd,
     encoding: 'utf8',
@@ -219,11 +229,15 @@ function runPlan(plan, label) {
   parsed.rawExitCode = r.status;
   parsed.durationMs = Date.now() - started;
   parsed.tail = `${r.stdout ?? ''}\n${r.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
+  logRun(plan, label, parsed, r.status);
+  return parsed;
+}
+
+function logRun(plan, label, parsed, exit) {
   console.log(
     `  [${label}] ${relative(ROOT, plan.dir) || '.'} (${plan.runner.family}) -> ${parsed.kind}` +
-      ` (pass ${parsed.passed ?? '?'}, fail ${parsed.failed ?? '?'}, total ${parsed.total ?? '?'}, exit ${r.status}, ${parsed.durationMs}ms)`,
+      ` (pass ${parsed.passed ?? '?'}, fail ${parsed.failed ?? '?'}, total ${parsed.total ?? '?'}, exit ${exit}, ${parsed.durationMs}ms)`,
   );
-  return parsed;
 }
 
 // ---------------------------------------------------------------------------
@@ -337,7 +351,24 @@ if (testPaths.length === 0) {
   );
 }
 
-const { plans, unassigned } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, opts.json, baseSha, headSha, prodPaths, die, EXIT_UNHANDLED_CFG_SHAPE);
+// #4472: when every production file erases to the same JavaScript, no test
+// RUN can observe the change -- only the type-checker can. Decided on the
+// revert set (after --only), at base vs head, with the repo's own typescript.
+const typeOnly = typeOnlyProduction(loadTypeScript(ROOT), prodPaths, (side, p) => gitShow(ROOT, side === 'base' ? mergeBase : headSha, p));
+const observer = typeOnly.typeOnly ? 'typecheck' : 'tests';
+console.log(`  observer: ${observer} (${typeOnly.reason})`);
+let plans;
+let unassigned;
+if (observer === 'typecheck') {
+  const t = typecheckPlans(testPaths, ROOT);
+  for (const s of t.skipped) console.log(`  skipped: ${s} is not TypeScript, so it cannot observe a type-only change`);
+  if (t.plans.length === 0 && t.unassigned.length === 0) {
+    die(opts.ci ? EXIT_UNOBSERVED : EXIT_NOTHING_CHECKED, 'type-only production change, and none of the changed test files is TypeScript: nothing can observe it.', prodPaths.map((p) => `changed: ${p}`));
+  }
+  ({ plans, unassigned } = t);
+} else {
+  ({ plans, unassigned } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, opts.json, baseSha, headSha, prodPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
+}
 if (unassigned.length > 0) {
   die(EXIT_NOTHING_CHECKED, 'could not find an owning package for some test files', unassigned);
 }
@@ -481,6 +512,7 @@ const banner = {
 console.log('\n' + '='.repeat(78));
 console.log(banner);
 console.log('='.repeat(78));
+console.log(`  observer:  ${observer}`);
 console.log(`  reverted:  ${result.prodPaths.join('\n             ')}`);
 console.log(`  tests run: ${result.testPaths.join('\n             ')}`);
 console.log(`  baseline:  ${result.baseline.kind} — ${result.baseline.passed ?? '?'} passed / ${result.baseline.total ?? '?'} collected`);
@@ -505,6 +537,7 @@ if (opts.json) {
     JSON.stringify(
       {
         verdict: result.verdict,
+        observer,
         reason: result.reason,
         base: baseSha,
         head: headSha,

--- a/scripts/lib/revert-oracle-type-only.mjs
+++ b/scripts/lib/revert-oracle-type-only.mjs
@@ -1,0 +1,291 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The TYPECHECK observer for the revert oracle (#4472).
+ *
+ * WHAT WENT WRONG. `check-test-revert-oracle.mjs` asks "do the branch's
+ * changed tests go red when its production change is reverted?", and it
+ * answers by RUNNING the tests. PR #4472 added four members to the
+ * `SceneContents` interface and a test file whose whole point is compile-time:
+ * `const fn: SceneContents['getMeshData'] = ...`. Reverting the interface makes
+ * `tsc` report TS2339 at that line -- and changes nothing at runtime, because
+ * an interface member has no runtime. `tsx --test` transpiles without checking,
+ * so the oracle saw 4 pass / 4 pass and reported UNOBSERVED. The change WAS
+ * observed; the oracle was listening on the wrong channel.
+ *
+ * WHAT THIS DOES. Two pure decisions plus one runner, all injectable so the
+ * verdict path is testable without git or tsc:
+ *
+ *   1. `isTypeOnlyChange(ts, path, baseText, headText)`: a TypeScript file
+ *      whose base and head TRANSPILE to the same JavaScript (comments
+ *      stripped, whitespace collapsed) changed only its types. Interfaces,
+ *      type aliases, `declare`, `import type`, annotations, generics -- all
+ *      of it erases. An `enum`, a class member, a default value, a new
+ *      statement -- none of it does, and such a file is NOT type-only, so the
+ *      ordinary runtime observer still runs for it.
+ *   2. `typeOnlyProduction(ts, paths, show)`: the branch is a type-only branch
+ *      when EVERY production file is TypeScript and type-only. One runtime
+ *      change anywhere and the runtime observer is the right one for the
+ *      whole revert set (a mixed revert is judged by the stricter tool).
+ *   3. `typecheckPlans` / `runTypecheckPlan`: group the changed TypeScript
+ *      test files by owning package and type-check that package's test
+ *      program through `scripts/typecheck-tests.mjs` (the repo's dedicated
+ *      lane for test-only type errors, #2457), at baseline and again with
+ *      production reverted. The result carries the SAME shape
+ *      `parseRunnerOutput` produces, so `aggregate()` and `verdict()` in
+ *      revert-oracle.mjs judge it unchanged:
+ *
+ *        baseline    exit 0                       -> pass          (required)
+ *        baseline    any diagnostic               -> load-failure  -> BASELINE-BROKEN
+ *        reverted    >= 1 diagnostic IN A CHANGED
+ *                    TEST FILE                    -> assertion-failure -> OBSERVED
+ *        reverted    diagnostics elsewhere only,
+ *                    or none                      -> pass          -> UNOBSERVED
+ *
+ *      "In a changed test file" is the whole rule. A diagnostic somewhere
+ *      else says the revert broke an OLD test's types, which is a fact about
+ *      the old test, not evidence that this branch's test observes this
+ *      branch's change -- the same wrong-reason-red the runtime observer
+ *      refuses to count.
+ *
+ * FAILS CLOSED. No `typescript` resolvable from the repo root, no
+ * `typecheck-tests.mjs`, a package without a `tsconfig.json`, a test file that
+ * is not TypeScript -- each is reported by name, never silently treated as a
+ * pass. The dispatcher reports `observer: "typecheck"` in `--json` so a reader
+ * of the verdict knows which channel it came from.
+ */
+
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, relative, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const TS_EXTS = ['.ts', '.tsx', '.mts', '.cts'];
+
+export const TYPECHECK_SCRIPT = 'scripts/typecheck-tests.mjs';
+
+/** `.ts` / `.tsx` / `.mts` / `.cts`, including `.d.ts`. */
+export function isTypeScriptPath(path) {
+  return TS_EXTS.some((ext) => path.endsWith(ext));
+}
+
+/**
+ * The repo's own `typescript`, resolved from `root` so the oracle judges with
+ * the compiler the branch builds with. `null` when it is not installed --
+ * callers must treat that as "cannot decide", never as "not type-only".
+ */
+export function loadTypeScript(root) {
+  try {
+    const req = createRequire(pathToFileURL(join(root, 'package.json')));
+    return req('typescript');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The JavaScript a TypeScript source erases to, normalised for comparison.
+ *
+ * `removeComments` so a JSDoc paragraph (the #4472 diff carried four) cannot
+ * make two type-identical files differ; whitespace collapsed so a reflowed
+ * line cannot either. ESNext/ESNext keeps the output closest to the source
+ * (no downlevel helpers that would differ on unrelated grounds); `jsx:
+ * preserve` so a `.tsx` file is not rewritten through React.createElement.
+ */
+export function erasedShape(ts, text, fileName) {
+  const out = ts.transpileModule(text, {
+    fileName,
+    reportDiagnostics: false,
+    compilerOptions: {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      jsx: ts.JsxEmit.Preserve,
+      removeComments: true,
+      sourceMap: false,
+      inlineSourceMap: false,
+      declaration: false,
+    },
+  });
+  // A module left with only type exports emits a bare `export {};` marker; a
+  // file with no statements at all is treated as a script and emits only the
+  // `"use strict";` prologue. Both mean "no runtime", so both are dropped
+  // before comparing -- an ADDED interface-only file ('' at base) is type-only.
+  return out.outputText
+    .replace(/^\s*"use strict";/, '')
+    .replace(/\bexport \{\};/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * True only when `path` is TypeScript and its base and head erase to the same
+ * JavaScript. An added or deleted file passes `''` for the missing side, so a
+ * new `.d.ts` or a new interface-only module is type-only too.
+ *
+ * @param {object} ts the `typescript` module
+ * @param {string} path repo-relative path
+ * @param {string} baseText contents at base ('' when the file did not exist)
+ * @param {string} headText contents at head ('' when the file was deleted)
+ */
+export function isTypeOnlyChange(ts, path, baseText, headText) {
+  if (!isTypeScriptPath(path)) return false;
+  if (baseText === headText) return false; // nothing changed: not a type-only CHANGE
+  // A declaration file has no runtime by definition (and transpileModule
+  // refuses to emit one), so any change to it is type-only.
+  if (/\.d\.[cm]?ts$/.test(path)) return true;
+  return erasedShape(ts, baseText, path) === erasedShape(ts, headText, path);
+}
+
+/**
+ * Is the whole production side of this branch type-only?
+ *
+ * @param {object|null} ts the `typescript` module, or null when unresolvable
+ * @param {string[]} paths every production path in the diff
+ * @param {(side: 'base'|'head', path: string) => string} show file contents
+ *   at that side ('' when absent)
+ * @returns {{typeOnly: boolean, reason: string}}
+ */
+export function typeOnlyProduction(ts, paths, show) {
+  if (paths.length === 0) return { typeOnly: false, reason: 'no production files' };
+  if (!ts) return { typeOnly: false, reason: 'typescript is not resolvable from the repo root' };
+  const runtime = paths.filter((p) => !isTypeOnlyChange(ts, p, show('base', p), show('head', p)));
+  if (runtime.length > 0) {
+    return { typeOnly: false, reason: `runtime change in ${runtime[0]}${runtime.length > 1 ? ` (+${runtime.length - 1} more)` : ''}` };
+  }
+  return { typeOnly: true, reason: `all ${paths.length} production file(s) erase to identical JavaScript` };
+}
+
+function findUp(startDir, filename, root) {
+  let dir = startDir;
+  for (;;) {
+    if (existsSync(join(dir, filename))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir || !parent.startsWith(root)) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * One plan per package that owns a changed TypeScript test file. Non-TypeScript
+ * test files can never observe a type-only change and are listed in `skipped`
+ * by name so the dispatcher can say so.
+ *
+ * The plan carries the same fields as `planRuns()`'s so `runPlan` can print
+ * it the same way; `runner.family` is `typecheck` and `runner.args` names the
+ * script that will be spawned, for the log line.
+ */
+export function typecheckPlans(testPaths, root) {
+  const groups = new Map();
+  const skipped = [];
+  const unassigned = [];
+  for (const rel of testPaths) {
+    if (!isTypeScriptPath(rel)) { skipped.push(rel); continue; }
+    const abs = join(root, rel);
+    const pkgDir = findUp(dirname(abs), 'package.json', root);
+    if (!pkgDir || pkgDir === root || !existsSync(join(pkgDir, 'tsconfig.json'))) { unassigned.push(rel); continue; }
+    if (!groups.has(pkgDir)) groups.set(pkgDir, { dir: pkgDir, files: [] });
+    groups.get(pkgDir).files.push(rel);
+  }
+  const plans = [...groups.values()].map((g) => ({
+    key: `typecheck:${g.dir}`,
+    dir: g.dir,
+    files: g.files,
+    relFiles: g.files.map((f) => relative(g.dir, join(root, f)).split(sep).join('/')),
+    script: undefined,
+    crate: null,
+    typecheck: true,
+    runner: { family: 'typecheck', bin: 'node', args: [TYPECHECK_SCRIPT] },
+  }));
+  return { plans, skipped, unassigned };
+}
+
+/**
+ * `path(line,col): error TSnnnn: message` lines, as tsc prints them (relative
+ * to its cwd -- the repo root, the way typecheck-tests.mjs spawns it).
+ */
+export function parseTscDiagnostics(text) {
+  const out = [];
+  const re = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.*)$/gm;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    out.push({ file: m[1].split('\\').join('/'), line: Number(m[2]), col: Number(m[3]), code: m[4], message: m[5] });
+  }
+  return out;
+}
+
+const samePath = (a, b) => a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`);
+
+/**
+ * Type-check one package's test program and score it like a test run.
+ *
+ * @param {object} plan from `typecheckPlans`
+ * @param {string} root repo root (where `scripts/typecheck-tests.mjs` lives)
+ * @param {'baseline'|'reverted'} phase which run this is -- see the header table
+ * @param {{spawn?: typeof spawnSync}} [deps] injectable for tests
+ */
+export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync } = {}) {
+  const script = join(root, TYPECHECK_SCRIPT);
+  if (!existsSync(script)) {
+    return { kind: 'runner-missing', passed: null, failed: null, total: null, evidence: [`${TYPECHECK_SCRIPT} not found under ${root}`] };
+  }
+  const r = spawn(process.execPath, [script], {
+    cwd: plan.dir,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
+  });
+  if (r.error) {
+    return { kind: 'runner-missing', passed: null, failed: null, total: null, evidence: [`could not spawn ${TYPECHECK_SCRIPT}: ${r.error.message}`] };
+  }
+  const output = `${r.stdout ?? ''}\n${r.stderr ?? ''}`;
+  const diagnostics = parseTscDiagnostics(output);
+  const total = plan.files.length;
+  const inChanged = diagnostics.filter((d) => plan.files.some((f) => samePath(d.file, f)));
+  const elsewhere = diagnostics.length - inChanged.length;
+  const describe = (d) => `${d.file}(${d.line},${d.col}): ${d.code} ${d.message}`;
+
+  if (phase === 'baseline') {
+    if (r.status === 0 && diagnostics.length === 0) {
+      return { kind: 'pass', passed: total, failed: 0, total, evidence: [] };
+    }
+    return {
+      kind: 'load-failure',
+      passed: null,
+      failed: null,
+      total,
+      evidence: [
+        diagnostics[0]
+          ? `the package's test program does not type-check before any revert: ${describe(diagnostics[0])}`
+          : `typecheck-tests.mjs exited ${r.status} with no diagnostics to report`,
+      ],
+    };
+  }
+  if (inChanged.length > 0) {
+    const hit = new Set(inChanged.map((d) => plan.files.find((f) => samePath(d.file, f)))).size;
+    return {
+      kind: 'assertion-failure',
+      passed: total - hit,
+      failed: hit,
+      total,
+      evidence: inChanged.slice(0, 5).map(describe),
+    };
+  }
+  return {
+    kind: 'pass',
+    passed: total,
+    failed: 0,
+    total,
+    evidence: elsewhere > 0
+      ? [`${elsewhere} diagnostic(s) outside the changed test files (first: ${describe(diagnostics[0])}) -- an old test's types broke, which does not show that THIS branch's tests observe the change`]
+      : [],
+  };
+}
+
+/** Repo-relative file contents at a git revision, '' when the path is absent there. */
+export function gitShow(root, rev, path, spawn = spawnSync) {
+  const r = spawn('git', ['show', `${rev}:${path}`], { cwd: root, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return r.status === 0 ? r.stdout : '';
+}

--- a/scripts/lib/revert-oracle-type-only.test.mjs
+++ b/scripts/lib/revert-oracle-type-only.test.mjs
@@ -1,0 +1,329 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The #4472 regression, pinned at three levels:
+ *
+ *   1. the CLASSIFIER: the exact shape of PR #4472's production diff -- four
+ *      interface members plus JSDoc -- is type-only, and the runtime shapes
+ *      that must NOT be (an enum, a class method, a default value) are not;
+ *   2. the OBSERVER: with `spawn` injected, a baseline that type-checks and a
+ *      revert that puts TS2339 in the changed test file score OBSERVED
+ *      through the unmodified `verdict()`; the old runtime answer (4 pass /
+ *      4 pass) would have been UNOBSERVED, and a diagnostic that lands only
+ *      in some OTHER test file still is;
+ *   3. the DISPATCHER, end to end: a throwaway git repo carrying a
+ *      #4472-shaped branch, judged by the real `check-test-revert-oracle.mjs`
+ *      with the real `tsc`, reports `"observer": "typecheck"` and OBSERVED --
+ *      and the same branch with a runtime-only test reports UNOBSERVED, so
+ *      the new channel cannot pass vacuously.
+ *
+ * Run: node --test scripts/lib/revert-oracle-type-only.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+import { aggregate, verdict } from './revert-oracle.mjs';
+import {
+  erasedShape,
+  isTypeOnlyChange,
+  loadTypeScript,
+  parseTscDiagnostics,
+  runTypecheckPlan,
+  typecheckPlans,
+  typeOnlyProduction,
+} from './revert-oracle-type-only.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../..');
+const ts = createRequire(import.meta.url)('typescript');
+
+// ---------------------------------------------------------------------------
+// 1. The classifier, on the #4472 shape and its runtime neighbours.
+// ---------------------------------------------------------------------------
+
+const BASE = `import type { MeshData } from '@ifc-lite/geometry';
+
+export interface SceneContents {
+  getMeshes(): MeshData[];
+  getMeshDataPieces(expressId: number, modelIndex?: number): MeshData[] | undefined;
+  getEntityBoundingBox(expressId: number): { min: number[]; max: number[] } | null;
+}
+`;
+
+// PR #4472's diff, verbatim in shape: four members and their JSDoc, nothing else.
+const HEAD_4472 = `import type { MeshData } from '@ifc-lite/geometry';
+
+export interface SceneContents {
+  getMeshes(): MeshData[];
+  getMeshDataPieces(expressId: number, modelIndex?: number): MeshData[] | undefined;
+  /**
+   * The single-mesh accessor: one representative mesh per entity, or
+   * \`undefined\` when the entity has no flat mesh data (#4357).
+   */
+  getMeshData(expressId: number, modelIndex?: number): MeshData | undefined;
+  /** Visits every flat mesh piece in the scene (#4357). */
+  forEachMeshData(visit: (md: MeshData) => void): void;
+  getEntityBoundingBox(expressId: number): { min: number[]; max: number[] } | null;
+  /** Row-major 4x4 local-to-world, f64 precision (#4357). */
+  getEntityTransform(expressId: number): Float64Array | null;
+  /** Bounds in the entity's OWN local frame (#4357). */
+  getEntityLocalBounds(
+    expressId: number,
+  ): { min: [number, number, number]; max: [number, number, number] } | null;
+}
+`;
+
+test('#4472: four interface members plus JSDoc is a type-only change', () => {
+  assert.equal(isTypeOnlyChange(ts, 'packages/renderer/src/scene-contents.ts', BASE, HEAD_4472), true);
+  // Anti-vacuity: the erased shape is not empty prose -- it is the one line
+  // that survives, and it survives identically on both sides.
+  assert.equal(erasedShape(ts, HEAD_4472, 'x.ts'), erasedShape(ts, BASE, 'x.ts'));
+  assert.equal(erasedShape(ts, BASE, 'x.ts'), '');
+});
+
+test('a type alias, a `declare`, an `import type`, a generic and an annotation all erase', () => {
+  const base = 'export function f(a: number) { return a + 1; }\n';
+  const head =
+    "import type { Foo } from './foo.js';\n" +
+    'declare const __brand: unique symbol;\n' +
+    'export type Wide<T extends Foo = Foo> = T & { [__brand]: true };\n' +
+    'export function f(a: number): number { return a + 1; }\n';
+  assert.equal(isTypeOnlyChange(ts, 'src/a.ts', base, head), true);
+});
+
+test('a NEW `.d.ts` and a NEW interface-only module are type-only (added file, base is empty)', () => {
+  assert.equal(isTypeOnlyChange(ts, 'src/types.d.ts', '', 'export interface X { a: number }\n'), true);
+  assert.equal(isTypeOnlyChange(ts, 'src/shapes.ts', '', 'export interface X { a: number }\nexport type Y = X[];\n'), true);
+});
+
+test('runtime shapes are NOT type-only: enum member, class method, default value, new statement', () => {
+  const cases = [
+    ['enum member', 'export enum K { A }\n', 'export enum K { A, B }\n'],
+    ['class method', 'export class C {}\n', 'export class C { m(): void {} }\n'],
+    ['default value', 'export function f(a: number) { return a; }\n', 'export function f(a: number = 1) { return a; }\n'],
+    ['new statement', 'export const a = 1;\n', 'export const a = 1;\nexport const b = 2;\n'],
+    ['changed literal', 'export const LIMIT = 5;\n', 'export const LIMIT = 6;\n'],
+    ['interface member AND a runtime line', BASE, `${HEAD_4472}export const VERSION = 2;\n`],
+  ];
+  for (const [name, base, head] of cases) {
+    assert.equal(isTypeOnlyChange(ts, 'src/a.ts', base, head), false, name);
+  }
+});
+
+test('a non-TypeScript path is never type-only, and an unchanged file is not a CHANGE', () => {
+  assert.equal(isTypeOnlyChange(ts, 'src/a.mjs', 'export const a = 1;\n', 'export const a = 1; // now with a comment\n'), false);
+  assert.equal(isTypeOnlyChange(ts, 'src/a.rs', 'fn a() {}', 'fn a() {}'), false);
+  assert.equal(isTypeOnlyChange(ts, 'src/a.ts', BASE, BASE), false);
+});
+
+test('a `.tsx` file with an added props type is type-only; JSX is preserved, not lowered', () => {
+  const base = 'export function Box(p) { return <div>{p.x}</div>; }\n';
+  const head = 'type Props = { x: number };\nexport function Box(p: Props) { return <div>{p.x}</div>; }\n';
+  assert.equal(isTypeOnlyChange(ts, 'src/Box.tsx', base, head), true);
+  assert.match(erasedShape(ts, head, 'src/Box.tsx'), /<div>/);
+});
+
+test('typeOnlyProduction: every production file must be type-only, and no typescript is "cannot decide"', () => {
+  const texts = {
+    'src/a.ts': [BASE, HEAD_4472],
+    'src/b.ts': ['export const n = 1;\n', 'export const n = 2;\n'],
+  };
+  const show = (side, p) => texts[p][side === 'base' ? 0 : 1];
+  assert.equal(typeOnlyProduction(ts, ['src/a.ts'], show).typeOnly, true);
+  const mixed = typeOnlyProduction(ts, ['src/a.ts', 'src/b.ts'], show);
+  assert.equal(mixed.typeOnly, false);
+  assert.match(mixed.reason, /runtime change in src\/b\.ts/);
+  assert.equal(typeOnlyProduction(null, ['src/a.ts'], show).typeOnly, false);
+  assert.equal(typeOnlyProduction(ts, [], show).typeOnly, false);
+});
+
+test('loadTypeScript resolves the repo\'s own compiler from the root, and null elsewhere', () => {
+  assert.equal(typeof loadTypeScript(REPO_ROOT)?.transpileModule, 'function');
+  assert.equal(loadTypeScript(mkdtempSync(join(tmpdir(), 'oracle-no-ts-'))), null);
+});
+
+// ---------------------------------------------------------------------------
+// 2. The observer, with spawn injected, judged by the unmodified verdict().
+// ---------------------------------------------------------------------------
+
+const TEST_FILE = 'packages/renderer/src/scene-contents-4357.test.ts';
+const PLAN = { dir: join(REPO_ROOT, 'packages/renderer'), files: [TEST_FILE], typecheck: true, runner: { family: 'typecheck' } };
+const TS2339 = `${TEST_FILE}(35,37): error TS2339: Property 'getMeshData' does not exist on type 'SceneContents'.\n`;
+const ELSEWHERE = `packages/renderer/src/other.test.ts(9,3): error TS2339: Property 'getMeshData' does not exist on type 'SceneContents'.\n`;
+
+const fakeSpawn = (status, stdout) => () => ({ status, stdout, stderr: '' });
+
+test('parseTscDiagnostics reads tsc\'s `file(line,col): error TSnnnn:` lines and nothing else', () => {
+  const d = parseTscDiagnostics(`typecheck-tests: packages/renderer FAILED (110 test files)\n${TS2339}${ELSEWHERE}some prose\n`);
+  assert.equal(d.length, 2);
+  assert.deepEqual(d[0], { file: TEST_FILE, line: 35, col: 37, code: 'TS2339', message: "Property 'getMeshData' does not exist on type 'SceneContents'." });
+  assert.equal(parseTscDiagnostics('typecheck-tests: packages/renderer OK (110 test files)\n').length, 0);
+  // Windows tsc prints backslashes; they are normalised so the changed-file match holds.
+  assert.equal(parseTscDiagnostics('packages\\renderer\\src\\x.test.ts(1,1): error TS1: m\n')[0].file, 'packages/renderer/src/x.test.ts');
+});
+
+test('#4472 through verdict(): baseline clean, revert puts TS2339 in the changed test -> OBSERVED', () => {
+  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, 'typecheck-tests: packages/renderer OK (110 test files)\n') });
+  assert.equal(baseline.kind, 'pass');
+  assert.deepEqual([baseline.passed, baseline.failed, baseline.total], [1, 0, 1]);
+
+  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339) });
+  assert.equal(reverted.kind, 'assertion-failure');
+  assert.deepEqual([reverted.passed, reverted.failed, reverted.total], [0, 1, 1]);
+  assert.match(reverted.evidence[0], /TS2339/);
+
+  const v = verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) });
+  assert.equal(v.verdict, 'OBSERVED');
+  assert.equal(v.exitCode, 0);
+});
+
+test('the pre-fix answer, for contrast: the runtime observer saw pass/pass and said UNOBSERVED', () => {
+  // This is what the CI job on #4472 printed: `[baseline] ... pass (pass 4,
+  // fail 0, total 4)` and `[reverted] ... pass (pass 4, fail 0, total 4)`.
+  const pass4 = { kind: 'pass', passed: 4, failed: 0, total: 4, evidence: [] };
+  assert.equal(verdict({ baseline: pass4, reverted: pass4 }).verdict, 'UNOBSERVED');
+});
+
+test('a diagnostic that lands ONLY in some other test file is UNOBSERVED, with the reason named', () => {
+  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, '') });
+  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, ELSEWHERE) });
+  assert.equal(reverted.kind, 'pass');
+  assert.match(reverted.evidence[0], /outside the changed test files/);
+  assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'UNOBSERVED');
+});
+
+test('a baseline that does not type-check is BASELINE-BROKEN, whichever file the diagnostic is in', () => {
+  for (const out of [TS2339, ELSEWHERE]) {
+    const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(1, out) });
+    assert.equal(baseline.kind, 'load-failure');
+    assert.match(baseline.evidence[0], /before any revert/);
+    const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339) });
+    assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'BASELINE-BROKEN');
+  }
+  // A non-zero exit with nothing parseable is broken too, never a pass.
+  assert.equal(runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(2, 'boom') }).kind, 'load-failure');
+});
+
+test('a runner that cannot be spawned, or a root without typecheck-tests.mjs, is runner-missing', () => {
+  assert.equal(runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: () => ({ error: new Error('ENOENT') }) }).kind, 'runner-missing');
+  assert.equal(runTypecheckPlan(PLAN, mkdtempSync(join(tmpdir(), 'oracle-no-script-')), 'baseline').kind, 'runner-missing');
+});
+
+test('typecheckPlans groups TypeScript tests by package, names non-TypeScript tests as skipped', () => {
+  const { plans, skipped, unassigned } = typecheckPlans(
+    ['packages/renderer/src/a.test.ts', 'packages/renderer/src/b.test.tsx', 'packages/parser/src/c.test.ts', 'scripts/lib/d.test.mjs'],
+    REPO_ROOT,
+  );
+  assert.deepEqual(plans.map((p) => p.files), [['packages/renderer/src/a.test.ts', 'packages/renderer/src/b.test.tsx'], ['packages/parser/src/c.test.ts']]);
+  assert.deepEqual(plans[0].relFiles, ['src/a.test.ts', 'src/b.test.tsx']);
+  assert.equal(plans[0].runner.family, 'typecheck');
+  assert.deepEqual(skipped, ['scripts/lib/d.test.mjs']);
+  assert.deepEqual(unassigned, []);
+});
+
+// ---------------------------------------------------------------------------
+// 3. End to end through the dispatcher, with the real tsc.
+// ---------------------------------------------------------------------------
+
+const oracle = resolve(HERE, '../check-test-revert-oracle.mjs');
+
+/**
+ * A throwaway repo with one package, a #4472-shaped branch on top of it, and
+ * just enough of this repository (typecheck-tests.mjs, tsconfig.tests.base.json,
+ * a node_modules link) for the real type-checker to run.
+ */
+function runOnce({ testObservesTypes }) {
+  const root = mkdtempSync(join(tmpdir(), 'oracle-type-only-'));
+  function run(bin, args) {
+    const r = spawnSync(bin, args, { cwd: root, encoding: 'utf8', timeout: 100_000, maxBuffer: 16 * 1024 * 1024 });
+    assert.equal(r.error, undefined, `${bin}: ${r.error?.message}`);
+    assert.equal(r.status, 0, `${bin} ${args.join(' ')}\n${r.stdout}\n${r.stderr}`);
+    return r.stdout;
+  }
+  try {
+    run('git', ['init', '-q']);
+    // LF in, LF out: a global `core.autocrlf=true` (the Git-for-Windows
+    // default) would otherwise make the restored tree read as modified.
+    run('git', ['config', 'core.autocrlf', 'false']);
+    run('git', ['config', 'user.name', 'Revert oracle fixture']);
+    run('git', ['config', 'user.email', 'oracle@example.invalid']);
+    // The slice of this repository the typecheck observer needs.
+    mkdirSync(join(root, 'scripts'));
+    copyFileSync(join(REPO_ROOT, 'scripts/typecheck-tests.mjs'), join(root, 'scripts/typecheck-tests.mjs'));
+    copyFileSync(join(REPO_ROOT, 'tsconfig.tests.base.json'), join(root, 'tsconfig.tests.base.json'));
+    symlinkSync(join(REPO_ROOT, 'node_modules'), join(root, 'node_modules'), 'junction');
+    writeFileSync(join(root, 'package.json'), '{ "name": "oracle-type-only-fixture", "private": true }\n');
+    writeFileSync(join(root, '.gitignore'), 'node_modules\ntsconfig.tests.json\n');
+    // The package: one interface, no runtime.
+    mkdirSync(join(root, 'pkg/src'), { recursive: true });
+    writeFileSync(join(root, 'pkg/package.json'), '{ "name": "fixture-pkg", "private": true, "scripts": { "test": "tsx --test src/*.test.ts" } }\n');
+    writeFileSync(
+      join(root, 'pkg/tsconfig.json'),
+      JSON.stringify({ compilerOptions: { target: 'es2022', module: 'nodenext', moduleResolution: 'nodenext', strict: true, types: [], outDir: './dist', rootDir: './src' }, include: ['src/**/*'] }, null, 2),
+    );
+    writeFileSync(join(root, 'pkg/src/contents.ts'), 'export interface Contents {\n  getMeshes(): number[];\n}\n');
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'base']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+
+    // The branch: a type-only production change plus the test that observes it.
+    writeFileSync(
+      join(root, 'pkg/src/contents.ts'),
+      'export interface Contents {\n  getMeshes(): number[];\n  /** One representative mesh per entity (#4357). */\n  getMeshData(expressId: number): number | undefined;\n}\n',
+    );
+    writeFileSync(
+      join(root, 'pkg/src/contents-4357.test.ts'),
+      testObservesTypes
+        ? "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport type { Contents } from './contents.js';\n\ntest('getMeshData is on Contents', () => {\n  const fn: Contents['getMeshData'] = (expressId: number): number | undefined => (expressId > 0 ? 1 : undefined);\n  assert.equal(typeof fn, 'function');\n});\n"
+        : "import { test } from 'node:test';\nimport assert from 'node:assert/strict';\nimport type { Contents } from './contents.js';\n\ntest('getMeshes is on Contents', () => {\n  const fn: Contents['getMeshes'] = () => [1];\n  assert.equal(fn().length, 1);\n});\n",
+    );
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'type-only production change plus a test']);
+
+    const r = spawnSync(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], {
+      encoding: 'utf8',
+      timeout: 100_000,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    assert.equal(r.error, undefined);
+    // The tree must be byte-identical afterwards, whatever the verdict.
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+const HAVE_TOOLING = existsSync(join(REPO_ROOT, 'node_modules/typescript/bin/tsc')) && existsSync(join(REPO_ROOT, 'node_modules/@types/node'));
+
+test('END TO END (#4472 shape): the dispatcher picks the typecheck observer and reports OBSERVED', { timeout: 120_000, skip: !HAVE_TOOLING && 'typescript / @types/node not installed' }, () => {
+  const { status, stdout, stderr } = runOnce({ testObservesTypes: true });
+  assert.equal(status, 0, `${stdout}\n${stderr}`);
+  assert.match(stdout, /observer: typecheck \(all 1 production file\(s\) erase to identical JavaScript\)/);
+  assert.match(stdout, /runner: pkg -> node scripts\/typecheck-tests\.mjs/);
+  assert.match(stdout, /\[reverted\] pkg \(typecheck\) -> assertion-failure/);
+  assert.match(stdout, /TS2339/);
+  assert.match(stdout, /✔ OBSERVED/);
+  const json = JSON.parse(stdout.slice(stdout.indexOf('\n{')));
+  assert.equal(json.verdict, 'OBSERVED');
+  assert.equal(json.observer, 'typecheck');
+});
+
+test('END TO END, the failing direction: a test that never names the new member is UNOBSERVED', { timeout: 120_000, skip: !HAVE_TOOLING && 'typescript / @types/node not installed' }, () => {
+  const { status, stdout, stderr } = runOnce({ testObservesTypes: false });
+  assert.equal(status, 1, `${stdout}\n${stderr}`);
+  assert.match(stdout, /observer: typecheck/);
+  assert.match(stdout, /\[baseline\] pkg \(typecheck\) -> pass/);
+  assert.match(stdout, /\[reverted\] pkg \(typecheck\) -> pass/);
+  assert.match(stdout, /UNOBSERVED/);
+  assert.equal(JSON.parse(stdout.slice(stdout.indexOf('\n{'))).observer, 'typecheck');
+});

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -341,7 +341,7 @@
    855 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
-   607 scripts/check-test-revert-oracle.mjs
+   640 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
    499 scripts/docs/check-doc-samples.mjs


### PR DESCRIPTION
CI redesign, step 9 (plan section 7): the revert oracle gains a TYPECHECK observer for type-only production diffs, so a PR like #4472 is judged on the channel its test actually uses.

## What changed

- `scripts/lib/revert-oracle-type-only.mjs` (new)
  - `isTypeOnlyChange(ts, path, base, head)`: a TypeScript file whose base and head erase (`ts.transpileModule`, comments stripped, whitespace collapsed) to identical JavaScript changed only its types. Enums, class members, defaults, new statements are NOT type-only and keep the runtime observer. `.d.ts` is type-only by definition.
  - `typeOnlyProduction(...)`: the branch is type-only only when EVERY production file in the revert set is.
  - `typecheckPlans` / `runTypecheckPlan`: group the changed TypeScript test files by owning package and type-check that package's test program through the existing `scripts/typecheck-tests.mjs` (the #2457 lane), at baseline and with production reverted. Scoring: baseline must be clean (else BASELINE-BROKEN); reverted must emit at least one diagnostic located IN A CHANGED TEST FILE (OBSERVED), else UNOBSERVED -- a diagnostic in some other test file is a fact about the old test and does not count. The result uses the same shape as `parseRunnerOutput`, so `aggregate()`/`verdict()` are unchanged.
- `scripts/check-test-revert-oracle.mjs`: picks the observer after the revert set is known (after `--only`), prints `observer: typecheck (...)` / `observer: tests (...)`, dispatches typecheck plans through the same `runPlan`, and reports `"observer"` in `--json`. A type-only branch whose changed tests are all non-TypeScript is UNOBSERVED with the reason named (nothing can observe it).
- `scripts/lib/revert-oracle-type-only.test.mjs` (new): the #4472 regression at three levels -- the classifier on the exact shape of #4472's diff (four interface members plus JSDoc) and its runtime neighbours; the observer with `spawn` injected, judged by the unmodified `verdict()` (OBSERVED for TS2339 in the changed test, UNOBSERVED for the old pass/pass answer and for an off-target diagnostic, BASELINE-BROKEN for a red baseline); and END TO END through the real dispatcher and the real `tsc` in a throwaway git repo, both directions (a test naming the new member is OBSERVED; one that does not is UNOBSERVED).
- `scripts/module-size-allowlist.txt`: `check-test-revert-oracle.mjs` 607 -> 640, recorded with `--update --allow-raise`. Justification: the dispatcher gains one observer branch (+33 lines: the `runPlan` dispatch, the observer decision, and the two report fields); all logic lives in the new lib module, same split as #4090 / #4079.

## Why (plan evidence)

Plan section 7: `classifyDiff` sees only files; `detectRunner` only vitest/tsx/cargo. #4472 added four members to the `SceneContents` interface and a compile-time test (`const fn: SceneContents['getMeshData'] = ...`); the CI oracle ran it with `tsx --test`, saw 4 pass / 4 pass, and reported UNOBSERVED. `tsc` reports TS2339 at that exact line when the interface is reverted (the PR author verified it by hand for each member), so the change WAS observed on the type channel. This unblocks the #4472 class without an exemption label.

## Guards preserved

- The runtime observer is untouched for any branch with a runtime change anywhere in its revert set (a mixed branch is judged by the stricter tool).
- Fail-closed throughout: no `typescript` resolvable -> not type-only (runtime observer runs as before); no `typecheck-tests.mjs` or an unspawnable runner -> `runner-missing` -> INCONCLUSIVE; a red baseline -> BASELINE-BROKEN (blocks under `--ci`, exit 3).
- `node --test scripts/lib/revert-oracle*.test.mjs`: every pre-existing suite stays green (164 pass; the 4 that fail on this Windows machine -- the cargo/root-scaffolding end-to-end cases -- fail identically on `origin/main` and pass on Linux).
- `check-module-size`, `check-test-wiring`, `check-ci-path-coverage`, `check-source-text-assertions`, license headers and oxlint all pass locally.

## Revert

`git revert` of this single commit removes the lib, its test, the dispatcher edits and the allowlist row change together. Scripts-only; no changeset.
