### PR TITLE
ci: benchmark/xmatch opt-in by label on PRs, wheels and server binaries linux-x64 only on PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,11 +22,14 @@
 name: Benchmark
 
 on:
-  pull_request:
+  # PUSH TO MAIN, not every PR (CI redesign, step 8). Measured: 87 runs a day,
+  # 76% of them cancelled by the next push before they reported, on a lane
+  # whose verdict is advisory. The per-merge number on main is the one that
+  # tracks the baseline; a PR that needs the number before merging asks for
+  # it with the `ci:benchmark` label (or a dispatch). Only paths that can
+  # plausibly move viewer load performance, on both triggers.
+  push:
     branches: [main]
-    # Only paths that can plausibly move viewer load performance. The job is
-    # advisory (not a required check), so skipping it entirely on unrelated
-    # PRs is safe and free.
     paths:
       - 'rust/**'
       - 'packages/**'
@@ -45,6 +48,35 @@ on:
       - 'tests/benchmark/**'
       - 'tests/models/manifest.json'
       - '.github/workflows/benchmark.yml'
+  pull_request:
+    branches: [main]
+    # `labeled` is the opt-in; `synchronize`/`reopened` keep an opted-in PR
+    # measured on every later push. The job itself gates on the label, so an
+    # unrelated label event skips in seconds.
+    types: [labeled, synchronize, reopened]
+    paths:
+      - 'rust/**'
+      - 'packages/**'
+      - 'apps/viewer/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'scripts/build-wasm.sh'
+      - 'scripts/check-benchmark-regression.js'
+      - 'scripts/update-benchmark-baseline.mjs'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'turbo.json'
+      - 'package.json'
+      - 'playwright.config.ts'
+      - 'tests/benchmark/**'
+      - 'tests/models/manifest.json'
+      - '.github/workflows/benchmark.yml'
+  schedule:
+    # Weekly, Thursday 04:53 UTC -- a slot no other weekly lane uses
+    # (determinism Mon 03:17, xmatch Tue 05:23, wide-arithmetic Wed 04:29,
+    # moonshot Sun 06:41). Catches baseline drift on a quiet main.
+    - cron: '53 4 * * 4'
   workflow_dispatch:
     inputs:
       record_baseline:
@@ -66,6 +98,8 @@ env:
 jobs:
   benchmark:
     name: Viewer benchmark (advisory)
+    # On a PR only when asked for by label; every other trigger runs it.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:benchmark')
     # Free GitHub-hosted runner (public repo). The benchmark measures a noisy
     # shared VM anyway; the +50% thresholds in benchmark:check absorb the
     # jitter, and the job is advisory. When Rust changed we compile wasm32

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -3,9 +3,27 @@ name: python-wheels
 # Build + publish the native ifc-lite geometry wheel (ifclite-geom, the PyO3
 # binding in rust/python). abi3-py39 -> one wheel per platform covers CPython
 # >= 3.9. Tag `ifclite-geom-v*` to publish to PyPI (trusted publishing / OIDC).
+#
+# TWO LANES (CI redesign, step 8). A pull request builds and tests the ONE
+# wheel its runner can import natively (linux x86_64); the other four legs --
+# linux aarch64, both macOS targets, Windows -- run on push to `main`, on a
+# release tag and on dispatch. The binding layer under test is
+# platform-independent, so a PR gets its verdict from one leg in a fraction
+# of the runner minutes; a cross-OS breakage that the single leg cannot see
+# surfaces on the first push to main, where `report-red-on-main` opens (or
+# updates) an issue for it rather than letting a red main scroll by.
 on:
   push:
     tags: ["ifclite-geom-v*"]
+    branches: [main]
+    paths:
+      - "rust/python/**"
+      - "rust/processing/**"
+      - "rust/geometry/**"
+      - "rust/export/**"
+      - "rust/core/**"
+      - "rust-toolchain.toml"
+      - ".github/workflows/python-wheels.yml"
   pull_request:
     paths:
       - "rust/python/**"
@@ -21,6 +39,9 @@ permissions:
   contents: read
 
 jobs:
+  # The PR lane: the one leg whose wheel this runner can import and test.
+  # Also runs on push/tag/dispatch, so `build-cross` below is strictly the
+  # OTHER four legs and the two together are the full matrix.
   build:
     name: wheel ${{ matrix.os }} / ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -29,6 +50,73 @@ jobs:
       matrix:
         include:
           - { os: ubuntu-latest, target: x86_64 }
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v5
+        with:
+          python-version: "3.9"
+      # Install the pinned toolchain the way rustup honours rust-toolchain.toml's
+      # `components` list. maturin-action installs it with `rustup update
+      # <name>`, i.e. BY NAME, and a named install does not read the file's
+      # components -- so rust-src is absent and build-std fails with
+      # "lib/rustlib/src/rust/library/Cargo.lock does not exist". A file-based
+      # selection (`rustup show` inside the repo) installs the components.
+      # `before-script-linux` below only covers the manylinux container, and
+      # build-std runs on every platform.
+      - name: Setup Rust (pinned by rust-toolchain.toml, with components)
+        run: rustup show
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        env:
+          # `build-std` used to live in the repo-root `.cargo/config.toml`'s
+          # `[unstable]` table, which applied to every cargo invocation in the
+          # workspace — including plain host builds with no `--target`, where
+          # it collided with `[profile.release] panic = "abort"` in the root
+          # workspace (duplicate `core` lang item; see
+          # scripts/build-wasm.sh for the wasm side of this fix). It's now
+          # scoped per-invocation via this env var instead, which
+          # maturin-action forwards into the manylinux container (it allowlists
+          # the `CARGO_` prefix — see its `ALLOWED_ENV_PREFIXES`).
+          CARGO_UNSTABLE_BUILD_STD: std,panic_abort
+        with:
+          working-directory: rust/python
+          target: ${{ matrix.target }}
+          manylinux: auto
+          # rust-toolchain.toml pins nightly; the manylinux container's
+          # toolchain needs rust-src installed to rebuild std for build-std
+          # (see the CARGO_UNSTABLE_BUILD_STD env var on this step).
+          before-script-linux: rustup component add rust-src
+          args: --release --out dist
+      # Exercise the wheel that was just built, on the one leg whose artifact is
+      # natively installable on its own runner (the aarch64/cross legs produce
+      # wheels this host cannot import). One leg is enough: the binding layer
+      # under test is platform-independent, and this reuses the existing build
+      # rather than adding a job that recompiles the workspace.
+      - name: Test wheel
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pip install --force-reinstall rust/python/dist/*.whl
+          python -m pytest rust/python/tests -q
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: rust/python/dist/*.whl
+
+  # The other four legs, OFF the PR lane. Same steps as `build` (kept
+  # verbatim rather than shared, since workflow YAML has no include); the
+  # `Test wheel` step stays gated to the linux x86_64 leg and so never runs
+  # here -- the aarch64/cross legs produce wheels their host cannot import.
+  build-cross:
+    name: wheel ${{ matrix.os }} / ${{ matrix.target }}
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - { os: ubuntu-latest, target: aarch64 }
           - { os: macos-14, target: aarch64 }
           # Cross-compile the Intel-mac wheel on the Apple-silicon runner: the
@@ -91,10 +179,39 @@ jobs:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: rust/python/dist/*.whl
 
+  # A red push to main must not scroll by. One issue per workflow, updated
+  # rather than duplicated while it is open; closed by whoever fixes it.
+  report-red-on-main:
+    name: Open an issue when main is red
+    needs: [build, build-cross]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.build.result == 'failure' || needs.build-cross.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          title="ci: python-wheels is red on main"
+          body="The full wheel matrix failed on push to main at ${SHA} (only the linux x86_64 leg runs on pull requests, so this is the first build of the other legs for this change). Run: ${RUN_URL}"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "\"$title\" in:title" --json number,title --jq "[.[] | select(.title == \"$title\") | .number] | first // empty")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+            echo "updated #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi
+
   publish:
     name: publish to PyPI
     if: startsWith(github.ref, 'refs/tags/ifclite-geom-v')
-    needs: build
+    needs: [build, build-cross]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/.github/workflows/server-binaries.yml
+++ b/.github/workflows/server-binaries.yml
@@ -5,9 +5,23 @@
 name: Server Binaries
 
 on:
-  # push:main intentionally dropped — branch-protected PR runs already
-  # validate the same SHA, and the release event re-validates before
-  # uploading binaries. See PR that introduced this change.
+  # TWO LANES (CI redesign, step 8). A pull request validates the ONE leg a
+  # merge most plausibly breaks (linux-x64, native); the cross legs
+  # (linux-arm64, linux-x64-musl) validate on push to `main`, where
+  # `report-red-on-main` opens or updates an issue if they fail. push:main
+  # was once dropped because PR runs validated the same SHA; it is back
+  # precisely because PR runs no longer validate the whole matrix.
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/server-binaries.yml'
+      - '.github/workflows/release.yml'
+      - '.cargo/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'apps/server/**'
+      - 'rust/**'
+      - 'rust-toolchain.toml'
   pull_request:
     paths:
       - '.github/workflows/server-binaries.yml'
@@ -51,11 +65,111 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The PR lane: the native leg only. scripts/check-server-bin-targets.mjs
+        # reads this list as the deliberate cost-saving SUBSET of the release
+        # matrix; the cross legs are `validate-server-binaries-cross` below.
         include:
           - target: linux-x64
             os: ubuntu-latest
             rust-target: x86_64-unknown-linux-gnu
             archive: tar.gz
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      - name: Setup Rust
+        # Pin to a master-branch SHA + explicit `toolchain: stable`;
+        # see docs.yml note for rationale on the pinning strategy.
+        #
+        # `toolchain: stable` here names what gets INSTALLED (and what
+        # `targets:` below adds the target std for) — it is NOT what actually
+        # compiles this crate. The repo's `rust-toolchain.toml` pins nightly,
+        # and rustup's per-directory toolchain file always wins over
+        # `rustup default` (which is all this action sets); every `cargo`
+        # invocation below runs on the pinned nightly regardless of this
+        # `stable` input. Confirmed locally: `rustup default stable` followed
+        # by `rustc --version` inside a checkout of this repo still reports
+        # the nightly pinned in rust-toolchain.toml, with rustup noting the
+        # override. See the CARGO_UNSTABLE_BUILD_STD env var on the "Build
+        # Server Binary" step below for the consequence: the aarch64/cross-arch
+        # target std was only ever installed for `stable`, never for the
+        # nightly that actually runs, so those targets need std rebuilt from
+        # source instead of relying on a prebuilt one that was never fetched.
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-05
+        with:
+          toolchain: stable
+          targets: ${{ matrix.rust-target }}
+
+      - name: Install cross
+        if: matrix.target == 'linux-x64-musl'
+        uses: taiki-e/install-action@b47b3b9ab771927700bcf4ef8a4f79e1d7c9a8cd # cross (snapshot pinned 2026-05)
+
+      - name: Install Linux Cross-Compilation Tools
+        if: matrix.cross == true && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Install musl Tools
+        if: matrix.target == 'linux-x64-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+
+      - name: Build Server Binary
+        # Force bash so the if/else runs under Git Bash on Windows runners too
+        # (default shell there is PowerShell, which choked on the POSIX test →
+        # win32-x64 release build failed with a ParserError).
+        shell: bash
+        run: |
+          if [ "${{ matrix.target }}" = "linux-x64-musl" ]; then
+            cross build --release --package ifc-lite-server --target ${{ matrix.rust-target }}
+          else
+            # See the "Setup Rust" step above: this actually runs on the
+            # nightly pinned by rust-toolchain.toml, not the `stable` named
+            # there, so cross-arch legs (linux-arm64, darwin-x64 on the
+            # arm64 macos-14 runner) need their target's std rebuilt from
+            # source — it was never installed for nightly. Was previously
+            # papered over by a global `[unstable] build-std` in
+            # .cargo/config.toml (removed — see scripts/build-wasm.sh);
+            # scoped here instead. It rebuilds std from source on every
+            # non-`cross` leg, including the host-matching ones
+            # (linux-x64, darwin-arm64, win32-x64) — build-std doesn't
+            # check for a prebuilt std first, so it's redundant there, not
+            # a no-op. That matches what `main`'s global build-std already
+            # did for all of them; narrowing it to just the cross-arch legs
+            # is deliberate follow-up work, not done here. Deliberately NOT
+            # set for the `cross build` branch above: that runs inside
+            # `cross`'s own Docker image with its own toolchain setup,
+            # wasn't reported broken, and forwarding host env vars into
+            # that container isn't verified here.
+            CARGO_UNSTABLE_BUILD_STD=std,panic_abort cargo build --release --package ifc-lite-server --target ${{ matrix.rust-target }}
+          fi
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      # The `cargo build` step above is the validation — it fails the job
+      # if the binary doesn't compile. We deliberately don't archive or
+      # upload the binary here: nothing downloads a PR-run server binary,
+      # and 90-day-retained artifacts on every Rust PR were burning Actions
+      # storage credits for no benefit.
+
+  # The cross legs, OFF the PR lane (push to main, release, dispatch). Same
+  # steps as `validate-server-binaries`, kept verbatim: workflow YAML has no
+  # include, and the PR job's matrix has to stay a literal list for the
+  # server-bin targets gate to read.
+  validate-server-binaries-cross:
+    name: Validate Server Binary (${{ matrix.target }})
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - target: linux-arm64
             os: ubuntu-latest
             rust-target: aarch64-unknown-linux-gnu
@@ -149,6 +263,35 @@ jobs:
       # upload the binary here: nothing downloads a PR-run server binary,
       # and 90-day-retained artifacts on every Rust PR were burning Actions
       # storage credits for no benefit.
+
+  # A red push to main must not scroll by. One issue per workflow, updated
+  # rather than duplicated while it is open; closed by whoever fixes it.
+  report-red-on-main:
+    name: Open an issue when main is red
+    needs: [validate-server-binaries, validate-server-binaries-cross]
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.validate-server-binaries.result == 'failure' || needs.validate-server-binaries-cross.result == 'failure')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          title="ci: server-binaries is red on main"
+          body="The server binary validation failed on push to main at ${SHA} (only the linux-x64 leg runs on pull requests, so this is the first build of the cross legs for this change). Run: ${RUN_URL}"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "\"$title\" in:title" --json number,title --jq "[.[] | select(.title == \"$title\") | .number] | first // empty")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+            echo "updated #$existing"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body "$body"
+          fi
 
   release-server-binaries:
     name: Release Server Binary (${{ matrix.target }})

--- a/.github/workflows/xmatch-fixture.yml
+++ b/.github/workflows/xmatch-fixture.yml
@@ -41,10 +41,14 @@
 # check:
 #   - weekly `schedule` + on-demand `workflow_dispatch`, the same profile as
 #     determinism.yml / wide-arithmetic.yml;
-#   - `push`/`pull_request` ONLY on the paths that can invalidate the result:
-#     the diff engine, the geometry kernel and the wasm bundle it is measured
-#     through, the CLI adapter that builds the fingerprints, and the harness
-#     itself. A docs-only or viewer-only PR never sees this job.
+#   - `push` ONLY on the paths that can invalidate the result: the diff
+#     engine, the geometry kernel and the wasm bundle it is measured through,
+#     the CLI adapter that builds the fingerprints, and the harness itself.
+#   - `pull_request` on those same paths, but ONLY when the PR carries the
+#     `ci:benchmark` label (CI redesign, step 8): the measurement is a
+#     ~20-minute wasm build for a ~15 s result, the verdict is advisory, and
+#     the push-to-main run measures every merge anyway. A PR that wants the
+#     number before merging opts in with the label.
 #   - free `ubuntu-latest` runners, never Depot.
 # The measured work is ~15 s for three models; the wall clock is the wasm build
 # (Swatinem cache) and ~9 MB of fixtures.
@@ -94,6 +98,9 @@ on:
       # move a number in it.
   pull_request:
     branches: [main]
+    # `labeled` is the opt-in; `synchronize`/`reopened` keep an opted-in PR
+    # measured on every later push. The job gates on the label below.
+    types: [labeled, synchronize, reopened]
     # Same list as `push`. Path-filtered, non-blocking, and NOT to be added to
     # branch protection.
     paths:
@@ -122,6 +129,8 @@ env:
 jobs:
   content-matching-fixture:
     name: Content matching vs a known correspondence
+    # On a PR only when asked for by label; every other trigger runs it.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:benchmark')
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
CI redesign, step 8 (peripheral triggers, first half): the advisory and cross-platform lanes stop running on every PR push. The `sdk-canary` fold into test.yml is the second half and comes as its own PR once the test.yml changes ahead of it have landed.

## What changed

- `.github/workflows/benchmark.yml`: runs on `push` to `main`, weekly (`Thu 04:53 UTC`, an unused slot) and `workflow_dispatch`; on a PR only when it carries the `ci:benchmark` label (`pull_request: types: [labeled, synchronize, reopened]` + a job-level `if`). Same path filter on both triggers. The PR-comment step was already gated on `pull_request`.
- `.github/workflows/xmatch-fixture.yml`: same opt-in on PRs (`ci:benchmark`); `push` to `main`, weekly and dispatch unchanged.
- `.github/workflows/python-wheels.yml`: `build` is now the linux x86_64 leg only (the one whose wheel the runner can import and test) and runs on every trigger; new `build-cross` (linux aarch64, macOS x2, Windows; steps verbatim) runs on push to `main`, release tags and dispatch. `push: branches: [main]` added with the same path filter. `publish` needs both. New `report-red-on-main` opens one issue (or comments on the open one) when a push-to-main build fails.
- `.github/workflows/server-binaries.yml`: `validate-server-binaries` keeps a literal one-entry matrix (linux-x64) so `scripts/check-server-bin-targets.mjs` can still parse it as the documented subset; new `validate-server-binaries-cross` (linux-arm64, linux-x64-musl; steps verbatim) runs off the PR lane; `push: branches: [main]` re-added (it was dropped when PR runs validated the whole matrix; they no longer do); same `report-red-on-main` job. The release matrix and the release/verify jobs are untouched.
- Label `ci:benchmark` created on the repo (the plan's opt-in name).

## Why (plan evidence)

- Benchmark: 87 runs/day, 76% cancelled before reporting, advisory verdict.
- The wheel and server-binary matrices are 5 and 3 full Rust builds per PR push for a platform-independent binding layer; plan section 1 puts the linux-x64 leg on PRs and the full matrix on push-main. Owner veto point (step 8) accepted: cross-OS breakage surfaces post-merge as an issue.

## Guards preserved

- Nothing in this PR is a required check or in the aggregate `needs`; benchmark and xmatch are advisory by their own headers, and the wheel/binary lanes were never merge-blocking.
- Every path filter stays in block-list form and every gate script stays reachable: `check-ci-path-coverage` (38 PR-triggered jobs), `check-test-wiring`, `check-swallowed-push`, `check-server-bin-targets` (+ its two test suites, 46 pass), `check-sdk-canary-coverage` all pass locally.
- Push-to-main runs use the existing per-workflow concurrency groups (cancel only on PRs), so consecutive merges queue rather than cancel each other.

## Assumptions noted

- The issue opener has no label (the repo's label-authority workflow polices pipeline labels; a plain `ci:` issue label would need an entry there first). Title-keyed dedup keeps it to one open issue per workflow.
- `ci:benchmark` on a PR also re-runs both lanes on every later push of that PR (`synchronize`), which is what an opted-in PR wants.

## Revert

`git revert` of this single commit restores every-PR triggers and the full matrices. Workflow-only, no changeset. The label can stay; it is inert without the workflows reading it.
