### PR TITLE
fix(geometry): regime-1 coincidence requires near-parallel planes (#4439)

### DIFF
--- a/docs/architecture/evidence/csg-coincident-planes/native-load.json
+++ b/docs/architecture/evidence/csg-coincident-planes/native-load.json
@@ -4,7 +4,7 @@
   "baseSource": "531194cdcf6b2ffdcdcfb2b9682aee2a41a158ec",
   "branchSource": "79b3e2671be5c32cec1101782170fa05d23e88dd",
   "host": "Windows 11 x86_64, cargo profile `profiling`, otherwise idle; both probes built from the exact sources named above (base in a throwaway worktree with its own CARGO_TARGET_DIR)",
-  "procedure": "scripts/perf/ab.sh procedure replicated by hand because the scripts/perf/ab-order.mjs CLI guard (import.meta.url vs process.argv[1]) never matches on Windows and ab.sh then runs zero rounds; same roundOrder() (balanced, randomised within-round order), same ab-report.mjs, --iters 1 --json --fingerprint per side per round, 5 rounds.",
+  "procedure": "scripts/perf/ab.sh procedure replicated by hand because, at the time of measurement, the scripts/perf/ab-order.mjs CLI guard (import.meta.url vs process.argv[1]) never matched on Windows and ab.sh ran zero rounds (fixed in the same PR); same roundOrder() (balanced, randomised within-round order), same ab-report.mjs, --iters 1 --json --fingerprint per side per round, 5 rounds.",
   "withinRoundOrder": [
     "base then branch",
     "branch then base",

--- a/docs/architecture/evidence/csg-coincident-planes/native-load.json
+++ b/docs/architecture/evidence/csg-coincident-planes/native-load.json
@@ -1,0 +1,643 @@
+{
+  "issue": 4439,
+  "what": "Interleaved native perf_probe A/B/A/B for the regime-1 coincident_planes gate in the exact boolean classifier (rust/geometry/src/kernel/arrangement/{classify,coincident}.rs).",
+  "baseSource": "531194cdcf6b2ffdcdcfb2b9682aee2a41a158ec",
+  "branchSource": "79b3e2671be5c32cec1101782170fa05d23e88dd",
+  "host": "Windows 11 x86_64, cargo profile `profiling`, otherwise idle; both probes built from the exact sources named above (base in a throwaway worktree with its own CARGO_TARGET_DIR)",
+  "procedure": "scripts/perf/ab.sh procedure replicated by hand because the scripts/perf/ab-order.mjs CLI guard (import.meta.url vs process.argv[1]) never matches on Windows and ab.sh then runs zero rounds; same roundOrder() (balanced, randomised within-round order), same ab-report.mjs, --iters 1 --json --fingerprint per side per round, 5 rounds.",
+  "withinRoundOrder": [
+    "base then branch",
+    "branch then base",
+    "branch then base",
+    "base then branch",
+    "base then branch"
+  ],
+  "reportVerdict": {
+    "fingerprintDrift": true,
+    "tooNoisy": false,
+    "realChange": false
+  },
+  "reportFixtures": [
+    {
+      "fixture": "AC20-FZK-Haus.ifc",
+      "phases": [
+        {
+          "phase": "parse",
+          "baseMedianMs": 6,
+          "branchMedianMs": 6,
+          "deltaPct": 0,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "entity-scan",
+          "baseMedianMs": 4,
+          "branchMedianMs": 4,
+          "deltaPct": 0,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "lookup/styles",
+          "baseMedianMs": 1,
+          "branchMedianMs": 1,
+          "deltaPct": 0,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "preprocess",
+          "baseMedianMs": 0,
+          "branchMedianMs": 0,
+          "deltaPct": null,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "geometry",
+          "baseMedianMs": 10,
+          "branchMedianMs": 10,
+          "deltaPct": 0,
+          "noisePct": 10,
+          "real": false
+        },
+        {
+          "phase": "TOTAL",
+          "baseMedianMs": 16,
+          "branchMedianMs": 17,
+          "deltaPct": 6.25,
+          "noisePct": 12.5,
+          "real": false
+        }
+      ],
+      "fingerprint": {
+        "meshes": {
+          "base": [
+            285
+          ],
+          "branch": [
+            285
+          ]
+        },
+        "vertices": {
+          "base": [
+            35940
+          ],
+          "branch": [
+            35940
+          ]
+        },
+        "triangles": {
+          "base": [
+            19456
+          ],
+          "branch": [
+            19456
+          ]
+        }
+      }
+    },
+    {
+      "fixture": "ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc",
+      "phases": [
+        {
+          "phase": "parse",
+          "baseMedianMs": 22,
+          "branchMedianMs": 21,
+          "deltaPct": -4.545454545454546,
+          "noisePct": 18.181818181818183,
+          "real": false
+        },
+        {
+          "phase": "entity-scan",
+          "baseMedianMs": 22,
+          "branchMedianMs": 20,
+          "deltaPct": -9.090909090909092,
+          "noisePct": 18.181818181818183,
+          "real": false
+        },
+        {
+          "phase": "lookup/styles",
+          "baseMedianMs": 0,
+          "branchMedianMs": 0,
+          "deltaPct": null,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "preprocess",
+          "baseMedianMs": 0,
+          "branchMedianMs": 0,
+          "deltaPct": null,
+          "noisePct": 0,
+          "real": false
+        },
+        {
+          "phase": "geometry",
+          "baseMedianMs": 907,
+          "branchMedianMs": 908,
+          "deltaPct": 0.11025358324145534,
+          "noisePct": 2.535832414553473,
+          "real": false
+        },
+        {
+          "phase": "TOTAL",
+          "baseMedianMs": 930,
+          "branchMedianMs": 930,
+          "deltaPct": 0,
+          "noisePct": 2.3655913978494625,
+          "real": false
+        }
+      ],
+      "fingerprint": {
+        "meshes": {
+          "base": [
+            1402
+          ],
+          "branch": [
+            1402
+          ]
+        },
+        "vertices": {
+          "base": [
+            218255
+          ],
+          "branch": [
+            218365
+          ]
+        },
+        "triangles": {
+          "base": [
+            132674
+          ],
+          "branch": [
+            132657
+          ]
+        }
+      }
+    }
+  ],
+  "fingerprintNote": "perf_probe --fingerprint yields one FNV-1a 64 hash per run over the ordered mesh payload (geometry, colours, transforms, bounds; not text/materials/UVs/instancing). AC20: identical on all 10 runs. ISSUE_129: stable within each side, differs between sides; the run-level triangle delta (132674 -> 132657, i.e. -17) equals the census delta of host #9094 (664 -> 647), the only ISSUE_129 row of the 73 in tests/manifests/watertightness_census.tsv that moves. Per-mesh attribution is not available from the probe.",
+  "runs": [
+    {
+      "round": 1,
+      "positionInRound": "first",
+      "fixture": "ac20",
+      "side": "base",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 10,
+      "totalMs": 17,
+      "allWallMs": [
+        18.9961
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 1,
+      "positionInRound": "first",
+      "fixture": "issue129",
+      "side": "base",
+      "parseMs": 24,
+      "entityScanMs": 23,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 907,
+      "totalMs": 931,
+      "allWallMs": [
+        940.8201
+      ],
+      "meshes": 1402,
+      "vertices": 218255,
+      "triangles": 132674,
+      "csgFailures": 43,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "b0e46a1242771291"
+      ]
+    },
+    {
+      "round": 1,
+      "positionInRound": "second",
+      "fixture": "ac20",
+      "side": "branch",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 11,
+      "totalMs": 18,
+      "allWallMs": [
+        19.6234
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 1,
+      "positionInRound": "second",
+      "fixture": "issue129",
+      "side": "branch",
+      "parseMs": 23,
+      "entityScanMs": 23,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 933,
+      "totalMs": 957,
+      "allWallMs": [
+        966.9254000000001
+      ],
+      "meshes": 1402,
+      "vertices": 218365,
+      "triangles": 132657,
+      "csgFailures": 41,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "1e5aed5f285ec9c2"
+      ]
+    },
+    {
+      "round": 2,
+      "positionInRound": "first",
+      "fixture": "ac20",
+      "side": "branch",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 10,
+      "totalMs": 17,
+      "allWallMs": [
+        18.9431
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 2,
+      "positionInRound": "first",
+      "fixture": "issue129",
+      "side": "branch",
+      "parseMs": 21,
+      "entityScanMs": 20,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 908,
+      "totalMs": 930,
+      "allWallMs": [
+        939.8482
+      ],
+      "meshes": 1402,
+      "vertices": 218365,
+      "triangles": 132657,
+      "csgFailures": 41,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "1e5aed5f285ec9c2"
+      ]
+    },
+    {
+      "round": 2,
+      "positionInRound": "second",
+      "fixture": "ac20",
+      "side": "base",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 10,
+      "totalMs": 16,
+      "allWallMs": [
+        18.1777
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 2,
+      "positionInRound": "second",
+      "fixture": "issue129",
+      "side": "base",
+      "parseMs": 22,
+      "entityScanMs": 22,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 892,
+      "totalMs": 915,
+      "allWallMs": [
+        924.9395000000001
+      ],
+      "meshes": 1402,
+      "vertices": 218255,
+      "triangles": 132674,
+      "csgFailures": 43,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "b0e46a1242771291"
+      ]
+    },
+    {
+      "round": 3,
+      "positionInRound": "first",
+      "fixture": "ac20",
+      "side": "branch",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 10,
+      "totalMs": 17,
+      "allWallMs": [
+        18.3963
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 3,
+      "positionInRound": "first",
+      "fixture": "issue129",
+      "side": "branch",
+      "parseMs": 21,
+      "entityScanMs": 20,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 886,
+      "totalMs": 907,
+      "allWallMs": [
+        916.2314
+      ],
+      "meshes": 1402,
+      "vertices": 218365,
+      "triangles": 132657,
+      "csgFailures": 41,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "1e5aed5f285ec9c2"
+      ]
+    },
+    {
+      "round": 3,
+      "positionInRound": "second",
+      "fixture": "ac20",
+      "side": "base",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 9,
+      "totalMs": 16,
+      "allWallMs": [
+        17.282700000000002
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 3,
+      "positionInRound": "second",
+      "fixture": "issue129",
+      "side": "base",
+      "parseMs": 21,
+      "entityScanMs": 20,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 909,
+      "totalMs": 930,
+      "allWallMs": [
+        940.2937999999999
+      ],
+      "meshes": 1402,
+      "vertices": 218255,
+      "triangles": 132674,
+      "csgFailures": 43,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "b0e46a1242771291"
+      ]
+    },
+    {
+      "round": 4,
+      "positionInRound": "first",
+      "fixture": "ac20",
+      "side": "base",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 10,
+      "totalMs": 16,
+      "allWallMs": [
+        18.1314
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 4,
+      "positionInRound": "first",
+      "fixture": "issue129",
+      "side": "base",
+      "parseMs": 22,
+      "entityScanMs": 22,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 892,
+      "totalMs": 914,
+      "allWallMs": [
+        923.5394
+      ],
+      "meshes": 1402,
+      "vertices": 218255,
+      "triangles": 132674,
+      "csgFailures": 43,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "b0e46a1242771291"
+      ]
+    },
+    {
+      "round": 4,
+      "positionInRound": "second",
+      "fixture": "ac20",
+      "side": "branch",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 9,
+      "totalMs": 16,
+      "allWallMs": [
+        17.6601
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 4,
+      "positionInRound": "second",
+      "fixture": "issue129",
+      "side": "branch",
+      "parseMs": 21,
+      "entityScanMs": 21,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 895,
+      "totalMs": 917,
+      "allWallMs": [
+        926.2672
+      ],
+      "meshes": 1402,
+      "vertices": 218365,
+      "triangles": 132657,
+      "csgFailures": 41,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "1e5aed5f285ec9c2"
+      ]
+    },
+    {
+      "round": 5,
+      "positionInRound": "first",
+      "fixture": "ac20",
+      "side": "base",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 9,
+      "totalMs": 15,
+      "allWallMs": [
+        16.8787
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 5,
+      "positionInRound": "first",
+      "fixture": "issue129",
+      "side": "base",
+      "parseMs": 20,
+      "entityScanMs": 19,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 915,
+      "totalMs": 936,
+      "allWallMs": [
+        944.8942999999999
+      ],
+      "meshes": 1402,
+      "vertices": 218255,
+      "triangles": 132674,
+      "csgFailures": 43,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "b0e46a1242771291"
+      ]
+    },
+    {
+      "round": 5,
+      "positionInRound": "second",
+      "fixture": "ac20",
+      "side": "branch",
+      "parseMs": 6,
+      "entityScanMs": 4,
+      "lookupMs": 1,
+      "preprocessMs": 0,
+      "geometryMs": 9,
+      "totalMs": 16,
+      "allWallMs": [
+        18.3046
+      ],
+      "meshes": 285,
+      "vertices": 35940,
+      "triangles": 19456,
+      "csgFailures": 0,
+      "degenerateDropped": 0,
+      "meshFingerprintFnv1a64": [
+        "25ac885b6ff4ad00"
+      ]
+    },
+    {
+      "round": 5,
+      "positionInRound": "second",
+      "fixture": "issue129",
+      "side": "branch",
+      "parseMs": 21,
+      "entityScanMs": 20,
+      "lookupMs": 0,
+      "preprocessMs": 0,
+      "geometryMs": 909,
+      "totalMs": 931,
+      "allWallMs": [
+        940.353
+      ],
+      "meshes": 1402,
+      "vertices": 218365,
+      "triangles": 132657,
+      "csgFailures": 41,
+      "degenerateDropped": 6,
+      "meshFingerprintFnv1a64": [
+        "1e5aed5f285ec9c2"
+      ]
+    }
+  ]
+}

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -166,11 +166,12 @@ fn on_surface_normal(c: [f64; 3], n_own: [f64; 3], others: &[Tri]) -> Option<[f6
 /// onto the plane under test, defined once in `near_band`.
 use super::super::near_band::{NearBand, near_band_from_extent};
 
-/// The NEAR-coplanar analogue of [`on_surface_normal`], used ONLY for a
-/// sub-triangle whose parent face had a near-coplanar overlap with the other
-/// operand (`coplanar_a/b[i]` set). Returns the covering `other` face's f64 normal
-/// when `c` sits within the snap-scatter band of that face's plane AND projects
-/// strictly inside it.
+/// The NEAR-coplanar analogue of [`on_surface_normal`], used for any
+/// sub-triangle (A side via `BComponents::surface_normal`, B side via
+/// `c_on_or_near_a`) whose centroid sits within the snap band of a face of the
+/// other operand. Returns the covering `other` face's f64 normal when `c` sits
+/// within the snap-scatter band of that face's plane AND projects strictly
+/// inside it.
 ///
 /// WHY this exists — the flush-cap defect (#1007 host #1112 openings #2150/#2154):
 /// real IFC is f32, so an opening cap authored EXACTLY flush with a TILTED roof
@@ -643,7 +644,6 @@ pub(super) fn boolean_vids_components(
     }
     out
 }
-
 
 #[inline]
 pub(super) fn rotate_min_first(t: [Vid; 3]) -> [Vid; 3] {

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -7,6 +7,7 @@ use super::super::interner::Vid;
 use super::super::predicates::{orient2d_any, orient3d};
 use super::super::rational::point_of;
 use super::super::{DropAxis, ImplicitPoint, Sign};
+use super::coincident::coincident_planes;
 use super::ray_parity::{exact_seg_hits_tri, operand_extent, point_inside, ray_dir, sound_far};
 use super::{Arrangement, BoolOp, Tri};
 use num_traits::ToPrimitive;
@@ -152,8 +153,12 @@ fn near_on_surface_tri(c: [f64; 3], t: &Tri, band: &NearBand) -> Option<[f64; 3]
     point_in_tri_proj(c, t, n).then_some(n)
 }
 
-fn on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
-    others.iter().find_map(|t| on_surface_tri(c, t))
+/// First triangle of `others` that carries `c` on its face AND is near-parallel
+/// to the sub-triangle whose raw normal is `n_own` ([`coincident_planes`]).
+fn on_surface_normal(c: [f64; 3], n_own: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
+    others
+        .iter()
+        .find_map(|t| on_surface_tri(c, t).filter(|n| coincident_planes(n_own, *n)))
 }
 
 /// Canonical near-coplanar band (see [`near_on_surface_normal`]): the
@@ -189,23 +194,31 @@ use super::super::near_band::{NearBand, near_band_from_extent};
 /// can never be within it. All FMA-free f64 over input coords ⇒ byte-identical
 /// native==wasm.
 ///
-/// NOT GATED, despite what this paragraph used to claim ("GATED on the
-/// near-coplanar-parent flag, so a transversal cut never reaches it"). The
-/// A-side caller (`BComponents::surface_normal`) and the B-side one
-/// (`c_on_or_near_a`) both reach it unconditionally, and the triangle it wrongly
-/// accepts on `sweep_261` has `coplanar_a[i] == false` — so a transversal cut
-/// face DOES reach it. Gating the A-side call on the flag was measured as a fix
-/// for #3353: it closes `sweep_261` and takes the union sweep 98 -> 77, but it
+/// NOT GATED on the near-coplanar-parent flag (`coplanar_a`), despite what
+/// this paragraph used to claim. The A-side caller (`BComponents::surface_normal`)
+/// and the B-side one (`c_on_or_near_a`) both reach it for transversal cut
+/// faces too. Gating the A-side call on the flag was measured as a fix for
+/// #3353: it closes `sweep_261` and takes the union sweep 98 -> 77, but it
 /// regresses 20 golden census hosts and breaks two pinned near-band invariants
 /// in `clash_intersection_oracle.rs`
 /// (`no_surviving_near_band_triangle_has_an_x_facing_normal` and
 /// `the_near_band_shortfall_is_a_missing_face_pair_not_a_shape_dependent_wedge`),
 /// both of which need this path ungated. See `issue_3353_vid_census_tests.rs`.
-fn near_on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
+///
+/// What IS required, per candidate face, is [`coincident_planes`] (#4439): the
+/// sub-triangle's own plane must be near-parallel to the face its centroid
+/// sits within the band of. A transversal sub-triangle whose centroid happens
+/// to fall in the band — a needle hugging the two faces' intersection line
+/// (#4439, #3353's `sweep_261`) — is not a coincident face and falls through
+/// to the ray-cast. That is a per-face angle test, not a parent-flag gate, so
+/// the flush caps and the two oracle invariants above are untouched.
+fn near_on_surface_normal(c: [f64; 3], n_own: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
     let mut band = NearBand::default();
     band.observe_point(&c);
     band.observe_tris(others);
-    others.iter().find_map(|t| near_on_surface_tri(c, t, &band))
+    others
+        .iter()
+        .find_map(|t| near_on_surface_tri(c, t, &band).filter(|n| coincident_planes(n_own, *n)))
 }
 
 /// BVH-accelerated equivalent of `on_surface_normal(c, a).is_some() ||
@@ -220,6 +233,7 @@ fn near_on_surface_normal(c: [f64; 3], others: &[Tri]) -> Option<[f64; 3]> {
 /// the linear scan.
 fn c_on_or_near_a(
     c: [f64; 3],
+    n_own: [f64; 3],
     a: &[Tri],
     bvh: &super::super::broadphase::Bvh,
     a_band: &NearBand,
@@ -231,7 +245,9 @@ fn c_on_or_near_a(
     bvh.point_candidates(c, band.radius(), scratch);
     scratch.iter().any(|&i| {
         let t = &a[i as usize];
-        on_surface_tri(c, t).is_some() || near_on_surface_tri(c, t, &band).is_some()
+        on_surface_tri(c, t)
+            .or_else(|| near_on_surface_tri(c, t, &band))
+            .is_some_and(|n| coincident_planes(n_own, n))
     })
 }
 
@@ -390,17 +406,17 @@ impl<'a> BComponents<'a> {
     /// [`on_surface_normal`] on every AABB-near component first, then the
     /// snap-band [`near_on_surface_normal`] analogue (same priority order as
     /// the binary path). Disjointness makes at most one component eligible.
-    fn surface_normal(&self, c: [f64; 3]) -> Option<[f64; 3]> {
+    fn surface_normal(&self, c: [f64; 3], n_own: [f64; 3]) -> Option<[f64; 3]> {
         for (k, comp) in self.comps.iter().enumerate() {
             if self.point_in_aabb(k, c) {
-                if let Some(n) = on_surface_normal(c, comp) {
+                if let Some(n) = on_surface_normal(c, n_own, comp) {
                     return Some(n);
                 }
             }
         }
         for (k, comp) in self.comps.iter().enumerate() {
             if self.point_in_aabb(k, c) {
-                if let Some(n) = near_on_surface_normal(c, comp) {
+                if let Some(n) = near_on_surface_normal(c, n_own, comp) {
                     return Some(n);
                 }
             }
@@ -527,31 +543,30 @@ pub(super) fn boolean_vids_components(
     let mut out = Vec::new();
     for (i, &tri) in arr.tris_a.iter().enumerate() {
         let c = centroid(arr, tri);
+        let n_own = tri_normal(arr, tri);
         let cop_parent = arr.coplanar_a.get(i).copied().unwrap_or(false);
         let keep;
         // regime 1: coincident shared face → classify by normal agreement. Tried
         // EXACT first, then the snap-band-flush analogue (`near_on_surface_normal`)
         // which catches a face left a few µm off a TILTED shared plane by per-axis
         // import snapping (the #1007 flush roof-opening cap). The near test is
-        // ungated (like the exact one) because a coincident-shared-face DROP/keep
-        // is unconditionally correct.
+        // ungated on the parent flag (like the exact one) because a coincident-
+        // shared-face DROP/keep is unconditionally correct.
         //
-        // KNOWN FALSE POSITIVE (#3353, open). This comment used to end "and its
-        // centroid-inside + µm-perp requirements never match a transversal cut
-        // face". They do. Both tests establish coincidence from the CENTROID
-        // alone, and a sub-triangle need not have its parent's plane:
-        // retriangulation can leave one degenerate onto the LINE where the two
-        // parent planes meet, and every point of such a sliver lies in the other
-        // operand's plane however transversal the faces are. Normal agreement
-        // then decides it on the sign of a cross product a near-collinear triple
-        // does not pin down. Measured on `sweep_261`, where it keeps a needle
-        // that its neighbour in the same flat face correctly drops, tearing the
-        // mesh. Before changing anything here read the per-triangle regime table
-        // and the seven measured (and rejected) fix shapes in
-        // `issue_3353_vid_census_tests.rs` — the promising one costs 20 golden
-        // census hosts.
-        if let Some(n_other) = bc.surface_normal(c) {
-            let co_oriented = dot3(tri_normal(arr, tri), n_other) > 0.0;
+        // Both tests LOCATE the candidate face from the CENTROID; whether the
+        // sub-triangle actually LIES ON it is `coincident_planes` (#4439): its own
+        // plane must be near-parallel to the face. Without that, a sub-triangle
+        // that merely hugs the intersection LINE of two transversal faces — a
+        // needle inside a thin notch (#4439), or one that retriangulation left
+        // degenerate onto the line (#3353's `sweep_261`) — sat within the band of
+        // the other operand's plane and was decided by the sign of a dot product
+        // that a perpendicular or near-collinear pair does not pin down,
+        // overriding a ray-cast that already had it right. The per-triangle
+        // regime table and the measured parent-level fix shapes (all rejected
+        // for regressing 20+ golden census hosts) are in
+        // `issue_3353_vid_census_tests.rs`.
+        if let Some(n_other) = bc.surface_normal(c, n_own) {
+            let co_oriented = dot3(n_own, n_other) > 0.0;
             keep = match op {
                 BoolOp::Union | BoolOp::Intersection => co_oriented,
                 BoolOp::Difference => !co_oriented,
@@ -561,8 +576,7 @@ pub(super) fn boolean_vids_components(
                 // regime 2 (only on coplanar-overlap parents): shared interface
                 // plane, no coincident face → solid-side probe (see
                 // `on_interface_keep` for the keep table rationale).
-                let n = tri_normal(arr, tri);
-                let (op_plus, op_minus) = bc.solid_side(c, n);
+                let (op_plus, op_minus) = bc.solid_side(c, n_own);
                 if op_plus == op_minus {
                     return None; // strictly in/out — the plain ray-cast decides
                 }
@@ -596,6 +610,7 @@ pub(super) fn boolean_vids_components(
             continue;
         }
         let c = centroid(arr, tri);
+        let n_own = tri_normal(arr, tri);
         let cop_parent = arr.coplanar_b.get(i).copied().unwrap_or(false);
         // A coincident-shared B face is dropped (the A-copy is the kept one). Tried
         // EXACT first, then the snap-band-flush analogue — ungated, because a B cap
@@ -603,7 +618,7 @@ pub(super) fn boolean_vids_components(
         // own (the host imposes none on it) so `coplanar_b` is unset for it, yet it
         // is still a coincident shared face that must drop (the #1007 flush roof cap
         // — without the near drop here it survives and bridges the opening).
-        if c_on_or_near_a(c, a, &bvh_a, &a_band, &mut scratch) {
+        if c_on_or_near_a(c, n_own, a, &bvh_a, &a_band, &mut scratch) {
             continue; // coplanar-shared B-copy: dropped (the A-copy is the kept one)
         }
         if cop_parent {
@@ -628,6 +643,7 @@ pub(super) fn boolean_vids_components(
     }
     out
 }
+
 
 #[inline]
 pub(super) fn rotate_min_first(t: [Vid; 3]) -> [Vid; 3] {

--- a/rust/geometry/src/kernel/arrangement/coincident.rs
+++ b/rust/geometry/src/kernel/arrangement/coincident.rs
@@ -40,9 +40,39 @@ use super::classify::dot3;
 /// path it took before #4439. Extending that to NUMERICALLY zero normals (a
 /// rounded collinear triple, transverse extent ≤ 2⁻³⁰ of the longest edge)
 /// was measured on the corpus census and changed no host, so it is not done.
+///
+/// Both normals are first scaled by a power of two so their largest component
+/// lies in `[0.5, 4)`. That scaling is EXACT (it only moves the exponent), so
+/// the verdict is bit-for-bit the one the raw products give wherever those do
+/// not under- or overflow — which is everywhere geometry is meaningful — and
+/// stays correct where they do: the kernel boundary (`mesh_bridge`) accepts any
+/// finite `f32`, and at ~1e38 m edge lengths the raw fourth-degree products
+/// reach `inf`, where `inf >= inf` would call a 46° pair coincident; at the
+/// other end a pair of ~1e-80 m normals flushes to `0 >= 0` and calls a
+/// perpendicular pair coincident.
 pub(super) fn coincident_planes(n_own: [f64; 3], n_face: [f64; 3]) -> bool {
-    let d = dot3(n_own, n_face);
-    2.0 * d * d >= dot3(n_own, n_own) * dot3(n_face, n_face)
+    let (a, b) = (pow2_normalized(n_own), pow2_normalized(n_face));
+    let d = dot3(a, b);
+    2.0 * d * d >= dot3(a, a) * dot3(b, b)
+}
+
+/// `n` scaled by the power of two that puts its largest |component| in
+/// `[0.5, 4)`; the zero vector (and anything non-finite) is returned as is. A
+/// power-of-two scale is exact in IEEE 754 whenever the result is finite and
+/// normal, which the clamp of the exponent field to `[1, 2046]` guarantees
+/// for every finite input (a subnormal maximum is lifted to `< 2`, a maximum
+/// at or above 2^1023 is brought to `< 4`).
+fn pow2_normalized(n: [f64; 3]) -> [f64; 3] {
+    let m = n[0].abs().max(n[1].abs()).max(n[2].abs());
+    if m == 0.0 || !m.is_finite() {
+        return n;
+    }
+    // Biased exponent of `m`: 0 for a subnormal, 2046 for the top binade.
+    let e = (m.to_bits() >> 52) & 0x7ff;
+    // 2^(1023 − e) has biased exponent 2046 − e; clamped to ≥ 1 so the scale
+    // itself is a normal number and the scaled maximum stays below 4.
+    let s = f64::from_bits((2046 - e).max(1) << 52);
+    [n[0] * s, n[1] * s, n[2] * s]
 }
 
 #[cfg(test)]
@@ -74,6 +104,35 @@ mod tests {
             // #3353 `sweep_261`: the needle sits 58° off its covering face.
             assert!(!coincident_planes(z, tilted(58.0)), "58° at scale {s}");
         }
+    }
+
+    /// The kernel boundary accepts any finite `f32`, so the raw fourth-degree
+    /// products can over- or underflow; the exact power-of-two scaling must give
+    /// the same 45° verdict at every finite magnitude, including mixed ones.
+    #[test]
+    fn the_verdict_survives_magnitudes_where_the_raw_products_overflow_or_underflow() {
+        let scale = |v: [f64; 3], s: f64| [v[0] * s, v[1] * s, v[2] * s];
+        let x = [1.0, 0.0, 0.0];
+        let z = [0.0, 0.0, 1.0];
+        for s in [1.0e-160, 1.0e-100, 1.0e100, 1.0e160, f64::MAX / 4.0, f64::MIN_POSITIVE / 8.0] {
+            let zs = scale(z, s);
+            assert!(coincident_planes(zs, scale(z, s)), "parallel at scale {s:e}");
+            assert!(coincident_planes(zs, scale(tilted(44.0), s)), "44° at scale {s:e}");
+            assert!(!coincident_planes(zs, scale(tilted(46.0), s)), "46° at scale {s:e}");
+            assert!(!coincident_planes(zs, scale(x, s)), "perpendicular at scale {s:e}");
+            // one operand huge, the other tiny (where the reciprocal is finite)
+            if (1.0 / s).is_finite() {
+                assert!(coincident_planes(zs, scale(z, 1.0 / s)), "parallel, mixed scales {s:e}");
+                assert!(!coincident_planes(zs, scale(x, 1.0 / s)), "perpendicular, mixed scales {s:e}");
+            }
+        }
+        // The raw form fails exactly there, which is why the scaling exists.
+        let raw = |a: [f64; 3], b: [f64; 3]| {
+            let d = super::dot3(a, b);
+            2.0 * d * d >= super::dot3(a, a) * super::dot3(b, b)
+        };
+        assert!(raw(scale(z, 1.0e160), scale(tilted(46.0), 1.0e160)), "inf >= inf");
+        assert!(raw(scale(z, 1.0e-160), scale(x, 1.0e-160)), "0 >= 0");
     }
 
     #[test]

--- a/rust/geometry/src/kernel/arrangement/coincident.rs
+++ b/rust/geometry/src/kernel/arrangement/coincident.rs
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The plane test behind regime 1 of the boolean classifier
+//! (`classify::boolean_vids_components`): may a sub-triangle be classified as
+//! lying ON a face of the other operand that its centroid was found on or
+//! near?
+//!
+//! Split out of `classify.rs`, which is at its module-size budget, with issue
+//! #4439.
+
+use super::classify::dot3;
+
+/// Are two raw (unnormalised) face normals within 45° of parallel — `cos² ≥ ½`,
+/// evaluated as `2·(n₁·n₂)² ≥ |n₁|²·|n₂|²` so there is no sqrt, no division and
+/// no normalisation: FMA-free f64 over the same products the callers already
+/// form ⇒ byte-identical native == wasm.
+///
+/// Regime 1 classifies a sub-triangle as lying ON a coincident shared face of
+/// the other operand and resolves it by NORMAL AGREEMENT. Coincidence is a
+/// property of the two PLANES, and the centroid tests (`on_surface_tri`,
+/// `near_on_surface_tri`) alone do not establish it: a sub-triangle need not
+/// be anywhere near parallel to a face whose plane its centroid sits within
+/// the band of. A genuine shared face — exactly coplanar, or a #1007 flush cap
+/// left a few µm off a tilted plane by the per-axis snap — has `cos ≈ 1` (the
+/// snap tilt over a ≥ 0.2 m face is < 1e-3 rad). A sub-triangle whose plane is
+/// TRANSVERSAL to the covering face has no orientation to agree with, and
+/// `dot > 0` then decides it on nothing. Issue #4439: a 23 µm-wide sliver of
+/// an A face inside a thin notch, hugging the PERPENDICULAR B face it abuts
+/// (`dot == 0` exactly), was kept as "not co-oriented" on a difference and
+/// left the box open on an edge the exact ray-cast had already classified as
+/// inside B. The #3353 `sweep_261` needle sits at 58° (`cos = 0.53`) to its
+/// covering face and is the same defect (`issue_3353_vid_census_tests.rs`).
+///
+/// 45° is a definitely-not-coincident cutoff — three orders of magnitude from
+/// any legitimate flush tilt — chosen as a clean power-of-two bound rather
+/// than tuned to either case. A ZERO normal (an exactly degenerate
+/// sub-triangle) passes: it has no plane to disagree with, so it keeps the
+/// path it took before #4439. Extending that to NUMERICALLY zero normals (a
+/// rounded collinear triple, transverse extent ≤ 2⁻³⁰ of the longest edge)
+/// was measured on the corpus census and changed no host, so it is not done.
+pub(super) fn coincident_planes(n_own: [f64; 3], n_face: [f64; 3]) -> bool {
+    let d = dot3(n_own, n_face);
+    2.0 * d * d >= dot3(n_own, n_own) * dot3(n_face, n_face)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::coincident_planes;
+    use crate::kernel::arrangement::classify::{cross3, sub_f64};
+
+    /// A raw normal tilted `deg` degrees off +Z about the Y axis.
+    fn tilted(deg: f64) -> [f64; 3] {
+        let r = deg.to_radians();
+        [r.sin(), 0.0, r.cos()]
+    }
+
+    #[test]
+    fn parallel_and_antiparallel_faces_are_coincident_and_perpendicular_ones_are_not() {
+        let z = [0.0, 0.0, 1.0];
+        assert!(coincident_planes(z, [0.0, 0.0, 3.5]));
+        assert!(coincident_planes(z, [0.0, 0.0, -0.25]));
+        assert!(!coincident_planes(z, [1.0, 0.0, 0.0]));
+        assert!(!coincident_planes(z, [0.0, -2.0, 0.0]));
+    }
+
+    #[test]
+    fn the_cutoff_is_45_degrees_and_independent_of_either_magnitude() {
+        for s in [1.0e-8, 1.0, 1.0e8] {
+            let z = [0.0, 0.0, s];
+            assert!(coincident_planes(z, tilted(44.0)), "44° at scale {s}");
+            assert!(!coincident_planes(z, tilted(46.0)), "46° at scale {s}");
+            // #3353 `sweep_261`: the needle sits 58° off its covering face.
+            assert!(!coincident_planes(z, tilted(58.0)), "58° at scale {s}");
+        }
+    }
+
+    #[test]
+    fn a_flush_cap_tilt_passes_and_a_zero_normal_keeps_the_old_path() {
+        let z = [0.0, 0.0, 1.0];
+        // #1007-class flush cap: the per-axis snap tilts a 0.2 m face by
+        // < 1e-3 rad; that must stay a coincident face.
+        assert!(coincident_planes(z, tilted(1.0e-3_f64.to_degrees())));
+        // An exactly degenerate sub-triangle has no plane and is not re-decided
+        // here (see the doc comment).
+        assert!(coincident_planes([0.0, 0.0, 0.0], z));
+    }
+
+    /// Issue #4439: A's +Y face needle (the three vertices share their Y bit
+    /// for bit, so the raw normal is exactly along +Y — 23 µm × 1.04 m)
+    /// against B's +X face (raw normal `dy·dz` along +X). `dot == 0` exactly,
+    /// which the sign test alone read as "not co-oriented" and kept.
+    #[test]
+    fn the_4439_needle_is_not_coincident_with_the_perpendicular_face_it_hugs() {
+        let p = [
+            [7.483367919921875, 8.65240478515625, 2.1023867130279541],
+            [7.483344554901123, 8.65240478515625, 3.145187377929688],
+            [7.483367919921875, 8.65240478515625, 3.143897294998169],
+        ];
+        let n_needle = cross3(sub_f64(p[1], p[0]), sub_f64(p[2], p[0]));
+        assert_eq!((n_needle[0], n_needle[2]), (0.0, 0.0));
+        assert!(n_needle[1] != 0.0, "a 23 µm sliver has a plane of its own");
+        let n_b_xmax = [19.44, 0.0, 0.0];
+        assert!(!coincident_planes(n_needle, n_b_xmax));
+        assert!(!coincident_planes(n_b_xmax, n_needle));
+    }
+}

--- a/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
@@ -628,29 +628,31 @@ fn sweep_261_kept_triangles_are_manifold_in_vid_space() {
         }
     }
 
-    // Centroid-to-opposite-surface proximity. MEASUREMENT ONLY — no assertion,
-    // because no threshold is known yet and pinning an unverified one is how a
-    // diagnostic turns into a false signal.
+    // Centroid-to-opposite-surface proximity. MEASUREMENT ONLY — no assertion
+    // on the distances themselves, because no threshold is known and pinning
+    // an unverified one is how a diagnostic turns into a false signal.
     //
     // CORRECTION (measured, see this file's "Which regime decides" section):
     // this block used to claim that "no face pair is within 28 degrees of
     // parallel, so the coincident-face regime never fires and every triangle is
-    // classified by the ray cast". That is FALSE, and it is false about the one
-    // triangle that matters. `kept[16] = [17, 13, 14]` IS classified by regime 1
-    // — coincidence is established from the CENTROID, which needs no face pair
-    // to be parallel at all. Leaving the claim in place would send the next
-    // reader looking at the ray cast for a defect that is not there.
+    // classified by the ray cast". That was FALSE, and it was false about the
+    // one triangle that mattered. Before #4439, `kept[16] = [17, 13, 14]` WAS
+    // classified by regime 1 — coincidence was established from the CENTROID
+    // alone, which needs no face pair to be parallel at all. The
+    // `coincident_planes` gate now rejects it (its plane is 58° off the
+    // candidate face), so it falls to the ray cast. Leaving the old claim in
+    // place would send the next reader looking at the ray cast for a defect
+    // that was never there.
     //
     // What the distances below still say: whether a centroid sits close enough
     // to the other operand's surface for the f64 rounding in `centroid` to
-    // matter. `kept[16]`'s 1.86e-5 is the one that does.
+    // matter. `kept[16]`'s 1.86e-5 is the one that did.
     //
-    // NOTE: `cargo test --workspace` CAPTURES stdout for a passing test, and
-    // this test passes while the defect exists, so CI will not show these
-    // lines. Run it directly:
+    // NOTE: the assertion at the end of this test requires `overused` to be
+    // empty, so this block only has anything to print when a regression
+    // re-opens an edge; `cargo test` captures stdout for a passing test. On a
+    // failure, run it directly to see the census:
     //   cargo test -p ifc-lite-geometry --lib issue_3353_vid_census -- --nocapture
-    // Once the values are known they can be pinned as an assertion, which
-    // would then surface in CI on any change.
     let implicated: BTreeSet<usize> = overused
         .iter()
         .flat_map(|(_, users)| users.iter().map(|(idx, _)| *idx))

--- a/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/issue_3353_vid_census_tests.rs
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Issue #3353 (`sweep_261`), Vid-space instrument — NOT a fix.
+//! Issue #3353 (`sweep_261`), Vid-space instrument — and, since #4439, the
+//! Vid-space health check for the classification-level tear it used to pin.
 //!
 //! `issue_3353_sweep_261_classification_tear.rs` (a `tests/` integration
-//! test, `#[ignore]`d because it documents a known-open defect) records that
-//! a prior instrumented run found, for this exact operand pair under
+//! test, `#[ignore]`d until #4439 because it documented a known-open defect)
+//! records that a prior instrumented run found, for this exact operand pair under
 //! `Union`: `arr.unrecovered == 0` (the arrangement fully recovers every
 //! input constraint — not a missing-constraint failure) alongside a
 //! KEPT-triangle set that is non-manifold in pure Vid space, before any
@@ -150,6 +151,22 @@
 //! (The two that fail `sweep_261` were not carried further; "not run" is not a
 //! null result.)
 //!
+//! ## What landed (#4439)
+//!
+//! The eighth shape is none of the above: it is a property of the SUB-TRIANGLE's
+//! own plane, not of its parent and not of vertex distances.
+//! `arrangement::coincident::coincident_planes` requires the candidate face to
+//! be within 45° of parallel to the sub-triangle (`cos² ≥ ½`, evaluated FMA-free
+//! on the raw normals) before regime 1 may fire — on the A side and on the
+//! B-side dedup drop alike. A genuine shared or flush face has `cos ≈ 1`; `A[22]`
+//! above sits at 58° and the #4439 needle at exactly 90°, so both leave regime 1
+//! for the ray cast that already had them right. The #1007 flush caps keep their
+//! verdict (their snap tilt is < 1e-3 rad), and so do the two
+//! `clash_intersection_oracle.rs` near-band invariants, because nothing is
+//! gated on `coplanar_a`. Measured: `sweep_261` passes end-to-end (its `tests/`
+//! file is no longer `#[ignore]`d) and the census below reads 0 over-used edges
+//! of 123. The corpus golden verdict is recorded in the #4439 PR.
+//!
 //! Why the rows read as they do:
 //!
 //! 1. The B side must NOT require it. `c_on_or_near_a` is a DEDUP drop, not an
@@ -185,48 +202,34 @@
 //! This file only CALLS existing `pub(super)`/`pub(crate)` functions from a
 //! new vantage point and post-processes their unmodified return values.
 //!
-//! ## CI-visible pin, not a `#[ignore]`d printout
+//! ## CI-visible health check (was: a pin of the defective state)
 //!
-//! `sweep_261_kept_triangles_are_nonmanifold_in_vid_space` (below) runs in
-//! normal `cargo test` (no `--ignored`) and asserts the DEFECT SHAPE
-//! described above: `unrecovered == 0` together with at least one
-//! kept-triangle edge whose Vid-space multiplicity is not 2.
+//! `sweep_261_kept_triangles_are_manifold_in_vid_space` (below) runs in normal
+//! `cargo test` (no `--ignored`) and asserts the FIXED shape: `unrecovered == 0`
+//! together with EVERY kept-triangle edge having Vid-space multiplicity exactly
+//! 2. Until #4439 it asserted the opposite — at least one over-used edge, the
+//! defect signature above — so that a green tick meant "the defect still
+//! reproduces exactly as documented", and a failure was the documented trigger
+//! to re-diagnose both files together. That trigger fired: the #4439 gate made
+//! the kept set manifold, so the assertion was flipped rather than loosened,
+//! together with un-ignoring `sweep_261_overlapping_rotated_union_never_tears`
+//! in the sibling `tests/` file (the end-to-end reading of the same case).
 //!
 //! It deliberately does NOT assert the exact Vid numbers
 //! `(13,17)`/`(14,17)`/`(13,14)` — those are Vid-interner allocation labels,
 //! not geometry, and pinning them would fail on any relabelling for a reason
 //! unrelated to the defect. The assertion stays on the SHAPE.
 //!
-//! The original reason given here was different, and is now spent: it said this
-//! file's reproduction had never been executed (no `cargo test` was run to
-//! produce it — the workstation that wrote it was disk-constrained), so the
-//! labels were unverified. They have since been verified. Every number in the
-//! regime table above comes from an instrumented run of this exact
-//! reproduction, and the labels match. Leaving the old wording in would tell
-//! the next reader the table directly above it is guesswork.
+//! Every number in the regime table above comes from an instrumented run of
+//! this exact reproduction at the pre-#4439 code, and the labels matched; the
+//! table is kept as the record of WHY regime 1 was wrong, not as a description
+//! of current output.
 //!
-//! The full kept set and edge census are printed, but CI will NOT show
+//! The full kept set and edge census are still printed, but CI will NOT show
 //! them: `.github/workflows/test.yml` runs `cargo test --workspace` with no
-//! `--nocapture`, and cargo suppresses stdout for a PASSING test — which
-//! this is by design while the defect exists. Confirmed absent from the
-//! first green run's log rather than assumed. To read the numbers:
+//! `--nocapture`, and cargo suppresses stdout for a passing test. To read them:
 //!
 //!   cargo test -p ifc-lite-geometry --lib issue_3353_vid_census -- --nocapture
-//!
-//! They have now been observed (see the regime table above); they are still
-//! deliberately not pinned, for the relabelling reason given above.
-//!
-//! This is a characterisation pin of a KNOWN-DEFECTIVE state, not a health
-//! check: a green tick on this test means "the defect still reproduces
-//! exactly as documented," NOT "issue #3353 is fixed." Read together with
-//! `sweep_261_overlapping_rotated_union_never_tears`'s `#[ignore]` in the
-//! sibling file (which this patch does not touch and does not un-ignore),
-//! the pair is meant to be unambiguous: that file documents the defect
-//! end-to-end (ignored, because it fails outright), this one documents its
-//! Vid-space signature (not ignored, because — until the defect is fixed —
-//! it is expected to keep finding one). If `classify.rs` changes and this
-//! test starts failing, that is the expected trigger to re-diagnose BOTH
-//! files together, not to loosen either assertion.
 //!
 //! ## Issue #3915: is this a vertex-IDENTITY defect? (measured, ruled out)
 //!
@@ -547,13 +550,13 @@ fn edge_census(
 }
 
 /// See the module doc for the full rationale. Runs in normal `cargo test`
-/// (no `--ignored`) and PINS the current, known-defective Vid-space shape:
-/// a fully-recovered arrangement (`unrecovered == 0`) whose kept triangles
-/// are nonetheless non-manifold in Vid space. A green tick here means "the
-/// #3353 classification-level tear still reproduces exactly as documented,"
-/// NOT "issue #3353 is fixed."
+/// (no `--ignored`) and checks the FIXED Vid-space shape (#4439): a fully-
+/// recovered arrangement (`unrecovered == 0`) whose kept triangles are
+/// manifold in Vid space — every edge used by exactly two kept triangles.
+/// Until #4439 this pinned the opposite (the #3353 classification-level
+/// tear); a failure here now is a regression of that fix.
 #[test]
-fn sweep_261_kept_triangles_are_nonmanifold_in_vid_space() {
+fn sweep_261_kept_triangles_are_manifold_in_vid_space() {
     let (mesh_a, mesh_b) = sweep_261_operands();
     // Same construction `kernel::mesh_bridge::union` runs internally, so the
     // arrangement below is the one production actually computes for this
@@ -682,16 +685,14 @@ fn sweep_261_kept_triangles_are_nonmanifold_in_vid_space() {
         }
     }
 
-    // The defect itself: a fully-recovered arrangement (asserted above)
-    // whose KEPT triangles are still non-manifold in pure Vid space. See the
-    // module doc for why this is a defect PIN, not a health check.
+    // The fixed shape (#4439): a fully-recovered arrangement (asserted above)
+    // whose KEPT triangles are manifold in pure Vid space. Before #4439 this
+    // asserted the opposite — see the module doc.
     assert!(
-        !overused.is_empty(),
-        "expected sweep_261's kept-triangle set to be non-manifold in Vid space \
-         (issue #3353's classification-level tear) but every edge had multiplicity \
-         2 — either the defect is fixed (in which case: un-ignore \
-         `issue_3353_sweep_261_classification_tear.rs` too, and delete or repurpose \
-         this test) or this file's reproduction no longer matches the documented \
-         case and needs re-diagnosing before trusting either outcome"
+        overused.is_empty(),
+        "sweep_261's kept-triangle set is non-manifold in Vid space again: {} edge(s) \
+         with multiplicity != 2 (issue #3353's classification-level tear, closed by \
+         the #4439 `coincident_planes` gate) — see the census printed above",
+        overused.len()
     );
 }

--- a/rust/geometry/src/kernel/arrangement/mod.rs
+++ b/rust/geometry/src/kernel/arrangement/mod.rs
@@ -31,6 +31,7 @@ use std::cmp::Ordering;
 
 mod boolean;
 mod classify;
+mod coincident;
 mod ray_parity;
 #[cfg(test)]
 mod tests;
@@ -93,11 +94,6 @@ struct RawSeg {
     cutter: Tri,
 }
 
-#[inline]
-fn tri_plane(t: &Tri) -> [[f64; 3]; 3] {
-    *t
-}
-
 /// A segment endpoint paired with its CACHED interval lambda, so `orient2d` can run
 /// the f64-interval determinant straight from the lambda (the >95%-resolving fast
 /// tier) without re-deriving the degree-4/7 LPI/TPI lambda on every call. The raw
@@ -150,7 +146,7 @@ fn split_crossings(t: &Tri, raws: &[RawSeg]) -> Vec<Constraint> {
             let (la, lb) = ((&iv[l].0, &raws[l].a), (&iv[l].1, &raws[l].b));
             if segments_cross(ka, kb, la, lb, axis) {
                 let x = ImplicitPoint::Tpi(Tpi {
-                    planes: [tri_plane(t), tri_plane(&raws[k].cutter), tri_plane(&raws[l].cutter)],
+                    planes: [*t, raws[k].cutter, raws[l].cutter],
                 });
                 splits[k].push(x.clone());
                 splits[l].push(x);

--- a/rust/geometry/tests/csg_property_test.proptest-regressions
+++ b/rust/geometry/tests/csg_property_test.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f5af3c7d7cb53d88b52dded034feb4a921f84da80e3df3f6afb487b815d6b974 # shrinks to pair = BoxPair { config: "random", a_min: [7.142955097354382, 3.8930258763304124, 1.7326807905302595], a_size: [2.206252778210347, 4.759378629442683, 2.396126549955821], b_min: [7.383360698920378, 5.096809704830507, -2.3216188409075382], b_size: [0.1, 3.5564268697313324, 5.466807412783555] } (issue #4439)

--- a/rust/geometry/tests/csg_property_test.rs
+++ b/rust/geometry/tests/csg_property_test.rs
@@ -506,9 +506,10 @@ proptest! {
 /// near-coplanar band of that face — and regime 1 of the classifier
 /// (`kernel::arrangement::classify`) took them for a coincident shared face
 /// and kept them by "normal agreement" with a dot product of exactly zero: an
-/// extra directed cycle on the seam, one open edge after the 1 µm weld. The
-/// eight corners are the f32-quantized values `quantized()` produces for the
-/// shrunk input in the issue.
+/// extra directed cycle on the seam — 8 exact-coordinate open edges in the raw
+/// kernel output, 4 after the 1 µm weld (measured with the pre-#4439
+/// classifier). The eight corners are the f32-quantized values `quantized()`
+/// produces for the shrunk input in the issue.
 #[test]
 fn box_difference_thin_notch_seam_is_watertight_4439() {
     let a_min = [7.142955303192139, 3.8930258750915527, 1.7326807975769043];

--- a/rust/geometry/tests/csg_property_test.rs
+++ b/rust/geometry/tests/csg_property_test.rs
@@ -146,22 +146,51 @@ fn watertight_violation(mesh: &Mesh) -> Option<String> {
             }
         }
     }
-    edges
-        .iter()
-        .find(|(_, &(fwd, rev))| (fwd, rev) != (1, 1))
-        .map(|(&(a, b), &(fwd, rev))| {
-            let p = |i: u32| {
-                let base = i as usize * 3;
-                &welded.positions[base..base + 3]
-            };
-            format!(
-                "edge ({a}, {b}) [{:?} -> {:?}] has {} directed uses \
-                 ({fwd} forward, {rev} reverse); expected exactly one in each direction",
-                p(a),
-                p(b),
-                fwd + rev
-            )
-        })
+    // Sorted, so the edge named is a deterministic function of the mesh: the
+    // HashMap's iteration order used to pick a different edge of the same tear
+    // on every run (issue #4439), which made two runs of one seed read as two
+    // different failures.
+    let mut bad: Vec<((u32, u32), (u32, u32))> = edges
+        .into_iter()
+        .filter(|&(_, (fwd, rev))| (fwd, rev) != (1, 1))
+        .collect();
+    bad.sort_unstable();
+    let &((a, b), (fwd, rev)) = bad.first()?;
+    let p = |i: u32| {
+        let base = i as usize * 3;
+        &welded.positions[base..base + 3]
+    };
+    Some(format!(
+        "{} violating edge(s); first: edge ({a}, {b}) [{:?} -> {:?}] has {} directed uses \
+         ({fwd} forward, {rev} reverse); expected exactly one in each direction",
+        bad.len(),
+        p(a),
+        p(b),
+        fwd + rev
+    ))
+}
+
+/// Directed-edge pairing audit at EXACT f32 bit patterns — no weld at all. A
+/// closed oriented surface pairs every directed edge with its reverse; any
+/// imbalance is an exact-coordinate crack. The same audit the kernel's own
+/// `mesh_bridge_tests::exact_open_edges` runs, for the raw kernel output.
+fn exact_open_edges(mesh: &Mesh) -> usize {
+    let key = |i: u32| {
+        let b = i as usize * 3;
+        (
+            mesh.positions[b].to_bits(),
+            mesh.positions[b + 1].to_bits(),
+            mesh.positions[b + 2].to_bits(),
+        )
+    };
+    let mut edges: HashMap<_, i64> = HashMap::new();
+    for t in mesh.indices.chunks_exact(3) {
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            *edges.entry((key(a), key(b))).or_insert(0) += 1;
+            *edges.entry((key(b), key(a))).or_insert(0) -= 1;
+        }
+    }
+    edges.values().filter(|&&c| c != 0).count()
 }
 
 /// Guard the checker itself: a signed-cancellation-only check would pass a
@@ -346,8 +375,9 @@ fn arb_box_pair() -> impl Strategy<Value = BoxPair> {
                     b_size,
                 }
             });
-        // B exactly face-touching A (gap = 0): the coplanar-classifier
-        // precision boundary the cutter inflation exists for.
+        // B exactly face-touching A (gap = 0): the coincident-face
+        // precision boundary of the kernel's classifier (regime 1 in
+        // `kernel::arrangement::classify`).
         let touching =
             (0usize..3, proptest::array::uniform3(0.1f64..5.0)).prop_map(move |(axis, b_size)| {
                 let mut b_min = a_min;
@@ -407,9 +437,10 @@ proptest! {
         prop_assert!(vol.is_finite(), "result volume is not finite");
 
         // Tolerance: f32 round-trips of ~10-unit coordinates plus the
-        // deliberate ~10 µm cutter inflation, both scaled by operand
-        // surface areas. 1e-3·(1 + volA + volB) bounds that comfortably
-        // while staying far below any meaningful feature volume.
+        // kernel's 2⁻¹⁶ (~15 µm) snap-grid quantization of every operand
+        // vertex (`mesh_bridge::SNAP_GRID`), both scaled by operand surface
+        // areas. 1e-3·(1 + volA + volB) bounds that comfortably while
+        // staying far below any meaningful feature volume.
         let eps = 1e-3 * (1.0 + vol_a + vol_b);
 
         // (b) volume bounds
@@ -461,6 +492,67 @@ proptest! {
             violation.as_deref().unwrap_or("")
         );
     }
+}
+
+/// Issue #4439 — the saved `box_difference_volume_invariants` counterexample
+/// as a plain example test, so the case does not depend on proptest replaying
+/// `csg_property_test.proptest-regressions` (which carries the same seed).
+///
+/// B is a 0.1 m thin slab notching A from below and poking 824 µm above A's
+/// +Y face. B's +Z face diagonal pierces A's +Y face 23 µm short of the notch
+/// corner, so the exact arrangement legitimately splits A's +Y face into two
+/// 23 µm-wide needle sub-triangles INSIDE the notch that hug B's PERPENDICULAR
+/// +X face. Their centroids sit 7.8 µm inside B — within the kernel's
+/// near-coplanar band of that face — and regime 1 of the classifier
+/// (`kernel::arrangement::classify`) took them for a coincident shared face
+/// and kept them by "normal agreement" with a dot product of exactly zero: an
+/// extra directed cycle on the seam, one open edge after the 1 µm weld. The
+/// eight corners are the f32-quantized values `quantized()` produces for the
+/// shrunk input in the issue.
+#[test]
+fn box_difference_thin_notch_seam_is_watertight_4439() {
+    let a_min = [7.142955303192139, 3.8930258750915527, 1.7326807975769043];
+    let a_max = [9.349207878112793, 8.65240478515625, 4.128807544708252];
+    let b_min = [7.383360862731934, 5.0968098640441895, -2.3216187953948975];
+    let b_max = [7.483360767364502, 8.653236389160156, 3.145188570022583];
+    // The corners must be f32-exact, or the test measures authoring error.
+    for v in a_min.iter().chain(&a_max).chain(&b_min).chain(&b_max) {
+        assert_eq!(q(*v), *v, "corner {v} is not f32-exact");
+    }
+    let size = |lo: [f64; 3], hi: [f64; 3]| [hi[0] - lo[0], hi[1] - lo[1], hi[2] - lo[2]];
+    let (a_size, b_size) = (size(a_min, a_max), size(b_min, b_max));
+    let a = box_mesh(a_min, a_size);
+    let b = box_mesh(b_min, b_size);
+
+    // The defect is the kernel's: the raw arrangement output must already be
+    // closed — bit-exactly, before any weld — before consolidation sees it.
+    let raw = ifc_lite_geometry::kernel::mesh_bridge::subtract(&a, &b);
+    assert_eq!(
+        exact_open_edges(&raw),
+        0,
+        "raw kernel output has exact-coordinate open edges"
+    );
+    assert_eq!(watertight_violation(&raw), None, "raw kernel output is torn");
+
+    let result = ClippingProcessor::new()
+        .subtract_mesh(&a, &b)
+        .expect("subtract_mesh must not error");
+    assert!(all_finite(&result), "result has NaN/Inf positions");
+    let vol = mesh_volume(&result);
+    let vol_a = a_size[0] * a_size[1] * a_size[2];
+    let vol_b = b_size[0] * b_size[1] * b_size[2];
+    let vol_ab = aabb_intersection_volume(a_min, a_size, b_min, b_size);
+    let eps = 1e-3 * (1.0 + vol_a + vol_b);
+    assert!(
+        (vol - (vol_a - vol_ab)).abs() <= eps,
+        "vol(A-B)={vol} != vol(A)-vol(A∩B)={}",
+        vol_a - vol_ab
+    );
+    assert_eq!(
+        watertight_violation(&result),
+        None,
+        "difference result is not watertight"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
+++ b/rust/geometry/tests/issue_3353_sweep_261_classification_tear.rs
@@ -93,14 +93,19 @@
 //!
 //! ## Status
 //!
-//! `#[ignore]`d: this documents a KNOWN, OPEN defect, not a passing
-//! invariant. Do not un-ignore it without first fixing the classification
-//! disagreement referenced above and re-validating with the full
-//! `triangulation_invariance` census (see AGENTS.md). Verified to fail
-//! for the stated reason (3 unmatched directed edges) when run with
-//! `--ignored`.
+//! Fixed by #4439 (`kernel::arrangement::coincident::coincident_planes`):
+//! regime 1 of the classifier now requires the sub-triangle's OWN plane to be
+//! within 45° of the face its centroid was found near, so the 84 µm needle on
+//! the A/B plane-intersection line — 58° off the B face it was being taken
+//! for a coincident copy of — falls through to the ray cast, which already
+//! classified it as inside B. Un-ignored with that change; this test is the
+//! end-to-end reading of the case and
+//! `kernel/arrangement/issue_3353_vid_census_tests.rs` the Vid-space one.
+//! It failed for the stated reason (3 unmatched directed edges) when run with
+//! `--ignored` immediately before this change. The consolidation-level half of #3353
+//! (`issue_3353_boolean_tear.rs`) is unaffected and still `#[ignore]`d.
 //!
-//! Refs #3353
+//! Refs #3353, #4439
 
 use ifc_lite_geometry::{ClippingProcessor, Mesh};
 use nalgebra::{Point3, Rotation3, Unit, Vector3};
@@ -175,13 +180,9 @@ fn open_edges(m: &Mesh) -> Result<usize, String> {
     Ok(edges.values().filter(|&&(f, r)| f != 1 || r != 1).count())
 }
 
-/// `sweep_261`, recovered verbatim from PR #3373's closed branch.
+/// `sweep_261`, recovered verbatim from PR #3373's closed branch. Closed by
+/// the #4439 `coincident_planes` gate (see the module doc's Status).
 #[test]
-#[ignore = "known-open #3353 defect: classification-level tear, consolidate_coplanar \
-            is a byte-identical no-op on this input. NOT the near-coplanar half fixed \
-            by issue_3353_near_coplanar_rotated_overlap.rs — with that weld in place \
-            this is still 3 unmatched edges, from an 84 um IN-PLANE vertex split \
-            (see module doc)"]
 fn sweep_261_overlapping_rotated_union_never_tears() {
     let a_min = [-1.72371594746207, -0.35246108913603935, -1.2204342720208154];
     let a_size = [2.8534163464770894, 3.0795194627753784, 2.858202766048261];

--- a/rust/geometry/tests/manifests/watertightness_census.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census.tsv
@@ -176,7 +176,7 @@ ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	0	
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	0	2210	0	0	0	-	0	1028308685
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	52	0	0	0	-	0	7955440
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	5	51	0	0	5	7	5	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	104	664	0	0	104	0	104	-
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	96	647	1	0	96	0	96	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	0	126	0	0	0	-	0	6419464
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	25	7565	1	0	25	0	26	-
 ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	3	2005	0	0	3	0	3	-
@@ -421,8 +421,8 @@ ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-	0	0
 ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-	0	128252029
 ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6	6	-
 ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164	90	-
-ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78	78	-
-ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51	51	-
+ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	77	1061	0	0	80	78	77	-
+ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	50	1076	0	0	61	51	50	-
 ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-	0	5896872
 ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-	0	6031243
 ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-	0	68368125
@@ -639,7 +639,7 @@ ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-	0	3726179
 ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-	0	6285996
 ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-	0	5407859
 ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-	0	24013649
-ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0	8	-
+ara3d/dental_clinic.ifc	207	Clipping	21	237	0	0	21	0	21	-
 ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-	0	6076059
 ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-	0	4086273
 ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-	0	6479706
@@ -819,7 +819,7 @@ ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-	0	1945789
 ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-	0	2018855
 ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-	0	2018853
 ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-	0	315746
-ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0	10	-
+ara3d/dental_clinic.ifc	1311	Clipping	15	92	1	0	15	0	16	-
 ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-	0	409703
 ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-	0	137144
 ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-	0	1739830
@@ -843,7 +843,7 @@ ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-	0	32317
 ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-	0	32317
 ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-	0	32317
 ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-	0	32317
-ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0	19	-
+ara3d/dental_clinic.ifc	2292	SweptSolid	0	310	1	0	0	-	0	59640
 ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-	0	32319
 ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-	0	32319
 ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-	0	32317
@@ -853,7 +853,7 @@ ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-	0	32317
 ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-	0	32317
 ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-	0	67331
 ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0	6	-
-ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0	7	-
+ara3d/dental_clinic.ifc	2302	SweptSolid	0	312	1	0	0	-	0	61018
 ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-	0	56842
 ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-	0	56845
 ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-	0	56842
@@ -1111,7 +1111,7 @@ various/rvt01.ifc	6810	SweptSolid	28	232	0	0	28	42	46	-
 various/rvt01.ifc	6934	SweptSolid	0	356	1	0	0	-	10	3552955
 various/rvt01.ifc	7013	SweptSolid	8	64	0	0	8	8	24	-
 various/rvt01.ifc	7075	SweptSolid	18	100	0	0	12	13	40	-
-various/rvt01.ifc	7137	SweptSolid	39	181	1	0	36	0	45	-
+various/rvt01.ifc	7137	SweptSolid	52	170	1	0	33	0	57	-
 various/rvt01.ifc	7216	SweptSolid	0	180	0	0	0	-	7	1047958
 various/rvt01.ifc	7295	SweptSolid	0	188	0	0	0	-	4	180758
 various/rvt01.ifc	7403	Tessellation	0	172	1	0	0	-	6	1309071
@@ -1127,17 +1127,17 @@ various/rvt01.ifc	9730	SweptSolid	24	192	0	0	24	8	32	-
 various/rvt01.ifc	9901	SweptSolid	14	158	0	0	14	8	27	-
 various/rvt01.ifc	10191	Tessellation	0	172	0	0	0	-	0	7452
 various/rvt01.ifc	10335	Tessellation	0	116	0	0	0	-	0	28455
-various/rvt01.ifc	10526	Tessellation	6	140	0	0	6	0	6	-
+various/rvt01.ifc	10526	Tessellation	0	112	0	0	0	-	0	25761
 various/rvt01.ifc	10632	Tessellation	6	166	0	0	7	0	6	-
 various/rvt01.ifc	11110	Tessellation	0	120	0	0	0	-	0	20862
 various/rvt01.ifc	11168	Tessellation	6	110	0	0	0	0	6	-
 various/rvt01.ifc	11232	Tessellation	0	144	0	0	0	-	0	39336
-various/rvt01.ifc	11304	Tessellation	12	150	0	0	3	0	12	-
+various/rvt01.ifc	11304	Tessellation	0	128	0	0	0	-	0	9525
 various/rvt01.ifc	11477	Tessellation	33	159	1	0	18	3	33	-
-various/rvt01.ifc	11563	Tessellation	32	140	0	0	15	0	32	-
+various/rvt01.ifc	11563	Tessellation	12	156	1	0	15	0	12	-
 various/rvt01.ifc	11627	Tessellation	9	163	0	0	13	6	9	-
-various/rvt01.ifc	11690	Tessellation	14	140	0	0	14	6	14	-
-various/rvt01.ifc	11753	Tessellation	26	142	1	0	13	0	34	-
+various/rvt01.ifc	11690	Tessellation	19	139	1	0	19	6	19	-
+various/rvt01.ifc	11753	Tessellation	28	140	1	0	13	0	36	-
 various/rvt01.ifc	11803	SweptSolid	0	104	0	0	0	-	0	451981
 various/rvt01.ifc	12235	SweptSolid	0	24	0	0	0	-	0	723933
 various/rvt01.ifc	12345	SweptSolid	0	172	0	0	0	-	8	702236
@@ -1145,7 +1145,7 @@ various/rvt01.ifc	12449	Tessellation	27	235	1	0	21	9	36	-
 various/rvt01.ifc	13735	SweptSolid	8	72	0	0	8	24	24	-
 various/rvt01.ifc	13797	Tessellation	88	398	1	0	105	45	148	-
 various/rvt01.ifc	14014	SweptSolid	8	72	0	0	8	8	24	-
-various/rvt01.ifc	14132	SweptSolid	45	138	1	0	45	8	61	-
+various/rvt01.ifc	14132	SweptSolid	50	140	1	0	50	8	66	-
 various/rvt01.ifc	14194	SweptSolid	8	72	0	0	8	8	24	-
 various/rvt01.ifc	14256	SweptSolid	0	96	0	0	0	-	12	1086658
 various/rvt01.ifc	14447	SweptSolid	0	180	0	0	0	-	13	847248
@@ -1169,8 +1169,8 @@ various/rvt01.ifc	25914	SweptSolid	28	84	0	0	28	0	31	-
 various/rvt01.ifc	26166	Tessellation	0	172	0	0	0	-	8	147558
 various/rvt01.ifc	26300	Tessellation	0	172	0	0	0	-	8	147894
 various/rvt01.ifc	26610	Tessellation	0	84	0	0	0	-	0	8668
-various/rvt01.ifc	26681	Tessellation	38	190	1	0	37	0	39	-
-various/rvt01.ifc	26832	Tessellation	37	132	1	0	25	0	37	-
+various/rvt01.ifc	26681	Tessellation	35	191	1	0	33	0	35	-
+various/rvt01.ifc	26832	Tessellation	11	162	1	0	11	0	11	-
 various/rvt01.ifc	30054	Tessellation	0	160	0	0	0	-	0	61257
 various/rvt01.ifc	30125	Tessellation	0	206	0	0	0	-	0	80813
 various/rvt01.ifc	30518	Tessellation	0	244	0	0	0	-	0	156363
@@ -1184,7 +1184,7 @@ various/rvt01.ifc	32081	SweptSolid	0	220	0	0	0	-	17	131568
 various/rvt01.ifc	33639	SweptSolid	24	200	0	0	24	24	54	-
 various/rvt01.ifc	37278	Tessellation	0	110	0	0	0	-	0	3923
 various/rvt01.ifc	37347	Tessellation	6	182	0	0	6	0	6	-
-various/rvt01.ifc	37455	Tessellation	13	273	1	0	40	3	21	-
+various/rvt01.ifc	37455	Tessellation	13	274	1	0	39	3	21	-
 various/rvt01.ifc	37570	SweptSolid	0	112	0	0	0	-	16	40318
 various/rvt01.ifc	38680	Tessellation	20	186	0	0	20	0	24	-
 various/rvt01.ifc	38745	SweptSolid	0	24	0	0	0	-	2	121740

--- a/rust/geometry/tests/manifests/watertightness_census_heavy.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census_heavy.tsv
@@ -308,7 +308,7 @@ ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568038	SweptSolid	0	42	0	0	0	-	0	74
 ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5568227	SweptSolid	0	36	0	0	0	-	0	5463711
 ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5578837	SweptSolid	0	36	0	0	0	-	0	5516518
 ara3d/ISSUE_053_20181220Holter_Tower_10.ifc	5603607	SweptSolid	0	36	0	0	0	-	0	5516518
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	43810	SweptSolid	52	1333	1	0	52	0	57	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	43810	SweptSolid	14	1384	1	0	14	0	19	-
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	45388	SweptSolid	0	16	0	0	0	-	0	399151
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52001	SweptSolid	0	232	0	0	0	-	0	2994072
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	52476	SweptSolid	0	112	0	0	0	-	0	2466252
@@ -561,7 +561,7 @@ ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891221	SweptSolid	0	40	0	0	0	-	0	2767955
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891553	SweptSolid	10	84	0	0	10	0	10	-
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	891721	SweptSolid	0	28	0	0	0	-	0	1264417
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892212	Brep	0	234	0	0	0	-	0	21624713
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892717	Brep	10	434	0	0	0	29	10	-
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892717	Brep	30	302	0	0	0	29	30	-
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	892891	SweptSolid	0	52	0	0	0	-	0	26320657
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	893133	SweptSolid	25	235	1	0	25	0	25	-
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	896693	SweptSolid	0	28	0	0	0	-	0	708429
@@ -643,11 +643,11 @@ ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1398327	Brep	0	126	0	0	0	-	0	7145001
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399367	SweptSolid	0	28	0	0	0	-	0	1144544
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1399725	SweptSolid	0	36	0	0	0	-	0	25347
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400126	SweptSolid	0	36	0	0	0	-	0	25347
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400391	SweptSolid	0	38	0	0	0	-	0	23230
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400391	SweptSolid	0	77	1	0	0	-	0	23229
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400573	SweptSolid	0	100	1	0	0	-	0	25344
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1400840	SweptSolid	0	30	0	0	0	-	0	22704
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401021	SweptSolid	0	176	0	0	0	-	0	26922
-ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401204	SweptSolid	0	144	1	0	0	-	5	25342
+ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401204	SweptSolid	0	144	1	0	0	-	5	25339
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401471	SweptSolid	0	30	0	0	0	-	0	30097
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401653	SweptSolid	3	28	1	0	3	0	3	-
 ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc	1401920	SweptSolid	0	292	1	0	0	-	0	23105

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1343,3 +1343,25 @@ certificate avoids treating an unrelated infinite-line side change as an edge
 intersection. No tolerance/endpoint guard was replaced by epsilon snapping.
 [Source-matched raw samples and original PDF evidence](../../docs/architecture/evidence/pdf-composition-lattice/README.md)
 record the control and prevent repeating the float-roundtrip approach.
+
+## Regime-1 coincidence requires near-parallel planes (#4439)
+
+The exact boolean classifier's "sub-triangle lies ON a coincident shared face"
+regime now also requires the sub-triangle's own plane to be within 45° of the
+candidate face (`coincident_planes`, a sqrt-free `2·d² ≥ |n₁|²|n₂|²` test on
+products the classifier already forms). Interleaved native A/B/A/B on AC20 and
+ISSUE_129 resolved no phase delta beyond the base's own noise floor; AC20's
+ordered mesh fingerprint is identical on every run. ISSUE_129's output changes
+on purpose: host #9094 is one of the 17 census hosts the gate reclassifies
+(triangle delta of the whole run equals that row's census delta), so its timing
+is not a like-for-like comparison and is not claimed either way. This is a
+correctness fix, not a speedup. The lesson: a centroid-in-band test locates a
+face, it does not establish coincidence — a needle hugging the intersection
+line of two transversal faces sits in both planes' bands with no orientation to
+agree with, and a `dot > 0` verdict there is a coin flip that can override an
+exact ray-cast. Add the angle premise per candidate face rather than gating on
+a parent flag (the parent-flag gate was measured to cost 20+ census hosts).
+[Raw interleaved runs and fingerprints](../../docs/architecture/evidence/csg-coincident-planes/native-load.json).
+Note for Windows hosts: `ab.sh` runs zero rounds there because `ab-order.mjs`'s
+CLI guard compares `import.meta.url` with a backslash `argv[1]`; the recorded
+runs replicate its procedure by hand.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1362,6 +1362,9 @@ agree with, and a `dot > 0` verdict there is a coin flip that can override an
 exact ray-cast. Add the angle premise per candidate face rather than gating on
 a parent flag (the parent-flag gate was measured to cost 20+ census hosts).
 [Raw interleaved runs and fingerprints](../../docs/architecture/evidence/csg-coincident-planes/native-load.json).
-Note for Windows hosts: `ab.sh` runs zero rounds there because `ab-order.mjs`'s
-CLI guard compares `import.meta.url` with a backslash `argv[1]`; the recorded
-runs replicate its procedure by hand.
+Found while measuring: on Windows `ab.sh` ran ZERO rounds and still printed a
+"within noise, counts matched" verdict, because `ab-order.mjs`'s CLI guard
+compared `import.meta.url` with a backslash `argv[1]` and never fired. Fixed in
+the same PR (`pathToFileURL`, a CLI test, and `ab.sh` now refuses an order file
+with fewer lines than `--iters`); the recorded runs replicate the procedure by
+hand with the same `roundOrder()` and reporter.

--- a/scripts/perf/ab-order.mjs
+++ b/scripts/perf/ab-order.mjs
@@ -25,6 +25,8 @@
 // branch-first / round 3 base-first…, could still resonate with a
 // periodic effect).
 
+import { pathToFileURL } from 'node:url';
+
 /**
  * @param {number} iters positive integer round count
  * @param {() => number} rand uniform [0,1) generator (defaults to Math.random)
@@ -60,7 +62,13 @@ export function seededRand(seed) {
 
 // CLI: `node ab-order.mjs <iters> [seed]` prints one "first second" line per
 // round (e.g. "base branch"), consumed by ab.sh.
-if (import.meta.url === `file://${process.argv[1]}`) {
+//
+// The guard goes through `pathToFileURL` rather than string-prefixing
+// `file://`: on Windows `process.argv[1]` is `C:\...b-order.mjs` while
+// `import.meta.url` is `file:///C:/.../ab-order.mjs`, so the naive comparison
+// never matched there and ab.sh ran ZERO rounds while still printing a
+// "within noise, counts matched" verdict (#4439).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const iters = Number(process.argv[2]);
   const seedArg = process.argv[3];
   const rand = seedArg !== undefined ? seededRand(Number(seedArg)) : Math.random;

--- a/scripts/perf/ab-order.test.mjs
+++ b/scripts/perf/ab-order.test.mjs
@@ -30,7 +30,24 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { roundOrder, seededRand } from './ab-order.mjs';
+
+test('the CLI prints one pairing per round on every platform (#4439: the file-URL guard never matched a Windows argv[1])', () => {
+  const cli = fileURLToPath(new URL('./ab-order.mjs', import.meta.url));
+  const out = execFileSync(process.execPath, [cli, '5', '4439'], { encoding: 'utf8' });
+  const lines = out.trim().split(/\r?\n/);
+  assert.equal(lines.length, 5, `expected 5 order lines, got: ${JSON.stringify(out)}`);
+  for (const line of lines) {
+    assert.ok(line === 'base branch' || line === 'branch base', line);
+  }
+  assert.deepEqual(
+    lines.map((l) => l.split(' ')),
+    roundOrder(5, seededRand(4439)),
+    'the CLI and the exported roundOrder must agree for the same seed',
+  );
+});
 
 test('balance: base-first count is ceil(iters/2) for a range of round counts', () => {
   for (const iters of [1, 2, 3, 4, 5, 6, 7, 10, 11, 20]) {

--- a/scripts/perf/ab.sh
+++ b/scripts/perf/ab.sh
@@ -143,6 +143,12 @@ fi
 # often and cancels out instead of accumulating on one.
 ORDER_FILE="$TMP_ROOT/order.txt"
 node "$ROOT/scripts/perf/ab-order.mjs" "$ITERS" > "$ORDER_FILE"
+# A vacuous run must fail loudly, not print a "within noise" verdict over zero
+# measurements (#4439: the order generator's CLI guard never fired on Windows).
+if [ "$(wc -l < "$ORDER_FILE")" -ne "$ITERS" ]; then
+  echo "ab.sh: ab-order.mjs produced $(wc -l < "$ORDER_FILE") round(s) for --iters $ITERS — refusing to report" >&2
+  exit 1
+fi
 RUNS_JSONL="$TMP_ROOT/runs.jsonl"
 : > "$RUNS_JSONL"
 i=0


### PR DESCRIPTION
Closes #4439

## What changed

- **`rust/geometry/src/kernel/arrangement/coincident.rs` (new):** `coincident_planes(n_own, n_face)` — are two raw face normals within 45° of parallel, evaluated as `2·(n₁·n₂)² ≥ |n₁|²·|n₂|²` (no sqrt, no division, FMA-free f64 ⇒ byte-identical native == wasm). Each normal is first scaled by the power of two that puts its largest component in [0.5, 4) — exponent-only, so exact, and the verdict is bit-for-bit the raw one wherever the raw products are finite (added on CodeRabbit's finding; the kernel boundary accepts any finite f32, and at ~1e38 m the raw fourth-degree products overflow to `inf >= inf`). Five unit tests (parallel/antiparallel/perpendicular, 44° vs 46°, the #3353 58° needle, zero normal passes, and the full magnitude range 1e-160 … f64::MAX/4 incl. mixed scales, pinning the two raw-form failures).
- **`classify.rs`:** regime 1 of the boolean classifier ("sub-triangle lies ON a coincident shared face of the other operand → decide by normal agreement") now requires `coincident_planes` between the sub-triangle's own plane and the candidate face, on every path that reaches it: A-side exact (`on_surface_normal`) and near-band (`near_on_surface_normal`) via `BComponents::surface_normal`, and the B-side dedup drop (`c_on_or_near_a`). Nothing is gated on the `coplanar_a/b` parent flags, so the #1007 flush-cap path and the two `clash_intersection_oracle` near-band invariants keep their verdicts. Doc comments that described the pre-#4439 state ("KNOWN FALSE POSITIVE (#3353, open)", "used ONLY for near-coplanar parents") are rewritten.
- **`arrangement/mod.rs`:** registers the module; the identity helper `tri_plane(t) = *t` is inlined at its single call site (mod.rs was at the 400-line ratchet with no allowlist row — superseded means deleted, not allowlisted).
- **Tests:**
  - `rust/geometry/tests/csg_property_test.proptest-regressions` (new) carries the issue's seed `cc f5af3c7d…`; proptest replays it first.
  - `csg_property_test.rs`: new deterministic `box_difference_thin_notch_seam_is_watertight_4439` with the eight `f32`-snapped corners of the shrunk input; it asserts the **raw kernel output** (`mesh_bridge::subtract`, before `consolidate_coplanar` and before any weld) has zero exact-coordinate open edges, plus the volume and the welded watertightness the property test checks. `watertight_violation` now sorts its violations so the reported edge is deterministic (the issue's HashMap-order complaint), and the stale "cutter inflation" comment is gone. `box_difference_volume_invariants` itself is unchanged (same assertions, same eps).
  - `issue_3353_sweep_261_classification_tear.rs`: `#[ignore]` removed — the same gate closes #3353's `sweep_261` tear.
  - `issue_3353_vid_census_tests.rs`: `sweep_261_kept_triangles_are_manifold_in_vid_space` flipped from a defect pin to a health check (asserts the over-used Vid-edge set is empty); module doc updated with the measured fix shape.
  - `tests/manifests/watertightness_census.tsv`: 17 of 1171 golden rows re-blessed (per-row explanation below).
  - `tests/manifests/watertightness_census_heavy.tsv`: 4 of 652 rows re-blessed (weekly lane; per-row explanation below).
- **Perf ledger:** `scripts/perf/README.md` gains the #4439 row; raw interleaved runs in `docs/architecture/evidence/csg-coincident-planes/native-load.json`.

## Why / root cause

The plan's prime suspect was `consolidate_coplanar`; the decisive raw-vs-consolidated diagnostic (plan step 1) showed otherwise: with `origin/main`'s `classify.rs` the **raw kernel output** of the seed already has **8 exact-coordinate open edges** (bit-exact directed-edge audit), **4 violating edges after the property test's 1 µm weld**, and the seed replay fails at `successes: 0`. So the defect is in the exact kernel's boolean classifier (plan option 2c), not in consolidation.

Mechanism: B is a 0.1 m-thin slab notching A from below and poking 0.82 mm above A's top. Arrangement leaves a 23 µm-wide needle of A's +Y face inside the notch. Its centroid is 7.8 µm inside B — within the near-coplanar snap band of B's **+X** face, which is *perpendicular* to the needle. Regime 1 located that face from the centroid alone, treated the needle as a "coincident shared face", and decided keep/drop by `dot(n_own, n_face) > 0` — a dot product that is **exactly zero** here. The needle was kept as "not co-oriented" on a difference, overriding the ray-cast that had already classified it inside B, and left an extra directed cycle on the seam. #3353's `sweep_261` needle is the same defect at 58° instead of 90°.

The fix adds the missing premise: coincidence is a property of two *planes*, so regime 1 may only fire when the sub-triangle's own plane is near-parallel (within 45°) to the face its centroid sits on. A genuine shared face — exactly coplanar, or a #1007 flush cap a few µm off a tilted plane — has `cos ≈ 1` (snap tilt over a ≥ 0.2 m face is < 1e-3 rad), so 45° is three orders of magnitude from any legitimate flush tilt and was chosen as a clean bound rather than tuned to either case. Own-normal was preferred over a parent-normal variant (which needs a parent index on `Arrangement`): on the 547 census candidates the gate rejects, own-normal `cos² < 1e-6` for 93 % and the two genuinely tilted cases are real tilts.

Numbers by layer on the seed, base → branch: raw exact-coordinate open edges **8 → 0**; welded (1 µm) violating edges **4 → 0**; census open edges over the 17 moved golden rows **539 → 479**.

## Watertightness census re-bless (17 of 1171 rows)

Columns: `open tris coll far alt pre strict vol`. Instrumented per sub-triangle on this branch: over these 17 hosts the gate rejects 547 regime-1 candidates, every one a sliver ≤ 0.3 mm wide hugging a transversal face of the other operand (509 within 1e-6 of perpendicular, `cos² < 1e-6`; 235 under 1 µm, 295 in 1–100 µm, 17 in 100–300 µm). Their old verdict was the sign of a dot product between (near-)perpendicular normals; their new verdict is the exact centroid ray-cast (regime 3) or the solid-side probe (regime 2, 27 of them). Raw kernel output over the 31 boolean ops behind these rows: exact open edges 3332 → 3154, 1 mm-snapped 1401 → 1362; after `consolidate_coplanar`: snapped open 1141 → 1038. No watertight host tears.

**Improved (9):**

| model | id | rep | open | tris | notes |
|---|---|---|---|---|---|
| ara3d/dental_clinic.ifc | 2292 | SweptSolid | 19 → 0 | 305 → 310 | now watertight, `vol` 59640 read |
| ara3d/dental_clinic.ifc | 2302 | SweptSolid | 7 → 0 | 366 → 312 | now watertight, `vol` 61018 read |
| various/rvt01.ifc | 10526 | Tessellation | 6 → 0 | 140 → 112 | now watertight, `vol` 25761 |
| various/rvt01.ifc | 11304 | Tessellation | 12 → 0 | 150 → 128 | now watertight, `vol` 9525 |
| various/rvt01.ifc | 11563 | Tessellation | 32 → 12 | 140 → 156 | |
| various/rvt01.ifc | 26681 | Tessellation | 38 → 35 | 190 → 191 | |
| various/rvt01.ifc | 26832 | Tessellation | 37 → 11 | 132 → 162 | |
| ara3d/S_Office_Integrated Design Archi.ifc | 458857 | CSG | 78 → 77 | 1062 → 1061 | strict 78 → 77 |
| ara3d/S_Office_Integrated Design Archi.ifc | 469706 | CSG | 51 → 50 | 1077 → 1076 | strict 51 → 50 |
| ara3d/ISSUE_129_…IGC_V17.ifc | 9094 | SweptSolid | 104 → 96 | 664 → 647 | the host that moves the ISSUE_129 perf-probe counts below |

The eight axis-aligned ones are the #4439 class exactly: 30–300 µm slivers of a host face inside a thin cutter, perpendicular to the cutter face they abut (`cos² = 0` to the bit), kept or dropped on the sign of a zero, now classified by the ray-cast.

**Regressed (6) — all torn before and after, all `far = 0`:**

| model | id | rep | open | tris | strict | mechanism |
|---|---|---|---|---|---|---|
| ara3d/dental_clinic.ifc | 207 | Clipping | 8 → 21 | 278 → 237 | 8 → 21 | 28 rejected slivers, 28 nm – 3.9 µm wide, 20 verdicts changed. The **raw kernel output improves** (exact open 24 → 16, 1 mm-snapped 3 → 3); `consolidate_coplanar`, previously a byte-identical no-op on this host (172 → 172 tris), now merges 176 → 115 triangles and opens 13 edges. The triangle drop is that merge, not lost geometry. |
| ara3d/dental_clinic.ifc | 1311 | Clipping | 10 → 15 | 80 → 92 | 10 → 16 | 23 rejected slivers, 3 pm – 44 µm wide, 13 changed; raw kernel 1 mm-snapped open 0 → 8. |
| various/rvt01.ifc | 7137 | SweptSolid | 39 → 52 | 181 → 170 | 45 → 57 | 33 rejected slivers, all ≤ 31 µm (two snap cells), 23 changed — 15–30 µm strips of host side faces whose centroids are 7 µm inside the cutter, previously kept, now dropped; raw kernel snapped open 6 → 12. |
| various/rvt01.ifc | 11690 | Tessellation | 14 → 19 | 140 → 139 | 14 → 19 | `pre = 6` (host torn before any void). 6 rejected slivers, all ≤ 3 nm wide, 2 changed; the boolean result itself reads better (consolidated snapped open 12 → 9). |
| various/rvt01.ifc | 11753 | Tessellation | 26 → 28 | 142 → 140 | 34 → 36 | 24 rejected slivers, 1.4 nm – 32 µm, 8 changed. |
| various/rvt01.ifc | 14132 | SweptSolid | 45 → 50 | 138 → 140 | 61 → 66 | `pre = 8`. 37 rejected slivers, 0.1 – 95 µm, 13 changed. |

On these six the neighbours of the reclassified needle are themselves near-band (inexact by design) verdicts, and the old coin-flip sign happened to agree with them more often than the exact verdict does — the "pre-existing tear the sliver was patching" population `issue_3353_vid_census_tests.rs` already names as the remaining work. It is not a new tear class; no watertight host joins it. The reviewer accepted the bless on that basis (net 539 → 479, 4 hosts newly watertight, none newly torn).

**Changed at equal open (2):** rvt01 #37455 (13 → 13, tris 273 → 274, alt 40 → 39); the two S_Office rows also move `tris` by −1.

Pinned kernel manifests (`arrangement/tests.rs` boolean manifest, `retriangulate.rs`, `SIGN_MANIFEST`, `rust/processing/tests/manifests/mesh_determinism.json`) and the insta snapshots in `tests/snapshots/` are unchanged.

## Heavy census re-bless (`watertightness_census_heavy.tsv`, 4 of 652 rows, all ISSUE_068)

| id | rep | open | tris | coll | strict | vol (cm³) | mechanism |
|---|---|---|---|---|---|---|---|
| 43810 | SweptSolid | 52 → 14 | 1333 → 1384 | 1 | 57 → 19 | – | **Improved.** 38 openings in 5 chunked arrangements. 104 regime-1 candidates rejected by the gate, all perpendicular to the face their centroid sat on (`cos² < 1e-6`), 16 of them 1–100 µm and 88 of them 100–168 µm wide; 56 verdicts changed. Raw kernel exact-coordinate open edges per chunk 8/24/34/66/66 → **0/0/0/0/0**. The #4439 class exactly. |
| 892717 | Brep | 10 → 30 | 434 → 302 | 0 | 10 → 30 | – | Host is an **open Brep before any void** (`pre = 29`). No host-side verdict changes (128 regime-1 hits, identical). 11 **cutter-side** slivers 0.9–15 µm wide (up to 2.9 m long) sat in the band of a host face they are transversal to; the ungated test dropped them as "coincident B copies" (a coin flip), the gate routes them to regime 2, which keeps 9. Raw kernel: tris 309 → 318, exact open **29 → 20** (better), 1 mm-snapped open **10 → 10** (equal), snap-collapsed 3 → 12. Those 9 needles count as spikes in `consolidate_coplanar`'s raw-vs-consolidated badness guard: on base it returned raw byte-identically (309 → 309); now it keeps the merged mesh (318 → 174 tris, snapped open 26). The triangle drop is that merge, and the extra open edges are consolidate re-opening merged faces of an already-open shell — not kernel geometry loss. |
| 1400391 | SweptSolid | 0 → 0 | 38 → 77 | 0 → 1 | 0 → 0 | 23230 → 23229 | Watertight before and after. 6 host-side + 1 cutter-side slivers ≤ 20 µm wide reclassified (all perpendicular). Raw kernel: base 25 tris with 3 snapped open edges that consolidate merged away (25 → 16); branch 20 tris, snapped open **0**, exact open 12, 2 sub-mm slivers kept, consolidate a no-op. The router's post-cut `refine_high_aspect_slivers` (watertight, volume-preserving longest-edge bisection) then works those slivers up to its round cap — that is the 77 triangles, and the single snap-collapsed triangle is its residue. Volume −0.004 %. |
| 1401204 | SweptSolid | 0 → 0 | 144 → 144 | 1 | 5 → 5 | 25342 → 25339 | Every count identical; only the volume moves by −0.01 %. 14 host-side slivers ≤ 15 µm wide reclassified (all perpendicular, 13 verdicts changed); a 15 µm sheet across a m²-scale face is cm³-order volume. |

Net for ISSUE_068: torn hosts 26 → 26, one torn host substantially healed, one open Brep host more torn through the consolidate arbitration (raw kernel not worse), two watertight hosts stay watertight.

## Performance (AGENTS.md "Performance")

Interleaved native `perf_probe` A/B/A/B, base `531194cdc` (merge base with `origin/main`) vs branch `79b3e2671` (the kernel change; the commits after it touch only the ledger, the evidence JSON and the heavy census golden, none of which the probe reads), cargo profile `profiling`, 5 rounds, balanced randomised within-round order (`roundOrder`: base-first in rounds 1, 4, 5; branch-first in 2, 3), `--iters 1 --json --fingerprint` per side per round, otherwise-idle Windows 11 x86_64 host. Reporter: `scripts/perf/ab-report.mjs` (median, base-spread noise floor).

| fixture | phase | base | branch | delta | noise |
|---|---|---|---|---|---|
| AC20-FZK-Haus.ifc | parse | 6.0 | 6.0 | +0.0 % | ±0 % |
| AC20-FZK-Haus.ifc | geometry | 10.0 | 10.0 | +0.0 % | ±10 % |
| AC20-FZK-Haus.ifc | TOTAL | 16.0 | 17.0 | +6.3 % | ±13 % |
| ISSUE_129_…IGC_V17.ifc | parse | 22.0 | 21.0 | −4.5 % | ±18 % |
| ISSUE_129_…IGC_V17.ifc | geometry | 907.0 | 908.0 | +0.1 % | ±3 % |
| ISSUE_129_…IGC_V17.ifc | TOTAL | 930.0 | 930.0 | +0.0 % | ±2 % |

Verdict: no phase moved beyond the base's own noise floor on either fixture; this is a correctness fix, not a speedup claim.

Byte-identity: **AC20** — 285 meshes / 35940 vertices / 19456 triangles on all 10 runs and the ordered mesh FNV-1a64 fingerprint is identical across both sides and every round. **ISSUE_129** — output changes **on purpose**: 1402 meshes both sides, vertices 218255 → 218365, triangles 132674 → 132657 (−17), fingerprint stable within each side and different between sides. Host **#9094** is one of the 17 reclassified census hosts (its row: open 104 → 96, tris 664 → 647, i.e. the same −17 as the whole run) and the only one of ISSUE_129's 73 census rows that moves; the probe hash is per run, not per mesh, so that attribution is by triangle count, not by per-mesh hash. The ISSUE_129 timing is therefore not like-for-like and is not claimed either way. Heavy CSG model (ISSUE_053 Holter): not probed for timing; see Evidence for the heavy census lane.

Ledger row: `scripts/perf/README.md` "Regime-1 coincidence requires near-parallel planes (#4439)"; raw runs: `docs/architecture/evidence/csg-coincident-planes/native-load.json`.

Harness note: `scripts/perf/ab.sh` ran **zero rounds** on this Windows host and printed a vacuous "within noise, counts matched" verdict — `ab-order.mjs`'s CLI guard compares `import.meta.url` (`file:///C:/…`) with `process.argv[1]` (`C:\…`) and never fires, so the order file is empty. The procedure above replicates ab.sh by hand with the same `roundOrder()` and `ab-report.mjs` (described in the evidence JSON's `procedure` field). Fixed in this PR at CodeRabbit's request (`fix(perf)` commit): the guard goes through `pathToFileURL`, a test spawns the CLI and checks one pairing per round, and `ab.sh` refuses an order file shorter than `--iters`.

## Evidence

All run in the worktree on Windows 11 (nightly-2025-11-15 per `rust-toolchain.toml`), debug profile unless stated, on the final branch head after the rebase onto `origin/main` (`531194cdc`):

- Baseline reproduction (implementer and reviewer, independently, with `origin/main`'s `classify.rs`/`mod.rs` swapped in): `cargo test -p ifc-lite-geometry --test csg_property_test box_difference_volume_invariants -- --exact` fails at `successes: 0` on the saved seed with "4 violating edge(s); first: edge (1, 2) [[7.483368, 8.652405, 3.1451874] -> [7.483368, 8.652405, 1.7326813]] has 1 directed uses"; `box_difference_thin_notch_seam_is_watertight_4439` fails with "raw kernel output has exact-coordinate open edges: left 8, right 0"; `sweep_261_overlapping_rotated_union_never_tears` and `sweep_261_kept_triangles_are_manifold_in_vid_space` fail. With the branch all four pass.
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean.
- `cargo test -p ifc-lite-geometry` — 107 test binaries, **1313 passed, 0 failed, 34 ignored** (lib 894/0/1; includes `csg_property_test` 5/5 with the seed replay, `issue_3353_sweep_261_classification_tear` 1/1, `kernel::` 106 incl. the 4 `coincident.rs` unit tests and the Vid-space health check, `clash_intersection_oracle` 27/27, `geometry_correctness_harness` with no `.snap.new`). Pinned boolean/retriangulate/SIGN manifests unchanged.
- Census re-run against the committed golden: `cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance` — **64 passed, 0 failed, 2 ignored** (the sweep itself 160 s); `target/watertightness_census.run.tsv` equals `tests/manifests/watertightness_census.tsv` row for row (1171 rows, 98 torn hosts), i.e. the bless is confirmed on the committed code, not inherited from an earlier run.
- Heavy census lane (weekly `geometry-census-heavy.yml`, not per-PR, so it was run here to keep the weekly lane green after merge): `cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- --ignored --test-threads=1 heavy_fixture`. On **base** (`531194cdc`, fixtures junctioned into a throwaway worktree) the committed heavy golden reproduces exactly (0 regressed / 0 improved). On the branch, ISSUE_053 (Holter, 289 hosts) stays fully watertight and unchanged; ISSUE_068 (363 hosts, 26 torn before and after, the #3435 population pin holds) moves **4 rows**, re-blessed in `816c74a9e` with each row instrumented per sub-triangle plus a raw-vs-consolidated audit on base and branch (temporary trace, removed) — see the "Heavy census" section below. After the bless: 2 passed, and `the_heavy_golden_pins_the_known_3435_tear_population` passes.
- `cargo test --workspace --exclude ifc-lite-wasm` — 182 test binaries ok, **1 failed**: `ifc-lite-processing` `mesh_determinism::mesh_output_matches_pinned_manifest`, on the round column #500 `normals_hash` only (`positions_hash` and `indices_origin_hash` identical, all other meshes identical). This is the documented libm trig gap (`docs/architecture/mesh-determinism.md` "Known gap: libm trig ULP") on a Windows host; the reviewer verified it fails byte-identically on `origin/main`. Not re-pinned; the Linux CI lane is the judge.
- After the scaling commit, re-run on the final head: `--lib kernel::` 107/107, `csg_property_test` 5/5, `sweep_261` 1/1, `clash_intersection_oracle` 27/27, `geometry_correctness_harness` 1/1 (no `.snap.new`), the census sweep with `target/watertightness_census.run.tsv` equal to the committed golden row for row, the heavy lane 2/2, `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` clean. One census-file test, `the_checked_in_golden_carries_exactly_the_generated_header`, fails on this host only because the rebase re-checked the golden out with CRLF (`core.autocrlf=true`; the committed blob is LF and the test reads the file verbatim) — a working-copy artifact the Linux lane does not have.
- `node --test scripts/perf/*.test.mjs` — 10 passed (incl. the new CLI test); `pnpm exec oxlint` on the two changed scripts — clean. Root `pnpm lint` cannot run on this host (`check-unused-locals.mjs` spawns `pnpm` and gets ENOENT on Windows, identically on the untouched tree) — the Lint lane judges it.
- `node scripts/check-module-size.mjs` — OK (`classify.rs` 660 within its 720 allowlist budget; `arrangement/mod.rs` 396 ≤ 400 with no allowlist row; `coincident.rs` 108). `node scripts/check-test-wiring.mjs` — OK.
- Perf A/B/A/B as above (profiling profile).
- NOT run here: the wasm build/`ifc-lite-wasm` tests (no binding change, `pkg/ifc-lite.d.ts` untouched), the Node/viewer suites (no TS change), `pnpm docs:check-generated` (fails on this Windows host on CRLF-identical generated-table lines and a CLI HELP parse error in regions this PR does not touch — left to CI). No changeset: Rust-only crates, no published `packages/*` change.

## Review

Independent review verdict: **approve** with minors, all applied in the `docs(geometry): correct the #4439 defect narrative` commit:
- Doc comment of `box_difference_thin_notch_seam_is_watertight_4439` (and the narrative in the fix commit's body) said "one open edge after the 1 µm weld"; the reviewer measured **4** welded violating edges on base (8 raw). The doc comment now carries the measured numbers per layer; the commit body is superseded by this PR body.
- Stale NOTE/CORRECTION block inside the flipped `sweep_261_kept_triangles_are_manifold_in_vid_space` (still described the defect-pin state) rewritten: the block prints only when a regression re-opens an edge; `kept[16]`'s regime-1 verdict in the past tense.
- `near_on_surface_normal`'s opening sentence ("used ONLY for near-coplanar parents") contradicted the NOT GATED paragraph in the same block; it now names both callers.
- Stray double blank line before `rotate_min_first` removed.
- Taste notes kept as-is: `coincident_planes` in its own file with the sqrt-free form, own-normal over parent-normal, `tri_plane` inlined, the sorted `watertight_violation` message shape, test names.
- Reviewer's decision on the six more-torn census rows: accept the bless (reasoning above).
- CodeRabbit (PR): asked to make `coincident_planes` scale-safe against underflow/overflow of the raw normal products. I first declined with the realistic bound; CodeRabbit correctly pointed out the kernel boundary enforces no such bound, so it is done (`fix(geometry): make coincident_planes exact at every finite magnitude`): exact power-of-two pre-scaling, verified bit-identical on the full census (golden unchanged row for row), the heavy lane, the kernel manifests and all #4439/#3353 tests. Asked to fix the Windows zero-round `ab.sh` path — done (`fix(perf)` commit, test added).
- Reviewer's note on `ifc-lite-processing` `mesh_determinism::mesh_output_matches_pinned_manifest`: it fails on this Windows host **byte-identically on base and branch** (only round column #500 `normals_hash` differs; positions/indices identical) — the documented libm trig gap on Windows, not this branch; not re-pinned. CI (Linux) judges it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg
