### PR TITLE
feat(appearance): preview masks across stream fragments

### DIFF
--- a/.changeset/streamed-face-mask-partitions.md
+++ b/.changeset/streamed-face-mask-partitions.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/renderer": major
+"@ifc-lite/viewer": minor
+---
+
+Preview face masks across every resident streaming fragment of one canonical evaluated surface (#4556).
+
+- `@ifc-lite/renderer`: `AppearancePartition` now identifies its canonical source item and full triangle count, and every `AppearancePartitionPart` has a side-local `partId`. Repeated IFC geometry item ids are valid across fragments; validation requires bounded, disjoint, complete canonical coverage and exact full-surface provenance before install or history replay. `validateAppearancePartition` is exported for hosts that construct history transitions.
+- Viewer: masked previews split selected and retained faces independently in each streaming fragment, preserve full-surface corner ordinals and retained UV/texture/style references, and join/split all fragments through Compare, Discard, Apply, Undo and Redo. Malformed, overlapping, incomplete, reordered and stale fragment provenance is refused.

--- a/apps/viewer/src/lib/appearance/preview-history.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-history.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import type { MeshData } from '@ifc-lite/geometry';
-import type { AppearanceChange, Renderer } from '@ifc-lite/renderer';
+import { invertAppearancePartition, type AppearanceChange, type AppearancePartition, type Renderer } from '@ifc-lite/renderer';
 import { appearanceHistoryParts } from './preview.js';
 
 function fixture() {
@@ -68,16 +68,20 @@ it('history joins and splits a partitioned owner through the inverted partition 
   const textured: MeshData = { ...original, geometryItemId: 101, color: [1, 1, 1, 1], indices: texturedIndices,
     positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0]), normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
     uvs: new Float32Array([0, 0, 1, 0, 1, 1]), textureRef: { textureId: -1, url: 'textures/a.png', repeatS: true, repeatT: true },
-    textureBitmap: {} as ImageBitmap, appearanceSource: { kind: 'canonical-item', indices: texturedIndices, sourceIndices: texturedIndices } };
+    textureBitmap: {} as ImageBitmap, appearanceSource: { kind: 'canonical-item', indices: texturedIndices, sourceIndices: indices,
+      cornerIndices: new Uint32Array([0, 1, 2]) } };
   const retained: MeshData = { ...original, geometryItemId: 102, indices: retainedIndices,
-    appearanceSource: { kind: 'canonical-item', indices: retainedIndices, sourceIndices: retainedIndices } };
-  const partition = { before: [{ geometryItemId: 21, triangles: [0, 1] }], after: [{ geometryItemId: 101, triangles: [0] }, { geometryItemId: 102, triangles: [1] }] };
+    appearanceSource: { kind: 'canonical-item', indices: retainedIndices, sourceIndices: indices,
+      cornerIndices: new Uint32Array([3, 4, 5]) } };
+  const partition = { sourceGeometryItemId: 21, triangleCount: 2,
+    before: [{ partId: 0, geometryItemId: 21, triangles: [0, 1] }],
+    after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [1] }] };
   const change: AppearanceChange = { owner: { expressId: 19, modelIndex: 0 }, before: [original], after: [textured, retained], partition };
   const renderer = (current: MeshData[]) => ({ getScene: () => ({ getMeshDataPieces: () => current }), getAppearancePreview: () => ({}) }) as unknown as Renderer;
   const undo = appearanceHistoryParts(renderer([textured, retained]), [change], 'undo')[0];
   assert.deepEqual(undo.parts.map(part => part.geometryItemId), [21]);
   assert.equal(undo.parts[0].positions, original.positions);
-  assert.deepEqual(undo.partition, { before: partition.after, after: partition.before });
+  assert.deepEqual(undo.partition, invertAppearancePartition(partition));
   assert.equal(undo.geometryItemRemaps, undefined);
   const redo = appearanceHistoryParts(renderer([original]), [change], 'redo')[0];
   assert.deepEqual(redo.parts.map(part => part.geometryItemId), [101, 102]);
@@ -88,4 +92,35 @@ it('history joins and splits a partitioned owner through the inverted partition 
   const moved = { ...retained, positions: retained.positions.slice() }; moved.positions[0] = 0.25;
   assert.throws(() => appearanceHistoryParts(renderer([textured, moved]), [change], 'undo'), /geometry or shading changed/);
   assert.throws(() => appearanceHistoryParts(renderer([textured, retained]), [change], 'redo'), /geometry or shading changed/);
+});
+
+it('history joins and re-splits streamed parts with repeated item ids (#4556)', () => {
+  const fullIndices = new Uint32Array([0, 1, 2, 0, 2, 3, 1, 4, 2, 4, 5, 2]);
+  const fullPositions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 2, 0, 0, 2, 1, 0]);
+  const fullNormals = new Float32Array(18).map((_, i) => i % 3 === 2 ? 1 : 0);
+  const make = (geometryItemId: number, triangles: readonly number[]): MeshData => {
+    const cornerIndices = Uint32Array.from(triangles.flatMap(ordinal => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
+    const indices = Uint32Array.from(cornerIndices, corner => fullIndices[corner]);
+    return { expressId: 19, modelIndex: 0, geometryItemId, color: [geometryItemId / 100, 0, 0, 1],
+      positions: fullPositions, normals: fullNormals, indices,
+      appearanceSource: { kind: 'canonical-item', indices, sourceIndices: fullIndices, cornerIndices } };
+  };
+  const before = [make(21, [0, 1]), make(21, [2, 3])];
+  const after = [make(101, [0]), make(102, [1]), make(101, [2]), make(102, [3])];
+  const partition: AppearancePartition = { sourceGeometryItemId: 21, triangleCount: 4,
+    before: [{ partId: 0, geometryItemId: 21, triangles: [0, 1] }, { partId: 1, geometryItemId: 21, triangles: [2, 3] }],
+    after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [1] },
+      { partId: 2, geometryItemId: 101, triangles: [2] }, { partId: 3, geometryItemId: 102, triangles: [3] }] };
+  const change: AppearanceChange = { owner: { expressId: 19, modelIndex: 0 }, before, after, partition };
+  const renderer = (current: MeshData[]) => ({ getScene: () => ({ getMeshDataPieces: () => current }),
+    getAppearancePreview: () => ({}) }) as unknown as Renderer;
+  const undo = appearanceHistoryParts(renderer(after), [change], 'undo')[0];
+  assert.deepEqual(undo.parts.map(part => part.geometryItemId), [21, 21]);
+  assert.deepEqual(undo.partition, invertAppearancePartition(partition));
+  const redo = appearanceHistoryParts(renderer(before), [change], 'redo')[0];
+  assert.deepEqual(redo.parts.map(part => part.geometryItemId), [101, 102, 101, 102]);
+  assert.deepEqual(redo.partition, partition);
+  assert.throws(() => appearanceHistoryParts(renderer([after[2], after[1], after[0], after[3]]), [change], 'undo'), /geometry or shading changed/);
+  const stale = { ...after[2], appearanceSource: { ...after[2].appearanceSource!, sourceIndices: fullIndices.slice() } };
+  assert.throws(() => appearanceHistoryParts(renderer([after[0], after[1], stale, after[3]]), [change], 'undo'), /geometry or shading changed/);
 });

--- a/apps/viewer/src/lib/appearance/preview-history.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-history.test.ts
@@ -121,6 +121,7 @@ it('history joins and re-splits streamed parts with repeated item ids (#4556)', 
   assert.deepEqual(redo.parts.map(part => part.geometryItemId), [101, 102, 101, 102]);
   assert.deepEqual(redo.partition, partition);
   assert.throws(() => appearanceHistoryParts(renderer([after[2], after[1], after[0], after[3]]), [change], 'undo'), /geometry or shading changed/);
-  const stale = { ...after[2], appearanceSource: { ...after[2].appearanceSource!, sourceIndices: fullIndices.slice() } };
+  const staleSource = fullIndices.slice(); staleSource[6] = 0;
+  const stale = { ...after[2], appearanceSource: { ...after[2].appearanceSource!, sourceIndices: staleSource } };
   assert.throws(() => appearanceHistoryParts(renderer([after[0], after[1], stale, after[3]]), [change], 'undo'), /geometry or shading changed/);
 });

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -119,12 +119,18 @@ test('a mask crossing forced-size fragments keeps repeated item ids and source a
   };
   const base = plan({});
   const crossed: AppearancePlan = { ...base,
-    items: [{ ...base.items[0], sourceIndices: [0, 1, 2, 1, 4, 2], targetIndices: [0, 1, 2, 3, 4, 5], targetVertexCount: 6,
+    items: [{ ...base.items[0], sourceIndices: [0, 1, 2, 1, 3, 2], targetIndices: [0, 1, 2, 3, 4, 5], targetVertexCount: 6,
       previewCornerUvs: [0, 0, 1, 0, 1, 1, .25, .25, .75, .25, .5, .75],
       targetCornerNormals: Array(18).fill(0).map((_, i) => i % 3 === 1 ? 1 : 0) }],
     conversions: [{ ...base.conversions![0], sourceIndices: full, sourcePositions: Array.from(positions),
       sourceNormals: Array.from(normals), maskedTriangles: [0, 2], retainedGeometryItemId: 102 }] };
   const fragments = [fragment(false), fragment(true)];
+  const permuted = { ...crossed, items: [{ ...crossed.items[0], sourceIndices: [1, 3, 2, 0, 1, 2] }] };
+  assert.throws(() => bind(permuted, fragments), /Invalid native occurrence conversion provenance/,
+    'equal-length masked topology cannot reorder the canonical selected triangles');
+  const altered = { ...crossed, items: [{ ...crossed.items[0], sourceIndices: [0, 1, 2, 1, 2, 3] }] };
+  assert.throws(() => bind(altered, fragments), /Invalid native occurrence conversion provenance/,
+    'equal-length masked topology cannot alter a canonical selected triangle');
   const [group] = bind(crossed, fragments);
   assert.deepEqual(group.parts.map(part => part.geometryItemId), [101, 102, 101, 102]);
   assert.deepEqual(group.partition?.before, [

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -114,7 +114,7 @@ test('a mask crossing forced-size fragments keeps repeated item ids and source a
       ? new Float32Array([1, 0, 0, 2, 0, 0, 1, 0, -1, 2, 0, -1]) : positions.slice(0, 12);
     return { ...original, positions: fragmentPositions, normals: second ? normals.slice(3, 15) : normals.slice(0, 12), indices: fragmentIndices,
       uvs: new Float32Array(fragmentPositions.length / 3 * 2), textureRef: oldTexture, textureBitmap: oldBitmap,
-      appearanceSource: { kind: 'canonical-item', indices: fragmentIndices, sourceIndices: fullIndices,
+      appearanceSource: { kind: 'canonical-item', indices: fragmentIndices, sourceIndices: second ? fullIndices.slice() : fullIndices,
         cornerIndices: Uint32Array.from(second ? [6, 7, 8, 9, 10, 11] : [0, 1, 2, 3, 4, 5]) } };
   };
   const base = plan({});

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -140,6 +140,7 @@ test('a mask crossing forced-size fragments keeps repeated item ids and source a
   assert.deepEqual(group.parts.map(part => [...part.appearanceSource!.cornerIndices!]), [
     [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11],
   ], 'every generated local triangle retains its canonical full-surface ordinal');
+  assert.deepEqual(group.parts.map(part => appearanceSourceTriangle(part, 0)), [0, 1, 2, 3]);
   for (const part of group.parts) assert.strictEqual(part.appearanceSource?.sourceIndices, fullIndices);
   for (const retained of [group.parts[1], group.parts[3]]) {
     assert.strictEqual(retained.textureRef, oldTexture);

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -59,6 +59,23 @@ test('a face-masked conversion previews as textured and retained parts of one ow
   assert.equal(group.geometryItemRemaps, undefined, 'a partition replaces the one-to-one item remap');
 });
 
+test('masked partition identities are renderer-global with a federation offset (#4556)', () => {
+  const offset = 1_000_000;
+  const federatedState = { ...state,
+    toGlobalId: (_model: string, id: number) => id + offset,
+    resolveGlobalIdFromModels: (id: number) => ({ modelId: 'offset-model', expressId: id - offset }),
+  } as unknown as ViewerState;
+  const federatedOriginal: MeshData = { ...original, expressId: 25 + offset, geometryItemId: 11 + offset, modelIndex: 1 };
+  const [group] = bindAppearancePreview(federatedState, renderer([federatedOriginal]), 'offset-model',
+    plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), bitmap, 'textures/a.png', true, true,
+    expandAppearanceCorners);
+  assert.equal(group.globalId, 25 + offset);
+  assert.equal(group.modelIndex, 1);
+  assert.equal(group.partition?.sourceGeometryItemId, 11 + offset);
+  assert.deepEqual(group.parts.map(part => part.geometryItemId), [101 + offset, 102 + offset]);
+  assert.deepEqual(group.partition?.after.map(part => part.geometryItemId), [101 + offset, 102 + offset]);
+});
+
 test('the masked binder refuses inconsistent provenance explicitly (#4404)', () => {
   assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 })), /Invalid native occurrence conversion provenance/);
   assert.throws(() => bind(plan({ maskedTriangles: [1, 0], retainedGeometryItemId: 102 }, maskedItem)), /Invalid native face mask provenance/);

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -137,6 +137,9 @@ test('a mask crossing forced-size fragments keeps repeated item ids and source a
     { partId: 2, geometryItemId: 101, triangles: [2] },
     { partId: 3, geometryItemId: 102, triangles: [3] },
   ]);
+  assert.deepEqual(group.parts.map(part => [...part.appearanceSource!.cornerIndices!]), [
+    [0, 1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11],
+  ], 'every generated local triangle retains its canonical full-surface ordinal');
   for (const part of group.parts) assert.strictEqual(part.appearanceSource?.sourceIndices, fullIndices);
   for (const retained of [group.parts[1], group.parts[3]]) {
     assert.strictEqual(retained.textureRef, oldTexture);

--- a/apps/viewer/src/lib/appearance/preview-mask.test.ts
+++ b/apps/viewer/src/lib/appearance/preview-mask.test.ts
@@ -53,12 +53,13 @@ test('a face-masked conversion previews as textured and retained parts of one ow
   assert.equal(appearanceSourceTriangle(textured, 0), 0);
   assert.equal(appearanceSourceTriangle(retained, 0), 1,
     'the retained subset keeps its full evaluated-surface ordinal');
-  assert.deepEqual(group.partition, { before: [{ geometryItemId: 11, triangles: [0, 1] }],
-    after: [{ geometryItemId: 101, triangles: [0] }, { geometryItemId: 102, triangles: [1] }] });
+  assert.deepEqual(group.partition, { sourceGeometryItemId: 11, triangleCount: 2,
+    before: [{ partId: 0, geometryItemId: 11, triangles: [0, 1] }],
+    after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [1] }] });
   assert.equal(group.geometryItemRemaps, undefined, 'a partition replaces the one-to-one item remap');
 });
 
