### PR TITLE
ci(node-lane): turbo test --only, provenance in its own job, eight viewer shards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -648,7 +648,7 @@ jobs:
       - name: Check changeset-bump gate regressions
         run: node --test scripts/check-changeset-bump.test.mjs
 
-  # The viewer's own suite, split out of `node-tests` AND sharded four ways.
+  # The viewer's own suite, split out of `node-tests` AND sharded eight ways.
   #
   # Measured, not guessed. Splitting it out of node-tests took that lane from
   # a 25:00 timeout to 5:32 SUCCESS, so everything except the viewer costs five
@@ -658,7 +658,13 @@ jobs:
   #
   # Healthy shard timings, recorded so the next person seeing this lane creep
   # knows what good looks like rather than only what broken looked like:
-  # 2:29, 2:01, 1:50 against a 25 minute cap.
+  # 2:29, 2:01, 1:50 against a 25 minute cap, at FOUR shards over 521 files.
+  # The suite had grown to 803 files by 2026-09-11 and the four shards were
+  # measured at 5.6-8.2 min on hosted runners, on the frontend PR's critical
+  # path; EIGHT shards (CI redesign, step 4) halves the per-shard file count
+  # back to roughly the size the timings above were recorded at. Membership
+  # is a hash of the path (below), so going 4 -> 8 reassigns files exactly
+  # once and then stays stable.
   #
   # Shard membership is a hash of the file PATH, not its index in the sorted
   # list. With `NR % n` every file after an added or removed test moves to a
@@ -725,7 +731,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -765,20 +771,21 @@ jobs:
       #    in turbo.json is an explicit allowlist and does not include these,
       #    and the `test` task declares no `env`/`passThroughEnv`. Routed
       #    through turbo, TEST_SHARD never reached the script and all four
-      #    shards ran the full 521 files, taking an identical 25:15 each. That
+      #    shards (then) ran the full 521 files, taking an identical 25:15 each. That
       #    identical timing is what exposed it: quartering the input cannot
       #    leave the duration unchanged.
       # 2. `test` dependsOn `build`, so turbo also ran the viewer's Vite app
       #    build (53s of "✓ built in 53.43s") which its tests do not need. The
       #    sibling dists the tests DO need come from the downloaded artifact.
       #
-      # `TEST_SHARDS`/`TEST_SHARD` select every Nth file (see apps/viewer's
-      # test script). Unset, the script takes all 521, so a local `pnpm test`
-      # is unchanged. The split is exact: 130+131+130+130 = 521 files, 521
-      # distinct paths, so nothing is dropped or run twice.
+      # `TEST_SHARDS`/`TEST_SHARD` select the files whose path hash lands in
+      # this shard (see apps/viewer's test script). Unset, the script takes
+      # every file, so a local `pnpm test` is unchanged. The split is exact:
+      # every path hashes to exactly one of the eight residues, so nothing is
+      # dropped or run twice (521 files split 130+131+130+130 at four).
       - run: pnpm --filter @ifc-lite/viewer run test
         env:
-          TEST_SHARDS: '4'
+          TEST_SHARDS: '8'
           TEST_SHARD: ${{ matrix.shard }}
 
   node-tests:
@@ -1485,7 +1492,18 @@ jobs:
       # finished 7m55s in, and the viewer then had 17 minutes and did not
       # finish. Splitting it out runs the two halves CONCURRENTLY, so each gets
       # a whole budget instead of a leftover.
-      - run: pnpm exec turbo test --filter=!@ifc-lite/viewer
+      #
+      # `@ifc-lite/provenance` runs in its own job too (`provenance-tests`,
+      # CI redesign step 4): measured on a 9.0 min Node tests run, `turbo test`
+      # was 6.05 min and ONE file, packages/provenance/test/merge-battery.test.ts,
+      # was 353 s of it -- more than every other package's suite combined.
+      #
+      # `--only`: the `test` task `dependsOn: ["build"]` in turbo.json, so
+      # without it turbo rebuilt all 46 packages here first -- work the
+      # `build` job already did and shipped in the artifact downloaded above.
+      # Every test runs against that artifact's dist/ exactly as before; only
+      # the redundant rebuild is gone.
+      - run: pnpm exec turbo test --only --filter=!@ifc-lite/viewer --filter=!@ifc-lite/provenance
       - name: Integration tests (parse → quantities → export)
         # Step-scoped timeout: a hung harness must fail fast here, not
         # silently consume the whole job budget.
