### PR TITLE
ci(module-size): print each allowlist's own remedy; refuse --base beside --all (#4388)

### DIFF
--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -255,11 +255,11 @@ function parseArgs(argv) {
       fail(`unknown argument: ${flag}`);
     }
   }
-  // `--allow-raise` alone reads as "budgets may go up" and does nothing, which
-  // is the worst way for a safety flag to behave. Refuse it instead, and refuse
-  // a bare `--all` for the same reason: it reads as "check everything".
+  // A safety flag that does nothing is the worst kind: refuse `--allow-raise` alone
+  // ("budgets may go up"), a bare `--all` ("check everything"), and `--base` beside `--all`.
   if (out.allowRaise && !out.update) fail('--allow-raise only means something with --update');
   if (out.all && !out.update) fail('--all only means something with --update');
+  if (out.base !== null && out.all) fail('--base names the merge base; --all skips the derivation, so pass one or the other');
   if (out.allowlist === null) out.allowlist = join(out.root, 'scripts', 'module-size-allowlist.txt');
   return out;
 }

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -805,6 +805,11 @@ test('no merge base: CI fails closed, a developer gets a loud skip, --base names
   const bogus = run(dir, null, { allowlistPath, extra: ['--base', 'no-such-ref'], env: { CI: '1' } });
   assert.equal(bogus.code, 1, bogus.out);
   assert.match(bogus.out, /no merge base with no-such-ref/);
+  // `--update --all` derives no merge base, so a `--base` beside it would be
+  // silently ignored -- the do-nothing safety flag the CLI already refuses.
+  const both = run(dir, null, { allowlistPath, extra: ['--update', '--all', '--base', 'upstream/main'] });
+  assert.equal(both.code, 1, both.out);
+  assert.match(both.out, /--base names the merge base; --all skips the derivation/);
 });
 
 test('the Rust allowlist is audited by the same rules from here (#4388)', () => {
@@ -825,6 +830,10 @@ test('the Rust allowlist is audited by the same rules from here (#4388)', () => 
     /rust\/processing\/tests\/module_size_allowlist\.txt vs merge-base origin\/main \([0-9a-f]{9}\): \+0 added, \^1 raised/,
   );
   assert.match(out, /rust\/core\/src\/big\.rs: row raised 500 -> 520, but the file measures 500: 20 line\(s\) of headroom/);
+  // The remedy is the Rust file's own: `--update` rewrites only the TS
+  // allowlist, so pointing a Rust row at it would leave the gate red.
+  assert.doesNotMatch(out, /lint:module-size-baseline/);
+  assert.match(out, /re-pin ALLOWLIST_DIGESTS in\s+rust\/processing\/tests\/module_size_ratchet\.rs/);
   // A duplicate row -- the classic conflict residue -- fails outright.
   writeFileSync(join(dir, rustAllowlist), `${rustRows(500)}     500 rust/core/src/big.rs\n`);
   const dup = run(dir, null, { allowlistPath });

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -243,9 +243,9 @@ function loadAllowlist() {
 
 /**
  * This worktree's merge base with origin/main, falling back to local main --
- * identical derivation to scripts/check-module-size.mjs's `changedFiles()`,
- * reused rather than reinvented so the two gates degrade the same way under
- * the same shallow-clone and no-remote conditions.
+ * identical derivation to `resolveBase()` in scripts/lib/module-size-git.mjs
+ * (the module-size ratchet's), kept in step so the two gates degrade the same
+ * way under the same shallow-clone and no-remote conditions.
  *
  * Returns `{ ref, sha }` or `null` if neither ref has a merge base with HEAD
  * (no `origin` remote, or a clone too shallow to share history).

--- a/scripts/lib/module-size-audit-run.mjs
+++ b/scripts/lib/module-size-audit-run.mjs
@@ -16,7 +16,11 @@
  * not that the number is right. Only rowed paths are measured on the Rust
  * side, so there is no walk and no exemption rule there: a row for a file
  * that moved under `tests/` still measures, and the cargo test reports that
- * one as its own advisory note.
+ * one as its own advisory note. The two allowlists also get different
+ * remedies: `--update` rewrites only the TypeScript one, while the Rust rows
+ * are edited by hand and their digest pin re-pinned from the cargo test's
+ * own output -- printing the TypeScript command for a Rust row would send
+ * the reader to a command that leaves the failing file untouched.
  */
 
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
@@ -27,6 +31,27 @@ import { auditAgainstBase, summarizeAudit } from './module-size-base-audit.mjs';
 
 /** The Rust twin's allowlist, repo-relative. */
 export const RUST_ALLOWLIST = 'rust/processing/tests/module_size_allowlist.txt';
+
+// What to do about a failing row, per allowlist. Each failure line already
+// says "delete it" or "restore it"; the remedy says how, and which tool (if
+// any) writes the number. The two-sided diff comes first on purpose: a row
+// is only "this change's" once the merge base says so.
+const TS_REMEDY = `Then do what each line above says -- DELETE a row it says
+needs no row, RESTORE a row it says was deleted -- for every file this change
+did not touch (a scoped \`--update\` leaves those alone); rebase or merge main
+so the count CI measures is the count you measure (CI judges the merge commit
+against origin/main, so a row exact on a stale branch can carry headroom
+there); then re-run \`pnpm lint:module-size-baseline\` (\`--allow-raise\` only
+for growth this change justifies in the PR) for the rest and commit what it
+writes (#4388).`;
+
+const RUST_REMEDY = `This file has no update mode: do what each line above
+says by hand -- set a row to the file's measured line count (\`wc -l\`, the
+same count \`str::lines()\` gives), DELETE a row it says needs no row, RESTORE
+a row it says was deleted -- then re-pin ALLOWLIST_DIGESTS in
+rust/processing/tests/module_size_ratchet.rs: \`cargo test -p
+ifc-lite-processing --test module_size_ratchet\` prints the new figures
+(#4388).`;
 
 /**
  * Run both audits. `headRows` is the parsed TS allowlist, `measured` a
@@ -78,8 +103,9 @@ and an origin/main ref, or pass --base <ref> to name the base by hand.
     return text === null ? null : countLines(text);
   };
 
-  // Audit one allowlist (`rel`, repo-relative) whose HEAD rows are `rows`.
-  const auditOne = (rel, rows, measure) => {
+  // Audit one allowlist (`rel`, repo-relative) whose HEAD rows are `rows`;
+  // `remedy` is that allowlist's own after-the-diff instruction.
+  const auditOne = (rel, rows, measure, remedy) => {
     const baseText = readBlobAt(root, scope.base.sha, rel);
     if (baseText === null) return unavailable(`${rel} is not readable at merge-base ${sha9}`);
     let baseRows;
@@ -98,15 +124,9 @@ measurement does not justify (vs merge-base ${describeBase(scope.base)}):\n
 ${audit.failures.join('\n')}
 
 A row that differs from the merge base is this change's row, and the only
-number it may carry is the one \`--update\` writes: the file's measured count.
-After a merge conflict, never resolve by picking a side -- diff BOTH sides
-against the merge base. Then: DELETE every row named above for a file this
-change did not touch (a scoped \`--update\` leaves those alone); rebase or
-merge main so the count CI measures is the count you measure (CI judges the
-merge commit against origin/main, so a row exact on a stale branch can carry
-headroom there); then re-run \`pnpm lint:module-size-baseline\`
-(\`--allow-raise\` only for growth this change justifies in the PR) for the
-rest and commit what it writes (#4388).
+number it may carry is the file's measured line count. After a merge
+conflict, never resolve by picking a side -- diff BOTH sides against the
+merge base. ${remedy}
 `);
     }
     return audit;
@@ -124,7 +144,7 @@ rest and commit what it writes (#4388).
   if (allowlistRel === null || allowlistRel.startsWith('..') || isAbsolute(allowlistRel)) {
     unavailable(`allowlist ${allowlistPath} is not inside the worktree ${scope.top}`);
   } else {
-    state.tsAudit = auditOne(allowlistRel, headRows, (rel) => measured.get(rel) ?? null);
+    state.tsAudit = auditOne(allowlistRel, headRows, (rel) => measured.get(rel) ?? null, TS_REMEDY);
   }
 
   // The Rust allowlist, when the tree has one.
@@ -153,6 +173,6 @@ rest and commit what it writes (#4388).
       throw new Error(`cannot read ${rel}: ${err.message}`);
     }
   };
-  auditOne(RUST_ALLOWLIST, rustRows, measureRust);
+  auditOne(RUST_ALLOWLIST, rustRows, measureRust, RUST_REMEDY);
   return state;
 }

--- a/scripts/lib/module-size-base-audit.mjs
+++ b/scripts/lib/module-size-base-audit.mjs
@@ -106,9 +106,12 @@ export function auditAgainstBase({ baseRows, headRows, measure, measureAtBase, c
         // this: it loosened nothing, and main shrinking the file a little
         // further while the branch sat in review must stay a note (the
         // pull_request merge commit is measured against the branch's row).
+        // It IS still failed, by the two branches above, when main's shrink
+        // took the file under the limit or removed it: that row is stale,
+        // and the same rebase + `--update` drops it.
         failures.push(
           `  ${rel}: row ${edit}, but the file measures ${lines}: ${budget - lines} line(s) of headroom ` +
-            `nothing measured; re-run --update so the row says what the file says`,
+            `the file does not have; re-run --update so the row says what the file says`,
         );
       }
       // lines > budget is growth past the budget, and the existing `grew`

--- a/scripts/lib/module-size-base-audit.test.mjs
+++ b/scripts/lib/module-size-base-audit.test.mjs
@@ -173,6 +173,9 @@ test('a lowered row with slack is a note, not a failure; lowered onto a file und
   // Lowering cannot loosen the ratchet. Failing headroom on a lowered row
   // would redden the branch whose file main shrank a little further while
   // the PR sat in review (CI measures the merge commit against the row).
+  // A lowered row IS still failed when that shrink took the file under the
+  // limit or removed it (second case): the row is stale, and the same
+  // rebase + --update drops it.
   const slack = auditAgainstBase({
     baseRows: rows({ 'a.ts': 800 }),
     headRows: rows({ 'a.ts': 700 }),


### PR DESCRIPTION
Follow-up to #4535 (`Closes #4388` landed there; this PR carries the review findings that arrived after the merge). No issue is closed by this PR.

## What changed

- **Each allowlist gets its own remedy.** `runMergeBaseAudits`'s `auditOne` now takes a `remedy` string. The TypeScript one still ends in `pnpm lint:module-size-baseline`; the Rust one (`rust/processing/tests/module_size_allowlist.txt`) says the file has no update mode, to set a row to the file's measured count (`wc -l`, the same count `str::lines()` gives) or delete it, and to re-pin `ALLOWLIST_DIGESTS` in `module_size_ratchet.rs` from the figures `cargo test -p ifc-lite-processing --test module_size_ratchet` prints. The black-box test `the Rust allowlist is audited by the same rules from here` now asserts the Rust failure output does not mention `lint:module-size-baseline` and does name the digest pin, so the wrong remedy cannot come back.
- **No contradictory step.** The old paragraph said "DELETE every row named above for a file this change did not touch" while the deleted-row failure line says "restore it" (CodeRabbit on #4535). Both remedies now defer to the failure line: delete a row it says needs no row, restore a row it says was deleted.
- **Headroom message reads as a sentence**: `... 1 line(s) of headroom the file does not have; re-run --update so the row says what the file says` (was `headroom nothing measured`). Existing regexes match up to `headroom` and are unchanged.
- **Lowered-row comment says what the code does** (`module-size-base-audit.mjs` and its unit test): slack on a lowered row is a note, but a lowered row whose file main took under the limit or removed still fails as a stale row; the same rebase + `--update` drops it. No behaviour change.
- **`--base` beside `--update --all` is refused** (`--base names the merge base; --all skips the derivation, so pass one or the other`) instead of being silently ignored -- the same do-nothing-safety-flag shape the CLI already refuses for `--allow-raise` and a bare `--all`. Line-neutral in `check-module-size.mjs` (allowlisted at 512, still 512). Asserted in the `no merge base` test.
- **`check-source-text-assertions.mjs` docstring** repointed from `check-module-size.mjs`'s `changedFiles()` (moved by #4535) to `resolveBase()` in `scripts/lib/module-size-git.mjs`. Comment only, line-neutral (allowlisted at 446, still 446).

Not changed, and why:
- **AGENTS.md** stays as on main. The review asked to drop the byte-neutral L42 rewrite from the branch (it named `pnpm lint:module-size-baseline` for both allowlists, which is wrong for the Rust one, and overstated the lowered-row rule); that commit was never pushed, so main never carried it. The remedy lives in the gate's failure text and both allowlist headers.
- **`measureRust` throwing on `EISDIR`/`EACCES`** (CodeRabbit nitpick, rated trivial/low value): left as is. The gate still exits non-zero with the path in the message; wrapping the audit in a catch-all would hide programming errors behind a one-line message.
- **Follow-ups not taken here** (as stated on #4535): `check-source-text-assertions.mjs` keeping its own `resolveBase`/`readBlobAt` copy rather than importing `scripts/lib/module-size-git.mjs` (touches that gate's warning text and tests); the stale `test.yml` comment about hand-raised budgets; `rust-major-offset.json` / `api-surface.json` / `rust-api-surface.json` / `unused-locals-baseline.json` and a general baseline-conflict lint.

No production code changed (scripts and their tests only); no changeset (`check-changesets` accepts none for tooling); nothing under `rust/` touched, so no perf probe.

## Why / root cause

`auditOne()` printed one remedy for both allowlists, written for the one `--update` rewrites. For the Rust twin the advice was exactly the "documented advice that does not work" shape the CLI's own docstring warns about: the command runs, touches nothing, and the gate stays red. The rest are wording the reviewer found either broken (`headroom nothing measured`), stale (the orphaned cross-reference), or promising more than the code gives (the lowered-row comment), plus one silently ignored flag.

## Evidence

Run in the worktree on this branch (Windows 11, `core.autocrlf=true` checkout):

- `node --test scripts/check-module-size.test.mjs scripts/lib/module-size-ratchet.test.mjs scripts/lib/module-size-base-audit.test.mjs` -> **78 tests, 77 pass, 1 fail**. The failure is `regenerating the real allowlist reproduces it byte for byte`, which fails identically on a clean `origin/main` checkout on this host (verified via `git stash`): the allowlist is CRLF on disk here and LF in the index. With the index's LF blob written to disk the same test passes (`# pass 1`), i.e. **78/78** on an LF checkout, which is what CI runs.
- `node scripts/check-module-size.mjs` -> exit 0: `scripts/module-size-allowlist.txt vs merge-base origin/main (531194cdc): +0 added, ^0 raised, v0 lowered, -0 deleted`, the Rust line all zeros, `OK (2750 files measured, 327 allowlisted, 0 new over 400; vs merge-base 531194cdc: +0 ^0 v0 -0)`. Same under `CI=1`.
- `node scripts/check-module-size.mjs --update --all --base main` -> exit 1 with the new refusal.
- `node scripts/check-test-wiring.mjs` -> exit 0. `node scripts/check-lint-ran.mjs` -> 0 errors, 5 pre-existing warnings, exit 0. `pnpm exec oxlint` over the six touched files -> clean. `node scripts/add-license-headers.mjs --check` -> all present.
- Line counts of the two allowlisted files edited: `check-module-size.mjs` 512/512, `check-source-text-assertions.mjs` 446/446.

NOT run: root `pnpm lint` end to end (`check-unused-locals.mjs` dies with `spawnSync pnpm ENOENT` on this Windows host before later gates; it only covers TS packages, none touched); `cargo` (nothing under `rust/` changed).

## Review

Stage-3 findings on #4535, applied here since the PR had already been merged:

- Major: Rust rows told to run `pnpm lint:module-size-baseline` -> fixed (per-allowlist remedy + test guard).
- Major: AGENTS.md L42 rewrite -> dropped (never pushed; main unchanged).
- Minor: orphaned `changedFiles()` cross-reference -> repointed; shared-helper consolidation named as a follow-up above.
- Minor: lowered-row comment overstated the guarantee -> comment and test comment amended, rule kept.
- Nit: `headroom nothing measured` -> reworded.
- Nit: `--base` silently ignored beside `--all` -> refused, tested.
- CodeRabbit (#4535) actionable: contradictory delete/restore instruction -> fixed by the remedy rewrite. Nitpick on `measureRust` throwing -> declined, reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg
