### PR TITLE
feat(viewer,lists): model tags — By tag grouping, row filter + isolate, list scope (#4215, part 2)

### DIFF
--- a/.changeset/model-tags-hierarchy-lists.md
+++ b/.changeset/model-tags-hierarchy-lists.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/viewer": minor
+"@ifc-lite/lists": minor
+---
+
+Model tags for federations (#4215, part 2): the hierarchy's Models section gains a "By tag" grouping (one group per tag plus an explicit Untagged group; a model under several tags is listed under each but stays one model — counts, visibility and selection deduplicate by model), tag chips that filter the listed rows without touching the viewport, and a separate explicit "Isolate matching models" action that shows the listed models and hides the rest in one store write. Lists gain a model tag scope (`ListDefinition.modelTagScope`, the same `has any` / `has all` / `has none` / `untagged` predicates as search and clash): the list runs only over the models in scope, and a scope naming a deleted tag — or one no loaded model satisfies — is refused with a visible reason instead of running over every model.

--- a/apps/viewer/src/components/viewer/HierarchyPanel.modelTags.test.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.modelTags.test.tsx
@@ -95,7 +95,7 @@ function byText(root: ParentNode, text: string): HTMLElement {
 
 describe('HierarchyPanel — model tags in the Models section (#4215)', () => {
   beforeEach(seed);
-  afterEach(() => { cleanup(); useViewerStore.setState({ modelTagView: DEFAULT_MODEL_TAG_VIEW }); });
+  afterEach(cleanup);
 
   it('flat by default: one row per model, no group headers, and the tag controls are offered', () => {
     const c = renderPanel();
@@ -149,6 +149,28 @@ describe('HierarchyPanel — model tags in the Models section (#4215)', () => {
     assert.equal(c.querySelectorAll('button[aria-label="Show model m1.ifc"]').length, 2, 'both rows of m1 read hidden');
     click(byLabel(c, 'Show models tagged Structure'));
     assert.deepEqual(visibility(), { m1: true, m2: true, m3: true });
+  });
+
+  it('a filter outlives the last model carrying its tag: Clear is still offered and lists every model again', () => {
+    const c = renderPanel();
+    click(byLabel(c, 'List models tagged Structure'));
+    act(() => { useViewerStore.getState().unassignModelTags(['m1', 'm2'], [structure]); });
+    assert.equal(c.querySelector('[data-model-tag-filter-count]')?.textContent, '0 of 3', 'the filter now lists nothing');
+    for (const id of ['m1', 'm2', 'm3']) assert.equal(modelRowsOf(c, id), 0);
+    assert.ok(c.querySelector('[aria-label="Stop listing models tagged Structure"]'), 'the filtering chip stays visible');
+    click(byLabel(c, 'Clear model tag filter'));
+    for (const id of ['m1', 'm2', 'm3']) assert.equal(modelRowsOf(c, id), 1, `${id} listed again`);
+    assert.equal(c.querySelector('[data-model-tag-filter-count]')?.textContent ?? null, null);
+    // Cleared and no longer carried by any model: Structure has no chip; Architecture (still on m1) has.
+    assert.equal(c.querySelector('[aria-label="List models tagged Structure"]') !== null, false);
+    assert.ok(c.querySelector('[aria-label="List models tagged Architecture"]'));
+  });
+
+  it('the view is torn down with the federation, so a fresh session never opens pre-filtered', () => {
+    useViewerStore.setState({ modelTagView: { groupByTag: true, filterTagIds: [structure], filterUntagged: false } });
+    useViewerStore.getState().clearAllModels();
+    assert.deepEqual(useViewerStore.getState().modelTagView, DEFAULT_MODEL_TAG_VIEW);
+    assert.equal(useViewerStore.getState().modelTags.size, 2, 'the vocabulary survives');
   });
 
   it('deleting a tag drops it from the row filter so the list does not silently go empty', () => {

--- a/apps/viewer/src/components/viewer/HierarchyPanel.modelTags.test.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.modelTags.test.tsx
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The federated hierarchy's Models section with model tags (issue #4215),
+ * mounted: the "By tag" grouping lists one header per tag plus Untagged with
+ * deduplicated counts, the tag chips FILTER the rows without touching
+ * visibility, "Isolate matching models" is the one action that does, and a
+ * group's eye flips every member in one write.
+ *
+ * Three models: m1 tagged Structure + Architecture, m2 Structure, m3 untagged.
+ */
+
+import '@/test/setup-dom.js';
+import { installLayout } from '@/test/dom-layout.js';
+
+installLayout();
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { federationRegistry } from '@ifc-lite/renderer';
+import { act } from 'react';
+import { render, cleanup, click } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types.js';
+import { DEFAULT_MODEL_TAG_VIEW } from '@/store/slices/modelTagsSlice.js';
+import { SourceHostProvider } from '@/services/sources/SourceHostProvider';
+import { HierarchyPanel } from './HierarchyPanel.js';
+
+/** Just what `buildUnifiedStoreys` and the MODELS section read: one storey. */
+function makeStore(storeyId: number, elevation: number, name: string): IfcDataStore {
+  return {
+    entityCount: 1,
+    spatialHierarchy: {
+      project: undefined,
+      byStorey: new Map([[storeyId, []]]),
+      storeyElevations: new Map([[storeyId, elevation]]),
+    },
+    entities: { getName: (id: number) => (id === storeyId ? name : undefined) },
+  } as unknown as IfcDataStore;
+}
+
+function federatedModel(id: string): FederatedModel {
+  return {
+    id, name: `${id}.ifc`, ifcDataStore: makeStore(5, 0, 'Level 1'), geometryResult: null, visible: true,
+    collapsed: false, schemaVersion: 'IFC4', loadedAt: 1, fileSize: 0, idOffset: 0, maxExpressId: 100,
+  } as FederatedModel;
+}
+
+let structure = '';
+let architecture = '';
+
+function seed(): void {
+  federationRegistry.clear();
+  for (const id of ['m1', 'm2', 'm3']) federationRegistry.registerModel(id, 100);
+  useViewerStore.setState({
+    models: new Map(['m1', 'm2', 'm3'].map((id) => [id, federatedModel(id)])),
+    ifcDataStore: null,
+    activeModelId: 'm1',
+    selectedStoreys: new Set<number>(),
+    hierarchyMode: 'spatial',
+    modelTags: new Map(),
+    modelTagAssignments: new Map(),
+    modelTagView: DEFAULT_MODEL_TAG_VIEW,
+  });
+  const s = useViewerStore.getState();
+  structure = s.createModelTag('Structure')!;
+  architecture = s.createModelTag('Architecture')!;
+  s.assignModelTags(['m1'], [structure, architecture]);
+  s.assignModelTags(['m2'], [structure]);
+}
+
+const renderPanel = () => render(<SourceHostProvider><HierarchyPanel /></SourceHostProvider>);
+
+const visibility = () =>
+  Object.fromEntries([...useViewerStore.getState().models].map(([id, m]) => [id, m.visible]));
+
+/** Every model row carries its eye toggle; a model listed twice has two. */
+const modelRowsOf = (root: ParentNode, modelId: string) =>
+  root.querySelectorAll(`button[aria-label^="Hide model ${modelId}.ifc"], button[aria-label^="Show model ${modelId}.ifc"]`).length;
+
+function byLabel(root: ParentNode, label: string): HTMLElement {
+  const hit = root.querySelector<HTMLElement>(`[aria-label="${label}"]`);
+  assert.ok(hit, `no control labelled "${label}"; have: ${[...root.querySelectorAll('[aria-label]')].map((e) => e.getAttribute('aria-label')).join(' | ')}`);
+  return hit;
+}
+
+function byText(root: ParentNode, text: string): HTMLElement {
+  const hit = [...root.querySelectorAll<HTMLElement>('button')].find((b) => b.textContent?.trim() === text);
+  assert.ok(hit, `no button reading "${text}"`);
+  return hit;
+}
+
+describe('HierarchyPanel — model tags in the Models section (#4215)', () => {
+  beforeEach(seed);
+  afterEach(() => { cleanup(); useViewerStore.setState({ modelTagView: DEFAULT_MODEL_TAG_VIEW }); });
+
+  it('flat by default: one row per model, no group headers, and the tag controls are offered', () => {
+    const c = renderPanel();
+    assert.equal(c.querySelectorAll('[data-model-tag-group]').length, 0);
+    for (const id of ['m1', 'm2', 'm3']) assert.equal(modelRowsOf(c, id), 1, `${id} listed once`);
+    assert.ok(c.querySelector('[data-model-tag-controls]'), 'the federation carries tags, so the controls show');
+  });
+
+  it('"By tag" lists one header per tag plus Untagged; a two-tag model is under both, counts are distinct models', () => {
+    const c = renderPanel();
+    click(byText(c, 'By tag'));
+    const headers = [...c.querySelectorAll<HTMLElement>('[data-model-tag-group]')];
+    // Name then the distinct-model count (the two spans render with no whitespace between).
+    assert.deepEqual(headers.map((h) => h.textContent?.trim()), ['Architecture1', 'Structure2', 'Untagged1']);
+    assert.equal(modelRowsOf(c, 'm1'), 2, 'm1 is listed under Architecture and under Structure');
+    assert.equal(modelRowsOf(c, 'm2'), 1);
+    assert.equal(modelRowsOf(c, 'm3'), 1);
+    assert.equal(useViewerStore.getState().models.size, 3, 'listing a model twice does not make it two models');
+    assert.deepEqual(visibility(), { m1: true, m2: true, m3: true }, 'grouping changes no visibility');
+  });
+
+  it('a tag chip FILTERS the rows and hides nothing; "Isolate matching models" is what hides', () => {
+    const c = renderPanel();
+    click(byLabel(c, 'List models tagged Structure'));
+    assert.equal(modelRowsOf(c, 'm1'), 1);
+    assert.equal(modelRowsOf(c, 'm2'), 1);
+    assert.equal(modelRowsOf(c, 'm3'), 0, 'the untagged model is not listed');
+    assert.deepEqual(visibility(), { m1: true, m2: true, m3: true }, 'filtering rows must not touch the viewport');
+    assert.equal(c.querySelector('[data-model-tag-filter-count]')?.textContent, '2 of 3');
+
+    click(byText(c, 'Isolate matching models'));
+    assert.deepEqual(visibility(), { m1: true, m2: true, m3: false }, 'the explicit action hides the rest');
+
+    click(byLabel(c, 'List untagged models'));
+    assert.equal(modelRowsOf(c, 'm3'), 1, 'Structure OR untagged lists all three');
+    click(byText(c, 'Isolate matching models'));
+    assert.deepEqual(visibility(), { m1: true, m2: true, m3: true }, 'isolate is absolute: a listed model is shown again');
+
+    click(byLabel(c, 'Clear model tag filter'));
+    assert.equal(c.querySelector('[data-model-tag-filter-count]'), null);
+    assert.equal(modelRowsOf(c, 'm3'), 1);
+  });
+
+  it('a group header\'s eye shows or hides every member of that group in one write, and only them', () => {
+    const c = renderPanel();
+    click(byText(c, 'By tag'));
+    click(byLabel(c, 'Hide models tagged Structure'));
+    assert.deepEqual(visibility(), { m1: false, m2: false, m3: true });
+    // m1 is also under Architecture: its ONE model is hidden there too.
+    assert.equal(modelRowsOf(c, 'm1'), 2);
+    assert.equal(c.querySelectorAll('button[aria-label="Show model m1.ifc"]').length, 2, 'both rows of m1 read hidden');
+    click(byLabel(c, 'Show models tagged Structure'));
+    assert.deepEqual(visibility(), { m1: true, m2: true, m3: true });
+  });
+
+  it('deleting a tag drops it from the row filter so the list does not silently go empty', () => {
+    const c = renderPanel();
+    click(byLabel(c, 'List models tagged Architecture'));
+    assert.equal(modelRowsOf(c, 'm2'), 0);
+    act(() => { useViewerStore.getState().deleteModelTag(architecture); });
+    assert.deepEqual(useViewerStore.getState().modelTagView.filterTagIds, []);
+    assert.equal(modelRowsOf(c, 'm2'), 1, 'no filter left → every model listed again');
+  });
+});

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -18,8 +18,7 @@ import { toast } from '@/components/ui/toast';
 import { useSourceHost } from '@/services/sources/SourceHostProvider';
 import { syncSourceModel } from '@/lib/sources/syncSourceModel';
 
-import type { TreeNode } from './hierarchy/types';
-import { isSpatialContainer } from './hierarchy/types';
+import { isSpatialContainer, type TreeNode } from './hierarchy/types';
 import { useHierarchyTree } from './hierarchy/useHierarchyTree';
 import { computeTypeIsolationLabel } from './hierarchy/typeIsolationLabel';
 import { HierarchyNode } from './hierarchy/HierarchyNode';

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -25,6 +25,7 @@ import { computeTypeIsolationLabel } from './hierarchy/typeIsolationLabel';
 import { HierarchyNode } from './hierarchy/HierarchyNode';
 import { SectionHeader } from './hierarchy/SectionHeader';
 import { useModelRowSize } from './hierarchy/ModelRowTags';
+import { ModelsSectionHeader, useModelTagView } from './hierarchy/ModelsSectionHeader';
 import { StoreyDisplayControls } from './hierarchy/StoreyDisplayControls';
 import { HierarchySortControl } from './hierarchy/HierarchySortControl';
 import { TOUR_ANCHORS, tourAnchor } from '@/lib/tours/anchors';
@@ -150,7 +151,7 @@ export function HierarchyPanel() {
   );
   const filteredNodes = useMemo(() => stripPartNodes(rawFilteredNodes), [stripPartNodes, rawFilteredNodes]);
   const storeysNodes = useMemo(() => stripPartNodes(rawStoreysNodes), [stripPartNodes, rawStoreysNodes]);
-  const modelsNodes = useMemo(() => stripPartNodes(rawModelsNodes), [stripPartNodes, rawModelsNodes]);
+  const modelsNodes = useModelTagView(useMemo(() => stripPartNodes(rawModelsNodes), [stripPartNodes, rawModelsNodes])); // #4215 tag filter / By tag: rows only
 
   // Explorer-style multi-select over the leaf element / space rows: Ctrl/Cmd
   // toggles, Shift selects the contiguous range in the visible order. Built
@@ -978,7 +979,7 @@ export function HierarchyPanel() {
 
           {/* Models Section */}
           <div style={{ height: `${(1 - splitRatio) * 100}%` }} className="flex flex-col min-h-0">
-            <SectionHeader icon={FileBox} title="Models" count={models.size} />
+            <ModelsSectionHeader count={models.size} />
             <div ref={modelsRef} className="flex-1 overflow-auto scrollbar-thin bg-white dark:bg-black">
               <div
                 style={{

--- a/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/HierarchyNode.tsx
@@ -19,6 +19,7 @@ import type { TreeNode } from './types';
 import { isSpatialContainer } from './types';
 import { IFC_ICON_CODEPOINTS, IFC_ICON_DEFAULT } from './ifc-icons';
 import { ModelRowTags } from './ModelRowTags';
+import { ModelTagGroupRow } from './ModelTagGroupRow';
 
 /**
  * Resolve the Material Symbols code point for a given IFC type string.
@@ -92,6 +93,7 @@ export function HierarchyNode({
       : 'text-zinc-700 dark:text-zinc-300';
   const strikeWhenHidden = nodeHidden && 'line-through decoration-zinc-400 dark:decoration-zinc-600';
 
+  if (node.type === 'model-tag-group') return <ModelTagGroupRow node={node} virtualRow={virtualRow} />;
   // Model header nodes (for visibility control and expansion)
   if (node.type === 'model-header' && node.id.startsWith('model-')) {
     const modelId = node.modelIds[0];

--- a/apps/viewer/src/components/viewer/hierarchy/ModelTagGroupRow.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/ModelTagGroupRow.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A `model-tag-group` header row in the Models section's "By tag" view
+ * (#4215): the tag's name, how many DISTINCT models carry it, and one eye
+ * that shows or hides all of them in a single store write.
+ *
+ * Rendered by `HierarchyNode` for that node type; everything the row needs
+ * beyond the node is read from the store here, so the (size-capped)
+ * `HierarchyNode` gains one line.
+ */
+
+import { Eye, EyeOff, Tag } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { useViewerStore } from '@/store';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { UNTAGGED_GROUP_ID } from './modelTagView';
+import type { TreeNode } from './types';
+
+export function ModelTagGroupRow({ node, virtualRow }: { node: TreeNode; virtualRow: { size: number; start: number } }) {
+  const { models, setModelsVisibility, tag } = useViewerStore(
+    useShallow((s) => ({
+      models: s.models,
+      setModelsVisibility: s.setModelsVisibility,
+      tag: s.modelTags.get(node.id.slice('model-tag-group:'.length)),
+    })),
+  );
+  const members = node.modelIds;
+  const visibleCount = members.filter((id) => models.get(id)?.visible).length;
+  const allVisible = members.length > 0 && visibleCount === members.length;
+  const isUntagged = node.id === `model-tag-group:${UNTAGGED_GROUP_ID}`;
+
+  return (
+    <div
+      style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: `${virtualRow.size}px`, transform: `translateY(${virtualRow.start}px)` }}
+    >
+      <div
+        className={cn(
+          'flex items-center gap-1.5 px-2 py-1.5 border-l-4 border-transparent group',
+          'bg-zinc-50 dark:bg-zinc-950 text-zinc-800 dark:text-zinc-200',
+          members.length > 0 && visibleCount === 0 && 'opacity-50',
+        )}
+        data-model-tag-group={isUntagged ? UNTAGGED_GROUP_ID : tag?.id ?? ''}
+      >
+        <Tag className="h-3.5 w-3.5 shrink-0 text-zinc-400" style={tag?.color ? { color: tag.color } : undefined} />
+        <span className={cn('flex-1 truncate text-xs font-semibold', isUntagged && 'italic')}>{node.name}</span>
+        <span
+          className="text-[10px] font-mono bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 text-zinc-500 dark:text-zinc-400"
+          title={`${members.length} model${members.length === 1 ? '' : 's'}`}
+        >
+          {members.length}
+        </span>
+        {members.length > 0 && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => { e.stopPropagation(); setModelsVisibility(members, !allVisible); }}
+                aria-label={allVisible ? `Hide models tagged ${node.name}` : `Show models tagged ${node.name}`}
+                className="p-0.5 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+              >
+                {allVisible ? (
+                  <Eye className="h-3.5 w-3.5 text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100" />
+                ) : (
+                  <EyeOff className="h-3.5 w-3.5 text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="text-xs">{allVisible ? 'Hide these models' : 'Show these models'}</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/hierarchy/ModelsSectionHeader.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/ModelsSectionHeader.tsx
@@ -8,8 +8,10 @@
  * Both halves read ONE store field (`modelTagView`), so the chips and the
  * rows cannot disagree about what is filtered or grouped.
  *
- * Controls (only once some loaded model carries a tag — a federation with no
- * tags looks exactly as it did):
+ * Controls (once some loaded model carries a tag — a federation with no tags
+ * looks exactly as it did — and for as long as a filter or the grouping is
+ * set, so the control that clears it can never vanish with the last tagged
+ * model and strand an empty section):
  *  - **By tag** — group the rows, with an explicit Untagged group;
  *  - one chip per tag in use, plus **Untagged** — a ROW filter: it lists
  *    fewer models and hides nothing in the viewport;
@@ -65,6 +67,13 @@ export function ModelsSectionHeader({ count }: { count: number }) {
     () => (filterActive ? modelIdsMatchingTagView(models.keys(), view, assignments) : null),
     [filterActive, models, view, assignments],
   );
+  // A filter naming a tag no loaded model carries any more (the user just
+  // unassigned it) keeps its chip, so the user can see what is filtering.
+  const strayFilterTags = useMemo(
+    () => view.filterTagIds.filter((id) => tags.has(id) && !inUse.some((t) => t.id === id)).map((id) => tags.get(id)!),
+    [view.filterTagIds, tags, inUse],
+  );
+  const chips = strayFilterTags.length > 0 ? [...inUse, ...strayFilterTags].sort((a, b) => a.name.localeCompare(b.name)) : inUse;
 
   const toggleTag = (id: string) =>
     setModelTagView({
@@ -74,7 +83,7 @@ export function ModelsSectionHeader({ count }: { count: number }) {
   return (
     <>
       <SectionHeader icon={FileBox} title="Models" count={count} />
-      {inUse.length > 0 && (
+      {(inUse.length > 0 || filterActive || view.groupByTag) && (
         <div className="flex flex-wrap items-center gap-1 px-2 py-1 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-950" data-model-tag-controls>
           <Button
             variant={view.groupByTag ? 'default' : 'outline'}
@@ -87,7 +96,7 @@ export function ModelsSectionHeader({ count }: { count: number }) {
             <Tag className="mr-1 h-3 w-3" /> By tag
           </Button>
           <span className="mx-1 h-3 w-px bg-zinc-300 dark:bg-zinc-700" aria-hidden />
-          {inUse.map((tag) => {
+          {chips.map((tag) => {
             const active = view.filterTagIds.includes(tag.id);
             return (
               <Button

--- a/apps/viewer/src/components/viewer/hierarchy/ModelsSectionHeader.tsx
+++ b/apps/viewer/src/components/viewer/hierarchy/ModelsSectionHeader.tsx
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Models section of the federated hierarchy (#4215): its header, the tag
+ * controls under it, and the hook that applies the same view to the rows.
+ * Both halves read ONE store field (`modelTagView`), so the chips and the
+ * rows cannot disagree about what is filtered or grouped.
+ *
+ * Controls (only once some loaded model carries a tag — a federation with no
+ * tags looks exactly as it did):
+ *  - **By tag** — group the rows, with an explicit Untagged group;
+ *  - one chip per tag in use, plus **Untagged** — a ROW filter: it lists
+ *    fewer models and hides nothing in the viewport;
+ *  - **Isolate matching models** — the explicit viewport action: show the
+ *    listed models, hide the rest, in one store write.
+ */
+
+import { useMemo } from 'react';
+import { Eye, FileBox, Tag } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import { useViewerStore } from '@/store';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { SectionHeader } from './SectionHeader';
+import type { TreeNode } from './types';
+import { applyModelTagView, isModelTagFilterActive, modelIdsMatchingTagView } from './modelTagView';
+
+/** The Models-section rows under the current tag view. */
+export function useModelTagView(nodes: TreeNode[]): TreeNode[] {
+  const { view, tags, assignments } = useViewerStore(
+    useShallow((s) => ({ view: s.modelTagView, tags: s.modelTags, assignments: s.modelTagAssignments })),
+  );
+  return useMemo(() => applyModelTagView(nodes, view, tags, assignments), [nodes, view, tags, assignments]);
+}
+
+const chipClass = (active: boolean) =>
+  cn(
+    'h-5 rounded-none px-1.5 text-[10px] uppercase tracking-wider',
+    !active && 'text-zinc-600 dark:text-zinc-400',
+  );
+
+export function ModelsSectionHeader({ count }: { count: number }) {
+  const { view, tags, assignments, models, setModelTagView, isolateModels } = useViewerStore(
+    useShallow((s) => ({
+      view: s.modelTagView,
+      tags: s.modelTags,
+      assignments: s.modelTagAssignments,
+      models: s.models,
+      setModelTagView: s.setModelTagView,
+      isolateModels: s.isolateModels,
+    })),
+  );
+
+  // Tags some LOADED model carries, by name — not the whole browser vocabulary.
+  const inUse = useMemo(() => {
+    const ids = new Set<string>();
+    for (const modelId of models.keys()) for (const id of assignments.get(modelId) ?? []) if (tags.has(id)) ids.add(id);
+    return [...ids].map((id) => tags.get(id)!).sort((a, b) => a.name.localeCompare(b.name));
+  }, [models, assignments, tags]);
+
+  const filterActive = isModelTagFilterActive(view);
+  const matching = useMemo(
+    () => (filterActive ? modelIdsMatchingTagView(models.keys(), view, assignments) : null),
+    [filterActive, models, view, assignments],
+  );
+
+  const toggleTag = (id: string) =>
+    setModelTagView({
+      filterTagIds: view.filterTagIds.includes(id) ? view.filterTagIds.filter((t) => t !== id) : [...view.filterTagIds, id],
+    });
+
+  return (
+    <>
+      <SectionHeader icon={FileBox} title="Models" count={count} />
+      {inUse.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1 px-2 py-1 border-b border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-950" data-model-tag-controls>
+          <Button
+            variant={view.groupByTag ? 'default' : 'outline'}
+            size="sm"
+            aria-pressed={view.groupByTag}
+            className={chipClass(view.groupByTag)}
+            onClick={() => setModelTagView({ groupByTag: !view.groupByTag })}
+            title="Group the model rows by tag, with an Untagged group"
+          >
+            <Tag className="mr-1 h-3 w-3" /> By tag
+          </Button>
+          <span className="mx-1 h-3 w-px bg-zinc-300 dark:bg-zinc-700" aria-hidden />
+          {inUse.map((tag) => {
+            const active = view.filterTagIds.includes(tag.id);
+            return (
+              <Button
+                key={tag.id}
+                variant={active ? 'default' : 'outline'}
+                size="sm"
+                aria-pressed={active}
+                aria-label={`${active ? 'Stop listing' : 'List'} models tagged ${tag.name}`}
+                className={chipClass(active)}
+                onClick={() => toggleTag(tag.id)}
+                title={`List the models tagged ${tag.name} — this filters the rows, it does not hide models`}
+              >
+                {tag.name}
+              </Button>
+            );
+          })}
+          <Button
+            variant={view.filterUntagged ? 'default' : 'outline'}
+            size="sm"
+            aria-pressed={view.filterUntagged}
+            aria-label={`${view.filterUntagged ? 'Stop listing' : 'List'} untagged models`}
+            className={chipClass(view.filterUntagged)}
+            onClick={() => setModelTagView({ filterUntagged: !view.filterUntagged })}
+            title="List the models that carry no tag"
+          >
+            Untagged
+          </Button>
+          {filterActive && matching && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className={chipClass(false)}
+                onClick={() => isolateModels(matching)}
+                title="Show the listed models and hide every other model in the viewport"
+              >
+                <Eye className="mr-1 h-3 w-3" /> Isolate matching models
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={chipClass(false)}
+                aria-label="Clear model tag filter"
+                onClick={() => setModelTagView({ filterTagIds: [], filterUntagged: false })}
+              >
+                Clear
+              </Button>
+              <span className="ml-auto text-[10px] font-mono text-zinc-500" data-model-tag-filter-count>
+                {matching.length} of {models.size}
+              </span>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/viewer/src/components/viewer/hierarchy/modelTagView.test.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/modelTagView.test.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Models section's tag view (issue #4215) over the rows the REAL tree
+ * builder emits for a three-model federation: the row filter lists fewer
+ * models and touches nothing else; "By tag" groups them under one header
+ * per tag plus an explicit Untagged group; a model under two tags is listed
+ * under both but counted once per group and keeps its own model id on every
+ * row.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { FederatedModel } from '@/store/types.js';
+import { DEFAULT_MODEL_TAG_VIEW, type ModelTagView } from '@/store/slices/modelTagsSlice.js';
+import type { ModelTag } from '@/lib/model-tags/types.js';
+import { buildTreeData, buildUnifiedStoreys, splitNodes } from './treeDataBuilder.js';
+import {
+  applyModelTagView,
+  groupModelBlocks,
+  modelIdsMatchingTagView,
+  splitModelBlocks,
+  UNTAGGED_GROUP_ID,
+} from './modelTagView.js';
+import type { TreeNode } from './types.js';
+
+/** Just what the MODELS section of `buildTreeData` reads: one storey, no project. */
+function makeStore(storeyId: number): IfcDataStore {
+  return {
+    entityCount: 7,
+    spatialHierarchy: {
+      project: undefined,
+      byStorey: new Map([[storeyId, []]]),
+      storeyElevations: new Map([[storeyId, 0]]),
+    },
+    entities: { getName: () => 'Level' },
+  } as unknown as IfcDataStore;
+}
+
+function federatedModel(id: string): FederatedModel {
+  return {
+    id, name: `${id}.ifc`, ifcDataStore: makeStore(5), geometryResult: null, visible: true, collapsed: false,
+    schemaVersion: 'IFC4', loadedAt: 1, fileSize: 0, idOffset: 0, maxExpressId: 100,
+  } as FederatedModel;
+}
+
+const S: ModelTag = { id: 'tag-s', name: 'Structure' };
+const A: ModelTag = { id: 'tag-a', name: 'Architecture' };
+const tags = new Map([[S.id, S], [A.id, A]]);
+/** m1 Structure + Architecture, m2 Structure, m3 untagged. */
+const assignments = new Map([['m1', new Set([S.id, A.id])], ['m2', new Set([S.id])]]);
+
+/** The Models-section rows exactly as the panel gets them from the builder. */
+function modelRows(): TreeNode[] {
+  const models = new Map(['m1', 'm2', 'm3'].map((id) => [id, federatedModel(id)]));
+  const storeys = buildUnifiedStoreys(models, 'elevation-desc');
+  const nodes = buildTreeData(models, null, new Set(), true, storeys, 'elevation-desc');
+  return splitNodes(nodes, true).modelsNodes;
+}
+
+const view = (patch: Partial<ModelTagView>): ModelTagView => ({ ...DEFAULT_MODEL_TAG_VIEW, ...patch });
+const modelIdsOf = (nodes: TreeNode[]) => nodes.filter((n) => n.type === 'model-header').map((n) => n.modelIds[0]);
+
+describe('modelTagView (#4215)', () => {
+  it('fixture sanity: the builder emits one model row per model, in federation order', () => {
+    assert.deepEqual(splitModelBlocks(modelRows()).map((b) => b.modelId), ['m1', 'm2', 'm3']);
+  });
+
+  it('no view → the rows pass through unchanged', () => {
+    const rows = modelRows();
+    assert.deepEqual(applyModelTagView(rows, DEFAULT_MODEL_TAG_VIEW, tags, assignments), rows);
+  });
+
+  it('the row filter lists models carrying ANY of the chosen tags, or untagged when asked — and nothing else changes', () => {
+    const rows = modelRows();
+    const structure = applyModelTagView(rows, view({ filterTagIds: [S.id] }), tags, assignments);
+    assert.deepEqual(modelIdsOf(structure), ['m1', 'm2']);
+    assert.deepEqual(structure.map((n) => n.isVisible), [true, true], 'a row filter never rewrites visibility');
+    assert.deepEqual(modelIdsOf(applyModelTagView(rows, view({ filterTagIds: [A.id] }), tags, assignments)), ['m1']);
+    assert.deepEqual(modelIdsOf(applyModelTagView(rows, view({ filterUntagged: true }), tags, assignments)), ['m3']);
+    assert.deepEqual(
+      modelIdsOf(applyModelTagView(rows, view({ filterTagIds: [A.id], filterUntagged: true }), tags, assignments)),
+      ['m1', 'm3'],
+    );
+    // What "Isolate matching models" is handed: the same answer, as ids.
+    assert.deepEqual(modelIdsMatchingTagView(['m1', 'm2', 'm3'], view({ filterTagIds: [S.id] }), assignments), ['m1', 'm2']);
+  });
+
+  it('a filter naming only a deleted tag lists nothing rather than everything', () => {
+    assert.deepEqual(modelIdsOf(applyModelTagView(modelRows(), view({ filterTagIds: ['tag-gone'] }), tags, assignments)), []);
+  });
+
+  it('"By tag" groups by tag name, then an explicit Untagged group; a two-tag model is under both, counted once each', () => {
+    const grouped = applyModelTagView(modelRows(), view({ groupByTag: true }), tags, assignments);
+    const headers = grouped.filter((n) => n.type === 'model-tag-group');
+    assert.deepEqual(headers.map((h) => [h.name, h.elementCount]), [['Architecture', 1], ['Structure', 2], ['Untagged', 1]]);
+    assert.deepEqual(
+      grouped.map((n) => (n.type === 'model-tag-group' ? `#${n.name}` : n.modelIds[0])),
+      ['#Architecture', 'm1', '#Structure', 'm1', 'm2', '#Untagged', 'm3'],
+    );
+    // One model, two rows: each row still names the model, and the ids differ only so React can key them.
+    const m1Rows = grouped.filter((n) => n.type === 'model-header' && n.modelIds[0] === 'm1');
+    assert.equal(m1Rows.length, 2);
+    assert.notEqual(m1Rows[0].id, m1Rows[1].id);
+    assert.ok(m1Rows.every((n) => n.id.startsWith('model-')), 'the panel recognises a model row by this prefix');
+    assert.ok(m1Rows.every((n) => !n.hasChildren), 'grouped rows do not drill down (expansion is keyed on the ungrouped id)');
+    const distinct = new Set(grouped.filter((n) => n.type === 'model-header').map((n) => n.modelIds[0]));
+    assert.equal(distinct.size, 3, 'the federation is still three models');
+  });
+
+  it('Untagged is shown when empty (every model is tagged) unless a filter excludes untagged models', () => {
+    const allTagged = new Map([...assignments, ['m3', new Set([A.id])]]);
+    const blocks = splitModelBlocks(modelRows());
+    const withEmpty = groupModelBlocks(blocks, view({ groupByTag: true }), tags, allTagged);
+    assert.deepEqual(withEmpty.at(-1), { id: UNTAGGED_GROUP_ID, name: 'Untagged', tag: null, modelIds: [] });
+
+    // Filtering to Architecture lists m1 only — which still carries Structure, so it is under both; no Untagged row.
+    const filtered = applyModelTagView(modelRows(), view({ groupByTag: true, filterTagIds: [A.id] }), tags, assignments);
+    assert.deepEqual(filtered.filter((n) => n.type === 'model-tag-group').map((n) => n.name), ['Architecture', 'Structure']);
+    assert.deepEqual(filtered.filter((n) => n.type === 'model-header').map((n) => n.modelIds[0]), ['m1', 'm1']);
+  });
+
+  it('a tag that was deleted but is still in an assignment set neither groups nor counts', () => {
+    const stale = new Map([['m1', new Set(['tag-gone'])]]);
+    const grouped = applyModelTagView(modelRows(), view({ groupByTag: true }), tags, stale);
+    assert.deepEqual(grouped.filter((n) => n.type === 'model-tag-group').map((n) => [n.name, n.elementCount]), [['Untagged', 3]]);
+  });
+});

--- a/apps/viewer/src/components/viewer/hierarchy/modelTagView.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/modelTagView.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Models section's tag view (#4215), as a pure transform over the rows
+ * `treeDataBuilder` already produces for that section: which model rows are
+ * LISTED (the tag filter) and whether they are grouped under one header per
+ * tag plus an explicit **Untagged** group.
+ *
+ * Two things this is not:
+ *  - It is not visibility. Filtering the rows changes nothing in the
+ *    viewport; "Isolate matching models" is a separate, explicit action
+ *    (`modelSlice.isolateModels`) that this module only computes the input
+ *    for ({@link modelIdsMatchingTagView}).
+ *  - It is not a second evaluator. The filter here is the hierarchy's quick
+ *    "show me models tagged …" (any-of, plus untagged); the search / clash /
+ *    list predicates with their four operators live in `lib/model-tags`.
+ *
+ * ## One model, several groups
+ * A model carrying two tags is listed under both groups. It is still ONE
+ * model: its rows keep `modelIds: [modelId]`, so the eye toggle and the
+ * row's actions act on the model wherever it was clicked; each group's count
+ * is its DISTINCT members; and the row ids are made unique per group
+ * (`model-<id>@<group>`) only so React can key the two rows — the id still
+ * starts with `model-`, which is how `HierarchyNode` and the panel's node
+ * state recognise a model row.
+ *
+ * Grouped rows do not expand to Project / Site / Building: expansion is
+ * keyed on the ungrouped `model-<id>` id in `treeDataBuilder`, and a model
+ * under two groups would otherwise have to expand in both or neither. The
+ * flat view and the storeys section keep the spatial drill-down.
+ */
+
+import type { ModelTag } from '@/lib/model-tags/types';
+import type { ModelTagView } from '@/store/slices/modelTagsSlice';
+import type { TreeNode } from './types';
+
+/** Group id of the explicit Untagged group; never a tag id (tag ids are UUIDs). */
+export const UNTAGGED_GROUP_ID = 'untagged';
+
+export type ModelTagAssignments = ReadonlyMap<string, ReadonlySet<string>>;
+
+/** Is any row filter set? (Grouping alone is not a filter.) */
+export function isModelTagFilterActive(view: ModelTagView): boolean {
+  return view.filterTagIds.length > 0 || view.filterUntagged;
+}
+
+/** Does a model carrying `tagIds` pass the row filter? Everything passes an inactive filter. */
+export function modelMatchesTagView(view: ModelTagView, tagIds: ReadonlySet<string> | undefined): boolean {
+  if (!isModelTagFilterActive(view)) return true;
+  const size = tagIds?.size ?? 0;
+  if (view.filterUntagged && size === 0) return true;
+  return view.filterTagIds.some((id) => tagIds?.has(id));
+}
+
+/** The loaded models the row filter lists — the input to "Isolate matching models". */
+export function modelIdsMatchingTagView(
+  modelIds: Iterable<string>,
+  view: ModelTagView,
+  assignments: ModelTagAssignments,
+): string[] {
+  const out: string[] = [];
+  for (const id of modelIds) if (modelMatchesTagView(view, assignments.get(id))) out.push(id);
+  return out;
+}
+
+/** One model row and the rows nested under it, as `treeDataBuilder` emitted them. */
+export interface ModelBlock {
+  modelId: string;
+  /** `nodes[0]` is the `model-<id>` row; the rest its expanded descendants. */
+  nodes: TreeNode[];
+}
+
+/** Cut the Models-section row list into per-model blocks, in federation order. */
+export function splitModelBlocks(nodes: readonly TreeNode[]): ModelBlock[] {
+  const blocks: ModelBlock[] = [];
+  for (const node of nodes) {
+    if (node.type === 'model-header' && node.id.startsWith('model-')) {
+      blocks.push({ modelId: node.modelIds[0], nodes: [node] });
+    } else if (blocks.length > 0) {
+      blocks[blocks.length - 1].nodes.push(node);
+    }
+  }
+  return blocks;
+}
+
+/** One group of the "By tag" view: a tag (or Untagged) and its distinct members. */
+export interface ModelTagGroup {
+  id: string;
+  name: string;
+  tag: ModelTag | null;
+  modelIds: string[];
+}
+
+/**
+ * Groups for `blocks`: one per tag some listed model carries (by name), then
+ * Untagged. Untagged is emitted even when empty unless the row filter is
+ * active and excludes untagged models — "every model is tagged" is worth a
+ * row that says so; "you filtered them out" is not.
+ */
+export function groupModelBlocks(
+  blocks: readonly ModelBlock[],
+  view: ModelTagView,
+  tags: ReadonlyMap<string, ModelTag>,
+  assignments: ModelTagAssignments,
+): ModelTagGroup[] {
+  const byTag = new Map<string, string[]>();
+  const untagged: string[] = [];
+  for (const { modelId } of blocks) {
+    const carried = [...(assignments.get(modelId) ?? [])].filter((id) => tags.has(id));
+    if (carried.length === 0) { untagged.push(modelId); continue; }
+    for (const id of carried) {
+      const members = byTag.get(id) ?? [];
+      if (!members.includes(modelId)) members.push(modelId);
+      byTag.set(id, members);
+    }
+  }
+  const groups: ModelTagGroup[] = [...byTag]
+    .map(([id, modelIds]) => ({ id, name: tags.get(id)!.name, tag: tags.get(id)!, modelIds }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const showUntagged = untagged.length > 0 || !isModelTagFilterActive(view) || view.filterUntagged;
+  if (showUntagged) groups.push({ id: UNTAGGED_GROUP_ID, name: 'Untagged', tag: null, modelIds: untagged });
+  return groups;
+}
+
+/**
+ * The rows the Models section renders under `view`: the filter applied, and
+ * when `groupByTag` is on, one `model-tag-group` header per group followed by
+ * its members' model rows (collapsed — see the module doc).
+ */
+export function applyModelTagView(
+  nodes: readonly TreeNode[],
+  view: ModelTagView,
+  tags: ReadonlyMap<string, ModelTag>,
+  assignments: ModelTagAssignments,
+): TreeNode[] {
+  if (!view.groupByTag && !isModelTagFilterActive(view)) return [...nodes];
+  const blocks = splitModelBlocks(nodes).filter((b) => modelMatchesTagView(view, assignments.get(b.modelId)));
+  if (!view.groupByTag) return blocks.flatMap((b) => b.nodes);
+
+  const rowOf = new Map(blocks.map((b) => [b.modelId, b.nodes[0]]));
+  const out: TreeNode[] = [];
+  for (const group of groupModelBlocks(blocks, view, tags, assignments)) {
+    out.push({
+      id: `model-tag-group:${group.id}`,
+      expressIds: [],
+      globalIds: [],
+      modelIds: group.modelIds,
+      name: group.name,
+      type: 'model-tag-group',
+      depth: 0,
+      hasChildren: group.modelIds.length > 0,
+      isExpanded: true,
+      isVisible: true,
+      elementCount: group.modelIds.length,
+    });
+    for (const modelId of group.modelIds) {
+      const row = rowOf.get(modelId)!;
+      out.push({ ...row, id: `${row.id}@${group.id}`, hasChildren: false, isExpanded: false, depth: 1 });
+    }
+  }
+  return out;
+}

--- a/apps/viewer/src/components/viewer/hierarchy/types.ts
+++ b/apps/viewer/src/components/viewer/hierarchy/types.ts
@@ -28,6 +28,7 @@ export type NodeType =
   | 'material-group'      // Material grouping (e.g., "Concrete (47)") from the Materials tab
   | 'group'               // IfcGroup/IfcSystem/IfcZone entity row from the Groups tab (#1622)
   | 'group-member'        // Member row under an expanded group (#1622)
+  | 'model-tag-group'     // Model-tag group header in the Models section's "By tag" view (#4215)
   | 'element';            // Individual element
 
 export interface TreeNode {

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.parts.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.parts.tsx
@@ -46,13 +46,11 @@ export function Chip({
   onClick,
   trailing,
   children,
-  className,
 }: {
   selected: boolean;
   onClick: () => void;
   trailing?: React.ReactNode;
   children: React.ReactNode;
-  className?: string;
 }) {
   return (
     <button
@@ -64,7 +62,6 @@ export function Chip({
         selected
           ? 'border-primary bg-primary text-primary-foreground shadow-sm'
           : 'border-border bg-background hover:bg-muted',
-        className,
       )}
     >
       {children}

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.parts.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.parts.tsx
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The list builder's two presentational shells, split out of
+ * `ListBuilder.tsx` (which carries a recorded budget in
+ * `scripts/module-size-allowlist.txt`) so the model tag scope editor (#4215)
+ * can share the same `Chip` and sit in the same `Section` as the entity-type
+ * chips.
+ */
+
+import type React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/** Section shell — consistent header with an accent rule. */
+export function Section({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="mb-2 flex items-center gap-2">
+        <span className="h-3 w-1 rounded-full bg-primary/70" aria-hidden />
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        {hint !== undefined && (
+          <Badge variant="secondary" className="h-4 px-1.5 text-[10px] font-normal">{hint}</Badge>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** A toggleable pill with an optional trailing count. */
+export function Chip({
+  selected,
+  onClick,
+  trailing,
+  children,
+  className,
+}: {
+  selected: boolean;
+  onClick: () => void;
+  trailing?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
+        selected
+          ? 'border-primary bg-primary text-primary-foreground shadow-sm'
+          : 'border-border bg-background hover:bg-muted',
+        className,
+      )}
+    >
+      {children}
+      {trailing !== undefined && (
+        <span className={cn('tabular-nums', selected ? 'opacity-80' : 'text-muted-foreground')}>{trailing}</span>
+      )}
+    </button>
+  );
+}

--- a/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListBuilder.tsx
@@ -18,7 +18,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ComboInput } from '@/components/ui/combo-input';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { IfcTypeEnum } from '@ifc-lite/data';
 import { collectSpatialContainerNames } from '@/utils/spatialHierarchy';
@@ -31,6 +30,7 @@ import {
 import type {
   ListDataProvider,
   ListDefinition,
+  ListModelTagScope,
   ColumnDefinition,
   DiscoveredColumns,
   PropertyCondition,
@@ -48,6 +48,8 @@ import { useViewerStore } from '@/store';
 import type { ZoneSet } from '@/lib/zones';
 import { collectScopeTypes } from '@/lib/lists/scope-types';
 import { rebuildGrouping } from './list-table-utils';
+import { Section, Chip } from './ListBuilder.parts';
+import { ListModelTagScopeEditor } from './ListModelTagScopeEditor';
 import {
   isEditableColumn,
   draftFromColumn,
@@ -182,6 +184,8 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
   );
   const [columns, setColumns] = useState<ColumnDefinition[]>(initial?.columns ?? []);
   const [conditions, setConditions] = useState<PropertyCondition[]>(initial?.conditions ?? []);
+  // Which federated models the list runs over, by model tag (#4215).
+  const [modelTagScope, setModelTagScope] = useState<ListModelTagScope | undefined>(initial?.modelTagScope);
   // Lazily-discovered distinct values for condition suggestions. This is the
   // EXPENSIVE sampling pass, so only run it when a property / material /
   // classification condition exists — storey-only filters never trigger it.
@@ -395,11 +399,12 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
       entityTypes: Array.from(selectedTypes),
       // Preserve a filter-snapshot scope (set at creation; not edited here).
       expressIdsByModel: initial?.expressIdsByModel,
+      modelTagScope,
       conditions,
       columns,
       grouping,
     };
-  }, [initial, name, description, selectedTypes, conditions, columns, groupByColumnIds, sumColumnIds]);
+  }, [initial, name, description, selectedTypes, modelTagScope, conditions, columns, groupByColumnIds, sumColumnIds]);
 
   const handleSave = useCallback(() => onSave(buildDefinition()), [buildDefinition, onSave]);
   const handleRun = useCallback(() => onExecute(buildDefinition()), [buildDefinition, onExecute]);
@@ -477,6 +482,7 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
                 )}
               </>
             )}
+            <ListModelTagScopeEditor value={modelTagScope} onChange={setModelTagScope} />
           </Section>
 
           {/* Filters */}
@@ -545,66 +551,6 @@ export function ListBuilder({ providers, stores, initial, onSave, onCancel, onEx
         </Button>
       </div>
     </div>
-  );
-}
-
-// ============================================================================
-// Section shell — consistent header with an accent rule
-// ============================================================================
-
-function Section({
-  label,
-  hint,
-  children,
-}: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <section>
-      <div className="mb-2 flex items-center gap-2">
-        <span className="h-3 w-1 rounded-full bg-primary/70" aria-hidden />
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          {label}
-        </span>
-        {hint !== undefined && (
-          <Badge variant="secondary" className="h-4 px-1.5 text-[10px] font-normal">{hint}</Badge>
-        )}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function Chip({
-  selected,
-  onClick,
-  trailing,
-  children,
-}: {
-  selected: boolean;
-  onClick: () => void;
-  trailing?: React.ReactNode;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={selected}
-      className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-colors',
-        selected
-          ? 'border-primary bg-primary text-primary-foreground shadow-sm'
-          : 'border-border bg-background hover:bg-muted',
-      )}
-    >
-      {children}
-      {trailing !== undefined && (
-        <span className={cn('tabular-nums', selected ? 'opacity-80' : 'text-muted-foreground')}>{trailing}</span>
-      )}
-    </button>
   );
 }
 

--- a/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.test.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.test.tsx
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The list builder's model tag scope editor (issue #4215), mounted: the
+ * operators read as they do in the advanced filter, a chosen scope is
+ * summarised under the select so a saved list shows what it is restricted
+ * to, and a tag the scope names but that no longer exists is drawn, not hidden.
+ */
+
+import '@/test/setup-dom.js';
+import { installLayout } from '@/test/dom-layout.js';
+
+installLayout();
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { ListModelTagScope } from '@ifc-lite/lists';
+import { render, cleanup, click } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { ListModelTagScopeEditor } from './ListModelTagScopeEditor.js';
+
+let structure = '';
+let mep = '';
+
+function seed(): void {
+  useViewerStore.setState({ models: new Map(), modelTags: new Map(), modelTagAssignments: new Map() });
+  const s = useViewerStore.getState();
+  structure = s.createModelTag('Structure')!;
+  mep = s.createModelTag('MEP')!;
+}
+
+function mount(value: ListModelTagScope | undefined) {
+  const changes: (ListModelTagScope | undefined)[] = [];
+  const container = render(<ListModelTagScopeEditor value={value} onChange={(next) => changes.push(next)} />);
+  return { container, changes };
+}
+
+const optionLabels = (root: ParentNode) => [...root.querySelectorAll<HTMLOptionElement>('select option')].map((o) => o.textContent);
+const hint = (root: ParentNode) => root.querySelector('[data-list-model-tag-scope-hint]')?.textContent ?? null;
+
+describe('ListModelTagScopeEditor (#4215)', () => {
+  beforeEach(seed);
+  afterEach(cleanup);
+
+  it('offers the four predicates in the advanced filter\'s own words, after "all models"', () => {
+    const { container } = mount(undefined);
+    assert.deepEqual(optionLabels(container), ['all models', 'has any of', 'has all of', 'has none of', 'is untagged']);
+    assert.equal(hint(container), null, 'no scope, nothing to summarise');
+  });
+
+  it('summarises the chosen scope under the select, and says when no tag is picked yet', () => {
+    const empty = mount({ op: 'hasAny', tagIds: [] });
+    assert.equal(hint(empty.container), null);
+    assert.match(empty.container.textContent ?? '', /Pick at least one tag/);
+    cleanup();
+
+    const { container, changes } = mount({ op: 'hasAll', tagIds: [structure, mep] });
+    assert.equal(hint(container), 'Runs over models that have all of Structure, MEP.');
+    click([...container.querySelectorAll('button')].find((b) => b.textContent?.startsWith('MEP'))!);
+    assert.deepEqual(changes, [{ op: 'hasAll', tagIds: [structure] }], 'toggling a chip narrows the scope by id');
+    cleanup();
+
+    assert.equal(hint(mount({ op: 'untagged', tagIds: [] }).container), 'Runs over untagged models.');
+  });
+
+  it('draws a tag the scope names but that no longer exists, with the refusal spelled out', () => {
+    const { container } = mount({ op: 'hasAny', tagIds: [structure, 'tag-gone'] });
+    assert.match(container.querySelector('[role="alert"]')?.textContent ?? '', /no longer exists/);
+    assert.ok(container.querySelector('[data-model-tag-chip][data-unresolved]'), 'the stale reference is visible so it can be removed');
+  });
+});

--- a/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.tsx
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The list builder's MODEL scope by tag (#4215): which federated models the
+ * list runs over, in the same four words search and clash use. Sits inside
+ * the builder's Scope section, under the entity-type chips those models are
+ * then filtered by.
+ *
+ * A tag id the scope names but that no longer exists is drawn as an amber
+ * "Unknown tag" chip, not hidden — the run refuses such a scope
+ * (`lib/lists/model-tag-scope.ts`), so the user must be able to see which
+ * chip to remove.
+ */
+
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { ListModelTagScope } from '@ifc-lite/lists';
+import { useViewerStore } from '@/store';
+import { MODEL_TAG_OPS, unresolvedModelTagIds, type ModelTagOp } from '@/lib/model-tags/types';
+import { ModelTagChip } from '@/components/viewer/hierarchy/ModelTagChip';
+import { Chip } from './ListBuilder.parts';
+
+const OP_LABEL: Record<ModelTagOp, string> = {
+  hasAny: 'tagged any of',
+  hasAll: 'tagged all of',
+  hasNone: 'tagged none of',
+  untagged: 'untagged',
+};
+
+export interface ListModelTagScopeEditorProps {
+  value: ListModelTagScope | undefined;
+  onChange: (next: ListModelTagScope | undefined) => void;
+}
+
+export function ListModelTagScopeEditor({ value, onChange }: ListModelTagScopeEditorProps) {
+  const { tags, assignments, models } = useViewerStore(
+    useShallow((s) => ({ tags: s.modelTags, assignments: s.modelTagAssignments, models: s.models })),
+  );
+  const options = useMemo(() => [...tags.values()].sort((a, b) => a.name.localeCompare(b.name)), [tags]);
+  const countFor = (tagId: string) => [...models.keys()].filter((m) => assignments.get(m)?.has(tagId)).length;
+  const unresolved = value ? unresolvedModelTagIds(value, new Set(tags.keys())) : [];
+
+  const setOp = (op: string) => {
+    if (op === 'all') return onChange(undefined);
+    onChange({ op: op as ModelTagOp, tagIds: value?.tagIds ?? [] });
+  };
+  const toggleTag = (id: string) => {
+    if (!value) return;
+    const tagIds = value.tagIds.includes(id) ? value.tagIds.filter((t) => t !== id) : [...value.tagIds, id];
+    onChange({ ...value, tagIds });
+  };
+
+  // Nothing to scope by: no tag exists and the list is not already scoped.
+  if (options.length === 0 && !value) return null;
+
+  return (
+    <div className="mt-3 space-y-1.5" data-list-model-tag-scope>
+      <label className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        <span className="shrink-0">Models</span>
+        <select
+          aria-label="Model tag scope"
+          value={value?.op ?? 'all'}
+          onChange={(e) => setOp(e.target.value)}
+          className="h-7 rounded-md border border-border bg-background px-1.5 text-xs text-foreground"
+        >
+          <option value="all">all models</option>
+          {MODEL_TAG_OPS.map((op) => (
+            <option key={op} value={op}>{OP_LABEL[op]}</option>
+          ))}
+        </select>
+      </label>
+      {value && value.op !== 'untagged' && (
+        <div className="flex flex-wrap gap-1.5">
+          {options.map((tag) => (
+            <Chip key={tag.id} selected={value.tagIds.includes(tag.id)} onClick={() => toggleTag(tag.id)} trailing={countFor(tag.id)}>
+              {tag.name}
+            </Chip>
+          ))}
+          {unresolved.map((id) => (
+            <ModelTagChip key={id} tag={undefined} unresolved onRemove={() => toggleTag(id)} />
+          ))}
+        </div>
+      )}
+      {value && value.op !== 'untagged' && value.tagIds.length === 0 && (
+        <p className="text-[10px] text-muted-foreground">Pick at least one tag, or the list runs over no model.</p>
+      )}
+      {unresolved.length > 0 && (
+        <p role="alert" className="text-[10px] text-amber-700 dark:text-amber-400">
+          {unresolved.length === 1 ? 'A tag in this scope' : `${unresolved.length} tags in this scope`} no longer
+          exist{unresolved.length === 1 ? 's' : ''}. The list will not run until {unresolved.length === 1 ? 'it is' : 'they are'} removed.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListModelTagScopeEditor.tsx
@@ -6,7 +6,8 @@
  * The list builder's MODEL scope by tag (#4215): which federated models the
  * list runs over, in the same four words search and clash use. Sits inside
  * the builder's Scope section, under the entity-type chips those models are
- * then filtered by.
+ * then filtered by. The operator labels are the advanced filter's own
+ * (`OP_LABEL`), so "has any of" reads the same in a list as in a search rule.
  *
  * A tag id the scope names but that no longer exists is drawn as an amber
  * "Unknown tag" chip, not hidden — the run refuses such a scope
@@ -19,15 +20,10 @@ import { useShallow } from 'zustand/react/shallow';
 import type { ListModelTagScope } from '@ifc-lite/lists';
 import { useViewerStore } from '@/store';
 import { MODEL_TAG_OPS, unresolvedModelTagIds, type ModelTagOp } from '@/lib/model-tags/types';
+import { describeListModelTagScope } from '@/lib/lists/model-tag-scope';
 import { ModelTagChip } from '@/components/viewer/hierarchy/ModelTagChip';
+import { OP_LABEL } from '../SearchModal.filter.editors.shared';
 import { Chip } from './ListBuilder.parts';
-
-const OP_LABEL: Record<ModelTagOp, string> = {
-  hasAny: 'tagged any of',
-  hasAll: 'tagged all of',
-  hasNone: 'tagged none of',
-  untagged: 'untagged',
-};
 
 export interface ListModelTagScopeEditorProps {
   value: ListModelTagScope | undefined;
@@ -83,8 +79,12 @@ export function ListModelTagScopeEditor({ value, onChange }: ListModelTagScopeEd
           ))}
         </div>
       )}
-      {value && value.op !== 'untagged' && value.tagIds.length === 0 && (
+      {value && value.op !== 'untagged' && value.tagIds.length === 0 ? (
         <p className="text-[10px] text-muted-foreground">Pick at least one tag, or the list runs over no model.</p>
+      ) : value && (
+        <p className="text-[10px] text-muted-foreground" data-list-model-tag-scope-hint>
+          Runs over {describeListModelTagScope(value, tags)}.
+        </p>
       )}
       {unresolved.length > 0 && (
         <p role="alert" className="text-[10px] text-amber-700 dark:text-amber-400">

--- a/apps/viewer/src/components/viewer/lists/ListPanel.modelTagScope.test.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.modelTagScope.test.tsx
@@ -103,7 +103,7 @@ describe('ListPanel — model tag scope (#4215)', () => {
     assert.deepEqual(listResult?.rows.map((r) => r.modelId).sort(), ['model-a', 'model-b']);
   });
 
-  it('"tagged any of Structure" runs over the tagged model only', async () => {
+  it('"has any of Structure" runs over the tagged model only', async () => {
     await run(definition({ op: 'hasAny', tagIds: [STRUCTURE] }));
     const { listResult, listError } = useViewerStore.getState();
     assert.equal(listError, null);

--- a/apps/viewer/src/components/viewer/lists/ListPanel.modelTagScope.test.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.modelTagScope.test.tsx
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A list's model tag scope through the real panel (issue #4215): clicking
+ * Run on a scoped list executes it over the tagged models only, and a scope
+ * naming a deleted tag ends in the visible error box instead of a wider run.
+ * Same harness as `ListPanel.wiring.test.tsx` (#4317).
+ */
+
+import '@/test/setup-dom.js';
+
+import { afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { StringTable, EntityTableBuilder } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { render, cleanup, click, advance } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import type { ListDefinition, ListModelTagScope } from '@/lib/lists';
+import { ListPanel } from './ListPanel.js';
+
+/** One real IfcWall named after its model, so a row says where it came from. */
+function buildStore(name: string): IfcDataStore {
+  const strings = new StringTable();
+  const builder = new EntityTableBuilder(1, strings);
+  builder.add(42, 'IFCWALL', '1abcdefghijklmnopqrstu', name, '', '', true, false);
+  return {
+    fileSize: 0,
+    schemaVersion: 'IFC4',
+    entityCount: 1,
+    parseTime: 0,
+    source: new Uint8Array(0),
+    entityIndex: { byId: { ranges: new Uint32Array(0), index: new Map() }, byType: new Map([['IFCWALL', [42]]]) },
+    strings,
+    entities: builder.build(),
+    properties: undefined,
+    quantities: undefined,
+    relationships: { count: 0, getRelated: () => [] },
+    spatialHierarchy: undefined,
+  } as unknown as IfcDataStore;
+}
+
+function definition(modelTagScope: ListModelTagScope | undefined): ListDefinition {
+  return {
+    id: 'list-scoped',
+    name: 'Scoped List',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    entityTypes: [],
+    conditions: [],
+    modelTagScope,
+    columns: [
+      { id: 'col-1', source: 'property', psetName: 'Pset_WallCommon', propertyName: 'NeverThere', label: 'Missing' },
+    ],
+  } as unknown as ListDefinition;
+}
+
+const STRUCTURE = 'tag-structure';
+
+function seedStore(def: ListDefinition) {
+  useViewerStore.setState({
+    models: new Map([
+      ['model-a', { id: 'model-a', name: 'model-a', visible: true, idOffset: 0, ifcDataStore: buildStore('Wall A') } as never],
+      ['model-b', { id: 'model-b', name: 'model-b', visible: true, idOffset: 0, ifcDataStore: buildStore('Wall B') } as never],
+    ]),
+    activeModelId: 'model-a',
+    modelTags: new Map([[STRUCTURE, { id: STRUCTURE, name: 'Structure' }]]),
+    modelTagAssignments: new Map([['model-a', new Set([STRUCTURE])]]),
+    listDefinitions: [def],
+    activeListId: null,
+    listResult: null,
+    listExecuting: false,
+    listError: null,
+    listPanelVisible: true,
+    pendingListDraft: null,
+    zoneSets: [],
+    zoneAssignments: {} as never,
+    zoneApportionment: undefined,
+  } as never);
+}
+
+async function run(def: ListDefinition): Promise<HTMLElement> {
+  seedStore(def);
+  const container = render(<ListPanel />);
+  const button = container.querySelector(`button[aria-label="Run list ${def.name}"]`);
+  assert.ok(button, 'expected a Run button');
+  click(button);
+  await advance(60); // handleExecuteList runs inside requestAnimationFrame
+  return container;
+}
+
+let initialState: ReturnType<typeof useViewerStore.getState>;
+
+describe('ListPanel — model tag scope (#4215)', () => {
+  before(() => { initialState = useViewerStore.getState(); });
+  afterEach(() => { cleanup(); useViewerStore.setState(initialState, true); });
+
+  it('fixture sanity: without a scope the list runs over both models', async () => {
+    await run(definition(undefined));
+    const { listResult, listError } = useViewerStore.getState();
+    assert.equal(listError, null);
+    assert.deepEqual(listResult?.rows.map((r) => r.modelId).sort(), ['model-a', 'model-b']);
+  });
+
+  it('"tagged any of Structure" runs over the tagged model only', async () => {
+    await run(definition({ op: 'hasAny', tagIds: [STRUCTURE] }));
+    const { listResult, listError } = useViewerStore.getState();
+    assert.equal(listError, null);
+    assert.deepEqual(listResult?.rows.map((r) => r.modelId), ['model-a']);
+  });
+
+  it('"untagged" runs over the other one', async () => {
+    await run(definition({ op: 'untagged', tagIds: [] }));
+    assert.deepEqual(useViewerStore.getState().listResult?.rows.map((r) => r.modelId), ['model-b']);
+  });
+
+  it('a scope naming a deleted tag is refused visibly, not widened to every model', async () => {
+    const container = await run(definition({ op: 'hasNone', tagIds: ['tag-gone'] }));
+    const state = useViewerStore.getState();
+    assert.equal(state.listExecuting, false);
+    assert.equal(state.listResult, null, 'no result — running over "every model" would be the silent widening');
+    assert.match(state.listError ?? '', /no longer exists/);
+    assert.match(container.textContent ?? '', /List failed/, 'the refusal must render');
+  });
+
+  it('a scope no loaded model satisfies is reported as such, not as an empty result', async () => {
+    const def = definition({ op: 'hasAny', tagIds: [STRUCTURE] });
+    seedStore(def);
+    useViewerStore.setState({ modelTagAssignments: new Map() }); // the tag exists; no model carries it
+    const container = render(<ListPanel />);
+    click(container.querySelector('button[aria-label="Run list Scoped List"]')!);
+    await advance(60);
+    const state = useViewerStore.getState();
+    assert.equal(state.listResult, null);
+    assert.match(state.listError ?? '', /No loaded model matches.*Structure.*Nothing was run/s);
+    assert.match(container.textContent ?? '', /List failed/);
+  });
+});

--- a/apps/viewer/src/components/viewer/lists/ListPanel.tsx
+++ b/apps/viewer/src/components/viewer/lists/ListPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/lib/lists';
 import type { ListDefinition, ListResult, ListDataProvider, ListGrouping } from '@/lib/lists';
 import { mergeResultColumns } from '@/lib/lists/merge-result-columns';
+import { scopeModelPairs } from '@/lib/lists/model-tag-scope';
 import { extractProjectUnits, ProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
 import { useRenderFrameOffsets } from '@/hooks/useRenderFrameOffsets';
 import { makeWorldPositionGetter } from '@/lib/geo/entity-world-position';
@@ -158,7 +159,9 @@ export function ListPanel({ onClose }: ListPanelProps) {
     requestAnimationFrame(() => {
       try {
         const resultParts: ListResult[] = [];
-        for (const { modelId, provider } of modelProviderPairs) {
+        // The list's model tag scope (#4215) decides which providers run;
+        // an unresolved or empty scope throws its reason into the box below.
+        for (const { modelId, provider } of scopeModelPairs(definition, modelProviderPairs, useViewerStore.getState())) {
           resultParts.push(executeList(definition, provider, modelId));
         }
 

--- a/apps/viewer/src/lib/lists/index.ts
+++ b/apps/viewer/src/lib/lists/index.ts
@@ -15,6 +15,7 @@ export type {
   DiscoveredColumns,
   EntityAttribute,
   ListGrouping,
+  ListModelTagScope,
 } from '@ifc-lite/lists';
 export {
   ENTITY_ATTRIBUTES,

--- a/apps/viewer/src/lib/lists/model-tag-scope.test.ts
+++ b/apps/viewer/src/lib/lists/model-tag-scope.test.ts
@@ -67,9 +67,9 @@ describe('list model tag scope (#4215)', () => {
     const empty = new Map([['m3', {}]]);
     assert.throws(
       () => scopeModelPairs({ modelTagScope: { op: 'hasAny', tagIds: [A.id] } }, [{ modelId: 'm3' }], { ...state, models: empty }),
-      /No loaded model matches.*models tagged any of Architecture.*Nothing was run/s,
+      /No loaded model matches.*models that have any of Architecture.*Nothing was run/s,
     );
-    assert.equal(describeListModelTagScope({ op: 'hasAll', tagIds: [S.id, A.id] }, state.modelTags), 'models tagged all of Structure, Architecture');
+    assert.equal(describeListModelTagScope({ op: 'hasAll', tagIds: [S.id, A.id] }, state.modelTags), 'models that have all of Structure, Architecture');
     assert.equal(describeListModelTagScope({ op: 'untagged', tagIds: [] }, state.modelTags), 'untagged models');
   });
 

--- a/apps/viewer/src/lib/lists/model-tag-scope.test.ts
+++ b/apps/viewer/src/lib/lists/model-tag-scope.test.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A list's model tag scope (issue #4215) resolves with the SAME predicate
+ * search and clash use — asserted by evaluating the identical rule through
+ * the search evaluator's model-level arm — refuses an unresolved tag, and
+ * refuses (with a reason) a scope that selects no loaded model.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { modelScopedRuleMatches } from '../search/filter-evaluate-model-tag.js';
+import { Rule } from '../search/filter-rules.js';
+import type { ModelTag, ModelTagOp } from '../model-tags/types.js';
+import { describeListModelTagScope, resolveListModelTagScope, scopeModelPairs, type ListModelTagState } from './model-tag-scope.js';
+
+const S: ModelTag = { id: 'tag-s', name: 'Structure' };
+const A: ModelTag = { id: 'tag-a', name: 'Architecture' };
+
+/** m1 Structure + Architecture, m2 Structure, m3 untagged. */
+const state: ListModelTagState = {
+  models: new Map([['m1', {}], ['m2', {}], ['m3', {}]]),
+  modelTags: new Map([[S.id, S], [A.id, A]]),
+  modelTagAssignments: new Map([['m1', new Set([S.id, A.id])], ['m2', new Set([S.id])]]),
+};
+const pairs = [{ modelId: 'm1' }, { modelId: 'm2' }, { modelId: 'm3' }];
+
+const ids = (r: ReturnType<typeof resolveListModelTagScope>) => (r.kind === 'models' ? [...r.modelIds] : r.kind);
+
+describe('list model tag scope (#4215)', () => {
+  it('no scope → every model', () => {
+    assert.deepEqual(resolveListModelTagScope(undefined, state), { kind: 'all' });
+    assert.deepEqual(scopeModelPairs({}, pairs, state), pairs);
+  });
+
+  it('the four operators select the same models the search / clash evaluator would', () => {
+    const cases: Array<[ModelTagOp, string[], string[]]> = [
+      ['hasAny', [S.id], ['m1', 'm2']],
+      ['hasAny', [A.id], ['m1']],
+      ['hasAll', [S.id, A.id], ['m1']],
+      ['hasNone', [S.id], ['m3']],
+      ['untagged', [], ['m3']],
+    ];
+    const defined = new Set(state.modelTags.keys());
+    for (const [op, tagIds, expected] of cases) {
+      assert.deepEqual(ids(resolveListModelTagScope({ op, tagIds }, state)), expected, `${op} ${tagIds}`);
+      const viaSearch = [...state.models.keys()].filter((id) =>
+        modelScopedRuleMatches(Rule.modelTag(op, tagIds), {
+          filterIdentity: id, tagIds: state.modelTagAssignments.get(id), definedModelTagIds: defined,
+        }));
+      assert.deepEqual(viaSearch, expected, `search agrees for ${op}`);
+    }
+  });
+
+  it('an unresolved tag id refuses the run with a named reason — never widens to every model', () => {
+    const resolved = resolveListModelTagScope({ op: 'hasNone', tagIds: ['tag-gone'] }, state);
+    assert.deepEqual(resolved, { kind: 'unresolved', tagIds: ['tag-gone'] });
+    assert.throws(
+      () => scopeModelPairs({ modelTagScope: { op: 'hasNone', tagIds: ['tag-gone'] } }, pairs, state),
+      /no longer exists.*not run/s,
+    );
+  });
+
+  it('a scope that selects no loaded model refuses with the scope spelled out', () => {
+    const empty = new Map([['m3', {}]]);
+    assert.throws(
+      () => scopeModelPairs({ modelTagScope: { op: 'hasAny', tagIds: [A.id] } }, [{ modelId: 'm3' }], { ...state, models: empty }),
+      /No loaded model matches.*models tagged any of Architecture.*Nothing was run/s,
+    );
+    assert.equal(describeListModelTagScope({ op: 'hasAll', tagIds: [S.id, A.id] }, state.modelTags), 'models tagged all of Structure, Architecture');
+    assert.equal(describeListModelTagScope({ op: 'untagged', tagIds: [] }, state.modelTags), 'untagged models');
+  });
+
+  it('a scoped run keeps only the providers of models in scope, in federation order', () => {
+    assert.deepEqual(scopeModelPairs({ modelTagScope: { op: 'hasAny', tagIds: [S.id] } }, pairs, state), [{ modelId: 'm1' }, { modelId: 'm2' }]);
+  });
+});

--- a/apps/viewer/src/lib/lists/model-tag-scope.ts
+++ b/apps/viewer/src/lib/lists/model-tag-scope.ts
@@ -85,10 +85,14 @@ export function scopeModelPairs<T extends { modelId: string }>(
   return scoped;
 }
 
-/** "models tagged any of Structure, MEP" — for the scope hint and the empty-scope message. */
+/**
+ * "models that have any of Structure, MEP" — the scope hint under the
+ * builder's select, and the empty-scope message. Same words as the advanced
+ * filter's operator labels (has any of / has all of / has none of / is untagged).
+ */
 export function describeListModelTagScope(scope: ListModelTagScope, tags: ReadonlyMap<string, ModelTag>): string {
   if (scope.op === 'untagged') return 'untagged models';
   const names = scope.tagIds.map((id) => tags.get(id)?.name ?? 'unknown tag').join(', ');
   const verb = scope.op === 'hasAny' ? 'any of' : scope.op === 'hasAll' ? 'all of' : 'none of';
-  return `models tagged ${verb} ${names || '—'}`;
+  return `models that have ${verb} ${names || '—'}`;
 }

--- a/apps/viewer/src/lib/lists/model-tag-scope.ts
+++ b/apps/viewer/src/lib/lists/model-tag-scope.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A list's MODEL TAG scope (#4215): which of the federation's models a list
+ * runs over, decided by the models' user-facing tags with the same four
+ * predicates search and clash use (`lib/model-tags/types.ts`), so "Structure"
+ * means the same set of models in a quantity list as in a clash rule.
+ *
+ * Lists have their own data-provider integration — one provider per model
+ * (`ListPanel.modelProviderPairs`) — so a `modelTag` search rule alone does
+ * not scope a list; this decides which providers the run is handed.
+ *
+ * Unresolved references are refused, never widened: a scope naming a tag
+ * that no longer exists resolves to an error the panel shows, and the list
+ * is not run — running it over every model, or over none with nothing on
+ * screen to say why, would both misreport what the list covers.
+ */
+
+import type { ListDefinition, ListModelTagScope } from '@ifc-lite/lists';
+import { modelTagRuleMatches, unresolvedModelTagIds, type ModelTag, type ModelTagOp } from '../model-tags/types.js';
+
+// The package type and the viewer's operator set are the same four words;
+// this fails to compile if either side ever changes alone.
+const _sameOps: ListModelTagScope['op'] extends ModelTagOp ? (ModelTagOp extends ListModelTagScope['op'] ? true : never) : never = true;
+void _sameOps;
+
+/** The slice of store state a scope resolves against. Structural so tests need no store. */
+export interface ListModelTagState {
+  models: ReadonlyMap<string, unknown>;
+  modelTags: ReadonlyMap<string, ModelTag>;
+  modelTagAssignments: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+export type ResolvedListModelTagScope =
+  /** No scope: every model. */
+  | { kind: 'all' }
+  /** The loaded models in scope, in federation order — possibly none. */
+  | { kind: 'models'; modelIds: ReadonlySet<string> }
+  /** The scope names tags that no longer exist; the list must not run. */
+  | { kind: 'unresolved'; tagIds: string[] };
+
+export function resolveListModelTagScope(
+  scope: ListModelTagScope | undefined,
+  state: ListModelTagState,
+): ResolvedListModelTagScope {
+  if (!scope) return { kind: 'all' };
+  const defined = new Set(state.modelTags.keys());
+  const unresolved = unresolvedModelTagIds(scope, defined);
+  if (unresolved.length > 0) return { kind: 'unresolved', tagIds: unresolved };
+  const modelIds = new Set<string>();
+  for (const modelId of state.models.keys()) {
+    if (modelTagRuleMatches(scope.op, scope.tagIds, state.modelTagAssignments.get(modelId), defined)) modelIds.add(modelId);
+  }
+  return { kind: 'models', modelIds };
+}
+
+/**
+ * The subset of `pairs` (anything carrying a `modelId`) a list runs over.
+ * Throws — with the reason the panel shows — when the scope is unresolved or
+ * selects no loaded model: an empty scope is not an empty result, it is a
+ * list that never looked at anything, and the user must be told which.
+ */
+export function scopeModelPairs<T extends { modelId: string }>(
+  definition: Pick<ListDefinition, 'modelTagScope'>,
+  pairs: readonly T[],
+  state: ListModelTagState,
+): T[] {
+  const resolved = resolveListModelTagScope(definition.modelTagScope, state);
+  if (resolved.kind === 'all') return [...pairs];
+  if (resolved.kind === 'unresolved') {
+    const n = resolved.tagIds.length;
+    throw new Error(
+      `This list's model tag scope names ${n === 1 ? 'a tag' : `${n} tags`} that no longer exist${n === 1 ? 's' : ''}. ` +
+        'Edit the list scope — it was not run rather than run over models it never named.',
+    );
+  }
+  const scoped = pairs.filter((p) => resolved.modelIds.has(p.modelId));
+  if (scoped.length === 0) {
+    throw new Error(
+      `No loaded model matches this list's model tag scope (${describeListModelTagScope(definition.modelTagScope!, state.modelTags)}). Nothing was run.`,
+    );
+  }
+  return scoped;
+}
+
+/** "models tagged any of Structure, MEP" — for the scope hint and the empty-scope message. */
+export function describeListModelTagScope(scope: ListModelTagScope, tags: ReadonlyMap<string, ModelTag>): string {
+  if (scope.op === 'untagged') return 'untagged models';
+  const names = scope.tagIds.map((id) => tags.get(id)?.name ?? 'unknown tag').join(', ');
+  const verb = scope.op === 'hasAny' ? 'any of' : scope.op === 'hasAll' ? 'all of' : 'none of';
+  return `models tagged ${verb} ${names || '—'}`;
+}

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -28,6 +28,7 @@ import {
   type ClashSceneTeardown,
 } from '@/lib/clash/visibility-ownership';
 import { markupTransitionPatch } from './drawing2DSlice.markupTransition.js';
+import { isolateModelsPatch, modelFieldPatch, modelsVisibilityPatch } from './modelSlice.visibility.js';
 import { upsertModelPatch } from './modelSlice.upsert.js';
 
 export interface ModelSlice {
@@ -52,6 +53,10 @@ export interface ModelSlice {
   setActiveModel: (modelId: string | null) => void;
   /** Toggle model visibility */
   setModelVisibility: (modelId: string, visible: boolean) => void;
+  /** Set visibility on many models in ONE write (`modelSlice.visibility.ts`, #4215). */
+  setModelsVisibility: (modelIds: Iterable<string>, visible: boolean) => void;
+  /** Show exactly `modelIds`, hide every other loaded model, in one write (#4215). */
+  isolateModels: (modelIds: Iterable<string>) => void;
   /** Toggle model collapsed state in hierarchy */
   setModelCollapsed: (modelId: string, collapsed: boolean) => void;
   /** Rename a model */
@@ -540,32 +545,11 @@ export const createModelSlice: StateCreator<ViewerState, [], [], ModelSlice> = (
     };
   }),
 
-  setModelVisibility: (modelId, visible) => set((state) => {
-    const model = state.models.get(modelId);
-    if (!model) return {};
-
-    const newModels = new Map(state.models);
-    newModels.set(modelId, { ...model, visible });
-    return { models: newModels };
-  }),
-
-  setModelCollapsed: (modelId, collapsed) => set((state) => {
-    const model = state.models.get(modelId);
-    if (!model) return {};
-
-    const newModels = new Map(state.models);
-    newModels.set(modelId, { ...model, collapsed });
-    return { models: newModels };
-  }),
-
-  setModelName: (modelId, name) => set((state) => {
-    const model = state.models.get(modelId);
-    if (!model) return {};
-
-    const newModels = new Map(state.models);
-    newModels.set(modelId, { ...model, name });
-    return { models: newModels };
-  }),
+  setModelVisibility: (modelId, visible) => set((state) => modelFieldPatch(state, modelId, { visible })),
+  setModelsVisibility: (modelIds, visible) => set((state) => modelsVisibilityPatch(state, modelIds, visible)),
+  isolateModels: (modelIds) => set((state) => isolateModelsPatch(state, modelIds)),
+  setModelCollapsed: (modelId, collapsed) => set((state) => modelFieldPatch(state, modelId, { collapsed })),
+  setModelName: (modelId, name) => set((state) => modelFieldPatch(state, modelId, { name })),
 
   // Getters (synchronous access via get())
   getModel: (modelId) => get().models.get(modelId),

--- a/apps/viewer/src/store/slices/modelSlice.visibility.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.visibility.test.ts
@@ -64,19 +64,10 @@ describe('modelSlice batched visibility (#4215)', () => {
 
     useViewerStore.getState().setModelsVisibility(new Set(['A', 'B']), true);
     assert.deepEqual(visibility(), { A: true, B: true, C: true });
-  });
 
-  it('the single-model writers still work through the shared field patch', () => {
-    const s = useViewerStore.getState();
-    s.setModelVisibility('B', false);
-    s.setModelCollapsed('C', true);
-    s.setModelName('A', 'Renamed');
-    const models = useViewerStore.getState().models;
-    assert.equal(models.get('B')?.visible, false);
-    assert.equal(models.get('C')?.collapsed, true);
-    assert.equal(models.get('A')?.name, 'Renamed');
-    const before = useViewerStore.getState().models;
-    s.setModelVisibility('nope', false);
-    assert.equal(useViewerStore.getState().models, before, 'an unknown id writes nothing');
+    // The single-model writers share the field patch: an unknown id writes nothing there either.
+    const untouched = useViewerStore.getState().models;
+    useViewerStore.getState().setModelVisibility('nope', false);
+    assert.equal(useViewerStore.getState().models, untouched, 'an unknown id writes nothing');
   });
 });

--- a/apps/viewer/src/store/slices/modelSlice.visibility.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.visibility.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Batched model visibility (issue #4215): `setModelsVisibility` and
+ * `isolateModels` flip a federation in ONE store write, dedupe repeated ids,
+ * ignore ids that are not loaded, and write nothing when nothing changes.
+ * Driven through the real store so the slice wiring is what is tested.
+ */
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { federationRegistry } from '@ifc-lite/renderer';
+import { useViewerStore } from '../index.js';
+import type { FederatedModel } from '../types.js';
+
+function model(id: string, visible = true): FederatedModel {
+  return {
+    id, name: `${id}.ifc`, ifcDataStore: null, geometryResult: null, visible, collapsed: false,
+    schemaVersion: 'IFC4', loadedAt: 1, fileSize: 0, idOffset: 0, maxExpressId: 10,
+  } as FederatedModel;
+}
+
+function seed(...ids: string[]): void {
+  federationRegistry.clear();
+  for (const id of ids) federationRegistry.registerModel(id, 10);
+  useViewerStore.setState({ models: new Map(ids.map((id) => [id, model(id)])), activeModelId: ids[0] ?? null });
+}
+
+const visibility = () =>
+  Object.fromEntries([...useViewerStore.getState().models].map(([id, m]) => [id, m.visible]));
+
+describe('modelSlice batched visibility (#4215)', () => {
+  beforeEach(() => seed('A', 'B', 'C'));
+
+  it('isolateModels shows exactly the given models and hides every other loaded model, in one write', () => {
+    let writes = 0;
+    const unsubscribe = useViewerStore.subscribe((s, prev) => { if (s.models !== prev.models) writes += 1; });
+    try {
+      useViewerStore.getState().isolateModels(['A', 'C', 'A']);
+    } finally {
+      unsubscribe();
+    }
+    assert.deepEqual(visibility(), { A: true, B: false, C: true });
+    assert.equal(writes, 1, 'a federation of three flips in ONE models-map write, not one per model');
+  });
+
+  it('isolateModels of an already-hidden model shows it again (isolate is absolute, not a toggle)', () => {
+    useViewerStore.getState().setModelVisibility('B', false);
+    useViewerStore.getState().isolateModels(['B']);
+    assert.deepEqual(visibility(), { A: false, B: true, C: false });
+  });
+
+  it('setModelsVisibility applies to the listed models only, ignores unknown ids, and no-ops without a change', () => {
+    const s = useViewerStore.getState();
+    s.setModelsVisibility(['A', 'B', 'not-loaded'], false);
+    assert.deepEqual(visibility(), { A: false, B: false, C: true });
+    assert.equal(useViewerStore.getState().models.has('not-loaded'), false, 'an unknown id is not conjured into the federation');
+
+    const before = useViewerStore.getState().models;
+    useViewerStore.getState().setModelsVisibility(['A', 'B'], false);
+    assert.equal(useViewerStore.getState().models, before, 'nothing changed → the models map identity is kept (no spurious re-render)');
+
+    useViewerStore.getState().setModelsVisibility(new Set(['A', 'B']), true);
+    assert.deepEqual(visibility(), { A: true, B: true, C: true });
+  });
+
+  it('the single-model writers still work through the shared field patch', () => {
+    const s = useViewerStore.getState();
+    s.setModelVisibility('B', false);
+    s.setModelCollapsed('C', true);
+    s.setModelName('A', 'Renamed');
+    const models = useViewerStore.getState().models;
+    assert.equal(models.get('B')?.visible, false);
+    assert.equal(models.get('C')?.collapsed, true);
+    assert.equal(models.get('A')?.name, 'Renamed');
+    const before = useViewerStore.getState().models;
+    s.setModelVisibility('nope', false);
+    assert.equal(useViewerStore.getState().models, before, 'an unknown id writes nothing');
+  });
+});

--- a/apps/viewer/src/store/slices/modelSlice.visibility.ts
+++ b/apps/viewer/src/store/slices/modelSlice.visibility.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `modelSlice`'s per-model field writes, beside the slice rather than inside
+ * it (`modelSlice.ts` carries a recorded budget in
+ * `scripts/module-size-allowlist.txt`; the `modelSlice.upsert.ts` pattern).
+ *
+ * `setModelVisibility`, `setModelCollapsed` and `setModelName` were three
+ * copies of the same seven lines; {@link modelFieldPatch} is that once. The
+ * two batched writes exist for the hierarchy's "Isolate matching models"
+ * action (#4215): a federation of N models must flip in ONE store write, not
+ * N — every subscriber (the renderer's model visibility, the tree) would
+ * otherwise re-render N times, and a subscriber reading a half-applied
+ * federation could see an isolate that hides nothing yet.
+ *
+ * Model ids are deduplicated through a `Set`: a model listed under several
+ * tag groups is still one model and is written once.
+ */
+
+import type { FederatedModel } from '../types.js';
+
+/** The slice of state these read and write. Structural so tests need no store. */
+export interface ModelsState {
+  models: Map<string, FederatedModel>;
+}
+
+/** Overwrite `fields` on one model; `{}` (no write) when the model is not loaded. */
+export function modelFieldPatch(
+  state: ModelsState,
+  modelId: string,
+  fields: Partial<Pick<FederatedModel, 'visible' | 'collapsed' | 'name'>>,
+): Partial<ModelsState> {
+  const model = state.models.get(modelId);
+  if (!model) return {};
+  const models = new Map(state.models);
+  models.set(modelId, { ...model, ...fields });
+  return { models };
+}
+
+/**
+ * Set `visible` on every loaded model in `modelIds` in one write. Ids that
+ * are not loaded are ignored; when nothing would change, nothing is written
+ * (so the `models` map identity — what memoised selectors key on — holds).
+ */
+export function modelsVisibilityPatch(
+  state: ModelsState,
+  modelIds: Iterable<string>,
+  visible: boolean,
+): Partial<ModelsState> {
+  return applyVisibility(state, (id) => (targets(modelIds).has(id) ? visible : undefined));
+}
+
+/**
+ * The hierarchy's "Isolate matching models" (#4215): every model in
+ * `modelIds` shown, every OTHER loaded model hidden, in one write. This is
+ * whole-model visibility (`FederatedModel.visible`), the same flag the
+ * model row's eye toggles — it does not touch the entity-level
+ * isolate/hide channels, so an element isolation a user set up stays as it
+ * was.
+ */
+export function isolateModelsPatch(state: ModelsState, modelIds: Iterable<string>): Partial<ModelsState> {
+  const keep = targets(modelIds);
+  return applyVisibility(state, (id) => keep.has(id));
+}
+
+function targets(modelIds: Iterable<string>): ReadonlySet<string> {
+  return modelIds instanceof Set ? modelIds : new Set(modelIds);
+}
+
+/** Apply `visibleFor(id)` (undefined = leave as is) across the federation; one map, or no write. */
+function applyVisibility(
+  state: ModelsState,
+  visibleFor: (modelId: string) => boolean | undefined,
+): Partial<ModelsState> {
+  let models: Map<string, FederatedModel> | null = null;
+  for (const [id, model] of state.models) {
+    const visible = visibleFor(id);
+    if (visible === undefined || model.visible === visible) continue;
+    models ??= new Map(state.models);
+    models.set(id, { ...model, visible });
+  }
+  return models ? { models } : {};
+}

--- a/apps/viewer/src/store/slices/modelTagsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelTagsSlice.teardown.ts
@@ -6,20 +6,24 @@
  * `modelTagsSlice`'s contribution to the store-wide teardown seam
  * (`store/teardown.ts`), beside the slice like every other contribution.
  *
- * Only the ASSIGNMENTS are torn down. Tag definitions (`modelTags`) are the
- * user's vocabulary — persisted to localStorage, referenced by id from saved
- * advanced filters and clash presets — and a file swap must no more destroy
- * them than it destroys saved filters. An assignment, by contrast, names a
- * model id, and a model id that is gone must not keep a tag on it: the next
- * model handed the same id by a setup-file reopen would inherit tags it was
- * never given.
+ * The ASSIGNMENTS and the Models-section VIEW are torn down; tag definitions
+ * are not. Definitions (`modelTags`) are the user's vocabulary — persisted to
+ * localStorage, referenced by id from saved advanced filters and clash
+ * presets — and a file swap must no more destroy them than it destroys saved
+ * filters. An assignment, by contrast, names a model id, and a model id that
+ * is gone must not keep a tag on it: the next model handed the same id by a
+ * setup-file reopen would inherit tags it was never given. The view
+ * (`modelTagView`: the row filter and "By tag") is about the federation that
+ * was open; left standing over a new one it would list nothing and — with no
+ * tagged model to show the chip strip for — offer nothing to clear.
  */
 
 import { defineSliceTeardown } from '../teardown.js';
+import { DEFAULT_MODEL_TAG_VIEW } from './modelTagsSlice.js';
 
-export const modelTagsTeardown = defineSliceTeardown('modelTagsSlice', ['modelTagAssignments'], {
-  'session-reset': () => ({ modelTagAssignments: new Map<string, ReadonlySet<string>>() }),
-  'all-models-cleared': () => ({ modelTagAssignments: new Map<string, ReadonlySet<string>>() }),
+export const modelTagsTeardown = defineSliceTeardown('modelTagsSlice', ['modelTagAssignments', 'modelTagView'], {
+  'session-reset': () => ({ modelTagAssignments: new Map<string, ReadonlySet<string>>(), modelTagView: DEFAULT_MODEL_TAG_VIEW }),
+  'all-models-cleared': () => ({ modelTagAssignments: new Map<string, ReadonlySet<string>>(), modelTagView: DEFAULT_MODEL_TAG_VIEW }),
   'model-removed': (scope, state) => {
     const prior = state.modelTagAssignments;
     if (!prior?.has(scope.modelId)) return {};

--- a/apps/viewer/src/store/slices/modelTagsSlice.ts
+++ b/apps/viewer/src/store/slices/modelTagsSlice.ts
@@ -26,9 +26,33 @@ import { loadPersistedModelTags, savePersistedModelTags } from '../../lib/model-
 
 export type ModelTagAssignments = ReadonlyMap<string, ReadonlySet<string>>;
 
+/**
+ * How the hierarchy's Models section shows the federation (#4215). Session
+ * UI state, like the hierarchy mode; lives here rather than in `uiSlice` so
+ * `deleteModelTag` can drop a deleted tag from the filter in the same write
+ * that drops its assignments — a filter naming a tag that no longer exists
+ * would list nothing and say nothing.
+ *
+ * The filter is a ROW filter: it decides which model rows are listed, never
+ * what the viewport shows. Changing viewport visibility is the separate,
+ * explicit "Isolate matching models" action (`modelSlice.isolateModels`).
+ */
+export interface ModelTagView {
+  /** Group the model rows by tag, with an explicit Untagged group. */
+  groupByTag: boolean;
+  /** List a model when it carries ANY of these tags (or, see below, none). */
+  filterTagIds: readonly string[];
+  /** Also list the models that carry no tag. */
+  filterUntagged: boolean;
+}
+
+export const DEFAULT_MODEL_TAG_VIEW: ModelTagView = { groupByTag: false, filterTagIds: [], filterUntagged: false };
+
 export interface ModelTagsSlice {
   modelTags: ReadonlyMap<string, ModelTag>;
   modelTagAssignments: ModelTagAssignments;
+  modelTagView: ModelTagView;
+  setModelTagView: (patch: Partial<ModelTagView>) => void;
 
   /** Create a tag; returns its id. Returns the EXISTING id when a tag of that
    *  name (case-insensitive) already exists, and `null` for a blank name. */
@@ -73,6 +97,8 @@ export const createModelTagsSlice: StateCreator<ModelTagsSlice, [], [], ModelTag
   return {
     modelTags: persistedDefinitions(),
     modelTagAssignments: new Map(),
+    modelTagView: DEFAULT_MODEL_TAG_VIEW,
+    setModelTagView: (patch) => set({ modelTagView: { ...get().modelTagView, ...patch } }),
 
     createModelTag: (name, color) => {
       const trimmed = name.trim();
@@ -113,7 +139,13 @@ export const createModelTagsSlice: StateCreator<ModelTagsSlice, [], [], ModelTag
         if (rest.size > 0) assignments.set(modelId, rest);
       }
       savePersistedModelTags([...nextTags.values()]);
-      set({ modelTags: nextTags, modelTagAssignments: assignments });
+      const view = get().modelTagView;
+      const filterTagIds = view.filterTagIds.filter((t) => t !== id);
+      set({
+        modelTags: nextTags,
+        modelTagAssignments: assignments,
+        ...(filterTagIds.length !== view.filterTagIds.length ? { modelTagView: { ...view, filterTagIds } } : {}),
+      });
     },
 
     upsertModelTagDefinitions: (tags) => {

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -28,7 +28,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
  * field on every file swap.
  */
 const PINNED_SESSION_RESET_KEYS: readonly string[] = [
-  'modelTagAssignments', // #4215 model tags: assignments die with the model, definitions survive
+  'modelTagAssignments', 'modelTagView', // #4215 model tags: assignments and the Models-section view die with the federation, definitions survive
   'appearanceReferences', 'referenceUndo', 'referenceRedo', 'referenceRevision', 'selectedAppearanceReferenceId', // #4308 drawing workspace lifecycle
   'modelPlacement', 'repositionNudge', 'repositionOpen', 'placementStaleMeasurements', // #4226 workspace placement lifecycle
   'activeBasketViewId', 'activeChangeSetId', 'activeLensId', 'activeListId', 'activeModelId',
@@ -91,7 +91,7 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
 
 /** The same, for `all-models-cleared`. */
 const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
-  'modelTagAssignments', // #4215 model tags: assignments die with the model, definitions survive
+  'modelTagAssignments', 'modelTagView', // #4215 model tags: assignments and the Models-section view die with the federation, definitions survive
   'modelPlacement', 'repositionNudge', 'repositionOpen', 'placementStaleMeasurements', // #4226 workspace placement lifecycle
   'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'basketVisibilityOwned', 'classFilter',
   'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
@@ -211,7 +211,7 @@ function modelRemovedFixture() {
  * `owns` list fails even when no scope emits it under an empty state.
  */
 const PINNED_OWNED_KEYS: readonly string[] = [
-  'modelTagAssignments', // #4215 model tags: assignments die with the model, definitions survive
+  'modelTagAssignments', 'modelTagView', // #4215 model tags: assignments and the Models-section view die with the federation, definitions survive
   'appearanceReferences', 'referenceUndo', 'referenceRedo', 'referenceRevision', 'selectedAppearanceReferenceId', // #4308 drawing workspace lifecycle
   'modelPlacement', 'repositionNudge', 'repositionOpen', 'placementStaleMeasurements', // #4226 workspace placement lifecycle
   'activeBasketViewId', 'activeChangeSetId', 'activeLensId', 'activeListId', 'activeModelId',

--- a/packages/lists/src/discovery.ts
+++ b/packages/lists/src/discovery.ts
@@ -10,7 +10,7 @@
 
 import type { IfcTypeEnum } from '@ifc-lite/data';
 import type { ListDataProvider, DiscoveredColumns } from './types.js';
-import { ENTITY_ATTRIBUTES } from './types.js';
+import { ENTITY_ATTRIBUTES } from './entity-attributes.js';
 
 /** Max entities to sample per type per provider for column discovery */
 const SAMPLE_SIZE = 50;

--- a/packages/lists/src/entity-attributes.ts
+++ b/packages/lists/src/entity-attributes.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** The built-in entity attributes a list column may read (`ColumnDefinition.attribute`). */
+export const ENTITY_ATTRIBUTES = [
+  'Name',
+  'GlobalId',
+  'Class',
+  'Type',
+  'Description',
+  'ObjectType',
+  'PredefinedType',
+  'Tag',
+] as const;
+
+export type EntityAttribute = typeof ENTITY_ATTRIBUTES[number];

--- a/packages/lists/src/index.ts
+++ b/packages/lists/src/index.ts
@@ -18,9 +18,9 @@ export type {
   ListSummary,
   ListScheduleRow,
   DiscoveredColumns,
-  EntityAttribute,
 } from './types.js';
-export { ENTITY_ATTRIBUTES } from './types.js';
+export type { ListModelTagScope } from './model-tag-scope.js';
+export { ENTITY_ATTRIBUTES, type EntityAttribute } from './entity-attributes.js';
 
 // Engine
 export {

--- a/packages/lists/src/model-tag-scope.ts
+++ b/packages/lists/src/model-tag-scope.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which models a list runs over, by the viewer's user-facing MODEL TAGS
+ * (issue #4215). Persisted on `ListDefinition.modelTagScope`.
+ *
+ * `tagIds` are the viewer's stable tag ids — a rename changes nothing here —
+ * and the four operators read exactly as they do in the viewer's search and
+ * clash rules: `hasAny` (at least one of), `hasAll` (every one of), `hasNone`
+ * (none of), `untagged` (the model carries no tag at all; `tagIds` is
+ * ignored). Independent of `expressIdsByModel` and `entityTypes`, which scope
+ * ELEMENTS within whichever models are in scope. Absent means every model,
+ * so a list persisted before this existed runs as it did.
+ *
+ * The package only carries the shape; resolving it against a federation's
+ * tags is the viewer's (`apps/viewer/src/lib/lists/model-tag-scope.ts`), and
+ * a scope naming a tag that no longer exists must be refused there, never
+ * widened.
+ */
+export interface ListModelTagScope {
+  op: 'hasAny' | 'hasAll' | 'hasNone' | 'untagged';
+  tagIds: string[];
+}

--- a/packages/lists/src/types.ts
+++ b/packages/lists/src/types.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import type { ListModelTagScope } from './model-tag-scope.js';
+
 /**
  * Types for the Lists feature - configurable property tables from IFC data
  */
@@ -194,6 +196,9 @@ export interface ListDefinition {
    * snapshots don't over-select when local express IDs collide across files.
    */
   expressIdsByModel?: Record<string, number[]>;
+
+  /** Optional MODEL scope by model tag (#4215, `model-tag-scope.ts`); absent = every model. */
+  modelTagScope?: ListModelTagScope;
 
   /** Optional property-based filter conditions */
   conditions: PropertyCondition[];
@@ -405,19 +410,3 @@ export interface DiscoveredColumns {
   quantities: Map<string, string[]>; // qsetName -> quantNames[]
 }
 
-// ============================================================================
-// Built-in Attributes
-// ============================================================================
-
-export const ENTITY_ATTRIBUTES = [
-  'Name',
-  'GlobalId',
-  'Class',
-  'Type',
-  'Description',
-  'ObjectType',
-  'PredefinedType',
-  'Tag',
-] as const;
-
-export type EntityAttribute = typeof ENTITY_ATTRIBUTES[number];

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -5881,6 +5881,7 @@
     "ListDefinition: interface",
     "ListGroup: interface",
     "ListGrouping: interface",
+    "ListModelTagScope: interface",
     "ListResult: interface",
     "ListRow: interface",
     "ListScheduleRow: interface",

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -88,7 +88,7 @@
    569 apps/viewer/src/components/viewer/KeyboardShortcutsDialog.tsx
    534 apps/viewer/src/components/viewer/layers/LayerMergeSection.tsx
   1709 apps/viewer/src/components/viewer/LensPanel.tsx
-  1465 apps/viewer/src/components/viewer/lists/ListBuilder.tsx
+  1411 apps/viewer/src/components/viewer/lists/ListBuilder.tsx
    548 apps/viewer/src/components/viewer/lists/ListResultsTable.tsx
   1139 apps/viewer/src/components/viewer/MainToolbar.tsx
    715 apps/viewer/src/components/viewer/measureHandlers.ts
@@ -164,7 +164,7 @@
    410 apps/viewer/src/lib/llm/stream-client.ts
    809 apps/viewer/src/lib/llm/system-prompt.ts
    491 apps/viewer/src/lib/scripts/templates/create-building.ts
-   598 apps/viewer/src/lib/search/filter-evaluate.ts
+   583 apps/viewer/src/lib/search/filter-evaluate.ts
    450 apps/viewer/src/lib/search/tier1-index.ts
    452 apps/viewer/src/lib/slab-edit.ts
    412 apps/viewer/src/lib/sources/persistence.ts
@@ -183,7 +183,7 @@
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts
    820 apps/viewer/src/store/slices/measurementSlice.ts
-   651 apps/viewer/src/store/slices/modelSlice.ts
+   635 apps/viewer/src/store/slices/modelSlice.ts
   3277 apps/viewer/src/store/slices/mutationSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts
    536 apps/viewer/src/store/slices/scriptSlice.ts
@@ -277,7 +277,7 @@
    426 packages/lens/src/matching.ts
    416 packages/lens/src/types.ts
    812 packages/lists/src/engine.ts
-   423 packages/lists/src/types.ts
+   412 packages/lists/src/types.ts
    467 packages/mcp/src/backend-query.ts
    420 packages/mcp/src/overlay.ts
    544 packages/mcp/src/server.ts


### PR DESCRIPTION
Closes #4215 — stacked PR 2 of 2, based on #4542 (`feat/4215-model-tags`); merge that first (this PR targets its branch; GitHub retargets it to `main` when #4542 lands).

## What changed

**Hierarchy — the Models section** (`ModelsSectionHeader`, `modelTagView`, `ModelTagGroupRow`, all new; one hook call swapped into the frozen `HierarchyPanel`):
- **By tag** grouping: one group header per tag some listed model carries, plus an explicit **Untagged** group. A model under two tags is listed under both but is *one* model — its rows keep `modelIds: [id]`, the group count is distinct members, a group's eye flips every member in one write and the second listing of the model reads hidden too. Grouped rows do not expand to Project / Site / Building (expansion is keyed on the ungrouped row id in the frozen tree builder; a model in two groups would otherwise have to expand in both or neither); the flat view keeps the drill-down. This is a Models-section *view* on `modelTagsSlice`, not a new `HierarchyMode` — the storeys section keeps its spatial view and the capped `uiSlice` / `useHierarchyTree` stay untouched.
- **Tag chips filter the rows** (any-of, plus Untagged) and never touch the viewport; **Isolate matching models** is the separate explicit action, through the new batched `modelSlice.isolateModels` / `setModelsVisibility` (one `models`-map write, Set-deduped; the three copy-pasted single-field writers in the capped slice collapsed into `modelFieldPatch` to make room). The strip stays while a filter or the grouping is set, and `modelTagView` is torn down with the federation, so the filter can never strand an empty section with nothing to clear; deleting a tag drops it from the filter in the same write.

**Lists — model tag scope** (`ListDefinition.modelTagScope`, new optional field in `@ifc-lite/lists`; `ListModelTagScope` lives in its own package module because `types.ts` is capped, `ENTITY_ATTRIBUTES` moved out to compensate). Same four predicates as search and clash (`has any of / has all of / has none of / is untagged`, labelled with the advanced filter's own `OP_LABEL`); `ListPanel` hands the run only the in-scope providers; the builder's Scope section gets the editor (`ListModelTagScopeEditor`, new) with a one-line summary of the scope. A scope naming a deleted tag, or one no loaded model satisfies, is **refused** with a visible reason rather than run over every model or over none — a 0-row table would misreport what the list covered.

## Why / root cause

Issue #4215's remaining scope: user-visible grouping and filtering in the hierarchy with row filtering and viewport visibility kept apart, deduplicated multi-tag models, and list scope by the same predicates search and clash use.

## Evidence

Commands run in the worktree (Git Bash, Windows 11):

- `pnpm --filter viewer typecheck`, `pnpm --filter @ifc-lite/lists typecheck` — clean.
- Targeted viewer tests for the whole stack (PR 1's set plus `HierarchyPanel.modelTags` mounted, `ListModelTagScopeEditor` mounted, `ListPanel.modelTagScope` mounted, `model-tag-scope`, `modelSlice.visibility`, `modelTagView`, `ListPanel.wiring`): 152 tests, 151 pass; the one failure is `teardown-registry` subtest 5 (`ERR_UNSUPPORTED_ESM_URL_SCHEME`, Windows ESM loader), which fails identically with `origin/main`'s own test on this host.
- `pnpm --filter @ifc-lite/lists test` — 10 files, 256/256 pass.
- `node scripts/check-module-size.mjs` — OK, 0 new files over 400; five frozen files shrank and their rows were lowered to the measured counts (`HierarchyPanel.tsx` 1147, `ListBuilder.tsx` 1411, `filter-evaluate.ts` 583, `modelSlice.ts` 635, `packages/lists/src/types.ts` 412). No row raised.
- `node scripts/check-api-surface.mjs` — matches (`ListModelTagScope: interface` added to the snapshot); `node scripts/check-test-wiring.mjs` — OK; `oxlint` over every touched source file — 0 warnings.
- `pnpm lint` (root): `check-changesets.mjs` / `check-unused-locals.mjs` fail on this host with `spawnSync pnpm ENOENT` (environmental). Changeset written by hand (`.changeset/model-tags-hierarchy-lists.md`: viewer minor, `@ifc-lite/lists` minor).
- **Real two-model session** (Chrome via Playwright against `vite` dev on this branch, real WebGPU, fixtures from `pnpm fixtures`): `AC20-FZK-Haus.ifc` tagged `Architecture` + `Tender`, `duplex.ifc` tagged `Structure` + `Tender` through the row editor. **By tag** listed the groups `Architecture 1`, `Structure 1`, `Tender 2`, `Untagged 0` (readback of the group headers), with AC20 under two groups and `models.size` still 2. Chip **Structure** listed `1 of 2` rows with both models still visible (`visible: true, true`); **Isolate matching models** then gave `AC20 visible:false, duplex visible:true`. Saved the setup (format 2, both slots with `tagIds`) and reopened it in a fresh page with a re-created `Structure` id: assignments restored onto the live id. Screenshots were taken locally and are not attached (no image host in this workflow); the readbacks above are from the script's log. Search / clash membership agreement and list scope are covered by tests over real parsed IFC text and the mounted `ListPanel`, not by this browser session.
- Not run: Rust/cargo, perf probe (no relevant paths touched), the full viewer suite in one process (cannot run through cmd.exe on this host).

## Review

Independent review before opening (verdict: request changes) and what was done:

- **Major — the tag filter could strand the Models section empty with no way to clear it** (strip gated on "some model carries a tag"; `modelTagView` never torn down). Fixed: the strip renders while a filter or the grouping is set, a filtered tag no model carries any more keeps its chip, and `modelTagView` joins the slice teardown for `session-reset` / `all-models-cleared` (pinned in `teardown-registry.test.ts`; the manual reset in the mounted test's `afterEach` is gone). Two mounted cases cover unassign-the-last-model and a cleared session.
- **Minor — `describeListModelTagScope` promised a hint nothing rendered.** Rendered under the scope select ("Runs over models that have any of Structure"); mounted editor test added.
- **Taste — list-scope select read "tagged any of" where search says "has any of".** Aligned to the filter's `OP_LABEL`.
- **Nit — `Chip.className` with no caller.** Dropped.
- **Nit — set-then-read test case in `modelSlice.visibility.test.ts`.** Reduced to its invariant (an unknown id writes nothing).
- Taste notes applied as decided: empty-scope **refusal** kept for lists; "By tag" kept as a Models-section view, grouped rows kept non-expandable (both documented above).
- Found during the real session, fixed in PR 1: chips beside the name squeezed it to zero width at the panel's default width; tagged rows are now taller with the chips on a second line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFsGAGjJeskfXwyXNSDGxg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model-tag filtering and “By tag” grouping in the Models panel, including distinct model counts and visibility controls.
  * Added options to isolate matching models and filter untagged models.
  * Added model-tag scoping for lists with support for any, all, none, and untagged operators.
  * Added scope descriptions, model counts, selectable tag chips, and warnings for empty or unresolved scopes.

* **Bug Fixes**
  * Model-tag views now reset when models are cleared, and deleted tags are removed from active filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->