### PR TITLE
ci(cache): shared main cargo cache for the WASM toolchain action, seed plato on push

### DIFF
--- a/.github/actions/setup-wasm-build/action.yml
+++ b/.github/actions/setup-wasm-build/action.yml
@@ -20,6 +20,24 @@ inputs:
   cache-prefix:
     description: 'Swatinem/rust-cache prefix-key, to namespace the cargo cache per workflow'
     required: true
+  # ONE CACHE PER WORKFLOW, WRITTEN FROM MAIN, READ BY EVERY PR (CI redesign,
+  # step 1; the same shape test.yml's Rust jobs adopted in #4511). Without
+  # `shared-key` rust-cache keys on the job AND the git ref, so every PR branch
+  # wrote its own copy: measured at 46 caches / 10.96 GB against a 10 GB
+  # budget, with `semver` alone at 19 x 269 MB and `build` at 19 x 142 MB,
+  # while `main` itself held NO rust-tests cache -- the one every PR could
+  # have restored from. With `shared-key: main` every caller of this action
+  # restores `<prefix>-main-<lockfile hash>`, and `save-if` defaults to
+  # writing it only from a push to main or a merge-queue batch, so PRs
+  # restore and never save. Footprint ~3.1 GB, x2 during a lockfile turnover.
+  shared-key:
+    description: 'Swatinem/rust-cache shared-key; every ref restores this one key'
+    required: false
+    default: main
+  save-if:
+    description: 'Swatinem/rust-cache save-if; by default only a push to main or a merge_group batch writes the cache'
+    required: false
+    default: ${{ github.ref == 'refs/heads/main' || github.event_name == 'merge_group' }}
 
 runs:
   using: composite
@@ -34,6 +52,8 @@ runs:
       uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
         prefix-key: ${{ inputs.cache-prefix }}
+        shared-key: ${{ inputs.shared-key }}
+        save-if: ${{ inputs.save-if }}
 
     - name: Install wasm-pack
       uses: jetli/wasm-pack-action@0d096b08b4e5a7de8c28de67e11e945404e9eefa # v0.4.0

--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -102,6 +102,12 @@ jobs:
         uses: ./.github/actions/setup-wasm-build
         with:
           cache-prefix: sdk-canary
+          # This workflow runs on pull requests only, so nothing on main would
+          # ever seed its shared key; let the first PR write it and every later
+          # PR restore it. The write is skipped when the key already exists.
+          # Goes away when this job moves into test.yml on the build artifact
+          # (CI redesign, step 8).
+          save-if: 'true'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1931,8 +1931,13 @@ jobs:
   plato-check:
     name: Plato clash-math freshness
     needs: changes
-    # PR-only — see viewer-e2e.
-    if: needs.changes.outputs.plato == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    # On plato-path PRs and merge-queue batches, and on EVERY push to main
+    # (CI redesign, step 1): the push run is what seeds the shared toolchain
+    # cache below (`plato-toolchain-*`, ~635 MB), so a PR that does touch
+    # tools/plato restores it instead of rebuilding Plato.CLI cold. The
+    # `plato` filter is `true` on push only when the push touched those
+    # paths, hence the event check comes first.
+    if: github.event_name == 'push' || (needs.changes.outputs.plato == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group'))
     # Free runner - the generator clones + builds Plato.CLI with dotnet; no
     # Depot cores needed.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}


### PR DESCRIPTION
CI redesign, step 1 (the part #4511 left): the composite WASM toolchain action adopts the same one-cache-per-workflow shape #4511 gave test.yml's Rust jobs, and the two caches nothing on main ever seeded get a push-to-main run.

## What changed

- `.github/actions/setup-wasm-build/action.yml`: new inputs `shared-key` (default `main`) and `save-if` (default `github.ref == 'refs/heads/main' || github.event_name == 'merge_group'`), passed to `Swatinem/rust-cache`. Every caller (test.yml `build`, release, benchmark, xmatch, wide-arithmetic, determinism) now restores `<prefix>-main-<lockfile hash>` and only a push to main or a merge-queue batch writes it.
- `.github/workflows/sdk-canary.yml`: passes `save-if: 'true'` -- it runs on PRs only, so nothing on main could seed its key; the first PR writes it (rust-cache skips the save when the key exists) and later PRs restore. Goes away with the step-8 fold of this job into test.yml.
- `.github/workflows/test.yml`: `plato-check` also runs on every `push` to main, seeding `plato-toolchain-*` (~635 MB, .NET SDK + Plato.CLI) so a PR that does touch tools/plato restores instead of rebuilding cold. Its PR/merge-queue gating on the `plato` filter is unchanged.

## Why (plan evidence)

46 caches / 10.96 GB against the 10 GB budget: `semver` 19 x 269 MB, `build` 19 x 142 MB, `plato` 2 x 635 MB -- one copy per PR branch -- while main held NO rust-tests cache, so every PR's Rust compile was cold (`Cargo cache` step 12 s = miss; Rust tests 21.4-25.0 min). #4511 fixed the test.yml Rust jobs; this is the same fix for the composite action and the seed runs. Expected footprint ~3.1 GB, x2 during a lockfile turnover.

## Guards preserved

Cache keys only; no job, step or gate changes verdict. `check-ci-path-coverage` (plato-check still gates on the `plato` filter for PRs), `check-ci-aggregate-coverage` and the review-signal lane tests pass locally. `rust-semver` already runs on push to main and seeds `ci-rust-semver-main-*` since #4511.

## Assumption noted

`save-if` as a composite-action input default is an Actions expression (`${{ ... }}`), the same form `actions/checkout` uses for its `token` default; the caller can still override it (sdk-canary does).

## Revert

`git revert` of the two commits restores per-branch cache keys and the PR-only plato job. Workflow-only, no changeset.
