### PR TITLE
test(bcf): give the archive XSD-conformance tests an explicit timeout

### DIFF
--- a/packages/bcf/src/interop-conformance.test.ts
+++ b/packages/bcf/src/interop-conformance.test.ts
@@ -391,7 +391,7 @@ describe('a plainly-exported archive validates entry by entry', () => {
         }
       }
       expect(failures).toEqual([]);
-    });
+    }, 30_000); // XSD validation of every archive entry: ~5 s on a loaded CI runner, past vitest's 5 s default
   }
 });
 


### PR DESCRIPTION
`packages/bcf/src/interop-conformance.test.ts › a plainly-exported archive validates entry by entry › BCF 2.1 / 3.0` validates every entry of an exported archive against the BCF XSDs. On today's loaded hosted runners that takes ~5 s and trips vitest's 5 s default:

```
Error: Test timed out in 5000ms.
 ❯ src/interop-conformance.test.ts:355:5
```

Seen on `Node tests` of #4522, #4523, #4524, #4364 and #4490 in the last hour — every PR, unrelated to their diffs. Same shape as the parser 65536-name test fixed in #4513/#4514. Explicit 30 s timeout; still a hang guard, no longer a load guard. No production change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended the BCF archive validation test timeout to accommodate complete validation of all archive entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->