### PR TITLE
fix(viewer): hold the Share invite until the initial seed is ready

### DIFF
--- a/.changeset/share-dialog-seed-ready.md
+++ b/.changeset/share-dialog-seed-ready.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the Share dialog handing out an invite before the model was actually in the room (#4446). `startCollab` publishes `collabRoomId` synchronously and the provider reports `connected` long before the owner's structure and geometry uploads finish, and the dialog minted the link off the room id alone — so a guest (or the owner navigating to their own link) could open an empty room.
+
+The initial seed is now explicit state, separate from connectivity: `collabSeedPhase` (`none | syncing | structure | geometry | ready | partial | failed`) with `collabSeedProgress` for the geometry blob count. The Share dialog shows an upload-progress row and keeps Copy disabled until the phase settles; a partial or failed seed still gets a link, but only alongside the existing incomplete-transfer alert. The room panel says "Uploading model" (with progress) instead of "Live" while the seed is in flight, disables its own copy-link button, and relabels Leave as abandoning the upload. Recipients never seed, so nothing changes for them.

--- a/apps/viewer/src/components/viewer/RoomPanel.seed-phase.test.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.seed-phase.test.tsx
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #4446 — the room panel must not call a room "Live" while the owner's
+ * initial seed is still going into it, and must not hand out its own copy
+ * link either (it mints one exactly like the Share dialog does).
+ *
+ * `collabStatus` is the PROVIDER's word ('connected' the moment the socket
+ * handshakes); the panel reads `collabSeedPhase` over it. Renders the real
+ * panel over the real store.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import { TooltipProvider } from '@/components/ui/tooltip.js';
+import { RoomPanel } from './RoomPanel.js';
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderPanel(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <RoomPanel onClose={() => {}} />
+      </TooltipProvider>,
+    );
+  });
+  mounted.push({ root, container });
+}
+
+function button(label: RegExp): HTMLButtonElement {
+  const el = Array.from(document.querySelectorAll('button')).find((b) => label.test(b.textContent?.trim() ?? ''));
+  assert.ok(el, `a button matching ${label} rendered`);
+  return el;
+}
+function statusText(): string {
+  return Array.from(document.querySelectorAll('[role="status"]'))
+    .map((el) => el.textContent ?? '')
+    .join(' ');
+}
+
+beforeEach(() => {
+  useViewerStore.setState({
+    // The owner, mid-seed: the socket is up ('connected'), the room is not.
+    collabRoomId: 'room-1',
+    collabRole: 'admin',
+    collabStatus: 'connected',
+    collabSelfToken: 'admin-token',
+    collabPeers: [],
+    collabSeedPhase: 'geometry',
+    collabSeedProgress: { uploaded: 120, total: 272 },
+  });
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  useViewerStore.setState({
+    collabRoomId: null,
+    collabRole: null,
+    collabStatus: 'disconnected',
+    collabSelfToken: null,
+    collabSeedPhase: 'none',
+    collabSeedProgress: null,
+  });
+});
+
+describe('RoomPanel: a connected room is not "Live" until the seed is in (#4446)', () => {
+  it('says the model is uploading, with progress, and withholds the copy link', () => {
+    renderPanel();
+    assert.match(document.body.textContent ?? '', /Uploading model/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Live room/, "'connected' alone does not make the room Live");
+    assert.match(statusText(), /uploading geometry 120\/272/);
+    assert.equal(button(/^Copy invite link$/).disabled, true, 'no invite until the model is in the room');
+    assert.match(button(/^Leave/).textContent ?? '', /abandons upload/, 'Leave says what it would abandon');
+  });
+
+  it('flips to Live, with the copy link and a plain Leave, the moment the seed reports ready', () => {
+    renderPanel();
+    act(() => {
+      useViewerStore.setState({ collabSeedPhase: 'ready', collabSeedProgress: null });
+    });
+    assert.match(document.body.textContent ?? '', /Live room/);
+    assert.equal(statusText().trim(), '', 'the progress row is gone');
+    assert.equal(button(/^Copy invite link$/).disabled, false);
+    assert.equal(button(/^Leave/).textContent?.trim(), 'Leave room');
+  });
+
+  it('a recipient never seeds, so its panel is Live as soon as it is connected', () => {
+    useViewerStore.setState({ collabRole: 'viewer', collabSelfToken: null, collabSeedPhase: 'none', collabSeedProgress: null });
+    renderPanel();
+    assert.match(document.body.textContent ?? '', /Live room/);
+    assert.equal(button(/^Copy invite link$/).disabled, false);
+  });
+});

--- a/apps/viewer/src/components/viewer/RoomPanel.seed-phase.test.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.seed-phase.test.tsx
@@ -81,7 +81,7 @@ describe('RoomPanel: a connected room is not "Live" until the seed is in (#4446)
     renderPanel();
     assert.match(document.body.textContent ?? '', /Uploading model/);
     assert.doesNotMatch(document.body.textContent ?? '', /Live room/, "'connected' alone does not make the room Live");
-    assert.match(statusText(), /uploading geometry 120\/272/);
+    assert.match(statusText(), /Uploading geometry 120\/272/);
     assert.equal(button(/^Copy invite link$/).disabled, true, 'no invite until the model is in the room');
     assert.match(button(/^Leave/).textContent ?? '', /abandons upload/, 'Leave says what it would abandon');
   });
@@ -95,6 +95,19 @@ describe('RoomPanel: a connected room is not "Live" until the seed is in (#4446)
     assert.equal(statusText().trim(), '', 'the progress row is gone');
     assert.equal(button(/^Copy invite link$/).disabled, false);
     assert.equal(button(/^Leave/).textContent?.trim(), 'Leave room');
+  });
+
+  it('a dropped socket mid-seed reads Offline, not Uploading, but still withholds the invite', () => {
+    // The provider lost the socket before whenSynced resolved: the seed is
+    // stalled, not progressing. 'disconnected' must win over the upload badge
+    // so the owner knows to reconnect; the upload is still pending, so the
+    // copy link stays withheld and Leave still says what it abandons.
+    useViewerStore.setState({ collabStatus: 'disconnected', collabSeedPhase: 'syncing', collabSeedProgress: null });
+    renderPanel();
+    assert.match(document.body.textContent ?? '', /Offline room/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Uploading model/, 'a stalled seed is not "uploading"');
+    assert.equal(button(/^Copy invite link$/).disabled, true, 'the room still does not hold the model');
+    assert.match(button(/^Leave/).textContent ?? '', /abandons upload/);
   });
 
   it('a recipient never seeds, so its panel is Live as soon as it is connected', () => {

--- a/apps/viewer/src/components/viewer/RoomPanel.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.tsx
@@ -172,7 +172,13 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
   const [revoked, setRevoked] = useState(false);
 
   const seeding = isCollabSeedInFlight(seedPhase);
-  const status = seeding ? SEEDING_META : (STATUS_META[collabStatus] ?? STATUS_META.disconnected);
+  // A seed whose socket dropped is stalled, not progressing: the provider's
+  // 'disconnected' wins over the upload badge so the user sees "Offline" and
+  // knows to reconnect — while the copy link stays withheld and Leave still
+  // says what it abandons, because the upload IS still pending.
+  const stalled = seeding && collabStatus === 'disconnected';
+  const uploading = seeding && !stalled;
+  const status = uploading ? SEEDING_META : (STATUS_META[collabStatus] ?? STATUS_META.disconnected);
   const seedLabel = seeding ? describeSeedPhase(seedPhase, seedProgress) : null;
   const selfRole: CollabRole = collabRole ?? 'admin';
   const isAdmin = collabRole === 'admin';
@@ -290,7 +296,7 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
         </span>
         <div className="min-w-0 flex-1">
           <div className="text-xs font-semibold leading-tight">
-            {seeding ? 'Uploading model' : `${status.label} room`}
+            {uploading ? 'Uploading model' : `${status.label} room`}
           </div>
           {seedLabel && (
             <div role="status" className="truncate text-[10px] text-muted-foreground">

--- a/apps/viewer/src/components/viewer/RoomPanel.tsx
+++ b/apps/viewer/src/components/viewer/RoomPanel.tsx
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useViewerStore } from '@/store';
 import type { CollabRole } from '@/store/slices/collabSlice';
 import { buildShareUrl, mintRoomToken } from '@/lib/collab/share-link';
+import { describeSeedPhase, isCollabSeedInFlight } from '@/lib/collab/seed-phase';
 
 interface RoomPanelProps {
   onClose: () => void;
@@ -35,6 +36,12 @@ const STATUS_META: Record<string, { tone: string; label: string; pulse: boolean 
   memory: { tone: 'bg-sky-500', label: 'Local', pulse: false },
   disconnected: { tone: 'bg-muted-foreground/50', label: 'Offline', pulse: false },
 };
+/**
+ * Overrides the connection status while the owner's initial seed is still
+ * going in (#4446): the socket IS connected, but a room that does not yet
+ * hold the model is not "Live" to anyone who would join it.
+ */
+const SEEDING_META = { tone: 'bg-amber-500', label: 'Uploading', pulse: true };
 
 /** Role → badge accent. Subtle, role-tinted, dark-mode aware. */
 const ROLE_META: Record<CollabRole, { label: string; cls: string }> = {
@@ -155,6 +162,8 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
   const collabRole = useViewerStore((s) => s.collabRole);
   const collabIdentity = useViewerStore((s) => s.collabIdentity);
   const collabPeers = useViewerStore((s) => s.collabPeers);
+  const seedPhase = useViewerStore((s) => s.collabSeedPhase);
+  const seedProgress = useViewerStore((s) => s.collabSeedProgress);
   const stopCollab = useViewerStore((s) => s.stopCollab);
   const kickPeer = useViewerStore((s) => s.kickPeer);
   const revokeCollabLink = useViewerStore((s) => s.revokeCollabLink);
@@ -162,7 +171,9 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
   const [copied, setCopied] = useState(false);
   const [revoked, setRevoked] = useState(false);
 
-  const status = STATUS_META[collabStatus] ?? STATUS_META.disconnected;
+  const seeding = isCollabSeedInFlight(seedPhase);
+  const status = seeding ? SEEDING_META : (STATUS_META[collabStatus] ?? STATUS_META.disconnected);
+  const seedLabel = seeding ? describeSeedPhase(seedPhase, seedProgress) : null;
   const selfRole: CollabRole = collabRole ?? 'admin';
   const isAdmin = collabRole === 'admin';
   const peerCount = collabPeers.length + 1;
@@ -278,7 +289,14 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
           <span className={`relative inline-flex size-2 rounded-full ${status.tone}`} />
         </span>
         <div className="min-w-0 flex-1">
-          <div className="text-xs font-semibold leading-tight">{status.label} room</div>
+          <div className="text-xs font-semibold leading-tight">
+            {seeding ? 'Uploading model' : `${status.label} room`}
+          </div>
+          {seedLabel && (
+            <div role="status" className="truncate text-[10px] text-muted-foreground">
+              {seedLabel}
+            </div>
+          )}
           <div className="truncate font-mono text-[10px] text-muted-foreground">{collabRoomId}</div>
         </div>
         <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
@@ -312,6 +330,9 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
           size="sm"
           className="h-8 w-full justify-start gap-2"
           onClick={handleCopyLink}
+          // Same rule as the Share dialog: no invite until the model is in the room.
+          disabled={seeding}
+          title={seeding ? 'Available once the upload finishes' : undefined}
         >
           {copied ? <Check className="size-3.5" /> : <Link2 className="size-3.5" />}
           {copied ? 'Link copied' : 'Copy invite link'}
@@ -340,7 +361,7 @@ export function RoomPanel({ onClose }: RoomPanelProps) {
             onClick={handleLeave}
           >
             <LogOut className="size-3.5" />
-            Leave room
+            {seeding ? 'Leave (abandons upload)' : 'Leave room'}
           </Button>
         </div>
       </div>

--- a/apps/viewer/src/components/viewer/ShareDialog.seed-ready.test.tsx
+++ b/apps/viewer/src/components/viewer/ShareDialog.seed-ready.test.tsx
@@ -118,7 +118,7 @@ describe('ShareDialog: invite waits for the initial seed (#4446)', () => {
   it('shows upload progress instead of a link while geometry is still going into the room', async () => {
     renderDialog();
     await settle();
-    assert.match(statusText(), /uploading geometry 120\/272/);
+    assert.match(statusText(), /Uploading geometry 120\/272/);
     assert.doesNotMatch(linkField().value, /room=/, 'no invite URL while the seed is in flight');
     assert.equal(copyButton().disabled, true, 'Copy stays disabled');
   });
@@ -127,7 +127,7 @@ describe('ShareDialog: invite waits for the initial seed (#4446)', () => {
     useViewerStore.setState({ collabSeedPhase: 'syncing', collabSeedProgress: null });
     renderDialog();
     await settle();
-    assert.match(statusText(), /connecting to the room/);
+    assert.match(statusText(), /Connecting to the room/);
     assert.equal(copyButton().disabled, true);
   });
 

--- a/apps/viewer/src/components/viewer/ShareDialog.seed-ready.test.tsx
+++ b/apps/viewer/src/components/viewer/ShareDialog.seed-ready.test.tsx
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #4446 — the Share dialog must not hand out an invite while the initial
+ * seed is still going into the room.
+ *
+ * `collabRoomId` is set synchronously at the top of `startCollab` and the
+ * provider reports `connected` before a single entity is in the doc; the
+ * dialog used to mint the link off the room id alone. It now keys off
+ * `collabSeedPhase`: a progress row stands in for the link until the seed
+ * settles, and a settled-but-incomplete seed shows the link WITH the
+ * incomplete-transfer alert, never as a plain success.
+ *
+ * Renders the real dialog over the real store as the room's admin; no server
+ * is configured, so minting is the local-only fallback and touches no network.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { ShareDialog } from './ShareDialog.js';
+
+function makeModel(): FederatedModel {
+  return {
+    id: 'model-1',
+    name: 'haus.ifc',
+    ifcDataStore: { schemaVersion: 'IFC4' } as unknown as FederatedModel['ifcDataStore'],
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 3,
+    idOffset: 0,
+    maxExpressId: 0,
+  };
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderDialog(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<ShareDialog open onOpenChange={() => {}} />);
+  });
+  mounted.push({ root, container });
+}
+
+/** Let the mint effect's awaited (local, network-free) token resolve. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+/** Radix renders the dialog into a portal, so read the whole document. */
+function linkField(): HTMLInputElement {
+  const el = document.querySelector<HTMLInputElement>('#share-link');
+  assert.ok(el, 'the dialog rendered its link field');
+  return el;
+}
+function copyButton(): HTMLButtonElement {
+  const el = Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Copy');
+  assert.ok(el, 'the dialog rendered its Copy button');
+  return el;
+}
+function statusText(): string {
+  return Array.from(document.querySelectorAll('[role="status"]'))
+    .map((el) => el.textContent ?? '')
+    .join(' ');
+}
+function alertText(): string {
+  return Array.from(document.querySelectorAll('[role="alert"]'))
+    .map((el) => el.textContent ?? '')
+    .join(' ');
+}
+
+beforeEach(() => {
+  useViewerStore.setState({
+    models: new Map([['model-1', makeModel()]]),
+    activeModelId: 'model-1',
+    // The owner, mid-join: room id public, admin bearer held, seed in flight.
+    collabRoomId: 'room-1',
+    collabRole: 'admin',
+    collabSelfToken: 'admin-token',
+    collabLastShareToken: null,
+    collabSeedFailure: null,
+    collabSeedPhase: 'geometry',
+    collabSeedProgress: { uploaded: 120, total: 272 },
+  });
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  useViewerStore.setState({
+    collabRoomId: null,
+    collabRole: null,
+    collabSelfToken: null,
+    collabLastShareToken: null,
+    collabSeedFailure: null,
+    collabSeedPhase: 'none',
+    collabSeedProgress: null,
+  });
+});
+
+describe('ShareDialog: invite waits for the initial seed (#4446)', () => {
+  it('shows upload progress instead of a link while geometry is still going into the room', async () => {
+    renderDialog();
+    await settle();
+    assert.match(statusText(), /uploading geometry 120\/272/);
+    assert.doesNotMatch(linkField().value, /room=/, 'no invite URL while the seed is in flight');
+    assert.equal(copyButton().disabled, true, 'Copy stays disabled');
+  });
+
+  it('says it is still connecting before the room has synced', async () => {
+    useViewerStore.setState({ collabSeedPhase: 'syncing', collabSeedProgress: null });
+    renderDialog();
+    await settle();
+    assert.match(statusText(), /connecting to the room/);
+    assert.equal(copyButton().disabled, true);
+  });
+
+  it('mints the invite and enables Copy the moment the seed reports ready', async () => {
+    renderDialog();
+    await settle();
+    assert.equal(copyButton().disabled, true, 'precondition: still uploading');
+
+    act(() => {
+      useViewerStore.setState({ collabSeedPhase: 'ready', collabSeedProgress: null });
+    });
+    await settle();
+
+    assert.match(linkField().value, /room=room-1/, 'the invite names the room');
+    assert.equal(copyButton().disabled, false, 'Copy is enabled once the room holds the model');
+    assert.equal(statusText().trim(), '', 'the progress row is gone');
+    assert.equal(alertText().trim(), '', 'a clean seed shows no alert');
+    assert.ok(useViewerStore.getState().collabLastShareToken, 'the minted token is recorded for revocation');
+  });
+
+  it('a seed that lost geometry hands out the link only alongside the incomplete-transfer alert', async () => {
+    renderDialog();
+    await settle();
+    act(() => {
+      useViewerStore.setState({
+        collabSeedPhase: 'partial',
+        collabSeedProgress: null,
+        collabSeedFailure: 'Shared, but 3 of 272 geometry uploads failed. People joining this link will be missing some elements.',
+      });
+    });
+    await settle();
+    assert.match(linkField().value, /room=room-1/, 'the room exists and can still be shared');
+    assert.equal(copyButton().disabled, false);
+    assert.match(alertText(), /missing some elements/, 'but never as a plain success');
+  });
+
+  it('a joiner is unaffected: forwards the invite it holds without waiting on any seed', async () => {
+    // Recipients never seed; their phase stays 'none'.
+    useViewerStore.setState({
+      collabRole: 'viewer',
+      collabSelfToken: null,
+      collabLastShareToken: 'token-1',
+      collabSeedPhase: 'none',
+      collabSeedProgress: null,
+    });
+    renderDialog();
+    await settle();
+    assert.match(linkField().value, /room=room-1/);
+    assert.equal(copyButton().disabled, false);
+    assert.equal(statusText().trim(), '');
+  });
+});

--- a/apps/viewer/src/components/viewer/ShareDialog.tsx
+++ b/apps/viewer/src/components/viewer/ShareDialog.tsx
@@ -8,10 +8,17 @@
  * Accountless, link-based sharing: pick an access level, mint a room token,
  * copy the link. The role is baked into the token and enforced on the
  * collab-server (plan §3). "Live now" reflects `session.presence`.
+ *
+ * Two independent effects (#4446): one creates the room (mints the admin
+ * token, starts the seeding join), the other mints the invite — and only once
+ * `collabSeedPhase` says the seed has settled. `startCollab` sets
+ * `collabRoomId` synchronously, long before the model is in the room, and a
+ * single effect keyed on it used to re-run for the new room and hand out a
+ * link to an empty one; whoever opened it reconstructed nothing.
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertTriangle, Check, Copy, Link2, Users } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AlertTriangle, Check, Copy, Link2, Loader2, Users } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -27,6 +34,7 @@ import { toast } from '@/components/ui/toast';
 import type { CollabRole } from '@/store/slices/collabSlice';
 import { buildShareUrl, mintRoomId, mintRoomToken, parseRoleFromToken } from '@/lib/collab/share-link';
 import { buildStepSeedSource } from '@/lib/collab/step-seed';
+import { describeSeedPhase, isCollabSeedInFlight } from '@/lib/collab/seed-phase';
 
 interface ShareDialogProps {
   open: boolean;
@@ -52,12 +60,20 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
   // viewer KNOWS is missing its geometry must not be presented as a plain
   // success: the recipient would open it and see an empty scene.
   const seedFailure = useViewerStore((s) => s.collabSeedFailure);
+  const seedPhase = useViewerStore((s) => s.collabSeedPhase);
+  const seedProgress = useViewerStore((s) => s.collabSeedProgress);
 
   const [role, setRole] = useState<CollabRole>('editor');
   const [link, setLink] = useState<string>('');
-  const [busy, setBusy] = useState(false);
+  // Room creation in flight (no room yet) / invite mint in flight.
+  const [creating, setCreating] = useState(false);
+  const [minting, setMinting] = useState(false);
   const [copied, setCopied] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
+  // One room-creation attempt per opening. A join whose session never comes up
+  // resets `collabRoomId` to null, which would otherwise re-trigger creation
+  // in a loop; the notice tells the user, and re-opening the dialog retries.
+  const roomAttemptRef = useRef<Promise<void> | null>(null);
 
   /**
    * Non-admins cannot mint role-scoped tokens (no escalation by design),
@@ -89,62 +105,93 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
   }, [models, activeModelId]);
 
   const hasModel = models.size > 0;
+  const isJoiner = Boolean(collabRoomId && collabRole && collabRole !== 'admin');
+  // The room exists but the model is still going in: no invite until it has.
+  const seedInFlight = Boolean(collabRoomId) && isCollabSeedInFlight(seedPhase);
 
-  // Re-mint the link whenever the dialog opens or the role changes, joining the
-  // room as owner (admin) so presence is live while the dialog is open.
+  // 1. Ensure a room: the creator mints an admin token (first-touch) and joins
+  // with it, seeding the model, so it's authorized to mint role-scoped share
+  // links thereafter. Deliberately NOT re-run by `collabRoomId` flipping to
+  // the new room — the attempt ref carries this promise across re-renders.
   useEffect(() => {
-    if (!open || !hasModel) return;
-    let cancelled = false;
-    setBusy(true);
+    if (!open) {
+      roomAttemptRef.current = null;
+      return;
+    }
+    if (!hasModel || collabRoomId || roomAttemptRef.current) return;
+    const roomId = mintRoomId();
+    setCreating(true);
+    setLink('');
     setCopied(false);
     setNotice(null);
-    (async () => {
-      const roomId = collabRoomId ?? mintRoomId();
-      // A joined non-admin can't mint: don't fire a doomed request, reuse
-      // the invite we hold and say so.
-      if (collabRoomId && collabRole && collabRole !== 'admin') {
-        const fallback = fallbackShareLink(roomId);
-        if (!cancelled) {
-          if (fallback) {
-            setLink(fallback.url);
-            if (fallback.role) setRole(fallback.role);
-            setNotice('You joined via an invite - sharing it forwards the same access. Only the room admin can mint new links.');
-          } else {
-            setLink('');
-            setNotice('Only the room admin can create invite links for this room.');
-          }
-          setBusy(false);
-        }
-        return;
-      }
+    roomAttemptRef.current = (async () => {
       try {
-        if (!collabRoomId) {
-          // The creator mints an admin token (first-touch) and joins with it,
-          // so it's authorized to mint role-scoped share links thereafter.
-          const adminToken = await mintRoomToken({ roomId, role: 'admin' });
-          await startCollab({
-            roomId,
-            role: 'admin',
-            token: adminToken,
-            // Owner seeds the model so recipients hydrate from the room.
-            // IFC5/IFCX seeds natively from the model's own bytes; legacy STEP
-            // seeds the IFCX-shaped StepSeedSource. (Seeding IFCX via the STEP
-            // path produces an empty room — it can't read an IFCX-origin store.)
-            seed: () => {
-              const store = ifcDataStore;
-              if (!store) return null;
-              const model = activeModelId ? models.get(activeModelId) : undefined;
-              const isIfcx = (model?.schemaVersion ?? store.schemaVersion) === 'IFC5';
-              return {
-                store,
-                isIfcx,
-                stepSource: isIfcx ? null : buildStepSeedSource(store, modelName),
-              };
-            },
-          });
+        const adminToken = await mintRoomToken({ roomId, role: 'admin' });
+        await startCollab({
+          roomId,
+          role: 'admin',
+          token: adminToken,
+          // Owner seeds the model so recipients hydrate from the room.
+          // IFC5/IFCX seeds natively from the model's own bytes; legacy STEP
+          // seeds the IFCX-shaped StepSeedSource. (Seeding IFCX via the STEP
+          // path produces an empty room — it can't read an IFCX-origin store.)
+          seed: () => {
+            const store = ifcDataStore;
+            if (!store) return null;
+            const model = activeModelId ? models.get(activeModelId) : undefined;
+            const isIfcx = (model?.schemaVersion ?? store.schemaVersion) === 'IFC5';
+            return {
+              store,
+              isIfcx,
+              stepSource: isIfcx ? null : buildStepSeedSource(store, modelName),
+            };
+          },
+        });
+        // `startCollab` resolves without a live room when the session never
+        // came up (it logs why) or the user left mid-join. Say so instead of
+        // sitting on "Creating room…" forever.
+        if (useViewerStore.getState().collabRoomId !== roomId) {
+          setNotice('Could not create the room. Check the connection and try again.');
         }
-        // Mint the role-scoped share link (server requires the owner's admin
-        // bearer once the room exists; ignored in local-only mode).
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[collab] room creation failed:', err);
+        setNotice('Link creation failed. Check the connection and try again.');
+      } finally {
+        setCreating(false);
+      }
+    })();
+  }, [open, hasModel, collabRoomId, startCollab, ifcDataStore, activeModelId, models, modelName]);
+
+  // 2. Mint the invite — re-minted when the dialog opens or the role changes,
+  // and only once the seed has settled (`seedInFlight` false). Until then the
+  // progress row below stands in for the link.
+  useEffect(() => {
+    if (!open || !hasModel || !collabRoomId) return;
+    setCopied(false);
+    // A joined non-admin can't mint: don't fire a doomed request, reuse the
+    // invite we hold and say so.
+    if (isJoiner) {
+      const fallback = fallbackShareLink(collabRoomId);
+      if (fallback) {
+        setLink(fallback.url);
+        if (fallback.role) setRole(fallback.role);
+        setNotice('You joined via an invite - sharing it forwards the same access. Only the room admin can mint new links.');
+      } else {
+        setLink('');
+        setNotice('Only the room admin can create invite links for this room.');
+      }
+      return;
+    }
+    if (seedInFlight) return;
+    let cancelled = false;
+    setMinting(true);
+    setNotice(null);
+    (async () => {
+      const roomId = collabRoomId;
+      try {
+        // Server requires the owner's admin bearer once the room exists;
+        // ignored in local-only mode.
         const adminBearer = useViewerStore.getState().collabSelfToken ?? undefined;
         const token = await mintRoomToken({ roomId, role, bearer: adminBearer });
         if (!cancelled) {
@@ -166,13 +213,13 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
           }
         }
       } finally {
-        if (!cancelled) setBusy(false);
+        if (!cancelled) setMinting(false);
       }
     })();
     return () => {
       cancelled = true;
     };
-  }, [open, hasModel, role, collabRoomId, collabRole, startCollab, ifcDataStore, modelName, fallbackShareLink]);
+  }, [open, hasModel, collabRoomId, isJoiner, seedInFlight, role, fallbackShareLink]);
 
   useEffect(() => {
     if (open && seedFailure) toast.error(seedFailure);
@@ -188,6 +235,14 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
       // clipboard may be blocked; the input is selectable as a fallback
     }
   }, [link]);
+
+  const waiting = (creating && !collabRoomId) || seedInFlight || minting;
+  const seedLabel = describeSeedPhase(seedPhase, seedProgress);
+  const linkFieldText = seedInFlight
+    ? 'Link is ready once the upload finishes…'
+    : creating && !collabRoomId
+      ? 'Creating room…'
+      : 'Generating link…';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -221,7 +276,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
                     size="sm"
                     // Only the room admin mints role-scoped links; a joiner
                     // forwards the invite they hold, so the role is fixed.
-                    disabled={Boolean(collabRoomId && collabRole && collabRole !== 'admin')}
+                    disabled={isJoiner}
                     onClick={() => setRole(opt.role)}
                   >
                     {opt.label}
@@ -239,15 +294,21 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
                 <Input
                   id="share-link"
                   readOnly
-                  value={busy ? 'Generating link…' : link}
+                  value={waiting ? linkFieldText : link}
                   onFocus={(e) => e.currentTarget.select()}
                 />
               </div>
-              <Button type="button" onClick={handleCopy} disabled={busy || !link} className="gap-1.5">
+              <Button type="button" onClick={handleCopy} disabled={waiting || !link} className="gap-1.5">
                 {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
                 {copied ? 'Copied' : 'Copy'}
               </Button>
             </div>
+            {seedInFlight && seedLabel && (
+              <p role="status" className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
+                <span>Uploading model to the room — {seedLabel}</span>
+              </p>
+            )}
             {notice && <p className="text-xs text-muted-foreground">{notice}</p>}
             {seedFailure && (
               <div

--- a/apps/viewer/src/components/viewer/ShareDialog.tsx
+++ b/apps/viewer/src/components/viewer/ShareDialog.tsx
@@ -148,10 +148,12 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
           },
         });
         // `startCollab` resolves without a live room when the session never
-        // came up (it logs why) or the user left mid-join. Say so instead of
-        // sitting on "Creating room…" forever.
+        // came up (it logs why) or the user left mid-join (RoomPanel's Leave).
+        // Neither is a connection failure this dialog can tell apart, and the
+        // attempt ref blocks a retry until it is re-opened — so say exactly
+        // that instead of sitting on "Creating room…" forever.
         if (useViewerStore.getState().collabRoomId !== roomId) {
-          setNotice('Could not create the room. Check the connection and try again.');
+          setNotice('No room was created. Close and reopen this dialog to try again.');
         }
       } catch (err) {
         // eslint-disable-next-line no-console
@@ -306,7 +308,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
             {seedInFlight && seedLabel && (
               <p role="status" className="flex items-center gap-2 text-xs text-muted-foreground">
                 <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
-                <span>Uploading model to the room — {seedLabel}</span>
+                <span>{seedLabel}</span>
               </p>
             )}
             {notice && <p className="text-xs text-muted-foreground">{notice}</p>}

--- a/apps/viewer/src/lib/collab/owner-seed.test.ts
+++ b/apps/viewer/src/lib/collab/owner-seed.test.ts
@@ -1,0 +1,219 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #4446 — the owner's seed reports where it stands, and a fresh guest who
+ * opens the room the moment it reports `ready` gets the complete model.
+ *
+ * Drives the REAL `runOwnerSeed` against a REAL `@ifc-lite/collab` session
+ * (memory provider) and blob store, then reconstructs the room the way the
+ * recipient branch of `startCollab` does: `snapshotToIfcx` -> the viewer's own
+ * IFCX ingest -> `hydrateGeometryFromRoom` keyed by the recipient's id space.
+ * The guest-side counts are asserted against the owner's own seed report, so
+ * "ready" and "complete" are pinned to the same numbers.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as collab from '@ifc-lite/collab';
+import type { MeshData } from '@ifc-lite/geometry';
+import { runOwnerSeed, type OwnerSeedDeps, type OwnerSeedResult } from './owner-seed.js';
+import { hydrateGeometryFromRoom } from './geometry-sync.js';
+import { readGeometrySeedMarker } from './geometry-seed-signal.js';
+import { buildStepSeedSource } from './step-seed.js';
+import { parseIfcxViewerModel } from '@/hooks/ingest/viewerModelIngest.js';
+import {
+  SEED_GUIDS,
+  SEED_TEXTURE_PIXELS,
+  seedFixtureMeshes,
+  seedFixtureStore,
+} from '@/test/collab-seed-fixture.js';
+
+const user = { id: 'owner', name: 'Owner', color: '#123456' };
+
+interface Harness {
+  session: collab.CollabSession;
+  blobStore: collab.MemoryBlobStore;
+  phases: string[];
+  progress: Array<[number, number]>;
+  run: (overrides?: Partial<OwnerSeedDeps>) => Promise<OwnerSeedResult | null>;
+}
+
+async function harness(meshes: readonly MeshData[] = seedFixtureMeshes()): Promise<Harness> {
+  const session = await collab.createCollabSession({ roomId: `seed-${Math.random()}`, user, provider: 'memory' });
+  const blobStore = new collab.MemoryBlobStore();
+  const store = seedFixtureStore();
+  const phases: string[] = [];
+  const progress: Array<[number, number]> = [];
+  const deps: OwnerSeedDeps = {
+    session,
+    seed: () => ({ store, isIfcx: false, stepSource: buildStepSeedSource(store, 'fixture.ifc') }),
+    collab,
+    geomApi: collab,
+    makeBlobStore: async () => blobStore,
+    stepMeshes: () => meshes,
+    stampBaseline: (path) => {
+      if (path) {
+        const current = collab.getEntityPlacement(session.doc, path);
+        collab.setPlacementBaseline(session.doc, path, current ?? { location: [0, 0, 0] });
+      }
+      return path;
+    },
+    isCurrent: () => true,
+    onPhase: (phase) => phases.push(phase),
+    onProgress: (uploaded, total) => progress.push([uploaded, total]),
+  };
+  return {
+    session,
+    blobStore,
+    phases,
+    progress,
+    run: (overrides = {}) => runOwnerSeed({ ...deps, ...overrides }),
+  };
+}
+
+describe('runOwnerSeed (#4446)', () => {
+  it('walks structure -> geometry, reports progress, and settles ready only once the room holds it all', async () => {
+    const h = await harness();
+    try {
+      const result = await h.run();
+      assert.deepEqual(result, { phase: 'ready', failure: null });
+      assert.deepEqual(h.phases, ['structure', 'geometry']);
+      // `seedGeometryToRoom` reports every 50 blobs and once at the end.
+      assert.deepEqual(h.progress.at(-1), [2, 2], 'the final progress tick is the full count');
+
+      // "Ready" is pinned to the doc actually holding the model.
+      const doc = h.session.doc;
+      assert.equal(doc.getMap('entities').size, 2, 'both products seeded');
+      assert.equal(doc.getMap('geometry').size, 2, 'both meshes referenced');
+      for (const guid of Object.values(SEED_GUIDS)) {
+        const ref = collab.getGeometryRef(doc, collab.guidToPath(guid));
+        assert.equal(ref?.geomIds.length, 1, `${guid} carries its geometry ref`);
+      }
+      const marker = readGeometrySeedMarker(doc);
+      assert.equal(marker?.expected, 2);
+      assert.equal(marker?.seeded, 2);
+      assert.equal(marker?.interrupted, false);
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('a fresh guest reconstructs the complete model and textures from the ready room', async () => {
+    const h = await harness();
+    try {
+      const result = await h.run();
+      assert.equal(result?.phase, 'ready');
+
+      // The recipient branch of startCollab, step for step: the synced doc is
+      // snapshotted to IFCX, parsed by the viewer's own ingest (which yields
+      // the recipient's id space), and geometry is hydrated from the blobs
+      // keyed by that id space.
+      const recipient = await collab.createCollabSession({ roomId: 'guest', user, provider: 'memory' });
+      try {
+        collab.seedFromIfcx(recipient.doc, JSON.stringify(collab.snapshotToIfcx(h.session.doc)));
+        const ifcx = new TextEncoder().encode(JSON.stringify(collab.snapshotToIfcx(recipient.doc)));
+        const parsed = await parseIfcxViewerModel(ifcx.buffer as ArrayBuffer, undefined, { allowEmptyGeometry: true });
+        assert.ok(parsed.pathToId, 'the ingest exposes the recipient id map');
+        for (const guid of Object.values(SEED_GUIDS)) {
+          assert.ok(parsed.pathToId.has(collab.guidToPath(guid)), `${guid} is an entity on the guest`);
+        }
+
+        const meshes = await hydrateGeometryFromRoom(collab, recipient, h.blobStore, parsed.pathToId);
+        const marker = readGeometrySeedMarker(h.session.doc);
+        assert.equal(meshes.length, marker?.seeded, 'the guest gets exactly what the owner reported as seeded');
+        assert.equal(meshes.length, 2);
+        const guestIds = new Set(Object.values(SEED_GUIDS).map((g) => parsed.pathToId!.get(collab.guidToPath(g))));
+        for (const mesh of meshes) {
+          assert.ok(guestIds.has(mesh.expressId), 'meshes are re-keyed into the guest id space');
+          assert.deepEqual(mesh.texture?.rgba, SEED_TEXTURE_PIXELS, 'the texture pixels arrive byte-exact');
+          assert.equal(mesh.texture?.repeatT, true, 'the sampler survives');
+          assert.deepEqual(mesh.uvs, seedFixtureMeshes()[0].uvs);
+        }
+      } finally {
+        recipient.dispose();
+      }
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('re-running on a room that already holds the model changes nothing and is ready at once', async () => {
+    const h = await harness();
+    try {
+      assert.equal((await h.run())?.phase, 'ready');
+      h.phases.length = 0;
+      const again = await h.run();
+      assert.deepEqual(again, { phase: 'ready', failure: null });
+      assert.deepEqual(h.phases, [], 'neither structure nor geometry is re-seeded');
+      assert.equal(h.session.doc.getMap('geometry').size, 2);
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('an abandoned join (user left during sync) seeds nothing and reports nothing', async () => {
+    const h = await harness();
+    try {
+      const result = await h.run({ isCurrent: () => false });
+      assert.equal(result, null);
+      assert.deepEqual(h.phases, []);
+      assert.equal(h.session.doc.getMap('entities').size, 0);
+      assert.equal(readGeometrySeedMarker(h.session.doc), null, 'no marker for a seed that never ran');
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('settles partial when a mesh the model has cannot be sent, with the owner-facing reason', async () => {
+    // One mesh memory-released (no triangles): the room gets the other one.
+    const released: MeshData = { ...seedFixtureMeshes()[1], positions: new Float32Array(0), indices: new Uint32Array(0) };
+    const h = await harness([seedFixtureMeshes()[0], released]);
+    try {
+      const result = await h.run();
+      assert.equal(result?.phase, 'partial');
+      assert.match(result?.failure ?? '', /1 of 2 elements could not be sent/);
+      assert.equal(h.session.doc.getMap('geometry').size, 1);
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('settles failed when the room got structure but none of the geometry', async () => {
+    // A textured mesh whose image is unavailable fails explicitly (#4232).
+    const orphaned: MeshData = { ...seedFixtureMeshes()[0] };
+    delete orphaned.texture;
+    orphaned.textureRef = { textureId: 1, url: 'image.png', repeatS: true, repeatT: false };
+    const h = await harness([orphaned]);
+    try {
+      const result = await h.run();
+      assert.equal(result?.phase, 'failed');
+      assert.match(result?.failure ?? '', /no 3D geometry|source image is unavailable/, 'names the loss to the owner');
+      assert.equal(h.session.doc.getMap('entities').size, 2, 'structure landed');
+      assert.equal(h.session.doc.getMap('geometry').size, 0, 'geometry did not');
+      const marker = readGeometrySeedMarker(h.session.doc);
+      assert.equal(marker?.expected, 1);
+      assert.equal(marker?.seeded, 0);
+    } finally {
+      h.session.dispose();
+    }
+  });
+
+  it('a seed that throws settles failed and stamps the room as interrupted', async () => {
+    const h = await harness();
+    try {
+      const result = await h.run({
+        makeBlobStore: async () => {
+          throw new Error('blob store unreachable');
+        },
+      });
+      assert.equal(result?.phase, 'failed');
+      assert.match(result?.failure ?? '', /did not complete/);
+      const marker = readGeometrySeedMarker(h.session.doc);
+      assert.equal(marker?.interrupted, true, 'joiners are told the seed was interrupted, not "nothing to seed"');
+    } finally {
+      h.session.dispose();
+    }
+  });
+});

--- a/apps/viewer/src/lib/collab/owner-seed.ts
+++ b/apps/viewer/src/lib/collab/owner-seed.ts
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The owner's seed-into-room (plan §4.6), lifted out of `collabSlice.startCollab`.
+ *
+ * Runs once the session has synced: structure first (only into an empty room,
+ * so a populated room or a peer's edits are never clobbered), then geometry as
+ * content-addressed mesh blobs (whenever the room has none yet — decoupled from
+ * the entity guard so a partially-seeded room backfills), then the seed marker
+ * that lets joiners tell "nothing to seed" from "seed never arrived".
+ *
+ * Reports its progress through `onPhase` / `onProgress` and returns the phase
+ * the seed settled in (#4446): the slice mirrors those into `collabSeedPhase`
+ * so the Share dialog can hold the invite back until the room actually holds
+ * the model. Every store write stays in the slice; this module only computes.
+ *
+ * The collab runtime is injected (never imported at module scope) so the
+ * feature stays code-split — see the import note in collabSlice.ts.
+ */
+
+import type { BlobStore, CollabSession, StepSeedSource } from '@ifc-lite/collab';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { MeshData } from '@ifc-lite/geometry';
+import { seedGeometryToRoom, type CollabGeomApi, type SeedGeometryReport } from './geometry-sync';
+import {
+  classifySeed,
+  interruptedSeedMarker,
+  markerFromReport,
+  seedFailureMessage,
+  writeGeometrySeedMarker,
+} from './geometry-seed-signal';
+import { pathForEntity, registerEntityMaps } from './mutation-bridge';
+import { seedPhaseFromOutcome } from './seed-phase';
+
+/**
+ * Model-share payload the owner hands to `startCollab`. Carries the parsed
+ * store plus enough context to seed both schema families:
+ *   - IFC5/IFCX → seed natively from the store's own IFCX bytes (`store.source`)
+ *     and key geometry by IFCX path (`idToPath`), since an IFCX-origin store has
+ *     no STEP `entityIndex.byId`/GUIDs to drive `buildStepSeedSource`.
+ *   - legacy STEP → seed the pre-built IFCX-shaped `stepSource`, key geometry by
+ *     `pathForEntity` (GUID path).
+ */
+export interface CollabSeedInput {
+  /** The active model's parsed store. For IFC5, `store.source` holds the IFCX bytes. */
+  store: IfcDataStore;
+  /** True when the model is IFC5/IFCX (seed natively from `store.source`). */
+  isIfcx: boolean;
+  /** Pre-built STEP seed source for legacy rooms; `null` for IFC5. */
+  stepSource: StepSeedSource | null;
+}
+
+/** The two runtime seeders this needs, off the lazy-loaded `@ifc-lite/collab`. */
+export type OwnerSeedRuntime = Pick<typeof import('@ifc-lite/collab'), 'seedFromIfcx' | 'seedFromStep'>;
+
+export interface OwnerSeedDeps {
+  session: CollabSession;
+  /** Lazily produces the seed; `null` means the model has nothing to offer. */
+  seed: () => CollabSeedInput | null;
+  collab: OwnerSeedRuntime;
+  geomApi: CollabGeomApi;
+  makeBlobStore: () => Promise<BlobStore>;
+  /** Meshes for the legacy STEP path (the owner's live geometry). */
+  stepMeshes: () => readonly MeshData[] | undefined;
+  /**
+   * Records the placement each entity's blob is baked at (so every client can
+   * render `blob + (current xformop − baseline)`) and returns the path unchanged.
+   */
+  stampBaseline: (path: string | null) => string | null;
+  /** False once this join was abandoned (a newer start/stop ran); stops all writes. */
+  isCurrent: () => boolean;
+  onPhase: (phase: 'structure' | 'geometry') => void;
+  onProgress: (uploaded: number, total: number) => void;
+}
+
+export interface OwnerSeedResult {
+  phase: 'ready' | 'partial' | 'failed';
+  /** Owner-facing message for a share that did not fully land, else `null`. */
+  failure: string | null;
+}
+
+/** View a `Uint8Array` as an `ArrayBuffer` (copying only when it's a sub-view). */
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  return u8.byteOffset === 0 && u8.byteLength === u8.buffer.byteLength
+    ? (u8.buffer as ArrayBuffer)
+    : (u8.slice().buffer as ArrayBuffer);
+}
+
+/**
+ * Seed the owner's model into the room. Resolves `null` when the join was
+ * abandoned before the seed could run (nothing was written, nothing to report).
+ * Never throws: a seed that blows up mid-way is reported as `'failed'` and
+ * stamped into the room as interrupted, because "the room may hold a partial
+ * model" is a fact the Share dialog has to act on rather than a rejection it
+ * can swallow (that swallowing is how a weeks-long geometry outage went unseen).
+ */
+export async function runOwnerSeed(deps: OwnerSeedDeps): Promise<OwnerSeedResult | null> {
+  const { session } = deps;
+  try {
+    await session.whenSynced;
+    if (!deps.isCurrent()) return null;
+    const seedData = deps.seed();
+    if (!seedData) return { phase: 'ready', failure: null };
+    const { store } = seedData;
+
+    // Structure seed — once; never clobber a populated room or peer edits.
+    if (session.doc.getMap('entities').size === 0) {
+      deps.onPhase('structure');
+      if (seedData.isIfcx) {
+        // IFC5: seed natively from the model's own IFCX bytes. The STEP path
+        // (buildStepSeedSource) can't read an IFCX-origin store (no
+        // entityIndex.byId / GUIDs) and would seed zero entities.
+        // Whole-file consumer: the IFCX seed re-parses the source.
+        const bytes = store.source;
+        if (bytes.length > 0) {
+          deps.collab.seedFromIfcx(session.doc, bytes.materialize());
+        }
+      } else if (seedData.stepSource) {
+        deps.collab.seedFromStep(session.doc, seedData.stepSource);
+      }
+    }
+
+    // Geometry already in the room (a re-join of a seeded room): nothing to add.
+    if (session.doc.getMap('geometry').size > 0) return { phase: 'ready', failure: null };
+
+    deps.onPhase('geometry');
+    const blobStore = await deps.makeBlobStore();
+    // `null` means no seed ran at all: the model had nothing to offer. That is
+    // a legitimate share (structure-only or empty model) and is NOT the same
+    // as a seed that ran and landed nothing, which is a broken share. Only
+    // here, on the owner, is that difference still knowable.
+    let report: SeedGeometryReport | null = null;
+    const opts = { onProgress: deps.onProgress };
+    if (seedData.isIfcx && store.source && store.source.length > 0) {
+      // IFCX geometry is explicit in the file: re-parse the source for
+      // COMPLETE meshes + the id->path map to key them. (The owner's render
+      // buffers may be memory-released for large models, so we never read
+      // those for seeding, plan Fix 2.)
+      const { parseIfcxViewerModel } = await import('@/hooks/ingest/viewerModelIngest');
+      const parsed = await parseIfcxViewerModel(toArrayBuffer(store.source.materialize()), undefined, {
+        allowEmptyGeometry: true,
+      });
+      if (parsed.idToPath && parsed.pathToId) {
+        // Let the owner's outbound mirror resolve paths on this IFCX store.
+        registerEntityMaps(store, parsed.idToPath, parsed.pathToId);
+      }
+      const meshes = parsed.geometryResult.meshes;
+      if (meshes.length > 0) {
+        report = await seedGeometryToRoom(
+          deps.geomApi,
+          session,
+          blobStore,
+          meshes,
+          (id) => deps.stampBaseline(parsed.idToPath?.get(id) ?? null),
+          opts,
+        );
+      }
+    } else {
+      const meshes = deps.stepMeshes();
+      if (meshes && meshes.length > 0) {
+        report = await seedGeometryToRoom(
+          deps.geomApi,
+          session,
+          blobStore,
+          meshes,
+          (id) => deps.stampBaseline(pathForEntity(store, id)),
+          opts,
+        );
+      }
+    }
+    // Stamp intent vs outcome into the room. Without it a joiner sees the
+    // same empty `geometry` map either way and cannot tell a geometry-less
+    // model from a failed upload.
+    session.transact(() => {
+      writeGeometrySeedMarker(session.doc, markerFromReport(report, new Date().toISOString()));
+    });
+    const failure = seedFailureMessage(report);
+    if (failure) {
+      // eslint-disable-next-line no-console
+      console.error('[collab] geometry seed incomplete:', failure, report);
+    }
+    return { phase: seedPhaseFromOutcome(classifySeed(report)), failure };
+  } catch (err) {
+    // A throw here means the seed did not complete: the room may hold a
+    // partial model or none at all. Never let the Share dialog call that a
+    // success.
+    // eslint-disable-next-line no-console
+    console.error('[collab] model seeding failed:', err);
+    // Tell joiners too. This path never learned how much geometry the model
+    // had, so the marker records "interrupted" rather than "expected: 0",
+    // which would read as the legitimate nothing-to-seed case and silence
+    // the very warning this room needs.
+    if (deps.isCurrent()) {
+      try {
+        session.transact(() => {
+          writeGeometrySeedMarker(session.doc, interruptedSeedMarker(new Date().toISOString()));
+        });
+      } catch (markerErr) {
+        // eslint-disable-next-line no-console
+        console.error('[collab] could not record the interrupted seed:', markerErr);
+      }
+    }
+    return {
+      phase: 'failed',
+      failure: 'Sharing this model did not complete. People joining this link may see an incomplete model.',
+    };
+  }
+}

--- a/apps/viewer/src/lib/collab/seed-phase.ts
+++ b/apps/viewer/src/lib/collab/seed-phase.ts
@@ -54,15 +54,19 @@ export function seedPhaseFromOutcome(outcome: SeedOutcome): 'ready' | 'partial' 
   return 'ready';
 }
 
-/** Short user-facing label for an in-flight phase, or `null` once settled. */
+/**
+ * User-facing sentence for an in-flight phase, or `null` once settled. A
+ * complete sentence so each surface renders it as-is, under its own heading,
+ * without doubling the verb.
+ */
 export function describeSeedPhase(phase: CollabSeedPhase, progress: CollabSeedProgress | null): string | null {
   switch (phase) {
     case 'syncing':
-      return 'connecting to the room';
+      return 'Connecting to the room…';
     case 'structure':
-      return 'uploading model structure';
+      return 'Uploading model structure…';
     case 'geometry':
-      return progress ? `uploading geometry ${progress.uploaded}/${progress.total}` : 'uploading geometry';
+      return progress ? `Uploading geometry ${progress.uploaded}/${progress.total}…` : 'Uploading geometry…';
     default:
       return null;
   }

--- a/apps/viewer/src/lib/collab/seed-phase.ts
+++ b/apps/viewer/src/lib/collab/seed-phase.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The initial model seed as explicit state, separate from connectivity (#4446).
+ *
+ * A connected websocket is not a seeded room. `collabStatus` flips to
+ * `'connected'` the moment the provider handshakes, while the owner is still
+ * uploading structure and geometry into it — and `collabRoomId` is set even
+ * earlier, synchronously, before any await. A Share dialog keyed on either of
+ * those handed out invites to rooms that were still empty; whoever opened one
+ * reconstructed nothing.
+ *
+ * This is the product-level answer to "is the room ready to be shared?", so no
+ * UI has to inspect the Y.Doc (or `collabSession`, which is only committed
+ * after the seed) to find out. Recipients never seed: for them the phase stays
+ * `'none'`, which reads as ready.
+ */
+
+import type { SeedOutcome } from './geometry-seed-signal';
+
+export type CollabSeedPhase =
+  /** No seed in this session: off a room, or a recipient/joiner (rooms arrive populated). */
+  | 'none'
+  /** Owner join begun; waiting for the room to sync before seeding. */
+  | 'syncing'
+  /** Writing entities (structure) into the doc. */
+  | 'structure'
+  /** Uploading mesh blobs; see `CollabSeedProgress`. */
+  | 'geometry'
+  /** Everything the model had is in the room (including "it had nothing"). */
+  | 'ready'
+  /** Some geometry landed, some did not; `collabSeedFailure` says what. */
+  | 'partial'
+  /** The room got structure but no geometry, or the seed threw; `collabSeedFailure` says what. */
+  | 'failed';
+
+/** Geometry blob uploads so far, for a progress row. */
+export interface CollabSeedProgress {
+  uploaded: number;
+  total: number;
+}
+
+/** Phases during which an invite must NOT be handed out yet. */
+export function isCollabSeedInFlight(phase: CollabSeedPhase): boolean {
+  return phase === 'syncing' || phase === 'structure' || phase === 'geometry';
+}
+
+/** The phase a finished seed lands in, from the marker classification. */
+export function seedPhaseFromOutcome(outcome: SeedOutcome): 'ready' | 'partial' | 'failed' {
+  if (outcome === 'partial') return 'partial';
+  if (outcome === 'failed') return 'failed';
+  return 'ready';
+}
+
+/** Short user-facing label for an in-flight phase, or `null` once settled. */
+export function describeSeedPhase(phase: CollabSeedPhase, progress: CollabSeedProgress | null): string | null {
+  switch (phase) {
+    case 'syncing':
+      return 'connecting to the room';
+    case 'structure':
+      return 'uploading model structure';
+    case 'geometry':
+      return progress ? `uploading geometry ${progress.uploaded}/${progress.total}` : 'uploading geometry';
+    default:
+      return null;
+  }
+}

--- a/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
@@ -32,89 +32,24 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { createModelSlice, type ModelSlice } from './modelSlice.js';
-import { createDataSlice, type DataSlice, type DataCrossSliceState } from './dataSlice.js';
-import { createCollabSlice, type CollabSlice } from './collabSlice.js';
 import { roomModelIdOf } from '../../lib/collab/room-model-target.js';
-import type { MutablePropertyView } from '@ifc-lite/mutations';
-import type { ViewerState } from '../index.js';
-
-type TestState = ModelSlice &
-  DataSlice &
-  DataCrossSliceState &
-  CollabSlice & {
-    // `startCollab` reads/writes these via `get()`/`set()`; cross-slice
-    // fields `startCollab` touches that neither modelSlice nor dataSlice nor
-    // collabSlice itself own.
-    setEditEnabled: (enabled: boolean) => void;
-    // `roomModelIdOf`'s narrow `RoomModelTargetState` view needs this field
-    // (owned by mutationSlice, not under test here); a bare stub is enough.
-    mutationViews: Map<string, MutablePropertyView>;
-  };
+import { buildCollabTestState } from '../../test/collab-slice-state.js';
 
 describe('collabSlice.startCollab — entry race (model removed before the call)', () => {
   it('records a live session (collabRoomId set) with a null room model id, and roomModelIdOf fails closed', () => {
-    let state: TestState;
-    const setState = (partial: unknown) => {
-      const updates =
-        typeof partial === 'function'
-          ? (partial as (s: TestState) => Partial<TestState>)(state)
-          : (partial as Partial<TestState>);
-      state = { ...state, ...updates };
-    };
-    const getState = () => state as unknown as ViewerState;
-
-    const modelSlice = createModelSlice(
-      setState as Parameters<typeof createModelSlice>[0],
-      getState as Parameters<typeof createModelSlice>[1],
-      undefined as unknown as Parameters<typeof createModelSlice>[2],
-    );
-    const dataSlice = createDataSlice(
-      setState as Parameters<typeof createDataSlice>[0],
-      getState as Parameters<typeof createDataSlice>[1],
-      undefined as unknown as Parameters<typeof createDataSlice>[2],
-    );
-    const collabSlice = createCollabSlice(
-      setState as Parameters<typeof createCollabSlice>[0],
-      getState as Parameters<typeof createCollabSlice>[1],
-      undefined as unknown as Parameters<typeof createCollabSlice>[2],
-    );
-
-    state = {
-      ...modelSlice,
-      ...dataSlice,
-      ...collabSlice,
-      // uiSlice's real action is not under test; `startCollab` only calls it
-      // when `canCollabEdit()` is false, which is not this test's path
-      // (role: 'admin'), but it must exist to type-check the call site.
-      setEditEnabled: () => {},
-      mutationViews: new Map(),
-      addElementModelId: null,
-      addElementStoreyId: null,
-      selectedEntityId: null,
-      selectedEntityIds: new Set(),
-      selectedStoreys: new Set(),
-      hiddenEntities: new Set(),
-      isolatedEntities: null,
-      ghostExceptEntities: null,
-      classFilter: null,
-      hiddenEntitiesByModel: new Map(),
-      isolatedEntitiesByModel: new Map(),
-      pinboardEntities: new Set(),
-      hierarchyBasketSelection: new Set(),
-    } as TestState;
+    const s = buildCollabTestState();
 
     // The precondition: no model was ever loaded, or the last one was removed
     // — either way `activeModelId` is null, matching the state `startCollab`
     // observes when it races `ShareDialog`'s unguarded post-await call.
-    assert.equal(state.activeModelId, null);
+    assert.equal(s.get().activeModelId, null);
 
     // Call WITHOUT awaiting: an async function body runs synchronously up to
     // its first `await`, and the mutation this test pins happens before that
     // point (before `await import('@ifc-lite/collab')`). So by the time this
     // call returns (a Promise, not yet settled), the state below already
     // reflects the real `startCollab` prefix having run.
-    const pending = state.startCollab({
+    const pending = s.get().startCollab({
       roomId: 'r1',
       role: 'admin',
       token: 'test-token',
@@ -127,13 +62,13 @@ describe('collabSlice.startCollab — entry race (model removed before the call)
     // on its outcome.
     pending.catch(() => {});
 
-    assert.notEqual(state.collabRoomId, null, 'a live session must be recorded (this is the entry-race precondition)');
-    assert.equal(state.collabRoomModelId, null, 'no active model existed, so the room model id is null');
+    assert.notEqual(s.get().collabRoomId, null, 'a live session must be recorded (this is the entry-race precondition)');
+    assert.equal(s.get().collabRoomModelId, null, 'no active model existed, so the room model id is null');
 
     // The bug this pins shut: the OLD `roomModelIdOf` could not tell "no
     // session" apart from "live session, id not yet known" and fell back to
     // `activeModelId` — which, if the user loads a private file next, would
     // silently become the (wrong) room model. Must resolve to null instead.
-    assert.equal(roomModelIdOf(state), null);
+    assert.equal(roomModelIdOf(s.get()), null);
   });
 });

--- a/apps/viewer/src/store/slices/collabSlice.gates.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.gates.test.ts
@@ -188,6 +188,8 @@ describe('collabSlice: stopCollab returns the room state to rest', () => {
       collabSelfToken: 'tok',
       collabLastShareToken: 'share-tok',
       collabSeedFailure: 'geometry upload failed',
+      collabSeedPhase: 'geometry',
+      collabSeedProgress: { uploaded: 12, total: 40 },
       collabGeometryNotice: 'stale notice',
       collabPanelVisible: true,
       collabPeersSinceBaseline: true,
@@ -201,6 +203,11 @@ describe('collabSlice: stopCollab returns the room state to rest', () => {
     assert.equal(after.collabSelfToken, null);
     assert.equal(after.collabLastShareToken, null);
     assert.equal(after.collabSeedFailure, null, 'a seed failure must not survive into the next room');
+    // #4446: a stale in-flight phase would hold the NEXT room's invite back
+    // forever (the Share dialog waits on it), and a stale progress row would
+    // report the previous room's upload.
+    assert.equal(after.collabSeedPhase, 'none', 'a seed phase must not survive into the next room');
+    assert.equal(after.collabSeedProgress, null);
     assert.equal(after.collabGeometryNotice, null);
     assert.equal(after.collabStatus, 'disconnected');
     assert.deepEqual(after.collabPeers, []);

--- a/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
@@ -52,80 +52,7 @@ import assert from 'node:assert/strict';
 
 register('../../test/collab-session-race-hook.mjs', import.meta.url);
 
-import { createModelSlice, type ModelSlice } from './modelSlice.js';
-import { createDataSlice, type DataSlice, type DataCrossSliceState } from './dataSlice.js';
-import { createCollabSlice, type CollabSlice } from './collabSlice.js';
-import type { ViewerState } from '../index.js';
-
-type TestState = ModelSlice &
-  DataSlice &
-  DataCrossSliceState &
-  CollabSlice & {
-    setEditEnabled: (enabled: boolean) => void;
-    mutationViews: Map<string, unknown>;
-  };
-
-function buildState() {
-  let state: TestState;
-  const setState = (partial: unknown) => {
-    const updates =
-      typeof partial === 'function'
-        ? (partial as (s: TestState) => Partial<TestState>)(state)
-        : (partial as Partial<TestState>);
-    state = { ...state, ...updates };
-  };
-  const getState = () => state as unknown as ViewerState;
-
-  const modelSlice = createModelSlice(
-    setState as Parameters<typeof createModelSlice>[0],
-    getState as Parameters<typeof createModelSlice>[1],
-    undefined as unknown as Parameters<typeof createModelSlice>[2],
-  );
-  const dataSlice = createDataSlice(
-    setState as Parameters<typeof createDataSlice>[0],
-    getState as Parameters<typeof createDataSlice>[1],
-    undefined as unknown as Parameters<typeof createDataSlice>[2],
-  );
-  const collabSlice = createCollabSlice(
-    setState as Parameters<typeof createCollabSlice>[0],
-    getState as Parameters<typeof createCollabSlice>[1],
-    undefined as unknown as Parameters<typeof createCollabSlice>[2],
-  );
-
-  state = {
-    ...modelSlice,
-    ...dataSlice,
-    ...collabSlice,
-    // uiSlice's real action is not under test; `startCollab` only calls it
-    // when `canCollabEdit()` is false, which is not this test's path
-    // (role: 'admin'), but it must exist to type-check the call site.
-    setEditEnabled: () => {},
-    mutationViews: new Map(),
-    // Fields other slices own that the teardown `removeModel` dispatches
-    // reads off this stub state (`store/teardown-registry.ts`). Every
-    // contribution falls back to its own initial value when a field is
-    // absent, so these are here to make the harness store-shaped rather than
-    // to satisfy a type. Same enumeration as the sibling
-    // `collabSlice.entry-race.test.ts`; keep the two in step.
-    addElementModelId: null,
-    addElementStoreyId: null,
-    selectedEntityId: null,
-    selectedEntityIds: new Set(),
-    selectedStoreys: new Set(),
-    hiddenEntities: new Set(),
-    isolatedEntities: null,
-    ghostExceptEntities: null,
-    classFilter: null,
-    hiddenEntitiesByModel: new Map(),
-    isolatedEntitiesByModel: new Map(),
-    pinboardEntities: new Set(),
-    hierarchyBasketSelection: new Set(),
-  } as TestState;
-
-  return {
-    get: () => state,
-  };
-}
+import { buildCollabTestState } from '../../test/collab-slice-state.js';
 
 /**
  * Await `p`, or fail with a message naming what did not happen.
@@ -200,7 +127,7 @@ describe('collabSlice — stopCollab() racing an in-flight startCollab()', () =>
     });
     (globalThis as { __collabSessionGated?: () => void }).__collabSessionGated = sessionGated;
 
-    const s = buildState();
+    const s = buildCollabTestState();
 
     // Owner path, `seed: () => null` — a legitimate "nothing to seed" share
     // (matches ShareDialog's real usage) that skips the heavy

--- a/apps/viewer/src/store/slices/collabSlice.seed-phase.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.seed-phase.test.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #4446 — `collabSeedPhase` models the owner's initial seed as explicit state,
+ * separate from connectivity.
+ *
+ * The defect: `startCollab` sets `collabRoomId` synchronously and the provider
+ * reports `connected` long before structure and geometry are in the room, so
+ * a Share dialog keyed on either handed out invites to rooms that were still
+ * empty. Whoever opened one — including the owner navigating to their own
+ * link — reconstructed 0 entities / 0 triangles.
+ *
+ * Proof technique: the REAL `startCollab` against a REAL `@ifc-lite/collab`
+ * session (real Y.Doc, real IndexedDB via `fake-indexeddb`, real IndexedDB
+ * blob store), with the loader hook from the leave-during-join race test
+ * gating `whenSynced` so the test can observe the state between "room id set"
+ * and "seed begun" deterministically. The hook also hands the real session out
+ * so the doc can be read at the moment the phase says `ready` — which is the
+ * moment the Share dialog mints the invite, and the moment the owner in the
+ * issue's reproduction navigated away.
+ */
+
+import 'fake-indexeddb/auto';
+import { register } from 'node:module';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+register('../../test/collab-session-race-hook.mjs', import.meta.url);
+
+import type { CollabSession } from '@ifc-lite/collab';
+import { buildCollabTestState } from '../../test/collab-slice-state.js';
+import { buildGeometryResultFromMeshes } from '@/lib/collab/geometry-sync.js';
+import { buildStepSeedSource } from '@/lib/collab/step-seed.js';
+import type { CollabSeedPhase } from '@/lib/collab/seed-phase.js';
+import { SEED_GUIDS, seedFixtureMesh, seedFixtureMeshes, seedFixtureStore } from '../../test/collab-seed-fixture.js';
+import type { MeshData } from '@ifc-lite/geometry';
+
+const TIMEOUT_MS = 30_000;
+
+async function within<T>(p: Promise<T>, expected: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${TIMEOUT_MS}ms waiting for ${expected}`)), TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([p, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface Trace {
+  phase: CollabSeedPhase;
+  sessionCommitted: boolean;
+  status: string;
+}
+
+/** Owner join with the fixture model; records every phase transition. */
+function ownerJoin(roomId: string, meshes: MeshData[]) {
+  const trace: Trace[] = [];
+  const store = seedFixtureStore();
+  const s = buildCollabTestState({
+    onSet: (before, after) => {
+      if (after.collabSeedPhase !== before.collabSeedPhase) {
+        trace.push({
+          phase: after.collabSeedPhase,
+          sessionCommitted: after.collabSession !== null,
+          status: after.collabStatus,
+        });
+      }
+    },
+  });
+  s.set({ geometryResult: buildGeometryResultFromMeshes(meshes) });
+  let created: CollabSession | null = null;
+  (globalThis as { __collabSessionCreated?: (session: CollabSession) => void }).__collabSessionCreated = (
+    session,
+  ) => {
+    created = session;
+  };
+  const pending = s.get().startCollab({
+    roomId,
+    role: 'admin',
+    token: 'admin-token',
+    seed: () => ({ store, isIfcx: false, stepSource: buildStepSeedSource(store, 'fixture.ifc') }),
+  });
+  return { s, trace, pending, session: () => created };
+}
+
+describe('collabSlice — collabSeedPhase (#4446)', () => {
+  it('goes syncing -> structure -> geometry -> ready, with the session committed only after, and the doc full at ready', async () => {
+    let releaseGate!: () => void;
+    (globalThis as { __collabSyncGate?: Promise<void> }).__collabSyncGate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let sessionGated!: () => void;
+    const gated = new Promise<void>((resolve) => {
+      sessionGated = resolve;
+    });
+    (globalThis as { __collabSessionGated?: () => void }).__collabSessionGated = sessionGated;
+
+    const { s, trace, pending, session } = ownerJoin('seed-phase-room-1', seedFixtureMeshes());
+    try {
+      // Before any await inside startCollab: the room id is public and so is
+      // the pending seed — set in the SAME synchronous set(), so no subscriber
+      // can see a room with nothing in flight.
+      assert.equal(s.get().collabRoomId, 'seed-phase-room-1');
+      assert.equal(s.get().collabSeedPhase, 'syncing');
+
+      const outcome = await within(
+        Promise.race([gated.then(() => 'gated' as const), pending.then(() => 'returned-early' as const)]),
+        'the session to be gated OR startCollab to return',
+      );
+      assert.equal(outcome, 'gated', 'bring-up failed before the seed (see the [collab] diagnostic above)');
+
+      // Parked on whenSynced: connected as far as the provider is concerned,
+      // nothing in the room yet. This is the window the issue reproduced in.
+      assert.equal(s.get().collabSeedPhase, 'syncing');
+      assert.equal(s.get().collabSession, null);
+      assert.equal(session()?.doc.getMap('entities').size, 0, 'the room is still empty here');
+
+      // Resolve once the phase says ready — the moment the Share dialog mints.
+      const ready = new Promise<void>((resolve) => {
+        const original = s.hooks.onSet;
+        s.hooks.onSet = (before, after) => {
+          original?.(before, after);
+          if (after.collabSeedPhase === 'ready') resolve();
+        };
+      });
+      releaseGate();
+      await within(ready, 'collabSeedPhase to reach ready');
+
+      // The owner navigates away the instant the invite becomes available.
+      s.get().stopCollab();
+
+      // What the guest would find in the room at that instant: everything.
+      const doc = session()!.doc;
+      assert.equal(doc.getMap('entities').size, 2, 'both products are in the room when ready is reported');
+      assert.equal(doc.getMap('geometry').size, 2, 'both meshes are referenced when ready is reported');
+      // Loaded here, after `register()`, so it resolves through the same hook
+      // as the slice's own lazy import.
+      const { getGeometryRef, guidToPath } = await import('@ifc-lite/collab');
+      for (const guid of Object.values(SEED_GUIDS)) {
+        assert.equal(getGeometryRef(doc, guidToPath(guid))?.geomIds.length, 1, `${guid} carries its geometry ref`);
+      }
+
+      assert.deepEqual(
+        trace.map((t) => t.phase),
+        ['syncing', 'structure', 'geometry', 'ready', 'none'],
+        'phases in order; the trailing none is stopCollab',
+      );
+      for (const t of trace.filter((t) => t.phase !== 'none')) {
+        assert.equal(t.sessionCommitted, false, `collabSession is still null at ${t.phase}: it is not the readiness signal`);
+      }
+      const atReady = trace.find((t) => t.phase === 'ready');
+      assert.deepEqual(s.get().collabSeedProgress, null, 'stopCollab cleared the progress row');
+      assert.ok(atReady, 'ready was observed');
+
+      await within(pending, 'startCollab to return after the leave');
+      assert.equal(s.get().collabSession, null, 'the abandoned join did not revive a session');
+      assert.equal(s.get().collabSeedPhase, 'none');
+    } finally {
+      s.get().collabSession?.dispose();
+      session()?.dispose();
+    }
+  });
+
+  it('records geometry progress and settles ready with no failure on a clean seed', async () => {
+    delete (globalThis as { __collabSyncGate?: Promise<void> }).__collabSyncGate;
+    const progress: Array<{ uploaded: number; total: number }> = [];
+    const { s, pending, session } = ownerJoin('seed-phase-room-2', seedFixtureMeshes());
+    const original = s.hooks.onSet;
+    s.hooks.onSet = (before, after) => {
+      original?.(before, after);
+      if (after.collabSeedProgress && after.collabSeedProgress !== before.collabSeedProgress) {
+        progress.push(after.collabSeedProgress);
+      }
+    };
+    try {
+      await within(pending, 'startCollab to complete');
+      assert.equal(s.get().collabSeedPhase, 'ready');
+      assert.equal(s.get().collabSeedFailure, null);
+      assert.deepEqual(progress.at(-1), { uploaded: 2, total: 2 });
+      assert.ok(s.get().collabSession, 'the session is committed once the seed is done');
+      assert.equal(s.get().collabStatus, 'indexeddb', 'status is the provider, not the seed');
+    } finally {
+      s.get().stopCollab();
+      session()?.dispose();
+    }
+  });
+
+  it('settles failed, with the owner-facing reason, when the geometry never makes it into the room', async () => {
+    delete (globalThis as { __collabSyncGate?: Promise<void> }).__collabSyncGate;
+    // A textured mesh whose image is unavailable fails its upload explicitly.
+    const orphaned: MeshData = { ...seedFixtureMesh(1) };
+    delete orphaned.texture;
+    orphaned.textureRef = { textureId: 1, url: 'image.png', repeatS: true, repeatT: false };
+    const { s, trace, pending, session } = ownerJoin('seed-phase-room-3', [orphaned]);
+    try {
+      await within(pending, 'startCollab to complete');
+      assert.equal(s.get().collabSeedPhase, 'failed');
+      assert.match(s.get().collabSeedFailure ?? '', /no 3D geometry|source image is unavailable/);
+      assert.deepEqual(trace.map((t) => t.phase), ['syncing', 'structure', 'geometry', 'failed']);
+      assert.equal(session()?.doc.getMap('geometry').size, 0);
+    } finally {
+      s.get().stopCollab();
+      session()?.dispose();
+    }
+  });
+});

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -133,8 +133,6 @@ export interface StartCollabOptions {
   seed?: () => CollabSeedInput | null;
 }
 
-export type { CollabSeedInput };
-
 export interface CollabSlice {
   // ── State ────────────────────────────────────────────────────────────────
   /** The live session, or `null` when not in a shared room. */

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -32,7 +32,6 @@ import type {
   LocalPlacement,
   PresenceState,
   ProviderKind,
-  StepSeedSource,
   UserIdentity,
   WebSocketStatus,
 } from '@ifc-lite/collab';
@@ -63,16 +62,10 @@ import {
   hydrateGeometryFromRoom,
   seedGeometryToRoom,
   type CollabGeomApi,
-  type SeedGeometryReport,
 } from '@/lib/collab/geometry-sync';
-import {
-  interruptedSeedMarker,
-  markerFromReport,
-  missingRoomGeometryMessage,
-  readGeometrySeedMarker,
-  seedFailureMessage,
-  writeGeometrySeedMarker,
-} from '@/lib/collab/geometry-seed-signal';
+import { missingRoomGeometryMessage, readGeometrySeedMarker } from '@/lib/collab/geometry-seed-signal';
+import { runOwnerSeed, type CollabSeedInput } from '@/lib/collab/owner-seed';
+import type { CollabSeedPhase, CollabSeedProgress } from '@/lib/collab/seed-phase';
 import { highestExpressId, raisedMaxExpressId } from '@/lib/collab/express-id-bounds';
 import { createSharedBlobStore } from '@/lib/collab/blob-store';
 import { applyRoomModelData } from '@/lib/collab/room-model-apply';
@@ -140,23 +133,7 @@ export interface StartCollabOptions {
   seed?: () => CollabSeedInput | null;
 }
 
-/**
- * Model-share payload the owner hands to `startCollab`. Carries the parsed
- * store plus enough context to seed both schema families:
- *   - IFC5/IFCX → seed natively from the store's own IFCX bytes (`store.source`)
- *     and key geometry by IFCX path (`idToPath`), since an IFCX-origin store has
- *     no STEP `entityIndex.byId`/GUIDs to drive `buildStepSeedSource`.
- *   - legacy STEP → seed the pre-built IFCX-shaped `stepSource`, key geometry by
- *     `pathForEntity` (GUID path).
- */
-export interface CollabSeedInput {
-  /** The active model's parsed store. For IFC5, `store.source` holds the IFCX bytes. */
-  store: IfcDataStore;
-  /** True when the model is IFC5/IFCX (seed natively from `store.source`). */
-  isIfcx: boolean;
-  /** Pre-built STEP seed source for legacy rooms; `null` for IFC5. */
-  stepSource: StepSeedSource | null;
-}
+export type { CollabSeedInput };
 
 export interface CollabSlice {
   // ── State ────────────────────────────────────────────────────────────────
@@ -230,6 +207,17 @@ export interface CollabSlice {
    * knows is missing its geometry and still call that success.
    */
   collabSeedFailure: string | null;
+  /**
+   * Where the owner's initial seed-into-room stands (#4446). A connected
+   * websocket is NOT a seeded room: `collabStatus` reads 'connected' while
+   * structure and geometry are still uploading, and `collabRoomId` is set
+   * before either begins. The Share dialog holds the invite back until this
+   * settles; RoomPanel says "uploading" rather than "live". `'none'` off a
+   * session and for recipients, who never seed. Reset by `stopCollab`.
+   */
+  collabSeedPhase: CollabSeedPhase;
+  /** Geometry blob uploads so far while `collabSeedPhase === 'geometry'`, else `null`. */
+  collabSeedProgress: CollabSeedProgress | null;
   /**
    * One-shot message for the toast channel: a joined room that hydrated with
    * entities but no meshes, or a local edit whose mesh never reached the room.
@@ -380,13 +368,6 @@ function remotePeers(peers: Record<number, PresenceState>, selfClientId: number)
     out.push({ ...state, clientId: Number(clientId) } as PresenceState);
   }
   return out;
-}
-
-/** View a `Uint8Array` as an `ArrayBuffer` (copying only when it's a sub-view). */
-function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
-  return u8.byteOffset === 0 && u8.byteLength === u8.buffer.byteLength
-    ? (u8.buffer as ArrayBuffer)
-    : (u8.slice().buffer as ArrayBuffer);
 }
 
 // Collab doc helpers captured from the lazy-loaded runtime (see startCollab),
@@ -548,6 +529,8 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
   collabLastShareToken: null,
   collabPanelVisible: false,
   collabSeedFailure: null,
+  collabSeedPhase: 'none',
+  collabSeedProgress: null,
   collabGeometryNotice: null,
 
   setCollabPanelVisible: (collabPanelVisible) => set({ collabPanelVisible }),
@@ -596,6 +579,11 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabRoomModelId: roomModelId,
       collabRole: role,
       collabSelfToken: token ?? null,
+      // An owner's seed is in flight from this very moment, before the session
+      // even exists: set in the SAME synchronous set() as `collabRoomId` so no
+      // subscriber can observe a room with nothing pending and mint an invite.
+      collabSeedPhase: seed ? 'syncing' : 'none',
+      collabSeedProgress: null,
     });
 
     // Role gate: joining as viewer/commenter must drop any edit mode the
@@ -610,13 +598,11 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
     const user: UserIdentity = { id: identity.id, name: identity.name, color: identity.color };
 
     let session: CollabSession;
-    let seedFromStep: typeof import('@ifc-lite/collab')['seedFromStep'];
     let collabMod: typeof import('@ifc-lite/collab');
     try {
       // Lazy-load the collab runtime (code-split) — see the import note above.
       const collab = await import('@ifc-lite/collab');
       collabMod = collab;
-      seedFromStep = collab.seedFromStep;
       // Capture the doc helpers the synchronous mutation mirror needs.
       docApi = {
         hasEntity: collab.hasEntity,
@@ -676,6 +662,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
           collabRoomId: null,
           collabRole: null,
           collabSelfToken: null,
+          collabSeedPhase: 'none',
         });
       } else {
         set({ collabConnecting: false, collabStatus: 'disconnected' });
@@ -739,119 +726,42 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
     // Owner seeds the model into the Y.Doc (plan §4.6 seed-into-room) once the
     // room has synced — but only if it's still empty, so we don't re-seed a
     // populated room or clobber a peer's edits. Recipients pass no `seed` and
-    // hydrate from the doc instead.
+    // hydrate from the doc instead. The seed's phases are mirrored into
+    // `collabSeedPhase` (#4446): `collabStatus` says 'connected' long before
+    // the room holds the model, and the Share dialog must key off THIS, not
+    // that. Every write is guarded on the join still being current, so a
+    // Leave landing mid-seed cannot have a stale continuation re-stamp it.
     if (seed) {
-      try {
-        await session.whenSynced;
-        if (get().collabRoomId === roomId) {
-          const seedData = seed();
-          if (seedData) {
-            const { store } = seedData;
-            // Structure seed — once; never clobber a populated room or peer edits.
-            if (session.doc.getMap('entities').size === 0) {
-              if (seedData.isIfcx) {
-                // IFC5: seed natively from the model's own IFCX bytes. The STEP
-                // path (buildStepSeedSource) can't read an IFCX-origin store (no
-                // entityIndex.byId / GUIDs) and would seed zero entities.
-                // Whole-file consumer: the IFCX seed re-parses the source.
-                const bytes = store.source;
-                if (bytes.length > 0) {
-                  collabMod.seedFromIfcx(session.doc, bytes.materialize());
-                }
-              } else if (seedData.stepSource) {
-                seedFromStep(session.doc, seedData.stepSource);
-              }
-            }
-            // Geometry seed — whenever the room has none yet (DECOUPLED from the
-            // entity guard, so a partially-seeded room backfills). Blobs are
-            // content-addressed, so re-seeding the same model dedupes.
-            if (session.doc.getMap('geometry').size === 0) {
-              const blobStore = await createSharedBlobStore(collabMod, collabServerUrl(), token);
-              // Record the placement each entity's blob is baked at, so every
-              // client (incl. late joiners) can render `blob + (current
-              // usd::xformop − baseline)`. The blob is baked at whatever
-              // placement the doc holds now: the seeded `usd::xformop` for IFCX
-              // models, identity for legacy STEP (geometry baked world-absolute).
-              const stampBaseline = (path: string | null): string | null => {
-                if (path && placementApi) {
-                  const current = placementApi.getEntityPlacement(session.doc, path);
-                  placementApi.setPlacementBaseline(session.doc, path, current ?? { location: [0, 0, 0] });
-                }
-                return path;
-              };
-              // `null` means no seed ran at all: the model had nothing to
-              // offer. That is a legitimate share (structure-only or empty
-              // model) and is NOT the same as a seed that ran and landed
-              // nothing, which is a broken share. Only here, on the owner, is
-              // that difference still knowable.
-              let report: SeedGeometryReport | null = null;
-              if (seedData.isIfcx && store.source && store.source.length > 0) {
-                // IFCX geometry is explicit in the file: re-parse the source for
-                // COMPLETE meshes + the id->path map to key them. (The owner's
-                // render buffers may be memory-released for large models, so we
-                // never read those for seeding, plan Fix 2.)
-                const { parseIfcxViewerModel } = await import('@/hooks/ingest/viewerModelIngest');
-                const parsed = await parseIfcxViewerModel(toArrayBuffer(store.source.materialize()), undefined, {
-                  allowEmptyGeometry: true,
-                });
-                if (parsed.idToPath && parsed.pathToId) {
-                  // Let the owner's outbound mirror resolve paths on this IFCX store.
-                  registerEntityMaps(store, parsed.idToPath, parsed.pathToId);
-                }
-                const meshes = parsed.geometryResult.meshes;
-                if (meshes.length > 0) {
-                  report = await seedGeometryToRoom(geomApi, session, blobStore, meshes, (id) =>
-                    stampBaseline(parsed.idToPath?.get(id) ?? null),
-                  );
-                }
-              } else {
-                const meshes = get().geometryResult?.meshes;
-                if (meshes && meshes.length > 0) {
-                  report = await seedGeometryToRoom(geomApi, session, blobStore, meshes, (id) =>
-                    stampBaseline(pathForEntity(store, id)),
-                  );
-                }
-              }
-              // Stamp intent vs outcome into the room. Without it a joiner sees
-              // the same empty `geometry` map either way and cannot tell a
-              // geometry-less model from a failed upload.
-              session.transact(() => {
-                writeGeometrySeedMarker(session.doc, markerFromReport(report, new Date().toISOString()));
-              });
-              const failure = seedFailureMessage(report);
-              if (failure) {
-                // eslint-disable-next-line no-console
-                console.error('[collab] geometry seed incomplete:', failure, report);
-                set({ collabSeedFailure: failure });
-              }
-            }
+      const current = () => get().collabRoomId === roomId;
+      const outcome = await runOwnerSeed({
+        session,
+        seed,
+        collab: collabMod,
+        geomApi,
+        makeBlobStore: () => createSharedBlobStore(collabMod, collabServerUrl(), token),
+        stepMeshes: () => get().geometryResult?.meshes,
+        // Record the placement each entity's blob is baked at, so every
+        // client (incl. late joiners) can render `blob + (current
+        // usd::xformop − baseline)`. The blob is baked at whatever
+        // placement the doc holds now: the seeded `usd::xformop` for IFCX
+        // models, identity for legacy STEP (geometry baked world-absolute).
+        stampBaseline: (path) => {
+          if (path && placementApi) {
+            const currentPlacement = placementApi.getEntityPlacement(session.doc, path);
+            placementApi.setPlacementBaseline(session.doc, path, currentPlacement ?? { location: [0, 0, 0] });
           }
-        }
-      } catch (err) {
-        // A throw here means the seed did not complete: the room may hold a
-        // partial model or none at all. Never let the Share dialog call that a
-        // success (this catch swallowing it is how a weeks-long geometry
-        // outage went unnoticed).
-        // eslint-disable-next-line no-console
-        console.error('[collab] model seeding failed:', err);
-        set({
-          collabSeedFailure:
-            'Sharing this model did not complete. People joining this link may see an incomplete model.',
-        });
-        // Tell joiners too. This path never learned how much geometry the model
-        // had, so the marker records "interrupted" rather than "expected: 0",
-        // which would read as the legitimate nothing-to-seed case and silence
-        // the very warning this room needs.
-        if (get().collabRoomId === roomId) {
-          try {
-            session.transact(() => {
-              writeGeometrySeedMarker(session.doc, interruptedSeedMarker(new Date().toISOString()));
-            });
-          } catch (markerErr) {
-            // eslint-disable-next-line no-console
-            console.error('[collab] could not record the interrupted seed:', markerErr);
-          }
-        }
+          return path;
+        },
+        isCurrent: current,
+        onPhase: (phase) => {
+          if (current()) set({ collabSeedPhase: phase });
+        },
+        onProgress: (uploaded, total) => {
+          if (current()) set({ collabSeedProgress: { uploaded, total } });
+        },
+      });
+      if (outcome && current()) {
+        set({ collabSeedPhase: outcome.phase, collabSeedFailure: outcome.failure });
       }
     } else {
       // Recipient (deep-link join, no local model): reconstruct the full model
@@ -1310,6 +1220,8 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
       collabLastShareToken: null,
       collabPanelVisible: false,
       collabSeedFailure: null,
+      collabSeedPhase: 'none',
+      collabSeedProgress: null,
       collabGeometryNotice: null,
     });
   },

--- a/apps/viewer/src/test/collab-seed-fixture.ts
+++ b/apps/viewer/src/test/collab-seed-fixture.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The smallest owner-side model that exercises the REAL seed-into-room path
+ * (#4446): a legacy STEP store with two IfcRoot products (`buildStepSeedSource`
+ * derives the structure from it, `pathForEntity` keys geometry by its GUIDs)
+ * and one textured mesh per product, so the guest side can prove it got the
+ * geometry AND the image back, not just the entity list.
+ *
+ * Shared by the `runOwnerSeed` unit test and the `startCollab` phase test so
+ * the two seed the same model and can be read against each other.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { MeshData } from '@ifc-lite/geometry';
+
+export const SEED_GUIDS = {
+  wall: '0aBcDeFgHiJkLmNoPqRsT1',
+  slab: '0aBcDeFgHiJkLmNoPqRsT2',
+} as const;
+
+/** 2x2 RGBA image, distinct per pixel so a byte-exact round-trip is meaningful. */
+export const SEED_TEXTURE_PIXELS = new Uint8Array([
+  255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 128,
+]);
+
+/**
+ * A STEP-origin store as `buildStepSeedSource` / `pathForEntity` read it. No
+ * source bytes and no spatial tree: the seed must come from the entity table
+ * alone (the same invariant `step-seed.test.ts` pins).
+ */
+export function seedFixtureStore(): IfcDataStore {
+  const rows = new Map<number, { guid: string; name: string; type: string }>([
+    [1, { guid: SEED_GUIDS.wall, name: 'Wall-A', type: 'IfcWall' }],
+    [2, { guid: SEED_GUIDS.slab, name: 'Slab-B', type: 'IfcSlab' }],
+  ]);
+  return {
+    source: new Uint8Array(0),
+    entityIndex: {
+      byId: new Map([
+        [1, { type: 'IFCWALL', byteOffset: 0, byteLength: 0 }],
+        [2, { type: 'IFCSLAB', byteOffset: 0, byteLength: 0 }],
+      ]),
+      byType: new Map(),
+    },
+    entities: {
+      getGlobalId: (id: number) => rows.get(id)?.guid ?? '',
+      getName: (id: number) => rows.get(id)?.name ?? '',
+      getDescription: () => '',
+      getObjectType: () => '',
+      getTypeName: (id: number) => rows.get(id)?.type ?? 'Unknown',
+    },
+    properties: { getForEntity: () => [] },
+    relationships: { getRelated: () => [] },
+    spatialHierarchy: null,
+    schemaVersion: 'IFC4',
+  } as unknown as IfcDataStore;
+}
+
+/** One textured triangle per product; `z` varies so the blobs are distinct. */
+export function seedFixtureMesh(expressId: number): MeshData {
+  return {
+    expressId,
+    ifcType: expressId === 1 ? 'IfcWall' : 'IfcSlab',
+    positions: new Float32Array([0, 0, expressId, 1, 0, expressId, 0, 1, expressId]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    uvs: new Float32Array([0, 0, 1, 0, 0, 1]),
+    texture: { width: 2, height: 2, rgba: SEED_TEXTURE_PIXELS, repeatS: false, repeatT: true },
+  };
+}
+
+export function seedFixtureMeshes(): MeshData[] {
+  return [seedFixtureMesh(1), seedFixtureMesh(2)];
+}

--- a/apps/viewer/src/test/collab-session-race-hook.mjs
+++ b/apps/viewer/src/test/collab-session-race-hook.mjs
@@ -58,6 +58,10 @@ export * from ${JSON.stringify(realUrl)};
 import { createCollabSession as __realCreateCollabSession } from ${JSON.stringify(realUrl)};
 export async function createCollabSession(opts) {
   const session = await __realCreateCollabSession(opts);
+  // Hand the REAL session to the test so it can inspect the doc the seed
+  // wrote (collabSlice.seed-phase.test.ts): \`collabSession\` is only committed
+  // at the very end of \`startCollab\`, after the phases under test.
+  globalThis.__collabSessionCreated?.(session);
   const gate = globalThis.__collabSyncGate;
   if (gate) {
     const original = session.whenSynced;

--- a/apps/viewer/src/test/collab-session-race-hook.mjs
+++ b/apps/viewer/src/test/collab-session-race-hook.mjs
@@ -3,19 +3,22 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Test-only loader hook for `collabSlice.leave-during-join-race.test.ts`.
+ * Test-only loader hook for the collabSlice race tests
+ * (`collabSlice.leave-during-join-race.test.ts`, `collabSlice.seed-phase.test.ts`).
  *
- * Registered via `node:module`'s `register()` from inside that one test
- * file, so it only affects that file's (isolated, per-file) process — it
+ * Registered via `node:module`'s `register()` from inside each of those test
+ * files, so it only affects that file's (isolated, per-file) process — it
  * does not touch the shared `vite-module-hooks` pipeline other suites rely
  * on, and it does not change what `@ifc-lite/collab` exports for anything
  * else.
  *
- * Wraps `createCollabSession` so the test can pause the REAL session's
- * `whenSynced` at a chosen point (after the real IndexedDB/CRDT bring-up
- * has actually happened) and resume it on demand — the deterministic
- * substitute for "the network happened to take a while". Every other
- * export passes through untouched.
+ * Wraps `createCollabSession` so a test can (a) receive the REAL session via
+ * `globalThis.__collabSessionCreated`, to read the doc before `startCollab`
+ * commits `collabSession`, and (b) pause that session's `whenSynced` via
+ * `globalThis.__collabSyncGate` at a chosen point (after the real
+ * IndexedDB/CRDT bring-up has actually happened) and resume it on demand —
+ * the deterministic substitute for "the network happened to take a while".
+ * Every other export passes through untouched.
  */
 
 const MARKER = 'collab-session-race-hook:';

--- a/apps/viewer/src/test/collab-slice-state.ts
+++ b/apps/viewer/src/test/collab-slice-state.ts
@@ -10,22 +10,27 @@
  * initial value when a field is absent, so these exist to make the harness
  * store-shaped rather than to satisfy a type.
  *
- * One copy of what `collabSlice.leave-during-join-race.test.ts` and
- * `collabSlice.entry-race.test.ts` each spell out inline; keep those in step
- * with this when the enumeration changes.
+ * Shared by the collabSlice race tests (`leave-during-join-race`,
+ * `entry-race`, `seed-phase`).
  */
 
 import { createModelSlice, type ModelSlice } from '../store/slices/modelSlice.js';
 import { createDataSlice, type DataSlice, type DataCrossSliceState } from '../store/slices/dataSlice.js';
 import { createCollabSlice, type CollabSlice } from '../store/slices/collabSlice.js';
 import type { ViewerState } from '../store/index.js';
+import type { Annotation } from '../store/slices/annotationsSlice.js';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
 
 export type CollabTestState = ModelSlice &
   DataSlice &
   DataCrossSliceState &
   CollabSlice & {
+    /** uiSlice's; `startCollab` only calls it when `canCollabEdit()` is false. */
     setEditEnabled: (enabled: boolean) => void;
-    mutationViews: Map<string, unknown>;
+    /** mutationSlice's; `roomMutationView` reads it through `RoomModelTargetState`. */
+    mutationViews: Map<string, MutablePropertyView>;
+    /** annotationsSlice's; `startCollab` seeds every local pin into the room. */
+    annotations: Map<string, Annotation>;
   };
 
 export interface CollabTestHooks {
@@ -71,6 +76,7 @@ export function buildCollabTestState(hooks: CollabTestHooks = {}) {
     // exist to type-check the call site.
     setEditEnabled: () => {},
     mutationViews: new Map(),
+    annotations: new Map(),
     addElementModelId: null,
     addElementStoreyId: null,
     selectedEntityId: null,

--- a/apps/viewer/src/test/collab-slice-state.ts
+++ b/apps/viewer/src/test/collab-slice-state.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A store-shaped state for driving the REAL `collabSlice` actions in node
+ * tests: the model + data + collab slices composed over a plain object, plus
+ * the fields other slices own that the teardown `removeModel` dispatches read
+ * (`store/teardown-registry.ts`). Every contribution falls back to its own
+ * initial value when a field is absent, so these exist to make the harness
+ * store-shaped rather than to satisfy a type.
+ *
+ * One copy of what `collabSlice.leave-during-join-race.test.ts` and
+ * `collabSlice.entry-race.test.ts` each spell out inline; keep those in step
+ * with this when the enumeration changes.
+ */
+
+import { createModelSlice, type ModelSlice } from '../store/slices/modelSlice.js';
+import { createDataSlice, type DataSlice, type DataCrossSliceState } from '../store/slices/dataSlice.js';
+import { createCollabSlice, type CollabSlice } from '../store/slices/collabSlice.js';
+import type { ViewerState } from '../store/index.js';
+
+export type CollabTestState = ModelSlice &
+  DataSlice &
+  DataCrossSliceState &
+  CollabSlice & {
+    setEditEnabled: (enabled: boolean) => void;
+    mutationViews: Map<string, unknown>;
+  };
+
+export interface CollabTestHooks {
+  /** Observes every store write (before/after), for tracing state transitions. */
+  onSet?: (before: CollabTestState, after: CollabTestState) => void;
+}
+
+export function buildCollabTestState(hooks: CollabTestHooks = {}) {
+  let state: CollabTestState;
+  const setState = (partial: unknown) => {
+    const updates =
+      typeof partial === 'function'
+        ? (partial as (s: CollabTestState) => Partial<CollabTestState>)(state)
+        : (partial as Partial<CollabTestState>);
+    const before = state;
+    state = { ...state, ...updates };
+    hooks.onSet?.(before, state);
+  };
+  const getState = () => state as unknown as ViewerState;
+
+  const modelSlice = createModelSlice(
+    setState as Parameters<typeof createModelSlice>[0],
+    getState as Parameters<typeof createModelSlice>[1],
+    undefined as unknown as Parameters<typeof createModelSlice>[2],
+  );
+  const dataSlice = createDataSlice(
+    setState as Parameters<typeof createDataSlice>[0],
+    getState as Parameters<typeof createDataSlice>[1],
+    undefined as unknown as Parameters<typeof createDataSlice>[2],
+  );
+  const collabSlice = createCollabSlice(
+    setState as Parameters<typeof createCollabSlice>[0],
+    getState as Parameters<typeof createCollabSlice>[1],
+    undefined as unknown as Parameters<typeof createCollabSlice>[2],
+  );
+
+  state = {
+    ...modelSlice,
+    ...dataSlice,
+    ...collabSlice,
+    // uiSlice's real action is not under test; `startCollab` only calls it
+    // when `canCollabEdit()` is false (never for role 'admin'), but it must
+    // exist to type-check the call site.
+    setEditEnabled: () => {},
+    mutationViews: new Map(),
+    addElementModelId: null,
+    addElementStoreyId: null,
+    selectedEntityId: null,
+    selectedEntityIds: new Set(),
+    selectedStoreys: new Set(),
+    hiddenEntities: new Set(),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    classFilter: null,
+    hiddenEntitiesByModel: new Map(),
+    isolatedEntitiesByModel: new Map(),
+    pinboardEntities: new Set(),
+    hierarchyBasketSelection: new Set(),
+  } as CollabTestState;
+
+  return {
+    get: () => state,
+    set: (partial: Partial<CollabTestState>) => setState(partial),
+    hooks,
+  };
+}

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -178,7 +178,7 @@
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    992 apps/viewer/src/store/slices/clashSlice.ts
-  1598 apps/viewer/src/store/slices/collabSlice.ts
+  1510 apps/viewer/src/store/slices/collabSlice.ts
    482 apps/viewer/src/store/slices/dataSlice.ts
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts


### PR DESCRIPTION
Part of #4446

The invite is now withheld until the initial seed is explicitly ready. What remains on the issue is the manual relay acceptance (AC20-FZK-Haus IFCZIP over the signed local relay per `docs/contributing/collaboration-testing.md`), which this PR proves in-process only — see Evidence.

## What changed

**The seed is explicit store state, separate from connectivity.** `collabSlice` gains

```ts
collabSeedPhase: 'none' | 'syncing' | 'structure' | 'geometry' | 'ready' | 'partial' | 'failed';
collabSeedProgress: { uploaded: number; total: number } | null;
```

`'syncing'` is set in the **same synchronous `set()`** as `collabRoomId`, so no subscriber can ever observe an owner's room with nothing pending. Recipients never seed, so their phase stays `'none'` (reads as ready — one source of truth, no `room:`-prefix selector). `stopCollab` resets both (pinned in `collabSlice.gates.test.ts`). The single product predicate is `isCollabSeedInFlight` in `apps/viewer/src/lib/collab/seed-phase.ts`; no caller inspects the Y.Doc or `collabSession`.

**`runOwnerSeed` extracted** (`apps/viewer/src/lib/collab/owner-seed.ts`, 210 L): the ~110-line owner seed branch left `collabSlice.startCollab`. It is pure w.r.t. the store — reports via `onPhase`/`onProgress` (the latter now actually wired to `seedGeometryToRoom`'s `onProgress`, which was never passed before), returns the settled phase plus the owner-facing failure message, never throws. `collabSlice.ts` drops 1598 → 1510 lines and its allowlist row is **lowered** to 1510.

**ShareDialog** split into two effects: an *ensure-room* effect (one creation attempt per opening, carried in a ref so `collabRoomId` flipping does not re-trigger it — the exact re-run that used to mint on the empty room) and a *mint-invite* effect that only mints once the phase has settled. While in flight it shows a `role="status"` row (`Uploading geometry 120/272…`) and Copy stays disabled. `'partial'`/`'failed'` still hand out the link, but only next to the existing `role="alert"` incomplete-transfer message — the room exists and re-seeding is not a thing, so hiding the link would help nobody.

**RoomPanel** shows "Uploading model" + progress instead of "Live" while seeding, disables its own copy-invite button, and relabels Leave as "Leave (abandons upload)". A dropped socket mid-seed outranks the badge ("Offline room") so the owner knows to reconnect, while the invite stays withheld.

Changeset: `.changeset/share-dialog-seed-ready.md` (`@ifc-lite/viewer` patch).

## Why / root cause

`startCollab` sets `collabRoomId` synchronously before its first await, and the provider reports `collabStatus === 'connected'` the moment the socket handshakes — both long before structure and geometry are in the doc (`collabSession` is only committed after the seed). The Share dialog's single effect was keyed on `collabRoomId`: it re-ran for the new room, the first run's `await startCollab` result was dropped, and the second run minted a guest token and cleared `busy` while the seed was still uploading. Anyone opening that link — including the owner navigating to it — reconstructed 0 entities / 0 triangles. A connected websocket is not a seeded room; the fix models the seed as its own state and keys both surfaces on it.

## Evidence

Run from `apps/viewer` with `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 <files>` on the final rebased head:

- `owner-seed.test.ts` (7), `collabSlice.seed-phase.test.ts` (3), `collabSlice.leave-during-join-race.test.ts`, `collabSlice.entry-race.test.ts`, `collabSlice.gates.test.ts`, `ShareDialog.seed-ready.test.tsx` (5), `ShareDialog.seed-failure.test.tsx`, `RoomPanel.seed-phase.test.tsx` (4) → **36 tests, 36 pass, 0 fail**; the `[collab] annotation sync setup failed` diagnostic that the harness used to trigger no longer appears (0 occurrences).
- All tests drive the REAL `startCollab` / `@ifc-lite/collab` session (real Y.Doc, `fake-indexeddb`), no mocks. `collabSlice.seed-phase.test.ts` gates `whenSynced` with the loader hook, asserts `syncing → structure → geometry → ready` with `collabSession` null throughout and `collabStatus` unchanged, then calls `stopCollab()` the instant `ready` is reported and reads the real doc: both entities and both geometry refs present. `owner-seed.test.ts` reconstructs the seeded room through the recipient path (`snapshotToIfcx → parseIfcxViewerModel → hydrateGeometryFromRoom`) over the same blob store and asserts entity count, mesh count == the seed report, and byte-exact texture pixels/UVs.
- `pnpm --filter viewer typecheck` → clean. `node scripts/check-module-size.mjs` → OK (2752 files, 327 allowlisted, 0 new over 400; vs merge-base: v1 = the lowered collabSlice row). `node scripts/check-test-wiring.mjs`, `check-collab-room-model-target.mjs` (3 regions, 10 self-gated actions, 16 call sites), `check-test-glob-coverage.mjs` (0 unrun), `check-lint-ran.mjs` (4,875 files, no errors) → all OK. `oxlint` on every changed file → 0 warnings, 0 errors.
- Full viewer suite (pre-review head, run as 4 hash-selected shards using the package.json selection): 7,850 tests, 7,831 pass, 6 fail in 4 files untouched by this branch and Windows-host-specific (raw absolute-path `import()` in teardown-registry/using-declaration-build tests, host locale `1’234` in productTypeCounts, backslash paths in toolbar-parity). Every collab/share test passed.

**Not run / could not run on this host (Windows):** root `pnpm lint` (its `check-changesets.mjs` / `check-unused-locals.mjs` spawn `pnpm` without a shell → ENOENT; changeset verified by hand, unused-locals emulated with the repo's own classifier: 265 == committed baseline). `check-api-surface.mjs` not applicable (no `packages/*` exports changed). No Rust/wasm/geometry changes, so no perf probe. **The manual relay acceptance from the issue — AC20-FZK-Haus IFCZIP over the signed local relay, owner navigates away as soon as the link appears, fresh guest gets the complete textured model (185 structural / 272 geometry entries) — was NOT performed.** Owner-navigates-away and fresh-guest completeness are proven in-process over a synthetic 2-entity STEP fixture and an in-memory blob store; the IFCX owner branch of `runOwnerSeed` has no automated coverage here.

## Review

Second-pass review approved with six findings; all applied:

1. **RoomPanel masked a lost connection** while seeding (amber "Uploading model" even when `collabStatus === 'disconnected'`). Now `'disconnected'` wins the header/dot; copy stays withheld and Leave keeps its "abandons upload" label. New 4th RoomPanel test case.
2. **Third copy of the slice harness.** `buildCollabTestState` now replaces the inline copies in `leave-during-join-race` and `entry-race` (deleted, not kept in step). The harness also gained `annotations: new Map()` so the real `startCollab` annotation-seed loop runs instead of a caught `TypeError`.
3. **Misleading notice** ("Could not create the room. Check the connection and try again.") fired on a deliberate Leave and named a retry the dialog does not offer → "No room was created. Close and reopen this dialog to try again."
4. **Doubled verb** in progress copy → `describeSeedPhase` returns complete sentences; the dialog renders the label alone.
5. Dead `export type { CollabSeedInput }` re-export removed.
6. Race-hook header updated to name both clients and the `__collabSessionCreated` contract.

Taste decisions kept per the reviewer: link shown alongside the alert on partial/failed; the extra `'syncing'` phase; recipient readiness as phase `'none'`; "Leave (abandons upload)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg
