### PR TITLE
ci(edited): replay the recorded verdict on a title/body edit instead of re-running every lane

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,20 @@ on:
   # A red PR would go green on a typo fix in its description. That is the exact
   # absence-reads-as-success class this trigger is being widened to close.
   #
-  # THE PRICE, STATED: every title or body edit now costs a second full 16-lane
-  # run of a head that already has a verdict -- routine on the changesets
-  # release PR, which rewrites its body after every merge. What it does NOT
-  # cost is the run already in flight; see `cancel-in-progress` below, which
-  # declines to cancel for `edited` alone.
+  # THE PRICE, AND HOW IT IS NOW PAID (CI redesign, step 2): a title or body
+  # edit used to cost a second full run of a head that already had a verdict
+  # -- 158 of 400 PR runs in 38 h, routine on the changesets release PR,
+  # which rewrites its body after every merge. `changes` now PROBES such an
+  # event (scripts/ci-verdict-replay.mjs --probe): when it is an `edited`
+  # with no `changes.base` AND the head SHA already carries a completed
+  # aggregate verdict, it emits `noop=true`, publishes no filter output, and
+  # every lane skips; the aggregate then REPLAYS that recorded verdict rather
+  # than judging the skipped lanes. A red head stays red, a green one stays
+  # green, and a retarget (`changes.base` present) or a head with no verdict
+  # yet still gets the full run. The decision lives in the script, which reads
+  # the event payload -- no job here gates on `changes.base`, for the reason
+  # the paragraph above gives. What an edit still does NOT cost is the run
+  # already in flight; see `cancel-in-progress` below.
   #
   # NO `ready_for_review` EITHER, and for the plainer reason: nothing in this
   # workflow gates on `draft`, so every job already runs on a draft PR. Adding
@@ -85,6 +94,9 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  # The no-op `edited` probe and replay read this head's check runs
+  # (scripts/ci-verdict-replay.mjs). Read-only.
+  checks: read
 
 # Force JavaScript actions onto Node 24. GitHub deprecated Node 20 for
 # actions in late 2025 and will flip the default in June 2026. Setting
@@ -120,6 +132,11 @@ jobs:
       docs: ${{ steps.all.outputs.docs || steps.filter.outputs.docs }}
       agents_md: ${{ steps.all.outputs.agents_md || steps.filter.outputs.agents_md }}
       license_headers: ${{ steps.all.outputs.license_headers || steps.filter.outputs.license_headers }}
+      # `true` only for a title/body `edited` of a head that already has a
+      # completed aggregate verdict. Every lane then skips (no filter output
+      # above is `true`) and the aggregate replays the verdict. See the
+      # `edited` trigger comment at the top of this file.
+      noop: ${{ steps.noop.outputs.noop || 'false' }}
       # `true` when the WASM source is byte-identical to the published release
       # tag, so `build` can fetch the prebuilt bundle instead of compiling
       # wasm32. See the `build` job and scripts/ci-wasm-prebuilt-eligible.sh.
@@ -132,6 +149,17 @@ jobs:
           # clone does not contain. PRs filter against the base ref and are
           # unaffected, so only the push path pays the extra object.
           fetch-depth: ${{ github.event_name == 'push' && 2 || 1 }}
+      # THE NO-OP EDIT PROBE. Only an `edited` event can be a no-op, so the
+      # step is skipped on every other event and costs nothing there; on an
+      # `edited` it is one check-runs read. `noop=true` requires BOTH a
+      # title/body-only edit and an existing completed verdict for this head;
+      # anything else is `noop=false` and the full run below proceeds.
+      - name: Probe for a no-op edit
+        id: noop
+        if: github.event_name == 'pull_request' && github.event.action == 'edited'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci-verdict-replay.mjs --probe
       # A merge-queue batch is validated as a whole: declare every area changed
       # so all lanes run. paths-filter is a pull_request/push tool and has no
       # PR to diff on merge_group.
@@ -139,7 +167,7 @@ jobs:
         id: all
         run: for k in rust frontend geometry python plato docs agents_md license_headers; do echo "$k=true" >> "$GITHUB_OUTPUT"; done
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && steps.noop.outputs.noop != 'true'
         id: filter
         with:
           filters: |
@@ -391,6 +419,7 @@ jobs:
       # green-light a stale bundle.
       - name: Resolve prebuilt-WASM eligibility
         id: wasm
+        if: steps.noop.outputs.noop != 'true'
         run: echo "eligible=$(bash scripts/ci-wasm-prebuilt-eligible.sh)" >> "$GITHUB_OUTPUT"
 
   # Shared install + WASM + workspace build. Uploads built dist/ for the
@@ -2022,6 +2051,12 @@ jobs:
   # and publishes.
   rust-semver:
     name: Rust crate semver
+    # No path filter of its own (see above), so it is the one lane the no-op
+    # probe has to gate explicitly; every other lane skips because no filter
+    # output is `true`. `noop` is not a path filter, and
+    # scripts/lib/ci-path-coverage.mjs knows to read it as none.
+    needs: changes
+    if: needs.changes.outputs.noop != 'true'
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -2129,7 +2164,26 @@ jobs:
     # Free runner — the gate just inspects upstream job results.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
     steps:
+      # THE NO-OP EDIT REPLAY (CI redesign, step 2). When `changes` found this
+      # to be a title/body edit of a head that already has a completed
+      # verdict, every lane above skipped -- and `skipped` reads as a pass in
+      # the map below, so judging it would turn a red head green on a typo
+      # fix. Instead this run REPLAYS the recorded verdict: exit 0 only for a
+      # recorded `success`, exit 1 for any other conclusion, exit 2 (refuse)
+      # if the verdict the probe saw cannot be found again. The check name on
+      # this run therefore carries the same conclusion the head already had.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.noop == 'true'
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Replay the verdict this head already has
+        if: needs.changes.outputs.noop == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci-verdict-replay.mjs --replay
       - name: Gate on dependencies
+        if: needs.changes.outputs.noop != 'true'
         run: |
           declare -A results=(
             # `changes` is judged like any other lane, and it matters most: every

--- a/scripts/check-ci-path-coverage.test.mjs
+++ b/scripts/check-ci-path-coverage.test.mjs
@@ -331,6 +331,23 @@ test('gatingFilters reads positive terms only', () => {
   assert.equal(gatingFilters('    runs-on: x'), null);
 });
 
+test('gatingFilters: the no-op `edited` probe output is not a path filter', () => {
+  // `rust-semver` has no path filter and is gated on the probe alone; reading
+  // `noop` as a filter term would turn "runs on every path" into "reaches no
+  // path" (an empty glob set) and flag every input of check-rust-semver.mjs.
+  assert.equal(gatingFilters("    if: needs.changes.outputs.noop != 'true'"), null);
+  assert.deepEqual(
+    gatingFilters("    if: needs.changes.outputs.noop != 'true' && needs.changes.outputs.plato == 'true'"),
+    ['plato'],
+    'a real filter beside the probe term still gates the job',
+  );
+  assert.deepEqual(
+    gatingFilters("    if: needs.changes.outputs.noop == 'true'"),
+    null,
+    'the probe term never counts as a positive filter either',
+  );
+});
+
 test('parseWorkflowPrPaths distinguishes no-paths from a paths list', () => {
   assert.deepEqual(
     parseWorkflowPrPaths("on:\n  pull_request:\n    branches: [main]\n    paths:\n      - 'a/**'\n"),

--- a/scripts/ci-verdict-replay.mjs
+++ b/scripts/ci-verdict-replay.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The two CLI doors of the no-op `edited` replay (see lib/ci-verdict-replay.mjs
+ * for the design and the reasons).
+ *
+ *   node scripts/ci-verdict-replay.mjs --probe
+ *       Run by the `changes` job. Reads the event payload; when it is a
+ *       title/body `edited` AND the head SHA already carries a completed
+ *       aggregate verdict from an earlier run, writes `noop=true` to
+ *       $GITHUB_OUTPUT. Any other event, a retarget, or a head with no verdict
+ *       yet writes `noop=false` and the full lane set runs. Exit 0 either way;
+ *       an API failure exits 1 (the job goes red rather than guessing).
+ *
+ *   node scripts/ci-verdict-replay.mjs --replay
+ *       Run by the aggregate job when `noop=true`. Finds the same verdict and
+ *       REPLAYS it: exit 0 for a recorded `success`, exit 1 for anything else,
+ *       exit 2 when nothing is there to replay (the probe found one, so this
+ *       means the API moved under us; refuse rather than pass).
+ *
+ * Inputs come from the Actions environment (GITHUB_EVENT_PATH, GITHUB_EVENT_NAME,
+ * GITHUB_REPOSITORY, GITHUB_RUN_ID, GH_TOKEN) or, for tests, from
+ * `--event-file <json>` / `--check-runs-file <json>` / `--sha` / `--run-id` /
+ * `--repo` / `--output <file>`.
+ */
+
+import { readFileSync, appendFileSync } from 'node:fs';
+
+import { gh, GhError } from './lib/gh.mjs';
+import { isMainEntry } from './lib/is-main-entry.mjs';
+import { AGGREGATE_CHECK_NAME, isNoopEdit, selectReplayVerdict } from './lib/ci-verdict-replay.mjs';
+
+function parseArgs(argv) {
+  const out = { mode: null, eventFile: process.env.GITHUB_EVENT_PATH ?? null, eventName: process.env.GITHUB_EVENT_NAME ?? null, checkRunsFile: null, sha: null, runId: process.env.GITHUB_RUN_ID ?? null, repo: process.env.GITHUB_REPOSITORY ?? null, output: process.env.GITHUB_OUTPUT ?? null, checkName: AGGREGATE_CHECK_NAME };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    const next = () => {
+      const v = argv[i + 1];
+      if (v === undefined) throw new Error(`${a} needs a value`);
+      i += 1;
+      return v;
+    };
+    if (a === '--probe' || a === '--replay') out.mode = a.slice(2);
+    else if (a === '--event-file') out.eventFile = next();
+    else if (a === '--event-name') out.eventName = next();
+    else if (a === '--check-runs-file') out.checkRunsFile = next();
+    else if (a === '--sha') out.sha = next();
+    else if (a === '--run-id') out.runId = next();
+    else if (a === '--repo') out.repo = next();
+    else if (a === '--output') out.output = next();
+    else if (a === '--check') out.checkName = next();
+    else throw new Error(`unknown argument: ${a}`);
+  }
+  if (!out.mode) throw new Error('one of --probe or --replay is required');
+  return out;
+}
+
+function readEvent(args) {
+  if (!args.eventFile) return { event: null, eventName: args.eventName };
+  const event = JSON.parse(readFileSync(args.eventFile, 'utf8'));
+  return { event, eventName: args.eventName ?? (event?.pull_request ? 'pull_request' : undefined) };
+}
+
+/** `check_runs` for the SHA: every run, not GitHub's default "latest per name". */
+function fetchCheckRuns(args, sha) {
+  if (args.checkRunsFile) {
+    const parsed = JSON.parse(readFileSync(args.checkRunsFile, 'utf8'));
+    return Array.isArray(parsed) ? parsed : parsed.check_runs;
+  }
+  if (!args.repo) throw new Error('GITHUB_REPOSITORY (or --repo) is required to read check runs');
+  // `filter=all`, deliberately: the default `latest` keeps ONE run per check
+  // name, which on the probe is this very run's in-progress aggregate.
+  const page = gh(
+    ['api', `repos/${args.repo}/commits/${sha}/check-runs?check_name=${encodeURIComponent(args.checkName)}&filter=all&per_page=100`, '--method', 'GET'],
+    `the check runs of ${sha.slice(0, 9)}`,
+  );
+  if (!page || !Array.isArray(page.check_runs)) throw new GhError('GH_BAD_SHAPE', 'check-runs response carried no check_runs array');
+  return page.check_runs;
+}
+
+function emit(args, key, value) {
+  const line = `${key}=${value}\n`;
+  if (args.output) appendFileSync(args.output, line);
+  console.log(`  ${key}=${value}`);
+}
+
+export function run(argv) {
+  const args = parseArgs(argv);
+  const { event, eventName } = readEvent(args);
+  const sha = args.sha ?? event?.pull_request?.head?.sha ?? null;
+
+  if (args.mode === 'probe') {
+    if (!isNoopEdit(event, eventName)) {
+      console.log(`[verdict-replay] ${eventName ?? 'unknown event'}${event?.action ? ` (${event.action})` : ''}: not a no-op edit; the full lane set runs.`);
+      emit(args, 'noop', 'false');
+      return 0;
+    }
+    if (!sha) throw new Error('a no-op edit event with no pull_request.head.sha cannot be probed');
+    const verdict = selectReplayVerdict(fetchCheckRuns(args, sha), { sha, checkName: args.checkName, excludeRunId: args.runId });
+    if (!verdict.found) {
+      console.log(`[verdict-replay] title/body edit of ${sha.slice(0, 9)}, but ${verdict.reason}; the full lane set runs.`);
+      emit(args, 'noop', 'false');
+      return 0;
+    }
+    console.log(
+      `[verdict-replay] title/body edit of ${sha.slice(0, 9)}: a completed "${args.checkName}" verdict already exists ` +
+        `(${verdict.conclusion}, run ${verdict.runId ?? '?'}, ${verdict.completedAt}). Every lane skips; the aggregate replays it.`,
+    );
+    emit(args, 'noop', 'true');
+    return 0;
+  }
+
+  // --replay
+  if (!sha) throw new Error('--replay needs the head SHA (from the event payload or --sha)');
+  const verdict = selectReplayVerdict(fetchCheckRuns(args, sha), { sha, checkName: args.checkName, excludeRunId: args.runId });
+  if (!verdict.found) {
+    console.error(`[verdict-replay] REFUSING: asked to replay a verdict for ${sha.slice(0, 9)} but ${verdict.reason}. Re-run the workflow for a full verdict.`);
+    return 2;
+  }
+  console.log(
+    `[verdict-replay] replaying "${args.checkName}" = ${verdict.conclusion} from run ${verdict.runId ?? '?'} (${verdict.completedAt})${verdict.url ? `: ${verdict.url}` : ''}`,
+  );
+  if (verdict.success) {
+    console.log('  ✔ the head already had a green verdict; this title/body edit changes nothing a test could see.');
+    return 0;
+  }
+  console.error(`  ✘ the head's recorded verdict is "${verdict.conclusion}"; a title/body edit does not clear it. Push a fix or re-run the earlier run.`);
+  return 1;
+}
+
+if (isMainEntry(import.meta.url)) {
+  try {
+    process.exitCode = run(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[verdict-replay] ${err instanceof GhError ? err.reason : 'ERROR'}: ${err.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/lib/ci-path-coverage.mjs
+++ b/scripts/lib/ci-path-coverage.mjs
@@ -151,6 +151,15 @@ export function splitJobs(text) {
 }
 
 /**
+ * `changes` outputs that are NOT path filters. `noop` is the no-op `edited`
+ * probe (scripts/ci-verdict-replay.mjs): `true` means "this head already has
+ * a verdict, skip every lane and replay it", which says nothing about which
+ * paths reach a job. A job gated on it alone still runs on every path, so it
+ * must read as `null` (full coverage) here and not as an empty glob set.
+ */
+const NON_FILTER_OUTPUTS = new Set(['noop']);
+
+/**
  * The filter outputs that must be `true` for a job to run, read off its `if:`.
  *
  * POSITIVE terms only: `needs.changes.outputs.docs == 'true'` gates the job on
@@ -162,12 +171,12 @@ export function gatingFilters(jobText) {
   const ifLine = jobText.match(/^\s{4}if:\s*(.*)$/m);
   if (!ifLine) return null;
   const expr = ifLine[1];
-  const positives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*==\s*'true'/g)].map(
-    (m) => m[1],
-  );
-  const negatives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*!=\s*'true'/g)].map(
-    (m) => m[1],
-  );
+  const positives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*==\s*'true'/g)]
+    .map((m) => m[1])
+    .filter((n) => !NON_FILTER_OUTPUTS.has(n));
+  const negatives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*!=\s*'true'/g)]
+    .map((m) => m[1])
+    .filter((n) => !NON_FILTER_OUTPUTS.has(n));
   if (positives.length === 0) {
     // An `if:` that never mentions a filter output (e.g. `always()`, or an
     // event-name guard) does not path-gate the job.

--- a/scripts/lib/ci-path-coverage.mjs
+++ b/scripts/lib/ci-path-coverage.mjs
@@ -150,13 +150,7 @@ export function splitJobs(text) {
   return jobs.map((j) => ({ id: j.id, text: j.lines.join('\n') }));
 }
 
-/**
- * `changes` outputs that are NOT path filters. `noop` is the no-op `edited`
- * probe (scripts/ci-verdict-replay.mjs): `true` means "this head already has
- * a verdict, skip every lane and replay it", which says nothing about which
- * paths reach a job. A job gated on it alone still runs on every path, so it
- * must read as `null` (full coverage) here and not as an empty glob set.
- */
+// Not path filters: `noop` (the no-op `edited` probe, scripts/ci-verdict-replay.mjs) says nothing about paths, so a job gated on it alone still reads as "every path".
 const NON_FILTER_OUTPUTS = new Set(['noop']);
 
 /**
@@ -171,12 +165,9 @@ export function gatingFilters(jobText) {
   const ifLine = jobText.match(/^\s{4}if:\s*(.*)$/m);
   if (!ifLine) return null;
   const expr = ifLine[1];
-  const positives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*==\s*'true'/g)]
-    .map((m) => m[1])
-    .filter((n) => !NON_FILTER_OUTPUTS.has(n));
-  const negatives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*!=\s*'true'/g)]
-    .map((m) => m[1])
-    .filter((n) => !NON_FILTER_OUTPUTS.has(n));
+  const isFilter = (n) => !NON_FILTER_OUTPUTS.has(n);
+  const positives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*==\s*'true'/g)].map((m) => m[1]).filter(isFilter);
+  const negatives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*!=\s*'true'/g)].map((m) => m[1]).filter(isFilter);
   if (positives.length === 0) {
     // An `if:` that never mentions a filter output (e.g. `always()`, or an
     // event-name guard) does not path-gate the job.

--- a/scripts/lib/ci-verdict-replay.mjs
+++ b/scripts/lib/ci-verdict-replay.mjs
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The no-op `edited` replay (CI redesign, step 2).
+ *
+ * THE WASTE. test.yml fires on `pull_request: edited` because a retarget --
+ * changing a PR's base branch -- fires `edited` and nothing else (#3772), and
+ * a PR moved onto `main` with no run at all reads identically to a green one.
+ * But `edited` also fires on every title and body edit, and the changesets
+ * release PR rewrites its own body after every merge: measured over 400 PR
+ * runs in 38 h, 158 (40%) re-tested a head SHA that already had a verdict.
+ *
+ * WHY NOT SKIP THE LANES. A skipped job still publishes a `skipped` check run,
+ * `skipped` counts as a pass both in the aggregate at the foot of test.yml and
+ * in GitHub's required-check evaluation, and that evaluation takes the LATEST
+ * run per check name -- so a body edit on a red PR would turn the required
+ * check green. That is the absence-reads-as-success class this repository's
+ * gates exist to close, and it is why the trigger was widened without a
+ * `changes.base` gate in the first place.
+ *
+ * WHAT THIS DOES INSTEAD. Two pure decisions, driven by the dispatcher in
+ * scripts/ci-verdict-replay.mjs:
+ *
+ *   1. `isNoopEdit(event)`: the event is a `pull_request` `edited` whose
+ *      `changes` carries no `base` -- a title/body edit, never a retarget.
+ *   2. `selectReplayVerdict(checkRuns, ...)`: among the check runs GitHub holds
+ *      for the head SHA, the LATEST COMPLETED aggregate (`Build + WASM + Rust +
+ *      Node`) that is not this run's own. Its conclusion is the verdict this
+ *      run REPLAYS: success stays success, anything else (failure, cancelled,
+ *      timed_out, ...) is a failure. No completed aggregate at all is "nothing
+ *      to replay", and the caller must then run the full lane set rather than
+ *      guess.
+ *
+ * The `changes` job PROBES (decision 1 + "does a verdict exist") and emits
+ * `noop=true` only when both hold; every lane then skips because no path
+ * filter output is `true`, and the aggregate job replays the recorded verdict
+ * instead of judging the (all-skipped) lanes. A retarget still gets the full
+ * run it always did. The lanes' own check runs from the earlier run stay on
+ * the SHA, which is what `PR review signal` reads.
+ *
+ * FAILS CLOSED. An unreadable event, an API error, or a probe that found a
+ * verdict which the replay then cannot find again all refuse loudly; none of
+ * them is a pass.
+ */
+
+export const AGGREGATE_CHECK_NAME = 'Build + WASM + Rust + Node';
+
+/**
+ * A `pull_request` `edited` event that changed neither the base branch nor
+ * anything a test could see: the title, the body, or nothing at all.
+ *
+ * `changes.base` is the retarget marker GitHub sets when the base moved; the
+ * workflow's own comment on the `edited` trigger documents why a retarget MUST
+ * get a full run. `changes.title` / `changes.body` are the no-op shapes; an
+ * `edited` with an empty `changes` object (observed on some API-driven edits)
+ * is treated as no-op too, since nothing in it could be a base move.
+ *
+ * @param {object|null|undefined} event the parsed `$GITHUB_EVENT_PATH` payload
+ * @param {string} [eventName] `$GITHUB_EVENT_NAME`; defaults to reading the
+ *   payload's shape (a `pull_request` key)
+ */
+export function isNoopEdit(event, eventName = event?.pull_request ? 'pull_request' : undefined) {
+  if (!event || typeof event !== 'object') return false;
+  if (eventName !== 'pull_request') return false;
+  if (event.action !== 'edited') return false;
+  const changes = event.changes;
+  if (changes && typeof changes === 'object' && Object.prototype.hasOwnProperty.call(changes, 'base')) return false;
+  return true;
+}
+
+/** The Actions run id a check run belongs to, read off its details_url. */
+export function runIdOf(checkRun) {
+  const m = /\/actions\/runs\/(\d+)(?:\/|$)/.exec(checkRun?.details_url ?? '');
+  return m ? m[1] : null;
+}
+
+/**
+ * @param {Array<object>} checkRuns the `check_runs` array of
+ *   `GET /repos/{owner}/{repo}/commits/{sha}/check-runs?filter=all`
+ * @param {{sha: string, checkName?: string, excludeRunId?: string|number|null}} opts
+ * @returns {{found: true, conclusion: string, success: boolean, url: string, runId: string|null, completedAt: string}
+ *   | {found: false, reason: string}}
+ */
+export function selectReplayVerdict(checkRuns, { sha, checkName = AGGREGATE_CHECK_NAME, excludeRunId = null } = {}) {
+  if (!Array.isArray(checkRuns)) return { found: false, reason: 'check_runs is not an array' };
+  if (typeof sha !== 'string' || !/^[0-9a-f]{40}$/.test(sha)) return { found: false, reason: `not a full SHA: ${JSON.stringify(sha)}` };
+  const exclude = excludeRunId == null ? null : String(excludeRunId);
+  const candidates = checkRuns.filter(
+    (r) =>
+      r &&
+      r.name === checkName &&
+      r.head_sha === sha &&
+      r.status === 'completed' &&
+      typeof r.completed_at === 'string' &&
+      (exclude === null || runIdOf(r) !== exclude),
+  );
+  if (candidates.length === 0) {
+    return { found: false, reason: `no completed "${checkName}" check run for ${sha.slice(0, 9)} other than this run's` };
+  }
+  candidates.sort((a, b) => (a.completed_at < b.completed_at ? 1 : a.completed_at > b.completed_at ? -1 : 0));
+  const latest = candidates[0];
+  const conclusion = typeof latest.conclusion === 'string' ? latest.conclusion : 'unknown';
+  return {
+    found: true,
+    conclusion,
+    // ONLY `success` replays as a pass. `skipped` cannot occur for the
+    // aggregate (it runs `if: always()`), and `neutral`, `cancelled`,
+    // `timed_out`, `action_required`, `stale` and `failure` all mean "no
+    // green verdict was reached for this head".
+    success: conclusion === 'success',
+    url: latest.html_url ?? latest.details_url ?? '',
+    runId: runIdOf(latest),
+    completedAt: latest.completed_at,
+  };
+}

--- a/scripts/lib/ci-verdict-replay.test.mjs
+++ b/scripts/lib/ci-verdict-replay.test.mjs
@@ -236,7 +236,7 @@ test('WIRING: `changes` probes, the aggregate replays on noop and judges otherwi
   // The gate needs to read check runs. Without this scope the probe fails
   // closed (noop=false, full run) and the saving silently never happens.
   const text = readFileSync(TEST_YML, 'utf8');
-  assert.match(text, /^permissions:\n(?:  [a-z-]+: read\n)*  checks: read/m, 'the workflow must hold `checks: read`');
+  assert.match(text, /^permissions:\n(?:  [a-z-]+: read\n|  #[^\n]*\n)*  checks: read/m, 'the workflow must hold `checks: read`');
 });
 
 test('WIRING: no job gates on `github.event.changes.base`; the decision lives in the probe', () => {

--- a/scripts/lib/ci-verdict-replay.test.mjs
+++ b/scripts/lib/ci-verdict-replay.test.mjs
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The no-op `edited` replay, pinned at three levels: the two pure decisions,
+ * the CLI's exit codes driven through fixture files (never `gh`), and the
+ * wiring in test.yml that makes the replay the thing a required check reads.
+ *
+ * Run: node --test scripts/lib/ci-verdict-replay.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+import { AGGREGATE_CHECK_NAME, isNoopEdit, runIdOf, selectReplayVerdict } from './ci-verdict-replay.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '../..');
+const CLI = join(REPO_ROOT, 'scripts/ci-verdict-replay.mjs');
+const TEST_YML = join(REPO_ROOT, '.github/workflows/test.yml');
+
+const SHA = 'a'.repeat(40);
+const OTHER = 'b'.repeat(40);
+
+const prEvent = (action, changes, sha = SHA) => ({ action, changes, pull_request: { number: 1, head: { sha } } });
+
+const run = (name, runId, status, conclusion, completed_at, sha = SHA) => ({
+  name,
+  head_sha: sha,
+  status,
+  conclusion,
+  completed_at,
+  details_url: `https://github.com/o/r/actions/runs/${runId}/job/${runId}1`,
+  html_url: `https://github.com/o/r/actions/runs/${runId}/job/${runId}1`,
+});
+
+// ---------------------------------------------------------------- decisions
+
+test('isNoopEdit: a title or body edit is a no-op; a retarget, a push or any other event is not', () => {
+  assert.equal(isNoopEdit(prEvent('edited', { title: { from: 'old' } })), true);
+  assert.equal(isNoopEdit(prEvent('edited', { body: { from: 'old' } })), true);
+  assert.equal(isNoopEdit(prEvent('edited', {})), true, 'an empty changes object cannot be a base move');
+  assert.equal(isNoopEdit(prEvent('edited', undefined)), true);
+  // THE RETARGET, which must keep its full run (#3772).
+  assert.equal(isNoopEdit(prEvent('edited', { base: { ref: { from: 'feature' }, sha: { from: 'x' } } })), false);
+  assert.equal(isNoopEdit(prEvent('edited', { base: { ref: { from: 'feature' } }, title: { from: 'o' } })), false, 'base + title is still a retarget');
+  for (const action of ['opened', 'synchronize', 'reopened', 'ready_for_review', 'labeled']) {
+    assert.equal(isNoopEdit(prEvent(action, {})), false, action);
+  }
+  assert.equal(isNoopEdit({ action: 'edited', changes: {} }, 'issues'), false, 'an issue edit is not a PR edit');
+  assert.equal(isNoopEdit({ ref: 'refs/heads/main' }, 'push'), false);
+  assert.equal(isNoopEdit({ merge_group: {} }, 'merge_group'), false);
+  assert.equal(isNoopEdit(null), false);
+  assert.equal(isNoopEdit(undefined), false);
+});
+
+test('selectReplayVerdict: the LATEST COMPLETED aggregate for the SHA, never this run\'s own', () => {
+  const runs = [
+    run(AGGREGATE_CHECK_NAME, 100, 'completed', 'failure', '2026-09-11T10:00:00Z'),
+    run(AGGREGATE_CHECK_NAME, 200, 'completed', 'success', '2026-09-11T11:00:00Z'),
+    run(AGGREGATE_CHECK_NAME, 300, 'in_progress', null, null), // this run
+    run('Node tests', 200, 'completed', 'failure', '2026-09-11T12:00:00Z'), // wrong name
+    run(AGGREGATE_CHECK_NAME, 400, 'completed', 'success', '2026-09-11T13:00:00Z', OTHER), // wrong sha
+  ];
+  const v = selectReplayVerdict(runs, { sha: SHA, excludeRunId: 300 });
+  assert.equal(v.found, true);
+  assert.equal(v.conclusion, 'success');
+  assert.equal(v.success, true);
+  assert.equal(v.runId, '200');
+  assert.equal(v.completedAt, '2026-09-11T11:00:00Z');
+});
+
+test('selectReplayVerdict: only `success` replays green; every other conclusion is a failure', () => {
+  for (const c of ['failure', 'cancelled', 'timed_out', 'action_required', 'neutral', 'stale', 'skipped', null]) {
+    const v = selectReplayVerdict([run(AGGREGATE_CHECK_NAME, 1, 'completed', c, '2026-09-11T10:00:00Z')], { sha: SHA });
+    assert.equal(v.found, true, String(c));
+    assert.equal(v.success, false, `${c} must not replay as a pass`);
+  }
+});
+
+test('selectReplayVerdict: the newest wins even when listed first, and the excluded run is skipped even when newest', () => {
+  const runs = [
+    run(AGGREGATE_CHECK_NAME, 2, 'completed', 'failure', '2026-09-11T12:00:00Z'),
+    run(AGGREGATE_CHECK_NAME, 1, 'completed', 'success', '2026-09-11T10:00:00Z'),
+  ];
+  assert.equal(selectReplayVerdict(runs, { sha: SHA }).conclusion, 'failure');
+  assert.equal(selectReplayVerdict(runs, { sha: SHA, excludeRunId: '2' }).conclusion, 'success');
+});
+
+test('selectReplayVerdict: nothing to replay is FOUND=false with a reason, never a pass', () => {
+  assert.equal(selectReplayVerdict([], { sha: SHA }).found, false);
+  assert.equal(selectReplayVerdict([run(AGGREGATE_CHECK_NAME, 1, 'in_progress', null, null)], { sha: SHA }).found, false, 'in progress is not completed');
+  assert.equal(selectReplayVerdict([run(AGGREGATE_CHECK_NAME, 1, 'completed', 'success', '2026-09-11T10:00:00Z')], { sha: SHA, excludeRunId: 1 }).found, false, 'only this run\'s own');
+  assert.equal(selectReplayVerdict([run(AGGREGATE_CHECK_NAME, 1, 'completed', 'success', '2026-09-11T10:00:00Z')], { sha: 'abc' }).found, false, 'a short sha is refused');
+  assert.equal(selectReplayVerdict(null, { sha: SHA }).found, false);
+  assert.match(selectReplayVerdict([], { sha: SHA }).reason, /no completed/);
+});
+
+test('runIdOf reads the run id from an Actions details_url and nothing else', () => {
+  assert.equal(runIdOf({ details_url: 'https://github.com/o/r/actions/runs/34595555257/job/103251768251' }), '34595555257');
+  assert.equal(runIdOf({ details_url: 'https://vercel.com/x' }), null);
+  assert.equal(runIdOf({}), null);
+});
+
+// ---------------------------------------------------------------- the CLI
+
+function cli(args, files) {
+  const dir = mkdtempSync(join(tmpdir(), 'verdict-replay-'));
+  try {
+    const argv = [CLI, ...args];
+    if (files.event !== undefined) {
+      writeFileSync(join(dir, 'event.json'), JSON.stringify(files.event));
+      argv.push('--event-file', join(dir, 'event.json'));
+    }
+    if (files.checkRuns !== undefined) {
+      writeFileSync(join(dir, 'runs.json'), JSON.stringify({ total_count: files.checkRuns.length, check_runs: files.checkRuns }));
+      argv.push('--check-runs-file', join(dir, 'runs.json'));
+    }
+    const output = join(dir, 'output.txt');
+    writeFileSync(output, '');
+    argv.push('--output', output);
+    const env = { ...process.env };
+    delete env.GITHUB_EVENT_PATH;
+    delete env.GITHUB_EVENT_NAME;
+    delete env.GITHUB_OUTPUT;
+    const r = spawnSync(process.execPath, argv, { encoding: 'utf8', env });
+    return { code: r.status, out: `${r.stdout}\n${r.stderr}`, outputs: readFileSync(output, 'utf8') };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const GREEN = [run(AGGREGATE_CHECK_NAME, 100, 'completed', 'success', '2026-09-11T11:00:00Z')];
+const RED = [run(AGGREGATE_CHECK_NAME, 100, 'completed', 'failure', '2026-09-11T11:00:00Z')];
+
+test('--probe: a body edit of a head with a verdict is noop=true', () => {
+  const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: GREEN });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.outputs, /^noop=true$/m);
+  assert.match(r.out, /already exists \(success, run 100/);
+});
+
+test('--probe: a body edit of a head with a RED verdict is still noop=true (the replay will be red)', () => {
+  const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: RED });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.outputs, /^noop=true$/m);
+});
+
+test('--probe: a retarget is noop=false, whatever verdicts the head carries', () => {
+  const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { base: { ref: { from: 'f' } } }), checkRuns: GREEN });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.outputs, /^noop=false$/m);
+  assert.match(r.out, /not a no-op edit/);
+});
+
+test('--probe: a synchronize, and a body edit with NO verdict yet, both run the full lane set', () => {
+  const sync = cli(['--probe', '--run-id', '300'], { event: prEvent('synchronize', {}), checkRuns: GREEN });
+  assert.match(sync.outputs, /^noop=false$/m);
+  const none = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: [] });
+  assert.equal(none.code, 0, none.out);
+  assert.match(none.outputs, /^noop=false$/m);
+  assert.match(none.out, /no completed/);
+  // Only this run's own aggregate exists (still in progress): nothing to replay.
+  const own = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: [run(AGGREGATE_CHECK_NAME, 300, 'in_progress', null, null)] });
+  assert.match(own.outputs, /^noop=false$/m);
+});
+
+test('--probe: a push or merge_group payload is noop=false without touching the API', () => {
+  const r = cli(['--probe', '--event-name', 'push'], { event: { ref: 'refs/heads/main' } });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.outputs, /^noop=false$/m);
+});
+
+test('--replay: exit 0 on a recorded success, 1 on anything else, 2 when nothing is there', () => {
+  const green = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: GREEN });
+  assert.equal(green.code, 0, green.out);
+  assert.match(green.out, /replaying .* = success from run 100/);
+
+  const red = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: RED });
+  assert.equal(red.code, 1, red.out);
+  assert.match(red.out, /recorded verdict is "failure"/);
+
+  const cancelled = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', {}), checkRuns: [run(AGGREGATE_CHECK_NAME, 100, 'completed', 'cancelled', '2026-09-11T11:00:00Z')] });
+  assert.equal(cancelled.code, 1, cancelled.out);
+
+  const none = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', {}), checkRuns: [] });
+  assert.equal(none.code, 2, none.out);
+  assert.match(none.out, /REFUSING/);
+});
+
+test('--replay ignores this run\'s own in-progress aggregate and replays the earlier one', () => {
+  const r = cli(['--replay', '--run-id', '300'], {
+    event: prEvent('edited', {}),
+    checkRuns: [run(AGGREGATE_CHECK_NAME, 300, 'in_progress', null, null), ...GREEN],
+  });
+  assert.equal(r.code, 0, r.out);
+});
+
+test('the CLI refuses an unknown flag and a missing mode instead of doing nothing quietly', () => {
+  assert.equal(cli(['--bogus'], {}).code, 1);
+  assert.equal(cli([], {}).code, 1);
+});
+
+// ---------------------------------------------------------------- the wiring
+
+/** A job's text from test.yml (2-space job key to the next), comments dropped. */
+function job(id) {
+  const text = readFileSync(TEST_YML, 'utf8');
+  const m = new RegExp(`^  ${id}:\\n([\\s\\S]*?)(?=\\n  [A-Za-z_][A-Za-z0-9_-]*:|(?![\\s\\S]))`, 'm').exec(text);
+  assert.ok(m, `test.yml must carry a job with id \`${id}\``);
+  return m[1].split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
+}
+
+test('WIRING: `changes` probes, the aggregate replays on noop and judges otherwise, and nothing skips silently', () => {
+  const changes = job('changes');
+  assert.match(changes, /^\s+noop: \$\{\{ steps\.noop\.outputs\.noop/m, '`changes` must expose a `noop` output');
+  assert.match(changes, /node scripts\/ci-verdict-replay\.mjs --probe/, '`changes` must run the probe');
+  // The paths filter is what makes every lane's `== 'true'` false on a no-op:
+  // it must not run then, or the lanes would run on a head that has a verdict.
+  assert.match(changes, /if: steps\.noop\.outputs\.noop != 'true'/, 'the filter steps must be skipped on a no-op');
+
+  const agg = job('test');
+  assert.match(agg, /if: needs\.changes\.outputs\.noop == 'true'[\s\S]*node scripts\/ci-verdict-replay\.mjs --replay/, 'the aggregate must replay on noop');
+  assert.match(agg, /if: needs\.changes\.outputs\.noop != 'true'[\s\S]*declare -A results/, 'the aggregate must still judge every lane when not a no-op');
+
+  // The one lane with no path filter of its own would otherwise run on every
+  // body edit; it is gated on the probe like the filtered lanes effectively are.
+  assert.match(job('rust-semver'), /^\s{4}if: needs\.changes\.outputs\.noop != 'true'/m, 'rust-semver must skip on a no-op');
+
+  // The gate needs to read check runs. Without this scope the probe fails
+  // closed (noop=false, full run) and the saving silently never happens.
+  const text = readFileSync(TEST_YML, 'utf8');
+  assert.match(text, /^permissions:\n(?:  [a-z-]+: read\n)*  checks: read/m, 'the workflow must hold `checks: read`');
+});
+
+test('WIRING: no job gates on `github.event.changes.base`; the decision lives in the probe', () => {
+  // The workflow comment on the `edited` trigger explains why: a skipped job
+  // reads as a pass to the required-check evaluation. The probe reads the
+  // event payload instead and the aggregate REPLAYS rather than skips.
+  const code = readFileSync(TEST_YML, 'utf8').split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
+  assert.ok(!/github\.event\.changes\.base/.test(code));
+});

--- a/scripts/lib/ci-verdict-replay.test.mjs
+++ b/scripts/lib/ci-verdict-replay.test.mjs
@@ -142,56 +142,56 @@ const RED = [run(AGGREGATE_CHECK_NAME, 100, 'completed', 'failure', '2026-09-11T
 test('--probe: a body edit of a head with a verdict is noop=true', () => {
   const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: GREEN });
   assert.equal(r.code, 0, r.out);
-  assert.match(r.outputs, /^noop=true$/m);
-  assert.match(r.out, /already exists \(success, run 100/);
+  assert.match(r.outputs, /^noop=true$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
+  assert.match(r.out, /already exists \(success, run 100/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--probe: a body edit of a head with a RED verdict is still noop=true (the replay will be red)', () => {
   const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: RED });
   assert.equal(r.code, 0, r.out);
-  assert.match(r.outputs, /^noop=true$/m);
+  assert.match(r.outputs, /^noop=true$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--probe: a retarget is noop=false, whatever verdicts the head carries', () => {
   const r = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { base: { ref: { from: 'f' } } }), checkRuns: GREEN });
   assert.equal(r.code, 0, r.out);
-  assert.match(r.outputs, /^noop=false$/m);
-  assert.match(r.out, /not a no-op edit/);
+  assert.match(r.outputs, /^noop=false$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
+  assert.match(r.out, /not a no-op edit/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--probe: a synchronize, and a body edit with NO verdict yet, both run the full lane set', () => {
   const sync = cli(['--probe', '--run-id', '300'], { event: prEvent('synchronize', {}), checkRuns: GREEN });
-  assert.match(sync.outputs, /^noop=false$/m);
+  assert.match(sync.outputs, /^noop=false$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
   const none = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: [] });
   assert.equal(none.code, 0, none.out);
-  assert.match(none.outputs, /^noop=false$/m);
-  assert.match(none.out, /no completed/);
+  assert.match(none.outputs, /^noop=false$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
+  assert.match(none.out, /no completed/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
   // Only this run's own aggregate exists (still in progress): nothing to replay.
   const own = cli(['--probe', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: [run(AGGREGATE_CHECK_NAME, 300, 'in_progress', null, null)] });
-  assert.match(own.outputs, /^noop=false$/m);
+  assert.match(own.outputs, /^noop=false$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--probe: a push or merge_group payload is noop=false without touching the API', () => {
   const r = cli(['--probe', '--event-name', 'push'], { event: { ref: 'refs/heads/main' } });
   assert.equal(r.code, 0, r.out);
-  assert.match(r.outputs, /^noop=false$/m);
+  assert.match(r.outputs, /^noop=false$/m); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--replay: exit 0 on a recorded success, 1 on anything else, 2 when nothing is there', () => {
   const green = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: GREEN });
   assert.equal(green.code, 0, green.out);
-  assert.match(green.out, /replaying .* = success from run 100/);
+  assert.match(green.out, /replaying .* = success from run 100/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 
   const red = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', { body: { from: 'x' } }), checkRuns: RED });
   assert.equal(red.code, 1, red.out);
-  assert.match(red.out, /recorded verdict is "failure"/);
+  assert.match(red.out, /recorded verdict is "failure"/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 
   const cancelled = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', {}), checkRuns: [run(AGGREGATE_CHECK_NAME, 100, 'completed', 'cancelled', '2026-09-11T11:00:00Z')] });
   assert.equal(cancelled.code, 1, cancelled.out);
 
   const none = cli(['--replay', '--run-id', '300'], { event: prEvent('edited', {}), checkRuns: [] });
   assert.equal(none.code, 2, none.out);
-  assert.match(none.out, /REFUSING/);
+  assert.match(none.out, /REFUSING/); // @source-text-assertion-ok not source text: the CLI is spawned over fixture files and its stdout/GITHUB_OUTPUT is what is asserted
 });
 
 test('--replay ignores this run\'s own in-progress aggregate and replays the earlier one', () => {
@@ -212,37 +212,37 @@ test('the CLI refuses an unknown flag and a missing mode instead of doing nothin
 /** A job's text from test.yml (2-space job key to the next), comments dropped. */
 function job(id) {
   const text = readFileSync(TEST_YML, 'utf8');
-  const m = new RegExp(`^  ${id}:\\n([\\s\\S]*?)(?=\\n  [A-Za-z_][A-Za-z0-9_-]*:|(?![\\s\\S]))`, 'm').exec(text);
+  const m = new RegExp(`^  ${id}:\\n([\\s\\S]*?)(?=\\n  [A-Za-z_][A-Za-z0-9_-]*:|(?![\\s\\S]))`, 'm').exec(text); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
   assert.ok(m, `test.yml must carry a job with id \`${id}\``);
-  return m[1].split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
+  return m[1].split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 }
 
 test('WIRING: `changes` probes, the aggregate replays on noop and judges otherwise, and nothing skips silently', () => {
   const changes = job('changes');
-  assert.match(changes, /^\s+noop: \$\{\{ steps\.noop\.outputs\.noop/m, '`changes` must expose a `noop` output');
-  assert.match(changes, /node scripts\/ci-verdict-replay\.mjs --probe/, '`changes` must run the probe');
+  assert.match(changes, /^\s+noop: \$\{\{ steps\.noop\.outputs\.noop/m, '`changes` must expose a `noop` output'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
+  assert.match(changes, /node scripts\/ci-verdict-replay\.mjs --probe/, '`changes` must run the probe'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
   // The paths filter is what makes every lane's `== 'true'` false on a no-op:
   // it must not run then, or the lanes would run on a head that has a verdict.
-  assert.match(changes, /if: steps\.noop\.outputs\.noop != 'true'/, 'the filter steps must be skipped on a no-op');
+  assert.match(changes, /if: steps\.noop\.outputs\.noop != 'true'/, 'the filter steps must be skipped on a no-op'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 
   const agg = job('test');
-  assert.match(agg, /if: needs\.changes\.outputs\.noop == 'true'[\s\S]*node scripts\/ci-verdict-replay\.mjs --replay/, 'the aggregate must replay on noop');
-  assert.match(agg, /if: needs\.changes\.outputs\.noop != 'true'[\s\S]*declare -A results/, 'the aggregate must still judge every lane when not a no-op');
+  assert.match(agg, /if: needs\.changes\.outputs\.noop == 'true'[\s\S]*node scripts\/ci-verdict-replay\.mjs --replay/, 'the aggregate must replay on noop'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
+  assert.match(agg, /if: needs\.changes\.outputs\.noop != 'true'[\s\S]*declare -A results/, 'the aggregate must still judge every lane when not a no-op'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 
   // The one lane with no path filter of its own would otherwise run on every
   // body edit; it is gated on the probe like the filtered lanes effectively are.
-  assert.match(job('rust-semver'), /^\s{4}if: needs\.changes\.outputs\.noop != 'true'/m, 'rust-semver must skip on a no-op');
+  assert.match(job('rust-semver'), /^\s{4}if: needs\.changes\.outputs\.noop != 'true'/m, 'rust-semver must skip on a no-op'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 
   // The gate needs to read check runs. Without this scope the probe fails
   // closed (noop=false, full run) and the saving silently never happens.
   const text = readFileSync(TEST_YML, 'utf8');
-  assert.match(text, /^permissions:\n(?:  [a-z-]+: read\n|  #[^\n]*\n)*  checks: read/m, 'the workflow must hold `checks: read`');
+  assert.match(text, /^permissions:\n(?:  [a-z-]+: read\n|  #[^\n]*\n)*  checks: read/m, 'the workflow must hold `checks: read`'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 });
 
 test('WIRING: no job gates on `github.event.changes.base`; the decision lives in the probe', () => {
   // The workflow comment on the `edited` trigger explains why: a skipped job
   // reads as a pass to the required-check evaluation. The probe reads the
   // event payload instead and the aggregate REPLAYS rather than skips.
-  const code = readFileSync(TEST_YML, 'utf8').split('\n').filter((l) => !/^\s*#/.test(l)).join('\n');
-  assert.ok(!/github\.event\.changes\.base/.test(code));
+  const code = readFileSync(TEST_YML, 'utf8').split('\n').filter((l) => !/^\s*#/.test(l)).join('\n'); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
+  assert.ok(!/github\.event\.changes\.base/.test(code)); // @source-text-assertion-ok workflow wiring pin: the subject IS the YAML text; there is no runtime to drive instead
 });


### PR DESCRIPTION
CI redesign, step 2: a title/body edit of a PR head that already has a verdict no longer re-runs the 16-lane suite; `changes` probes the event, every lane skips, and the aggregate REPLAYS the recorded verdict for that SHA.

## What changed

- `scripts/lib/ci-verdict-replay.mjs` (new): two pure decisions. `isNoopEdit(event)` -- a `pull_request` `edited` whose `changes` carries no `base` (a title/body edit, never a retarget). `selectReplayVerdict(checkRuns, {sha, excludeRunId})` -- the LATEST COMPLETED `Build + WASM + Rust + Node` check run on the head SHA that is not this run's own; only `success` replays green, every other conclusion (failure, cancelled, timed_out, ...) replays red; no such run is "nothing to replay".
- `scripts/ci-verdict-replay.mjs` (new): `--probe` (run by `changes`; writes `noop=true` only when both decisions hold, else `noop=false` and the full run proceeds) and `--replay` (run by the aggregate; exit 0 on a recorded success, 1 otherwise, 2 = refuse when nothing is there). Reads `commits/{sha}/check-runs?filter=all` -- `all`, because the default `latest` would return this run's own in-progress aggregate.
- `.github/workflows/test.yml`: `permissions: checks: read`; `changes` gains the probe step (only on `edited`), a `noop` output, and skips the paths-filter and prebuilt-WASM steps on a no-op; `rust-semver` (the one lane with no path filter) gets `needs: changes` + `if: noop != 'true'`; the aggregate replays on `noop == 'true'` and judges the map otherwise. The `edited` trigger comment is rewritten to describe the mechanism.
- `scripts/lib/ci-path-coverage.mjs`: `gatingFilters` ignores the `noop` output (`NON_FILTER_OUTPUTS`) so `check-ci-path-coverage` keeps reading `rust-semver` as "runs on every path" (a `noop != 'true'` term alone used to parse as an empty glob set). Test added.
- `scripts/lib/ci-verdict-replay.test.mjs` (new): the two decisions, the CLI's exit codes driven through fixture files (never `gh`), and the test.yml wiring (probe present, filter steps skipped on noop, replay-vs-judge gated on noop, rust-semver gated, `checks: read` held, and still no job gating on `github.event.changes.base`).

## Why (plan evidence)

158 of 400 PR `Test` runs in 38 h (40%) were same-SHA re-runs from `edited` waves -- routine on the changesets release PR, which rewrites its body after every merge. Each was a full 16-lane run of a head that already had a verdict.

## Guards preserved

- The verdict is REPLAYED, never skipped: a red head stays red on a body edit (the replay exits 1), a green one stays green, and a head with no completed verdict yet gets the full run. This is exactly the fail-closed shape the `edited` trigger comment demanded, and why no job here gates on `changes.base` (a skipped run would read as a pass to GitHub's required-check evaluation); the existing test in `check-pr-review-signal.test.mjs` still pins that.
- A retarget (`changes.base` present) is `noop=false`: full run, as before (#3772).
- Merge-queue and push runs are untouched (the probe step only runs on `edited`).
- Fail-closed throughout: an unreadable event or API error fails the probe step (red `Detect changes`, judged by the aggregate), and a replay that cannot find the verdict the probe saw refuses (exit 2).
- `check-ci-aggregate-coverage`, `check-ci-path-coverage`, `check-test-wiring`, the review-signal suites and the CI-coverage suites pass locally.

## Assumption noted

The lanes' own check runs from the earlier run stay on the SHA, which is what `PR review signal` (no longer fired on `edited` since #4515) reads; the no-op run publishes `skipped` for every lane and the replayed conclusion for the aggregate.

## Revert

`git revert` of the squash commit removes the probe/replay steps, the `noop` output, the scripts and the gate exemption together; `edited` goes back to a full re-run. Workflow + scripts only, no changeset.
