### PR TITLE
ci(module-size): judge allowlist conflict resolutions against the merge base (#4388)

### DIFF
--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -6,6 +6,12 @@
 # The rule: shrink or split. When you split a file below 400, delete its row
 # (the total must trend DOWN). Only ADD a row with a written justification.
 # Regenerated against the branch's merge base; refresh on rebase if a listed
+# file's count moved under you. After a merge conflict HERE, never pick a side:
+# diff both sides against the merge base, row by row (the rule and the two git
+# commands are in scripts/module-size-allowlist.txt). scripts/check-module-size.mjs
+# judges every row of this file that differs from the merge base against the
+# file's measured count and fails a hand-picked number; a duplicate row fails
+# in module_size_ratchet.rs (#4388).
      756 apps/server/src/services/parquet_data_model.rs
      581 apps/server/src/services/parquet_optimized.rs
 # +8: add set_entity_index setter so the processor can install its inline-built index (perf/single-scan).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -163,8 +163,20 @@ fn is_exempt(rel: &str) -> bool {
 /// Parse the committed allowlist into (relpath -> budget). Skips comment/blank
 /// lines. A malformed data line is a hard error (the file is a contract).
 fn parse_allowlist() -> std::collections::HashMap<String, usize> {
+    parse_allowlist_text(ALLOWLIST)
+}
+
+/// `parse_allowlist` over any text, so the firing paths are unit-testable.
+///
+/// A DUPLICATE path is a hard error too (#4388). `HashMap::insert` used to
+/// last-wins it silently, and a duplicate row is exactly what a merge
+/// conflict resolved by keeping both sides leaves behind: two budgets for one
+/// file, with the one that survives decided by line order. The TypeScript
+/// twin (`parseAllowlist` in scripts/lib/module-size-ratchet.mjs) has
+/// refused this since it was written; this side now agrees.
+fn parse_allowlist_text(text: &str) -> std::collections::HashMap<String, usize> {
     let mut map = std::collections::HashMap::new();
-    for line in ALLOWLIST.lines() {
+    for line in text.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
@@ -176,7 +188,14 @@ fn parse_allowlist() -> std::collections::HashMap<String, usize> {
             .trim()
             .parse()
             .unwrap_or_else(|_| panic!("module_size_allowlist.txt: bad budget in: {line:?}"));
-        map.insert(path.trim().to_string(), budget);
+        let path = path.trim().to_string();
+        if let Some(previous) = map.insert(path.clone(), budget) {
+            panic!(
+                "module_size_allowlist.txt: duplicate row for {path} (budgets {previous} and \
+                 {budget}). Two rows for one file is what a conflict resolved by keeping \
+                 both sides leaves behind; keep the one the file's measured count justifies."
+            );
+        }
     }
     map
 }
@@ -324,6 +343,31 @@ fn evaluate_is_clean_when_within_budget() {
     ];
     let (new_offenders, grew) = evaluate(&files, &allowlist);
     assert!(new_offenders.is_empty() && grew.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "duplicate row for rust/a/big.rs (budgets 500 and 520)")]
+fn parse_allowlist_refuses_a_duplicate_row() {
+    // The residue of a conflict resolved by keeping both sides (#4388). Before
+    // this, the second row silently won and the digest pin only proved that
+    // SOMETHING in the scope moved, not that the surviving number was right.
+    parse_allowlist_text("# header
+   500 rust/a/big.rs
+   520 rust/a/big.rs
+");
+}
+
+#[test]
+fn parse_allowlist_text_reads_rows_past_comments_and_blanks() {
+    let map = parse_allowlist_text("# h
+
+   500 rust/a/big.rs
+# +3: why
+   620 rust/b/c.rs
+");
+    assert_eq!(map.len(), 2);
+    assert_eq!(map["rust/a/big.rs"], 500);
+    assert_eq!(map["rust/b/c.rs"], 620);
 }
 
 #[test]

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -89,8 +89,24 @@
  *
  * What the step breaks on afterwards, by design: any PR adding a TS/TSX/MJS/
  * CJS file over 400 lines, or any PR growing a listed file past its recorded
- * budget. It does NOT break on a file shrinking or disappearing; those are
- * advisory notes.
+ * budget. It does NOT break on a file shrinking or disappearing in a PR that
+ * never touched the file or its row; those stay advisory notes.
+ *
+ * THE MERGE-BASE AUDIT (#4388) is the third thing check mode fails on: an
+ * allowlist ROW that this change wrote and the measurement does not justify.
+ * The two teeth judge files against rows; neither judged the row, so a
+ * conflict resolution that resurrected a deleted row for a 268-line file,
+ * kept the row of a file a split had taken to 348, and carried 766 for a
+ * 765-line file printed three notes and OK (#4330). Check mode now diffs the
+ * allowlist against `git merge-base origin/main HEAD` and holds every row
+ * that differs -- added, raised or lowered -- to the count `--update` would
+ * have written, and fails a row kept unchanged when this change's own diff
+ * took the file under the limit or removed it. The Rust twin's allowlist is
+ * audited by the same rules from here (the cargo test has no git). Rows this
+ * change did not write and files it did not touch stay advisory, which is
+ * the advisory rationale below preserved rather than dropped. No base (no
+ * `origin/main`, no `main`, or --root not a worktree top) is a hard failure
+ * under CI and a loud skip elsewhere; `--base <ref>` names a base by hand.
  *
  * WHAT THIS GATE CANNOT SEE: it counts lines, nothing else. A 400-line file
  * doing five jobs passes; a cohesive 900-line table fails. It does not look at
@@ -159,10 +175,11 @@
  *   --allow-raise      with --update, permit budget raises and new exemptions
  *   --all              with --update, re-record EVERY row in the tree, not
  *                      only the changed ones (and skip the git derivation)
+ *   --base <ref>       merge base against this ref instead of origin/main
+ *                      (then main); for odd clones and the test harness
  */
 
-import { readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -175,6 +192,9 @@ import {
   planUpdate,
   renderAllowlist,
 } from './lib/module-size-ratchet.mjs';
+import { changedFilesWarned, describeBase } from './lib/module-size-git.mjs';
+import { compactAudit } from './lib/module-size-base-audit.mjs';
+import { runMergeBaseAudits } from './lib/module-size-audit-run.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPTS_DIR, '..');
@@ -208,11 +228,12 @@ function parseArgs(argv) {
     update: false,
     allowRaise: false,
     all: false,
+    base: null,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const flag = argv[i];
     const value = argv[i + 1];
-    if (flag === '--root' || flag === '--allowlist') {
+    if (flag === '--root' || flag === '--allowlist' || flag === '--base') {
       if (value === undefined) fail(`${flag} needs a value`);
       out[flag.slice(2)] = value;
       i += 1;
@@ -280,86 +301,6 @@ function safeIsDir(path) {
   }
 }
 
-function safeRealpath(path) {
-  try {
-    return realpathSync(path);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * The paths this worktree changed relative to its merge base with main:
- * committed, staged, unstaged and untracked, all relative to the repo top.
- * `{ changed: Set, base: string }` on success, `{ error }` on failure.
- *
- * Git is the only honest discriminator between slack THIS change created and
- * slack inherited from main, which is why `--update` derives the scope instead
- * of taking a `--scope` flag: a flag nobody passes is the annexation with extra
- * steps.
- *
- * It FAILS CLOSED rather than falling back to repo-wide. A silent fallback is
- * the annexation again, in the one context — a shallow clone, a detached
- * checkout, a script — where nobody is reading the output, and "absence read as
- * success" is the shape this family of gates exists to avoid.
- */
-function changedFiles(root) {
-  const git = (...argv) => spawnSync('git', ['-C', root, ...argv], { encoding: 'utf8' });
-  const top = git('rev-parse', '--show-toplevel');
-  if (top.status !== 0) return { error: `${root} is not inside a git worktree` };
-  // Compare resolved paths: `git` answers with the physical path, while --root
-  // may arrive through a symlink (macOS /var -> /private/var). Requiring the
-  // top to BE the scanned root stops a synthetic tree nested inside some other
-  // repository from silently inheriting that repository's diff.
-  const toplevel = top.stdout.trim();
-  // Either side unresolvable is a REFUSAL, not a pass. `safeRealpath` answers
-  // null on failure, so a bare `!==` compares null to null and lets the guard
-  // through in exactly the case where it knows least about the two paths.
-  // Fail-closed is this function's whole contract; a guard that opens when its
-  // input is unreadable is the "absence read as success" shape again.
-  const resolvedTop = safeRealpath(toplevel);
-  const resolvedRoot = safeRealpath(root);
-  if (resolvedTop === null || resolvedRoot === null || resolvedTop !== resolvedRoot) {
-    return { error: `${root} is not the top of its git worktree (that is ${toplevel})` };
-  }
-  let base = null;
-  for (const ref of ['origin/main', 'main']) {
-    const merged = git('merge-base', ref, 'HEAD');
-    const sha = merged.stdout.trim();
-    if (merged.status === 0 && sha !== '') {
-      base = { ref, sha };
-      break;
-    }
-  }
-  if (base === null) return { error: 'no merge base with origin/main or main' };
-  // `main` can be arbitrarily far behind `origin/main` (measured here: 147
-  // commits, widening scope from 0 files to 381, 49 of them allowlisted), which
-  // is the annexation this scoping exists to prevent. The fallback is still the
-  // right behaviour -- not every clone names its upstream `origin` -- but it
-  // must not be a routine log line.
-  if (base.ref !== 'origin/main') {
-    console.warn(
-      `check-module-size: WARNING -- no merge base with origin/main; fell back to ` +
-        `local '${base.ref}' (${base.sha.slice(0, 9)}). If that ref is stale, the scope ` +
-        `is WIDER than your change and this regenerate may annex rows you did not touch. ` +
-        `Fetch origin/main and re-run.`,
-    );
-  }
-  const nulSeparated = (res) => (res.status === 0 ? res.stdout.split('\0').filter(Boolean) : null);
-  // `--no-renames` so a renamed module reports BOTH paths. Rename detection
-  // reports only the destination, and the source's row is exactly the one that
-  // has to be dropped.
-  const diffed = nulSeparated(git('diff', '--name-only', '--no-renames', '-z', base.sha));
-  // Untracked too: a god file written but not yet committed is the single most
-  // likely thing a contributor is running this for.
-  const untracked = nulSeparated(git('ls-files', '--others', '--exclude-standard', '-z'));
-  if (diffed === null || untracked === null) return { error: 'git could not list the changed files' };
-  return {
-    changed: new Set([...diffed, ...untracked]),
-    base: `${base.ref} (${base.sha.slice(0, 9)})`,
-  };
-}
-
 const args = parseArgs(process.argv.slice(2));
 
 let allowlistText;
@@ -405,7 +346,7 @@ if (args.update) {
     'check-module-size: --all: re-recording EVERY row in the tree, ' +
     'including rows this change never touched.';
   if (!args.all) {
-    const derived = changedFiles(args.root);
+    const derived = changedFilesWarned(args.root, args.base);
     if (derived.error !== undefined) {
       fail(
         `--update re-records only the files your change touched, and deriving those needs git.\n\n` +
@@ -426,7 +367,7 @@ if (args.update) {
     ).length;
     scopeNote =
       `check-module-size: scoped to ${actionable} changed module(s) ` +
-      `(of ${changed.size} changed path(s)) vs ${derived.base}; ` +
+      `(of ${changed.size} changed path(s)) vs ${describeBase(derived.base)}; ` +
       `pass --all to re-record every row.`;
   }
   console.log(scopeNote);
@@ -532,8 +473,9 @@ ${grew.join('\n')}
 `);
 }
 
-// Advisory: never fails the build, so a shrink landing in another PR cannot
-// turn this one red. Mirrors the Rust gate's advisory notes.
+// Advisory when the shrink is somebody else's: a shrink landing in another
+// PR cannot turn this one red. Mirrors the Rust gate's advisory notes. When
+// the shrink is THIS change's, the merge-base audit below fails it (#4388).
 for (const row of shrunk) {
   console.log(`note: ${row.trim()} <= ${LIMIT}; delete its allowlist row (the total must trend down)`);
 }
@@ -543,12 +485,28 @@ for (const row of missing) {
 // Advisory: headroom a file can grow into with nothing firing. Not a failure,
 // because a shrink landing in another PR would otherwise turn this one red —
 // but it must be VISIBLE, or the ratchet quietly stops being one for that row.
+// A row THIS change wrote with headroom in it is a different thing, and the
+// audit below fails that one.
 for (const row of slack) {
   console.log(`note:${row}; lower the budget to the measured count`);
 }
 
+// The merge-base audit (#4388): rows that differ from the base were written by
+// this change, and each must say what the file says. Rules in
+// lib/module-size-base-audit.mjs, the run in lib/module-size-audit-run.mjs.
+const { failed: auditFailed, tsAudit, scope } = runMergeBaseAudits({
+  root: args.root,
+  allowlistPath: args.allowlist,
+  headRows: allowlist,
+  measured: new Map(files.map((f) => [f.rel, f.lines])),
+  baseRef: args.base,
+});
+if (auditFailed) failed = true;
+
 if (failed) process.exit(1);
 
+const auditNote =
+  tsAudit === null ? 'merge-base audit SKIPPED' : `vs merge-base ${scope.base.sha.slice(0, 9)}: ${compactAudit(tsAudit)}`;
 console.log(
-  `check-module-size: OK (${files.length} files measured, ${allowlist.size} allowlisted, 0 new over ${LIMIT})`,
+  `check-module-size: OK (${files.length} files measured, ${allowlist.size} allowlisted, 0 new over ${LIMIT}; ${auditNote})`,
 );

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -92,21 +92,21 @@
  * budget. It does NOT break on a file shrinking or disappearing in a PR that
  * never touched the file or its row; those stay advisory notes.
  *
- * THE MERGE-BASE AUDIT (#4388) is the third thing check mode fails on: an
- * allowlist ROW that this change wrote and the measurement does not justify.
- * The two teeth judge files against rows; neither judged the row, so a
- * conflict resolution that resurrected a deleted row for a 268-line file,
- * kept the row of a file a split had taken to 348, and carried 766 for a
- * 765-line file printed three notes and OK (#4330). Check mode now diffs the
- * allowlist against `git merge-base origin/main HEAD` and holds every row
- * that differs -- added, raised or lowered -- to the count `--update` would
- * have written, and fails a row kept unchanged when this change's own diff
- * took the file under the limit or removed it. The Rust twin's allowlist is
- * audited by the same rules from here (the cargo test has no git). Rows this
- * change did not write and files it did not touch stay advisory, which is
- * the advisory rationale below preserved rather than dropped. No base (no
- * `origin/main`, no `main`, or --root not a worktree top) is a hard failure
- * under CI and a loud skip elsewhere; `--base <ref>` names a base by hand.
+ * THE MERGE-BASE AUDIT (#4388) is one more thing check mode fails on, beside
+ * the two teeth and the stale-row check: an allowlist ROW this change wrote
+ * that the measurement does not justify. The teeth judge files against rows;
+ * neither judged the row, so a resolution that resurrected a deleted row for
+ * a 268-line file, kept the row of a file a split took to 348, and carried
+ * 766 for a 765-line file printed three notes and OK (#4330). Check mode now
+ * diffs the allowlist against `git merge-base origin/main HEAD`: a row added
+ * or raised must equal the count `--update` would have written; a lowered
+ * row must still name a file over 400 (slack on it is a note: lowering
+ * loosens nothing); a kept row fails when this change's own diff took a file
+ * over 400 at the base under it, or removed it. The Rust twin's allowlist is
+ * audited by the same rules from here. Rows this change did not write and
+ * files it did not touch stay advisory (the rationale below, preserved). No
+ * base (no `origin/main`, no `main`, --root not a worktree top) fails under
+ * CI, skips loudly elsewhere; `--base <ref>` names one by hand.
  *
  * WHAT THIS GATE CANNOT SEE: it counts lines, nothing else. A 400-line file
  * doing five jobs passes; a cohesive 900-line table fails. It does not look at

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -63,14 +63,23 @@ function makeTree(files) {
   return dir;
 }
 
-function run(dir, allowlistText, { allowlistPath, extra = [] } = {}) {
+/**
+ * `CI` is stripped from the child's environment: a synthetic tree outside any
+ * repository has no merge base, and under CI the checker fails closed on that
+ * (#4388) -- correctly for the real gate, wrongly for a fixture that exists to
+ * test something else. The merge-base cases below set `env` themselves.
+ */
+function run(dir, allowlistText, { allowlistPath, extra = [], env = {} } = {}) {
   let path = allowlistPath;
   if (path === undefined) {
     path = join(dir, 'allowlist.txt');
     writeFileSync(path, allowlistText ?? '');
   }
+  const childEnv = { ...process.env, ...env };
+  if (!Object.hasOwn(env, 'CI')) delete childEnv.CI;
   const res = spawnSync(process.execPath, [CHECKER, '--root', dir, '--allowlist', path, ...extra], {
     encoding: 'utf8',
+    env: childEnv,
   });
   return { code: res.status, out: `${res.stdout}${res.stderr}`, allowlistPath: path };
 }
@@ -94,7 +103,7 @@ function tree(files) {
  * `tmpdir()` has no enclosing repository (asserted below), which is what keeps
  * the derivation hermetic rather than reading this checkout's own diff.
  */
-function gitTree(files) {
+function gitTree(files, { allowlist, extraFiles = {} } = {}) {
   const dir = tree(files);
   const git = (...argv) => {
     const res = spawnSync('git', ['-C', dir, ...argv], { encoding: 'utf8' });
@@ -104,9 +113,22 @@ function gitTree(files) {
   git('init', '-q', '-b', 'main');
   git('config', 'user.email', 'ratchet@example.invalid');
   git('config', 'user.name', 'ratchet test');
-  git('add', '--', ...Object.keys(files));
+  const committed = Object.keys(files);
+  // The merge-base audit (#4388) reads the allowlist AS IT WAS AT THE BASE,
+  // so the cases for it commit one on main and edit the working copy after.
+  if (allowlist !== undefined) {
+    writeFileSync(join(dir, 'allowlist.txt'), allowlist);
+    committed.push('allowlist.txt');
+  }
+  for (const [rel, text] of Object.entries(extraFiles)) {
+    const full = join(dir, rel);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, text);
+    committed.push(rel);
+  }
+  git('add', '--', ...committed);
   git('commit', '-qm', 'base');
-  return { dir, git };
+  return { dir, git, allowlistPath: join(dir, 'allowlist.txt') };
 }
 
 test('clean tree passes and says how much it measured', () => {
@@ -199,12 +221,23 @@ test('a stale row at or under the limit fails', () => {
   assert.match(out, /rows at or under the 400-line limit/);
 });
 
-test('a shrunk or vanished row is advisory, not a failure', () => {
-  const dir = tree({ 'packages/a/big.ts': 300 });
-  const { code, out } = run(dir, '500 packages/a/big.ts\n700 packages/a/gone.ts\n');
+test('a shrunk or vanished row is advisory when the shrink is not this change\'s', () => {
+  // Committed on main already shrunk and already gone, rows kept: the
+  // branch touches neither file nor row, so the notes stay notes (#4388
+  // keeps the L535 rationale -- a shrink landing elsewhere cannot redden
+  // this PR). The A/B where the branch DID the shrinking is below.
+  const { dir, git, allowlistPath } = gitTree(
+    { 'packages/a/big.ts': 300 },
+    { allowlist: '500 packages/a/big.ts\n700 packages/a/gone.ts\n' },
+  );
+  git('update-ref', 'refs/remotes/origin/main', 'main');
+  git('checkout', '-q', '-b', 'feature');
+  writeSource(dir, 'packages/c/unrelated.ts', 10);
+  const { code, out } = run(dir, null, { allowlistPath });
   assert.equal(code, 0, out);
   assert.match(out, /note: packages\/a\/big\.ts: now 300 lines <= 400; delete its allowlist row/);
   assert.match(out, /note:\s+packages\/a\/gone\.ts \(budget 700\) no longer matches a tracked file/);
+  assert.match(out, /vs merge-base origin\/main \([0-9a-f]{9}\): \+0 added, \^0 raised, v0 lowered, -0 deleted/);
 });
 
 // ---------------------------------------------------------------------------
@@ -403,7 +436,14 @@ test('the committed gate runs green against the real repo', () => {
   const res = spawnSync(process.execPath, [CHECKER], { encoding: 'utf8', cwd: ROOT });
   const out = `${res.stdout}${res.stderr}`;
   assert.equal(res.status, 0, out);
-  assert.match(out, /check-module-size: OK \(\d+ files measured, \d+ allowlisted, 0 new over 400\)/);
+  // The OK line carries the merge-base audit (#4388): the real repo has an
+  // origin/main (or main) to diff against, so a SKIPPED here means the gate
+  // certified this branch's allowlist edits without judging them.
+  assert.match(
+    out,
+    /check-module-size: OK \(\d+ files measured, \d+ allowlisted, 0 new over 400; vs merge-base [0-9a-f]{9}: \+\d+ \^\d+ v\d+ -\d+\)/,
+  );
+  assert.doesNotMatch(out, /SKIPPED/);
 });
 
 // ---------------------------------------------------------------------------
@@ -633,3 +673,158 @@ test('a scoped regenerate that leaves the gate red exits 1 and names the sweep',
 // --update writes is what the gate then accepts' and by the scoped --update
 // cases.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// The merge-base audit (#4388). A conflict resolution in the allowlist that
+// resurrected a deleted row (file 268 lines), kept the row of a file a split
+// had taken to 348, and carried 766 for a 765-line file printed three notes
+// and OK. Every row that differs from the merge base is this change's row and
+// must equal the measurement; a kept row fails only when THIS change shrank or
+// removed the file. Each case commits the allowlist on main and edits the
+// working copy, exactly as a resolution would.
+// ---------------------------------------------------------------------------
+
+const AUDIT_BASE = `${HEADER}   500 packages/a/big.ts\n`;
+
+/** main with `files` and `allowlist` committed, origin/main pointing at it, on a feature branch. */
+function auditTree(files, allowlist, extraFiles = {}) {
+  const made = gitTree(files, { allowlist, extraFiles });
+  made.git('update-ref', 'refs/remotes/origin/main', 'main');
+  made.git('checkout', '-q', '-b', 'feature');
+  return made;
+}
+
+test('a resurrected row for a file under the limit fails (#4388, the project-units case)', () => {
+  const { dir, allowlistPath } = auditTree({ 'packages/a/big.ts': 500, 'packages/p/units.ts': 268 }, AUDIT_BASE);
+  writeFileSync(allowlistPath, `${AUDIT_BASE}   523 packages/p/units.ts\n`);
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 1, out);
+  assert.match(out, /packages\/p\/units\.ts: row added at 523, but the file measures 268 <= 400 and needs no row/);
+  assert.match(out, /\+1 added, \^0 raised, v0 lowered, -0 deleted/);
+  assert.match(out, /never resolve by picking a side/);
+});
+
+test('a raise the file did not grow into fails (#4388, the 766-for-765 case)', () => {
+  const { dir, allowlistPath } = auditTree(
+    { 'packages/a/big.ts': 500, 'packages/x/x.ts': 765 },
+    `${AUDIT_BASE}   765 packages/x/x.ts\n`,
+  );
+  writeFileSync(allowlistPath, `${AUDIT_BASE}   766 packages/x/x.ts\n`);
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 1, out);
+  assert.match(out, /packages\/x\/x\.ts: row raised 765 -> 766, but the file measures 765: 1 line\(s\) of headroom/);
+});
+
+test('a split PR that keeps its row fails; the same shrink landed elsewhere does not (#4388)', () => {
+  const before = `${AUDIT_BASE}   594 packages/s/extractor.ts\n`;
+  // The branch takes extractor.ts from 594 to 348 and keeps the row.
+  const mine = auditTree({ 'packages/a/big.ts': 500, 'packages/s/extractor.ts': 594 }, before);
+  writeSource(mine.dir, 'packages/s/extractor.ts', 348);
+  const red = run(mine.dir, null, { allowlistPath: mine.allowlistPath });
+  assert.equal(red.code, 1, red.out);
+  assert.match(
+    red.out,
+    /packages\/s\/extractor\.ts: this change took the file to 348 <= 400 but kept its row \(budget 594\)/,
+  );
+  // Same allowlist, but main already holds the file at 348 and the branch
+  // never touches it: advisory, exactly as before.
+  const theirs = auditTree({ 'packages/a/big.ts': 500, 'packages/s/extractor.ts': 348 }, before);
+  writeSource(theirs.dir, 'packages/c/unrelated.ts', 10);
+  const green = run(theirs.dir, null, { allowlistPath: theirs.allowlistPath });
+  assert.equal(green.code, 0, green.out);
+  assert.match(green.out, /note: packages\/s\/extractor\.ts: now 348 lines <= 400/);
+});
+
+test('a kept row for a file this change deleted fails (#4388)', () => {
+  const { dir, git, allowlistPath } = auditTree(
+    { 'packages/a/big.ts': 500, 'packages/b/gone.ts': 450 },
+    `${AUDIT_BASE}   450 packages/b/gone.ts\n`,
+  );
+  git('rm', '-q', 'packages/b/gone.ts');
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 1, out);
+  assert.match(out, /packages\/b\/gone\.ts: this change removed or renamed the file but kept its row \(budget 450\)/);
+});
+
+test('a row deleted relative to the base for a file still over the limit says so (#4388)', () => {
+  // main's deletion taken for the other side's addition, in reverse: the
+  // resolution dropped a row main still needs. newOffenders fires (as it
+  // always did); the audit adds the WHY.
+  const { dir, allowlistPath } = auditTree(
+    { 'packages/a/big.ts': 500, 'packages/b/kept.ts': 450 },
+    `${AUDIT_BASE}   450 packages/b/kept.ts\n`,
+  );
+  writeFileSync(allowlistPath, AUDIT_BASE);
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 1, out);
+  assert.match(out, /New source file\(s\) over 400 lines with no allowlist row/);
+  assert.match(
+    out,
+    /packages\/b\/kept\.ts: row \(budget 450\) deleted relative to the merge base, but the file measures 450 > 400/,
+  );
+  assert.match(out, /-1 deleted/);
+});
+
+test('what --update writes on a grown file is what the audit then accepts (#4388)', () => {
+  const { dir, allowlistPath } = auditTree({ 'packages/a/big.ts': 500 }, AUDIT_BASE);
+  writeSource(dir, 'packages/a/big.ts', 520);
+  const updated = run(dir, null, { allowlistPath, extra: ['--update', '--allow-raise'] });
+  assert.equal(updated.code, 0, updated.out);
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 0, out);
+  assert.match(out, /\+0 added, \^1 raised, v0 lowered, -0 deleted/);
+  assert.match(out, /OK \(1 files measured, 1 allowlisted, 0 new over 400; vs merge-base [0-9a-f]{9}: \+0 \^1 v0 -0\)/);
+});
+
+test('no merge base: CI fails closed, a developer gets a loud skip, --base names one by hand (#4388)', () => {
+  // A plain directory has no repository, so nothing to diff against.
+  const plain = tree({ 'packages/a/big.ts': 500 });
+  const ci = run(plain, '500 packages/a/big.ts\n', { env: { CI: 'true' } });
+  assert.equal(ci.code, 1, ci.out);
+  assert.match(ci.out, /merge-base audit could not run: .*is not inside a git worktree/);
+  assert.match(ci.out, /CI is set, so this is a failure, not a skip/);
+  const local = run(plain, '500 packages/a/big.ts\n');
+  assert.equal(local.code, 0, local.out);
+  assert.match(local.out, /WARNING -- merge-base audit SKIPPED/);
+  assert.match(local.out, /OK \(1 files measured, 1 allowlisted, 0 new over 400; merge-base audit SKIPPED\)/);
+
+  // A repository whose upstream is not called origin: `--base` says which ref.
+  const { dir, git, allowlistPath } = gitTree({ 'packages/a/big.ts': 500 }, { allowlist: AUDIT_BASE });
+  git('update-ref', 'refs/remotes/upstream/main', 'main');
+  git('checkout', '-q', '-b', 'feature');
+  const fellBack = run(dir, null, { allowlistPath });
+  assert.equal(fellBack.code, 0, fellBack.out);
+  assert.match(fellBack.out, /WARNING -- no merge base with origin\/main; fell back to local 'main'/);
+  const named = run(dir, null, { allowlistPath, extra: ['--base', 'upstream/main'] });
+  assert.equal(named.code, 0, named.out);
+  assert.doesNotMatch(named.out, /WARNING/);
+  assert.match(named.out, /vs merge-base upstream\/main \([0-9a-f]{9}\)/);
+  const bogus = run(dir, null, { allowlistPath, extra: ['--base', 'no-such-ref'], env: { CI: '1' } });
+  assert.equal(bogus.code, 1, bogus.out);
+  assert.match(bogus.out, /no merge base with no-such-ref/);
+});
+
+test('the Rust allowlist is audited by the same rules from here (#4388)', () => {
+  // The cargo test has no git, so a hand-picked Rust row is judged here.
+  const rustAllowlist = 'rust/processing/tests/module_size_allowlist.txt';
+  const rustRows = (budget) => `# rust rows\n${String(budget).padStart(8)} rust/core/src/big.rs\n`;
+  const { dir, git, allowlistPath } = gitTree(
+    { 'packages/a/big.ts': 500 },
+    { allowlist: AUDIT_BASE, extraFiles: { [rustAllowlist]: rustRows(500), 'rust/core/src/big.rs': source(500) } },
+  );
+  git('update-ref', 'refs/remotes/origin/main', 'main');
+  git('checkout', '-q', '-b', 'feature');
+  writeFileSync(join(dir, rustAllowlist), rustRows(520));
+  const { code, out } = run(dir, null, { allowlistPath });
+  assert.equal(code, 1, out);
+  assert.match(
+    out,
+    /rust\/processing\/tests\/module_size_allowlist\.txt vs merge-base origin\/main \([0-9a-f]{9}\): \+0 added, \^1 raised/,
+  );
+  assert.match(out, /rust\/core\/src\/big\.rs: row raised 500 -> 520, but the file measures 500: 20 line\(s\) of headroom/);
+  // A duplicate row -- the classic conflict residue -- fails outright.
+  writeFileSync(join(dir, rustAllowlist), `${rustRows(500)}     500 rust/core/src/big.rs\n`);
+  const dup = run(dir, null, { allowlistPath });
+  assert.equal(dup.code, 1, dup.out);
+  assert.match(dup.out, /module_size_allowlist\.txt: duplicate row for rust\/core\/src\/big\.rs/);
+});

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -724,7 +724,7 @@ test('a split PR that keeps its row fails; the same shrink landed elsewhere does
   assert.equal(red.code, 1, red.out);
   assert.match(
     red.out,
-    /packages\/s\/extractor\.ts: this change took the file to 348 <= 400 but kept its row \(budget 594\)/,
+    /packages\/s\/extractor\.ts: this change took the file from 594 to 348 <= 400 but kept its row \(budget 594\)/,
   );
   // Same allowlist, but main already holds the file at 348 and the branch
   // never touches it: advisory, exactly as before.
@@ -743,7 +743,10 @@ test('a kept row for a file this change deleted fails (#4388)', () => {
   git('rm', '-q', 'packages/b/gone.ts');
   const { code, out } = run(dir, null, { allowlistPath });
   assert.equal(code, 1, out);
-  assert.match(out, /packages\/b\/gone\.ts: this change removed or renamed the file but kept its row \(budget 450\)/);
+  assert.match(
+    out,
+    /packages\/b\/gone\.ts: this change removed or renamed the file \(450 lines at the merge base\) but kept its row \(budget 450\)/,
+  );
 });
 
 test('a row deleted relative to the base for a file still over the limit says so (#4388)', () => {

--- a/scripts/lib/module-size-audit-run.mjs
+++ b/scripts/lib/module-size-audit-run.mjs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Check mode's merge-base audit (#4388), the I/O half: resolve the base and
+ * the changed-path set, read each allowlist as it was at the base, hand the
+ * rows to `auditAgainstBase` and report. Lives beside the CLI rather than in
+ * it because `scripts/check-module-size.mjs` is allowlisted and may not grow;
+ * the rules are in `module-size-base-audit.mjs`, the git plumbing in
+ * `module-size-git.mjs`.
+ *
+ * Two allowlists are audited: the TypeScript one this gate owns, and the
+ * Rust twin's (`rust/processing/tests/module_size_allowlist.txt`), whose
+ * cargo test has no git and whose digest pin only proves a row was edited,
+ * not that the number is right. Only rowed paths are measured on the Rust
+ * side, so there is no walk and no exemption rule there: a row for a file
+ * that moved under `tests/` still measures, and the cargo test reports that
+ * one as its own advisory note.
+ */
+
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+import { countLines, parseAllowlist } from './module-size-ratchet.mjs';
+import { changedFilesWarned, describeBase, readBlobAt, underCi } from './module-size-git.mjs';
+import { auditAgainstBase, summarizeAudit } from './module-size-base-audit.mjs';
+
+/** The Rust twin's allowlist, repo-relative. */
+export const RUST_ALLOWLIST = 'rust/processing/tests/module_size_allowlist.txt';
+
+/**
+ * Run both audits. `headRows` is the parsed TS allowlist, `measured` a
+ * `Map<rel, lines>` of every non-exempt module the walk saw. Returns
+ * `{ failed, tsAudit, scope }`: `failed` when any row a measurement does not
+ * justify was found (or the audit could not run under CI); `tsAudit` is the
+ * TS allowlist's `auditAgainstBase` result, or `null` when it did not run;
+ * `scope` is `changedFiles()`'s answer, or `{ error }`.
+ */
+export function runMergeBaseAudits({ root, allowlistPath, headRows, measured, baseRef }) {
+  const state = { failed: false, tsAudit: null, scope: null };
+
+  // The audit could not run. Under CI that is a failure: a run that cannot see
+  // the base cannot tell a resolved conflict from a measured row, and "skipped"
+  // would print the same OK line as "judged" — the shape every gate in this
+  // family exists to avoid. Elsewhere it is a loud skip naming what was skipped.
+  const unavailable = (why) => {
+    if (underCi()) {
+      state.failed = true;
+      console.error(`
+check-module-size: the merge-base audit could not run: ${why}.
+
+CI is set, so this is a failure, not a skip (#4388). Check out with full history
+and an origin/main ref, or pass --base <ref> to name the base by hand.
+`);
+    } else {
+      console.warn(
+        `check-module-size: WARNING -- merge-base audit SKIPPED: ${why}. Allowlist rows were ` +
+          `NOT judged against the merge base this run (#4388); fetch origin/main or pass --base <ref>.`,
+      );
+    }
+    return null;
+  };
+
+  const scope = changedFilesWarned(root, baseRef);
+  state.scope = scope;
+  if (scope.error !== undefined) {
+    unavailable(scope.error);
+    return state;
+  }
+  const sha9 = scope.base.sha.slice(0, 9);
+
+  // Audit one allowlist (`rel`, repo-relative) whose HEAD rows are `rows`.
+  const auditOne = (rel, rows, measure) => {
+    const baseText = readBlobAt(root, scope.base.sha, rel);
+    if (baseText === null) return unavailable(`${rel} is not readable at merge-base ${sha9}`);
+    let baseRows;
+    try {
+      baseRows = parseAllowlist(baseText, `${rel}@${sha9}`);
+    } catch (err) {
+      return unavailable(err.message);
+    }
+    const audit = auditAgainstBase({ baseRows, headRows: rows, measure, changed: scope.changed });
+    console.log(`check-module-size: ${rel} vs merge-base ${describeBase(scope.base)}: ${summarizeAudit(audit)}`);
+    if (audit.failures.length > 0) {
+      state.failed = true;
+      console.error(`
+Allowlist row(s) in ${rel} that this change wrote or kept, and that the
+measurement does not justify (vs merge-base ${describeBase(scope.base)}):\n
+${audit.failures.join('\n')}
+
+A row that differs from the merge base is this change's row, and the only
+number it may carry is the one \`--update\` writes: the file's measured count.
+After a merge conflict, never resolve by picking a side -- diff BOTH sides
+against the merge base, then re-run \`pnpm lint:module-size-baseline\`
+(\`--allow-raise\` only for growth this change justifies in the PR) and commit
+what it writes (#4388).
+`);
+    }
+    return audit;
+  };
+
+  // The TS allowlist: judged against the walk's own measurement. The path must
+  // be inside the worktree, or there is no base-side blob to read.
+  let allowlistReal = null;
+  try {
+    allowlistReal = realpathSync.native(allowlistPath);
+  } catch {
+    allowlistReal = null;
+  }
+  const allowlistRel = allowlistReal === null ? null : relative(scope.top, allowlistReal).split('\\').join('/');
+  if (allowlistRel === null || allowlistRel.startsWith('..') || isAbsolute(allowlistRel)) {
+    unavailable(`allowlist ${allowlistPath} is not inside the worktree ${scope.top}`);
+  } else {
+    state.tsAudit = auditOne(allowlistRel, headRows, (rel) => measured.get(rel) ?? null);
+  }
+
+  // The Rust allowlist, when the tree has one.
+  const rustHead = join(root, RUST_ALLOWLIST);
+  if (!existsSync(rustHead)) {
+    console.log(`check-module-size: no ${RUST_ALLOWLIST} under ${root}; the Rust allowlist was not audited`);
+    return state;
+  }
+  let rustRows;
+  try {
+    rustRows = parseAllowlist(readFileSync(rustHead, 'utf8'), RUST_ALLOWLIST);
+  } catch (err) {
+    // The HEAD file is this change's, so a duplicate row -- the classic
+    // conflict residue -- is a failure here, not an unavailable audit.
+    state.failed = true;
+    console.error(`check-module-size: ${err.message}`);
+    return state;
+  }
+  const measureRust = (rel) => {
+    try {
+      return countLines(readFileSync(join(root, rel), 'utf8'));
+    } catch (err) {
+      if (err.code === 'ENOENT') return null;
+      // An unreadable file must not pass as "no file": null is the one answer
+      // that makes a deleted row look justified.
+      throw new Error(`cannot read ${rel}: ${err.message}`);
+    }
+  };
+  auditOne(RUST_ALLOWLIST, rustRows, measureRust);
+  return state;
+}

--- a/scripts/lib/module-size-audit-run.mjs
+++ b/scripts/lib/module-size-audit-run.mjs
@@ -69,6 +69,15 @@ and an origin/main ref, or pass --base <ref> to name the base by hand.
   }
   const sha9 = scope.base.sha.slice(0, 9);
 
+  // The same path as it was at the merge base. Consulted only for a kept row
+  // whose file this change touched and which is now under the limit or gone
+  // (a handful of blobs at most), to tell this change's shrink from a stale
+  // row main already carried.
+  const measureAtBase = (rel) => {
+    const text = readBlobAt(root, scope.base.sha, rel);
+    return text === null ? null : countLines(text);
+  };
+
   // Audit one allowlist (`rel`, repo-relative) whose HEAD rows are `rows`.
   const auditOne = (rel, rows, measure) => {
     const baseText = readBlobAt(root, scope.base.sha, rel);
@@ -79,7 +88,7 @@ and an origin/main ref, or pass --base <ref> to name the base by hand.
     } catch (err) {
       return unavailable(err.message);
     }
-    const audit = auditAgainstBase({ baseRows, headRows: rows, measure, changed: scope.changed });
+    const audit = auditAgainstBase({ baseRows, headRows: rows, measure, measureAtBase, changed: scope.changed });
     console.log(`check-module-size: ${rel} vs merge-base ${describeBase(scope.base)}: ${summarizeAudit(audit)}`);
     if (audit.failures.length > 0) {
       state.failed = true;
@@ -91,9 +100,13 @@ ${audit.failures.join('\n')}
 A row that differs from the merge base is this change's row, and the only
 number it may carry is the one \`--update\` writes: the file's measured count.
 After a merge conflict, never resolve by picking a side -- diff BOTH sides
-against the merge base, then re-run \`pnpm lint:module-size-baseline\`
-(\`--allow-raise\` only for growth this change justifies in the PR) and commit
-what it writes (#4388).
+against the merge base. Then: DELETE every row named above for a file this
+change did not touch (a scoped \`--update\` leaves those alone); rebase or
+merge main so the count CI measures is the count you measure (CI judges the
+merge commit against origin/main, so a row exact on a stale branch can carry
+headroom there); then re-run \`pnpm lint:module-size-baseline\`
+(\`--allow-raise\` only for growth this change justifies in the PR) for the
+rest and commit what it writes (#4388).
 `);
     }
     return audit;

--- a/scripts/lib/module-size-base-audit.mjs
+++ b/scripts/lib/module-size-base-audit.mjs
@@ -19,14 +19,21 @@
  * The merge base is what separates the two. A row that differs from its
  * base-side twin was written by this change (or by its conflict resolution),
  * and `--update` writes exactly the measured count, so the discipline is
- * already "the row equals the measurement" -- this makes the gate say so. A
- * row that is byte-identical to the base was written by someone else, and
- * stays advisory UNLESS this change also touched the file: then the shrink
- * is this change's, and keeping the old budget is the re-growth headroom the
- * split PR in #4388 left behind.
+ * already "the row equals the measurement" -- this makes the gate say so for
+ * a row ADDED or RAISED. A row LOWERED with slack left is held only to "the
+ * file is still over the limit": lowering cannot loosen the ratchet, and
+ * failing it on headroom would redden the branch whose file main shrank a
+ * little further while the PR sat in review -- the one shape the advisory
+ * notes exist to keep green. A row that is byte-identical to the base was
+ * written by someone else, and stays advisory UNLESS this change also
+ * touched the file AND the file was over the limit at the base: then the
+ * shrink is this change's, and keeping the old budget is the re-growth
+ * headroom the split PR in #4388 left behind. (A row main already carried
+ * for a file under the limit is main's stale row, whoever edits the file
+ * next; the `shrunk` note reports it, and a scoped `--update` drops it.)
  *
- * Pure: takes parsed rows, a measurement function and the changed-path set,
- * returns strings. The CLI resolves the base and reads the blobs.
+ * Pure: takes parsed rows, two measurement functions and the changed-path
+ * set, returns strings. The CLI resolves the base and reads the blobs.
  */
 
 import { LIMIT } from './module-size-ratchet.mjs';
@@ -38,6 +45,12 @@ import { LIMIT } from './module-size-ratchet.mjs';
  * @param {(rel: string) => number | null} input.measure  line count of a
  *        module at HEAD, or null when it was not measured (gone, renamed or
  *        exempt)
+ * @param {(rel: string) => number | null} input.measureAtBase  line count
+ *        of the same path at the merge base, or null when it had none there.
+ *        Consulted only for a kept row whose file this change touched and
+ *        which now measures under the limit or not at all: it decides whether
+ *        the shrink is this change's (the file was over the limit at the
+ *        base) or main's stale row.
  * @param {Set<string>} input.changed   repo-relative paths this change
  *        touched, from `changedFiles()`
  * @returns {{ added: string[], raised: string[], lowered: string[],
@@ -46,7 +59,7 @@ import { LIMIT } from './module-size-ratchet.mjs';
  *   so the resolution is visible on every run); `failures` are the rows a
  *   measurement does not justify, each a `  <path>: <why>` line.
  */
-export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
+export function auditAgainstBase({ baseRows, headRows, measure, measureAtBase, changed }) {
   const added = [];
   const raised = [];
   const lowered = [];
@@ -58,11 +71,14 @@ export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
     const before = baseRows.get(rel);
     const lines = measure(rel);
     let edit = null;
+    let loosened = false;
     if (before === undefined) {
       edit = `added at ${budget}`;
+      loosened = true;
       added.push(`  ${rel}: ${edit}`);
     } else if (budget > before) {
       edit = `raised ${before} -> ${budget}`;
+      loosened = true;
       raised.push(`  ${rel}: ${edit}`);
     } else if (budget < before) {
       edit = `lowered ${before} -> ${budget}`;
@@ -72,10 +88,9 @@ export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
     }
 
     if (edit !== null) {
-      // A row this change wrote. `--update` writes the measured count, so
-      // anything else is a hand-picked number: a resurrected row (file under
-      // the limit), annexed headroom (budget above the file), or a row for a
-      // file that is not there.
+      // A row this change wrote. It must describe a file that is there and
+      // over the limit, whichever way it was edited: a resurrected row for a
+      // 268-line file is the #4330 case however the number compares.
       if (lines === null) {
         failures.push(
           `  ${rel}: row ${edit}, but no such module was measured (gone, renamed or exempt); delete the row`,
@@ -84,7 +99,13 @@ export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
         failures.push(
           `  ${rel}: row ${edit}, but the file measures ${lines} <= ${LIMIT} and needs no row; delete it`,
         );
-      } else if (lines < budget) {
+      } else if (loosened && lines < budget) {
+        // Added or raised above the file: annexed headroom (the 766-for-765
+        // case). `--update` writes the measured count, so anything above it
+        // is a hand-picked number. A LOWERED row with slack is not held to
+        // this: it loosened nothing, and main shrinking the file a little
+        // further while the branch sat in review must stay a note (the
+        // pull_request merge commit is measured against the branch's row).
         failures.push(
           `  ${rel}: row ${edit}, but the file measures ${lines}: ${budget - lines} line(s) of headroom ` +
             `nothing measured; re-run --update so the row says what the file says`,
@@ -96,17 +117,26 @@ export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
     }
 
     // Kept byte-for-byte from the base: somebody else's row, UNLESS this
-    // change touched the file. Then the shrink (or the delete) is this
-    // change's, and the row it left behind is exactly what #4388's split PR
-    // lost in its conflict resolution.
+    // change touched the file AND the file was over the limit at the base.
+    // Then the shrink (or the delete) is this change's, and the row it left
+    // behind is exactly what #4388's split PR lost in its conflict
+    // resolution. A file already under the limit at the base means main was
+    // carrying a stale row before this change existed; that is the `shrunk`
+    // note's job, and blaming it on whoever edits the file next would send
+    // them to a conflict resolution that never happened.
     if (!changed.has(rel)) continue;
+    if (lines !== null && lines > LIMIT) continue;
+    const atBase = measureAtBase(rel);
+    if (atBase === null || atBase <= LIMIT) continue;
     if (lines === null) {
       failures.push(
-        `  ${rel}: this change removed or renamed the file but kept its row (budget ${budget}); delete the row`,
+        `  ${rel}: this change removed or renamed the file (${atBase} lines at the merge base) but kept ` +
+          `its row (budget ${budget}); delete the row`,
       );
-    } else if (lines <= LIMIT) {
+    } else {
       failures.push(
-        `  ${rel}: this change took the file to ${lines} <= ${LIMIT} but kept its row (budget ${budget}); delete the row`,
+        `  ${rel}: this change took the file from ${atBase} to ${lines} <= ${LIMIT} but kept its row ` +
+          `(budget ${budget}); delete the row`,
       );
     }
   }

--- a/scripts/lib/module-size-base-audit.mjs
+++ b/scripts/lib/module-size-base-audit.mjs
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The merge-base audit of a module-size allowlist (#4388): which rows THIS
+ * change edited relative to the base, and whether the file each of them
+ * describes justifies the number it now carries.
+ *
+ * WHY THIS EXISTS: the gate's two teeth (a new god file, a listed file over
+ * its budget) both judge a FILE against a ROW. Neither judges the row. So a
+ * conflict resolution in the allowlist that resurrected a deleted row for a
+ * 268-line file, kept the row of a file a split had taken to 348 lines, and
+ * carried a 766 budget for a 765-line file printed three `note:` lines and
+ * `OK` (#4330, described in #4388). The information was present and nothing
+ * acted on it, because the shrink/slack notes are advisory by design: a
+ * shrink landing in ANOTHER PR must not turn this one red.
+ *
+ * The merge base is what separates the two. A row that differs from its
+ * base-side twin was written by this change (or by its conflict resolution),
+ * and `--update` writes exactly the measured count, so the discipline is
+ * already "the row equals the measurement" -- this makes the gate say so. A
+ * row that is byte-identical to the base was written by someone else, and
+ * stays advisory UNLESS this change also touched the file: then the shrink
+ * is this change's, and keeping the old budget is the re-growth headroom the
+ * split PR in #4388 left behind.
+ *
+ * Pure: takes parsed rows, a measurement function and the changed-path set,
+ * returns strings. The CLI resolves the base and reads the blobs.
+ */
+
+import { LIMIT } from './module-size-ratchet.mjs';
+
+/**
+ * @param {object} input
+ * @param {Map<string, number>} input.baseRows   rows at the merge base
+ * @param {Map<string, number>} input.headRows   rows in the working tree
+ * @param {(rel: string) => number | null} input.measure  line count of a
+ *        module at HEAD, or null when it was not measured (gone, renamed or
+ *        exempt)
+ * @param {Set<string>} input.changed   repo-relative paths this change
+ *        touched, from `changedFiles()`
+ * @returns {{ added: string[], raised: string[], lowered: string[],
+ *             deleted: string[], kept: number, failures: string[] }}
+ *   The four lists name the rows that differ from the base (for the log,
+ *   so the resolution is visible on every run); `failures` are the rows a
+ *   measurement does not justify, each a `  <path>: <why>` line.
+ */
+export function auditAgainstBase({ baseRows, headRows, measure, changed }) {
+  const added = [];
+  const raised = [];
+  const lowered = [];
+  const deleted = [];
+  const failures = [];
+  let kept = 0;
+
+  for (const [rel, budget] of headRows) {
+    const before = baseRows.get(rel);
+    const lines = measure(rel);
+    let edit = null;
+    if (before === undefined) {
+      edit = `added at ${budget}`;
+      added.push(`  ${rel}: ${edit}`);
+    } else if (budget > before) {
+      edit = `raised ${before} -> ${budget}`;
+      raised.push(`  ${rel}: ${edit}`);
+    } else if (budget < before) {
+      edit = `lowered ${before} -> ${budget}`;
+      lowered.push(`  ${rel}: ${edit}`);
+    } else {
+      kept += 1;
+    }
+
+    if (edit !== null) {
+      // A row this change wrote. `--update` writes the measured count, so
+      // anything else is a hand-picked number: a resurrected row (file under
+      // the limit), annexed headroom (budget above the file), or a row for a
+      // file that is not there.
+      if (lines === null) {
+        failures.push(
+          `  ${rel}: row ${edit}, but no such module was measured (gone, renamed or exempt); delete the row`,
+        );
+      } else if (lines <= LIMIT) {
+        failures.push(
+          `  ${rel}: row ${edit}, but the file measures ${lines} <= ${LIMIT} and needs no row; delete it`,
+        );
+      } else if (lines < budget) {
+        failures.push(
+          `  ${rel}: row ${edit}, but the file measures ${lines}: ${budget - lines} line(s) of headroom ` +
+            `nothing measured; re-run --update so the row says what the file says`,
+        );
+      }
+      // lines > budget is growth past the budget, and the existing `grew`
+      // tooth (Rust: the cargo test) already fails it with its own message.
+      continue;
+    }
+
+    // Kept byte-for-byte from the base: somebody else's row, UNLESS this
+    // change touched the file. Then the shrink (or the delete) is this
+    // change's, and the row it left behind is exactly what #4388's split PR
+    // lost in its conflict resolution.
+    if (!changed.has(rel)) continue;
+    if (lines === null) {
+      failures.push(
+        `  ${rel}: this change removed or renamed the file but kept its row (budget ${budget}); delete the row`,
+      );
+    } else if (lines <= LIMIT) {
+      failures.push(
+        `  ${rel}: this change took the file to ${lines} <= ${LIMIT} but kept its row (budget ${budget}); delete the row`,
+      );
+    }
+  }
+
+  for (const [rel, before] of baseRows) {
+    if (headRows.has(rel)) continue;
+    deleted.push(`  ${rel}: deleted (was ${before})`);
+    const lines = measure(rel);
+    // On the TS side this is also a `newOffenders` failure; the point of
+    // saying it here too is the WHY: the row went missing relative to the
+    // merge base, which after a conflict means somebody's deletion was
+    // taken for the other side's addition (#4388 has the worked example).
+    if (lines !== null && lines > LIMIT) {
+      failures.push(
+        `  ${rel}: row (budget ${before}) deleted relative to the merge base, but the file measures ` +
+          `${lines} > ${LIMIT}; restore it -- was the deletion main's or this change's?`,
+      );
+    }
+  }
+
+  for (const list of [added, raised, lowered, deleted, failures]) list.sort();
+  return { added, raised, lowered, deleted, kept, failures };
+}
+
+/** `+A added, ^R raised, vL lowered, -D deleted` — zero counts included. */
+export function summarizeAudit({ added, raised, lowered, deleted }) {
+  return `+${added.length} added, ^${raised.length} raised, v${lowered.length} lowered, -${deleted.length} deleted`;
+}
+
+/** The compact form the OK line carries: `+A ^R vL -D`. */
+export function compactAudit({ added, raised, lowered, deleted }) {
+  return `+${added.length} ^${raised.length} v${lowered.length} -${deleted.length}`;
+}

--- a/scripts/lib/module-size-base-audit.test.mjs
+++ b/scripts/lib/module-size-base-audit.test.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Unit tests for the merge-base audit rules (#4388), against the three
+ * conflict resolutions the issue records verbatim plus the boundaries that
+ * separate "this change's row" from "somebody else's".
+ *
+ * Run: node --test scripts/lib/module-size-base-audit.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { auditAgainstBase, compactAudit, summarizeAudit } from './module-size-base-audit.mjs';
+
+const rows = (obj) => new Map(Object.entries(obj));
+const measureFrom = (obj) => (rel) => (Object.hasOwn(obj, rel) ? obj[rel] : null);
+
+test('the #4330 resolution fails on all three rows, each for its own reason (#4388)', () => {
+  // main deleted project-units.ts's row (the file is 268 lines); the PR
+  // split schedule-extractor.ts 594 -> 348 and deleted its row; the
+  // resolution resurrected the first, kept the second, and carried a 766 for
+  // a 765-line file. Base = main's allowlist; HEAD = the resolution.
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'packages/parser/src/schedule-extractor.ts': 594, 'packages/parser/src/x.ts': 765 }),
+    headRows: rows({
+      'packages/parser/src/project-units.ts': 523,
+      'packages/parser/src/schedule-extractor.ts': 594,
+      'packages/parser/src/x.ts': 766,
+    }),
+    measure: measureFrom({
+      'packages/parser/src/project-units.ts': 268,
+      'packages/parser/src/schedule-extractor.ts': 348,
+      'packages/parser/src/x.ts': 765,
+    }),
+    changed: new Set(['packages/parser/src/schedule-extractor.ts', 'packages/parser/src/x.ts']),
+  });
+  assert.deepEqual(audit.added, ['  packages/parser/src/project-units.ts: added at 523']);
+  assert.deepEqual(audit.raised, ['  packages/parser/src/x.ts: raised 765 -> 766']);
+  assert.deepEqual(audit.lowered, []);
+  assert.deepEqual(audit.deleted, []);
+  assert.equal(audit.kept, 1);
+  assert.equal(audit.failures.length, 3, audit.failures.join('\n'));
+  assert.match(audit.failures[0], /project-units\.ts: row added at 523, but the file measures 268 <= 400 and needs no row/);
+  assert.match(audit.failures[1], /schedule-extractor\.ts: this change took the file to 348 <= 400 but kept its row \(budget 594\)/);
+  assert.match(audit.failures[2], /x\.ts: row raised 765 -> 766, but the file measures 765: 1 line\(s\) of headroom/);
+  assert.equal(summarizeAudit(audit), '+1 added, ^1 raised, v0 lowered, -0 deleted');
+  assert.equal(compactAudit(audit), '+1 ^1 v0 -0');
+});
+
+test('what --update writes passes: every edited row equals its measurement', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500, 'b.ts': 600, 'c.ts': 450 }),
+    headRows: rows({ 'a.ts': 520, 'b.ts': 580, 'd.ts': 401 }),
+    measure: measureFrom({ 'a.ts': 520, 'b.ts': 580, 'c.ts': 300, 'd.ts': 401 }),
+    changed: new Set(['a.ts', 'b.ts', 'c.ts', 'd.ts']),
+  });
+  assert.deepEqual(audit.failures, []);
+  assert.equal(summarizeAudit(audit), '+1 added, ^1 raised, v1 lowered, -1 deleted');
+});
+
+test('a kept row is advisory when the shrink landed elsewhere, a failure when it is this change\'s', () => {
+  const input = {
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 300 }),
+  };
+  const elsewhere = auditAgainstBase({ ...input, changed: new Set(['unrelated.ts']) });
+  assert.deepEqual(elsewhere.failures, []);
+  assert.equal(elsewhere.kept, 1);
+  const mine = auditAgainstBase({ ...input, changed: new Set(['a.ts']) });
+  assert.equal(mine.failures.length, 1);
+  assert.match(mine.failures[0], /this change took the file to 300 <= 400 but kept its row/);
+});
+
+test('a kept row with slack on a file this change touched stays advisory', () => {
+  // main carries 14 rows with headroom today; failing a PR that merely
+  // edits one of those files would redden work that never touched the row.
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 480 }),
+    changed: new Set(['a.ts']),
+  });
+  assert.deepEqual(audit.failures, []);
+});
+
+test('a kept row for a file this change removed fails; removed elsewhere, it does not', () => {
+  const input = { baseRows: rows({ 'a.ts': 500 }), headRows: rows({ 'a.ts': 500 }), measure: () => null };
+  assert.deepEqual(auditAgainstBase({ ...input, changed: new Set() }).failures, []);
+  const mine = auditAgainstBase({ ...input, changed: new Set(['a.ts']) });
+  assert.match(mine.failures[0], /removed or renamed the file but kept its row \(budget 500\)/);
+});
+
+test('an edited row for a module that was not measured fails', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500, 'ghost.ts': 450 }),
+    measure: measureFrom({ 'a.ts': 500 }),
+    changed: new Set(),
+  });
+  assert.match(audit.failures[0], /ghost\.ts: row added at 450, but no such module was measured/);
+});
+
+test('a deleted row whose file is still over the limit names the merge base', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500, 'b.ts': 450 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 500, 'b.ts': 450 }),
+    changed: new Set(),
+  });
+  assert.deepEqual(audit.deleted, ['  b.ts: deleted (was 450)']);
+  assert.match(audit.failures[0], /b\.ts: row \(budget 450\) deleted relative to the merge base, but the file measures 450 > 400/);
+});
+
+test('growth past an edited budget is left to the grew tooth, not double-reported', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 510 }),
+    measure: measureFrom({ 'a.ts': 530 }),
+    changed: new Set(['a.ts']),
+  });
+  assert.deepEqual(audit.failures, []);
+  assert.deepEqual(audit.raised, ['  a.ts: raised 500 -> 510']);
+});
+
+test('a lowered row must still equal the measurement', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 800 }),
+    headRows: rows({ 'a.ts': 700 }),
+    measure: measureFrom({ 'a.ts': 650 }),
+    changed: new Set(['a.ts']),
+  });
+  assert.match(audit.failures[0], /row lowered 800 -> 700, but the file measures 650: 50 line\(s\) of headroom/);
+});
+
+test('an identical allowlist produces zero counts and zero failures', () => {
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 500 }),
+    changed: new Set(['a.ts']),
+  });
+  assert.deepEqual(audit.failures, []);
+  assert.equal(summarizeAudit(audit), '+0 added, ^0 raised, v0 lowered, -0 deleted');
+});

--- a/scripts/lib/module-size-base-audit.test.mjs
+++ b/scripts/lib/module-size-base-audit.test.mjs
@@ -17,6 +17,8 @@ import { auditAgainstBase, compactAudit, summarizeAudit } from './module-size-ba
 
 const rows = (obj) => new Map(Object.entries(obj));
 const measureFrom = (obj) => (rel) => (Object.hasOwn(obj, rel) ? obj[rel] : null);
+/** Base-side counts: every rowed file was over the limit there unless a case says otherwise. */
+const overAtBase = () => 500;
 
 test('the #4330 resolution fails on all three rows, each for its own reason (#4388)', () => {
   // main deleted project-units.ts's row (the file is 268 lines); the PR
@@ -35,6 +37,11 @@ test('the #4330 resolution fails on all three rows, each for its own reason (#43
       'packages/parser/src/schedule-extractor.ts': 348,
       'packages/parser/src/x.ts': 765,
     }),
+    measureAtBase: measureFrom({
+      'packages/parser/src/project-units.ts': 268,
+      'packages/parser/src/schedule-extractor.ts': 594,
+      'packages/parser/src/x.ts': 765,
+    }),
     changed: new Set(['packages/parser/src/schedule-extractor.ts', 'packages/parser/src/x.ts']),
   });
   assert.deepEqual(audit.added, ['  packages/parser/src/project-units.ts: added at 523']);
@@ -44,7 +51,7 @@ test('the #4330 resolution fails on all three rows, each for its own reason (#43
   assert.equal(audit.kept, 1);
   assert.equal(audit.failures.length, 3, audit.failures.join('\n'));
   assert.match(audit.failures[0], /project-units\.ts: row added at 523, but the file measures 268 <= 400 and needs no row/);
-  assert.match(audit.failures[1], /schedule-extractor\.ts: this change took the file to 348 <= 400 but kept its row \(budget 594\)/);
+  assert.match(audit.failures[1], /schedule-extractor\.ts: this change took the file from 594 to 348 <= 400 but kept its row \(budget 594\)/);
   assert.match(audit.failures[2], /x\.ts: row raised 765 -> 766, but the file measures 765: 1 line\(s\) of headroom/);
   assert.equal(summarizeAudit(audit), '+1 added, ^1 raised, v0 lowered, -0 deleted');
   assert.equal(compactAudit(audit), '+1 ^1 v0 -0');
@@ -55,6 +62,7 @@ test('what --update writes passes: every edited row equals its measurement', () 
     baseRows: rows({ 'a.ts': 500, 'b.ts': 600, 'c.ts': 450 }),
     headRows: rows({ 'a.ts': 520, 'b.ts': 580, 'd.ts': 401 }),
     measure: measureFrom({ 'a.ts': 520, 'b.ts': 580, 'c.ts': 300, 'd.ts': 401 }),
+    measureAtBase: measureFrom({ 'a.ts': 500, 'b.ts': 600, 'c.ts': 450, 'd.ts': 380 }),
     changed: new Set(['a.ts', 'b.ts', 'c.ts', 'd.ts']),
   });
   assert.deepEqual(audit.failures, []);
@@ -66,13 +74,39 @@ test('a kept row is advisory when the shrink landed elsewhere, a failure when it
     baseRows: rows({ 'a.ts': 500 }),
     headRows: rows({ 'a.ts': 500 }),
     measure: measureFrom({ 'a.ts': 300 }),
+    measureAtBase: overAtBase,
   };
   const elsewhere = auditAgainstBase({ ...input, changed: new Set(['unrelated.ts']) });
   assert.deepEqual(elsewhere.failures, []);
   assert.equal(elsewhere.kept, 1);
   const mine = auditAgainstBase({ ...input, changed: new Set(['a.ts']) });
   assert.equal(mine.failures.length, 1);
-  assert.match(mine.failures[0], /this change took the file to 300 <= 400 but kept its row/);
+  assert.match(mine.failures[0], /this change took the file from 500 to 300 <= 400 but kept its row/);
+});
+
+test("a kept row main already carried for a file under the limit is not this change's shrink", () => {
+  // main tolerates a stale row (the `shrunk` note is advisory and staleRows
+  // judges the budget, not the file). A PR that merely edits that file did
+  // not do the shrinking, and must not be told it resolved a conflict badly;
+  // the note (and a scoped --update, which drops the row) still apply.
+  const audit = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 290 }),
+    measureAtBase: measureFrom({ 'a.ts': 300 }),
+    changed: new Set(['a.ts']),
+  });
+  assert.deepEqual(audit.failures, []);
+  assert.equal(audit.kept, 1);
+  // The same for a file that did not exist at the base at all.
+  const ghost = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: measureFrom({ 'a.ts': 290 }),
+    measureAtBase: () => null,
+    changed: new Set(['a.ts']),
+  });
+  assert.deepEqual(ghost.failures, []);
 });
 
 test('a kept row with slack on a file this change touched stays advisory', () => {
@@ -82,16 +116,22 @@ test('a kept row with slack on a file this change touched stays advisory', () =>
     baseRows: rows({ 'a.ts': 500 }),
     headRows: rows({ 'a.ts': 500 }),
     measure: measureFrom({ 'a.ts': 480 }),
+    measureAtBase: overAtBase,
     changed: new Set(['a.ts']),
   });
   assert.deepEqual(audit.failures, []);
 });
 
 test('a kept row for a file this change removed fails; removed elsewhere, it does not', () => {
-  const input = { baseRows: rows({ 'a.ts': 500 }), headRows: rows({ 'a.ts': 500 }), measure: () => null };
+  const input = {
+    baseRows: rows({ 'a.ts': 500 }),
+    headRows: rows({ 'a.ts': 500 }),
+    measure: () => null,
+    measureAtBase: overAtBase,
+  };
   assert.deepEqual(auditAgainstBase({ ...input, changed: new Set() }).failures, []);
   const mine = auditAgainstBase({ ...input, changed: new Set(['a.ts']) });
-  assert.match(mine.failures[0], /removed or renamed the file but kept its row \(budget 500\)/);
+  assert.match(mine.failures[0], /removed or renamed the file \(500 lines at the merge base\) but kept its row \(budget 500\)/);
 });
 
 test('an edited row for a module that was not measured fails', () => {
@@ -99,6 +139,7 @@ test('an edited row for a module that was not measured fails', () => {
     baseRows: rows({ 'a.ts': 500 }),
     headRows: rows({ 'a.ts': 500, 'ghost.ts': 450 }),
     measure: measureFrom({ 'a.ts': 500 }),
+    measureAtBase: overAtBase,
     changed: new Set(),
   });
   assert.match(audit.failures[0], /ghost\.ts: row added at 450, but no such module was measured/);
@@ -109,6 +150,7 @@ test('a deleted row whose file is still over the limit names the merge base', ()
     baseRows: rows({ 'a.ts': 500, 'b.ts': 450 }),
     headRows: rows({ 'a.ts': 500 }),
     measure: measureFrom({ 'a.ts': 500, 'b.ts': 450 }),
+    measureAtBase: overAtBase,
     changed: new Set(),
   });
   assert.deepEqual(audit.deleted, ['  b.ts: deleted (was 450)']);
@@ -120,20 +162,34 @@ test('growth past an edited budget is left to the grew tooth, not double-reporte
     baseRows: rows({ 'a.ts': 500 }),
     headRows: rows({ 'a.ts': 510 }),
     measure: measureFrom({ 'a.ts': 530 }),
+    measureAtBase: overAtBase,
     changed: new Set(['a.ts']),
   });
   assert.deepEqual(audit.failures, []);
   assert.deepEqual(audit.raised, ['  a.ts: raised 500 -> 510']);
 });
 
-test('a lowered row must still equal the measurement', () => {
-  const audit = auditAgainstBase({
+test('a lowered row with slack is a note, not a failure; lowered onto a file under the limit fails', () => {
+  // Lowering cannot loosen the ratchet. Failing headroom on a lowered row
+  // would redden the branch whose file main shrank a little further while
+  // the PR sat in review (CI measures the merge commit against the row).
+  const slack = auditAgainstBase({
     baseRows: rows({ 'a.ts': 800 }),
     headRows: rows({ 'a.ts': 700 }),
     measure: measureFrom({ 'a.ts': 650 }),
+    measureAtBase: overAtBase,
     changed: new Set(['a.ts']),
   });
-  assert.match(audit.failures[0], /row lowered 800 -> 700, but the file measures 650: 50 line\(s\) of headroom/);
+  assert.deepEqual(slack.failures, []);
+  assert.deepEqual(slack.lowered, ['  a.ts: lowered 800 -> 700']);
+  const under = auditAgainstBase({
+    baseRows: rows({ 'a.ts': 800 }),
+    headRows: rows({ 'a.ts': 420 }),
+    measure: measureFrom({ 'a.ts': 380 }),
+    measureAtBase: overAtBase,
+    changed: new Set(['a.ts']),
+  });
+  assert.match(under.failures[0], /row lowered 800 -> 420, but the file measures 380 <= 400 and needs no row/);
 });
 
 test('an identical allowlist produces zero counts and zero failures', () => {
@@ -141,6 +197,7 @@ test('an identical allowlist produces zero counts and zero failures', () => {
     baseRows: rows({ 'a.ts': 500 }),
     headRows: rows({ 'a.ts': 500 }),
     measure: measureFrom({ 'a.ts': 500 }),
+    measureAtBase: overAtBase,
     changed: new Set(['a.ts']),
   });
   assert.deepEqual(audit.failures, []);

--- a/scripts/lib/module-size-git.mjs
+++ b/scripts/lib/module-size-git.mjs
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Git plumbing for the TypeScript module-size ratchet
+ * (`scripts/check-module-size.mjs`): the merge base with main, the paths a
+ * change touched, and a blob at a commit. Split out of the CLI when #4388
+ * gave check mode its own use for the merge base — the CLI is allowlisted
+ * and may not grow, and `check-source-text-assertions.mjs` carries the same
+ * derivation, so this is the copy the next gate should import rather than
+ * write a third time.
+ *
+ * Every function here FAILS CLOSED: an unreadable path, a root that is not
+ * the top of its worktree, or no merge base at all is an `{ error }`, never a
+ * silent repo-wide fallback. A fallback is the annexation #3398 was about, in
+ * the one context — a shallow clone, a detached checkout, a script — where
+ * nobody is reading the output.
+ */
+
+import { realpathSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+function git(root, ...argv) {
+  return spawnSync('git', ['-C', root, ...argv], { encoding: 'utf8' });
+}
+
+function safeRealpath(path) {
+  try {
+    return realpathSync.native(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The physical top of the worktree `root` is in, or `{ error }` when `root`
+ * is not inside one or is not itself that top.
+ *
+ * Compare resolved paths: `git` answers with the physical path, while --root
+ * may arrive through a symlink (macOS /var -> /private/var). Requiring the
+ * top to BE the scanned root stops a synthetic tree nested inside some other
+ * repository from silently inheriting that repository's diff. Either side
+ * unresolvable is a REFUSAL, not a pass: `safeRealpath` answers null on
+ * failure, so a bare `!==` would compare null to null and let the guard
+ * through in exactly the case where it knows least about the two paths.
+ */
+export function worktreeTop(root) {
+  const top = git(root, 'rev-parse', '--show-toplevel');
+  if (top.status !== 0) return { error: `${root} is not inside a git worktree` };
+  const toplevel = top.stdout.trim();
+  const resolvedTop = safeRealpath(toplevel);
+  const resolvedRoot = safeRealpath(root);
+  if (resolvedTop === null || resolvedRoot === null || resolvedTop !== resolvedRoot) {
+    return { error: `${root} is not the top of its git worktree (that is ${toplevel})` };
+  }
+  return { top: resolvedTop };
+}
+
+/**
+ * This worktree's merge base with main: `{ ref, sha, fellBack }` or
+ * `{ error }`. Tries `origin/main` then a local `main`, or ONLY `ref` when
+ * one is given (`--base`), so a clone that names its upstream differently can
+ * still say which ref it means.
+ *
+ * `main` can be arbitrarily far behind `origin/main` (measured: 147 commits,
+ * widening `--update`'s scope from 0 files to 381, 49 of them allowlisted),
+ * which is the annexation the scoping exists to prevent. The fallback is
+ * still the right behaviour -- not every clone names its upstream `origin`
+ * -- but it must not be a routine log line, so the caller is told it
+ * happened and warns.
+ */
+export function resolveBase(root, { ref = null } = {}) {
+  const candidates = ref === null ? ['origin/main', 'main'] : [ref];
+  for (const candidate of candidates) {
+    const merged = git(root, 'merge-base', candidate, 'HEAD');
+    const sha = merged.stdout.trim();
+    if (merged.status === 0 && sha !== '') {
+      return { ref: candidate, sha, fellBack: ref === null && candidate !== 'origin/main' };
+    }
+  }
+  return { error: `no merge base with ${candidates.join(' or ')}` };
+}
+
+/** `git show <sha>:<rel>` from `root`, or `null` if the blob is unreadable. */
+export function readBlobAt(root, sha, rel) {
+  const res = git(root, 'show', `${sha}:${rel}`);
+  return res.status === 0 ? res.stdout : null;
+}
+
+/**
+ * The paths this worktree changed relative to its merge base with main:
+ * committed, staged, unstaged and untracked, all relative to the repo top.
+ * `{ changed: Set, base: { ref, sha, fellBack }, top }` on success (`top` is
+ * the physical worktree top, the directory the paths are relative to),
+ * `{ error }` on failure.
+ *
+ * Git is the only honest discriminator between slack THIS change created and
+ * slack inherited from main, which is why `--update` derives the scope
+ * instead of taking a `--scope` flag: a flag nobody passes is the annexation
+ * with extra steps. The same set is what check mode uses (#4388) to tell a
+ * shrink this change made from one that landed elsewhere.
+ */
+export function changedFiles(root, { baseRef = null } = {}) {
+  const top = worktreeTop(root);
+  if (top.error !== undefined) return top;
+  const base = resolveBase(root, { ref: baseRef });
+  if (base.error !== undefined) return base;
+  const nulSeparated = (res) => (res.status === 0 ? res.stdout.split('\0').filter(Boolean) : null);
+  // `--no-renames` so a renamed module reports BOTH paths. Rename detection
+  // reports only the destination, and the source's row is exactly the one that
+  // has to be dropped.
+  const diffed = nulSeparated(git(root, 'diff', '--name-only', '--no-renames', '-z', base.sha));
+  // Untracked too: a god file written but not yet committed is the single most
+  // likely thing a contributor is running this for.
+  const untracked = nulSeparated(git(root, 'ls-files', '--others', '--exclude-standard', '-z'));
+  if (diffed === null || untracked === null) return { error: 'git could not list the changed files' };
+  return { changed: new Set([...diffed, ...untracked]), base, top: top.top };
+}
+
+/** `origin/main (abc123456)` — how the CLI names a base in its output. */
+export function describeBase(base) {
+  return `${base.ref} (${base.sha.slice(0, 9)})`;
+}
+
+/**
+ * `changedFiles()` with the fallback warning both of the CLI's modes must
+ * print the same way. A stale local `main` widens the scope, so the warning
+ * is the only thing between a contributor and the annexation #3398 was
+ * about -- and it must not be a routine log line.
+ */
+export function changedFilesWarned(root, baseRef, warn = console.warn) {
+  const derived = changedFiles(root, { baseRef });
+  if (derived.error === undefined && derived.base.fellBack) {
+    warn(
+      `check-module-size: WARNING -- no merge base with origin/main; fell back to ` +
+        `local '${derived.base.ref}' (${derived.base.sha.slice(0, 9)}). If that ref is stale, the scope ` +
+        `is WIDER than your change: a regenerate may annex rows you did not touch, and the ` +
+        `merge-base audit may judge rows you did not write. Fetch origin/main and re-run.`,
+    );
+  }
+  return derived;
+}
+
+/**
+ * `CI` the way the Rust gates read it (`common::refuse_to_skip_in_ci`): set,
+ * non-empty, and not a spelled-out "no".
+ */
+export function underCi(env = process.env) {
+  const ci = env.CI;
+  return ci !== undefined && ci !== '' && ci !== '0' && ci !== 'false';
+}

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -181,7 +181,9 @@ export function allowlistDigests(map) {
  *  - `grew` (FAILS): allowlisted and over its recorded budget.
  *  - `shrunk` / `missing` / `slack` (ADVISORY): rows that should be deleted or
  *    lowered. Advisory only, so that a merge landing a shrink elsewhere cannot
- *    turn an unrelated PR red — the same choice the Rust gate makes.
+ *    turn an unrelated PR red — the same choice the Rust gate makes. When
+ *    the shrink is the change's OWN, check mode's merge-base audit fails the
+ *    kept row instead (#4388, `module-size-base-audit.mjs`).
  *
  * `slack` is the one this gate could not previously see at all. A row whose
  * budget sits ABOVE the file's current size is headroom the file may grow into

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -34,6 +34,21 @@
 # says what changed) while making any two PRs touching the same scope collide
 # on that single pinned line, even when their row edits were disjoint. See
 # scripts/check-module-size.mjs for the two teeth this gate still has.
+#
+# AFTER A MERGE CONFLICT IN THIS FILE (#4388): never resolve by picking a side.
+# The two sides usually change DIFFERENT rows for DIFFERENT reasons, so "take
+# main's" and "take theirs" are both wrong at once. Diff BOTH sides against
+# the MERGE BASE and ask, per row, who changed it and why:
+#
+#   git diff $(git merge-base main BRANCH) main   -- scripts/module-size-allowlist.txt
+#   git diff $(git merge-base main BRANCH) BRANCH -- scripts/module-size-allowlist.txt
+#
+# then re-run `pnpm lint:module-size-baseline` and commit what it writes. The
+# gate diffs this file against the merge base on every run and FAILS a row
+# that differs from it when the file's measured count does not justify it: a
+# row added or raised above the file's size, a row resurrected for a file
+# under 400, or a row kept for a file this change shrank under 400 or removed.
+# A hand-picked number fails; a shrink that landed in another PR stays a note.
    524 apps/viewer-embed/src/bridge/handler.ts
    481 apps/viewer/src/components/extensions/ExtensionsPanel.tsx
    431 apps/viewer/src/components/extensions/FlavorDialog.tsx
@@ -334,7 +349,7 @@
    957 scripts/check-issue-queue.mjs
    448 scripts/check-legacy-entity-coverage.mjs
   1145 scripts/check-loader-hook-specifier-match.mjs
-   554 scripts/check-module-size.mjs
+   512 scripts/check-module-size.mjs
   1066 scripts/check-pr-review-signal.mjs
    855 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -43,12 +43,16 @@
 #   git diff $(git merge-base main BRANCH) main   -- scripts/module-size-allowlist.txt
 #   git diff $(git merge-base main BRANCH) BRANCH -- scripts/module-size-allowlist.txt
 #
-# then re-run `pnpm lint:module-size-baseline` and commit what it writes. The
+# Then DELETE every row for a file your change did not touch that the gate
+# names (a scoped `--update` leaves those alone), rebase or merge main so the
+# count CI measures is the count you measure, and re-run
+# `pnpm lint:module-size-baseline` for the rest and commit what it writes. The
 # gate diffs this file against the merge base on every run and FAILS a row
 # that differs from it when the file's measured count does not justify it: a
-# row added or raised above the file's size, a row resurrected for a file
-# under 400, or a row kept for a file this change shrank under 400 or removed.
-# A hand-picked number fails; a shrink that landed in another PR stays a note.
+# row added or raised above the file's size, a row edited for a file under
+# 400 (or gone), or a row kept for a file this change shrank under 400 or
+# removed. A hand-picked number fails; a shrink that landed in another PR
+# stays a note, and so does slack left on a row this change only lowered.
    524 apps/viewer-embed/src/bridge/handler.ts
    481 apps/viewer/src/components/extensions/ExtensionsPanel.tsx
    431 apps/viewer/src/components/extensions/FlavorDialog.tsx


### PR DESCRIPTION
Closes #4388

## What changed

`check-module-size` now judges allowlist conflict resolutions instead of printing `note:` and `OK` on them.

- **Merge-base audit in check mode.** Resolves `git merge-base origin/main HEAD` (then `main`, or `--base <ref>`), reads `scripts/module-size-allowlist.txt` as it was at that base, and diffs the rows:
  - a row **added or raised** must equal the HEAD measurement of a file over 400 (the resurrected `523` for a 268-line `project-units.ts` and the `766` for a 765-line file from #4330 both fail, each with its own message);
  - a row **lowered** must still name a file over 400; slack left on it stays a note (lowering loosens nothing, and main shrinking the same file a little further while the PR sits in review must not redden it);
  - a row **kept unchanged** fails when this PR's own diff took a file that was over 400 at the merge base under 400, or removed it (the split-PR case: `this change took the file from 594 to 348 <= 400 but kept its row`). The same shrink landing in another PR, or a stale row main already carried for a file under 400, stays advisory as before.
  - a row **deleted** relative to the base whose file is still over 400 gets a message saying so (beside the existing `newOffenders` failure), so a reviewer sees a resolution, not new growth.
- **Counts on every run.** `check-module-size: scripts/module-size-allowlist.txt vs merge-base origin/main (e700a7ba3): +0 added, ^0 raised, v1 lowered, -0 deleted`, and the compact form rides the OK line: `OK (2748 files measured, 328 allowlisted, 0 new over 400; vs merge-base e700a7ba3: +0 ^0 v1 -0)`.
- **No base is a failure under `CI`**, a loud `WARNING -- merge-base audit SKIPPED` elsewhere (the OK line then says `merge-base audit SKIPPED`). `--base <ref>` names the base by hand.
- **The Rust twin** (`rust/processing/tests/module_size_allowlist.txt`) is audited from the same script by the same rules (the cargo test has no git). `module_size_ratchet.rs`'s `parse_allowlist` now panics on a duplicate row (the classic conflict residue) instead of last-wins, and its truncated header sentence is finished. Digest pin unchanged (comment-only allowlist edit).
- **Layout.** The CLI is allowlisted and may not grow, so the git plumbing moved to `scripts/lib/module-size-git.mjs` (`worktreeTop`/`resolveBase`/`readBlobAt`/`changedFiles`/`changedFilesWarned`/`underCi`), the pure rules live in `scripts/lib/module-size-base-audit.mjs` (`auditAgainstBase`/`summarizeAudit`/`compactAudit`), and the I/O run in `scripts/lib/module-size-audit-run.mjs` (`runMergeBaseAudits`). The CLI shrank 554 -> 512 and its own row was re-recorded by `--update` (which is why the audit on this branch prints `v1 lowered`).
- **Docs.** The TS allowlist header carries the issue's rule ("never resolve by picking a side; diff BOTH sides against the MERGE BASE") with both `git diff` commands and the remedy: delete rows the gate names for files you did not touch (a scoped `--update` leaves those alone), rebase/merge main so CI measures what you measure, then `pnpm lint:module-size-baseline` for the rest. The gate's failure trailer says the same.

## Why / root cause

The gate's two teeth (a new file over 400 with no row; a listed file grown past its budget) both judge a **file against a row**. Nothing judged the **row**. `shrunk` and `slack` were advisory by design so a shrink landing in another PR would not redden this one -- but that rationale cannot tell "somebody else's shrink" from "this PR's conflict resolution". The merge base can: a row that differs from its base-side twin was written by this change, and `--update` writes exactly the measured count, so the discipline "the row equals the measurement" already existed -- it just was not enforced. Rows this change did not write, and files it did not touch, stay advisory exactly as before.

Not done, and why:
- **AGENTS.md** was not amended (plan wanted one sentence): it sits exactly at its byte budget (`scripts/agents-md-budget.txt` = 45038, `check-agents-md-size.mjs` ratchets down only), so a sentence cannot be added without deleting elsewhere. The rule lives in the allowlist header -- the file anyone resolving the conflict is looking at -- and in the gate's own failure text.
- "Shrank but still over 400" on a file this PR touched stays advisory: main carries 22 slack rows today; failing them would redden any PR that merely edits those files. Stated in the unit test.
- **Out of scope** (per plan): `rust-major-offset.json` (prose `reason`/`refs` conflicts), `api-surface.json` / `rust-api-surface.json` (exact-equality snapshots already fail a bad resolution by construction), `unused-locals-baseline.json` (already strict on slack), and a general baseline-conflict lint.

Follow-ups (not in this PR):
- `.github/workflows/test.yml` ~L1000-1005: the comment "Raising a budget by hand is NOT one of them (#3745) -- it is sanctioned" is now stale -- a hand raise the measurement does not justify fails. Workflow edits are outside this PR's plan; one-line comment fix.
- `scripts/check-source-text-assertions.mjs` still carries its own `resolveBase`/`readBlobAt`; switching it to `scripts/lib/module-size-git.mjs` touches that gate's warning text and tests.

No changeset (tooling-only; `check-changesets.mjs` accepts none). No perf probe: the only `rust/processing` change is a test file plus allowlist comment lines.

## Evidence

Run in the worktree at `ec580e8ad` (Windows 11, CRLF checkout; every committed blob verified LF via `git show HEAD:<file> | file -`):

- `node --test scripts/check-module-size.test.mjs scripts/lib/module-size-ratchet.test.mjs scripts/lib/module-size-base-audit.test.mjs` -> **78 tests, 78 pass, 0 fail** (49 black-box incl. 8 new merge-base cases on real `git init` trees; 18 ratchet; 11 unit cases for the rules incl. the #4330 resolution verbatim, the lowered-with-slack note, and the base-already-shrunk shape).
- `node scripts/check-module-size.mjs` -> exit 0, prints the TS audit line (`+0 added, ^0 raised, v1 lowered, -0 deleted`), the Rust audit line (all zeros) and `OK (2748 files measured, 328 allowlisted, 0 new over 400; vs merge-base e700a7ba3: +0 ^0 v1 -0)`. Same under `CI=1`.
- Smoke on a plain (non-git) directory: `CI=1` -> exit 1 `CI is set, so this is a failure, not a skip`; unset -> exit 0 with `WARNING -- merge-base audit SKIPPED`.
- `cargo test -p ifc-lite-processing --test module_size_ratchet` -> **8 passed, 0 failed** (incl. new `parse_allowlist_refuses_a_duplicate_row` should_panic; `allowlist_digest_is_pinned` still green). `cargo clippy -p ifc-lite-processing --tests -- -D warnings` -> clean (stage 1).
- `node scripts/check-test-wiring.mjs` -> exit 0 (the new lib test is reached by the `scripts/lib/*.test.mjs` catch-all). `node scripts/add-license-headers.mjs --check` -> 0 missing. `pnpm exec oxlint` over the six touched `.mjs` files -> exit 0.
- `node scripts/check-ci-path-coverage.mjs` -> **exit 1 on this host, pre-existing**: it names two stale exemptions at `scripts/ci-path-coverage-allowlist.txt:80-81` (`scripts/fixtures/*`, `tests/models/README.md`) and fails identically on a clean detached worktree at `e700a7ba3`. Not this PR's; not claimed green.

NOT run: root `pnpm lint` end to end (`check-unused-locals.mjs` dies with `spawnSync pnpm ENOENT` on this Windows host before reaching later gates -- unrelated); `cargo test --workspace` / `cargo clippy --workspace --all-targets` (only a test file in one crate changed; the crate-level runs above are the relevant ones); the whole-crate `cargo test -p ifc-lite-processing` in stage 1 had one failure, `mesh_determinism::mesh_output_matches_pinned_manifest`, a geometry normals hash on this Windows host that nothing in this diff touches.

## Review

Fable review verdict: approve, with three minors and two nits.

- **Remedy text wrong for the headline case** (scoped `--update` does not remove a resurrected row for an untouched file, so "re-run and commit" left the gate red): fixed. Trailer and header now say delete-then-rebase-then-update.
- **`lowered` rows held to exact equality** (not in the plan; false red when main shrinks the file further while the PR waits): fixed. Headroom fails only on added/raised rows; a lowered row still fails for a file gone or under 400. Unit test rewritten; CLI docstring updated.
- **Kept-row failure misattributed the shrink** when main already carried a stale row for a file under 400: fixed the preferred way. `auditAgainstBase` takes `measureAtBase(rel)` (built from `readBlobAt` + `countLines`, called only for kept rows on touched files now under the limit or gone) and fails only when the file was over 400 at the base; the message carries both counts. New unit case for the base-already-shrunk shape (and for a file absent at the base).
- Nit: docstring called the audit "the third thing check mode fails on" -> reworded.
- Nit: `check-source-text-assertions.mjs` keeps its own `resolveBase`/`readBlobAt` copy -> named as a follow-up above rather than widening the PR; the workflow-comment staleness likewise.
- Taste decisions applied: module split and names kept, `realpathSync.native` kept (this host's `tmpdir()` is an 8.3 short path and git answers the long name), `+A ^R vL -D` glyphs kept, harness attribution lines kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Module-size checks now compare allowlist entries against the merge base to identify changes specific to the current branch.
  - Added support for selecting an explicit comparison base.
  - Check results now include audit summaries and distinguish inherited growth from branch-specific changes.

- **Bug Fixes**
  - Duplicate allowlist entries are now rejected instead of silently overriding one another.
  - CI checks fail safely when required audit information is unavailable.

- **Documentation**
  - Added guidance for resolving merge conflicts and refreshing module-size baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->