### PR TITLE
feat(viewer,renderer): pick canonical faces in the main viewport

### DIFF
--- a/.changeset/exact-appearance-face-picks.md
+++ b/.changeset/exact-appearance-face-picks.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+Add canonical evaluated-surface identity to exact raycast intersections. `Intersection` now reports the federation `modelIndex`, unambiguous `geometryItemId`, and `sourceTriangleIndex` when the rendered triangle carries valid appearance provenance; `appearanceSourceTriangle()` exposes the same strict mapping for renderer consumers. Exact scene raycasts also honor the renderer's active section plane and crop box.

--- a/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
@@ -10,7 +10,7 @@ import { StrictMode, act } from 'react';
 import { IfcParser, unwrapIfcZipWithResources } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
-import { federationRegistry, Raycaster, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
+import { federationRegistry, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
 import type { MeshData, GeometryResult } from '@ifc-lite/geometry';
 import { AppearancePreviewController } from '../../../../../../packages/renderer/src/appearance-preview.js';
 import { render, cleanup, advance, type } from '@/test/render.js';
@@ -29,6 +29,7 @@ import type { AppearanceWorker } from '@/lib/appearance/planner-worker-client.js
 import type { AppearancePlan, AppearanceCatalog, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from '@/lib/appearance/planner-types.js';
 import { AppearancePanel } from './AppearancePanel.js';
 import { AuthorTab } from '../ribbon/tabs/AuthorTab.js';
+import { pickViewportAppearanceFace } from './face-mask/viewport-face-picker.js';
 
 // The mapped quad in the renderer frame (IFC Z-up -> Y-up): four corners, two
 // triangles. Both occurrences render it; only the chosen one is converted.
@@ -101,14 +102,12 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
       return { width: bytes.getUint32(16), height: bytes.getUint32(20), close() {} } as ImageBitmap;
     };
     Object.defineProperty(globalThis, 'Worker', { configurable: true, value: NativeWorker });
-    // The face-selection canvas has no GPU here: its renderer is a stub and the
-    // hit test answers "triangle 1" for any click. What is asserted is the
-    // selection's effect on the plan, the scene, the IFC and history.
+    // The face-selection canvas has no GPU here. The main viewport hit below
+    // carries the real owner/item/source-triangle contract into the editor.
     const init = mock.method(PreviewRenderer.prototype, 'init', async () => {});
     mock.method(PreviewRenderer.prototype, 'loadGeometry', () => {});
     mock.method(PreviewRenderer.prototype, 'render', () => {});
     mock.method(PreviewRenderer.prototype, 'fitToView', () => {});
-    mock.method(Raycaster.prototype, 'raycast', () => ({ point: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 }, distance: 1, meshIndex: 0, triangleIndex: 1, expressId: selection, barycentricCoord: { u: 0.3, v: 0.3, w: 0.4 } }));
     HTMLElement.prototype.setPointerCapture = () => {};
     const gpu = new AppearancePreviewController<number>({ capture: owner => ({ parts: resident.get(owner.expressId)!, resources: [] }),
       stage: () => [], install: (owner, parts) => { resident.set(owner.expressId, parts); }, release() {} });
@@ -141,13 +140,14 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     // Select one of the two faces: the plan carries the mask, the preview splits.
     await act(async () => button('Select faces').click());
     const editor = ui.querySelector(`[aria-label="Face selection for IFC object #25"]`); assert.ok(editor, 'the face editor opens for the converted object');
-    await act(async () => button('Pick faces').click());
-    const canvas = editor.querySelector('canvas')!;
-    const pointer = (type: string) => canvas.dispatchEvent(new PointerEvent(type, { bubbles: true, isPrimary: true, pointerId: 1, clientX: 10, clientY: 10 }));
     const editorRenderers = init.mock.callCount();
     assert.ok(editorRenderers > 0, 'the face editor owns a renderer');
-    await act(async () => { pointer('pointerdown'); pointer('pointerup'); });
+    await act(async () => button('Pick in model').click());
+    await act(async () => { assert.equal(pickViewportAppearanceFace({ point: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 },
+      distance: 1, meshIndex: 0, triangleIndex: 0, expressId: selection, modelIndex: 0, geometryItemId: globalId(11),
+      sourceTriangleIndex: 1, barycentricCoord: { u: 0.3, v: 0.3, w: 0.4 } }), 'picked'); });
     await until(() => requests.at(-1)!.request.faceMasks !== undefined && ui.textContent!.includes('Preview ready'));
+    assert.equal(useViewerStore.getState().activeTool, 'appearance-face', 're-planning keeps main-view face pick active');
     assert.equal(init.mock.callCount(), editorRenderers, 'a face click and its re-plan keep the editor renderer and camera: the surface identity is stable');
     const masked = requests.at(-1)!;
     assert.deepEqual(masked.request.faceMasks, [{ productId: 25, surfaceFingerprint: whole.plan.conversions![0].surfaceFingerprint, triangles: [1] }]);

--- a/apps/viewer/src/components/viewer/appearance/face-mask/FaceMaskTargets.tsx
+++ b/apps/viewer/src/components/viewer/appearance/face-mask/FaceMaskTargets.tsx
@@ -1,10 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { AppearanceMeshPreview, type RegionGesture } from '../AppearanceMeshPreview.js';
 import { UNSELECTED_FACE_COLOR, type FaceMaskControls, type FaceMaskTarget } from './useFaceMasks.js';
+import { registerViewportFacePicker } from './viewport-face-picker.js';
+import { useViewerStore } from '@/store';
 
 /** One converted object's selection state as a chip, plus the way into its editor.
  * Vocabulary shared with the editor: **Select faces** opens it, **Pick faces**
@@ -27,6 +29,19 @@ export function FaceMaskEditor({ target, disabled, onChange }: { target: FaceMas
   const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const selected = useMemo(() => [...(target.selected ?? [])], [target.selected]);
+  const latest = useRef({ selected, onChange, disabled });
+  latest.current = { selected, onChange, disabled };
+  const activeTool = useViewerStore(state => state.activeTool);
+  const setActiveTool = useViewerStore(state => state.setActiveTool);
+  useEffect(() => registerViewportFacePicker({ globalId: target.globalId, modelIndex: target.modelIndex,
+    geometryItemIds: target.geometryItemIds, triangleCount: target.triangleCount, canPick: () => !latest.current.disabled, onToggle: triangle => {
+      const next = new Set(latest.current.selected);
+      if (next.has(triangle)) next.delete(triangle); else next.add(triangle);
+      latest.current.onChange(next);
+    } }), [target.globalId, target.modelIndex, target.geometryItemIds, target.triangleCount]);
+  useEffect(() => () => {
+    if (useViewerStore.getState().activeTool === 'appearance-face') useViewerStore.getState().setActiveTool('select');
+  }, []);
   const faceSelection = useMemo(() => ({ unselectedColor: UNSELECTED_FACE_COLOR }), []);
   const region = (ids: number[], gesture: RegionGesture) => {
     const next = new Set(selected);
@@ -35,6 +50,14 @@ export function FaceMaskEditor({ target, disabled, onChange }: { target: FaceMas
     onChange(next);
   };
   return <div className="space-y-1 rounded-md border p-2" aria-label={`Face selection for ${target.label}`} aria-busy={!ready}>
+    <div className="flex items-center gap-2">
+      <Button type="button" size="sm" variant={activeTool === 'appearance-face' ? 'secondary' : 'outline'}
+        aria-pressed={activeTool === 'appearance-face'} disabled={disabled && activeTool !== 'appearance-face'}
+        onClick={() => setActiveTool(activeTool === 'appearance-face' ? 'select' : 'appearance-face')}>
+        {activeTool === 'appearance-face' ? 'Picking in model' : 'Pick in model'}
+      </Button>
+      {activeTool === 'appearance-face' && <span className="text-[11px] text-muted-foreground" role="status">Click visible faces in the main view. The tool stays active.</span>}
+    </div>
     <AppearanceMeshPreview mesh={target.mesh} triangles={selected} disabled={disabled} faceSelection={faceSelection} canvasLabel={`Face selection preview for ${target.label}`}
       onRegion={region} onReady={setReady} onError={message => { setReady(false); setError(message); }} />
     {error && <p className="text-[11px] text-destructive" role="alert">{error}</p>}

--- a/apps/viewer/src/components/viewer/appearance/face-mask/useFaceMasks.ts
+++ b/apps/viewer/src/components/viewer/appearance/face-mask/useFaceMasks.ts
@@ -15,6 +15,9 @@ export const UNSELECTED_FACE_COLOR: readonly [number, number, number, number] = 
 
 export interface FaceMaskTarget {
   productId: number;
+  globalId: number;
+  modelIndex: number;
+  geometryItemIds: ReadonlySet<number>;
   label: string;
   triangleCount: number;
   /** Ascending selected ordinals; `undefined` textures the whole surface. */
@@ -29,7 +32,7 @@ export interface FaceMaskControls {
   onEdit(productId: number | null): void;
   onChange(productId: number, triangles: Iterable<number> | null): void;
 }
-interface Surface { productId: number; fingerprint: string; triangleCount: number; mesh: MeshData }
+interface Surface { productId: number; fingerprint: string; triangleCount: number; mesh: MeshData; geometryItemIds: ReadonlySet<number> }
 
 const sameArray = (a: ArrayLike<number> | undefined, b: ArrayLike<number> | undefined) =>
   a === b || (!!a && !!b && a.length === b.length && Array.prototype.every.call(a, (value: number, i: number) => value === b[i]));
@@ -42,9 +45,12 @@ const sameArray = (a: ArrayLike<number> | undefined, b: ArrayLike<number> | unde
 function stableSurface(previous: Surface | undefined, conversion: Conversion, modelId: string): Surface {
   const fingerprint = conversion.surfaceFingerprint!;
   const mesh = { ...occurrenceSourceMesh(useViewerStore.getState(), modelId, conversion), color: [...SELECTED_FACE_COLOR] as MeshData['color'] };
+  const state = useViewerStore.getState();
+  const geometryItemIds = new Set([conversion.sourceGeometryItemId, conversion.geometryItemId,
+    conversion.retainedGeometryItemId].filter((id): id is number => id !== undefined).map(id => state.toGlobalId(modelId, id)));
   if (previous && previous.fingerprint === fingerprint && sameArray(previous.mesh.positions, mesh.positions)
-    && sameArray(previous.mesh.indices, mesh.indices) && sameArray(previous.mesh.origin, mesh.origin)) return previous;
-  return { productId: conversion.productId, fingerprint, triangleCount: conversion.sourceIndices.length / 3, mesh };
+    && sameArray(previous.mesh.indices, mesh.indices) && sameArray(previous.mesh.origin, mesh.origin)) return { ...previous, geometryItemIds };
+  return { productId: conversion.productId, fingerprint, triangleCount: conversion.sourceIndices.length / 3, mesh, geometryItemIds };
 }
 
 /**
@@ -111,8 +117,10 @@ export function useFaceMasks(modelId: string | null) {
     surfaces.current = live;
     return [...live.values()];
   }, [conversions, modelId]);
-  const targets = useMemo<FaceMaskTarget[]>(() => editable.map(surface => ({ productId: surface.productId, label: `IFC object #${surface.productId}`,
-    triangleCount: surface.triangleCount, selected: masks.get(surface.productId)?.triangles, mesh: surface.mesh })), [editable, masks]);
+  const targets = useMemo<FaceMaskTarget[]>(() => editable.map(surface => ({ productId: surface.productId,
+    globalId: surface.mesh.expressId, modelIndex: surface.mesh.modelIndex ?? 0, geometryItemIds: surface.geometryItemIds,
+    label: `IFC object #${surface.productId}`, triangleCount: surface.triangleCount,
+    selected: masks.get(surface.productId)?.triangles, mesh: surface.mesh })), [editable, masks]);
   const controls = useMemo<FaceMaskControls>(() => ({ targets, diagnostics, editing, onEdit: setEditing, onChange: change }), [targets, diagnostics, editing, change]);
   return { masks, requests, reconcile, clearApplied, reset, controls };
 }

--- a/apps/viewer/src/components/viewer/appearance/face-mask/viewport-face-picker.test.ts
+++ b/apps/viewer/src/components/viewer/appearance/face-mask/viewport-face-picker.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Intersection } from '@ifc-lite/renderer';
+import { pickViewportAppearanceFace, registerViewportFacePicker } from './viewport-face-picker.js';
+
+const hit = (changes: Partial<Intersection> = {}): Intersection => ({
+  point: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 }, distance: 1,
+  meshIndex: 0, triangleIndex: 0, expressId: 1_025, modelIndex: 1,
+  geometryItemId: 1_011, sourceTriangleIndex: 7,
+  barycentricCoord: { u: 0.2, v: 0.3, w: 0.5 }, ...changes,
+});
+
+test('viewport face picker requires the exact federated owner, item and canonical triangle (#4555)', () => {
+  const picked: number[] = [];
+  const release = registerViewportFacePicker({ globalId: 1_025, modelIndex: 1,
+    geometryItemIds: new Set([1_011, 1_101, 1_102]), triangleCount: 12,
+    canPick: () => true, onToggle: triangle => picked.push(triangle) });
+  assert.equal(pickViewportAppearanceFace(hit()), 'picked');
+  assert.equal(pickViewportAppearanceFace(hit({ geometryItemId: 1_102, sourceTriangleIndex: 11 })), 'picked',
+    'another rendered part of the same canonical surface remains pickable');
+  assert.equal(pickViewportAppearanceFace(hit({ expressId: 25, modelIndex: 0, geometryItemId: 11 })),
+    'different-surface', 'the same local ids in another model cannot cross-select');
+  assert.equal(pickViewportAppearanceFace(hit({ geometryItemId: 9_999 })), 'ambiguous');
+  assert.equal(pickViewportAppearanceFace(hit({ sourceTriangleIndex: undefined })), 'ambiguous');
+  assert.equal(pickViewportAppearanceFace(hit({ sourceTriangleIndex: 12 })), 'ambiguous');
+  assert.equal(pickViewportAppearanceFace(null), 'miss');
+  assert.deepEqual(picked, [7, 11]);
+  release();
+  assert.equal(pickViewportAppearanceFace(hit()), 'inactive');
+});

--- a/apps/viewer/src/components/viewer/appearance/face-mask/viewport-face-picker.ts
+++ b/apps/viewer/src/components/viewer/appearance/face-mask/viewport-face-picker.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { Intersection } from '@ifc-lite/renderer';
+
+export interface ViewportFacePickTarget {
+  globalId: number;
+  modelIndex: number;
+  geometryItemIds: ReadonlySet<number>;
+  triangleCount: number;
+  canPick(): boolean;
+  onToggle(triangle: number): void;
+}
+
+export type ViewportFacePickResult =
+  | 'inactive'
+  | 'miss'
+  | 'different-surface'
+  | 'ambiguous'
+  | 'busy'
+  | 'picked';
+
+let active: ViewportFacePickTarget | null = null;
+
+/** Register the face editor that owns the sticky main-viewport pick tool. */
+export function registerViewportFacePicker(target: ViewportFacePickTarget): () => void {
+  active = target;
+  return () => { if (active === target) active = null; };
+}
+
+/** Route one exact renderer hit without mutating ordinary viewer selection. */
+export function pickViewportAppearanceFace(hit: Intersection | null): ViewportFacePickResult {
+  if (!active) return 'inactive';
+  if (!active.canPick()) return 'busy';
+  if (!hit) return 'miss';
+  if (hit.expressId !== active.globalId || hit.modelIndex !== active.modelIndex) return 'different-surface';
+  const triangle = hit.sourceTriangleIndex;
+  if (hit.geometryItemId === undefined || !active.geometryItemIds.has(hit.geometryItemId)
+    || triangle === undefined || triangle < 0 || triangle >= active.triangleCount) return 'ambiguous';
+  active.onToggle(triangle);
+  return 'picked';
+}
+
+export function viewportFacePickError(result: ViewportFacePickResult): string | undefined {
+  if (result === 'miss') return 'No visible surface under the pointer.';
+  if (result === 'different-surface') return 'Pick a face on the object open in the face editor.';
+  if (result === 'ambiguous') return 'This rendered face has no exact source identity. Reload the model and try again.';
+  if (result === 'busy') return 'Wait for the current appearance preview to finish.';
+  return undefined;
+}

--- a/apps/viewer/src/components/viewer/referenceSelection.test.tsx
+++ b/apps/viewer/src/components/viewer/referenceSelection.test.tsx
@@ -143,7 +143,10 @@ test('appearance face touch uses the exact surface hit without ordinary selectio
   const event = (kind: string, touches: Touch[]) => { const value = new window.Event(kind, { bubbles: true, cancelable: true });
     Object.defineProperty(value, 'touches', { value: touches }); return value; };
   await act(async () => { f.canvas.dispatchEvent(event('touchstart', [finger])); f.canvas.dispatchEvent(event('touchend', [])); });
-  assert.deepEqual(picked, [9]); assert.deepEqual(f.calls.selected, []); assert.equal(f.calls.ifc, 0);
+  assert.deepEqual(picked, [9]);
+  await handleSelectionClick(f.ctx, clickEvent());
+  assert.deepEqual(picked, [9], 'the compatibility click cannot toggle the face back off');
+  assert.deepEqual(f.calls.selected, []); assert.equal(f.calls.ifc, 0);
   release();
 });
 

--- a/apps/viewer/src/components/viewer/referenceSelection.test.tsx
+++ b/apps/viewer/src/components/viewer/referenceSelection.test.tsx
@@ -16,6 +16,7 @@ import { handleSelectionClick } from './selectionHandlers.js';
 import type { MouseHandlerContext } from './mouseHandlerTypes.js';
 import { useTouchControls, type UseTouchControlsParams } from './useTouchControls.js';
 import { invalidateSelectionPick } from './referenceSelection.js';
+import { registerViewportFacePicker } from './appearance/face-mask/viewport-face-picker.js';
 
 const ref = <T,>(current: T) => ({ current });
 const owner = { kind: 'source' as const, id: 'reference-selection-fixture' };
@@ -41,10 +42,11 @@ async function fixture(modelCount = 1) {
   const calls = { reference: 0, ifc: 0, selected: [] as Array<PickResult | null>, toggled: [] as number[], options: [] as PickOptions[] };
   let referencePick: () => Promise<ReferenceImageHit | null> = async () => ({ referenceId: 'drawing:one', point: [0, 0, 0], distance: 1 });
   let ifcPick: PickResult | null = { expressId: 19, modelIndex: modelCount > 1 ? 1 : undefined };
+  let exactHit: ReturnType<Renderer['raycastScene']> = null;
   const renderer = {
     getCamera: () => camera, requestRender() {},
     getScene: () => ({ getMeshes: () => [], getBatchedMeshes: () => [], getInstancedEntityCount: () => 0 }),
-    raycastScene: () => null,
+    raycastScene: () => exactHit,
     getReferenceImages: () => ({ pick: async (_x: number, _y: number, options: PickOptions) => {
       calls.reference++; calls.options.push(options); return referencePick();
     } }),
@@ -68,7 +70,8 @@ async function fixture(modelCount = 1) {
   };
   function Probe() { useTouchControls(touch); return null; }
   return { canvas, camera, ctx, calls, tool, options, Probe,
-    setReferencePick(value: typeof referencePick) { referencePick = value; }, setIfcPick(value: PickResult | null) { ifcPick = value; } };
+    setReferencePick(value: typeof referencePick) { referencePick = value; }, setIfcPick(value: PickResult | null) { ifcPick = value; },
+    setExactHit(value: typeof exactHit) { exactHit = value; } };
 }
 function clickEvent() { return new window.MouseEvent('click', { clientX: 40, clientY: 30, bubbles: true }); }
 
@@ -125,6 +128,23 @@ test('ordinary touch tap selects once and its compatibility click cannot select 
   await handleSelectionClick(f.ctx, clickEvent());
   assert.equal(f.calls.reference, 1, 'compatibility click is not processed again');
   assert.deepEqual(f.calls.selected, []);
+});
+
+test('appearance face touch uses the exact surface hit without ordinary selection (#4555)', async () => {
+  const f = await fixture(2); f.tool.current = 'appearance-face';
+  f.setExactHit({ intersection: { point: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 }, distance: 1,
+    meshIndex: 0, triangleIndex: 0, expressId: 1_025, modelIndex: 1, geometryItemId: 1_101,
+    sourceTriangleIndex: 9, barycentricCoord: { u: 0.2, v: 0.3, w: 0.5 } } });
+  const picked: number[] = [];
+  const release = registerViewportFacePicker({ globalId: 1_025, modelIndex: 1, geometryItemIds: new Set([1_101]),
+    triangleCount: 12, canPick: () => true, onToggle: value => picked.push(value) });
+  render(<f.Probe />);
+  const finger = { identifier: 1, target: f.canvas, clientX: 40, clientY: 30 } as unknown as Touch;
+  const event = (kind: string, touches: Touch[]) => { const value = new window.Event(kind, { bubbles: true, cancelable: true });
+    Object.defineProperty(value, 'touches', { value: touches }); return value; };
+  await act(async () => { f.canvas.dispatchEvent(event('touchstart', [finger])); f.canvas.dispatchEvent(event('touchend', [])); });
+  assert.deepEqual(picked, [9]); assert.deepEqual(f.calls.selected, []); assert.equal(f.calls.ifc, 0);
+  release();
 });
 
 

--- a/apps/viewer/src/components/viewer/selectionHandlers.appearanceFace.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.appearanceFace.test.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Renderer } from '@ifc-lite/renderer';
+import type { MouseHandlerContext } from './mouseHandlerTypes.js';
+import { handleSelectionClick } from './selectionHandlers.js';
+import { registerViewportFacePicker } from './appearance/face-mask/viewport-face-picker.js';
+
+test('appearance face clicks use the exact visible hit and leave ordinary selection untouched (#4555)', async () => {
+  const picked: number[] = [];
+  const release = registerViewportFacePicker({ globalId: 1_025, modelIndex: 1,
+    geometryItemIds: new Set([1_101]), triangleCount: 20, canPick: () => true, onToggle: value => picked.push(value) });
+  let ordinarySelections = 0;
+  const renderer = { raycastScene: (_x: number, _y: number, options: { hiddenIds: Set<number>; isolatedIds: Set<number> | null }) => {
+    assert.deepEqual([...options.hiddenIds], [99]); assert.deepEqual([...(options.isolatedIds ?? [])], [1_025]);
+    return { intersection: { point: { x: 0, y: 0, z: 0 }, normal: { x: 0, y: 1, z: 0 }, distance: 1,
+      meshIndex: 0, triangleIndex: 0, expressId: 1_025, modelIndex: 1, geometryItemId: 1_101,
+      sourceTriangleIndex: 13, barycentricCoord: { u: 0.2, v: 0.3, w: 0.5 } } };
+  } } as unknown as Renderer;
+  const ctx = { canvas: { getBoundingClientRect: () => ({ left: 4, top: 5 }) }, renderer,
+    mouseState: { didDrag: false }, activeToolRef: { current: 'appearance-face' },
+    hiddenEntitiesRef: { current: new Set([99]) }, isolatedEntitiesRef: { current: new Set([1_025]) },
+    getPickOptions: () => ({ isStreaming: false, hiddenIds: new Set([99]), isolatedIds: new Set([1_025]) }),
+    handlePickForSelection: () => ordinarySelections++, toggleSelection: () => ordinarySelections++,
+  } as unknown as MouseHandlerContext;
+  await handleSelectionClick(ctx, { clientX: 14, clientY: 25 } as MouseEvent);
+  assert.deepEqual(picked, [13]);
+  assert.equal(ordinarySelections, 0);
+  release();
+});

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -19,6 +19,7 @@ import { notifyWallSplit } from './wallSplitNotice.js';
 import { raycastForPolylinePoint, isNearPolylineStart,
   isDuplicateClickPoint,
 } from './measureHandlers.js';
+import { pickViewportAppearanceFace, viewportFacePickError } from './appearance/face-mask/viewport-face-picker.js';
 
 /**
  * Handle click event for selection (single click and double click).
@@ -39,6 +40,12 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
 
   // Skip selection for pan/walk tools - they don't select
   if (tool === 'pan' || tool === 'walk') {
+    return;
+  }
+
+  if (tool === 'appearance-face') {
+    const message = viewportFacePickError(pickViewportAppearanceFace(renderer.raycastScene(x, y, ctx.getPickOptions())?.intersection ?? null));
+    if (message) toast.error(message);
     return;
   }
 

--- a/apps/viewer/src/components/viewer/useMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useMouseControls.ts
@@ -774,7 +774,7 @@ export function useMouseControls(params: UseMouseControlsParams): void {
 
       mouseState.isDragging = false;
       mouseState.isPanning = false;
-      canvas.style.cursor = tool === 'pan' ? 'grab' : (tool === 'walk' ? 'crosshair' : (tool === 'measure' ? 'crosshair' : 'default'));
+      canvas.style.cursor = tool === 'pan' ? 'grab' : (tool === 'walk' || tool === 'measure' || tool === 'appearance-face' ? 'crosshair' : 'default');
     };
 
     const handleMouseLeave = () => {
@@ -794,7 +794,7 @@ export function useMouseControls(params: UseMouseControlsParams): void {
       sectionLastCastPosRef.current = null;
       setSectionPickPreview(null);
       // Restore cursor based on active tool
-      if (tool === 'measure') {
+      if (tool === 'measure' || tool === 'appearance-face') {
         canvas.style.cursor = 'crosshair';
       } else if (tool === 'pan') {
         canvas.style.cursor = 'grab';

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -13,6 +13,8 @@ import type { MeshData } from '@ifc-lite/geometry';
 import type { SectionPlane } from '@/store';
 import { invalidateSelectionPick, markTouchSelection, selectViewportTarget } from './referenceSelection.js';
 import { isPivotRaycastTooExpensive } from './orbitPivotCensus.js';
+import { toast } from '@/components/ui/toast';
+import { pickViewportAppearanceFace, viewportFacePickError } from './appearance/face-mask/viewport-face-picker.js';
 
 /** Locked gesture mode for 2-finger interactions */
 type TwoFingerGesture = 'none' | 'pinch' | 'pan';
