### PR TITLE
fix(viewer): basket isolation claims only what it inserted and never narrows a channel it lost

### DIFF
--- a/.changeset/basket-owned-isolation.md
+++ b/.changeset/basket-owned-isolation.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the basket evicting isolation it did not own. `isolatedEntities` is shared by the basket, direct isolate, BCF viewpoint restore, lens and search; unpinning an element deleted its global id from that set even when another feature had isolated it independently, and emptying the basket by removal cleared every isolation channel. The basket now keeps a value-matched ownership record (`basketIsolationOwned`, the repo-wide `lib/visibility/ownership` convention): it claims only the ids it inserted, never narrows a channel another writer has since replaced, closes the channel on empty only when it opened it, and hands back the remainder otherwise. The unused legacy `addToPinboard` / `removeFromPinboard` / `setPinboard` / `isInPinboard` / `getPinboardCount` / `getPinboardEntities` actions are removed.

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -131,11 +131,14 @@ export function releaseOwnedVisibility(
 export interface OwnedVisibilityRecords {
   idsFocusVisibilityOwned?: VisibilityOwnership;
   clashVisibilityOwned?: VisibilityOwnership;
+  /** The basket's claim on the isolate channel (`store/slices/pinboard-isolation.ts`, #4527). */
+  basketIsolationOwned?: VisibilityOwnership;
 }
 
 const OWNERSHIP_RECORD_FIELDS = [
   'idsFocusVisibilityOwned',
   'clashVisibilityOwned',
+  'basketIsolationOwned',
 ] as const satisfies readonly (keyof OwnedVisibilityRecords)[];
 
 /**

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -132,13 +132,13 @@ export interface OwnedVisibilityRecords {
   idsFocusVisibilityOwned?: VisibilityOwnership;
   clashVisibilityOwned?: VisibilityOwnership;
   /** The basket's claim on the isolate channel (`store/slices/pinboard-isolation.ts`, #4527). */
-  basketIsolationOwned?: VisibilityOwnership;
+  basketVisibilityOwned?: VisibilityOwnership;
 }
 
 const OWNERSHIP_RECORD_FIELDS = [
   'idsFocusVisibilityOwned',
   'clashVisibilityOwned',
-  'basketIsolationOwned',
+  'basketVisibilityOwned',
 ] as const satisfies readonly (keyof OwnedVisibilityRecords)[];
 
 /**
@@ -175,7 +175,8 @@ const OWNERSHIP_RECORD_FIELDS = [
  * `installClashGhost`, `useIDS.installFocusIsolation` / `installFocusGhost`),
  * so a record can never be invalidated by the very write that installed it.
  * (The middleware also leaves a record the patch itself carries alone, so an
- * installer that committed both in ONE `set()` would be safe too.)
+ * installer that commits both in ONE `set()` is safe too — the basket does,
+ * `store/slices/pinboard-isolation.ts`.)
  *
  * @returns a partial state patch — `{}` when nothing went stale, so the common
  *   case adds no keys to the `set()` and slice-level harnesses that stub `get()`

--- a/apps/viewer/src/store/basketVisibleSet.test.ts
+++ b/apps/viewer/src/store/basketVisibleSet.test.ts
@@ -276,7 +276,7 @@ describe('basketVisibleSet', () => {
       assert.strictEqual(isBasketIsolationActiveFromStore(), false);
     });
 
-    it('returns false when isolated size differs from basket', () => {
+    it('returns false when a basket element is missing from the isolation', () => {
       useViewerStore.setState({
         pinboardEntities: new Set(['legacy:100', 'legacy:200']),
         isolatedEntities: new Set([100]),
@@ -285,29 +285,22 @@ describe('basketVisibleSet', () => {
       assert.strictEqual(isBasketIsolationActiveFromStore(), false);
     });
 
+    it('returns true when the isolation is a SUPERSET of the basket (the basket widened a foreign isolation, #4527)', () => {
+      useViewerStore.setState({
+        pinboardEntities: new Set(['legacy:100', 'legacy:200']),
+        isolatedEntities: new Set([100, 200, 900]),
+        models: new Map(),
+      });
+
+      assert.strictEqual(isBasketIsolationActiveFromStore(), true, 'every basket element is shown; "Show active basket" would evict 900');
+    });
+
     it('returns false when isolated has the same SIZE as the basket but different members', () => {
       // A size-only check would be fooled by a swap: same cardinality,
       // disjoint contents. Membership must actually be verified.
       useViewerStore.setState({
         pinboardEntities: new Set(['legacy:100', 'legacy:200']),
         isolatedEntities: new Set([300, 400]),
-        models: new Map(),
-      });
-
-      assert.strictEqual(isBasketIsolationActiveFromStore(), false);
-    });
-
-    it('returns false when the isolation is a strict SUPERSET of the basket', () => {
-      // The existing "size differs" case only covers isolation SMALLER than
-      // the basket, where the membership loop also fails — so the `!==`
-      // size check itself was never discriminated and could be weakened to
-      // `>` unnoticed. Here every basket id IS isolated but extra elements
-      // are isolated too, so only the size check can say "no". Getting this
-      // wrong lights up the basket's "isolation active" toggle when the
-      // viewport is showing more than the basket.
-      useViewerStore.setState({
-        pinboardEntities: new Set(['legacy:100']),
-        isolatedEntities: new Set([100, 200]),
         models: new Map(),
       });
 

--- a/apps/viewer/src/store/basketVisibleSet.ts
+++ b/apps/viewer/src/store/basketVisibleSet.ts
@@ -551,13 +551,18 @@ export function getSmartBasketInputFromStore(): { refs: EntityRef[]; source: Bas
   return { refs: [], source: 'empty' };
 }
 
+/**
+ * "Is the basket shown?" — every basket element is in the active isolation.
+ * A subset test, not equality: the basket may have WIDENED an isolation
+ * another feature opened (#4527), and then every basket element is visible
+ * even though the channel holds more. Reading that as "not active" would
+ * offer "Show active basket", whose wholesale `showPinboard` evicts exactly
+ * the foreign ids `removeFromBasket` is careful to keep.
+ */
 export function isBasketIsolationActiveFromStore(): boolean {
   const state = useViewerStore.getState();
   if (state.pinboardEntities.size === 0 || state.isolatedEntities === null) return false;
-
-  const basketIds = basketToGlobalIds(state);
-  if (basketIds.size !== state.isolatedEntities.size) return false;
-  for (const id of basketIds) {
+  for (const id of basketToGlobalIds(state)) {
     if (!state.isolatedEntities.has(id)) return false;
   }
   return true;

--- a/apps/viewer/src/store/basketVisibleSet.ts
+++ b/apps/viewer/src/store/basketVisibleSet.ts
@@ -551,14 +551,8 @@ export function getSmartBasketInputFromStore(): { refs: EntityRef[]; source: Bas
   return { refs: [], source: 'empty' };
 }
 
-/**
- * "Is the basket shown?" — every basket element is in the active isolation.
- * A subset test, not equality: the basket may have WIDENED an isolation
- * another feature opened (#4527), and then every basket element is visible
- * even though the channel holds more. Reading that as "not active" would
- * offer "Show active basket", whose wholesale `showPinboard` evicts exactly
- * the foreign ids `removeFromBasket` is careful to keep.
- */
+/** "Is the basket shown?" — every basket element is isolated. A subset test, not equality: a basket that
+ *  WIDENED a foreign isolation (#4527) is shown too, and "Show active basket" would evict the foreign ids. */
 export function isBasketIsolationActiveFromStore(): boolean {
   const state = useViewerStore.getState();
   if (state.pinboardEntities.size === 0 || state.isolatedEntities === null) return false;

--- a/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
@@ -60,4 +60,26 @@ describe('removeModel purges pinboard basket state pointing at a removed model',
       'only the surviving basket entry (B:5 -> global id 1005) should be isolated',
     );
   });
+  it("drops the basket's isolation-ownership record when it names an id of the removed model (#4527)", () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+    useViewerStore.getState().setBasket([
+      { modelId: 'A', expressId: 42 },
+      { modelId: 'B', expressId: 5 },
+    ]);
+    assert.ok(useViewerStore.getState().basketIsolationOwned?.ids.has(42), 'setup: the record claims A:42');
+
+    useViewerStore.getState().removeModel('A');
+
+    assert.strictEqual(
+      useViewerStore.getState().basketIsolationOwned,
+      null,
+      "a claim on the removed model's raw id would collide with a surviving idOffset-0 model — the record must go",
+    );
+  });
 });

--- a/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
@@ -60,7 +60,7 @@ describe('removeModel purges pinboard basket state pointing at a removed model',
       'only the surviving basket entry (B:5 -> global id 1005) should be isolated',
     );
   });
-  it("drops the basket's isolation-ownership record when it names an id of the removed model (#4527)", () => {
+  it("filters the basket's ownership record like the channel when a model is removed (#4527)", () => {
     useViewerStore.setState({
       models: new Map([
         ['A', model('A', 0, 100)],
@@ -72,14 +72,15 @@ describe('removeModel purges pinboard basket state pointing at a removed model',
       { modelId: 'A', expressId: 42 },
       { modelId: 'B', expressId: 5 },
     ]);
-    assert.ok(useViewerStore.getState().basketIsolationOwned?.ids.has(42), 'setup: the record claims A:42');
+    assert.ok(useViewerStore.getState().basketVisibilityOwned?.ids.has(42), 'setup: the record claims A:42');
 
     useViewerStore.getState().removeModel('A');
 
-    assert.strictEqual(
-      useViewerStore.getState().basketIsolationOwned,
-      null,
-      "a claim on the removed model's raw id would collide with a surviving idOffset-0 model — the record must go",
-    );
+    const owned = useViewerStore.getState().basketVisibilityOwned;
+    assert.deepStrictEqual(owned?.ids, new Set([1005]), 'the record is filtered like the channel, not dropped');
+    assert.deepStrictEqual(owned?.claims, new Set([1005]));
+    // The surviving basket can still close the isolation it opened.
+    useViewerStore.getState().removeFromBasket([{ modelId: 'B', expressId: 5 }]);
+    assert.strictEqual(useViewerStore.getState().isolatedEntities, null, 'emptying the basket closes the isolation it opened');
   });
 });

--- a/apps/viewer/src/store/slices/pinboard-isolation.ts
+++ b/apps/viewer/src/store/slices/pinboard-isolation.ts
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The basket's relationship to the shared `isolatedEntities` channel — pure
+ * helpers for `pinboardSlice.ts` (#4527).
+ *
+ * `isolatedEntities` is one `Set<number> | null` written by several owners
+ * (basket, direct isolate, BCF viewpoint restore, lens, search). The basket API
+ * is incremental: `addToBasket` widens whatever is isolated and
+ * `removeFromBasket` narrows it — so it must know which ids IT put there. That
+ * record is `BasketIsolationOwnership`, the basket's instance of the repo-wide
+ * ownership convention in `lib/visibility/ownership.ts`:
+ *
+ *  - `ids`    the channel content as the basket last wrote it. Ownership is
+ *             judged BY VALUE (`ownsCurrentVisibility`): if another writer has
+ *             since replaced the channel, the basket no longer owns it and its
+ *             claims are void — the invalidation middleware
+ *             (`store/visibility-invalidation.ts`) nulls the record on such a
+ *             write, and every helper here re-checks before trusting it.
+ *  - `claims` the ids the basket itself inserted (absent from the channel when
+ *             pinned). An id that was already isolated by someone else when it
+ *             was pinned is NOT claimed, so unpinning it leaves it isolated.
+ *  - `seeded` whether the basket turned `null` into a Set — i.e. opened the
+ *             isolation channel and may close it again when it empties. Not
+ *             derivable from `claims`: a basket added onto a restored
+ *             empty-but-active isolate (#4509) claims everything yet did not
+ *             open the channel.
+ */
+
+import type { EntityRef } from '../types.js';
+import { entityRefToString, stringToEntityRef } from '../types.js';
+import { toGlobalIdForRef } from '../globalId.js';
+import { ownsCurrentVisibility, type VisibilityChannels } from '../../lib/visibility/ownership.js';
+
+export type BasketIsolationOwnership =
+  | { channel: 'isolate'; ids: ReadonlySet<number>; claims: ReadonlySet<number>; seeded: boolean }
+  | null;
+
+type Models = Map<string, { idOffset: number }>;
+
+/** Convert basket EntityRefs to global IDs using model offsets */
+export function basketToGlobalIds(basketEntities: Set<string>, models: Models): Set<number> {
+  const globalIds = new Set<number>();
+  for (const str of basketEntities) {
+    globalIds.add(toGlobalIdForRef(models, stringToEntityRef(str)));
+  }
+  return globalIds;
+}
+
+/** Compute a single EntityRef's global ID */
+export function refToGlobalId(ref: EntityRef, models: Models): number {
+  return toGlobalIdForRef(models, ref);
+}
+
+export function refsToEntityKeySet(refs: EntityRef[]): Set<string> {
+  const keys = new Set<string>();
+  for (const ref of refs) keys.add(entityRefToString(ref));
+  return keys;
+}
+
+export function entityKeysToRefs(keys: Iterable<string>): EntityRef[] {
+  return [...keys].map(stringToEntityRef);
+}
+
+/** The record for a channel the basket wrote wholesale: it owns every id. */
+export function ownedWholesale(isolated: Set<number> | null): BasketIsolationOwnership {
+  return isolated === null ? null : { channel: 'isolate', ids: new Set(isolated), claims: new Set(isolated), seeded: true };
+}
+
+/**
+ * Wholesale basket → visibility (`setBasket`, view restore, `showPinboard`):
+ * the channel becomes exactly the basket's ids, and the basket owns all of it.
+ */
+export function computeBasketVisibility(
+  nextBasket: Set<string>,
+  models: Models,
+  currentHidden: Set<number>,
+  unhideRefs?: EntityRef[],
+): { isolatedEntities: Set<number> | null; hiddenEntities: Set<number>; basketIsolationOwned: BasketIsolationOwnership } {
+  if (nextBasket.size === 0) {
+    return { isolatedEntities: null, hiddenEntities: currentHidden, basketIsolationOwned: null };
+  }
+  const isolatedEntities = basketToGlobalIds(nextBasket, models);
+  const basketIsolationOwned = ownedWholesale(isolatedEntities);
+  if (!unhideRefs || unhideRefs.length === 0) {
+    return { isolatedEntities, hiddenEntities: currentHidden, basketIsolationOwned };
+  }
+  const hiddenEntities = new Set<number>(currentHidden);
+  for (const ref of unhideRefs) hiddenEntities.delete(toGlobalIdForRef(models, ref));
+  return { isolatedEntities, hiddenEntities, basketIsolationOwned };
+}
+
+interface IsolationState extends VisibilityChannels {
+  isolatedEntities: Set<number> | null;
+  hiddenEntities: Set<number>;
+  models: Models;
+  basketIsolationOwned: BasketIsolationOwnership;
+}
+
+/** The basket's record, but only if the channel still holds what the basket wrote. */
+function liveRecord(state: IsolationState): Exclude<BasketIsolationOwnership, null> | null {
+  const owned = state.basketIsolationOwned;
+  return owned && ownsCurrentVisibility(state, owned) ? owned : null;
+}
+
+/**
+ * `addToBasket`: widen the isolation with the pinned refs' ids, claiming only
+ * the ones that were not isolated already; open the channel when it was null.
+ */
+export function basketAddIsolation(
+  state: IsolationState,
+  nextBasket: Set<string>,
+  refs: EntityRef[],
+): { isolatedEntities: Set<number>; hiddenEntities: Set<number>; basketIsolationOwned: BasketIsolationOwnership } {
+  const hiddenEntities = new Set<number>(state.hiddenEntities);
+  const prev = state.isolatedEntities;
+  let isolatedEntities: Set<number>;
+  let claims: Set<number>;
+  let seeded: boolean;
+  if (prev === null) {
+    // The basket opens the channel: everything in it is the basket's.
+    isolatedEntities = basketToGlobalIds(nextBasket, state.models);
+    claims = new Set(isolatedEntities);
+    seeded = true;
+  } else {
+    const live = liveRecord(state);
+    isolatedEntities = new Set(prev);
+    claims = new Set(live?.claims ?? []);
+    seeded = live?.seeded ?? false;
+    for (const ref of refs) {
+      const gid = refToGlobalId(ref, state.models);
+      if (!isolatedEntities.has(gid)) {
+        isolatedEntities.add(gid);
+        claims.add(gid);
+      }
+    }
+  }
+  for (const ref of refs) hiddenEntities.delete(refToGlobalId(ref, state.models));
+  return {
+    isolatedEntities,
+    hiddenEntities,
+    basketIsolationOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded },
+  };
+}
+
+/**
+ * `removeFromBasket`: narrow the isolation by the removed refs' ids — only the
+ * ids the basket claimed and no surviving basket entry still needs. A channel
+ * the basket does not own (replaced by another writer) is left untouched; a
+ * channel the basket opened is closed again when the basket empties.
+ */
+export function basketRemoveIsolation(
+  state: IsolationState,
+  nextBasket: Set<string>,
+  removed: EntityRef[],
+): { isolatedEntities?: Set<number> | null; basketIsolationOwned: BasketIsolationOwnership } {
+  const prev = state.isolatedEntities;
+  if (nextBasket.size === 0) {
+    if (prev === null) return { basketIsolationOwned: null };
+    const live = liveRecord(state);
+    if (!live) return { basketIsolationOwned: null }; // someone else's isolation: leave it
+    if (live.seeded) return { isolatedEntities: null, basketIsolationOwned: null };
+    // The basket widened an isolation it did not open: give back the remainder
+    // (possibly an empty, still-active Set — a valid state, see #4509).
+    const remainder = new Set(prev);
+    for (const id of live.claims) remainder.delete(id);
+    return { isolatedEntities: remainder, basketIsolationOwned: null };
+  }
+  if (prev === null) {
+    // The channel was cleared externally while the basket was non-empty
+    // ("hide active basket"): the surviving basket re-takes it wholesale.
+    const isolatedEntities = basketToGlobalIds(nextBasket, state.models);
+    return { isolatedEntities, basketIsolationOwned: ownedWholesale(isolatedEntities) };
+  }
+  const live = liveRecord(state);
+  if (!live) return { basketIsolationOwned: null }; // replaced by another writer: not ours to narrow
+  const surviving = basketToGlobalIds(nextBasket, state.models);
+  const isolatedEntities = new Set(prev);
+  const claims = new Set(live.claims);
+  for (const ref of removed) {
+    const gid = refToGlobalId(ref, state.models);
+    // Two refs can alias one global id (`toGlobalIdForRef` falls back to the raw
+    // expressId for unregistered models), so an id a surviving entry still
+    // derives stays; so does an id the basket never claimed.
+    if (surviving.has(gid) || !claims.has(gid)) continue;
+    isolatedEntities.delete(gid);
+    claims.delete(gid);
+  }
+  return {
+    isolatedEntities,
+    basketIsolationOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded: live.seeded },
+  };
+}

--- a/apps/viewer/src/store/slices/pinboard-isolation.ts
+++ b/apps/viewer/src/store/slices/pinboard-isolation.ts
@@ -78,30 +78,30 @@ export function computeBasketVisibility(
   models: Models,
   currentHidden: Set<number>,
   unhideRefs?: EntityRef[],
-): { isolatedEntities: Set<number> | null; hiddenEntities: Set<number>; basketIsolationOwned: BasketIsolationOwnership } {
+): { isolatedEntities: Set<number> | null; hiddenEntities: Set<number>; basketVisibilityOwned: BasketIsolationOwnership } {
   if (nextBasket.size === 0) {
-    return { isolatedEntities: null, hiddenEntities: currentHidden, basketIsolationOwned: null };
+    return { isolatedEntities: null, hiddenEntities: currentHidden, basketVisibilityOwned: null };
   }
   const isolatedEntities = basketToGlobalIds(nextBasket, models);
-  const basketIsolationOwned = ownedWholesale(isolatedEntities);
+  const basketVisibilityOwned = ownedWholesale(isolatedEntities);
   if (!unhideRefs || unhideRefs.length === 0) {
-    return { isolatedEntities, hiddenEntities: currentHidden, basketIsolationOwned };
+    return { isolatedEntities, hiddenEntities: currentHidden, basketVisibilityOwned };
   }
   const hiddenEntities = new Set<number>(currentHidden);
   for (const ref of unhideRefs) hiddenEntities.delete(toGlobalIdForRef(models, ref));
-  return { isolatedEntities, hiddenEntities, basketIsolationOwned };
+  return { isolatedEntities, hiddenEntities, basketVisibilityOwned };
 }
 
 interface IsolationState extends VisibilityChannels {
   isolatedEntities: Set<number> | null;
   hiddenEntities: Set<number>;
   models: Models;
-  basketIsolationOwned: BasketIsolationOwnership;
+  basketVisibilityOwned: BasketIsolationOwnership;
 }
 
 /** The basket's record, but only if the channel still holds what the basket wrote. */
 function liveRecord(state: IsolationState): Exclude<BasketIsolationOwnership, null> | null {
-  const owned = state.basketIsolationOwned;
+  const owned = state.basketVisibilityOwned;
   return owned && ownsCurrentVisibility(state, owned) ? owned : null;
 }
 
@@ -113,7 +113,7 @@ export function basketAddIsolation(
   state: IsolationState,
   nextBasket: Set<string>,
   refs: EntityRef[],
-): { isolatedEntities: Set<number>; hiddenEntities: Set<number>; basketIsolationOwned: BasketIsolationOwnership } {
+): { isolatedEntities: Set<number>; hiddenEntities: Set<number>; basketVisibilityOwned: BasketIsolationOwnership } {
   const hiddenEntities = new Set<number>(state.hiddenEntities);
   const prev = state.isolatedEntities;
   let isolatedEntities: Set<number>;
@@ -141,7 +141,7 @@ export function basketAddIsolation(
   return {
     isolatedEntities,
     hiddenEntities,
-    basketIsolationOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded },
+    basketVisibilityOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded },
   };
 }
 
@@ -155,27 +155,27 @@ export function basketRemoveIsolation(
   state: IsolationState,
   nextBasket: Set<string>,
   removed: EntityRef[],
-): { isolatedEntities?: Set<number> | null; basketIsolationOwned: BasketIsolationOwnership } {
+): { isolatedEntities?: Set<number> | null; basketVisibilityOwned: BasketIsolationOwnership } {
   const prev = state.isolatedEntities;
   if (nextBasket.size === 0) {
-    if (prev === null) return { basketIsolationOwned: null };
+    if (prev === null) return { basketVisibilityOwned: null };
     const live = liveRecord(state);
-    if (!live) return { basketIsolationOwned: null }; // someone else's isolation: leave it
-    if (live.seeded) return { isolatedEntities: null, basketIsolationOwned: null };
+    if (!live) return { basketVisibilityOwned: null }; // someone else's isolation: leave it
+    if (live.seeded) return { isolatedEntities: null, basketVisibilityOwned: null };
     // The basket widened an isolation it did not open: give back the remainder
     // (possibly an empty, still-active Set — a valid state, see #4509).
     const remainder = new Set(prev);
     for (const id of live.claims) remainder.delete(id);
-    return { isolatedEntities: remainder, basketIsolationOwned: null };
+    return { isolatedEntities: remainder, basketVisibilityOwned: null };
   }
   if (prev === null) {
     // The channel was cleared externally while the basket was non-empty
     // ("hide active basket"): the surviving basket re-takes it wholesale.
     const isolatedEntities = basketToGlobalIds(nextBasket, state.models);
-    return { isolatedEntities, basketIsolationOwned: ownedWholesale(isolatedEntities) };
+    return { isolatedEntities, basketVisibilityOwned: ownedWholesale(isolatedEntities) };
   }
   const live = liveRecord(state);
-  if (!live) return { basketIsolationOwned: null }; // replaced by another writer: not ours to narrow
+  if (!live) return { basketVisibilityOwned: null }; // replaced by another writer: not ours to narrow
   const surviving = basketToGlobalIds(nextBasket, state.models);
   const isolatedEntities = new Set(prev);
   const claims = new Set(live.claims);
@@ -190,6 +190,6 @@ export function basketRemoveIsolation(
   }
   return {
     isolatedEntities,
-    basketIsolationOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded: live.seeded },
+    basketVisibilityOwned: { channel: 'isolate', ids: new Set(isolatedEntities), claims, seeded: live.seeded },
   };
 }

--- a/apps/viewer/src/store/slices/pinboard-isolation.ts
+++ b/apps/viewer/src/store/slices/pinboard-isolation.ts
@@ -146,6 +146,16 @@ export function basketAddIsolation(
 }
 
 /**
+ * Clearing the basket (`clearBasket`, `clearPinboard`, `setBasket([])`): the
+ * same release rule as emptying it by removal — close the channel only if the
+ * basket opened it, hand back the remainder if it only widened someone else's,
+ * leave a channel it lost untouched.
+ */
+export function basketReleaseIsolation(state: IsolationState): { isolatedEntities?: Set<number> | null; basketVisibilityOwned: BasketIsolationOwnership } {
+  return basketRemoveIsolation(state, new Set(), []);
+}
+
+/**
  * `removeFromBasket`: narrow the isolation by the removed refs' ids — only the
  * ids the basket claimed and no surviving basket entry still needs. A channel
  * the basket does not own (replaced by another writer) is left untouched; a

--- a/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
@@ -24,6 +24,7 @@ export const pinboardTeardown = defineSliceTeardown(
     'basketViews',
     'activeBasketViewId',
     'basketPresentationVisible',
+    'basketIsolationOwned',
   ],
   {
     'session-reset': () => ({
@@ -33,6 +34,7 @@ export const pinboardTeardown = defineSliceTeardown(
       activeBasketViewId: null,
       basketPresentationVisible: false,
       hierarchyBasketSelection: new Set<string>(),
+      basketIsolationOwned: null,
     }),
     // Same dangling-ref shape as the 'model-removed' purge below, for the
     // full-teardown path: with every model gone, every basket ref is stale by
@@ -43,6 +45,7 @@ export const pinboardTeardown = defineSliceTeardown(
     'all-models-cleared': () => ({
       pinboardEntities: new Set<string>(),
       hierarchyBasketSelection: new Set<string>(),
+      basketIsolationOwned: null,
     }),
     'model-removed': (scope, state) => {
       // Pinboard/basket state is keyed the same way as `selectedEntitiesSet` --
@@ -70,14 +73,26 @@ export const pinboardTeardown = defineSliceTeardown(
       // equal-but-new Sets. `syncSourceModel` runs this same scope again
       // straight after `removeModel`, and a fresh reference there would re-notify
       // every basket subscriber for a set that did not move.
+      // The ownership record names global ids; one that belonged to the
+      // removed model is stale, and a stale raw-expressId claim would collide
+      // with a surviving idOffset-0 model — drop the whole record, the basket
+      // re-records on its next write.
+      const owned = state.basketIsolationOwned ?? null;
+      const ownedStale =
+        owned !== null && ([...owned.ids].some(scope.isStale) || [...owned.claims].some(scope.isStale));
       if (
         keptPinboard.size === priorPinboard.size &&
-        keptHierarchyBasket.size === priorHierarchyBasket.size
+        keptHierarchyBasket.size === priorHierarchyBasket.size &&
+        !ownedStale
       ) {
         return {};
       }
 
-      return { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket };
+      return {
+        pinboardEntities: keptPinboard,
+        hierarchyBasketSelection: keptHierarchyBasket,
+        ...(ownedStale ? { basketIsolationOwned: null } : {}),
+      };
     },
   },
 );

--- a/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
@@ -24,7 +24,7 @@ export const pinboardTeardown = defineSliceTeardown(
     'basketViews',
     'activeBasketViewId',
     'basketPresentationVisible',
-    'basketIsolationOwned',
+    'basketVisibilityOwned',
   ],
   {
     'session-reset': () => ({
@@ -34,7 +34,7 @@ export const pinboardTeardown = defineSliceTeardown(
       activeBasketViewId: null,
       basketPresentationVisible: false,
       hierarchyBasketSelection: new Set<string>(),
-      basketIsolationOwned: null,
+      basketVisibilityOwned: null,
     }),
     // Same dangling-ref shape as the 'model-removed' purge below, for the
     // full-teardown path: with every model gone, every basket ref is stale by
@@ -45,7 +45,7 @@ export const pinboardTeardown = defineSliceTeardown(
     'all-models-cleared': () => ({
       pinboardEntities: new Set<string>(),
       hierarchyBasketSelection: new Set<string>(),
-      basketIsolationOwned: null,
+      basketVisibilityOwned: null,
     }),
     'model-removed': (scope, state) => {
       // Pinboard/basket state is keyed the same way as `selectedEntitiesSet` --
@@ -73,11 +73,13 @@ export const pinboardTeardown = defineSliceTeardown(
       // equal-but-new Sets. `syncSourceModel` runs this same scope again
       // straight after `removeModel`, and a fresh reference there would re-notify
       // every basket subscriber for a set that did not move.
-      // The ownership record names global ids; one that belonged to the
-      // removed model is stale, and a stale raw-expressId claim would collide
-      // with a surviving idOffset-0 model — drop the whole record, the basket
-      // re-records on its next write.
-      const owned = state.basketIsolationOwned ?? null;
+      // The ownership record names global ids; the visibility teardown drops
+      // the removed model's ids from the channel in this same merged patch,
+      // so the record is FILTERED the same way — dropping it instead would
+      // leave the surviving basket unable to close an isolation it opened
+      // (an empty basket with the dock's buttons disabled). Null only when
+      // nothing of it survives.
+      const owned = state.basketVisibilityOwned ?? null;
       const ownedStale =
         owned !== null && ([...owned.ids].some(scope.isStale) || [...owned.claims].some(scope.isStale));
       if (
@@ -87,11 +89,16 @@ export const pinboardTeardown = defineSliceTeardown(
       ) {
         return {};
       }
+      const keptIds = owned ? new Set([...owned.ids].filter((id) => !scope.isStale(id))) : null;
+      const keptOwned =
+        owned && keptIds && keptIds.size > 0
+          ? { ...owned, ids: keptIds, claims: new Set([...owned.claims].filter((id) => !scope.isStale(id))) }
+          : null;
 
       return {
         pinboardEntities: keptPinboard,
         hierarchyBasketSelection: keptHierarchyBasket,
-        ...(ownedStale ? { basketIsolationOwned: null } : {}),
+        ...(ownedStale ? { basketVisibilityOwned: keptOwned } : {}),
       };
     },
   },

--- a/apps/viewer/src/store/slices/pinboardSlice.test.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.test.ts
@@ -207,24 +207,24 @@ describe('PinboardSlice', () => {
   // invalidation middleware, so a foreign replacement is simulated by writing
   // the channel and nulling the record — exactly what the middleware does.
   describe('basket-owned isolation (#4527)', () => {
-    const foreignReplace = (ids: number[]) => setState({ isolatedEntities: new Set(ids), basketIsolationOwned: null });
+    const foreignReplace = (ids: number[]) => setState({ isolatedEntities: new Set(ids), basketVisibilityOwned: null });
 
     it('emptying the basket by removal keeps an isolation it only widened', () => {
       const FOREIGN = 500;
       setState({ isolatedEntities: new Set([FOREIGN]) }); // opened by someone else
       state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
-      assert.ok(state.basketIsolationOwned && !state.basketIsolationOwned.seeded, 'the basket did not open the channel');
+      assert.ok(state.basketVisibilityOwned && !state.basketVisibilityOwned.seeded, 'the basket did not open the channel');
 
       state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
 
       assert.deepStrictEqual(state.isolatedEntities, new Set([FOREIGN]), 'the external isolation survives, not null');
-      assert.strictEqual(state.basketIsolationOwned, null);
+      assert.strictEqual(state.basketVisibilityOwned, null);
     });
 
     it('emptying the basket by removal closes an isolation the basket opened', () => {
       assert.strictEqual(state.isolatedEntities, null);
       state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
-      assert.ok(state.basketIsolationOwned?.seeded);
+      assert.ok(state.basketVisibilityOwned?.seeded);
       state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
       assert.strictEqual(state.isolatedEntities, null);
     });
@@ -232,7 +232,7 @@ describe('PinboardSlice', () => {
     it('an id that was already isolated when pinned is not claimed and survives unpinning', () => {
       setState({ isolatedEntities: new Set([100]) });
       state.addToBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
-      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([200]));
+      assert.deepStrictEqual(state.basketVisibilityOwned?.claims, new Set([200]));
       state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
       assert.ok(state.isolatedEntities!.has(100), '100 belonged to another writer');
       state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
@@ -256,19 +256,19 @@ describe('PinboardSlice', () => {
 
     it('after an external clearIsolation the surviving basket re-takes the channel and records it', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
-      setState({ isolatedEntities: null, basketIsolationOwned: null }); // "hide active basket"
+      setState({ isolatedEntities: null, basketVisibilityOwned: null }); // "hide active basket"
       state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
       assert.deepStrictEqual(state.isolatedEntities, new Set([200]));
-      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([200]));
+      assert.deepStrictEqual(state.basketVisibilityOwned?.claims, new Set([200]));
       state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
       assert.strictEqual(state.isolatedEntities, null, 'the re-take opened the channel, so emptying closes it');
     });
 
     it('showPinboard records ownership so a later removal narrows', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
-      setState({ isolatedEntities: null, basketIsolationOwned: null });
+      setState({ isolatedEntities: null, basketVisibilityOwned: null });
       state.showPinboard();
-      assert.deepStrictEqual(state.basketIsolationOwned?.ids, new Set([100, 200]));
+      assert.deepStrictEqual(state.basketVisibilityOwned?.ids, new Set([100, 200]));
       state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
       assert.deepStrictEqual(state.isolatedEntities, new Set([100]));
     });
@@ -276,19 +276,19 @@ describe('PinboardSlice', () => {
     it('adding onto an empty-but-active foreign isolate and removing everything gives the empty Set back', () => {
       setState({ isolatedEntities: new Set() }); // a restored BCF viewpoint isolating nothing (#4509)
       state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
-      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([100]));
-      assert.ok(!state.basketIsolationOwned?.seeded);
+      assert.deepStrictEqual(state.basketVisibilityOwned?.claims, new Set([100]));
+      assert.ok(!state.basketVisibilityOwned?.seeded);
       state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
       assert.deepStrictEqual(state.isolatedEntities, new Set(), 'active-but-empty, not null');
     });
 
     it('adding with the channel closed and a pre-existing basket claims the union', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
-      setState({ isolatedEntities: null, basketIsolationOwned: null });
+      setState({ isolatedEntities: null, basketVisibilityOwned: null });
       state.addToBasket([{ modelId: 'legacy', expressId: 200 }]);
       assert.deepStrictEqual(state.isolatedEntities, new Set([100, 200]));
-      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([100, 200]));
-      assert.ok(state.basketIsolationOwned?.seeded);
+      assert.deepStrictEqual(state.basketVisibilityOwned?.claims, new Set([100, 200]));
+      assert.ok(state.basketVisibilityOwned?.seeded);
     });
   });
 

--- a/apps/viewer/src/store/slices/pinboardSlice.test.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.test.ts
@@ -282,6 +282,23 @@ describe('PinboardSlice', () => {
       assert.deepStrictEqual(state.isolatedEntities, new Set(), 'active-but-empty, not null');
     });
 
+    it('clearBasket closes an isolation the basket opened, keeps one it only widened, leaves one it lost', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      state.clearBasket();
+      assert.strictEqual(state.isolatedEntities, null, 'opened by the basket: closed');
+
+      setState({ isolatedEntities: new Set([500]) });
+      state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
+      state.clearBasket();
+      assert.deepStrictEqual(state.isolatedEntities, new Set([500]), 'widened only: the remainder is handed back');
+
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      foreignReplace([100, 900]);
+      state.clearBasket();
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100, 900]), "lost to another writer: not the basket's to close");
+      assert.strictEqual(state.pinboardEntities.size, 0);
+    });
+
     it('adding with the channel closed and a pre-existing basket claims the union', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
       setState({ isolatedEntities: null, basketVisibilityOwned: null });

--- a/apps/viewer/src/store/slices/pinboardSlice.test.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.test.ts
@@ -201,6 +201,97 @@ describe('PinboardSlice', () => {
     });
   });
 
+  // #4527: the basket records which isolation ids it inserted and whether it
+  // opened the channel, and judges ownership of the channel BY VALUE before it
+  // narrows anything (lib/visibility/ownership.ts). The harness has no
+  // invalidation middleware, so a foreign replacement is simulated by writing
+  // the channel and nulling the record — exactly what the middleware does.
+  describe('basket-owned isolation (#4527)', () => {
+    const foreignReplace = (ids: number[]) => setState({ isolatedEntities: new Set(ids), basketIsolationOwned: null });
+
+    it('emptying the basket by removal keeps an isolation it only widened', () => {
+      const FOREIGN = 500;
+      setState({ isolatedEntities: new Set([FOREIGN]) }); // opened by someone else
+      state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.ok(state.basketIsolationOwned && !state.basketIsolationOwned.seeded, 'the basket did not open the channel');
+
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+
+      assert.deepStrictEqual(state.isolatedEntities, new Set([FOREIGN]), 'the external isolation survives, not null');
+      assert.strictEqual(state.basketIsolationOwned, null);
+    });
+
+    it('emptying the basket by removal closes an isolation the basket opened', () => {
+      assert.strictEqual(state.isolatedEntities, null);
+      state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.ok(state.basketIsolationOwned?.seeded);
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.strictEqual(state.isolatedEntities, null);
+    });
+
+    it('an id that was already isolated when pinned is not claimed and survives unpinning', () => {
+      setState({ isolatedEntities: new Set([100]) });
+      state.addToBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
+      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([200]));
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.ok(state.isolatedEntities!.has(100), '100 belonged to another writer');
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100]));
+    });
+
+    it('a foreign REPLACEMENT of the channel ends the basket claim: unpinning touches nothing', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      foreignReplace([100, 900]); // e.g. search isolates a set that happens to include 100
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100, 900]), "the search isolation is not the basket's");
+      assert.strictEqual(state.pinboardEntities.size, 0);
+    });
+
+    it('a foreign subset replacement is not emptied either', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
+      foreignReplace([100]);
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100]));
+    });
+
+    it('after an external clearIsolation the surviving basket re-takes the channel and records it', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
+      setState({ isolatedEntities: null, basketIsolationOwned: null }); // "hide active basket"
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([200]));
+      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([200]));
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
+      assert.strictEqual(state.isolatedEntities, null, 'the re-take opened the channel, so emptying closes it');
+    });
+
+    it('showPinboard records ownership so a later removal narrows', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }, { modelId: 'legacy', expressId: 200 }]);
+      setState({ isolatedEntities: null, basketIsolationOwned: null });
+      state.showPinboard();
+      assert.deepStrictEqual(state.basketIsolationOwned?.ids, new Set([100, 200]));
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 200 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100]));
+    });
+
+    it('adding onto an empty-but-active foreign isolate and removing everything gives the empty Set back', () => {
+      setState({ isolatedEntities: new Set() }); // a restored BCF viewpoint isolating nothing (#4509)
+      state.addToBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([100]));
+      assert.ok(!state.basketIsolationOwned?.seeded);
+      state.removeFromBasket([{ modelId: 'legacy', expressId: 100 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set(), 'active-but-empty, not null');
+    });
+
+    it('adding with the channel closed and a pre-existing basket claims the union', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      setState({ isolatedEntities: null, basketIsolationOwned: null });
+      state.addToBasket([{ modelId: 'legacy', expressId: 200 }]);
+      assert.deepStrictEqual(state.isolatedEntities, new Set([100, 200]));
+      assert.deepStrictEqual(state.basketIsolationOwned?.claims, new Set([100, 200]));
+      assert.ok(state.basketIsolationOwned?.seeded);
+    });
+  });
+
   describe('saveCurrentBasketView', () => {
     it('creates view with unique id and sets activeBasketViewId', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }]);

--- a/apps/viewer/src/store/slices/pinboardSlice.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.ts
@@ -19,8 +19,17 @@
 import type { StateCreator } from 'zustand';
 import type { Drawing2D } from '@ifc-lite/drawing-2d';
 import type { CameraCallbacks, CameraViewpoint, EntityRef, SectionPlane } from '../types.js';
-import { entityRefToString, stringToEntityRef } from '../types.js';
-import { toGlobalIdForRef } from '../globalId.js';
+import { entityRefToString } from '../types.js';
+import {
+  basketAddIsolation,
+  basketRemoveIsolation,
+  basketToGlobalIds,
+  computeBasketVisibility,
+  entityKeysToRefs,
+  ownedWholesale,
+  refsToEntityKeySet,
+  type BasketIsolationOwnership,
+} from './pinboard-isolation.js';
 
 export type BasketSource = 'selection' | 'visible' | 'hierarchy' | 'manual';
 
@@ -90,23 +99,18 @@ export interface PinboardSlice {
   /** Last hierarchy-derived set used for "Hierarchy" basket source */
   hierarchyBasketSelection: Set<string>;
 
+  /**
+   * The basket's claim on `isolatedEntities` — which ids it inserted and
+   * whether it opened the channel. Nulled by the ownership middleware the
+   * moment another writer replaces the channel. See pinboard-isolation.ts.
+   */
+  basketIsolationOwned: BasketIsolationOwnership;
+
   // Actions
-  /** Add entities to pinboard/basket */
-  addToPinboard: (refs: EntityRef[]) => void;
-  /** Remove entities from pinboard/basket */
-  removeFromPinboard: (refs: EntityRef[]) => void;
-  /** Replace pinboard/basket contents (= operation) */
-  setPinboard: (refs: EntityRef[]) => void;
   /** Clear pinboard/basket and isolation */
   clearPinboard: () => void;
   /** Isolate pinboard entities (sync basket → isolatedEntities) */
   showPinboard: () => void;
-  /** Check if entity is in basket */
-  isInPinboard: (ref: EntityRef) => boolean;
-  /** Get basket count */
-  getPinboardCount: () => number;
-  /** Get all basket entities as EntityRef array */
-  getPinboardEntities: () => EntityRef[];
 
   // Basket actions (semantic aliases that also sync isolation)
   /** = Set basket to exactly these entities and isolate them */
@@ -139,63 +143,6 @@ export interface PinboardSlice {
   refreshBasketViewThumbnail: (viewId: string, thumbnailDataUrl: string | null, viewpoint?: CameraViewpoint | null) => void;
   /** Set optional transition duration for a saved basket view (ms). */
   setBasketViewTransitionMs: (viewId: string, transitionMs: number | null) => void;
-}
-
-/** Convert basket EntityRefs to global IDs using model offsets */
-function basketToGlobalIds(
-  basketEntities: Set<string>,
-  models: Map<string, { idOffset: number }>,
-): Set<number> {
-  const globalIds = new Set<number>();
-  for (const str of basketEntities) {
-    const ref = stringToEntityRef(str);
-    globalIds.add(toGlobalIdForRef(models, ref));
-  }
-  return globalIds;
-}
-
-/** Compute a single EntityRef's global ID */
-function refToGlobalId(ref: EntityRef, models: Map<string, { idOffset: number }>): number {
-  return toGlobalIdForRef(models, ref);
-}
-
-function refsToEntityKeySet(refs: EntityRef[]): Set<string> {
-  const keys = new Set<string>();
-  for (const ref of refs) keys.add(entityRefToString(ref));
-  return keys;
-}
-
-function entityKeysToRefs(keys: Iterable<string>): EntityRef[] {
-  const refs: EntityRef[] = [];
-  for (const key of keys) refs.push(stringToEntityRef(key));
-  return refs;
-}
-
-/**
- * Compute isolation + hidden state from basket entities, unhiding any newly added refs.
- *
- * This is the single source of truth for the "basket → visibility" sync that
- * several pinboard actions need.  The incremental add/remove methods bypass
- * this for performance and maintain their own logic.
- */
-function computeBasketVisibility(
-  nextBasket: Set<string>,
-  models: Map<string, { idOffset: number }>,
-  currentHidden: Set<number>,
-  unhideRefs?: EntityRef[],
-): { isolatedEntities: Set<number> | null; hiddenEntities: Set<number> } {
-  if (nextBasket.size === 0) {
-    return { isolatedEntities: null, hiddenEntities: currentHidden };
-  }
-  const isolatedEntities = basketToGlobalIds(nextBasket, models);
-  if (!unhideRefs || unhideRefs.length === 0) {
-    return { isolatedEntities, hiddenEntities: currentHidden };
-  }
-  const hiddenEntities = new Set<number>(currentHidden);
-  for (const ref of unhideRefs) {
-    hiddenEntities.delete(toGlobalIdForRef(models, ref));
-  }
-  return { isolatedEntities, hiddenEntities };
 }
 
 function createViewId(): string {
@@ -235,76 +182,24 @@ export const createPinboardSlice: StateCreator<
 > = (set, get) => ({
   // Initial state
   pinboardEntities: new Set(),
+  basketIsolationOwned: null,
   basketViews: [],
   activeBasketViewId: null,
   basketPresentationVisible: false,
   hierarchyBasketSelection: new Set(),
 
-  // Legacy actions (kept for backward compat, but now they also sync isolation)
-  addToPinboard: (refs) => {
-    if (refs.length > 0) {
-      get().clearEntitySelection();
-    }
-    set((state) => {
-      const next = new Set<string>(state.pinboardEntities);
-      for (const ref of refs) {
-        next.add(entityRefToString(ref));
-      }
-      const visibility = computeBasketVisibility(next, state.models, state.hiddenEntities, refs);
-      return {
-        pinboardEntities: next,
-        ...visibility,
-        activeBasketViewId: null,
-      };
-    });
-  },
-
-  removeFromPinboard: (refs) => {
-    set((state) => {
-      const next = new Set<string>(state.pinboardEntities);
-      for (const ref of refs) {
-        next.delete(entityRefToString(ref));
-      }
-      if (next.size === 0) {
-        return { pinboardEntities: next, isolatedEntities: null, activeBasketViewId: null };
-      }
-      const isolatedEntities = basketToGlobalIds(next, state.models);
-      return { pinboardEntities: next, isolatedEntities, activeBasketViewId: null };
-    });
-  },
-
-  setPinboard: (refs) => {
-    if (refs.length > 0) {
-      get().clearEntitySelection();
-    }
-    const next = new Set<string>();
-    for (const ref of refs) {
-      next.add(entityRefToString(ref));
-    }
-    const s = get();
-    const visibility = computeBasketVisibility(next, s.models, s.hiddenEntities, refs);
-    set({ pinboardEntities: next, ...visibility, activeBasketViewId: null });
-  },
-
-  clearPinboard: () => set({ pinboardEntities: new Set(), isolatedEntities: null, activeBasketViewId: null }),
+  // The basket is the isolation mechanism when non-empty. Every write of
+  // `isolatedEntities` below carries `basketIsolationOwned` in the SAME patch
+  // (the ownership middleware resets records absent from a channel-writing
+  // patch), and the incremental steps re-check ownership by value first.
+  clearPinboard: () =>
+    set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null }),
 
   showPinboard: () => {
     const state = get();
     if (state.pinboardEntities.size === 0) return;
     const isolatedEntities = basketToGlobalIds(state.pinboardEntities, state.models);
-    set({ isolatedEntities });
-  },
-
-  isInPinboard: (ref) => get().pinboardEntities.has(entityRefToString(ref)),
-
-  getPinboardCount: () => get().pinboardEntities.size,
-
-  getPinboardEntities: () => {
-    const result: EntityRef[] = [];
-    for (const str of get().pinboardEntities) {
-      result.push(stringToEntityRef(str));
-    }
-    return result;
+    set({ isolatedEntities, basketIsolationOwned: ownedWholesale(isolatedEntities) });
   },
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -315,7 +210,7 @@ export const createPinboardSlice: StateCreator<
   /** = Set basket to exactly these entities and isolate them */
   setBasket: (refs) => {
     if (refs.length === 0) {
-      set({ pinboardEntities: new Set(), isolatedEntities: null, activeBasketViewId: null });
+      set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null });
       return;
     }
     get().clearEntitySelection();
@@ -334,19 +229,8 @@ export const createPinboardSlice: StateCreator<
     get().clearEntitySelection();
     set((state) => {
       const next = new Set<string>(state.pinboardEntities);
-      for (const ref of refs) {
-        next.add(entityRefToString(ref));
-      }
-      const hiddenEntities = new Set<number>(state.hiddenEntities);
-      // Incrementally add new globalIds to existing isolation set instead of re-parsing all
-      const prevIsolated = state.isolatedEntities;
-      const isolatedEntities = prevIsolated ? new Set<number>(prevIsolated) : basketToGlobalIds(state.pinboardEntities, state.models);
-      for (const ref of refs) {
-        const gid = refToGlobalId(ref, state.models);
-        isolatedEntities.add(gid);
-        hiddenEntities.delete(gid);
-      }
-      return { pinboardEntities: next, isolatedEntities, hiddenEntities, activeBasketViewId: null };
+      for (const ref of refs) next.add(entityRefToString(ref));
+      return { pinboardEntities: next, ...basketAddIsolation(state, next, refs), activeBasketViewId: null };
     });
   },
 
@@ -355,43 +239,16 @@ export const createPinboardSlice: StateCreator<
     if (refs.length === 0) return;
     set((state) => {
       const next = new Set<string>(state.pinboardEntities);
-      // Only refs that were IN the basket may touch the isolation below (a never-pinned ref has no claim on its global id).
+      // Only refs that were IN the basket may touch the isolation (a never-pinned ref has no claim on its global id).
       const removed = refs.filter((ref) => next.delete(entityRefToString(ref)));
       if (removed.length === 0) return {};
-      if (next.size === 0) {
-        return { pinboardEntities: next, isolatedEntities: null, activeBasketViewId: null };
-      }
-      // Two distinct EntityRefs can derive the SAME global id
-      // (`toGlobalIdForRef` falls back to the raw expressId for the
-      // 'legacy'/'default'/'__legacy__' sentinels and for any modelId not yet
-      // registered in `models`), so deleting each removed ref's global id
-      // outright could evict one that a surviving basket entry still
-      // requires. Recompute the surviving basket's own global ids and delete
-      // only ids that set no longer contains.
-      //
-      // The deletion is applied to the PREVIOUS isolation rather than
-      // replacing it with the recomputed set, to stay symmetric with
-      // `addToBasket`, which seeds from `state.isolatedEntities` and so
-      // preserves ids this slice did not author (a restored BCF viewpoint, a
-      // lens rule, a search isolate). A wholesale recompute would let pinning
-      // one element and unpinning another quietly destroy the isolation the
-      // user was working inside.
-      const surviving = basketToGlobalIds(next, state.models);
-      const prevIsolated = state.isolatedEntities;
-      if (prevIsolated === null) {
-        return { pinboardEntities: next, isolatedEntities: surviving, activeBasketViewId: null };
-      }
-      const isolatedEntities = new Set<number>(prevIsolated);
-      for (const ref of removed) {
-        const gid = refToGlobalId(ref, state.models);
-        if (!surviving.has(gid)) isolatedEntities.delete(gid);
-      }
-      return { pinboardEntities: next, isolatedEntities, activeBasketViewId: null };
+      return { pinboardEntities: next, ...basketRemoveIsolation(state, next, removed), activeBasketViewId: null };
     });
   },
 
   /** Clear basket and clear isolation */
