### PR TITLE
ci(rust): link host builds with lld

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1681,6 +1681,16 @@ jobs:
           persist-credentials: false
       - name: Setup Rust (pinned by rust-toolchain.toml)
         run: rustup show
+      - name: Use lld for host links
+        # ~200 integration-test binaries in the workspace make link time a
+        # real share of `cargo test`; lld links several times faster than
+        # bfd. Scoped to the x86_64 Linux host target via env, not
+        # .cargo/config.toml, so local builds and the wasm target are
+        # untouched. Hosted images ship clang but not lld.
+        run: |
+          command -v ld.lld >/dev/null 2>&1 || sudo apt-get install -y --no-install-recommends lld
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
       - name: Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
@@ -1842,6 +1852,16 @@ jobs:
           persist-credentials: false
       - name: Setup Rust (pinned by rust-toolchain.toml)
         run: rustup show
+      - name: Use lld for host links
+        # ~200 integration-test binaries in the workspace make link time a
+        # real share of `cargo test`; lld links several times faster than
+        # bfd. Scoped to the x86_64 Linux host target via env, not
+        # .cargo/config.toml, so local builds and the wasm target are
+        # untouched. Hosted images ship clang but not lld.
+        run: |
+          command -v ld.lld >/dev/null 2>&1 || sudo apt-get install -y --no-install-recommends lld
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
       - name: Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
@@ -1925,6 +1945,16 @@ jobs:
           persist-credentials: false
       - name: Setup Rust (pinned by rust-toolchain.toml)
         run: rustup show
+      - name: Use lld for host links
+        # ~200 integration-test binaries in the workspace make link time a
+        # real share of `cargo test`; lld links several times faster than
+        # bfd. Scoped to the x86_64 Linux host target via env, not
+        # .cargo/config.toml, so local builds and the wasm target are
+        # untouched. Hosted images ship clang but not lld.
+        run: |
+          command -v ld.lld >/dev/null 2>&1 || sudo apt-get install -y --no-install-recommends lld
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
       - name: Cargo cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:


### PR DESCRIPTION
CI redesign, step 7 (plan §3 "Rust": lld linker, measure before/after).

## What changed (`.github/workflows/test.yml`)

The three host Rust jobs — `rust-tests`, `geometry-census`, `csg-accept-gates` — gain one step after `rustup show`:

```
command -v ld.lld >/dev/null 2>&1 || sudo apt-get install -y --no-install-recommends lld
echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=clang" >> "$GITHUB_ENV"
echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS=-C link-arg=-fuse-ld=lld" >> "$GITHUB_ENV"
```

Scoped to the x86_64 Linux host target through env rather than `.cargo/config.toml`, so local builds (Windows/macOS, or Linux without clang/lld), the wasm32 target and `scripts/build-wasm.sh`'s `build-std` invocation are untouched. Hosted `ubuntu-latest` ships clang but not lld (hence the guarded install, ~5 s); the self-hosted runner image already has both.

## Why (plan evidence)

`cargo test --workspace` builds 200+ integration-test binaries (geometry 111, processing 68); link time is a real share of the 21–25 min lane. lld links several times faster than bfd.

## Guards preserved

Nothing about what is tested changes — same crates, same tests, same clippy flags; only the linker. The first run after landing is cold (RUSTFLAGS is part of the fingerprint, so the `shared-key: main` cache re-warms on the push-to-main run).

## Measurement

Baseline, `Rust tests` on the last three main pushes (after #4521's shared cache): 21, 22, 21 min. After-numbers will be posted in this thread from the first warm main runs.

## Revert

`git revert` of the squash commit removes the three steps; nothing else depends on them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CI test-job linking by configuring the LLVM linker where needed.
  * Added automatic setup to install the linker when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->