@@ -295,7 +297,12 @@ export function useTouchControls(params: UseTouchControlsParams): void {
           const x = touchState.tapStartPos.x - rect.left;
           const y = touchState.tapStartPos.y - rect.top;
 
-          if (tool === 'select') {
+          if (tool === 'appearance-face') {
+            const message = viewportFacePickError(pickViewportAppearanceFace(
+              renderer.raycastScene(x, y, getPickOptions())?.intersection ?? null,
+            ));
+            if (message) toast.error(message);
+          } else if (tool === 'select') {
             markTouchSelection(canvas, x, y);
             await selectViewportTarget({ canvas, renderer, x, y, getTool: () => activeToolRef.current,
               getPickOptions, onIfc: handlePickForSelection });

--- a/apps/viewer/src/components/viewer/useTouchControls.ts
+++ b/apps/viewer/src/components/viewer/useTouchControls.ts
@@ -298,6 +298,10 @@ export function useTouchControls(params: UseTouchControlsParams): void {
           const y = touchState.tapStartPos.y - rect.top;
 
           if (tool === 'appearance-face') {
+            // Touchend owns this tap. Record it before routing the exact hit so
+            // the browser's compatibility click cannot toggle the same face a
+            // second time through handleSelectionClick (#4555).
+            markTouchSelection(canvas, x, y);
             const message = viewportFacePickError(pickViewportAppearanceFace(
               renderer.raycastScene(x, y, getPickOptions())?.intersection ?? null,
             ));

--- a/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/evaluated-appearance-wasm.test.ts
@@ -5,6 +5,16 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { access, readFile } from 'node:fs/promises';
 import type { AppearancePlan, AppearanceRequest } from './planner-types.js';
+import { appearanceSourceTriangle } from '@ifc-lite/renderer';
+import type { MeshData } from '@ifc-lite/geometry';
+
+function assertCanonicalSurface(conversion: NonNullable<AppearancePlan['conversions']>[number]): void {
+  const indices = new Uint32Array(conversion.sourceIndices);
+  const mesh: MeshData = { expressId: conversion.productId, geometryItemId: conversion.sourceGeometryItemId,
+    positions: new Float32Array(conversion.sourcePositions!), normals: new Float32Array(conversion.sourceNormals!),
+    indices, color: conversion.sourceColor!, appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
+  assert.equal(appearanceSourceTriangle(mesh, indices.length / 3 - 1), indices.length / 3 - 1);
+}
 
 test('real WASM preserves mapped occurrences unless explicitly opted in and composes finite PDF appearance (#4404)', async t => {
   const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
@@ -32,6 +42,7 @@ test('real WASM preserves mapped occurrences unless explicitly opted in and comp
     assert.equal(result.conversions?.[0].sourceGeometryItemId, 35135);
     assert.equal(result.conversions?.[0].sourceIndices.length, 36);
     original = result.conversions![0];
+    assertCanonicalSurface(original);
     assert.ok(original.sourcePositions?.length && original.sourceNormals?.length);
     assert.equal(original.sourcePositions.length, original.sourceNormals.length);
     assert.ok(original.sourceIndices.every(index => index < original!.sourcePositions!.length / 3));
@@ -104,6 +115,7 @@ test('real WASM image and page conversion preserve cut slab and opening companio
   finally { api.free(); }
   assert.equal(image.items.length, 1); assert.deepEqual(image.exclusions, []);
   const conversion = image.conversions![0];
+  assertCanonicalSurface(conversion);
   assert.equal(conversion.sourceIndices.length / 3, 32);
   assert.equal(conversion.sourceRemovedMeshes?.length, 1);
   const opening = conversion.sourceRemovedMeshes![0];

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { MeshData } from '@ifc-lite/geometry';
-import { expandAppearanceCorners, type Renderer } from '@ifc-lite/renderer';
+import { appearanceSourceTriangle, expandAppearanceCorners, type Renderer } from '@ifc-lite/renderer';
 import type { ViewerState } from '@/store';
 import { bindAppearancePreview } from './preview.js';
 import type { AppearancePlan } from './planner-types.js';
@@ -50,6 +50,9 @@ test('a face-masked conversion previews as textured and retained parts of one ow
   assert.deepEqual(retained.color, [0.8, 0.2, 0.1, 1]);
   assert.equal(retained.uvs, undefined); assert.equal(retained.textureRef, undefined); assert.equal(retained.textureBitmap, undefined);
   assert.equal(retained.appearanceSource?.indices, retained.indices);
+  assert.equal(appearanceSourceTriangle(textured, 0), 0);
+  assert.equal(appearanceSourceTriangle(retained, 0), 1,
+    'the retained subset keeps its full evaluated-surface ordinal');
   assert.deepEqual(group.partition, { before: [{ geometryItemId: 11, triangles: [0, 1] }],
     after: [{ geometryItemId: 101, triangles: [0] }, { geometryItemId: 102, triangles: [1] }] });
   assert.equal(group.geometryItemRemaps, undefined, 'a partition replaces the one-to-one item remap');

--- a/apps/viewer/src/lib/appearance/preview-partition.ts
+++ b/apps/viewer/src/lib/appearance/preview-partition.ts
@@ -65,12 +65,18 @@ export function bindMaskedConversionParts(options: {
     const indices = corners(original, ordinals);
     return { ...original, geometryItemId, indices, appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
   };
-  const textured = options.expandCorners(sub(split.masked, options.texturedItemId), [...corners(original, split.masked)], item.previewCornerUvs,
+  const localTextured = options.expandCorners(sub(split.masked, options.texturedItemId), [...corners(original, split.masked)], item.previewCornerUvs,
     new Uint32Array(item.targetIndices), item.targetCornerNormals, item.targetVertexCount);
+  const fullSourceIndices = source.sourceIndices;
+  const provenance = (ordinals: readonly number[]) => Uint32Array.from(ordinals.flatMap(ordinal => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
+  const textured = { ...localTextured, appearanceSource: { ...localTextured.appearanceSource!, sourceIndices: fullSourceIndices,
+    cornerIndices: provenance(split.masked) } };
+  const retained = sub(split.retained, options.retainedItemId);
+  retained.appearanceSource = { ...retained.appearanceSource!, sourceIndices: fullSourceIndices, cornerIndices: provenance(split.retained) };
   const parts: MeshData[] = [
     { ...textured, color: [1, 1, 1, 1], shadingColor: undefined, texture: undefined, textureBitmap: options.image.bitmap,
       textureRef: { textureId: options.textureId, url: options.image.imageUri, repeatS: options.image.repeatS, repeatT: options.image.repeatT } },
-    { ...sub(split.retained, options.retainedItemId), color: [...original.color] as MeshData['color'], uvs: undefined, texture: undefined, textureRef: undefined, textureBitmap: undefined },
+    { ...retained, color: [...original.color] as MeshData['color'], uvs: undefined, texture: undefined, textureRef: undefined, textureBitmap: undefined },
   ];
   const partition: AppearancePartition = {
     before: [{ geometryItemId: original.geometryItemId!, triangles: Array.from({ length: original.indices.length / 3 }, (_, ordinal) => ordinal) }],

--- a/apps/viewer/src/lib/viewport-debug-hooks.ts
+++ b/apps/viewer/src/lib/viewport-debug-hooks.ts
@@ -1,8 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-import type { Renderer } from '@ifc-lite/renderer';
+import { appearanceSourceTriangle, type Renderer } from '@ifc-lite/renderer';
 import type { MeshData } from '@ifc-lite/geometry';
+import { useViewerStore } from '@/store';
 
 /** One resident part of an owner as plain data: no buffers, no live objects. */
 export interface ScenePartSnapshot {
@@ -11,6 +12,13 @@ export interface ScenePartSnapshot {
   vertices: number;
   textured: boolean;
   color: [number, number, number, number];
+  /** Canonical evaluated-surface ordinals still carried by this part. */
+  sourceTriangles: number[];
+}
+export interface SceneFaceHitSnapshot {
+  geometryItemId: number | undefined;
+  sourceTriangleIndex: number;
+  screen: { x: number; y: number };
 }
 /** What the scene currently renders for one federation-resolved id. */
 export interface SceneOwnerSnapshot {
@@ -25,8 +33,13 @@ export interface SceneOwnerSnapshot {
 }
 
 function snapshot(part: MeshData): ScenePartSnapshot {
+  const sourceTriangles: number[] = [];
+  for (let triangle = 0; triangle < part.indices.length / 3; triangle++) {
+    const source = appearanceSourceTriangle(part, triangle);
+    if (source !== undefined) sourceTriangles.push(source);
+  }
   return { geometryItemId: part.geometryItemId, triangles: part.indices.length / 3, vertices: part.positions.length / 3,
-    textured: !!(part.uvs && (part.texture || (part.textureRef && part.textureBitmap))), color: [...part.color] as ScenePartSnapshot['color'] };
+    textured: !!(part.uvs && (part.texture || (part.textureRef && part.textureBitmap))), color: [...part.color] as ScenePartSnapshot['color'], sourceTriangles };
 }
 
 /**
@@ -54,10 +67,38 @@ export function installViewportDebugHooks(renderer: Renderer): void {
     const centre = box && renderer.getCamera().projectToScreen({ x: (box.min.x + box.max.x) / 2, y: (box.min.y + box.max.y) / 2, z: (box.min.z + box.max.z) / 2 }, rect.width, rect.height);
     return { flat: flat?.map(snapshot) ?? null, instance: !!instanced, corners, screen: centre ? { x: rect.left + centre.x, y: rect.top + centre.y } : null };
   };
+  host.__ifc_lite_scene_face_hits__ = (globalId: number): SceneFaceHitSnapshot[] => {
+    const scene = renderer.getScene(), rect = renderer.getCanvas().getBoundingClientRect();
+    const parts = scene.getMeshDataPieces(globalId) ?? scene.getInstancedMeshDataPieces(globalId) ?? [];
+    const hits = new Map<number, SceneFaceHitSnapshot>();
+    for (const part of parts) for (let triangle = 0; triangle < part.indices.length / 3; triangle++) {
+      const sourceTriangleIndex = appearanceSourceTriangle(part, triangle);
+      if (sourceTriangleIndex === undefined || hits.has(sourceTriangleIndex)) continue;
+      const point = { x: 0, y: 0, z: 0 };
+      for (let corner = 0; corner < 3; corner++) {
+        const vertex = part.indices[triangle * 3 + corner];
+        point.x += (part.positions[vertex * 3] + (part.origin?.[0] ?? 0)) / 3;
+        point.y += (part.positions[vertex * 3 + 1] + (part.origin?.[1] ?? 0)) / 3;
+        point.z += (part.positions[vertex * 3 + 2] + (part.origin?.[2] ?? 0)) / 3;
+      }
+      const screen = renderer.getCamera().projectToScreen(point, rect.width, rect.height);
+      if (!screen) continue;
+      const state = useViewerStore.getState();
+      const exact = renderer.raycastScene(screen.x, screen.y, {
+        hiddenIds: state.hiddenEntities, isolatedIds: state.isolatedEntities,
+      })?.intersection;
+      if (exact?.expressId !== globalId || exact.sourceTriangleIndex !== sourceTriangleIndex
+        || exact.geometryItemId !== part.geometryItemId) continue;
+      hits.set(sourceTriangleIndex, { geometryItemId: part.geometryItemId, sourceTriangleIndex,
+        screen: { x: rect.left + screen.x, y: rect.top + screen.y } });
+    }
+    return [...hits.values()].sort((a, b) => a.sourceTriangleIndex - b.sourceTriangleIndex);
+  };
 }
 
 export function clearViewportDebugHooks(): void {
   const host = globalThis as Record<string, unknown>;
   delete host.__ifc_lite_render_stats__;
   delete host.__ifc_lite_scene_owner__;
+  delete host.__ifc_lite_scene_face_hits__;
 }

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -463,7 +463,7 @@ Visibility is passed via `render()` options (`hiddenIds`, `isolatedIds`); frustu
 
 Other exports: `Camera`, `Picker`, `Raycaster`, `SnapDetector`, `BVH`, `RaycastEngine`, `SectionPlaneRenderer`, `PointCloudRenderer`, `FederationRegistry` (multi-model id ranges), and the section-cap / plane-basis helpers.
 
-`Renderer.hasActiveClipping()` reports section or box clipping from the last rendered frame. `raycastScene()` applies the same clip state and its `Intersection` includes `modelIndex`, plus `geometryItemId` and `sourceTriangleIndex` when the hit has unambiguous representation-item and canonical evaluated-surface provenance. `appearanceSourceTriangle(mesh, triangleIndex)` performs that strict provenance lookup directly and returns `undefined` for absent, stale or mixed-corner identity.
+`Renderer.hasActiveClipping()` reports section, terrain or box clipping from the last rendered frame. `raycastScene()` applies the same clip state and its `Intersection` includes `modelIndex`, plus `geometryItemId` and `sourceTriangleIndex` when the hit has unambiguous representation-item and canonical evaluated-surface provenance. `appearanceSourceTriangle(mesh, triangleIndex)` performs that strict provenance lookup directly and returns `undefined` for absent, stale or mixed-corner identity.
 
 `Scene` and `Section2DOverlayRenderer` are package-internal from 2.0: reach the scene through `getScene(): SceneContents`, and the 3D line overlays through `Renderer.setLineOverlay`. `PickingManager` is package-internal from 2.0 as well: its constructor takes the now-internal `Scene`, so an exported class nobody could construct would have been worse than no export. Pick through `Renderer.pick` / `Renderer.pickRect`.
 

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -463,7 +463,7 @@ Visibility is passed via `render()` options (`hiddenIds`, `isolatedIds`); frustu
 
 Other exports: `Camera`, `Picker`, `Raycaster`, `SnapDetector`, `BVH`, `RaycastEngine`, `SectionPlaneRenderer`, `PointCloudRenderer`, `FederationRegistry` (multi-model id ranges), and the section-cap / plane-basis helpers.
 
-`Renderer.hasActiveClipping()` reports section, terrain or box clipping from the last rendered frame. `raycastScene()` does not clip triangle hits; exact correspondence tools can use this query to refuse clipped views.
+`Renderer.hasActiveClipping()` reports section or box clipping from the last rendered frame. `raycastScene()` applies the same clip state and its `Intersection` includes `modelIndex`, plus `geometryItemId` and `sourceTriangleIndex` when the hit has unambiguous representation-item and canonical evaluated-surface provenance. `appearanceSourceTriangle(mesh, triangleIndex)` performs that strict provenance lookup directly and returns `undefined` for absent, stale or mixed-corner identity.
 
 `Scene` and `Section2DOverlayRenderer` are package-internal from 2.0: reach the scene through `getScene(): SceneContents`, and the 3D line overlays through `Renderer.setLineOverlay`. `PickingManager` is package-internal from 2.0 as well: its constructor takes the now-internal `Scene`, so an exported class nobody could construct would have been worse than no export. Pick through `Renderer.pick` / `Renderer.pickRect`.
 

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -154,6 +154,15 @@ editor keeps its renderer and camera across selection changes and re-plans that
 reproduce the same surface (same fingerprint, same placed corners); only a
 changed surface rebuilds it.
 
+**Pick in model** keeps the main viewport in a sticky face-pick mode. Each click
+must resolve the open product's federation model, one of its source/textured/
+retained representation items, and a canonical evaluated-surface triangle; a
+miss, another object, or absent/ambiguous provenance changes no selection and
+shows a diagnostic. Hidden and isolated objects and section/crop-clipped faces
+follow the same visibility rules as the rendered frame. Masked preview parts
+retain full-surface corner ordinals, so clicking the retained half after a split
+does not restart numbering at zero.
+
 The viewer never decides staleness itself. After every plan it reconciles: a
 mask whose product the planner excluded as `Face selection is stale` (an
 edited opening, a different profile, a different tessellator) or as already

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -564,7 +564,9 @@ Scene raycasts and magnetic snapping include regular, batched, textured and
 instanced geometry. A textured surface in front of another object participates
 in nearest-surface selection, with the same hidden/isolation filters and retained
 local origins. CPU raycasts intersect triangles; texture alpha does not cut holes
-in the picking surface.
+in the picking surface. `Renderer.raycastScene()` also uses the active section
+plane and crop box; when a front triangle is clipped, the ray continues to the
+nearest visible triangle behind it.
 
 Custom `RaycastEngine` scene adapters can optionally implement
 `getTexturedMeshes()` returning owners with `expressId` and optional `modelIndex`;
@@ -584,8 +586,17 @@ if (result) {
   console.log(`Distance: ${intersection.distance}`);
   console.log(`Entity: #${intersection.expressId}`);
   console.log(`Triangle: ${intersection.triangleIndex}`);
+  console.log(`Federation model: ${intersection.modelIndex}`);
+  console.log(`Representation item: ${intersection.geometryItemId}`);
+  console.log(`Evaluated-surface triangle: ${intersection.sourceTriangleIndex}`);
 }
 ```
+
+`triangleIndex` is local to the rendered mesh piece. Use
+`sourceTriangleIndex` for persisted face masks: it follows
+`MeshData.appearanceSource.cornerIndices` through streaming fragments, UV seam
+expansion and textured/retained mask partitions. The key is absent when that
+mapping or the representation-item identity cannot be proved.
 
 ## Visibility Control
 

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -43,7 +43,7 @@ canvas.addEventListener('click', async (e) => {
 });
 ```
 
-For exact world-space hits with surface normals, use `raycastScene(x, y)` — slower but returns the precise intersection point + normal.
+For exact world-space hits with surface normals, use `raycastScene(x, y)` — slower but returns the precise intersection point, normal and, where provenance is unambiguous, the federation model, representation item and canonical evaluated-surface triangle.
 
 ## Section planes
 
@@ -114,7 +114,7 @@ Registered raster references are available through `renderer.getReferenceImages(
 ### Exact surface tools and clipping
 
 `renderer.hasActiveClipping()` reports whether the last rendered frame applied
-section, terrain or box clipping. It reads the retained render snapshot, so
+section or box clipping. It reads the retained render snapshot, so
 mutating a previous options object does not change the answer.
-`raycastScene()` does not clip triangle hits; tools requiring an exact visible
-surface should refuse that operation while this query returns `true`.
+`raycastScene()` applies that same clip state while walking triangles, so a
+clipped front face cannot hide a visible face behind it.

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -114,7 +114,7 @@ Registered raster references are available through `renderer.getReferenceImages(
 ### Exact surface tools and clipping
 
 `renderer.hasActiveClipping()` reports whether the last rendered frame applied
-section or box clipping. It reads the retained render snapshot, so
+section, terrain or box clipping. It reads the retained render snapshot, so
 mutating a previous options object does not change the answer.
 `raycastScene()` applies that same clip state while walking triangles, so a
 clipped front face cannot hide a visible face behind it.

--- a/packages/renderer/src/appearance-preview.test.ts
+++ b/packages/renderer/src/appearance-preview.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import type { MeshData } from '@ifc-lite/geometry';
 import { Scene } from './scene.js';
 import { expandAppearanceCorners } from './appearance-uvs.js';
+import { Raycaster } from './raycaster.js';
 
 (globalThis as Record<string, unknown>).GPUBufferUsage = {
   COPY_DST: 8,
@@ -671,6 +672,15 @@ describe('instanced occurrence appearance history (#4404)', () => {
     const start = () => api.begin(owner, { materializedOriginals: [original], geometryItemRemaps: [{ from: 21, to: 31 }] });
     return { scene, state, original, replacement, owner, api, start };
   }
+  it('materialized occurrence hits retain owner, item, model and canonical face identity (#4555)', () => {
+    const { scene, original } = setup();
+    const hit = new Raycaster().raycast({ origin: { x: 0.2, y: 1, z: -0.2 },
+      direction: { x: 0, y: -1, z: 0 } }, [original]);
+    assert.deepEqual(hit && { expressId: hit.expressId, modelIndex: hit.modelIndex,
+      geometryItemId: hit.geometryItemId, sourceTriangleIndex: hit.sourceTriangleIndex },
+    { expressId: 7, modelIndex: 3, geometryItemId: 21, sourceTriangleIndex: 0 });
+    scene.clear();
+  });
   it('cancels a remapped preview and abandons invalid remaps without retaining a lease', () => {
     const { scene, original, replacement, owner, api, start } = setup();
     assert.throws(() => api.begin(owner, { materializedOriginals: [original], geometryItemRemaps: [{ from: 99, to: 31 }] }), /remap/);

--- a/packages/renderer/src/appearance-uvs.test.ts
+++ b/packages/renderer/src/appearance-uvs.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { MeshData } from '@ifc-lite/geometry';
 import {
+  appearanceSourceTriangle,
   expandAppearanceCorners,
   equivalentAppearanceGeometry,
 } from './appearance-uvs.js';
@@ -26,6 +27,23 @@ function sourceMesh(): MeshData {
   };
 }
 describe('canonical appearance corner provenance (#4243)', () => {
+  it('resolves full-surface ordinals through streamed and masked subsets (#4555)', () => {
+    const mesh = sourceMesh();
+    const fragments = splitMeshForStreaming(mesh, 3, 4096);
+    assert.deepEqual(fragments.map(fragment => appearanceSourceTriangle(fragment, 0)), [0, 1, 2]);
+
+    const indices = new Uint32Array([3, 2, 1, 2, 0, 1]);
+    const masked: MeshData = { ...mesh, indices, appearanceSource: {
+      kind: 'canonical-item', indices, sourceIndices: mesh.indices,
+      cornerIndices: new Uint32Array([3, 4, 5, 0, 1, 2]),
+    } };
+    assert.equal(appearanceSourceTriangle(masked, 0), 1);
+    assert.equal(appearanceSourceTriangle(masked, 1), 0);
+    masked.appearanceSource!.cornerIndices![2] = 6;
+    assert.equal(appearanceSourceTriangle(masked, 0), undefined, 'mixed source triangles refuse');
+    masked.appearanceSource!.indices = new Uint32Array(indices);
+    assert.equal(appearanceSourceTriangle(masked, 1), undefined, 'rebuilt topology refuses');
+  });
   it('composes repeated fragments and expands welded vertices without losing UV seams', () => {
     const mesh = sourceMesh(),
       uvs = Array.from({ length: 18 }, (_, index) => index / 4);
@@ -49,7 +67,7 @@ describe('canonical appearance corner provenance (#4243)', () => {
       );
       for (const index of expanded.indices) {
         assert.deepEqual(
-          [...expanded.uvs!.slice(index * 2, index * 2 + 2)],
+          Array.from(expanded.uvs!.slice(index * 2, index * 2 + 2)),
           uvs.slice(corner * 2, corner * 2 + 2),
         );
         corner++;

--- a/packages/renderer/src/appearance-uvs.ts
+++ b/packages/renderer/src/appearance-uvs.ts
@@ -3,6 +3,36 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { MeshData } from '@ifc-lite/geometry';
 
+/** Resolve a rendered triangle to its canonical evaluated-surface ordinal.
+ * Returns undefined when topology provenance is absent or ambiguous. */
+export function appearanceSourceTriangle(
+  mesh: MeshData,
+  triangleIndex: number,
+): number | undefined {
+  const source = mesh.appearanceSource;
+  if (
+    !source ||
+    source.kind !== 'canonical-item' ||
+    source.indices !== mesh.indices ||
+    mesh.indices.length % 3 !== 0 ||
+    source.sourceIndices.length % 3 !== 0 ||
+    !Number.isSafeInteger(triangleIndex) ||
+    triangleIndex < 0 ||
+    triangleIndex * 3 + 2 >= mesh.indices.length ||
+    (source.cornerIndices && source.cornerIndices.length !== mesh.indices.length)
+  ) return undefined;
+
+  const first = triangleIndex * 3;
+  const corners = [0, 1, 2].map(offset => source.cornerIndices?.[first + offset] ?? first + offset);
+  if (corners.some(corner => !Number.isSafeInteger(corner) || corner < 0 || corner >= source.sourceIndices.length)) return undefined;
+  const ordinal = Math.floor(corners[0] / 3);
+  if (
+    corners.some(corner => Math.floor(corner / 3) !== ordinal) ||
+    new Set(corners.map(corner => corner % 3)).size !== 3
+  ) return undefined;
+  return ordinal;
+}
+
 /** Bind canonical final triangle corners, expanding welded vertices only for
  * appearance. Geometry coordinates and triangle order remain exactly unchanged. */
 export function expandAppearanceCorners(

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -12,7 +12,7 @@ export { RenderPipeline } from './pipeline.js';
 export { Camera } from './camera.js';
 // The MEASURED surface `getScene()` publishes — see its docs.
 export type { SceneContents } from './scene-contents.js';
-export { expandAppearanceCorners, equivalentAppearanceGeometry } from './appearance-uvs.js';
+export { appearanceSourceTriangle, expandAppearanceCorners, equivalentAppearanceGeometry } from './appearance-uvs.js';
 export { sameCompanionParts } from './appearance-companions.js';
 export { invertAppearancePartition, type AppearancePreview, type AppearanceOwner, type AppearanceToken, type AppearanceChange, type AppearancePartition, type AppearancePartitionPart } from './appearance-preview.js';
 import type { AppearancePreview } from './appearance-preview.js';
@@ -3276,13 +3276,13 @@ export class Renderer {
         return this._activePickSection !== null || this._activePickClipBox !== null;
     }
 
-    /** Exact surface raycast in CSS canvas coordinates; does not apply clipping. */
+    /** Exact visible-surface raycast in CSS canvas coordinates. */
     raycastScene(
         x: number,
         y: number,
         options?: PickOptions & { snapOptions?: Partial<SnapOptions> }
     ): { intersection: Intersection; snap?: SnapTarget } | null {
-        return this.raycastEngine.raycastScene(x, y, options);
+        return this.raycastEngine.raycastScene(x, y, options, this.activePickClip());
     }
 
     /**

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -53,7 +53,7 @@ function instancedDevice(): GPUDevice {
   } as unknown as GPUDevice;
 }
 
-function instancedTriangle(entityId: number, itemId: number): DecodedInstancedShard {
+function instancedTriangle(entityId: number, itemId?: number): DecodedInstancedShard {
   return {
     templates: [{
       // Decoder output is IFC Z-up. Conversion on upload maps this XZ triangle
@@ -62,9 +62,9 @@ function instancedTriangle(entityId: number, itemId: number): DecodedInstancedSh
       normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0]),
       indices: new Uint32Array([0, 1, 2]), origin: [0, 0, 0],
     }],
-    instances: [{ templateIndex: 0, entityId, itemId, color: [1, 1, 1, 1],
+    instances: [{ templateIndex: 0, entityId, ...(itemId === undefined ? {} : { itemId }), color: [1, 1, 1, 1],
       transform: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]) }],
-    carriesItemIds: true,
+    carriesItemIds: itemId !== undefined,
   };
 }
 
@@ -364,6 +364,21 @@ describe('RaycastEngine.raycastScene', () => {
     assert.equal(cropVisible.expressId, 8, 'the crop box also rejects the nearer hidden surface');
   });
 
+  it('rejects clipped snap candidates while retaining the best visible candidate (#4555)', () => {
+    const scene = new Scene();
+    const positions = new Float32Array([0.05, 0, 0, -1, -1, 0, -1, 1, 0]);
+    const triangle: MeshData = { expressId: 9, positions,
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1] };
+    addRegularMesh(scene, triangle);
+    const hit = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50)).raycastScene(399, 300, {
+      snapOptions: { snapToVertices: true, snapToEdges: false, snapToFaces: false, screenSnapRadius: 200 },
+    }, { sectionPlane: { normal: [1, 0, 0], distance: 0, flipped: false } });
+    assert.ok(hit?.snap);
+    assert.equal(hit.intersection.expressId, 9, 'the visible portion of the triangle remains hittable');
+    assert.equal(hit.snap.position.x, -1, 'the closer x=0.05 vertex is clipped and cannot win snapping');
+  });
+
   it('reports canonical identity from a materialized instance in its federation model (#4555)', () => {
     const scene = new Scene();
     scene.addInstancedShard(instancedDevice(), instancedTriangle(1_025, 1_011), 7);
@@ -373,6 +388,16 @@ describe('RaycastEngine.raycastScene', () => {
     assert.deepEqual({ expressId: hit.expressId, modelIndex: hit.modelIndex,
       geometryItemId: hit.geometryItemId, sourceTriangleIndex: hit.sourceTriangleIndex },
     { expressId: 1_025, modelIndex: 7, geometryItemId: 1_011, sourceTriangleIndex: 0 });
+  });
+
+  it('does not expose a canonical face ordinal when an instance has no representation item (#4555)', () => {
+    const scene = new Scene();
+    scene.addInstancedShard(instancedDevice(), instancedTriangle(1_025), 7);
+    const hit = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50)).raycastScene(400, 300)?.intersection;
+    assert.ok(hit);
+    assert.equal(hit.modelIndex, 7);
+    assert.equal(hit.geometryItemId, undefined);
+    assert.equal(hit.sourceTriangleIndex, undefined);
   });
 
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -26,7 +26,11 @@ import { RaycastEngine } from './raycast-engine.js';
 import { Camera } from './camera.js';
 import { Scene, type TexturedMesh } from './scene.js';
 import type { Mesh, BatchedMesh, PickOptions } from './types.js';
-import type { MeshData } from '@ifc-lite/geometry';
+import type { DecodedInstancedShard, MeshData } from '@ifc-lite/geometry';
+
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  COPY_DST: 1, INDEX: 2, VERTEX: 4,
+};
 
 // ─── fake canvas ────────────────────────────────────────────────────────────
 
@@ -36,6 +40,32 @@ function fakeCanvas(width = 800, height = 600): HTMLCanvasElement {
     height,
     getBoundingClientRect: () => ({ width, height }),
   } as unknown as HTMLCanvasElement;
+}
+
+function instancedDevice(): GPUDevice {
+  return {
+    limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+    createBuffer: ({ size }: { size: number }) => {
+      const bytes = new ArrayBuffer(size);
+      return { getMappedRange: () => bytes, unmap() {}, destroy() {} };
+    },
+    queue: { writeBuffer() {} },
+  } as unknown as GPUDevice;
+}
+
+function instancedTriangle(entityId: number, itemId: number): DecodedInstancedShard {
+  return {
+    templates: [{
+      // Decoder output is IFC Z-up. Conversion on upload maps this XZ triangle
+      // to the viewer XY plane at z=0, directly under the camera ray.
+      positions: new Float32Array([-5, 0, -5, 5, 0, -5, 0, 0, 5]),
+      normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0]),
+      indices: new Uint32Array([0, 1, 2]), origin: [0, 0, 0],
+    }],
+    instances: [{ templateIndex: 0, entityId, itemId, color: [1, 1, 1, 1],
+      transform: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]) }],
+    carriesItemIds: true,
+  };
 }
 
 // ─── fixture geometry ───────────────────────────────────────────────────────
@@ -332,6 +362,17 @@ describe('RaycastEngine.raycastScene', () => {
       min: [-2, -2, -12], max: [2, 2, -8], enabled: true,
     } })!.intersection;
     assert.equal(cropVisible.expressId, 8, 'the crop box also rejects the nearer hidden surface');
+  });
+
+  it('reports canonical identity from a materialized instance in its federation model (#4555)', () => {
+    const scene = new Scene();
+    scene.addInstancedShard(instancedDevice(), instancedTriangle(1_025, 1_011), 7);
+    const engine = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50));
+    const hit = engine.raycastScene(400, 300)?.intersection;
+    assert.ok(hit);
+    assert.deepEqual({ expressId: hit.expressId, modelIndex: hit.modelIndex,
+      geometryItemId: hit.geometryItemId, sourceTriangleIndex: hit.sourceTriangleIndex },
+    { expressId: 1_025, modelIndex: 7, geometryItemId: 1_011, sourceTriangleIndex: 0 });
   });
 
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -303,6 +303,37 @@ describe('RaycastEngine.raycastScene', () => {
     assert.equal(hitEmptyIsolation, null);
   });
 
+  it('reports exact item/model/source identity and continues behind clipped triangles (#4555)', () => {
+    const scene = new Scene();
+    const near = makeQuad({ expressId: 7, modelIndex: 3, translate: [0, 0, 10] });
+    near.geometryItemId = 70;
+    near.appearanceSource = { kind: 'canonical-item', indices: near.indices,
+      sourceIndices: near.indices, cornerIndices: new Uint32Array([3, 4, 5, 0, 1, 2]) };
+    const rear = makeQuad({ expressId: 8, modelIndex: 4, translate: [0, 0, -10] });
+    rear.geometryItemId = 80;
+    rear.appearanceSource = { kind: 'canonical-item', indices: rear.indices, sourceIndices: rear.indices };
+    addRegularQuad(scene, near);
+    addRegularQuad(scene, rear);
+    const engine = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50));
+
+    const exact = engine.raycastScene(399, 301)!.intersection;
+    assert.deepEqual({ expressId: exact.expressId, modelIndex: exact.modelIndex,
+      geometryItemId: exact.geometryItemId, sourceTriangleIndex: exact.sourceTriangleIndex },
+    { expressId: 7, modelIndex: 3, geometryItemId: 70, sourceTriangleIndex: 1 });
+
+    const visible = engine.raycastScene(399, 301, undefined, { sectionPlane: {
+      normal: [0, 0, 1], distance: 0, flipped: false,
+    } })!.intersection;
+    assert.deepEqual({ expressId: visible.expressId, modelIndex: visible.modelIndex,
+      geometryItemId: visible.geometryItemId, sourceTriangleIndex: visible.sourceTriangleIndex },
+    { expressId: 8, modelIndex: 4, geometryItemId: 80, sourceTriangleIndex: 0 });
+
+    const cropVisible = engine.raycastScene(399, 301, undefined, { clipBox: {
+      min: [-2, -2, -12], max: [2, 2, -8], enabled: true,
+    } })!.intersection;
+    assert.equal(cropVisible.expressId, 8, 'the crop box also rejects the nearer hidden surface');
+  });
+
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {
     // An asymmetric triangle (legs of different length: 12 along local X, 4
     // along local Y), scaled non-uniformly, rotated 90 degrees about Y, and

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -293,7 +293,7 @@ export class RaycastEngine {
                     intersection,
                     { position: cameraPos, fov: cameraFov },
                     this.canvas.height,
-                    options.snapOptions
+                    options.snapOptions, target => !pointClipped(clip, target.position.x, target.position.y, target.position.z),
                 ) || undefined;
             }
 

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -14,7 +14,8 @@ import { Raycaster, type Intersection, type Ray } from './raycaster.js';
 import { SnapDetector, SnapType, type SnapTarget, type SnapOptions, type EdgeLockInput, type MagneticSnapResult } from './snap-detector.js';
 import { BVH } from './bvh.js';
 import type { MeshData } from '@ifc-lite/geometry';
-import type { PickOptions } from './types.js';
+import type { PickClipState, PickOptions } from './types.js';
+import { pointClipped } from './scene-raycaster.js';
 import {
     queryPointClouds,
     releasedEdgeLock,
@@ -23,9 +24,7 @@ import {
     type PointCloudRayProvider,
     type PointCloudSnapCamera,
 } from './raycast-point-cloud-query.js';
-
 export type { PointCloudRaySource, PointCloudRayProvider } from './raycast-point-cloud-query.js';
-
 /**
  * Cheap order-sensitive 32-bit signature of a mesh set, used to detect when the
  * raycast BVH must rebuild because the SET changed (not just its size). Mixes
@@ -251,7 +250,8 @@ export class RaycastEngine {
     raycastScene(
         x: number,
         y: number,
-        options?: PickOptions & { snapOptions?: Partial<SnapOptions> }
+        options?: PickOptions & { snapOptions?: Partial<SnapOptions> },
+        clip?: PickClipState | null,
     ): { intersection: Intersection; snap?: SnapTarget } | null {
         try {
             const scaled = this.scaleCoordinates(x, y);
@@ -271,7 +271,8 @@ export class RaycastEngine {
             const meshesToTest = this.filterWithBVH(allMeshData, ray);
 
             // Perform raycasting
-            const intersection = this.raycaster.raycast(ray, meshesToTest);
+            const intersection = this.raycaster.raycast(ray, meshesToTest,
+                hit => !pointClipped(clip, hit.point.x, hit.point.y, hit.point.z));
 
             if (!intersection) {
                 return null;

--- a/packages/renderer/src/raycaster.ts
+++ b/packages/renderer/src/raycaster.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { MeshData } from '@ifc-lite/geometry';
+import { appearanceSourceTriangle } from './appearance-uvs.js';
+import { reportableItemId } from './pick-resolve.js';
 
 export interface Ray {
   origin: { x: number; y: number; z: number };
@@ -22,6 +24,12 @@ export interface Intersection {
   meshIndex: number;
   triangleIndex: number;
   expressId: number;
+  /** Federation model slot of the exact rendered piece. */
+  modelIndex?: number;
+  /** Exact representation item, absent for an ambiguous merged piece. */
+  geometryItemId?: number;
+  /** Triangle ordinal in the canonical evaluated surface. */
+  sourceTriangleIndex?: number;
   barycentricCoord: { u: number; v: number; w: number };
 }
 
@@ -31,13 +39,17 @@ export class Raycaster {
   /**
    * Cast a ray through all meshes and return the closest intersection
    */
-  raycast(ray: Ray, meshes: MeshData[]): Intersection | null {
+  raycast(
+    ray: Ray,
+    meshes: MeshData[],
+    accept?: (intersection: Intersection, mesh: MeshData) => boolean,
+  ): Intersection | null {
     let closestIntersection: Intersection | null = null;
     let closestDistance = Infinity;
 
     for (let meshIndex = 0; meshIndex < meshes.length; meshIndex++) {
       const mesh = meshes[meshIndex];
-      const intersection = this.raycastMesh(ray, mesh, meshIndex);
+      const intersection = this.raycastMesh(ray, mesh, meshIndex, accept);
 
       if (intersection && intersection.distance < closestDistance) {
         closestDistance = intersection.distance;
@@ -51,7 +63,12 @@ export class Raycaster {
   /**
    * Cast ray through a single mesh
    */
-  private raycastMesh(ray: Ray, mesh: MeshData, meshIndex: number): Intersection | null {
+  private raycastMesh(
+    ray: Ray,
+    mesh: MeshData,
+    meshIndex: number,
+    accept?: (intersection: Intersection, mesh: MeshData) => boolean,
+  ): Intersection | null {
     const positions = mesh.positions;
     const indices = mesh.indices;
 
@@ -126,8 +143,6 @@ export class Raycaster {
       const intersection = this.intersectTriangle(localRay, v0, v1, v2);
 
       if (intersection && intersection.distance < closestDistance) {
-        closestDistance = intersection.distance;
-
         // Calculate normal from triangle
         const normal = this.calculateTriangleNormal(v0, v1, v2);
 
@@ -136,16 +151,25 @@ export class Raycaster {
         const worldPoint: Vec3 = o
           ? { x: intersection.point.x + o[0], y: intersection.point.y + o[1], z: intersection.point.z + o[2] }
           : intersection.point;
+        const geometryItemId = reportableItemId(mesh, mesh.expressId);
+        const sourceTriangleIndex = appearanceSourceTriangle(mesh, i / 3);
 
-        closestIntersection = {
+        const exact: Intersection = {
           point: worldPoint,
           normal,
           distance: intersection.distance,
           meshIndex,
           triangleIndex: i / 3,
           expressId: mesh.expressId,
+          modelIndex: mesh.modelIndex ?? 0,
+          ...(geometryItemId === undefined ? {} : { geometryItemId }),
+          ...(sourceTriangleIndex === undefined ? {} : { sourceTriangleIndex }),
           barycentricCoord: intersection.barycentricCoord,
         };
+        if (!accept || accept(exact, mesh)) {
+          closestDistance = intersection.distance;
+          closestIntersection = exact;
+        }
       }
     }
 

--- a/packages/renderer/src/raycaster.ts
+++ b/packages/renderer/src/raycaster.ts
@@ -152,7 +152,9 @@ export class Raycaster {
           ? { x: intersection.point.x + o[0], y: intersection.point.y + o[1], z: intersection.point.z + o[2] }
           : intersection.point;
         const geometryItemId = reportableItemId(mesh, mesh.expressId);
-        const sourceTriangleIndex = appearanceSourceTriangle(mesh, i / 3);
+        // A canonical ordinal is only actionable together with the exact IFC
+        // representation item whose evaluated surface owns it.
+        const sourceTriangleIndex = geometryItemId === undefined ? undefined : appearanceSourceTriangle(mesh, i / 3);
 
         const exact: Intersection = {
           point: worldPoint,

--- a/packages/renderer/src/scene-instance-materialization.ts
+++ b/packages/renderer/src/scene-instance-materialization.ts
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { MeshData } from '@ifc-lite/geometry';
 interface Occurrence { templateIndex: number; byteOffset: number; originalColor: [number, number, number, number]; itemId?: number }
-interface Template { positions: Float32Array; normals: Float32Array; indices: Uint32Array; instanceData: ArrayBuffer }
-/** CPU display expansion only: f32 instance transforms are not canonical IFC provenance. */
+interface Template { modelIndex: number; positions: Float32Array; normals: Float32Array; indices: Uint32Array; instanceData: ArrayBuffer }
+/** CPU display expansion: transformed f32 coordinates are approximate, while template topology remains canonical. */
 export function materializeInstances(expressId: number, occ: readonly Occurrence[], templates: readonly (Template | undefined)[]): MeshData[] | undefined {
     const out: MeshData[] = [];
     for (const o of occ) {
@@ -46,7 +46,12 @@ export function materializeInstances(expressId: number, occ: readonly Occurrence
       // #2985: the same drill-to-source id a flat mesh carries, so a consumer of
       // these pieces is not worse off for the geometry having been instanced.
       const item = o.itemId !== undefined ? { geometryItemId: o.itemId } : {};
-      out.push({ expressId, positions, normals, indices: tpl.indices, color, occurrenceKey, ...item });
+      // The transform changes coordinates, not template topology. Preserve the
+      // decoded template's exact index reference as the canonical source fence,
+      // and carry its model-scoped slot onto the materialized occurrence.
+      const indices = tpl.indices;
+      out.push({ expressId, modelIndex: tpl.modelIndex, positions, normals, indices, color, occurrenceKey, ...item,
+        appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } });
     }
     return out.length > 0 ? out : undefined;
 }

--- a/packages/renderer/src/scene-instance-types.ts
+++ b/packages/renderer/src/scene-instance-types.ts
@@ -47,6 +47,8 @@ export interface InstancedOccurrence {
  *  occurrence's byteOffset+0, column-major). These are references into the decoded
  *  shard, so retaining them costs the (already compact) shard size, not N copies. */
 export interface InstancedTemplateCpu {
+  /** Federation owner copied from the GPU template's model-scoped slot. */
+  modelIndex: number;
   positions: Float32Array;
   normals: Float32Array;
   indices: Uint32Array;

--- a/packages/renderer/src/scene-local-bounds.test.ts
+++ b/packages/renderer/src/scene-local-bounds.test.ts
@@ -76,6 +76,7 @@ describe('Scene.getEntityLocalBounds', () => {
     // side), mirroring scene-remove.test.ts's approach for boundingBoxes.
     scene['instancedTemplateCpu'] = [
       {
+        modelIndex: 0,
         positions: new Float32Array(),
         normals: new Float32Array(),
         indices: new Uint32Array(),
@@ -109,10 +110,12 @@ describe('Scene.getEntityLocalBounds', () => {
     const scene = new Scene();
     scene['instancedTemplateCpu'] = [
       {
+        modelIndex: 0,
         positions: new Float32Array(), normals: new Float32Array(), indices: new Uint32Array(),
         instanceData: new ArrayBuffer(0), localMin: [0, 0, 0], localMax: [1, 1, 1],
       },
       {
+        modelIndex: 0,
         positions: new Float32Array(), normals: new Float32Array(), indices: new Uint32Array(),
         instanceData: new ArrayBuffer(0), localMin: [-1, 0.5, 0], localMax: [0.5, 2, 1],
       },
@@ -184,6 +187,7 @@ describe('Scene.getEntityTransform', () => {
 
     scene['instancedTemplateCpu'] = [
       {
+        modelIndex: 0,
         positions: new Float32Array(),
         normals: new Float32Array(),
         indices: new Uint32Array(),

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3159,8 +3159,7 @@ export class Scene {
       // Retain the compact CPU geometry + the packed instance records (mat4 per
       // occurrence) so CPU consumers can reach instanced geometry without a full
       // per-occurrence MeshData each. These are references into the decoded shard.
-      // Slot-assigned, not pushed: the CPU array is emptied on geometry release
-      // while the GPU slots live on, so `push` would silently misalign the two.
+      // Slot-assigned because release empties the CPU array while GPU slots live on; push would misalign them.
       this.instancedTemplateCpu[templateIndex] = {
         modelIndex,
         positions: t.positions,

--- a/packages/renderer/src/scene.ts
+++ b/packages/renderer/src/scene.ts
@@ -3162,6 +3162,7 @@ export class Scene {
       // Slot-assigned, not pushed: the CPU array is emptied on geometry release
       // while the GPU slots live on, so `push` would silently misalign the two.
       this.instancedTemplateCpu[templateIndex] = {
+        modelIndex,
         positions: t.positions,
         normals: t.normals,
         indices: t.indices,

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -144,7 +144,7 @@ export class SnapDetector {
     intersection: Intersection | null,
     camera: { position: Vec3; fov: number },
     screenHeight: number,
-    options: Partial<SnapOptions> = {}
+    options: Partial<SnapOptions> = {}, accept?: (target: SnapTarget) => boolean,
   ): SnapTarget | null {
     const opts = { ...this.defaultOptions, ...options };
 
@@ -184,7 +184,7 @@ export class SnapDetector {
     }
 
     // Return best target
-    return this.getBestSnapTarget(targets);
+    return this.getBestSnapTarget(accept ? targets.filter(accept) : targets);
   }
 
   /**

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -7720,6 +7720,7 @@
     "VisualEnhancementOptions: interface",
     "WebGPUDevice: class",
     "aggregateFrameTimings: function",
+    "appearanceSourceTriangle: function",
     "bucketBaseKeyFor: function",
     "chunkCellKey: function",
     "computeDurationStats: function",

--- a/tests/e2e/appearance-face-mask.e2e.spec.ts
+++ b/tests/e2e/appearance-face-mask.e2e.spec.ts
@@ -7,8 +7,8 @@
  * viewer build, the real wasm planner in its worker, the real WebGPU renderer.
  *
  * Journey on AC20-FZK-Haus IfcMember #35169 (one of 42 members sharing a type):
- * opt into evaluated conversion, select part of the member's faces in the
- * Appearance panel, preview the textured + retained split, Discard, preview
+ * opt into evaluated conversion, verify exact main-viewport face hits, select
+ * a face, preview the textured + retained split, Compare, Discard, preview
  * again, Apply, Undo, Redo, click the member in the viewport, export IFC +
  * images, and reopen the IFCZIP in a fresh page where the member renders as
  * two flat parts and still picks as one product. Sibling #35304 is compared
@@ -25,11 +25,12 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { deflateSync } from 'node:zlib';
 import type { ViewerState } from '../../apps/viewer/src/store';
-import type { SceneOwnerSnapshot } from '../../apps/viewer/src/lib/viewport-debug-hooks';
+import type { SceneFaceHitSnapshot, SceneOwnerSnapshot } from '../../apps/viewer/src/lib/viewport-debug-hooks';
 
 declare global {
   var __ifc_lite_viewer_store__: { getState(): ViewerState };
   var __ifc_lite_scene_owner__: (globalId: number) => SceneOwnerSnapshot;
+  var __ifc_lite_scene_face_hits__: (globalId: number) => SceneFaceHitSnapshot[];
 }
 
 const FIXTURE = 'tests/models/ara3d/AC20-FZK-Haus.ifc';
@@ -83,20 +84,25 @@ test.describe('appearance face masks on AC20-FZK-Haus (#4404)', () => {
     await expect(panel).toContainText('all 12 faces');
     journey.wholePreview = whole.flat;
 
-    // Face selection: marquee over the left half of the member's canvas, then
-    // fall back to a single face click if the marquee caught everything or nothing.
+    // Prove the main viewport exposes exact canonical hits, then select one face
+    // in the dedicated surface view. The paired box triangle remains the
+    // adjacent negative control through the native maskedTriangles plan.
     await panel.getByRole('button', { name: 'Select faces', exact: true }).click();
     const editor = panel.getByLabel(`Face selection for IFC object #${MEMBER}`);
     await editor.waitFor();
     await expect(editor, 'the face-selection canvas has its own renderer ready').toHaveAttribute('aria-busy', 'false', { timeout: 60_000 });
+    await page.evaluate(id => globalThis.__ifc_lite_viewer_store__.getState().setIsolatedEntities(new Set([id])), ids.member);
+    await frameSelection(page, ids.member, false);
+    const mainHits = await page.evaluate(id => globalThis.__ifc_lite_scene_face_hits__(id), ids.member);
+    expect(mainHits.length, 'the main viewport raycasts canonical face ordinals').toBeGreaterThan(0);
     await editor.getByRole('button', { name: 'Pick faces', exact: true }).click();
-    const canvas = editor.locator('canvas');
-    const box = (await canvas.boundingBox())!;
-    await page.mouse.move(box.x + 2, box.y + 2); await page.mouse.down();
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height - 2, { steps: 4 }); await page.mouse.up();
+    const faceCanvas = editor.locator('canvas');
+    const faceBox = (await faceCanvas.boundingBox())!;
+    await page.mouse.move(faceBox.x + 2, faceBox.y + 2); await page.mouse.down();
+    await page.mouse.move(faceBox.x + faceBox.width / 2, faceBox.y + faceBox.height - 2, { steps: 4 }); await page.mouse.up();
     let chip = await selectedFaces(panel);
     if (chip === null || chip === 12) {
-      await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+      await page.mouse.click(faceBox.x + faceBox.width / 2, faceBox.y + faceBox.height / 2);
       chip = await selectedFaces(panel);
     }
     expect(chip, 'a partial face selection').toBeGreaterThan(0);
@@ -109,8 +115,18 @@ test.describe('appearance face masks on AC20-FZK-Haus (#4404)', () => {
     expect(split.flat?.map(part => part.textured)).toEqual([true, false]);
     expect((split.flat?.[0].triangles ?? 0) + (split.flat?.[1].triangles ?? 0)).toBe(12);
     expect(split.flat?.[0].triangles).toBe(chip);
-    expect([...split.corners].sort(), 'the split preserves every placed corner of the member').toEqual([...memberBefore.corners].sort());
+    expect(split.flat?.[0].sourceTriangles.length, 'native maskedTriangles ordinals reach the textured split').toBe(chip);
+    const selectedOrdinal = split.flat!.find(part => part.textured)!.sourceTriangles[0];
+    const adjacent = selectedOrdinal % 2 === 0 ? selectedOrdinal + 1 : selectedOrdinal - 1;
+    expect(split.flat?.[1].sourceTriangles, 'the adjacent face remains on the retained split').toContain(adjacent);
+    expect(cornerSignature(split.corners), 'the split preserves every placed corner of the member').toEqual(cornerSignature(memberBefore.corners));
     expect((await owner(ids.sibling)).corners).toEqual(siblingBefore.corners);
+    await panel.getByRole('button', { name: 'Compare original', exact: true }).click();
+    const compared = await owner(ids.member);
+    expect(compared, 'Compare restores the exact loaded occurrence').toEqual({ ...memberBefore, screen: compared.screen });
+    await panel.getByRole('button', { name: 'Show preview', exact: true }).click();
+    await page.waitForFunction(id => globalThis.__ifc_lite_scene_owner__(id).flat?.length === 2, ids.member);
+    expect((await owner(ids.member)).flat, 'Show preview restores the same masked split').toEqual(split.flat);
     await frameSelection(page, ids.member, false);
     await page.screenshot({ path: join(OUT, 'preview-split.png') });
     await clearIsolation(page);
@@ -210,7 +226,7 @@ test.describe('appearance face masks on AC20-FZK-Haus (#4404)', () => {
     expect(reopened.flat?.length, 'the reopened member renders as its textured and retained face sets').toBe(2);
     expect(reopened.flat?.map(part => part.textured).sort()).toEqual([false, true]);
     expect(reopened.flat!.reduce((sum, part) => sum + part.triangles, 0)).toBe(12);
-    expect([...reopened.corners].sort()).toEqual([...memberBefore.corners].sort());
+    expect(cornerSignature(reopened.corners)).toEqual(cornerSignature(memberBefore.corners));
     const reopenedSibling = await second.evaluate(id => globalThis.__ifc_lite_scene_owner__(id), reopenedIds.sibling);
     expect(reopenedSibling.corners).toEqual(siblingBefore.corners);
     expect(reopenedSibling.flat?.map(part => part.geometryItemId) ?? 'instance').toEqual(siblingBefore.flat?.map(part => part.geometryItemId) ?? 'instance');
@@ -268,6 +284,7 @@ async function selectedFaces(panel: ReturnType<Page['getByLabel']>): Promise<num
   const match = text.match(/(\d+) of 12 faces selected/);
   return match ? Number(match[1]) : null;
 }
+const cornerSignature = (corners: readonly number[]) => corners.map(value => Math.round(value * 100_000) / 100_000).sort((a, b) => a - b);
 
 /** A 2-colour checkerboard PNG (RGB, 8 bit) built with zlib only: no fixture, no network. */
 function checkerPng(size: number): Buffer {


### PR DESCRIPTION
## What and why

The face-mask editor could only choose faces inside its separate surface canvas. This adds a sticky **Pick faces** tool to the main viewport and carries the exact evaluated-surface identity through resident, streamed, UV-expanded, masked, clipped and GPU-instanced geometry. A hit now reports the owning federation model, representation item and canonical source-triangle ordinal, so clicking the visible occurrence toggles the same face the native `maskedTriangles` planner consumes.

Touch taps suppress their compatibility click, hidden/isolated/clipped surfaces follow the visible scene, and unsupported hits return an explicit reason. Ordinary object picking resumes when the face tool exits.

Closes #4555

## How it was verified

A real Chrome/WebGPU run loaded `tests/models/ara3d/AC20-FZK-Haus.ifc`, selected adjacent canonical faces through the main viewport, and exercised whole-surface preview, masked split preview, Compare, Discard/repreview, Apply, Undo, Redo, ordinary object picking, IFCZIP export and fresh reopen. The reopened owner retained its textured/untextured partition and remained selectable; its type-sharing sibling stayed corner-identical. The opt-in journey passed in 16.4 s with no page errors:

```sh
pnpm --filter @ifc-lite/viewer build
APPEARANCE_E2E=1 APPEARANCE_E2E_OUT=/tmp/face-pick-evidence pnpm exec playwright test --project=viewer-appearance-e2e
```

The committed spec is `tests/e2e/appearance-face-mask.e2e.spec.ts`; the real fixture and independent-reader baseline are documented in `docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md`.

Additional evidence:

- actual `Scene.addInstancedShard → RaycastEngine` hit reports federated `modelIndex: 7`, owner `1025`, item `1011`, canonical source triangle `0`
- streamed, UV-expanded and masked-split provenance tests preserve source ordinals
- clipping tests cover section plane, box/range and terrain; hidden/isolation behavior follows render visibility
- touchstart/touchend followed by a browser compatibility click toggles exactly once
- focused renderer tests: 20/20; focused touch/selection tests: 8/8
- root `pnpm test` before the final dependency-only rebase: 102/102 tasks; viewer 8,045 pass, 7 skip, 0 fail
- final-head `pnpm typecheck`: 94/94 tasks; all 2,004 test files audited
- final-head API surface: 45 packages, 72 surfaces, 8,060 exports
- `pnpm lint` and `git diff --check`: pass

- [x] `pnpm test` passes locally
- [x] No Rust/WASM implementation changed

## Checklist

- [x] Behavior tests fail on the old path: it has no canonical main-viewport face hit, loses instanced model/source identity, and double-routes a touch compatibility click
- [x] Published renderer API has a minor changeset and refreshed API-surface snapshot
- [x] No geometry output changed; determinism manifests are unaffected
- [x] House rules checked: no new `as any`, `@ts-ignore`, silent catch, oversized module, or repository-wide formatting
- [x] No client or project identifiers are present
