### PR TITLE
ci(rust): PR lane = clippy + cargo test --workspace; feature legs, census and CSG gates blocking on main and in the merge queue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1654,6 +1654,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+  # THE PR LANE FOR RUST (CI redesign, step 5): workspace clippy and
+  # `cargo test --workspace`, on every push, warm from main's shared cache.
+  # The off-by-default feature legs that used to follow in this same job --
+  # parquet-bos, csg_manifold_gate, csg_capture, the all-features clippy --
+  # are `rust-full` below, which runs on push to main and in the merge queue
+  # and is judged by the aggregate there. Measured before the split: this
+  # job was 21.4-25.0 min cold on a hosted runner (the `Cargo cache` step
+  # took 12 s, i.e. a miss, on every PR because main saved no cache), and it
+  # was the whole critical path of a Rust-touching PR.
   rust-tests:
     name: Rust tests
     needs: changes
@@ -1716,6 +1725,62 @@ jobs:
           IFC_LITE_REQUIRE_FIXTURES: "1"
         run: cargo test --workspace
 
+      # The feature legs (parquet-bos, csg_manifold_gate, csg_capture, the
+      # all-features clippy) run in `rust-full` below -- OFF the PR lane,
+      # ON push to main and in the merge queue, where the aggregate judges
+      # them. See that job for why each exists.
+
+  # THE FULL RUST LANE, OFF THE PR (CI redesign, step 5). Everything here is
+  # an off-by-default feature build: the workspace never compiles these, so a
+  # lane has to, or they rot while looking maintained (#2802, #3440, #4182).
+  # They ran in `rust-tests` on every PR push, at 5-10 min of a lane that was
+  # the Rust PR's whole critical path. They now run on push to main and on
+  # every merge-queue batch -- on the exact merge result, ~15 min later than
+  # a PR push -- and this job is in the aggregate's `needs:` and results map,
+  # so a red feature build fails the required check and DEQUEUES the batch;
+  # nothing here got weaker, it moved. OWNER VETO POINT, accepted: a Rust PR
+  # no longer shows these legs pre-merge.
+  #
+  # Its own cache prefix: rust-cache skips the save when the key exists, and
+  # `rust-tests` writes `ci-rust-main-*` first, so sharing that key would
+  # leave the arrow/parquet dependency tree cold on every run.
+  rust-full:
+    name: Rust tests (feature builds)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request'
+    runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+      - name: Setup Rust (pinned by rust-toolchain.toml)
+        run: rustup show
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          prefix-key: ci-rust-full
+          shared-key: main
+          save-if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'merge_group' }}
+      - name: Cache test fixtures
+        id: fixtures-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/models
+          key: ci-fixtures-${{ runner.os }}-${{ hashFiles('tests/models/manifest.json') }}
+      - name: Fetch fixtures
+        if: steps.fixtures-cache.outputs.cache-hit != 'true'
+        # The fixtures script is pure Node (no npm deps) so we skip the
+        # pnpm install dance Rust-only jobs don't need.
+        run: node scripts/fixtures/fetch-fixtures.mjs
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
       # `parquet-bos` is OFF by default because arrow/parquet/zip do not target
       # wasm32 cleanly (rust/export/Cargo.toml:33). The consequence is that
       # `cargo test --workspace` above never COMPILES the module, let alone
@@ -1818,9 +1883,13 @@ jobs:
   geometry-census:
     name: Geometry watertightness census
     needs: changes
-    # PR-only — see viewer-e2e.
-    if: needs.changes.outputs.geometry == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
-    # This high-volume PR gate must not consume metered runner minutes.
+    # OFF THE PR LANE, ON push to main and the merge queue (CI redesign,
+    # step 5). Measured at 6.6 min on a hosted runner; it stays in the
+    # aggregate's `needs:`, so in the queue a moved baseline fails the required
+    # check and dequeues the batch. The heavy-fixture variant is weekly
+    # (geometry-census-heavy.yml).
+    if: needs.changes.outputs.geometry == 'true' && github.event_name != 'pull_request'
+    # This lane must not consume metered runner minutes.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
@@ -1876,22 +1945,26 @@ jobs:
   # targets from the day #3717 landed and no lane said so. This is the lane that
   # says so.
   #
-  # NOT on the aggregate `test` gate's `needs:` list, deliberately, and this is
-  # the one thing about this job that must not drift. What it asserts are pinned
-  # MEASUREMENTS of a fallback path known to be worse than the tear it replaces
-  # (issue_098_v5c, issue_960_segmented_roof_clip), for a configuration nothing
-  # ships. A number moving there is a thing to look at, not a thing to block a
-  # merge on. Adding this job to that `needs:` list, or to the `results` map
-  # beside it, turns a report into a gate.
+  # ON the aggregate `test` gate's `needs:` list since the CI redesign (step
+  # 5), and OFF the PR lane. It used to be advisory on every PR: 25-27 min of
+  # feature builds whose failure could not stop a merge. What it asserts are
+  # pinned MEASUREMENTS of a fallback path known to be worse than the tear it
+  # replaces (issue_098_v5c, issue_960_segmented_roof_clip), for a
+  # configuration nothing ships -- so on a PR the verdict was a thing to look
+  # at, not a thing to block on. In the merge queue the trade is different: the
+  # numbers moved on the exact merge result, nobody is looking, and a batch
+  # that lands them silently is how #3717's red pins went unnoticed. So here it
+  # blocks: a moved pin dequeues the batch, and the fix is a deliberate
+  # re-bless in a PR of its own.
   #
   # `geometry`, not `rust`: the same scope argument geometry-census above spells
   # out. The gates live in rust/geometry, they sit downstream of rust/core's
   # parse path, and the per-fixture numbers they pin move with the fixture
   # corpus, so `tests/models/manifest.json` is in that filter too.
   #
-  # PR-only, like geometry-census and viewer-e2e: three feature builds of the
-  # geometry crate and its test targets are not free, and a PR lane already
-  # catches the flip before it reaches main.
+  # Push-to-main and merge-queue only, like geometry-census: three feature
+  # builds of the geometry crate and its test targets are not free, and the
+  # queue runs them on the exact merge result before anything reaches main.
   #
   # ONE STEP PER FEATURE COMBINATION, not one `--all-features` run. The two
   # gates read different defect classes and reject different hosts, so each
@@ -1902,7 +1975,7 @@ jobs:
   csg-accept-gates:
     name: CSG accept gates (feature builds)
     needs: changes
-    if: needs.changes.outputs.geometry == 'true' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+    if: needs.changes.outputs.geometry == 'true' && github.event_name != 'pull_request'
     # This lane must not consume metered runner minutes.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
     timeout-minutes: 60
@@ -2177,7 +2250,7 @@ jobs:
 
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, provenance-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks, agents-md, license-headers]
+    needs: [changes, build, revert-oracle, typecheck, lint, node-tests, provenance-tests, viewer-tests, viewer-e2e, rust-tests, rust-full, rust-semver, geometry-census, csg-accept-gates, plato-check, docs-checks, agents-md, license-headers]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ${{ (vars.SELF_HOSTED_CI == 'true' && (github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'ci:hosted')))) && fromJSON('["self-hosted","linux","x64","ifclite"]') || 'ubuntu-latest' }}
@@ -2200,8 +2273,10 @@ jobs:
             [viewer-tests]="${{ needs.viewer-tests.result }}"
             [viewer-e2e]="${{ needs.viewer-e2e.result }}"
             [rust-tests]="${{ needs.rust-tests.result }}"
+            [rust-full]="${{ needs.rust-full.result }}"
             [rust-semver]="${{ needs.rust-semver.result }}"
             [geometry-census]="${{ needs.geometry-census.result }}"
+            [csg-accept-gates]="${{ needs.csg-accept-gates.result }}"
             [plato-check]="${{ needs.plato-check.result }}"
             [docs-checks]="${{ needs.docs-checks.result }}"
             [agents-md]="${{ needs.agents-md.result }}"

--- a/scripts/check-ci-aggregate-coverage.mjs
+++ b/scripts/check-ci-aggregate-coverage.mjs
@@ -119,10 +119,11 @@ export function unreachable({ needs, judged }) {
  * failure cannot stop a merge.
  */
 export const UNJUDGED_BY_DESIGN = {
-  'csg-accept-gates':
-    'Advisory. Runs only when geometry changed and reports accept-gate deltas; ' +
-    'it is not in the branch ruleset either. Whether it SHOULD block is an open ' +
-    'question, tracked separately rather than decided by this gate.',
+  // Empty since the CI redesign (step 5): `csg-accept-gates`, the one entry,
+  // moved off the PR lane into the merge queue and INTO the aggregate's
+  // `needs:` there, where a moved pin dequeues the batch. Keep this list empty
+  // unless a lane genuinely must not block; the default has to be "blocking"
+  // for the aggregate to mean anything.
 };
 
 /**

--- a/scripts/check-ci-aggregate-coverage.test.mjs
+++ b/scripts/check-ci-aggregate-coverage.test.mjs
@@ -135,6 +135,24 @@ jobs:
   assert.deepEqual(prJobs(text), ['real']);
 });
 
+test('CI redesign step 5: the CSG accept gates are JUDGED, not exempt, and the exemption list is empty', () => {
+  // The one entry `UNJUDGED_BY_DESIGN` ever had was `csg-accept-gates`, an
+  // advisory PR lane. It moved off the PR lane and into the aggregate's
+  // `needs:` + results map (blocking in the merge queue and on push to main);
+  // an exemption left behind would let a later edit drop it from `needs:`
+  // again with this gate silent. Pinned against the REAL test.yml so the
+  // three facts cannot drift apart: in `needs:`, judged in the map, not
+  // exempt -- and the list empty, so the default is "blocking" for everything.
+  const text = readFileSync(join(ROOT, '.github/workflows/test.yml'), 'utf8');
+  const agg = readAggregate(text);
+  assert.ok(agg.needs.includes('csg-accept-gates'), 'csg-accept-gates must be a dependency of the aggregate');
+  assert.ok(agg.judged.includes('csg-accept-gates'), 'csg-accept-gates must be judged by the results map');
+  assert.ok(agg.needs.includes('rust-full'), 'rust-full (the moved feature legs) must be a dependency of the aggregate');
+  assert.ok(agg.judged.includes('rust-full'), 'rust-full must be judged by the results map');
+  assert.ok(!('csg-accept-gates' in UNJUDGED_BY_DESIGN), 'a judged job must not also be exempt');
+  assert.deepEqual(Object.keys(UNJUDGED_BY_DESIGN), [], 'no lane is advisory by design any more');
+});
+
 test('every exemption carries a stated reason', () => {
   // An exemption is a decision. One with no reason is an oversight wearing a
   // decision's clothes, and this list is meant to ratchet down.

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -98,6 +98,9 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
     'Typecheck',
     'Lint',
     'Node tests',
+    // CI redesign step 5: the feature legs of the Rust lane, off the PR and
+    // judged in the merge queue. On a PR its check run is `skipped`.
+    'Rust tests (feature builds)',
     // CI redesign step 4: provenance's 353 s merge battery in its own job,
     // and the viewer suite at eight shards instead of four.
     'Provenance tests',
@@ -116,7 +119,7 @@ test('the REAL test.yml derives the lane names the REAL rollup publishes', () =>
   ]) {
     assert.ok(names.includes(observed), `derived set is missing the observed lane "${observed}"`);
   }
-  assert.equal(names.length, 25);
+  assert.equal(names.length, 26);
 });
 
 test('FAIL CLOSED: an empty workflow file is NO_WORKFLOW_TEXT, not an empty lane set', () => {


### PR DESCRIPTION
CI redesign, step 5: the Rust PR lane becomes workspace clippy + `cargo test --workspace`; the off-by-default feature legs, the watertightness census and the CSG accept gates move to push-to-main and the merge queue, where ALL of them are judged by the required aggregate.

## What changed (`.github/workflows/test.yml`)

- `rust-tests` (name unchanged, `Rust tests`): keeps fixtures, `cargo metadata --locked`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`. The six feature steps move out.
- New `rust-full` (`Rust tests (feature builds)`): parquet-bos test + clippy, csg_manifold_gate test + clippy, all-features clippy, csg_capture test -- the same steps verbatim, on `push` to main and `merge_group` (`if: rust == 'true' && event != 'pull_request'`), own cache prefix `ci-rust-full` with `shared-key: main` / `save-if` (rust-cache skips a save when the key exists, so sharing `ci-rust` would leave the arrow/parquet tree cold). Added to the aggregate `needs:` and results map.
- `geometry-census`: `if: geometry == 'true' && event != 'pull_request'` (already in the aggregate).
- `csg-accept-gates`: same `if:`; ADDED to the aggregate `needs:` and map -- it was advisory on every PR, it is now blocking in the queue. Its "NOT on the aggregate, deliberately" header is rewritten to say why the trade flips in the queue (numbers moved on the exact merge result, nobody looking, #3717's shape).
- `scripts/check-ci-aggregate-coverage.mjs`: `UNJUDGED_BY_DESIGN` is now empty (csg-accept-gates was its one entry).
- `scripts/lib/pr-review-signal.test.mjs`: lane tripwire gains `Rust tests (feature builds)` (26 derived lanes).

## Why (plan evidence)

- Rust PR critical path: Rust tests 21.4-25.0 min cold on hosted runners (measured 25.5 min on #4497's run); the feature legs are 5-10 min of that lane, and CSG accept gates 25-27 min in parallel, advisory.
- Target (plan section 2): Rust-touching PR ~25 min -> ~11-12 min once the shared cache from #4511/#4521 is warm; merge batch ~17-20 min.

## Guards preserved (hard rule 3)

- Every moved job stays in the aggregate `needs:` AND the results map, so in the merge queue a failure fails the required check `Build + WASM + Rust + Node` and the batch is dequeued; on push to main it is the post-merge backstop. `csg-accept-gates` is a strengthening: it could not block anything before.
- `check-ci-aggregate-coverage` (17 needs, 17 judged), `check-ci-path-coverage` (37 PR-triggered jobs), `check-test-wiring` and the review-signal / aggregate-coverage suites pass locally.
- Owner veto point (step 5) accepted per the brief: a Rust PR no longer shows the feature legs, the census or the CSG gates pre-merge; they run ~15 min later on the exact merge result.

## Assumption noted

Until the merge-queue rule is enabled (step 6), "in the queue" means the push-to-main run; an admin merge that bypasses the queue is covered by that run and by `report`-style visibility only. Enabling the rule is the next step.

## Revert

`git revert` of the squash commit puts the feature steps back into `rust-tests`, restores PR-lane census/CSG gates, drops `rust-full` and `csg-accept-gates` from the aggregate, and restores the exemption. Workflow + scripts only, no changeset.