@@ -1509,6 +1527,41 @@ jobs:
       # emission order does -- the #2388 failure class). Issue #2199.
       - name: Snap edge reconstruction (real wasm pipeline)
         run: pnpm test:snap-edges
+
+  # `@ifc-lite/provenance` alone. Measured (CI redesign, step 4): its
+  # merge-battery.test.ts is 353 s on a hosted runner, which on the shared
+  # Node tests lane was more than every other package's suite together and
+  # put that one file on the frontend PR's critical path. Its own job runs it
+  # CONCURRENTLY with the rest of node-tests, the same move that took the
+  # viewer suite out of that lane. Run directly, not through turbo, for the
+  # reasons viewer-tests spells out (no rebuild; the sibling dists it imports
+  # come from the artifact). No fixtures: the suite reads only its own
+  # committed golden vectors under packages/provenance/test/golden.
+  provenance-tests:
+    name: Provenance tests
+    needs: [changes, build]
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
+    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    # 353 s for the one file, ~6.5 min for the package on a hosted runner; 15
+    # leaves headroom without hiding a hang for long.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-output
+          path: packages
+      - run: pnpm --filter @ifc-lite/provenance --fail-if-no-match run test
 
   # Functional smoke of the real viewer: real WASM pipeline + WebGPU
   # renderer (swiftshader) + pick pass + section plane, asserted through
@@ -2105,7 +2158,7 @@ jobs:
 
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md, license-headers]
+    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, provenance-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md, license-headers]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
@@ -2124,6 +2177,7 @@ jobs:
             [typecheck]="${{ needs.typecheck.result }}"
             [lint]="${{ needs.lint.result }}"
             [node-tests]="${{ needs.node-tests.result }}"
+            [provenance-tests]="${{ needs.provenance-tests.result }}"
             [viewer-tests]="${{ needs.viewer-tests.result }}"
             [viewer-e2e]="${{ needs.viewer-e2e.result }}"
             [rust-tests]="${{ needs.rust-tests.result }}"

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -165,7 +165,7 @@ test('END TO END: a wholesale-skipped matrix job passes the REAL required set', 
   assert.match(r.output, /All \d+ required lane\(s\)/);
   // Reported, never absorbed: the skip is named along with how many lanes it covered.
   assert.match(r.output, /was SKIPPED as a whole job/);
-  assert.match(r.output, /its 4 lane\(s\)/);
+  assert.match(r.output, /its 8 lane\(s\)/);
 });
 
 test('a fixture alias with a NON-STRING template is BAD_STATE_FILE, not MISSING_LANES', () => {
@@ -189,7 +189,7 @@ test('a fixture alias with a NON-STRING template is BAD_STATE_FILE, not MISSING_
   }
 });
 
