### PR TITLE
test(bcf): explicit timeout for the IDS-derived conformance cases too

### DIFF
--- a/packages/bcf/src/interop-conformance.test.ts
+++ b/packages/bcf/src/interop-conformance.test.ts
@@ -500,7 +500,7 @@ describe('an IDS-derived archive validates entry by entry', () => {
           }
         }
         expect(failures).toEqual([]);
-      });
+      }, 30_000); // same validateXML loop as the plain-export cases above
     }
   }
 });


### PR DESCRIPTION
Follow-up to #4524's review thread: the six `an IDS-derived archive validates entry by entry` cases run the same `validateXML` loop over up to six entries as the plain-export cases and kept vitest's 5 s default. Same 30 s hang-guard timeout. Test-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the allowed time for archive validation test cases to 30 seconds while preserving existing validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->