-  clearBasket: () => set({ pinboardEntities: new Set(), isolatedEntities: null, activeBasketViewId: null }),
+  clearBasket: () =>
+    set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null }),
 
   setHierarchyBasketSelection: (refs) => set({ hierarchyBasketSelection: refsToEntityKeySet(refs) }),
   clearHierarchyBasketSelection: () => set({ hierarchyBasketSelection: new Set() }),

--- a/apps/viewer/src/store/slices/pinboardSlice.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.ts
@@ -12,7 +12,8 @@
  *   − (remove) — remove source set from basket
  *
  * When the basket is non-empty, only basket entities are visible (isolation).
- * The basket also syncs to isolatedEntities for renderer consumption.
+ * The basket also syncs to isolatedEntities for renderer consumption,
+ * claiming only the ids it inserts there (#4527).
  * Users can persist any basket as a saved "view" with a thumbnail preview.
  */
 
@@ -66,10 +67,11 @@ export interface SaveBasketViewOptions {
 /**
  * Cross-slice state that pinboard reads/writes via the combined store.
  *
- * When the basket is non-empty, pinboard owns `isolatedEntities` and
- * `hiddenEntities` — it is the isolation mechanism.  The visibility slice
- * also writes these fields for non-basket isolation (direct UI isolation).
- * They share the same state fields by design.
+ * The basket writes `isolatedEntities` and `hiddenEntities`, which it shares
+ * with every other isolation writer (direct UI isolation, BCF viewpoint
+ * restore, lens, search). Which ids the basket may take back is decided by
+ * its ownership record, `basketVisibilityOwned` — see pinboard-isolation.ts
+ * (#4527) — not by whether the basket is non-empty.
  */
 interface PinboardCrossSliceState {
   isolatedEntities: Set<number> | null;
@@ -104,7 +106,7 @@ export interface PinboardSlice {
    * whether it opened the channel. Nulled by the ownership middleware the
    * moment another writer replaces the channel. See pinboard-isolation.ts.
    */
-  basketIsolationOwned: BasketIsolationOwnership;
+  basketVisibilityOwned: BasketIsolationOwnership;
 
   // Actions
   /** Clear pinboard/basket and isolation */
@@ -182,24 +184,24 @@ export const createPinboardSlice: StateCreator<
 > = (set, get) => ({
   // Initial state
   pinboardEntities: new Set(),
-  basketIsolationOwned: null,
+  basketVisibilityOwned: null,
   basketViews: [],
   activeBasketViewId: null,
   basketPresentationVisible: false,
   hierarchyBasketSelection: new Set(),
 
   // The basket is the isolation mechanism when non-empty. Every write of
-  // `isolatedEntities` below carries `basketIsolationOwned` in the SAME patch
+  // `isolatedEntities` below carries `basketVisibilityOwned` in the SAME patch
   // (the ownership middleware resets records absent from a channel-writing
   // patch), and the incremental steps re-check ownership by value first.
   clearPinboard: () =>
-    set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null }),
+    set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null }),
 
   showPinboard: () => {
     const state = get();
     if (state.pinboardEntities.size === 0) return;
     const isolatedEntities = basketToGlobalIds(state.pinboardEntities, state.models);
-    set({ isolatedEntities, basketIsolationOwned: ownedWholesale(isolatedEntities) });
+    set({ isolatedEntities, basketVisibilityOwned: ownedWholesale(isolatedEntities) });
   },
 
   // ──────────────────────────────────────────────────────────────────────────
@@ -210,7 +212,7 @@ export const createPinboardSlice: StateCreator<
   /** = Set basket to exactly these entities and isolate them */
   setBasket: (refs) => {
     if (refs.length === 0) {
-      set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null });
+      set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null });
       return;
     }
     get().clearEntitySelection();