-test('END TO END: the same rollup WITHOUT the template still fails, naming all four shards', () => {
+test('END TO END: the same rollup WITHOUT the template still fails, naming all eight shards', () => {
   // The anti-vacuity pair. If the test above passed for any reason other than
   // the alias map -- a required set that never contained the shards, say -- this
   // one would pass too, and it must not.
@@ -200,8 +200,8 @@ test('END TO END: the same rollup WITHOUT the template still fails, naming all f
 
   const r = run({ lanes, reviewChecks: [] });
   assert.equal(r.code, 1, r.output);
-  assert.match(r.output, /MISSING_LANES: 4 of/);
-  for (const shard of [0, 1, 2, 3]) {
+  assert.match(r.output, /MISSING_LANES: 8 of/);
+  for (const shard of [0, 1, 2, 3, 4, 5, 6, 7]) {
     assert.ok(r.output.includes(`Viewer tests (shard ${shard})`), `must name shard ${shard}`);
   }
 });
@@ -215,7 +215,7 @@ test('END TO END: the template at SUCCESS is not a skip, and does not cover the 
 
   const r = run({ lanes, reviewChecks: [] });
   assert.equal(r.code, 1, r.output);
-  assert.match(r.output, /MISSING_LANES: 4 of/);
+  assert.match(r.output, /MISSING_LANES: 8 of/);
 });
 
 /**

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -98,11 +98,15 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
     'Typecheck',
     'Lint',
     'Node tests',
+    // CI redesign step 4: provenance's 353 s merge battery in its own job,
+    // and the viewer suite at eight shards instead of four.
+    'Provenance tests',
     'Rust tests',
     'Rust crate semver',
     'Viewer E2E smoke',
     'Viewer tests (shard 0)',
     'Viewer tests (shard 3)',
+    'Viewer tests (shard 7)',
     'Docs checks (docs-only PRs)',
     'AGENTS.md ratchet',
     'MPL license headers',
@@ -112,7 +116,7 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
   ]) {
     assert.ok(names.includes(observed), `derived set is missing the observed lane "${observed}"`);
   }
-  assert.equal(names.length, 20);
+  assert.equal(names.length, 25);
 });
 
 test('FAIL CLOSED: an empty workflow file is NO_WORKFLOW_TEXT, not an empty lane set', () => {
@@ -251,7 +255,7 @@ test('the REAL test.yml maps every viewer shard to the template the REAL rollup 
   const aliases = matrixSkipAliases(
     readFileSync(join(REPO_ROOT, '.github/workflows/test.yml'), 'utf8'),
   );
-  for (const shard of [0, 1, 2, 3]) {
+  for (const shard of [0, 1, 2, 3, 4, 5, 6, 7]) {
     assert.equal(
       aliases.get(`Viewer tests (shard ${shard})`),
       MATRIX_TEMPLATE,
@@ -286,7 +290,7 @@ test('`excludeJobKeys` must reach BOTH derivations, or the alias map stops cover
 
   // Asymmetric: excluding the job from the ALIASES only puts the shards back.
   const asymmetric = missingLanes(required, PR3581_ROLLUP, matrixSkipAliases(wf, { exclude: [...exclude, 'viewer-tests'] }));
-  for (const shard of [0, 1, 2, 3]) {
+  for (const shard of [0, 1, 2, 3, 4, 5, 6, 7]) {
     assert.ok(asymmetric.includes(`Viewer tests (shard ${shard})`), `shard ${shard} uncovered`);
   }
 });


### PR DESCRIPTION
CI redesign, step 4: the Node lane stops rebuilding the workspace it already downloaded, the provenance suite gets its own job, and the viewer suite runs on eight shards.

## What changed (`.github/workflows/test.yml`)

- `node-tests`: `pnpm exec turbo test --only --filter=!@ifc-lite/viewer --filter=!@ifc-lite/provenance`. `--only` stops turbo from walking `test -> build` (turbo.json's `dependsOn: ["build"]`) and rebuilding all 46 packages that the `build` job already built and shipped in the `build-output` artifact this job downloads. Every test still runs against that artifact's `dist/`.
- New job `provenance-tests` (`Provenance tests`): `needs: [changes, build]`, same `if:` as node-tests, downloads the artifact, runs `pnpm --filter @ifc-lite/provenance --fail-if-no-match run test` directly (no turbo, no rebuild), 15 min cap. No fixture cache: the suite reads only its committed golden vectors.
- `viewer-tests`: matrix `[0..7]`, `TEST_SHARDS: '8'`. Membership is already a hash of the path, so the reassignment happens once.
- Aggregate `test`: `provenance-tests` added to `needs:` AND to the results map, so its failure fails the required check `Build + WASM + Rust + Node`.
- `scripts/check-pr-review-signal.test.mjs`, `scripts/lib/pr-review-signal.test.mjs`: the lane-set tripwires now expect `Provenance tests`, shards 0-7 (25 derived lanes, was 20) and the "its 8 lane(s)" wholesale-skip message.

## Why (plan evidence)

- Node tests: 9.0 min, of which `turbo test` 6.05 min, of which ONE file, `packages/provenance/test/merge-battery.test.ts`, is 353 s; the `test -> build` dependency rebuilt 46 packages despite the artifact.
- Viewer shards: 803 test files (the workflow comment still said 521), four shards at 5.6-8.2 min each on the frontend PR's critical path.
- Target: frontend PR critical path ~15 min -> ~12 min (plan section 2).

## Guards preserved

- Nothing is removed from the PR lane: the same packages' tests run, provenance included, and the new job is judged by the aggregate (`scripts/check-ci-aggregate-coverage.mjs` passes: 16 needs, 16 judged).
- `check-ci-path-coverage` (35 PR-triggered jobs), `check-test-wiring` (`turbo test` is still the task CI fans out; the viewer and provenance scripts are invoked by name) pass locally; `node --test` of the review-signal, dirty-PR-scan and CI-coverage suites shows no new failure against `origin/main` beyond the tripwires updated here.
- The `runs-on` line of the new job is taken verbatim from `viewer-tests`, so it follows whatever routing expression main carries at merge time.

## Assumption noted

`--only` relies on the artifact being complete for every package a test imports; that is the same assumption the viewer, typecheck and lint jobs already make, and the `build` job uploads with `if-no-files-found: error`.

## Revert

`git revert` of this single commit restores the 4-shard matrix, the shared Node lane and the two tripwire tests. Workflow-only, no changeset.