-test('the masked binder refuses inconsistent or fragmented provenance explicitly (#4404)', () => {
+test('the masked binder refuses inconsistent provenance explicitly (#4404)', () => {
   assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 })), /Invalid native occurrence conversion provenance/);
   assert.throws(() => bind(plan({ maskedTriangles: [1, 0], retainedGeometryItemId: 102 }, maskedItem)), /Invalid native face mask provenance/);
   assert.throws(() => bind(plan({ maskedTriangles: [0, 1], retainedGeometryItemId: 102 }, maskedItem)), /Invalid native face mask provenance/);
@@ -67,8 +68,10 @@ test('the masked binder refuses inconsistent or fragmented provenance explicitly
     const part = new Uint32Array(sourceIndices.slice(from, from + 3));
     return { ...original, indices: part, appearanceSource: { kind: 'canonical-item', indices: part, sourceIndices: indices, cornerIndices: Uint32Array.from([from, from + 1, from + 2]) } };
   };
-  assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), [half(0), half(3)]), /in one piece, but it renders in 2 pieces/);
-  assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), [half(0)]), /in one piece/);
+  const fragmented = bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), [half(0), half(3)])[0];
+  assert.deepEqual(fragmented.parts.map(part => part.geometryItemId), [101, 102]);
+  assert.deepEqual(fragmented.partition?.before.map(part => part.triangles), [[0], [1]]);
+  assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), [half(0)]), /geometry of IFC object #25 changed/);
   const renumbered = { ...original, indices: new Uint32Array([0, 2, 3, 0, 1, 2]) };
   renumbered.appearanceSource = { kind: 'canonical-item', indices: renumbered.indices, sourceIndices: renumbered.indices };
   assert.throws(() => bind(plan({ maskedTriangles: [0], retainedGeometryItemId: 102 }, maskedItem), [renumbered]), /geometry of IFC object #25 changed/);
@@ -77,4 +80,53 @@ test('the masked binder refuses inconsistent or fragmented provenance explicitly
   assert.equal(whole.parts.length, 1); assert.equal(whole.partition, undefined);
   assert.deepEqual(whole.geometryItemRemaps, [{ from: 11, to: 101 }]);
   assert.throws(() => bindAppearancePreview(state, renderer(undefined), 'model', plan({}), bitmap, 'textures/a.png', true, true, expandAppearanceCorners), /Geometry for IFC object #25 is not available/);
+});
+
+test('a mask crossing forced-size fragments keeps repeated item ids and source appearance (#4556)', () => {
+  const full = [0, 1, 2, 0, 2, 3, 1, 4, 2, 4, 5, 2];
+  const fullIndices = new Uint32Array(full);
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 0, -1, 0, 0, -1, 2, 0, 0, 2, 0, -1]);
+  const normals = new Float32Array(18).map((_, i) => i % 3 === 1 ? 1 : 0);
+  const oldTexture = { textureId: 77, url: 'textures/old.png', repeatS: false, repeatT: false };
+  const oldBitmap = {} as ImageBitmap;
+  // Equivalent to a six-index streaming threshold: each resident fragment
+  // carries two canonical triangles and the same complete source topology.
+  const fragment = (second: boolean): MeshData => {
+    const fragmentIndices = second ? new Uint32Array([0, 1, 2, 1, 3, 2]) : new Uint32Array(full.slice(0, 6));
+    const fragmentPositions = second
+      ? new Float32Array([1, 0, 0, 2, 0, 0, 1, 0, -1, 2, 0, -1]) : positions.slice(0, 12);
+    return { ...original, positions: fragmentPositions, normals: second ? normals.slice(3, 15) : normals.slice(0, 12), indices: fragmentIndices,
+      uvs: new Float32Array(fragmentPositions.length / 3 * 2), textureRef: oldTexture, textureBitmap: oldBitmap,
+      appearanceSource: { kind: 'canonical-item', indices: fragmentIndices, sourceIndices: fullIndices,
+        cornerIndices: Uint32Array.from(second ? [6, 7, 8, 9, 10, 11] : [0, 1, 2, 3, 4, 5]) } };
+  };
+  const base = plan({});
+  const crossed: AppearancePlan = { ...base,
+    items: [{ ...base.items[0], sourceIndices: [0, 1, 2, 1, 4, 2], targetIndices: [0, 1, 2, 3, 4, 5], targetVertexCount: 6,
+      previewCornerUvs: [0, 0, 1, 0, 1, 1, .25, .25, .75, .25, .5, .75],
+      targetCornerNormals: Array(18).fill(0).map((_, i) => i % 3 === 1 ? 1 : 0) }],
+    conversions: [{ ...base.conversions![0], sourceIndices: full, sourcePositions: Array.from(positions),
+      sourceNormals: Array.from(normals), maskedTriangles: [0, 2], retainedGeometryItemId: 102 }] };
+  const fragments = [fragment(false), fragment(true)];
+  const [group] = bind(crossed, fragments);
+  assert.deepEqual(group.parts.map(part => part.geometryItemId), [101, 102, 101, 102]);
+  assert.deepEqual(group.partition?.before, [
+    { partId: 0, geometryItemId: 11, triangles: [0, 1] },
+    { partId: 1, geometryItemId: 11, triangles: [2, 3] },
+  ]);
+  assert.deepEqual(group.partition?.after.map(part => ({ ...part })), [
+    { partId: 0, geometryItemId: 101, triangles: [0] },
+    { partId: 1, geometryItemId: 102, triangles: [1] },
+    { partId: 2, geometryItemId: 101, triangles: [2] },
+    { partId: 3, geometryItemId: 102, triangles: [3] },
+  ]);
+  for (const part of group.parts) assert.strictEqual(part.appearanceSource?.sourceIndices, fullIndices);
+  for (const retained of [group.parts[1], group.parts[3]]) {
+    assert.strictEqual(retained.textureRef, oldTexture);
+    assert.strictEqual(retained.textureBitmap, oldBitmap);
+    assert.ok(retained.uvs, 'the retained fragment keeps its prior UV lane');
+  }
+  const overlap = fragment(true);
+  overlap.appearanceSource = { ...overlap.appearanceSource!, cornerIndices: Uint32Array.from([3, 4, 5, 9, 10, 11]) };
+  assert.throws(() => bind(crossed, [fragments[0], overlap]), /overlap/);
 });

--- a/apps/viewer/src/lib/appearance/preview-partition.ts
+++ b/apps/viewer/src/lib/appearance/preview-partition.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { MeshData } from '@ifc-lite/geometry';
-import { equivalentAppearanceGeometry, invertAppearancePartition } from '@ifc-lite/renderer';
+import { equivalentAppearanceGeometry, invertAppearancePartition, validateAppearancePartition } from '@ifc-lite/renderer';
 import type { AppearanceChange, AppearancePartition } from '@ifc-lite/renderer';
 import type { AppearancePlan } from './planner-types.js';
 import type { AppearancePreviewImage, AppearancePreviewParts } from './preview.js';
@@ -11,6 +11,7 @@ type Conversion = NonNullable<AppearancePlan['conversions']>[number];
 type Item = AppearancePlan['items'][number];
 type ExpandCorners = (mesh: MeshData, sourceIndices: readonly number[], cornerUvs: readonly number[], targetIndices: Uint32Array,
   targetCornerNormals: readonly number[], targetVertexCount: number) => MeshData;
+const MAX_PARTITION_TRIANGLES = 500_000;
 
 /** The accepted mask of a conversion as ascending source triangle ordinals and
  * their complement; `undefined` for a whole-surface conversion (#4404). */
@@ -19,6 +20,7 @@ export function maskedSplit(conversion: Conversion): { masked: number[]; retaine
   if (maskedTriangles === undefined && retainedGeometryItemId === undefined) return undefined;
   const count = conversion.sourceIndices.length / 3;
   if (!maskedTriangles || !Number.isSafeInteger(retainedGeometryItemId) || retainedGeometryItemId! <= 0
+    || !Number.isSafeInteger(count) || count <= 0 || count > MAX_PARTITION_TRIANGLES
     || retainedGeometryItemId === conversion.geometryItemId || !maskedTriangles.length || maskedTriangles.length >= count
     || maskedTriangles.some((ordinal, index) => !Number.isSafeInteger(ordinal) || ordinal < 0 || ordinal >= count
       || (index > 0 && ordinal <= maskedTriangles[index - 1]))) {
@@ -45,42 +47,85 @@ function corners(source: MeshData, ordinals: readonly number[]): Uint32Array {
  * prove corner-for-corner equivalence and lets history join them again.
  */
 export function bindMaskedConversionParts(options: {
-  original: MeshData; conversion: Conversion; item: Item; texturedItemId: number; retainedItemId: number;
+  originals: readonly MeshData[]; conversion: Conversion; item: Item; texturedItemId: number; retainedItemId: number;
   image: AppearancePreviewImage; textureId: number; expandCorners: ExpandCorners;
 }): { parts: MeshData[]; partition: AppearancePartition } {
-  const { original, conversion, item } = options;
+  const { originals, conversion, item } = options;
   const split = maskedSplit(conversion);
-  const source = original.appearanceSource;
-  if (!split) throw new Error('Invalid native occurrence conversion provenance.');
-  if (source?.cornerIndices) {
-    throw new Error(`Face selection needs the evaluated surface of IFC object #${conversion.productId} in one piece, but it renders in several pieces. Clear its face selection to texture the whole surface.`);
+  if (!split || !originals.length) throw new Error('Invalid native occurrence conversion provenance.');
+  const full = originals[0].appearanceSource?.sourceIndices;
+  if (!full || originals.length > conversion.sourceIndices.length / 3
+    || full.length !== conversion.sourceIndices.length
+    || conversion.sourceIndices.some((index, corner) => index !== full[corner])) {
+    throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
   }
-  if (!source || source.kind !== 'canonical-item' || source.indices !== original.indices
-    || original.indices.length !== conversion.sourceIndices.length
-    || conversion.sourceIndices.some((index, corner) => index !== original.indices[corner])) {
+  const seenCorners = new Uint8Array(conversion.sourceIndices.length);
+  const fragments = originals.map((original) => {
+    const source = original.appearanceSource;
+    if (!source || source.kind !== 'canonical-item' || source.indices !== original.indices
+      || original.geometryItemId !== conversion.sourceGeometryItemId
+      || source.sourceIndices !== full
+      || original.indices.length % 3 !== 0
+      || (originals.length > 1 && !source.cornerIndices)) {
+      throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
+    }
+    const canonicalCorners = source.cornerIndices ?? Uint32Array.from({ length: original.indices.length }, (_, i) => i);
+    if (canonicalCorners.length !== original.indices.length) throw new Error('Invalid streamed appearance corner provenance.');
+    const triangles: number[] = [];
+    for (let local = 0; local < original.indices.length; local += 3) {
+      const first = canonicalCorners[local];
+      if (first % 3 || canonicalCorners[local + 1] !== first + 1 || canonicalCorners[local + 2] !== first + 2
+        || first + 2 >= seenCorners.length) throw new Error('Invalid streamed appearance triangle provenance.');
+      for (let corner = first; corner < first + 3; corner++) {
+        if (seenCorners[corner]) throw new Error('Streamed appearance fragments overlap.');
+        seenCorners[corner] = 1;
+      }
+      triangles.push(first / 3);
+    }
+    return { original, triangles };
+  });
+  if (seenCorners.some(value => value !== 1)) {
     throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
   }
   if (item.sourceIndices.length !== split.masked.length * 3) throw new Error('Invalid native occurrence conversion provenance.');
-  const sub = (ordinals: readonly number[], geometryItemId: number): MeshData => {
-    const indices = corners(original, ordinals);
-    return { ...original, geometryItemId, indices, appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
-  };
-  const localTextured = options.expandCorners(sub(split.masked, options.texturedItemId), [...corners(original, split.masked)], item.previewCornerUvs,
-    new Uint32Array(item.targetIndices), item.targetCornerNormals, item.targetVertexCount);
-  const fullSourceIndices = source.sourceIndices;
-  const provenance = (ordinals: readonly number[]) => Uint32Array.from(ordinals.flatMap(ordinal => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
-  const textured = { ...localTextured, appearanceSource: { ...localTextured.appearanceSource!, sourceIndices: fullSourceIndices,
-    cornerIndices: provenance(split.masked) } };
-  const retained = sub(split.retained, options.retainedItemId);
-  retained.appearanceSource = { ...retained.appearanceSource!, sourceIndices: fullSourceIndices, cornerIndices: provenance(split.retained) };
-  const parts: MeshData[] = [
-    { ...textured, color: [1, 1, 1, 1], shadingColor: undefined, texture: undefined, textureBitmap: options.image.bitmap,
-      textureRef: { textureId: options.textureId, url: options.image.imageUri, repeatS: options.image.repeatS, repeatT: options.image.repeatT } },
-    { ...retained, color: [...original.color] as MeshData['color'], uvs: undefined, texture: undefined, textureRef: undefined, textureBitmap: undefined },
-  ];
+  const maskedRank = new Map(split.masked.map((ordinal, rank) => [ordinal, rank]));
+  const selected = new Set(split.masked);
+  const parts: MeshData[] = [];
+  const before: AppearancePartition['before'][number][] = [];
+  const after: AppearancePartition['after'][number][] = [];
+  fragments.forEach(({ original, triangles }, fragment) => {
+    before.push({ partId: fragment, geometryItemId: original.geometryItemId!, triangles });
+    const local = (wanted: boolean) => triangles.map((ordinal, triangle) => ({ ordinal, triangle }))
+      .filter(({ ordinal }) => selected.has(ordinal) === wanted);
+    const masked = local(true), retained = local(false);
+    if (masked.length) {
+      const indices = corners(original, masked.map(({ triangle }) => triangle));
+      const cornerMap = Uint32Array.from(masked.flatMap(({ ordinal }) => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
+      const ranks = masked.map(({ ordinal }) => maskedRank.get(ordinal)!);
+      const take = (values: ArrayLike<number>, width: number) => ranks.flatMap(rank =>
+        Array.from({ length: 3 * width }, (_, offset) => values[rank * 3 * width + offset]));
+      const temporary: MeshData = { ...original, geometryItemId: options.texturedItemId, indices,
+        appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
+      const textured = options.expandCorners(temporary, Array.from(indices), take(item.previewCornerUvs, 2),
+        Uint32Array.from(take(item.targetIndices, 1)), take(item.targetCornerNormals, 3), item.targetVertexCount);
+      textured.appearanceSource = { kind: 'canonical-item', indices: textured.indices, sourceIndices: full, cornerIndices: cornerMap };
+      parts.push({ ...textured, color: [1, 1, 1, 1], shadingColor: undefined, texture: undefined, textureBitmap: options.image.bitmap,
+        textureRef: { textureId: options.textureId, url: options.image.imageUri, repeatS: options.image.repeatS, repeatT: options.image.repeatT } });
+      after.push({ partId: after.length, geometryItemId: options.texturedItemId, triangles: masked.map(({ ordinal }) => ordinal) });
+    }
+    if (retained.length) {
+      const indices = corners(original, retained.map(({ triangle }) => triangle));
+      const cornerIndices = Uint32Array.from(retained.flatMap(({ ordinal }) => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
+      parts.push({ ...original, geometryItemId: options.retainedItemId, indices,
+        appearanceSource: { kind: 'canonical-item', indices, sourceIndices: full, cornerIndices } });
+      after.push({ partId: after.length, geometryItemId: options.retainedItemId, triangles: retained.map(({ ordinal }) => ordinal) });
+    }
+  });
   const partition: AppearancePartition = {
-    before: [{ geometryItemId: original.geometryItemId!, triangles: Array.from({ length: original.indices.length / 3 }, (_, ordinal) => ordinal) }],
-    after: [{ geometryItemId: options.texturedItemId, triangles: split.masked }, { geometryItemId: options.retainedItemId, triangles: split.retained }],
+    sourceGeometryItemId: conversion.sourceGeometryItemId,
+    triangleCount: conversion.sourceIndices.length / 3,
+    before,
+    after,
   };
   return { parts, partition };
 }
@@ -96,6 +141,9 @@ export function partitionHistoryParts(change: AppearanceChange, current: readonl
     mesh.geometryItemId !== expectedCurrent[index].geometryItemId || !equivalentAppearanceGeometry(mesh, expectedCurrent[index]))) {
     throw new Error('Cannot restore appearance because current geometry or shading changed.');
   }
+  const transition = direction === 'undo' ? invertAppearancePartition(partition) : partition;
+  try { validateAppearancePartition(transition, current, target); }
+  catch (cause) { throw new Error('Cannot restore appearance because current geometry or shading changed.', { cause }); }
   // Every part of a partitioned owner shares the first live part's frame and metadata.
   const live = current[0];
   const parts = target.map(appearance => ({ ...live, geometryItemId: appearance.geometryItemId, positions: appearance.positions,
@@ -105,5 +153,5 @@ export function partitionHistoryParts(change: AppearanceChange, current: readonl
   const instanced = direction === 'undo' ? change.beforeInstanced : change.afterInstanced;
   const materializedOriginals = change.beforeInstanced ? change.before : change.afterInstanced ? change.after : undefined;
   return { globalId: change.owner.expressId, modelIndex: change.owner.modelIndex, parts, instanced, materializedOriginals,
-    partition: direction === 'undo' ? invertAppearancePartition(partition) : partition };
+    partition: transition };
 }

--- a/apps/viewer/src/lib/appearance/preview-partition.ts
+++ b/apps/viewer/src/lib/appearance/preview-partition.ts
@@ -13,9 +13,9 @@ type ExpandCorners = (mesh: MeshData, sourceIndices: readonly number[], cornerUv
   targetCornerNormals: readonly number[], targetVertexCount: number) => MeshData;
 const MAX_PARTITION_TRIANGLES = 500_000;
 
-/** The accepted mask of a conversion as ascending source triangle ordinals and
- * their complement; `undefined` for a whole-surface conversion (#4404). */
-export function maskedSplit(conversion: Conversion): { masked: number[]; retained: number[] } | undefined {
+/** The accepted mask as ascending full-surface triangle ordinals;
+ * `undefined` for a whole-surface conversion (#4404). */
+export function maskedSplit(conversion: Conversion): { masked: readonly number[] } | undefined {
   const { maskedTriangles, retainedGeometryItemId } = conversion;
   if (maskedTriangles === undefined && retainedGeometryItemId === undefined) return undefined;
   const count = conversion.sourceIndices.length / 3;
@@ -26,10 +26,7 @@ export function maskedSplit(conversion: Conversion): { masked: number[]; retaine
       || (index > 0 && ordinal <= maskedTriangles[index - 1]))) {
     throw new Error(`Invalid native face mask provenance for IFC object #${conversion.productId}.`);
   }
-  const selected = new Set(maskedTriangles);
-  const retained: number[] = [];
-  for (let ordinal = 0; ordinal < count; ordinal++) if (!selected.has(ordinal)) retained.push(ordinal);
-  return { masked: [...maskedTriangles], retained };
+  return { masked: maskedTriangles };
 }
 
 function corners(source: MeshData, ordinals: readonly number[]): Uint32Array {
@@ -65,7 +62,7 @@ export function bindMaskedConversionParts(options: {
     const source = original.appearanceSource;
     if (!source || source.kind !== 'canonical-item' || source.indices !== original.indices
       || original.geometryItemId !== options.sourceGeometryItemId
-      || source.sourceIndices !== full
+      || source.sourceIndices.length !== full.length
       || original.indices.length % 3 !== 0
       || (originals.length > 1 && !source.cornerIndices)) {
       throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
@@ -78,6 +75,7 @@ export function bindMaskedConversionParts(options: {
       if (first % 3 || canonicalCorners[local + 1] !== first + 1 || canonicalCorners[local + 2] !== first + 2
         || first + 2 >= seenCorners.length) throw new Error('Invalid streamed appearance triangle provenance.');
       for (let corner = first; corner < first + 3; corner++) {
+        if (source.sourceIndices[corner] !== full[corner]) throw new Error('Invalid streamed appearance full-surface provenance.');
         if (seenCorners[corner]) throw new Error('Streamed appearance fragments overlap.');
         seenCorners[corner] = 1;
       }
@@ -89,20 +87,20 @@ export function bindMaskedConversionParts(options: {
     throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
   }
   if (item.sourceIndices.length !== split.masked.length * 3) throw new Error('Invalid native occurrence conversion provenance.');
-  const maskedRank = new Map(split.masked.map((ordinal, rank) => [ordinal, rank]));
-  const selected = new Set(split.masked);
+  const maskedRank = new Uint32Array(conversion.sourceIndices.length / 3);
+  split.masked.forEach((ordinal, rank) => { maskedRank[ordinal] = rank + 1; });
   const parts: MeshData[] = [];
   const before: AppearancePartition['before'][number][] = [];
   const after: AppearancePartition['after'][number][] = [];
   fragments.forEach(({ original, triangles }, fragment) => {
     before.push({ partId: fragment, geometryItemId: original.geometryItemId!, triangles });
     const local = (wanted: boolean) => triangles.map((ordinal, triangle) => ({ ordinal, triangle }))
-      .filter(({ ordinal }) => selected.has(ordinal) === wanted);
+      .filter(({ ordinal }) => (maskedRank[ordinal] !== 0) === wanted);
     const masked = local(true), retained = local(false);
     if (masked.length) {
       const indices = corners(original, masked.map(({ triangle }) => triangle));
       const cornerMap = Uint32Array.from(masked.flatMap(({ ordinal }) => [ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]));
-      const ranks = masked.map(({ ordinal }) => maskedRank.get(ordinal)!);
+      const ranks = masked.map(({ ordinal }) => maskedRank[ordinal] - 1);
       const take = (values: ArrayLike<number>, width: number) => ranks.flatMap(rank =>
         Array.from({ length: 3 * width }, (_, offset) => values[rank * 3 * width + offset]));
       const temporary: MeshData = { ...original, geometryItemId: options.texturedItemId, indices,

--- a/apps/viewer/src/lib/appearance/preview-partition.ts
+++ b/apps/viewer/src/lib/appearance/preview-partition.ts
@@ -47,7 +47,8 @@ function corners(source: MeshData, ordinals: readonly number[]): Uint32Array {
  * prove corner-for-corner equivalence and lets history join them again.
  */
 export function bindMaskedConversionParts(options: {
-  originals: readonly MeshData[]; conversion: Conversion; item: Item; texturedItemId: number; retainedItemId: number;
+  originals: readonly MeshData[]; conversion: Conversion; item: Item; sourceGeometryItemId: number;
+  texturedItemId: number; retainedItemId: number;
   image: AppearancePreviewImage; textureId: number; expandCorners: ExpandCorners;
 }): { parts: MeshData[]; partition: AppearancePartition } {
   const { originals, conversion, item } = options;
@@ -63,7 +64,7 @@ export function bindMaskedConversionParts(options: {
   const fragments = originals.map((original) => {
     const source = original.appearanceSource;
     if (!source || source.kind !== 'canonical-item' || source.indices !== original.indices
-      || original.geometryItemId !== conversion.sourceGeometryItemId
+      || original.geometryItemId !== options.sourceGeometryItemId
       || source.sourceIndices !== full
       || original.indices.length % 3 !== 0
       || (originals.length > 1 && !source.cornerIndices)) {
@@ -122,7 +123,7 @@ export function bindMaskedConversionParts(options: {
     }
   });
   const partition: AppearancePartition = {
-    sourceGeometryItemId: conversion.sourceGeometryItemId,
+    sourceGeometryItemId: options.sourceGeometryItemId,
     triangleCount: conversion.sourceIndices.length / 3,
     before,
     after,

--- a/apps/viewer/src/lib/appearance/preview-partition.ts
+++ b/apps/viewer/src/lib/appearance/preview-partition.ts
@@ -87,6 +87,25 @@ export function bindMaskedConversionParts(options: {
     throw new Error(`The geometry of IFC object #${conversion.productId} changed. Reload it before applying appearance.`);
   }
   if (item.sourceIndices.length !== split.masked.length * 3) throw new Error('Invalid native occurrence conversion provenance.');
+  // The authored masked face set retains the selected canonical corner order,
+  // while its decoded source lane densely renumbers vertices by first use.
+  // Reconstruct that exact lane from each selected full-surface ordinal.
+  const localVertices = new Map<number, number>();
+  let nextVertex = 0;
+  for (let rank = 0; rank < split.masked.length; rank++) {
+    const canonical = split.masked[rank] * 3;
+    for (let corner = 0; corner < 3; corner++) {
+      const sourceVertex = conversion.sourceIndices[canonical + corner];
+      let localVertex = localVertices.get(sourceVertex);
+      if (localVertex === undefined) {
+        localVertex = nextVertex++;
+        localVertices.set(sourceVertex, localVertex);
+      }
+      if (item.sourceIndices[rank * 3 + corner] !== localVertex) {
+        throw new Error('Invalid native occurrence conversion provenance.');
+      }
+    }
+  }
   const maskedRank = new Uint32Array(conversion.sourceIndices.length / 3);
   split.masked.forEach((ordinal, rank) => { maskedRank[ordinal] = rank + 1; });
   const parts: MeshData[] = [];

--- a/apps/viewer/src/lib/appearance/preview.ts
+++ b/apps/viewer/src/lib/appearance/preview.ts
@@ -112,9 +112,22 @@ export function bindAppearancePreview(
     if (!originals?.length) throw new Error(`Geometry for IFC object #${productId} is not available. Reload the model and try again.`);
     const represented = new Set<number>();
     const modelIndex = originals[0].modelIndex ?? 0;
-    const pieces = originals.length;
     const geometryItemRemaps: NonNullable<AppearanceChange['geometryItemRemaps']>[number][] = [];
-    let partition: AppearancePartition | undefined;
+    const firstRef = originals[0].geometryItemId === undefined ? null : state.resolveGlobalIdFromModels(originals[0].geometryItemId);
+    const firstItem = firstRef?.modelId === modelId ? items.get(firstRef.expressId) : undefined;
+    const maskedConversion = firstItem && conversions.get(firstItem.geometryItemId);
+    if (firstItem && maskedConversion && maskedSplit(maskedConversion)) {
+      if (originals.some(mesh => mesh.geometryItemId !== originals![0].geometryItemId || (mesh.modelIndex ?? 0) !== modelIndex)) {
+        throw new Error(`Face selection requires one canonical surface for IFC object #${productId}.`);
+      }
+      const image = itemImages ? itemImages.get(firstItem.geometryItemId) : { bitmap, imageUri, repeatS, repeatT };
+      if (!image) throw new Error(`The baked image for IFC geometry #${firstItem.geometryItemId} is missing.`);
+      const masked = bindMaskedConversionParts({ originals, conversion: maskedConversion, item: firstItem, image, expandCorners,
+        textureId: textureIdentity(image.bitmap), texturedItemId: state.toGlobalId(modelId, firstItem.geometryItemId),
+        retainedItemId: state.toGlobalId(modelId, maskedConversion.retainedGeometryItemId!) });
+      return { globalId, modelIndex, parts: masked.parts, ...(materializedOriginals ? { materializedOriginals, validate } : {}),
+        partition: masked.partition };
+    }
     const parts = originals.flatMap(mesh => {
       const ref = mesh.geometryItemId === undefined ? null : state.resolveGlobalIdFromModels(mesh.geometryItemId);
       const item = ref?.modelId === modelId ? items.get(ref.expressId) : undefined;
@@ -125,14 +138,7 @@ export function bindAppearancePreview(
       const image = itemImages ? itemImages.get(item.geometryItemId) : { bitmap, imageUri, repeatS, repeatT };
       if (!image) throw new Error(`The baked image for IFC geometry #${item.geometryItemId} is missing.`);
       const conversion = conversions.get(item.geometryItemId);
-      if (conversion && maskedSplit(conversion)) {
-        // The partition names the whole owner, so a masked owner must be one part.
-        if (pieces !== 1) throw new Error(`Face selection needs the evaluated surface of IFC object #${productId} in one piece, but it renders in ${pieces} pieces. Clear its face selection to texture the whole surface.`);
-        const masked = bindMaskedConversionParts({ original: mesh, conversion, item, image, expandCorners, textureId: textureIdentity(image.bitmap),
-          texturedItemId: state.toGlobalId(modelId, item.geometryItemId), retainedItemId: state.toGlobalId(modelId, conversion.retainedGeometryItemId!) });
-        partition = masked.partition;
-        return masked.parts;
-      }
+      if (conversion && maskedSplit(conversion)) throw new Error(`Face selection requires one canonical surface for IFC object #${productId}.`);
       if (conversion && !geometryItemRemaps.some(pair => pair.from === mesh.geometryItemId)) {
         geometryItemRemaps.push({ from: mesh.geometryItemId!, to: state.toGlobalId(modelId, item.geometryItemId) });
       }
@@ -143,7 +149,7 @@ export function bindAppearancePreview(
     });
     if (represented.size !== items.size) throw new Error(`Some geometry for IFC object #${productId} is still loading.`);
     return { globalId, modelIndex, parts, ...(materializedOriginals ? { materializedOriginals, validate } : {}),
-      ...(geometryItemRemaps.length ? { geometryItemRemaps } : {}), ...(partition ? { partition } : {}) };
+      ...(geometryItemRemaps.length ? { geometryItemRemaps } : {}) };
   });
   return [...groups, ...bindCompanionPreview(state, renderer, modelId, plan)];
 }

--- a/apps/viewer/src/lib/appearance/preview.ts
+++ b/apps/viewer/src/lib/appearance/preview.ts
@@ -123,6 +123,7 @@ export function bindAppearancePreview(
       const image = itemImages ? itemImages.get(firstItem.geometryItemId) : { bitmap, imageUri, repeatS, repeatT };
       if (!image) throw new Error(`The baked image for IFC geometry #${firstItem.geometryItemId} is missing.`);
       const masked = bindMaskedConversionParts({ originals, conversion: maskedConversion, item: firstItem, image, expandCorners,
+        sourceGeometryItemId: originals[0].geometryItemId!,
         textureId: textureIdentity(image.bitmap), texturedItemId: state.toGlobalId(modelId, firstItem.geometryItemId),
         retainedItemId: state.toGlobalId(modelId, maskedConversion.retainedGeometryItemId!) });
       return { globalId, modelIndex, parts: masked.parts, ...(materializedOriginals ? { materializedOriginals, validate } : {}),

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -465,6 +465,8 @@ Other exports: `Camera`, `Picker`, `Raycaster`, `SnapDetector`, `BVH`, `RaycastE
 
 `Renderer.hasActiveClipping()` reports section, terrain or box clipping from the last rendered frame. `raycastScene()` applies the same clip state and its `Intersection` includes `modelIndex`, plus `geometryItemId` and `sourceTriangleIndex` when the hit has unambiguous representation-item and canonical evaluated-surface provenance. `appearanceSourceTriangle(mesh, triangleIndex)` performs that strict provenance lookup directly and returns `undefined` for absent, stale or mixed-corner identity.
 
+An appearance preview may carry an `AppearancePartition` whose `sourceGeometryItemId` and `triangleCount` name one canonical evaluated surface. Its `before` and `after` parts use side-local `partId` values and canonical triangle ordinals, allowing repeated representation-item ids across streaming fragments. `validateAppearancePartition(partition, before, after)` verifies bounded, disjoint and complete provenance plus exact ownership, placement and corner geometry; `invertAppearancePartition(partition)` describes the reverse transition for Undo.
+
 `Scene` and `Section2DOverlayRenderer` are package-internal from 2.0: reach the scene through `getScene(): SceneContents`, and the 3D line overlays through `Renderer.setLineOverlay`. `PickingManager` is package-internal from 2.0 as well: its constructor takes the now-internal `Scene`, so an exported class nobody could construct would have been worse than no export. Pick through `Renderer.pick` / `Renderer.pickRect`.
 
 ---

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -184,20 +184,26 @@ safe for a mask (kept only when the planner reproduces the identical surface
 identity, otherwise dropped with the diagnostic), and the viewer test asserts
 that invariant rather than either verdict.
 
-The renderer preview stages a masked plan as two parts of one owner through an
-explicit `AppearancePartition`: the textured face set expanded with the planned
-UVs and the retained face set with the source colour, over exactly the
-original's triangle corners. The renderer proves corner-for-corner position
-equality, an identical placement frame and ownership, and full single coverage
-of the reference surface before installing the parts; Compare and Discard
-restore the single original; Apply commits both parts; history records the
-partition and joins the parts again on Undo through the inverted record. The
-partition names the whole owner, so a masked product whose original renders in
-more than one resident fragment is refused explicitly (`Face selection needs
-the evaluated surface ... in one piece, but it renders in N pieces. Clear its
-face selection to texture the whole surface.`); evaluated conversions have one
-source surface, so this only affects streaming fragments above the renderer's
-fragment size. Picking either part selects the product; a portable
+The renderer preview stages a masked plan through an explicit
+`AppearancePartition`: each resident fragment contributes a textured subset, a
+retained subset, or both. Every part has a side-local `partId`, so several
+streaming fragments may retain the same IFC `geometryItemId` without becoming
+ambiguous. The partition also names the canonical source item, its complete
+triangle count and the canonical triangle ordinals carried by every fragment.
+Each mesh keeps the complete `appearanceSource.sourceIndices` plus its
+current-corner-to-canonical-corner map. Later viewport hits therefore remain
+full-surface ordinals rather than becoming subset-local ordinals.
+
+Before installing any GPU part, the renderer proves that both sides provide
+disjoint complete coverage of at most 500,000 canonical triangles, that every
+declared part matches its corner map, and that owner, model, placement and exact
+corner positions are unchanged. Missing, overlapping, reordered or detached
+provenance is refused. Compare and Discard restore every original fragment;
+Apply commits the generated parts; history validates the live side and inverts
+the same partition to join on Undo and split again on Redo. Retained fragments
+keep their previous UV, texture and style references. Empty selected or
+retained halves are omitted per fragment. Picking any generated part selects
+the product; a portable
 IFCZIP export carries the image; reopening the export tessellates the product
 into its two face sets under one selectable product. Real-browser and
 independent-reader evidence, including a masked opening-bearing slab, is in

--- a/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
+++ b/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
@@ -145,6 +145,15 @@ remesh. The planar member reopens 1:1.
 - `apps/viewer/src/lib/appearance/preview-mask.test.ts`, `preview-history.test.ts`,
   `packages/renderer/src/appearance-partition.test.ts`: the split binder, the
   partition's Undo/Redo inversion and the renderer's exact partition contract.
+  The #4556 cases force a six-index streaming threshold over a four-triangle
+  surface, select triangles on both fragments, preserve the complete canonical
+  corner map and the retained fragments' prior UV/texture references, and
+  exercise repeated source/generated item ids, empty halves, Apply, Discard,
+  Undo, Redo, overlap, reorder, stale-provenance and work-budget refusal. The
+  portable result is still the native two-face-set plan exercised by
+  `face-mask-reopen-wasm.test.ts` and the independent-reader runs above;
+  streaming fragmentation is a viewer residency detail and does not enter the
+  exported IFC.
 
 ## Not verified here
 

--- a/packages/renderer/src/appearance-partition.test.ts
+++ b/packages/renderer/src/appearance-partition.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import type { MeshData } from '@ifc-lite/geometry';
 import { Scene } from './scene.js';
 import { invertAppearancePartition, validateAppearancePartition, type AppearancePartition } from './appearance-partition.js';
+import { splitMeshForStreaming } from './scene-stream-split.js';
 
 (globalThis as Record<string, unknown>).GPUBufferUsage = { COPY_DST: 8, INDEX: 16, VERTEX: 32, UNIFORM: 64 };
 (globalThis as Record<string, unknown>).GPUTextureUsage = { COPY_DST: 2, TEXTURE_BINDING: 4 };
@@ -24,8 +25,9 @@ const quad: MeshData = { expressId: 7, geometryItemId: 21, color: [0.8, 0.2, 0.1
   positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]),
   normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1]), indices,
   appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } };
-const split: AppearancePartition = { before: [{ geometryItemId: 21, triangles: [0, 1] }],
-  after: [{ geometryItemId: 101, triangles: [0] }, { geometryItemId: 102, triangles: [1] }] };
+const split: AppearancePartition = { sourceGeometryItemId: 21, triangleCount: 2,
+  before: [{ partId: 0, geometryItemId: 21, triangles: [0, 1] }],
+  after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [1] }] };
 
 /** The textured half carries triangle 0 with expanded corners and UVs; the
  * retained half keeps triangle 1 with the source colour, exactly as the
@@ -36,10 +38,12 @@ function halves(original: MeshData): [MeshData, MeshData] {
   const textured: MeshData = { ...original, geometryItemId: 101, color: [1, 1, 1, 1], indices: texturedIndices,
     positions: new Float32Array([...corner(0), ...corner(1), ...corner(2)]), normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
     uvs: new Float32Array([0, 0, 1, 0, 1, 1]), texture: { rgba: new Uint8Array([255, 0, 0, 255]), width: 1, height: 1, repeatS: true, repeatT: true },
-    appearanceSource: { kind: 'canonical-item', indices: texturedIndices, sourceIndices: texturedIndices } };
+    appearanceSource: { kind: 'canonical-item', indices: texturedIndices, sourceIndices: indices,
+      cornerIndices: new Uint32Array([0, 1, 2]) } };
   const retainedIndices = new Uint32Array([0, 2, 3]);
   const retained: MeshData = { ...original, geometryItemId: 102, indices: retainedIndices,
-    appearanceSource: { kind: 'canonical-item', indices: retainedIndices, sourceIndices: retainedIndices } };
+    appearanceSource: { kind: 'canonical-item', indices: retainedIndices, sourceIndices: indices,
+      cornerIndices: new Uint32Array([3, 4, 5]) } };
   return [textured, retained];
 }
 
@@ -78,9 +82,9 @@ describe('partitioned appearance preview (#4404)', () => {
   it('refuses a split that renames, moves, duplicates or drops triangles without touching the scene', () => {
     const { scene, original, api, owner } = setup();
     const [textured, retained] = halves(original);
-    assert.throws(() => api.begin(owner, { partition: { ...split, before: [{ geometryItemId: 99, triangles: [0, 1] }] } }), /Invalid appearance partition/);
+    assert.throws(() => api.begin(owner, { partition: { ...split, before: [{ partId: 0, geometryItemId: 99, triangles: [0, 1] }] } }), /Invalid appearance partition/);
     assert.throws(() => api.begin(owner, { partition: split, geometryItemRemaps: [{ from: 21, to: 31 }] }), /Invalid appearance partition/);
-    assert.throws(() => api.begin(owner, { partition: { ...split, after: [{ geometryItemId: 21, triangles: [0, 1] }] } }), /Invalid appearance partition/);
+    assert.throws(() => api.begin(owner, { partition: { ...split, after: [{ partId: 0, geometryItemId: 21, triangles: [0, 1] }] } }), /Invalid appearance partition/);
     const token = api.begin(owner, { partition: split });
     assert.throws(() => api.update(token, [textured]), /does not name every part/);
     assert.throws(() => api.update(token, [retained, textured]), /identity does not match/);
@@ -89,7 +93,7 @@ describe('partitioned appearance preview (#4404)', () => {
     assert.throws(() => api.update(token, [moved, retained]), /changes triangle geometry/);
     assert.throws(() => api.update(token, [{ ...textured, expressId: 8 }, retained]), /ownership or placement/);
     assert.throws(() => api.update(token, [{ ...textured, origin: [1, 0, 0] }, retained]), /ownership or placement/);
-    assert.throws(() => api.update(token, [textured, { ...retained, indices: new Uint32Array([0, 1, 2]) }]), /changes triangle geometry/);
+    assert.throws(() => api.update(token, [textured, { ...retained, indices: new Uint32Array([0, 1, 2]) }]), /geometry|provenance/);
     assert.throws(() => api.update(token, [{ ...textured, uvs: undefined }, retained]), /finite UVs/);
     assert.deepEqual(scene.getMeshDataPieces(7)!.map(part => part.geometryItemId), [21]);
     api.cancel(token);
@@ -98,10 +102,64 @@ describe('partitioned appearance preview (#4404)', () => {
   it('validates coverage on both sides independently of the scene', () => {
     const [textured, retained] = halves(quad);
     validateAppearancePartition(split, [quad], [textured, retained]);
-    assert.throws(() => validateAppearancePartition({ ...split, after: [{ geometryItemId: 101, triangles: [0] }, { geometryItemId: 102, triangles: [0] }] },
-      [quad], [textured, { ...retained, indices: new Uint32Array([0, 1, 2]) }]), /names a triangle twice/);
-    assert.throws(() => validateAppearancePartition({ ...split, before: [{ geometryItemId: 21, triangles: [0, 2] }] }, [quad], [textured, retained]), /changes triangle geometry/);
-    assert.throws(() => validateAppearancePartition({ ...split, after: [{ geometryItemId: 101, triangles: [0, 1] }, { geometryItemId: 102, triangles: [1] }] }, [quad], [textured, retained]), /triangle count/);
+    assert.throws(() => validateAppearancePartition({ ...split, after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [0] }] },
+      [quad], [textured, { ...retained, indices: new Uint32Array([0, 1, 2]) }]), /canonical triangles|provenance/);
+    assert.throws(() => validateAppearancePartition({ ...split, before: [{ partId: 0, geometryItemId: 21, triangles: [0, 2] }] }, [quad], [textured, retained]), /canonical triangles|full-surface coverage|changes triangle geometry/);
+    assert.throws(() => validateAppearancePartition({ ...split, after: [{ partId: 0, geometryItemId: 101, triangles: [0, 1] }, { partId: 1, geometryItemId: 102, triangles: [1] }] }, [quad], [textured, retained]), /triangle count/);
     assert.throws(() => validateAppearancePartition(split, [quad], [textured, { ...retained, normals: new Float32Array([0, 0, 1]) }]), /normals are invalid/);
+    assert.throws(() => validateAppearancePartition({ ...split, triangleCount: 500_001 }, [quad], [textured, retained]), /full-surface identity/);
+  });
+
+  it('validates a mask crossing forced streaming fragments with repeated item ids (#4556)', () => {
+    const fullIndices = new Uint32Array([0, 1, 2, 0, 2, 3, 1, 4, 2, 4, 5, 2]);
+    const full: MeshData = { ...quad, indices: fullIndices,
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 2, 0, 0, 2, 1, 0]),
+      normals: new Float32Array(18).map((_, i) => i % 3 === 2 ? 1 : 0),
+      appearanceSource: { kind: 'canonical-item', indices: fullIndices, sourceIndices: fullIndices } };
+    const fragments = splitMeshForStreaming(full, 6, 4096);
+    assert.deepEqual(fragments.map(part => part.geometryItemId), [21, 21]);
+    assert.deepEqual(fragments.map(part => [...part.appearanceSource!.cornerIndices!]), [[0, 1, 2, 3, 4, 5], [6, 7, 8, 9, 10, 11]]);
+    const pieces = fragments.flatMap((fragment, fragmentIndex) => [0, 1].map(localTriangle => {
+      const start = localTriangle * 3;
+      const pieceIndices = fragment.indices.slice(start, start + 3);
+      const canonical = fragment.appearanceSource!.cornerIndices!.slice(start, start + 3);
+      return { ...fragment, geometryItemId: localTriangle === 0 ? 101 : 102, indices: pieceIndices,
+        appearanceSource: { kind: 'canonical-item' as const, indices: pieceIndices,
+          sourceIndices: fullIndices, cornerIndices: canonical },
+        color: [fragmentIndex, localTriangle, 0, 1] as [number, number, number, number] };
+    }));
+    const multipart: AppearancePartition = { sourceGeometryItemId: 21, triangleCount: 4,
+      before: [{ partId: 0, geometryItemId: 21, triangles: [0, 1] }, { partId: 1, geometryItemId: 21, triangles: [2, 3] }],
+      after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [1] },
+        { partId: 2, geometryItemId: 101, triangles: [2] }, { partId: 3, geometryItemId: 102, triangles: [3] }] };
+    validateAppearancePartition(multipart, fragments, pieces);
+    validateAppearancePartition(invertAppearancePartition(multipart), pieces, fragments);
+    assert.throws(() => validateAppearancePartition({ ...multipart,
+      after: multipart.after.map((part, index) => ({ ...part, partId: index % 2 })) }, fragments, pieces), /item identity/);
+    const detachedSource = { ...pieces[3], appearanceSource: { ...pieces[3].appearanceSource!, sourceIndices: fullIndices.slice() } };
+    assert.throws(() => validateAppearancePartition(multipart, fragments, [...pieces.slice(0, 3), detachedSource]), /full-surface provenance/);
+
+    const scene = new Scene();
+    try {
+      scene.appendToBatches(fragments, device, pipeline);
+      const resident = scene.getMeshDataPieces(7)!;
+      const placedPieces = pieces.map(piece => scene.placeAppearanceSource(piece));
+      assert.equal(resident.length, 2, 'the real scene streaming path is forced below the source size');
+      const api = scene.appearancePreview(device, pipeline), owner = { expressId: 7, modelIndex: 0 };
+      const apply = api.begin(owner, { partition: multipart });
+      api.update(apply, placedPieces);
+      const change = api.commit(apply);
+      assert.deepEqual(scene.getMeshDataPieces(7)!.map(part => part.geometryItemId), [101, 102, 101, 102]);
+      const undo = api.begin(owner, { partition: invertAppearancePartition(change.partition!) });
+      api.update(undo, resident);
+      api.commit(undo);
+      assert.deepEqual(scene.getMeshDataPieces(7)!.map(part => part.geometryItemId), [21, 21]);
+      const redo = api.begin(owner, { partition: multipart });
+      api.update(redo, placedPieces);
+      api.cancel(redo);
+      assert.deepEqual(scene.getMeshDataPieces(7)!.map(part => part.geometryItemId), [21, 21]);
+    } finally {
+      scene.clear();
+    }
   });
 });

--- a/packages/renderer/src/appearance-partition.test.ts
+++ b/packages/renderer/src/appearance-partition.test.ts
@@ -104,7 +104,7 @@ describe('partitioned appearance preview (#4404)', () => {
     validateAppearancePartition(split, [quad], [textured, retained]);
     assert.throws(() => validateAppearancePartition({ ...split, after: [{ partId: 0, geometryItemId: 101, triangles: [0] }, { partId: 1, geometryItemId: 102, triangles: [0] }] },
       [quad], [textured, { ...retained, indices: new Uint32Array([0, 1, 2]) }]), /canonical triangles|provenance/);
-    assert.throws(() => validateAppearancePartition({ ...split, before: [{ partId: 0, geometryItemId: 21, triangles: [0, 2] }] }, [quad], [textured, retained]), /canonical triangles|full-surface coverage|changes triangle geometry/);
+    assert.throws(() => validateAppearancePartition({ ...split, before: [{ partId: 0, geometryItemId: 21, triangles: [0, 2] }] }, [quad], [textured, retained]), /invalid triangle|canonical triangles|full-surface coverage|changes triangle geometry/);
     assert.throws(() => validateAppearancePartition({ ...split, after: [{ partId: 0, geometryItemId: 101, triangles: [0, 1] }, { partId: 1, geometryItemId: 102, triangles: [1] }] }, [quad], [textured, retained]), /triangle count/);
     assert.throws(() => validateAppearancePartition(split, [quad], [textured, { ...retained, normals: new Float32Array([0, 0, 1]) }]), /normals are invalid/);
     assert.throws(() => validateAppearancePartition({ ...split, triangleCount: 500_001 }, [quad], [textured, retained]), /full-surface identity/);

--- a/packages/renderer/src/appearance-partition.test.ts
+++ b/packages/renderer/src/appearance-partition.test.ts
@@ -136,8 +136,9 @@ describe('partitioned appearance preview (#4404)', () => {
     validateAppearancePartition(invertAppearancePartition(multipart), pieces, fragments);
     assert.throws(() => validateAppearancePartition({ ...multipart,
       after: multipart.after.map((part, index) => ({ ...part, partId: index % 2 })) }, fragments, pieces), /item identity/);
-    const detachedSource = { ...pieces[3], appearanceSource: { ...pieces[3].appearanceSource!, sourceIndices: fullIndices.slice() } };
-    assert.throws(() => validateAppearancePartition(multipart, fragments, [...pieces.slice(0, 3), detachedSource]), /full-surface provenance/);
+    const changedSource = fullIndices.slice(); changedSource[9] = 0;
+    const detachedSource = { ...pieces[3], appearanceSource: { ...pieces[3].appearanceSource!, sourceIndices: changedSource } };
+    assert.throws(() => validateAppearancePartition(multipart, fragments, [...pieces.slice(0, 3), detachedSource]), /canonical triangles|full-surface provenance/);
 
     const scene = new Scene();
     try {

--- a/packages/renderer/src/appearance-partition.test.ts
+++ b/packages/renderer/src/appearance-partition.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import type { MeshData } from '@ifc-lite/geometry';
+import type { DecodedInstancedShard, MeshData } from '@ifc-lite/geometry';
 import { Scene } from './scene.js';
 import { invertAppearancePartition, validateAppearancePartition, type AppearancePartition } from './appearance-partition.js';
 import { splitMeshForStreaming } from './scene-stream-split.js';
@@ -162,5 +162,40 @@ describe('partitioned appearance preview (#4404)', () => {
     } finally {
       scene.clear();
     }
+  });
+
+  it('replays a federated instanced mask through Apply, Undo and Redo (#4556)', () => {
+    const modelIndex = 7, expressId = 1_007, sourceItem = 1_021;
+    const shard: DecodedInstancedShard = { carriesItemIds: true,
+      templates: [{ positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1]),
+        normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0]), indices, origin: [0, 0, 0] }],
+      instances: [{ templateIndex: 0, entityId: expressId, itemId: sourceItem, color: [0.8, 0.2, 0.1, 1],
+        transform: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]) }] };
+    const scene = new Scene();
+    scene.addInstancedShard(device, shard, modelIndex);
+    const source: MeshData = { ...quad, expressId, modelIndex, geometryItemId: sourceItem, origin: [0, 0, 0] };
+    const [localTextured, localRetained] = halves(source);
+    const textured = { ...localTextured, geometryItemId: 1_101 };
+    const retained = { ...localRetained, geometryItemId: 1_102 };
+    const partition: AppearancePartition = { sourceGeometryItemId: sourceItem, triangleCount: 2,
+      before: [{ partId: 0, geometryItemId: sourceItem, triangles: [0, 1] }],
+      after: [{ partId: 0, geometryItemId: 1_101, triangles: [0] }, { partId: 1, geometryItemId: 1_102, triangles: [1] }] };
+    const owner = { expressId, modelIndex }, api = scene.appearancePreview(device, pipeline);
+    const apply = api.begin(owner, { materializedOriginals: [source], partition });
+    api.update(apply, [textured, retained]);
+    const release = api.retainSource(owner), change = api.commit(apply);
+    assert.equal(change.beforeInstanced, true);
+    assert.deepEqual(scene.getMeshDataPieces(expressId, modelIndex)!.map(part => part.geometryItemId), [1_101, 1_102]);
+
+    const undo = api.begin(owner, { partition: invertAppearancePartition(change.partition!) });
+    api.update(undo, [source]); api.commit(undo);
+    assert.equal(scene.isInstancedEntity(expressId), true);
+    assert.equal(scene.getMeshDataPieces(expressId, modelIndex), undefined);
+
+    const redo = api.begin(owner, { partition });
+    api.update(redo, [textured, retained]); api.commit(redo);
+    assert.equal([...scene.getInstancedEntityIds()].includes(expressId), false, 'the retained instance is suppressed behind the flat mask');
+    assert.deepEqual(scene.getMeshDataPieces(expressId, modelIndex)!.map(part => part.geometryItemId), [1_101, 1_102]);
+    release(); scene.clear();
   });
 });

--- a/packages/renderer/src/appearance-partition.ts
+++ b/packages/renderer/src/appearance-partition.ts
@@ -50,7 +50,8 @@ function sameFrame(a: MeshData, b: MeshData): boolean {
 }
 
 /** Items appear in declaration order; part identity, rather than IFC item id, is unique. */
-function checkSide(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string, triangleCount: number): void {
+function checkSide(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string, triangleCount: number,
+  referenceSource: Uint32Array): void {
   if (!side.length || side.length !== parts.length) throw new Error(`Appearance partition ${label} does not name every part`);
   const seen = new Set<number>();
   let work = 0;
@@ -61,7 +62,7 @@ function checkSide(side: readonly AppearancePartitionPart[], parts: readonly Mes
     seen.add(entry.partId);
     if (entry.triangles.length * 3 !== parts[index].indices.length) throw new Error(`Appearance partition ${label} triangle count does not match its part`);
     const source = parts[index].appearanceSource;
-    if (!source || source.indices !== parts[index].indices || source.sourceIndices.length % 3
+    if (!source || source.indices !== parts[index].indices || source.sourceIndices.length !== triangleCount * 3
       || source.cornerIndices && source.cornerIndices.length !== parts[index].indices.length) {
       throw new Error(`Appearance partition ${label} has invalid full-surface provenance`);
     }
@@ -74,7 +75,9 @@ function checkSide(side: readonly AppearancePartitionPart[], parts: readonly Mes
         throw new Error(`Appearance partition ${label} names an invalid triangle`);
       }
       for (let corner = 0; corner < 3; corner++) {
-        if ((source.cornerIndices?.[triangle * 3 + corner] ?? triangle * 3 + corner) !== ordinal * 3 + corner) {
+        const canonicalCorner = ordinal * 3 + corner;
+        if ((source.cornerIndices?.[triangle * 3 + corner] ?? triangle * 3 + corner) !== canonicalCorner
+          || source.sourceIndices[canonicalCorner] !== referenceSource[canonicalCorner]) {
           throw new Error(`Appearance partition ${label} part identity does not match its canonical triangles`);
         }
       }
@@ -122,16 +125,14 @@ export function validateAppearancePartition(partition: AppearancePartition, befo
     || partition.before.length > partition.triangleCount || partition.after.length > partition.triangleCount) {
     throw new Error('Appearance partition full-surface identity is invalid');
   }
-  checkSide(partition.before, before, 'original', partition.triangleCount);
-  checkSide(partition.after, after, 'replacement', partition.triangleCount);
-  const sourceIndices = before[0].appearanceSource!.sourceIndices;
-  if (sourceIndices.length !== partition.triangleCount * 3
-    || before.some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
-    || after.some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
-    || !(before.every(part => part.geometryItemId === partition.sourceGeometryItemId)
-      || after.every(part => part.geometryItemId === partition.sourceGeometryItemId))) {
+  const sourceSide = before.every(part => part.geometryItemId === partition.sourceGeometryItemId) ? before
+    : after.every(part => part.geometryItemId === partition.sourceGeometryItemId) ? after : undefined;
+  const sourceIndices = sourceSide?.[0].appearanceSource?.sourceIndices;
+  if (!sourceIndices || sourceIndices.length !== partition.triangleCount * 3) {
     throw new Error('Appearance partition full-surface provenance does not match its source item');
   }
+  checkSide(partition.before, before, 'original', partition.triangleCount, sourceIndices);
+  checkSide(partition.after, after, 'replacement', partition.triangleCount, sourceIndices);
   const owner = before[0];
   for (const part of [...before, ...after]) {
     if (part.expressId !== owner.expressId || (part.modelIndex ?? 0) !== (owner.modelIndex ?? 0) || part.entityIds

--- a/packages/renderer/src/appearance-partition.ts
+++ b/packages/renderer/src/appearance-partition.ts
@@ -50,9 +50,10 @@ function sameFrame(a: MeshData, b: MeshData): boolean {
 }
 
 /** Items appear in declaration order; part identity, rather than IFC item id, is unique. */
-function checkSide(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string): void {
+function checkSide(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string, triangleCount: number): void {
   if (!side.length || side.length !== parts.length) throw new Error(`Appearance partition ${label} does not name every part`);
   const seen = new Set<number>();
+  let work = 0;
   side.forEach((entry, index) => {
     if (!Number.isSafeInteger(entry.partId) || entry.partId < 0 || seen.has(entry.partId)
       || !Number.isSafeInteger(entry.geometryItemId) || entry.geometryItemId <= 0
@@ -64,7 +65,14 @@ function checkSide(side: readonly AppearancePartitionPart[], parts: readonly Mes
       || source.cornerIndices && source.cornerIndices.length !== parts[index].indices.length) {
       throw new Error(`Appearance partition ${label} has invalid full-surface provenance`);
     }
+    if (!entry.triangles.length || entry.triangles.length > triangleCount - work) {
+      throw new Error(`Appearance partition ${label} exceeds its triangle work budget`);
+    }
+    work += entry.triangles.length;
     entry.triangles.forEach((ordinal, triangle) => {
+      if (!Number.isSafeInteger(ordinal) || ordinal < 0 || ordinal >= triangleCount) {
+        throw new Error(`Appearance partition ${label} names an invalid triangle`);
+      }
       for (let corner = 0; corner < 3; corner++) {
         if ((source.cornerIndices?.[triangle * 3 + corner] ?? triangle * 3 + corner) !== ordinal * 3 + corner) {
           throw new Error(`Appearance partition ${label} part identity does not match its canonical triangles`);
@@ -72,24 +80,33 @@ function checkSide(side: readonly AppearancePartitionPart[], parts: readonly Mes
       }
     });
   });
+  if (work !== triangleCount) throw new Error(`Appearance partition ${label} does not cover the full surface`);
 }
 
-/** Reference corner -> position, from one side of the partition. */
-function referenceCorners(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string): Map<number, readonly [number, number, number]> {
-  const corners = new Map<number, readonly [number, number, number]>();
+/** Write or compare reference-corner positions using a fixed-size allocation. */
+function referenceCorners(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string,
+  triangleCount: number, expected?: Float32Array): Float32Array {
+  const corners = expected ?? new Float32Array(triangleCount * 9);
+  const seen = new Uint8Array(triangleCount * 3);
   side.forEach((entry, index) => {
     const part = parts[index];
     entry.triangles.forEach((ordinal, triangle) => {
-      if (!Number.isSafeInteger(ordinal) || ordinal < 0) throw new Error(`Appearance partition ${label} names an invalid triangle`);
       for (let corner = 0; corner < 3; corner++) {
         const reference = ordinal * 3 + corner;
-        if (corners.has(reference)) throw new Error(`Appearance partition ${label} names a triangle twice`);
+        if (seen[reference]) throw new Error(`Appearance partition ${label} names a triangle twice`);
+        seen[reference] = 1;
         const vertex = part.indices[triangle * 3 + corner] * 3;
         if (vertex + 2 >= part.positions.length) throw new Error(`Appearance partition ${label} part index is out of range`);
-        corners.set(reference, [part.positions[vertex], part.positions[vertex + 1], part.positions[vertex + 2]]);
+        const output = reference * 3;
+        for (let axis = 0; axis < 3; axis++) {
+          const value = part.positions[vertex + axis];
+          if (expected && expected[output + axis] !== value) throw new Error('Appearance partition changes triangle geometry');
+          corners[output + axis] = value;
+        }
       }
     });
   });
+  if (seen.some(value => value !== 1)) throw new Error(`Appearance partition ${label} does not provide complete coverage`);
   return corners;
 }
 
@@ -105,11 +122,12 @@ export function validateAppearancePartition(partition: AppearancePartition, befo
     || partition.before.length > partition.triangleCount || partition.after.length > partition.triangleCount) {
     throw new Error('Appearance partition full-surface identity is invalid');
   }
-  checkSide(partition.before, before, 'original');
-  checkSide(partition.after, after, 'replacement');
+  checkSide(partition.before, before, 'original', partition.triangleCount);
+  checkSide(partition.after, after, 'replacement', partition.triangleCount);
   const sourceIndices = before[0].appearanceSource!.sourceIndices;
   if (sourceIndices.length !== partition.triangleCount * 3
-    || [...before, ...after].some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
+    || before.some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
+    || after.some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
     || !(before.every(part => part.geometryItemId === partition.sourceGeometryItemId)
       || after.every(part => part.geometryItemId === partition.sourceGeometryItemId))) {
     throw new Error('Appearance partition full-surface provenance does not match its source item');
@@ -120,16 +138,6 @@ export function validateAppearancePartition(partition: AppearancePartition, befo
       || !sameFrame(part, owner)) throw new Error('Appearance partition cannot change ownership or placement');
     if (part.normals.length !== part.positions.length || !part.normals.every(Number.isFinite)) throw new Error('Appearance partition part normals are invalid');
   }
-  const original = referenceCorners(partition.before, before, 'original');
-  const replacement = referenceCorners(partition.after, after, 'replacement');
-  if (original.size !== partition.triangleCount * 3 || replacement.size !== original.size
-    || [...original.keys()].some(reference => reference >= partition.triangleCount * 3)) {
-    throw new Error('Appearance partition does not provide disjoint complete full-surface coverage');
-  }
-  for (const [reference, position] of original) {
-    const other = replacement.get(reference);
-    if (!other || other[0] !== position[0] || other[1] !== position[1] || other[2] !== position[2]) {
-      throw new Error('Appearance partition changes triangle geometry');
-    }
-  }
+  const original = referenceCorners(partition.before, before, 'original', partition.triangleCount);
+  referenceCorners(partition.after, after, 'replacement', partition.triangleCount, original);
 }

--- a/packages/renderer/src/appearance-partition.ts
+++ b/packages/renderer/src/appearance-partition.ts
@@ -3,9 +3,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { MeshData } from '@ifc-lite/geometry';
 
+/** Matches the native face-mask plan's aggregate ordinal budget. */
+const MAX_PARTITION_TRIANGLES = 500_000;
+
 /** One item on either side of a partition: the triangle ordinals of a shared
  * reference surface it carries, in its own triangle order. */
 export interface AppearancePartitionPart {
+  /** Unique within this side; geometryItemId may repeat across fragments. */
+  readonly partId: number;
   readonly geometryItemId: number;
   readonly triangles: readonly number[];
 }
@@ -17,18 +22,22 @@ export interface AppearancePartitionPart {
  * inverted describes the join that Undo performs.
  */
 export interface AppearancePartition {
+  /** Canonical full surface whose triangle ordinals every side partitions. */
+  readonly sourceGeometryItemId: number;
+  readonly triangleCount: number;
   readonly before: readonly AppearancePartitionPart[];
   readonly after: readonly AppearancePartitionPart[];
 }
 
 export function invertAppearancePartition(partition: AppearancePartition): AppearancePartition {
-  return { before: partition.after, after: partition.before };
+  return { ...partition, before: partition.after, after: partition.before };
 }
 
 export function freezeAppearancePartition(partition: AppearancePartition): AppearancePartition {
   const side = (parts: readonly AppearancePartitionPart[]) => Object.freeze(parts.map(part =>
-    Object.freeze({ geometryItemId: part.geometryItemId, triangles: Object.freeze([...part.triangles]) })));
-  return Object.freeze({ before: side(partition.before), after: side(partition.after) });
+    Object.freeze({ partId: part.partId, geometryItemId: part.geometryItemId, triangles: Object.freeze([...part.triangles]) })));
+  return Object.freeze({ sourceGeometryItemId: partition.sourceGeometryItemId, triangleCount: partition.triangleCount,
+    before: side(partition.before), after: side(partition.after) });
 }
 
 function sameFrame(a: MeshData, b: MeshData): boolean {
@@ -40,15 +49,28 @@ function sameFrame(a: MeshData, b: MeshData): boolean {
   return true;
 }
 
-/** Items must appear in declaration order with unique, positive identities. */
+/** Items appear in declaration order; part identity, rather than IFC item id, is unique. */
 function checkSide(side: readonly AppearancePartitionPart[], parts: readonly MeshData[], label: string): void {
   if (!side.length || side.length !== parts.length) throw new Error(`Appearance partition ${label} does not name every part`);
   const seen = new Set<number>();
   side.forEach((entry, index) => {
-    if (!Number.isSafeInteger(entry.geometryItemId) || entry.geometryItemId <= 0 || seen.has(entry.geometryItemId)
+    if (!Number.isSafeInteger(entry.partId) || entry.partId < 0 || seen.has(entry.partId)
+      || !Number.isSafeInteger(entry.geometryItemId) || entry.geometryItemId <= 0
       || parts[index].geometryItemId !== entry.geometryItemId) throw new Error(`Appearance partition ${label} item identity does not match its part`);
-    seen.add(entry.geometryItemId);
+    seen.add(entry.partId);
     if (entry.triangles.length * 3 !== parts[index].indices.length) throw new Error(`Appearance partition ${label} triangle count does not match its part`);
+    const source = parts[index].appearanceSource;
+    if (!source || source.indices !== parts[index].indices || source.sourceIndices.length % 3
+      || source.cornerIndices && source.cornerIndices.length !== parts[index].indices.length) {
+      throw new Error(`Appearance partition ${label} has invalid full-surface provenance`);
+    }
+    entry.triangles.forEach((ordinal, triangle) => {
+      for (let corner = 0; corner < 3; corner++) {
+        if ((source.cornerIndices?.[triangle * 3 + corner] ?? triangle * 3 + corner) !== ordinal * 3 + corner) {
+          throw new Error(`Appearance partition ${label} part identity does not match its canonical triangles`);
+        }
+      }
+    });
   });
 }
 
@@ -77,8 +99,21 @@ function referenceCorners(side: readonly AppearancePartitionPart[], parts: reado
  * only shading normals and appearance attributes may differ.
  */
 export function validateAppearancePartition(partition: AppearancePartition, before: readonly MeshData[], after: readonly MeshData[]): void {
+  if (!Number.isSafeInteger(partition.sourceGeometryItemId) || partition.sourceGeometryItemId <= 0
+    || !Number.isSafeInteger(partition.triangleCount) || partition.triangleCount <= 0
+    || partition.triangleCount > MAX_PARTITION_TRIANGLES
+    || partition.before.length > partition.triangleCount || partition.after.length > partition.triangleCount) {
+    throw new Error('Appearance partition full-surface identity is invalid');
+  }
   checkSide(partition.before, before, 'original');
   checkSide(partition.after, after, 'replacement');
+  const sourceIndices = before[0].appearanceSource!.sourceIndices;
+  if (sourceIndices.length !== partition.triangleCount * 3
+    || [...before, ...after].some(part => part.appearanceSource!.sourceIndices !== sourceIndices)
+    || !(before.every(part => part.geometryItemId === partition.sourceGeometryItemId)
+      || after.every(part => part.geometryItemId === partition.sourceGeometryItemId))) {
+    throw new Error('Appearance partition full-surface provenance does not match its source item');
+  }
   const owner = before[0];
   for (const part of [...before, ...after]) {
     if (part.expressId !== owner.expressId || (part.modelIndex ?? 0) !== (owner.modelIndex ?? 0) || part.entityIds
@@ -87,7 +122,10 @@ export function validateAppearancePartition(partition: AppearancePartition, befo
   }
   const original = referenceCorners(partition.before, before, 'original');
   const replacement = referenceCorners(partition.after, after, 'replacement');
-  if (original.size !== replacement.size) throw new Error('Appearance partition does not cover the same triangles on both sides');
+  if (original.size !== partition.triangleCount * 3 || replacement.size !== original.size
+    || [...original.keys()].some(reference => reference >= partition.triangleCount * 3)) {
+    throw new Error('Appearance partition does not provide disjoint complete full-surface coverage');
+  }
   for (const [reference, position] of original) {
     const other = replacement.get(reference);
     if (!other || other[0] !== position[0] || other[1] !== position[1] || other[2] !== position[2]) {

--- a/packages/renderer/src/appearance-preview.ts
+++ b/packages/renderer/src/appearance-preview.ts
@@ -6,7 +6,7 @@ import { equivalentAppearanceGeometry } from './appearance-uvs.js';
 import { sameCompanionParts } from './appearance-companions.js';
 import { freezeAppearancePartition, validateAppearancePartition, type AppearancePartition } from './appearance-partition.js';
 // The partition is part of the preview contract; the package publishes it from here.
-export { invertAppearancePartition, type AppearancePartition, type AppearancePartitionPart } from './appearance-partition.js';
+export { invertAppearancePartition, validateAppearancePartition, type AppearancePartition, type AppearancePartitionPart } from './appearance-partition.js';
 
 /** expressId is already federation-resolved; modelIndex is the renderer model. */
 export interface AppearanceOwner {
@@ -113,10 +113,12 @@ export class AppearancePreviewController<Resource>
       if (partition) {
         // The partition names the whole owner: every original part in order,
         // and replacement identities that do not collide with them.
-        const ids = new Set(partition.after.map(part => part.geometryItemId));
+        const partIds = new Set(partition.after.map(part => part.partId));
         if (remaps.length || companions || partition.before.length !== captured.parts.length
           || partition.before.some((part, index) => part.geometryItemId !== captured.parts[index].geometryItemId)
-          || ids.size !== partition.after.length || [...ids].some(id => !Number.isSafeInteger(id) || id <= 0 || originals.has(id))) {
+          || partIds.size !== partition.after.length
+          || partition.after.some(part => !Number.isSafeInteger(part.geometryItemId) || part.geometryItemId <= 0
+            || originals.has(part.geometryItemId))) {
           throw new Error('Invalid appearance partition');
         }
       }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -14,7 +14,7 @@ export { Camera } from './camera.js';
 export type { SceneContents } from './scene-contents.js';
 export { appearanceSourceTriangle, expandAppearanceCorners, equivalentAppearanceGeometry } from './appearance-uvs.js';
 export { sameCompanionParts } from './appearance-companions.js';
-export { invertAppearancePartition, type AppearancePreview, type AppearanceOwner, type AppearanceToken, type AppearanceChange, type AppearancePartition, type AppearancePartitionPart } from './appearance-preview.js';
+export { invertAppearancePartition, validateAppearancePartition, type AppearancePreview, type AppearanceOwner, type AppearanceToken, type AppearanceChange, type AppearancePartition, type AppearancePartitionPart } from './appearance-preview.js';
 import type { AppearancePreview } from './appearance-preview.js';
 import { createReferenceImageManager } from './reference-image-host.js';
 export type { ReferenceImages, ReferenceImageInput, ReferenceImageHit, ReferenceCorners } from './reference-image-types.js';

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -400,6 +400,19 @@ describe('RaycastEngine.raycastScene', () => {
     assert.equal(hit.sourceTriangleIndex, undefined);
   });
 
+  it('keeps equal-sized fragments that share an owner, origin and first vertex (#4556)', () => {
+    const scene = new Scene();
+    const fragment = (x: number): MeshData => ({ expressId: 7, modelIndex: 3,
+      positions: new Float32Array([0, 0, 0, x, -1, 0, x, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), indices: new Uint32Array([0, 1, 2]),
+      color: [1, 1, 1, 1] });
+    addRegularMesh(scene, fragment(-10));
+    addRegularMesh(scene, fragment(10));
+    const engine = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50));
+    assert.ok(engine.raycastScene(300, 300), 'the left fragment remains raycastable');
+    assert.ok(engine.raycastScene(500, 300), 'the equal-signature right fragment must not be deduplicated');
+  });
+
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {
     // An asymmetric triangle (legs of different length: 12 along local X, 4
     // along local Y), scaled non-uniformly, rotated 90 degrees about Y, and

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -402,15 +402,25 @@ describe('RaycastEngine.raycastScene', () => {
 
   it('keeps equal-sized fragments that share an owner, origin and first vertex (#4556)', () => {
     const scene = new Scene();
-    const fragment = (x: number): MeshData => ({ expressId: 7, modelIndex: 3,
-      positions: new Float32Array([0, 0, 0, x, -1, 0, x, 1, 0]),
-      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), indices: new Uint32Array([0, 1, 2]),
-      color: [1, 1, 1, 1] });
-    addRegularMesh(scene, fragment(-10));
-    addRegularMesh(scene, fragment(10));
+    const sourceIndices = new Uint32Array([0, 1, 2, 0, 3, 4]);
+    const fragment = (x: number, ordinal: number): MeshData => {
+      const indices = new Uint32Array([0, 1, 2]);
+      return { expressId: 7, modelIndex: 3, geometryItemId: 70,
+        positions: new Float32Array([0, 0, 0, x, -1, 0, x, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), indices, color: [1, 1, 1, 1],
+        appearanceSource: { kind: 'canonical-item', indices, sourceIndices,
+          cornerIndices: Uint32Array.from([ordinal * 3, ordinal * 3 + 1, ordinal * 3 + 2]) } };
+    };
+    addRegularMesh(scene, fragment(-10, 0));
+    addRegularMesh(scene, fragment(10, 1));
     const engine = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50));
-    assert.ok(engine.raycastScene(300, 300), 'the left fragment remains raycastable');
-    assert.ok(engine.raycastScene(500, 300), 'the equal-signature right fragment must not be deduplicated');
+    const left = engine.raycastScene(300, 300)?.intersection;
+    const right = engine.raycastScene(500, 300)?.intersection;
+    assert.deepEqual(left && { modelIndex: left.modelIndex, geometryItemId: left.geometryItemId,
+      sourceTriangleIndex: left.sourceTriangleIndex }, { modelIndex: 3, geometryItemId: 70, sourceTriangleIndex: 0 });
+    assert.deepEqual(right && { modelIndex: right.modelIndex, geometryItemId: right.geometryItemId,
+      sourceTriangleIndex: right.sourceTriangleIndex }, { modelIndex: 3, geometryItemId: 70, sourceTriangleIndex: 1 },
+    'the equal-signature right fragment must remain raycastable with its canonical ordinal');
   });
 
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {

--- a/packages/renderer/src/raycast-engine.test.ts
+++ b/packages/renderer/src/raycast-engine.test.ts
@@ -423,6 +423,33 @@ describe('RaycastEngine.raycastScene', () => {
     'the equal-signature right fragment must remain raycastable with its canonical ordinal');
   });
 
+  it('rebuilds a populated BVH when equal-shaped owner fragments are replaced and reordered (#4556)', () => {
+    const scene = new Scene();
+    const fullSource = new Uint32Array([0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7]);
+    const fragment = (x: number, itemId: number, firstCorner: number): MeshData => {
+      const mesh = makeQuad({ expressId: 7, modelIndex: 3, translate: [x, 0, 0] });
+      return { ...mesh, geometryItemId: itemId,
+        appearanceSource: { kind: 'canonical-item', indices: mesh.indices, sourceIndices: fullSource,
+          cornerIndices: Uint32Array.from({ length: 6 }, (_, corner) => firstCorner + corner) } };
+    };
+    addRegularMesh(scene, fragment(-10, 70, 0));
+    addRegularMesh(scene, fragment(10, 71, 6));
+    for (let i = 0; i < 99; i++) {
+      addRegularMesh(scene, makeQuad({ expressId: 100 + i, translate: [1_000 + i * 20, 0, 0] }));
+    }
+    const engine = engineFor(scene, orthoCameraLookingDownZ([0, 0, 0], 50));
+    assert.equal(engine.raycastScene(200, 350)?.intersection.geometryItemId, 70,
+      'the first ray populates the >100-piece BVH with the old left fragment');
+
+    const newRight = fragment(10, 170, 0);
+    const newLeft = fragment(-10, 171, 6);
+    (scene as unknown as { meshDataMap: Map<number, MeshData[]> }).meshDataMap.set(7, [newRight, newLeft]);
+    const hit = engine.raycastScene(200, 350)?.intersection;
+    assert.deepEqual(hit && { geometryItemId: hit.geometryItemId, sourceTriangleIndex: hit.sourceTriangleIndex,
+      x: Math.round(hit.point.x) }, { geometryItemId: 171, sourceTriangleIndex: 2, x: -10 },
+    'same-count, same-shape replacement and reorder must return the new piece, ordinal and location');
+  });
+
   it('off-origin, rotated, non-uniformly-scaled geometry is hit at the transformed location, not the local one', () => {
     // An asymmetric triangle (legs of different length: 12 along local X, 4
     // along local Y), scaled non-uniformly, rotated 90 degrees about Y, and

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -25,22 +25,6 @@ import {
     type PointCloudSnapCamera,
 } from './raycast-point-cloud-query.js';
 export type { PointCloudRaySource, PointCloudRayProvider } from './raycast-point-cloud-query.js';
-/**
- * Cheap order-sensitive 32-bit signature of a mesh set, used to detect when the
- * raycast BVH must rebuild because the SET changed (not just its size). Mixes
- * each mesh's express id + vertex count via a rolling hash — O(n) integer ops,
- * no allocation. Different sets of the same length differ with high probability.
- */
-function computeMeshSetSignature(meshData: readonly MeshData[]): number {
-    let sig = meshData.length | 0;
-    for (let i = 0; i < meshData.length; i++) {
-        const m = meshData[i];
-        sig = (Math.imul(sig, 31) + (m.expressId | 0)) | 0;
-        sig = (Math.imul(sig, 31) + (m.positions.length | 0)) | 0;
-    }
-    return sig;
-}
-
 /** Raycast-only capability; does not widen Renderer.getScene()'s public surface. */
 type RaycastScene = SceneContents & {
     getTexturedMeshes?(): readonly Pick<MeshData, 'expressId' | 'modelIndex'>[];
@@ -58,11 +42,8 @@ export class RaycastEngine {
     // BVH cache
     private bvhCache: {
         meshCount: number;
-        /** Cheap content signature of the built mesh set (#1238): catches a
-         *  same-COUNT but different-MEMBERS set — e.g. two rays materializing
-         *  different instanced pieces — which a count-only check would miss,
-         *  leaving the BVH stale and raycasts wrong. */
-        signature: number;
+        /** Exact ordered objects used to build the BVH. Geometry pieces with
+         *  equal ids and buffer lengths can still occupy different bounds. */
         meshData: MeshData[];
         isBuilt: boolean;
     } | null = null;
@@ -189,23 +170,20 @@ export class RaycastEngine {
             return allMeshData;
         }
 
-        // Check if BVH needs rebuilding. Compare a content signature, not just the
-        // count: instanced pieces are materialized per-ray (only AABB-hit
-        // occurrences), so two rays can yield the SAME count over DIFFERENT
-        // geometry — a count-only check would reuse a stale BVH. (#1238 review)
-        const signature = computeMeshSetSignature(allMeshData);
+        // Instanced pieces are materialized per-ray and resident fragments can
+        // be replaced or reordered while keeping the same ids and buffer sizes.
+        // Reuse is safe only for the exact ordered objects the BVH indexed.
         const needsRebuild =
             !this.bvhCache ||
             !this.bvhCache.isBuilt ||
             this.bvhCache.meshCount !== allMeshData.length ||
-            this.bvhCache.signature !== signature;
+            this.bvhCache.meshData.some((mesh, index) => mesh !== allMeshData[index]);
 
         if (needsRebuild) {
             // Build BVH only when needed
             this.bvh.build(allMeshData);
             this.bvhCache = {
                 meshCount: allMeshData.length,
-                signature,
                 meshData: allMeshData,
                 isBuilt: true,
             };

--- a/packages/renderer/src/raycast-engine.ts
+++ b/packages/renderer/src/raycast-engine.ts
@@ -107,9 +107,17 @@ export class RaycastEngine {
         const allMeshData: MeshData[] = [];
         const meshes = this.scene.getMeshes();
         const batchedMeshes = this.scene.getBatchedMeshes();
-        const seenKeys = new Set<string>();
+        const queriedOwners = new Set<string>();
+        const seenPieces = new Set<MeshData>();
+        const seenInstancedKeys = new Set<string>();
 
         const pushVisiblePieces = (expressId: number, modelIndex?: number) => {
+            // One owner/model query returns every resident fragment. Deduplicate
+            // the query, then retain each distinct MeshData object; geometry
+            // signatures can collide for equal-sized fragments sharing a vertex.
+            const ownerKey = `${expressId}:${modelIndex ?? 'any'}`;
+            if (queriedOwners.has(ownerKey)) return;
+            queriedOwners.add(ownerKey);
             const pieces = this.scene.getMeshDataPieces(expressId, modelIndex);
             if (!pieces) return;
 
@@ -117,23 +125,8 @@ export class RaycastEngine {
                 // Apply visibility filtering
                 if (!isEntityVisible(piece.expressId, options?.hiddenIds, options?.isolatedIds)) continue;
 
-                // Avoid duplicates when a piece is reachable from both regular and
-                // batched passes — but DON'T collapse distinct pieces of one entity.
-                // Mapped copies (IfcMappedItem, e.g. the 4 bolts of one fastener)
-                // become several flat pieces sharing expressId/modelIndex AND buffer
-                // sizes (same template), differing only in position/origin. A
-                // size-based key dropped all but the first, so 3 of 4 bolts were
-                // absent from the raycast set → unpickable / unsnappable. Include the
-                // per-piece origin + first vertex so distinct placements survive while
-                // a truly identical piece reached twice still dedups. (Mirrors the
-                // instanced-piece key fix in #1238.)
-                const p0 = piece.positions;
-                const o = piece.origin;
-                const key = `${piece.expressId}:${piece.modelIndex ?? 'any'}:${piece.positions.length}:${piece.indices.length}`
-                    + `:${o ? `${o[0]},${o[1]},${o[2]}` : ''}`
-                    + `:${p0.length >= 3 ? `${p0[0]},${p0[1]},${p0[2]}` : ''}`;
-                if (seenKeys.has(key)) continue;
-                seenKeys.add(key);
+                if (seenPieces.has(piece)) continue;
+                seenPieces.add(piece);
                 allMeshData.push(piece);
             }
         };
@@ -177,8 +170,8 @@ export class RaycastEngine {
                 for (let p = 0; p < pieces.length; p++) {
                     const piece = pieces[p];
                     const key = `${piece.expressId}:inst:${p}`;
-                    if (seenKeys.has(key)) continue;
-                    seenKeys.add(key);
+                    if (seenInstancedKeys.has(key)) continue;
+                    seenInstancedKeys.add(key);
                     allMeshData.push(piece);
                 }
             }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -7753,6 +7753,7 @@
     "selectEvictions: function",
     "simplifyIndicesByClustering: function",
     "sumResidentGpuBytes: function",
+    "validateAppearancePartition: function",
     "viewBasis: function"
   ],
   "@ifc-lite/sandbox": [

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -315,7 +315,7 @@
    952 packages/renderer/src/pipeline.ts
    475 packages/renderer/src/pointcloud/point-cloud-renderer.ts
    758 packages/renderer/src/pointcloud/point-cloud-spatial-index.ts
-   474 packages/renderer/src/raycast-engine.ts
+   467 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
    462 packages/renderer/src/scene-raycaster.ts
   4214 packages/renderer/src/scene.ts


### PR DESCRIPTION
Streamed appearance masks previously stopped at renderer fragment boundaries, so selecting a face on one evaluated surface could not preview or commit the corresponding canonical mask across all of its resident, streamed, instanced, or federated pieces. This change carries a validated multipart partition through preview history while preserving canonical source triangles and per-corner provenance.

- represent one canonical evaluated surface as bounded, disjoint `before`/`after` parts, including repeated representation-item IDs across stream fragments
- validate ownership, placement, triangle coverage, source indices, and corner maps before previewing or inverting a partition
- preserve deterministic Compare/Discard/Apply/Undo/Redo behavior for multipart and federated instanced geometry
- enumerate actual raycast pieces by owner/model and mesh identity so equal-sized fragments sharing their first vertex remain independently pickable
- export and document the partition validation and canonical source-triangle helpers

Validation (Node 22.23.2):

- `pnpm typecheck` — 94/94 tasks; all 2,004 test files included in a typecheck program
- `pnpm test` — 102/102 tasks; viewer 8,052 passed, 15 skipped, 0 failed
- focused renderer provenance/partition suite — 28/28 passed
- focused viewer preview/history suite — 11/11 passed
- `pnpm lint`
- `pnpm docs:check-samples` — 383 snippets across 87 docs
- `pnpm docs:check-generated`
- `pnpm docs:check-readmes`
- `node scripts/check-api-surface.mjs` — 8,061 exports match
- `node scripts/check-module-size.mjs`
- `git diff --check`

Closes #4556