@@ -248,7 +250,7 @@ export const createPinboardSlice: StateCreator<
 
   /** Clear basket and clear isolation */
   clearBasket: () =>
-    set({ pinboardEntities: new Set(), isolatedEntities: null, basketIsolationOwned: null, activeBasketViewId: null }),
+    set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null }),
 
   setHierarchyBasketSelection: (refs) => set({ hierarchyBasketSelection: refsToEntityKeySet(refs) }),
   clearHierarchyBasketSelection: () => set({ hierarchyBasketSelection: new Set() }),

--- a/apps/viewer/src/store/slices/pinboardSlice.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.ts
@@ -23,6 +23,7 @@ import type { CameraCallbacks, CameraViewpoint, EntityRef, SectionPlane } from '
 import { entityRefToString } from '../types.js';
 import {
   basketAddIsolation,
+  basketReleaseIsolation,
   basketRemoveIsolation,
   basketToGlobalIds,
   computeBasketVisibility,
@@ -195,7 +196,7 @@ export const createPinboardSlice: StateCreator<
   // (the ownership middleware resets records absent from a channel-writing
   // patch), and the incremental steps re-check ownership by value first.
   clearPinboard: () =>
-    set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null }),
+    set((state) => ({ pinboardEntities: new Set(), ...basketReleaseIsolation(state), activeBasketViewId: null })),
 
   showPinboard: () => {
     const state = get();
@@ -212,7 +213,7 @@ export const createPinboardSlice: StateCreator<
   /** = Set basket to exactly these entities and isolate them */
   setBasket: (refs) => {
     if (refs.length === 0) {
-      set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null });
+      set((state) => ({ pinboardEntities: new Set(), ...basketReleaseIsolation(state), activeBasketViewId: null }));
       return;
     }
     get().clearEntitySelection();
@@ -249,8 +250,10 @@ export const createPinboardSlice: StateCreator<
   },
 
   /** Clear basket and clear isolation */
+  // Ownership-aware like removeFromBasket: a foreign isolation the basket
+  // only widened (or lost) is not the basket's to close.
   clearBasket: () =>
-    set({ pinboardEntities: new Set(), isolatedEntities: null, basketVisibilityOwned: null, activeBasketViewId: null }),
+    set((state) => ({ pinboardEntities: new Set(), ...basketReleaseIsolation(state), activeBasketViewId: null })),
 
   setHierarchyBasketSelection: (refs) => set({ hierarchyBasketSelection: refsToEntityKeySet(refs) }),
   clearHierarchyBasketSelection: () => set({ hierarchyBasketSelection: new Set() }),

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -34,7 +34,7 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
   'activePresetId',
   'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId', 'activeViewpointId',
   'activeWorkScheduleId', 'animationEnabled', 'annotation2DActiveTool',
-  'annotation2DCursorPos', 'basketPresentationVisible', 'basketViews', 'bcfError',
+  'annotation2DCursorPos', 'basketIsolationOwned', 'basketPresentationVisible', 'basketViews', 'bcfError',
   'bcfLoading', 'bcfPanelVisible', 'cameraRotation', 'cesiumAvailable', 'cesiumEnabled',
   'cesiumGlbLoaded', 'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft',
   'cesiumPlacementDraftModelId', 'cesiumPlacementEditMode', 'cesiumSourceModelId',
@@ -91,7 +91,7 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
 /** The same, for `all-models-cleared`. */
 const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
   'modelPlacement', 'repositionNudge', 'repositionOpen', 'placementStaleMeasurements', // #4226 workspace placement lifecycle
-  'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'classFilter',
+  'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'basketIsolationOwned', 'classFilter',
   'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
   'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
   'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId',
@@ -212,7 +212,7 @@ const PINNED_OWNED_KEYS: readonly string[] = [
   'activePresetId', 'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId',
   'activeViewpointId', 'activeWorkScheduleId', 'addElementModelId', 'addElementStoreyId',
   'animationEnabled', 'annotation2DActiveTool', 'annotation2DCursorPos',
-  'basketPresentationVisible', 'basketViews', 'bcfError', 'bcfLoading', 'bcfPanelVisible',
+  'basketIsolationOwned', 'basketPresentationVisible', 'basketViews', 'bcfError', 'bcfLoading', 'bcfPanelVisible',
   'cameraRotation', 'cesiumAvailable', 'cesiumEnabled', 'cesiumGlbLoaded',
   'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft', 'cesiumPlacementDraftModelId',
   'cesiumPlacementEditMode', 'cesiumSourceModelId', 'cesiumTerrainClipY',

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -34,7 +34,7 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
   'activePresetId',
   'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId', 'activeViewpointId',
   'activeWorkScheduleId', 'animationEnabled', 'annotation2DActiveTool',
-  'annotation2DCursorPos', 'basketIsolationOwned', 'basketPresentationVisible', 'basketViews', 'bcfError',
+  'annotation2DCursorPos', 'basketVisibilityOwned', 'basketPresentationVisible', 'basketViews', 'bcfError',
   'bcfLoading', 'bcfPanelVisible', 'cameraRotation', 'cesiumAvailable', 'cesiumEnabled',
   'cesiumGlbLoaded', 'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft',
   'cesiumPlacementDraftModelId', 'cesiumPlacementEditMode', 'cesiumSourceModelId',
@@ -91,7 +91,7 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
 /** The same, for `all-models-cleared`. */
 const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
   'modelPlacement', 'repositionNudge', 'repositionOpen', 'placementStaleMeasurements', // #4226 workspace placement lifecycle
-  'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'basketIsolationOwned', 'classFilter',
+  'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'basketVisibilityOwned', 'classFilter',
   'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
   'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
   'layerDiffBusy', 'layerStack', 'layerStackDiff', 'layerStackPathToId',
@@ -212,7 +212,7 @@ const PINNED_OWNED_KEYS: readonly string[] = [
   'activePresetId', 'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId',
   'activeViewpointId', 'activeWorkScheduleId', 'addElementModelId', 'addElementStoreyId',
   'animationEnabled', 'annotation2DActiveTool', 'annotation2DCursorPos',
-  'basketIsolationOwned', 'basketPresentationVisible', 'basketViews', 'bcfError', 'bcfLoading', 'bcfPanelVisible',
+  'basketVisibilityOwned', 'basketPresentationVisible', 'basketViews', 'bcfError', 'bcfLoading', 'bcfPanelVisible',
   'cameraRotation', 'cesiumAvailable', 'cesiumEnabled', 'cesiumGlbLoaded',
   'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft', 'cesiumPlacementDraftModelId',
   'cesiumPlacementEditMode', 'cesiumSourceModelId', 'cesiumTerrainClipY',

--- a/apps/viewer/src/store/visibility-channel-invalidation.test.ts
+++ b/apps/viewer/src/store/visibility-channel-invalidation.test.ts
@@ -123,7 +123,7 @@ describe('showAllInAllModels ends every claim on the channels it clears', () => 
   });
 });
 
-// ─── D2: `pinboardSlice` — a different slice, ten bare writers ──────────────
+// ─── D2: `pinboardSlice` — a different slice, seven bare writers ────────────
 
 describe('every pinboard write of the isolate channel ends the claims it invalidates', () => {
   const REFS = [{ modelId: 'A', expressId: 3 }];
@@ -142,22 +142,8 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
     assert.equal(store().idsFocusVisibilityOwned, null);
   });
 
-  it('addToPinboard', () => {
-    idsOwns('isolate', [9]);
-    store().addToPinboard(REFS);
-    assert.deepEqual(isolated(), [3], 'setup: the basket now owns the channel');
-    assert.equal(store().idsFocusVisibilityOwned, null);
-  });
-
-  it('setPinboard', () => {
-    idsOwns('isolate', [9]);
-    store().setPinboard(REFS);
-    assert.deepEqual(isolated(), [3], 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
-  });
-
   it('showPinboard', () => {
-    store().setPinboard(REFS);
+    store().setBasket(REFS);
     idsOwns('isolate', [9]);
     store().showPinboard();
     assert.deepEqual(isolated(), [3], 'setup: re-isolating the basket replaced the IDS isolation');
@@ -189,36 +175,35 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
     );
   });
 
-  it('removeFromBasket (down to empty)', () => {
+  // The two `removeFromBasket` shapes are the mirror image (#4527): once
+  // another owner has REPLACED the channel, the basket no longer owns it
+  // (its own record was nulled by this middleware), so unpinning must not
+  // touch the channel at all — and therefore invalidates nothing.
+  it('removeFromBasket (down to empty) leaves a channel another owner replaced, and its record, alone', () => {
     store().setBasket(REFS);
     idsOwns('isolate', [9]);
+    assert.equal(store().basketIsolationOwned, null, 'setup: the IDS replacement ended the basket claim');
     store().removeFromBasket(REFS);
-    assert.equal(isolated(), null, 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+    assert.deepEqual(isolated(), [9], "the IDS isolation is not the basket's to close");
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
   });
 
-  it('removeFromBasket (still non-empty)', () => {
+  it('removeFromBasket (still non-empty) leaves a channel another owner replaced alone', () => {
     store().setBasket([{ modelId: 'A', expressId: 3 }, { modelId: 'A', expressId: 4 }]);
     idsOwns('isolate', [9, 4]);
     store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
-    assert.deepEqual(isolated(), [9], 'setup: the incremental remove worked off the current isolation set');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+    assert.deepEqual(isolated(), [4, 9], "the IDS isolation is not the basket's to narrow");
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([4, 9]) });
   });
 
-  it('removeFromPinboard (down to empty)', () => {
-    store().setPinboard(REFS);
-    idsOwns('isolate', [9]);
-    store().removeFromPinboard(REFS);
-    assert.equal(isolated(), null, 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
-  });
-
-  it('removeFromPinboard (still non-empty)', () => {
-    store().setPinboard([{ modelId: 'A', expressId: 3 }, { modelId: 'A', expressId: 4 }]);
-    idsOwns('isolate', [9]);
-    store().removeFromPinboard([{ modelId: 'A', expressId: 4 }]);
-    assert.deepEqual(isolated(), [3], 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+  it('removeFromBasket on a channel the basket still owns narrows it and ends a stale foreign record', () => {
+    store().setBasket([{ modelId: 'A', expressId: 3 }, { modelId: 'A', expressId: 4 }]);
+    // A foreign record that happens to match by value (installed after the basket).
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([3, 4]) });
+    store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
+    assert.deepEqual(isolated(), [3]);
+    assert.equal(store().clashVisibilityOwned, null, 'the channel no longer holds exactly {3, 4}');
+    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3]), 'the basket record follows its own write');
   });
 
   it('restoreBasketEntities', () => {
@@ -267,7 +252,7 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
 
 describe('a write that leaves a record\'s content intact does not invalidate it', () => {
   it('showPinboard re-installing exactly what is already isolated keeps the basket owner\'s claim', () => {
-    store().setPinboard([{ modelId: 'A', expressId: 3 }]);
+    store().setBasket([{ modelId: 'A', expressId: 3 }]);
     // Pretend the basket's isolation is a feature-owned presentation with a
     // record — the same content-preserving replay Space Sketch's view capture
     // and `syncSourceModel`'s rebuild perform (#2662 P2).
@@ -295,6 +280,21 @@ describe('a write that leaves a record\'s content intact does not invalidate it'
     store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
     assert.deepEqual(isolated(), [9], 'setup: the content is unchanged');
     assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
+  });
+
+  it("the basket's own record survives its own writes and dies on a foreign replacement (#4527 chain)", () => {
+    store().setBasket([{ modelId: 'A', expressId: 3 }]);
+    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3]), 'setup: wholesale write records ownership');
+    store().addToBasket([{ modelId: 'A', expressId: 4 }]);
+    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3, 4]), 'an incremental write refreshes the record');
+    // Foreign replacement: the basket record is gone even though 3 and 4 are still in the set.
+    store().setIsolatedEntities(new Set([3, 4, 9]));
+    assert.equal(store().basketIsolationOwned, null);
+    // A third owner installs the same content again: still not the basket's — its record stays null.
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([3, 4, 9]) });
+    store().removeFromBasket([{ modelId: 'A', expressId: 3 }]);
+    assert.deepEqual(isolated(), [3, 4, 9], 'the basket must not narrow what it does not own');
+    assert.deepEqual(store().clashVisibilityOwned, { channel: 'isolate', ids: new Set([3, 4, 9]) });
   });
 
   it('a write of ONE channel leaves a record on the OTHER one alone', () => {

--- a/apps/viewer/src/store/visibility-channel-invalidation.test.ts
+++ b/apps/viewer/src/store/visibility-channel-invalidation.test.ts
@@ -128,18 +128,22 @@ describe('showAllInAllModels ends every claim on the channels it clears', () => 
 describe('every pinboard write of the isolate channel ends the claims it invalidates', () => {
   const REFS = [{ modelId: 'A', expressId: 3 }];
 
-  it('clearPinboard', () => {
+  // The clear paths are ownership-aware (#4527): a channel another owner
+  // installed is not the basket's to close, so they write nothing to it and
+  // invalidate nothing; a channel the basket opened is closed as before.
+  it('clearPinboard leaves a foreign-owned isolation and its record alone', () => {
     idsOwns('isolate', [9]);
     store().clearPinboard();
-    assert.equal(isolated(), null, 'setup: the basket clear nulls the isolation');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+    assert.deepEqual(isolated(), [9]);
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
   });
 
-  it('clearBasket', () => {
-    idsOwns('isolate', [9]);
+  it('clearBasket closes a basket-opened isolation and ends a stale foreign record', () => {
+    store().setBasket(REFS);
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([3]) }); // value-matched foreign record
     store().clearBasket();
-    assert.equal(isolated(), null, 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+    assert.equal(isolated(), null, 'the basket opened this channel, so it closes it');
+    assert.equal(store().clashVisibilityOwned, null);
   });
 
   it('showPinboard', () => {
@@ -157,11 +161,11 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
     assert.equal(store().idsFocusVisibilityOwned, null);
   });
 
-  it('setBasket (empty — the early-return branch)', () => {
+  it('setBasket (empty — the early-return branch) is a clear: foreign-owned isolation is left alone', () => {
     idsOwns('isolate', [9]);
     store().setBasket([]);
-    assert.equal(isolated(), null, 'setup');
-    assert.equal(store().idsFocusVisibilityOwned, null);
+    assert.deepEqual(isolated(), [9]);
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
   });
 
   it('addToBasket', () => {
@@ -230,9 +234,10 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
   it("the destruction chain: a stranded record wipes the user's own hand-made isolation", () => {
     // 1. An IDS row focus isolates element 3 and records `{isolate, {3}}`.
     idsOwns('isolate', [3]);
-    // 2. The user clears the basket. `clearPinboard` nulls the isolate channel,
-    //    so the IDS presentation is gone from the screen.
-    store().clearPinboard();
+    // 2. The user clears the isolation directly (the basket's own clear is
+    //    ownership-aware since #4527 and would leave an IDS-owned channel
+    //    alone), so the IDS presentation is gone from the screen.
+    store().clearIsolation();
     assert.equal(isolated(), null, 'setup: the IDS isolation is off screen');
     // 3. The user isolates element 3 BY HAND ("Isolate in 3D" / the model tree).
     //    Equal content to what IDS once installed — and IDS installed none of it.

--- a/apps/viewer/src/store/visibility-channel-invalidation.test.ts
+++ b/apps/viewer/src/store/visibility-channel-invalidation.test.ts
@@ -182,7 +182,7 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
   it('removeFromBasket (down to empty) leaves a channel another owner replaced, and its record, alone', () => {
     store().setBasket(REFS);
     idsOwns('isolate', [9]);
-    assert.equal(store().basketIsolationOwned, null, 'setup: the IDS replacement ended the basket claim');
+    assert.equal(store().basketVisibilityOwned, null, 'setup: the IDS replacement ended the basket claim');
     store().removeFromBasket(REFS);
     assert.deepEqual(isolated(), [9], "the IDS isolation is not the basket's to close");
     assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
@@ -203,7 +203,7 @@ describe('every pinboard write of the isolate channel ends the claims it invalid
     store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
     assert.deepEqual(isolated(), [3]);
     assert.equal(store().clashVisibilityOwned, null, 'the channel no longer holds exactly {3, 4}');
-    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3]), 'the basket record follows its own write');
+    assert.deepEqual(store().basketVisibilityOwned?.ids, new Set([3]), 'the basket record follows its own write');
   });
 
   it('restoreBasketEntities', () => {
@@ -284,12 +284,12 @@ describe('a write that leaves a record\'s content intact does not invalidate it'
 
   it("the basket's own record survives its own writes and dies on a foreign replacement (#4527 chain)", () => {
     store().setBasket([{ modelId: 'A', expressId: 3 }]);
-    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3]), 'setup: wholesale write records ownership');
+    assert.deepEqual(store().basketVisibilityOwned?.ids, new Set([3]), 'setup: wholesale write records ownership');
     store().addToBasket([{ modelId: 'A', expressId: 4 }]);
-    assert.deepEqual(store().basketIsolationOwned?.ids, new Set([3, 4]), 'an incremental write refreshes the record');
+    assert.deepEqual(store().basketVisibilityOwned?.ids, new Set([3, 4]), 'an incremental write refreshes the record');
     // Foreign replacement: the basket record is gone even though 3 and 4 are still in the set.
     store().setIsolatedEntities(new Set([3, 4, 9]));
-    assert.equal(store().basketIsolationOwned, null);
+    assert.equal(store().basketVisibilityOwned, null);
     // A third owner installs the same content again: still not the basket's — its record stays null.
     store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([3, 4, 9]) });
     store().removeFromBasket([{ modelId: 'A', expressId: 3 }]);

--- a/apps/viewer/src/store/visibility-invalidation.ts
+++ b/apps/viewer/src/store/visibility-invalidation.ts
@@ -41,8 +41,8 @@
  * A record field the patch ITSELF carries is left exactly as the patch has it.
  * An installer committing the channel and its claim in one `set()` is stating
  * both at once and must not have the claim eaten by the write that created it.
- * (Today's installers write the channel first and the record second, two
- * `set()`s — this makes the atomic form safe too rather than a latent trap.)
+ * (The clash and IDS installers write the channel first and the record second,
+ * two `set()`s; the basket commits both in one patch, `basketVisibilityOwned`.)
  *
  * A patch touching NEITHER channel is returned by reference, so the common
  * case adds no keys, allocates nothing, and preserves the identity-return

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -166,7 +166,6 @@
    820 apps/viewer/src/store/slices/measurementSlice.ts
    651 apps/viewer/src/store/slices/modelSlice.ts
   3277 apps/viewer/src/store/slices/mutationSlice.ts
-   492 apps/viewer/src/store/slices/pinboardSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts
    536 apps/viewer/src/store/slices/scriptSlice.ts
    574 apps/viewer/src/store/slices/sectionSlice.ts


### PR DESCRIPTION
Closes #4527.

## Problem

`isolatedEntities` is one `Set<number> | null` shared by every isolation writer (basket, direct isolate, BCF viewpoint restore, lens, search). The basket API is incremental — `addToBasket` widens, `removeFromBasket` narrows — but it had no record of which ids it put there. Unpinning an element deleted its global id even when search or a viewpoint had isolated it independently, and emptying the basket by removal set the channel to `null`, wiping every other channel's work.

## Fix — the repo's ownership convention, applied to the basket

`lib/visibility/ownership.ts` already defines value-matched ownership records (`idsFocusVisibilityOwned`, `clashVisibilityOwned`) that the store middleware (`store/visibility-invalidation.ts`) nulls the moment another writer replaces the channel. The basket now keeps one too:

```ts
basketVisibilityOwned: { channel: 'isolate'; ids /* channel as the basket last wrote it */; claims /* ids the basket inserted */; seeded /* it turned null into a Set */ } | null
```

- `addToBasket` claims only ids that were **not** already isolated; an id another writer isolated first stays theirs.
- `removeFromBasket` (helpers in the new `store/slices/pinboard-isolation.ts`):
  - channel replaced by someone else (record voided) → the basket edits `pinboardEntities` only, the channel is untouched;
  - owned → deletes only claimed ids that no surviving (possibly aliased) basket entry still derives;
  - basket empties → `null` only if the basket opened the channel, otherwise the remainder is handed back (an empty-but-active Set included, per #4509);
  - channel cleared externally while the basket was non-empty → the surviving basket re-takes it wholesale and records that.
- Wholesale writers (`setBasket`, `showPinboard`, view restore) record full ownership; `clearBasket`/`clearPinboard` null it. Every channel write carries the record **in the same patch**, as the middleware requires.
- Teardown: nulled on session reset / all-models-cleared; on model removal, dropped if it names a stale id (a raw-expressId claim would collide with a surviving idOffset-0 model).
- The six legacy pinboard actions with zero non-test callers (`addToPinboard`, `removeFromPinboard`, `setPinboard`, `isInPinboard`, `getPinboardCount`, `getPinboardEntities`) are deleted rather than taught the record. `pinboardSlice.ts` drops from 492 to 349 lines and leaves the module-size allowlist.

## Tests

`pinboardSlice.test.ts` (+9): widened-only isolation survives emptying; basket-opened isolation closes; pre-isolated id not claimed; foreign replacement (superset and subset) untouched; re-take after external clear; `showPinboard` records; empty-but-active foreign isolate given back; union claimed when the channel was closed. `visibility-channel-invalidation.test.ts`: the two `removeFromBasket` rows now assert the foreign-owned channel and its record are left alone, plus the basket-record chain (own writes refresh it, a foreign replace nulls it, a third owner's equal content stays theirs). `removeModel-pinboard-stale.test.ts`: the record goes with the removed model. `teardown-registry.test.ts` pins the new key. 100 tests across the touched files pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Basket isolation now tracks ownership, preserving unrelated visibility changes made by other features.
  * Adding or removing basket items updates isolation accurately, including baskets combined with existing isolated items.
  * Basket isolation can be restored after external changes and closes appropriately when its items are removed.

* **Bug Fixes**
  * Improved model-removal handling so surviving basket items retain correct visibility state.
  * Fixed detection of active basket isolation when additional entities are also isolated.

* **Refactor**
  * Consolidated pinboard visibility behavior around basket actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->