### PR TITLE
refactor(viewer): table-driven bottom strip + single overlay compositor

### DIFF
--- a/.changeset/bottom-panels-table.md
+++ b/.changeset/bottom-panels-table.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+The bottom strip (Schedule / Script / Lists) is table-driven: `lib/panels/bottom-panels` owns the id list, the store flags and the precedence rule, and the store actions, layout (`BottomStrip`), mobile sheet, panel controls, command palette and tour snapshot derive from it instead of each spelling the trio out by hand. The overlay compositor (`useOverlayCompositor`) is mounted once by `ViewerLayout` for the whole session rather than by the Gantt panel, so an overlay layer registered by any panel is composited by exactly one writer. No user-visible change; groundwork for the charts panel (#3944).

--- a/apps/viewer/src/components/viewer/BottomStrip.tsx
+++ b/apps/viewer/src/components/viewer/BottomStrip.tsx
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The bottom strip: the docked bottom-region panel (Schedule / Script / Lists,
+ * per `lib/panels/bottom-panels`) or a bottom-placed analysis extension, under
+ * a drag-to-resize edge and a detach grip. Extracted from `ViewerLayout` so the
+ * strip reads the panel table instead of a hand-written ternary per panel.
+ */
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { Grip } from 'lucide-react';
+import { usePanelDetachDrag } from '@/hooks/usePanelDetachDrag';
+import { renderPanelBody } from '@/lib/panels/renderPanelBody';
+import type { BottomPanelId } from '@/lib/panels/bottom-panels';
+import { closeActiveAnalysisExtension, type AnalysisExtensionDefinition } from '@/services/analysis-extensions';
+
+const BOTTOM_PANEL_MIN_HEIGHT = 120;
+const BOTTOM_PANEL_DEFAULT_HEIGHT = 300;
+const BOTTOM_PANEL_MAX_RATIO = 0.7; // max 70% of container
+
+/** Slim grip atop a bottom-strip panel — drag to lift it into a floating window,
+ *  or drag onto another screen to pop it out (#1208). */
+function BottomPanelGrip({ id }: { id: BottomPanelId }) {
+  const onPointerDown = usePanelDetachDrag(id);
+  // Pointer-only drag affordance — not a real button (no keyboard action);
+  // keyboard users dock / float via the sidebar rail / Alt+N (#1208).
+  return (
+    <div
+      onPointerDown={onPointerDown}
+      title="Drag to float · drag onto another screen to pop out"
+      className="flex items-center justify-center h-5 shrink-0 cursor-grab active:cursor-grabbing select-none touch-none border-b border-border/40 bg-muted/10"
+    >
+      <Grip className="h-3.5 w-3.5 text-muted-foreground/50" />
+    </div>
+  );
+}
+
+export interface BottomStripProps {
+  /** The bottom panel docked in the strip, or `null` when none is. */
+  dockedPanel: BottomPanelId | null;
+  /** A bottom-placed analysis extension owning the strip instead. */
+  analysisExtension: AnalysisExtensionDefinition | null;
+  /** The layout container the strip is resized against (its max height is a ratio of it). */
+  containerRef: RefObject<HTMLDivElement | null>;
+  closePanel: (id: BottomPanelId) => void;
+}
+
+export function BottomStrip({ dockedPanel, analysisExtension, containerRef, closePanel }: BottomStripProps) {
+  // Pixel height, persisted in a ref during the drag to avoid re-renders per move.
+  const [bottomHeight, setBottomHeight] = useState(BOTTOM_PANEL_DEFAULT_HEIGHT);
+  const isDraggingRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  // Cleanup drag listeners on unmount
+  useEffect(() => {
+    return () => { cleanupRef.current?.(); };
+  }, []);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+
+    const startY = e.clientY;
+    const startHeight = bottomHeight;
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      const container = containerRef.current;
+      if (!container) return;
+
+      const maxHeight = container.clientHeight * BOTTOM_PANEL_MAX_RATIO;
+      const delta = startY - moveEvent.clientY;
+      const newHeight = Math.min(
+        maxHeight,
+        Math.max(BOTTOM_PANEL_MIN_HEIGHT, startHeight + delta)
+      );
+      setBottomHeight(newHeight);
+    };
+
+    const cleanup = () => {
+      isDraggingRef.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      cleanupRef.current = null;
+    };
+
+    const onMouseUp = () => { cleanup(); };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    document.body.style.cursor = 'row-resize';
+    document.body.style.userSelect = 'none';
+    cleanupRef.current = cleanup;
+  }, [bottomHeight, containerRef]);
+
+  if (!dockedPanel && !analysisExtension) return null;
+
+  return (
+    <div data-detach-root style={{ height: bottomHeight, flexShrink: 0 }} className="relative">
+      {/* Drag handle (resize height) */}
+      <div
+        className="absolute inset-x-0 top-0 h-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-row-resize z-10"
+        onMouseDown={handleResizeStart}
+      />
+      <div className="h-full w-full overflow-hidden border-t pt-1.5 flex flex-col">
+        {/* Detach grip — drag to float / pop the bottom panel onto another
+            screen (hidden for analysis extensions, which own their chrome). */}
+        {!analysisExtension && dockedPanel && <BottomPanelGrip id={dockedPanel} />}
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {analysisExtension
+            ? analysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })
+            : dockedPanel && renderPanelBody(dockedPanel, () => closePanel(dockedPanel))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -102,6 +102,7 @@ import { buildCommandPaletteJsonEntities } from './commandPaletteJsonExport';
 import { getRecentFiles, formatFileSize, getCachedFile, getCachedFileNames } from '@/lib/recent-files';
 import type { RecentFileEntry } from '@/lib/recent-files';
 import { closeActiveAnalysisExtension } from '@/services/analysis-extensions';
+import type { BottomPanelId } from '@/lib/panels/bottom-panels';
 import { describeRunCommandError } from '@/services/extensions/runtime-errors';
 import {
   type Command,
@@ -122,11 +123,10 @@ function activateRightPanel(panel: 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' 
   useViewerStore.getState().toggleWorkspacePanel(panel);
 }
 
-/** Bottom panel (Script / Lists / Gantt) — mutually exclusive in the bottom strip,
- *  independent of the sidebar. The store owns the toggle, including the re-dock of a
- *  floating or popped-out panel; the hand-rolled flag flips that used to live here
- *  knew only the dock flags, so toggling a FLOATING Lists panel left it on screen with nothing latched. */
-function activateBottomPanel(panel: 'script' | 'lists' | 'gantt') {
+/** Bottom panel — mutually exclusive in the bottom strip, independent of the sidebar. The store
+ *  owns the toggle, including the re-dock of a floating or popped-out panel; the hand-rolled flag
+ *  flips that used to live here knew only the dock flags, so toggling a FLOATING Lists panel left it on screen with nothing latched. */
+function activateBottomPanel(panel: BottomPanelId) {
   closeActiveAnalysisExtension();
   useViewerStore.getState().toggleBottomPanel(panel);
 }

--- a/apps/viewer/src/components/viewer/ViewerLayout.tsx
+++ b/apps/viewer/src/components/viewer/ViewerLayout.tsx
@@ -19,8 +19,7 @@ import { useSearchIndex } from '@/hooks/useSearchIndex';
 import { useActionLogger } from '@/hooks/useActionLogger';
 import { usePrivacyDisclosure } from '@/hooks/usePrivacyDisclosure';
 import { isSafeMode } from '@/lib/safe-mode';
-import { ShieldAlert, Grip } from 'lucide-react';
-import { usePanelDetachDrag } from '@/hooks/usePanelDetachDrag';
+import { ShieldAlert } from 'lucide-react';
 import { ExtensionDockHost } from '@/components/extensions/ExtensionDockHost';
 import { useIfc } from '@/hooks/useIfc';
 import { useViewerStore } from '@/store';
@@ -31,9 +30,8 @@ import { EntityContextMenu } from './EntityContextMenu';
 import { AnonymizedExportDialog } from './anonymized-export/AnonymizedExportDialog';
 import { useDuplicateShortcut } from './useDuplicateShortcut';
 import { HoverTooltip } from './HoverTooltip';
-import { ListPanel } from './lists/ListPanel';
-import { ScriptPanel } from './ScriptPanel';
-import { GanttPanel } from './schedule/GanttPanel';
+import { BottomStrip } from './BottomStrip';
+import { useOverlayCompositor } from './schedule/useOverlayCompositor';
 import { CommandPalette } from './CommandPalette';
 import { SearchModal } from './SearchModal';
 import { TourHost } from '@/components/tours/TourHost';
@@ -47,30 +45,10 @@ import {
   subscribeAnalysisExtensions,
 } from '@/services/analysis-extensions';
 import { renderPanelBody } from '@/lib/panels/renderPanelBody';
+import { activeBottomPanel } from '@/lib/panels/bottom-panels';
 import { getPanelDef } from '@/lib/panels/registry';
 import { resolveMobileSheet } from '@/lib/panels/mobileSheet';
 import { usePanelControls } from '@/hooks/usePanelControls';
-
-const BOTTOM_PANEL_MIN_HEIGHT = 120;
-const BOTTOM_PANEL_DEFAULT_HEIGHT = 300;
-const BOTTOM_PANEL_MAX_RATIO = 0.7; // max 70% of container
-
-/** Slim grip atop a bottom-strip panel — drag to lift it into a floating window,
- *  or drag onto another screen to pop it out (#1208). */
-function BottomPanelGrip({ id }: { id: 'gantt' | 'script' | 'lists' }) {
-  const onPointerDown = usePanelDetachDrag(id);
-  // Pointer-only drag affordance — not a real button (no keyboard action);
-  // keyboard users dock / float via the sidebar rail / Alt+N (#1208).
-  return (
-    <div
-      onPointerDown={onPointerDown}
-      title="Drag to float · drag onto another screen to pop out"
-      className="flex items-center justify-center h-5 shrink-0 cursor-grab active:cursor-grabbing select-none touch-none border-b border-border/40 bg-muted/10"
-    >
-      <Grip className="h-3.5 w-3.5 text-muted-foreground/50" />
-    </div>
-  );
-}
 
 export function ViewerLayout() {
   useSearchIndex();
@@ -78,6 +56,11 @@ export function ViewerLayout() {
   useKeyboardShortcuts();
   // ⌘D / Ctrl+D to duplicate the current selection.
   useDuplicateShortcut();
+  // THE writer from the overlay-layer registry into the renderer's legacy
+  // hiddenEntities / pendingColorUpdates channels. Mounted once, here, for
+  // the whole session: a second instance would keep its own ownership map and
+  // double-write. Layer owners (4D animation, charts, …) only register layers.
+  useOverlayCompositor();
   // Bridge viewer state transitions into the extension action log so the idle pattern miner can surface one-click tool suggestions.
   useActionLogger();
   // Show the RFC §06 §7 privacy disclosure on first launch.
@@ -205,20 +188,14 @@ export function ViewerLayout() {
   const rightPanelCollapsed = useViewerStore((s) => s.rightPanelCollapsed);
   const setLeftPanelCollapsed = useViewerStore((s) => s.setLeftPanelCollapsed);
   const setRightPanelCollapsed = useViewerStore((s) => s.setRightPanelCollapsed);
-  const bcfPanelVisible = useViewerStore((s) => s.bcfPanelVisible);
   const activeTool = useViewerStore((s) => s.activeTool);
   const setActiveTool = useViewerStore((s) => s.setActiveTool);
-  const idsPanelVisible = useViewerStore((s) => s.idsPanelVisible);
-  const extensionsPanelVisible = useViewerStore((s) => s.extensionsPanelVisible);
   const listPanelVisible = useViewerStore((s) => s.listPanelVisible);
-  const setListPanelVisible = useViewerStore((s) => s.setListPanelVisible);
-  const lensPanelVisible = useViewerStore((s) => s.lensPanelVisible);
-  const clashPanelVisible = useViewerStore((s) => s.clashPanelVisible);
-  const comparePanelVisible = useViewerStore((s) => s.comparePanelVisible);
   const scriptPanelVisible = useViewerStore((s) => s.scriptPanelVisible);
-  const setScriptPanelVisible = useViewerStore((s) => s.setScriptPanelVisible);
   const ganttPanelVisible = useViewerStore((s) => s.ganttPanelVisible);
-  const setGanttPanelVisible = useViewerStore((s) => s.setGanttPanelVisible);
+  // Which bottom panel the flags say is open (table precedence), and whether
+  // it is actually docked here rather than floating / popped out.
+  const bottomPanel = activeBottomPanel({ ganttPanelVisible, scriptPanelVisible, listPanelVisible });
   // The right pane is owned by the sidebar (#1208); here we only need to know which
   // BOTTOM panel (Script / Schedule / Lists) is docked vs detached, so the bottom strip skips a floating (#1201) or popped-out one.
   const floatingPanels = useViewerStore((s) => s.floatingPanels);
@@ -227,9 +204,7 @@ export function ViewerLayout() {
     () => new Set<string>([...floatingPanels.map((p) => p.id), ...poppedOutIds]),
     [floatingPanels, poppedOutIds],
   );
-  const ganttDocked = ganttPanelVisible && !detachedIds.has('gantt');
-  const scriptDocked = scriptPanelVisible && !detachedIds.has('script');
-  const listDocked = listPanelVisible && !detachedIds.has('lists');
+  const dockedBottomPanel = bottomPanel && !detachedIds.has(bottomPanel) ? bottomPanel : null;
 
   // ── Mobile bottom sheet ──
   // Mobile shows exactly ONE panel at a time, so resolve which, then render it
@@ -255,11 +230,9 @@ export function ViewerLayout() {
   const mobileSheet = useMemo(() => resolveMobileSheet({
     hasAnalysisExtension: activeAnalysisExtension !== null && activeAnalysisExtension !== undefined,
     activeTool,
-    ganttVisible: ganttPanelVisible,
-    scriptVisible: scriptPanelVisible,
-    listVisible: listPanelVisible,
+    bottomPanel,
     sidebarActivePanel,
-  }), [activeAnalysisExtension, activeTool, ganttPanelVisible, scriptPanelVisible, listPanelVisible, sidebarActivePanel]);
+  }), [activeAnalysisExtension, activeTool, bottomPanel, sidebarActivePanel]);
 
   // Panel ref for programmatic collapse/expand (command palette, keyboard
   // shortcuts). The right region is the unified sidebar (#1208), which owns its
@@ -274,55 +247,7 @@ export function ViewerLayout() {
     else if (!leftPanelCollapsed && panel.isCollapsed()) panel.expand();
   }, [leftPanelCollapsed]);
 
-  // Bottom panel resize state (pixel height, persisted in ref to avoid re-renders during drag)
-  const [bottomHeight, setBottomHeight] = useState(BOTTOM_PANEL_DEFAULT_HEIGHT);
   const containerRef = useRef<HTMLDivElement>(null);
-  const isDraggingRef = useRef(false);
-  const cleanupRef = useRef<(() => void) | null>(null);
-
-  // Cleanup drag listeners on unmount
-  useEffect(() => {
-    return () => { cleanupRef.current?.(); };
-  }, []);
-
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-
-    const startY = e.clientY;
-    const startHeight = bottomHeight;
-
-    const onMouseMove = (moveEvent: MouseEvent) => {
-      if (!isDraggingRef.current) return;
-      const container = containerRef.current;
-      if (!container) return;
-
-      const maxHeight = container.clientHeight * BOTTOM_PANEL_MAX_RATIO;
-      const delta = startY - moveEvent.clientY;
-      const newHeight = Math.min(
-        maxHeight,
-        Math.max(BOTTOM_PANEL_MIN_HEIGHT, startHeight + delta)
-      );
-      setBottomHeight(newHeight);
-    };
-
-    const cleanup = () => {
-      isDraggingRef.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      cleanupRef.current = null;
-    };
-
-    const onMouseUp = () => { cleanup(); };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-    document.body.style.cursor = 'row-resize';
-    document.body.style.userSelect = 'none';
-    cleanupRef.current = cleanup;
-  }, [bottomHeight]);
 
   // Track the gap between the layout viewport (innerHeight) and the visual
   // viewport. On iOS Safari with bottom URL bar, dvh/innerHeight INCLUDES the
@@ -449,36 +374,15 @@ export function ViewerLayout() {
               <SidebarDock />
             </div>
 
-            {/* Bottom Panel - Lists / Script / Gantt / analysis ext (custom resizable).
-                Launched from the sidebar rail but docked here (their home region).
-                A panel that's been dragged out to float / another screen is skipped. */}
-            {(listDocked || scriptDocked || ganttDocked || !!activeBottomAnalysisExtension) && (
-              <div data-detach-root style={{ height: bottomHeight, flexShrink: 0 }} className="relative">
-                {/* Drag handle (resize height) */}
-                <div
-                  className="absolute inset-x-0 top-0 h-1.5 bg-border hover:bg-primary/50 active:bg-primary/70 transition-colors cursor-row-resize z-10"
-                  onMouseDown={handleResizeStart}
-                />
-                <div className="h-full w-full overflow-hidden border-t pt-1.5 flex flex-col">
-                  {/* Detach grip — drag to float / pop the bottom panel onto another
-                      screen (hidden for analysis extensions, which own their chrome). */}
-                  {!activeBottomAnalysisExtension && (
-                    <BottomPanelGrip id={ganttDocked ? 'gantt' : scriptDocked ? 'script' : 'lists'} />
-                  )}
-                  <div className="flex-1 min-h-0 overflow-hidden">
-                    {activeBottomAnalysisExtension ? (
-                      activeBottomAnalysisExtension.renderPanel({ onClose: closeActiveAnalysisExtension })
-                    ) : ganttDocked ? (
-                      <GanttPanel onClose={() => setGanttPanelVisible(false)} />
-                    ) : scriptDocked ? (
-                      <ScriptPanel onClose={() => setScriptPanelVisible(false)} />
-                    ) : (
-                      <ListPanel onClose={() => setListPanelVisible(false)} />
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
+            {/* Bottom strip — Schedule / Script / Lists / analysis ext. Launched from the
+                sidebar rail but docked here (their home region); a panel dragged out to
+                float / another screen is skipped. */}
+            <BottomStrip
+              dockedPanel={dockedBottomPanel}
+              analysisExtension={activeBottomAnalysisExtension}
+              containerRef={containerRef}
+              closePanel={closePanel}
+            />
 
             {/* Floating / docked workspace-panel windows (#1201) */}
             <FloatingPanelHost />

--- a/apps/viewer/src/components/viewer/schedule/GanttPanel.tsx
+++ b/apps/viewer/src/components/viewer/schedule/GanttPanel.tsx
@@ -17,7 +17,6 @@ import { extractScheduleOnDemand } from '@ifc-lite/parser';
 import { useViewerStore } from '@/store';
 import { resolveScheduleSourceModelId } from '@/store/slices/schedule-edit-helpers';
 import { useIfc } from '@/hooks/useIfc';
-import { toast } from '@/components/ui/toast';
 import { Button } from '@/components/ui/button';
 import { GanttToolbar } from './GanttToolbar';
 import { GanttTaskTree } from './GanttTaskTree';
@@ -29,7 +28,6 @@ import { canGenerateScheduleFrom, resolveActiveDataStore } from './generate-sche
 import { useConstructionSequence } from './useConstructionSequence';
 import { useScheduleFileImport } from './useScheduleFileImport';
 import { useGanttSelection3DHighlight } from './useGanttSelection3DHighlight';
-import { useOverlayCompositor } from './useOverlayCompositor';
 
 interface GanttPanelProps {
   onClose?: () => void;
@@ -125,15 +123,11 @@ export function GanttPanel({ onClose }: GanttPanelProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeStore]);
 
-  // Single compositor — reads the overlay-layer registry and writes the
-  // composite into the renderer's legacy hiddenEntities / pendingColorUpdates
-  // channels. Must be mounted BEFORE any layer owner in the render tree so
-  // its first reconcile can observe their initial contributions.
-  useOverlayCompositor();
-
   // Drive the 3D viewport's hidden-entity set from the playback clock.
-  // Registers the 'animation' overlay layer; the compositor above does
-  // the actual write.
+  // Registers the 'animation' overlay layer; the single compositor mounted
+  // by `ViewerLayout` (`useOverlayCompositor`) does the actual write, so a
+  // layer registered by any panel — docked, floating or popped out — is
+  // composited by exactly one writer.
   useConstructionSequence();
 
   // Highlight the current Gantt selection's products in 3D. Selection-only

--- a/apps/viewer/src/components/viewer/schedule/useOverlayCompositor.test.tsx
+++ b/apps/viewer/src/components/viewer/schedule/useOverlayCompositor.test.tsx
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The compositor is the ONE writer from the overlay-layer registry into the
+ * renderer channels, and it is mounted once by `ViewerLayout` rather than by
+ * the panel that happens to own a layer (#3944). What that buys — and what
+ * this pins — is that a layer registered while no Gantt panel is open still
+ * reaches `hiddenEntities`, and that a user's own hide survives the layer's
+ * removal.
+ */
+import '@/test/setup-dom.js';
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { useViewerStore } from '@/store/index.js';
+import { render, cleanup } from '@/test/render.js';
+import { useOverlayCompositor } from './useOverlayCompositor.js';
+
+function Host() {
+  useOverlayCompositor();
+  return null;
+}
+
+describe('useOverlayCompositor as the single session writer', () => {
+  afterEach(() => {
+    cleanup();
+    useViewerStore.setState({ hiddenEntities: new Set(), overlayLayers: new Map(), pendingColorUpdates: null });
+  });
+
+  it('hides what a registered layer asks for and restores it on removal, keeping a user-hidden id hidden', () => {
+    useViewerStore.setState({ hiddenEntities: new Set([7]), overlayLayers: new Map() });
+    render(<Host />);
+
+    act(() => {
+      useViewerStore.getState().registerOverlayLayer({
+        id: 'charts',
+        priority: 75,
+        hiddenIds: new Set([7, 8, 9]),
+        colorOverrides: new Map([[8, [1, 0, 0, 1]]]),
+      });
+    });
+    const afterRegister = useViewerStore.getState();
+    assert.deepEqual([...afterRegister.hiddenEntities].sort(), [7, 8, 9]);
+    // Colour writes are one-shot; the compositor hands the composite to the
+    // renderer sync and the store keeps the pending map until it is consumed.
+    assert.deepEqual([...(afterRegister.pendingColorUpdates?.keys() ?? [])], [8]);
+
+    act(() => {
+      useViewerStore.getState().removeOverlayLayer('charts');
+    });
+    // 8 and 9 come back; 7 was the user's and stays hidden.
+    assert.deepEqual([...useViewerStore.getState().hiddenEntities], [7]);
+  });
+});

--- a/apps/viewer/src/components/viewer/schedule/useOverlayCompositor.ts
+++ b/apps/viewer/src/components/viewer/schedule/useOverlayCompositor.ts
@@ -16,8 +16,9 @@
  * Ownership tracking lives here exactly once — previously duplicated as
  * `contributedHiddenRef` / `contributedColorsRef` inside every consumer.
  *
- * This hook must be mounted high in the viewer tree so it runs throughout
- * the session. Mount it alongside the root viewport or the Gantt panel.
+ * Mounted ONCE, by `ViewerLayout`, for the whole session. Two instances
+ * would each keep their own ownership map and double-write the channels —
+ * a panel that owns a layer must only register it, never mount this hook.
  */
 
 import { useEffect, useRef } from 'react';

--- a/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
+++ b/apps/viewer/src/components/viewer/toolbar/useWorkspacePanelControls.ts
@@ -18,13 +18,14 @@ import {
   subscribeAnalysisExtensions,
 } from '@/services/analysis-extensions';
 import { closePanelWindow } from '@/services/panel-windows';
+import { BOTTOM_PANEL_IDS, isBottomPanelOpen, type BottomPanelId } from '@/lib/panels/bottom-panels';
 
 /** Registry ids, deliberately. This hook used to spell the entity-list panel
  *  `'list'` while the registry and the store spell it `'lists'`, and the cost
  *  was structural rather than cosmetic: with ids that did not match, the bottom
  *  branch below could not simply hand the click to the store, so it re-derived
  *  the flag flips and lost the float / pop-out cleanup along the way. */
-export type BottomPanel = 'script' | 'lists' | 'gantt';
+export type BottomPanel = BottomPanelId;
 export type RightPanel = 'bcf' | 'ids' | 'lens' | 'clash' | 'compare' | 'addElement' | 'extensions' | 'sources' | 'appearance';
 export type WorkspacePanel = BottomPanel | RightPanel | string;
 
@@ -237,9 +238,8 @@ export function useWorkspacePanelControls() {
     // activity bar never had the bug because it reads `panelLocation`.
     for (const panel of floatingPanels) panels.add(panel.id);
     for (const id of poppedOutIds) panels.add(id);
-    if (scriptPanelVisible) panels.add('script');
-    if (listPanelVisible) panels.add('lists');
-    if (ganttPanelVisible) panels.add('gantt');
+    const bottomFlags = { ganttPanelVisible, scriptPanelVisible, listPanelVisible };
+    for (const id of BOTTOM_PANEL_IDS) if (isBottomPanelOpen(bottomFlags, id)) panels.add(id);
     if (bcfPanelVisible) panels.add('bcf');
     if (idsPanelVisible) panels.add('ids');
     if (lensPanelVisible) panels.add('lens');

--- a/apps/viewer/src/hooks/usePanelControls.ts
+++ b/apps/viewer/src/hooks/usePanelControls.ts
@@ -17,11 +17,11 @@ import { useCallback, useMemo } from 'react';
 import { useViewerStore } from '@/store';
 import {
   isAnalysisPanel,
-  isBottomPanel,
   isLeftPanel,
   type WorkspacePanelId,
   type AnalysisPanelId,
 } from '@/lib/panels/registry';
+import { isBottomPanel, isBottomPanelOpen, type BottomPanelFlags } from '@/lib/panels/bottom-panels';
 import { openPanelWindow, closePanelWindow } from '@/services/panel-windows';
 
 export type PanelLocation = 'docked' | 'floating' | 'popped' | 'closed';
@@ -68,10 +68,15 @@ export function usePanelControls(): PanelControls {
   const floatingPanels = useViewerStore((s) => s.floatingPanels);
   const poppedOutIds = useViewerStore((s) => s.poppedOutIds);
   const activePanel = useViewerStore((s) => s.sidebarActivePanel);
-  // Bottom-strip visibility flags (their "docked" state).
-  const scriptVisible = useViewerStore((s) => s.scriptPanelVisible);
+  // Bottom-strip visibility flags (their "docked" state), one subscription
+  // per flag so an unrelated store write does not re-render every rail icon.
   const ganttVisible = useViewerStore((s) => s.ganttPanelVisible);
+  const scriptVisible = useViewerStore((s) => s.scriptPanelVisible);
   const listVisible = useViewerStore((s) => s.listPanelVisible);
+  const bottomFlags = useMemo<BottomPanelFlags>(
+    () => ({ ganttPanelVisible: ganttVisible, scriptPanelVisible: scriptVisible, listPanelVisible: listVisible }),
+    [ganttVisible, scriptVisible, listVisible],
+  );
   // The Hierarchy panel (left region, #1267) is "docked" while its slot is open.
   const leftPanelCollapsed = useViewerStore((s) => s.leftPanelCollapsed);
   // The lower half of a docked split (#1266), also docked/visible.
@@ -104,13 +109,11 @@ export function usePanelControls(): PanelControls {
   const isDockedInHome = useCallback(
     (id: WorkspacePanelId): boolean => {
       if (id === 'hierarchy') return !leftPanelCollapsed; // left slot open
-      if (id === 'script') return scriptVisible;
-      if (id === 'gantt') return ganttVisible;
-      if (id === 'lists') return listVisible;
+      if (isBottomPanel(id)) return isBottomPanelOpen(bottomFlags, id);
       // A side panel is docked as the right-pane primary OR the split secondary.
       return id === sideDocked || id === secondaryDocked;
     },
-    [sideDocked, secondaryDocked, scriptVisible, ganttVisible, listVisible, leftPanelCollapsed],
+    [sideDocked, secondaryDocked, bottomFlags, leftPanelCollapsed],
   );
 
   const panelLocation = useCallback(

--- a/apps/viewer/src/lib/panels/bottom-panels.test.ts
+++ b/apps/viewer/src/lib/panels/bottom-panels.test.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The bottom strip is single-tenant and table-driven (#3944): the store's
+ * three entry points (`toggleBottomPanel`, `openPanelInHome`,
+ * `showWorkspacePanel`) must each leave EXACTLY the requested panel's flag on
+ * for every id in the table, and the strip's precedence rule must be the one
+ * the store, the mobile sheet and the tour snapshot all read. These are the
+ * behaviours that used to be re-derived by hand in six places.
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { useViewerStore } from '@/store/index.js';
+import { WORKSPACE_PANELS } from './registry.js';
+import {
+  BOTTOM_PANEL_FLAG,
+  BOTTOM_PANEL_IDS,
+  activeBottomPanel,
+  bottomPanelFlags,
+  isBottomPanel,
+  isBottomPanelOpen,
+} from './bottom-panels.js';
+
+describe('bottom-panel table', () => {
+  it('lists exactly the registry panels whose home region is the bottom strip', () => {
+    const fromRegistry = WORKSPACE_PANELS.filter((p) => p.region === 'bottom').map((p) => p.id).sort();
+    assert.deepEqual([...BOTTOM_PANEL_IDS].sort(), fromRegistry);
+    for (const p of WORKSPACE_PANELS) assert.equal(isBottomPanel(p.id), p.region === 'bottom', p.id);
+  });
+
+  it('builds a patch with exactly one flag on, and none on for null', () => {
+    for (const id of BOTTOM_PANEL_IDS) {
+      const patch = bottomPanelFlags(id);
+      assert.equal(Object.keys(patch).length, BOTTOM_PANEL_IDS.length);
+      assert.deepEqual(
+        Object.entries(patch).filter(([, on]) => on).map(([flag]) => flag),
+        [BOTTOM_PANEL_FLAG[id]],
+      );
+      assert.equal(activeBottomPanel(patch), id);
+      assert.equal(isBottomPanelOpen(patch, id), true);
+    }
+    assert.equal(activeBottomPanel(bottomPanelFlags(null)), null);
+  });
+
+  it('resolves a doubly-set state by table precedence, so every reader agrees', () => {
+    const flags = { ...bottomPanelFlags(null), [BOTTOM_PANEL_FLAG.lists]: true, [BOTTOM_PANEL_FLAG.script]: true };
+    assert.equal(activeBottomPanel(flags), 'script');
+  });
+});
+
+describe('store bottom-strip actions (#3944)', () => {
+  beforeEach(() => {
+    useViewerStore.setState({ ...bottomPanelFlags(null), floatingPanels: [], poppedOutIds: [], rightPanelCollapsed: true });
+  });
+
+  const openFlags = () =>
+    BOTTOM_PANEL_IDS.filter((id) => isBottomPanelOpen(useViewerStore.getState(), id));
+
+  it('toggleBottomPanel docks exactly the requested panel, then closes it on the second call', () => {
+    for (const id of BOTTOM_PANEL_IDS) {
+      useViewerStore.getState().toggleBottomPanel(id);
+      assert.deepEqual(openFlags(), [id]);
+      assert.equal(useViewerStore.getState().rightPanelCollapsed, false);
+    }
+    // The last one is open; toggling it closes the strip.
+    const last = BOTTOM_PANEL_IDS[BOTTOM_PANEL_IDS.length - 1];
+    useViewerStore.getState().toggleBottomPanel(last);
+    assert.deepEqual(openFlags(), []);
+  });
+
+  it('openPanelInHome and showWorkspacePanel each dock exactly the requested panel', () => {
+    for (const id of BOTTOM_PANEL_IDS) {
+      useViewerStore.getState().openPanelInHome(id);
+      assert.deepEqual(openFlags(), [id]);
+    }
+    for (const id of BOTTOM_PANEL_IDS) {
+      useViewerStore.getState().showWorkspacePanel(id);
+      assert.deepEqual(openFlags(), [id]);
+    }
+  });
+
+  it('toggling a floating bottom panel re-docks it instead of closing it', () => {
+    const [id] = BOTTOM_PANEL_IDS;
+    useViewerStore.getState().toggleBottomPanel(id);
+    useViewerStore.getState().floatPanel(id);
+    assert.ok(useViewerStore.getState().floatingPanels.some((p) => p.id === id));
+    useViewerStore.getState().toggleBottomPanel(id);
+    assert.deepEqual(openFlags(), [id]);
+    assert.equal(useViewerStore.getState().floatingPanels.some((p) => p.id === id), false);
+  });
+});

--- a/apps/viewer/src/lib/panels/bottom-panels.ts
+++ b/apps/viewer/src/lib/panels/bottom-panels.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The bottom strip's panels, as ONE table.
+ *
+ * Script / Schedule / Lists dock in the bottom strip, mutually exclusive,
+ * each behind its own store flag (`scriptPanelVisible` and so on — the flags
+ * predate the registry and other code reads them directly). Six places used
+ * to spell that trio out by hand: three store actions, the layout's ternary,
+ * the mobile sheet's precedence and the tour snapshot — and two of them
+ * disagreed on the order in which a doubly-set flag wins. Adding a fourth
+ * bottom panel meant finding all six, three of them at their module-size
+ * budget. Now the id list, the flag names and the "which one is showing"
+ * rule live here, and every reader derives from them (#3944).
+ *
+ * Order is precedence: when more than one flag is somehow on (the flag
+ * setters are independent), the FIRST one here is what the strip shows.
+ */
+
+/** Bottom-strip panel ids, in display precedence. Append only. */
+export const BOTTOM_PANEL_IDS = ['gantt', 'script', 'lists'] as const;
+
+export type BottomPanelId = (typeof BOTTOM_PANEL_IDS)[number];
+
+/** The store flag that says a bottom panel is docked open. */
+export const BOTTOM_PANEL_FLAG = {
+  gantt: 'ganttPanelVisible',
+  script: 'scriptPanelVisible',
+  lists: 'listPanelVisible',
+} as const satisfies Record<BottomPanelId, string>;
+
+export type BottomPanelFlag = (typeof BOTTOM_PANEL_FLAG)[BottomPanelId];
+
+/** The slice of store state the bottom strip reads. */
+export type BottomPanelFlags = Record<BottomPanelFlag, boolean>;
+
+export function isBottomPanel(id: string): id is BottomPanelId {
+  return (BOTTOM_PANEL_IDS as readonly string[]).includes(id);
+}
+
+/**
+ * The flag patch that docks exactly `active` open (or, with `null`, closes
+ * the whole strip). Always writes every flag, so a stray second flag cannot
+ * survive a switch.
+ */
+export function bottomPanelFlags(active: BottomPanelId | null): BottomPanelFlags {
+  const patch = {} as BottomPanelFlags;
+  for (const id of BOTTOM_PANEL_IDS) patch[BOTTOM_PANEL_FLAG[id]] = id === active;
+  return patch;
+}
+
+/** Which bottom panel the flags say is docked open — the first in precedence. */
+export function activeBottomPanel(flags: BottomPanelFlags): BottomPanelId | null {
+  for (const id of BOTTOM_PANEL_IDS) if (flags[BOTTOM_PANEL_FLAG[id]]) return id;
+  return null;
+}
+
+/** Whether the flag for one bottom panel is on. */
+export function isBottomPanelOpen(flags: BottomPanelFlags, id: BottomPanelId): boolean {
+  return flags[BOTTOM_PANEL_FLAG[id]];
+}

--- a/apps/viewer/src/lib/panels/mobileSheet.test.ts
+++ b/apps/viewer/src/lib/panels/mobileSheet.test.ts
@@ -22,9 +22,7 @@ import { resolveMobileSheet, type MobileSheetInput } from './mobileSheet.js';
 const IDLE: MobileSheetInput = {
   hasAnalysisExtension: false,
   activeTool: 'select',
-  ganttVisible: false,
-  scriptVisible: false,
-  listVisible: false,
+  bottomPanel: null,
   sidebarActivePanel: 'properties',
 };
 
@@ -39,15 +37,15 @@ describe('mobile bottom sheet occupant', () => {
 
   it('prefers a bottom-strip panel over the docked side panel', () => {
     assert.deepEqual(
-      resolveMobileSheet({ ...IDLE, sidebarActivePanel: 'bcf', listVisible: true }),
+      resolveMobileSheet({ ...IDLE, sidebarActivePanel: 'bcf', bottomPanel: 'lists' }),
       { kind: 'panel', id: 'lists' },
     );
     assert.deepEqual(
-      resolveMobileSheet({ ...IDLE, scriptVisible: true }),
+      resolveMobileSheet({ ...IDLE, bottomPanel: 'script' }),
       { kind: 'panel', id: 'script' },
     );
     assert.deepEqual(
-      resolveMobileSheet({ ...IDLE, ganttVisible: true, scriptVisible: true, listVisible: true }),
+      resolveMobileSheet({ ...IDLE, bottomPanel: 'gantt' }),
       { kind: 'panel', id: 'gantt' },
     );
   });
@@ -69,9 +67,7 @@ describe('mobile bottom sheet occupant', () => {
       resolveMobileSheet({
         ...IDLE,
         activeTool: 'addElement',
-        ganttVisible: true,
-        scriptVisible: true,
-        listVisible: true,
+        bottomPanel: 'gantt',
       }),
       { kind: 'addElement' },
     );
@@ -90,7 +86,7 @@ describe('mobile bottom sheet occupant', () => {
         ...IDLE,
         hasAnalysisExtension: true,
         activeTool: 'addElement',
-        ganttVisible: true,
+        bottomPanel: 'gantt',
       }),
       { kind: 'extension' },
     );

--- a/apps/viewer/src/lib/panels/mobileSheet.ts
+++ b/apps/viewer/src/lib/panels/mobileSheet.ts
@@ -18,6 +18,7 @@
  */
 
 import type { WorkspacePanelId } from './registry';
+import type { BottomPanelId } from './bottom-panels';
 
 export type MobileSheetContent =
   | { kind: 'extension' }
@@ -28,9 +29,8 @@ export interface MobileSheetInput {
   /** An analysis extension currently owns the slot (either placement). */
   hasAnalysisExtension: boolean;
   activeTool: string;
-  ganttVisible: boolean;
-  scriptVisible: boolean;
-  listVisible: boolean;
+  /** The bottom-strip panel whose flag is on (`activeBottomPanel`), if any. */
+  bottomPanel: BottomPanelId | null;
   /** The single side panel the sidebar considers docked. */
   sidebarActivePanel: WorkspacePanelId;
 }
@@ -43,8 +43,6 @@ export interface MobileSheetInput {
 export function resolveMobileSheet(input: MobileSheetInput): MobileSheetContent {
   if (input.hasAnalysisExtension) return { kind: 'extension' };
   if (input.activeTool === 'addElement') return { kind: 'addElement' };
-  if (input.ganttVisible) return { kind: 'panel', id: 'gantt' };
-  if (input.scriptVisible) return { kind: 'panel', id: 'script' };
-  if (input.listVisible) return { kind: 'panel', id: 'lists' };
+  if (input.bottomPanel) return { kind: 'panel', id: input.bottomPanel };
   return { kind: 'panel', id: input.sidebarActivePanel };
 }

--- a/apps/viewer/src/lib/panels/registry.ts
+++ b/apps/viewer/src/lib/panels/registry.ts
@@ -122,13 +122,9 @@ export const WORKSPACE_PANELS: readonly WorkspacePanelDef[] = [
   { id: 'appearance', title: 'Appearance', short: 'Appearance', Icon: Palette, group: 'author', region: 'side' },
 ];
 
-/** The bottom-strip panel ids, mapped to their store visibility flag + setter
- *  names — these stay independent of the single-tenant right pane. */
-export type BottomPanelId = Extract<WorkspacePanelId, 'script' | 'gantt' | 'lists'>;
-
-export function isBottomPanel(id: WorkspacePanelId): id is BottomPanelId {
-  return id === 'script' || id === 'gantt' || id === 'lists';
-}
+// The bottom strip (Script / Schedule / Lists) is table-driven; the id union and
+// the type guard are re-exported here so registry consumers keep one import.
+export { isBottomPanel, type BottomPanelId } from './bottom-panels';
 
 /** The left-slot nav panel (Hierarchy, #1267): toggled via `leftPanelCollapsed`,
  *  never floated / popped / docked into the right pane. */

--- a/apps/viewer/src/lib/tours/snapshot.ts
+++ b/apps/viewer/src/lib/tours/snapshot.ts
@@ -17,6 +17,7 @@
  */
 
 import type { ViewerState } from '@/store';
+import { activeBottomPanel, bottomPanelFlags } from '@/lib/panels/bottom-panels';
 import type { UiSnapshot, UiSnapshotKey, ViewerStoreApi } from './types';
 
 export function captureUiSnapshot(store: ViewerStoreApi): UiSnapshot {
@@ -32,7 +33,7 @@ export function captureUiSnapshot(store: ViewerStoreApi): UiSnapshot {
       : null,
     leftPanelCollapsed: s.leftPanelCollapsed,
     rightPanelCollapsed: s.rightPanelCollapsed,
-    bottomPanel: s.scriptPanelVisible ? 'script' : s.ganttPanelVisible ? 'gantt' : s.listPanelVisible ? 'lists' : null,
+    bottomPanel: activeBottomPanel(s),
     activeTool: s.activeTool,
     editEnabled: s.editEnabled,
     propertiesActiveTab: s.propertiesActiveTab,
@@ -86,7 +87,7 @@ export function restoreUiSnapshot(
     if (snapshot.bottomPanel) {
       s.showWorkspacePanel(snapshot.bottomPanel);
     } else {
-      store.setState({ scriptPanelVisible: false, ganttPanelVisible: false, listPanelVisible: false });
+      store.setState(bottomPanelFlags(null));
     }
   }
 

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -34,7 +34,8 @@ import { createClashSlice, type ClashSlice } from './slices/clashSlice.js';
 import { createCompareSlice, type CompareSlice } from './slices/compareSlice.js';
 import { createDockSlice, type DockSlice } from './slices/dockSlice.js';
 import { createSidebarSlice, type SidebarSlice } from './slices/sidebarSlice.js';
-import { isBottomPanel, type WorkspacePanelId, type BottomPanelId } from '@/lib/panels/registry';
+import { type WorkspacePanelId } from '@/lib/panels/registry';
+import { bottomPanelFlags, isBottomPanel, isBottomPanelOpen, type BottomPanelId } from '@/lib/panels/bottom-panels';
 import { createScriptSlice, type ScriptSlice } from './slices/scriptSlice.js';
 import { createChatSlice, type ChatSlice } from './slices/chatSlice.js';
 import { createCesiumSlice, type CesiumSlice } from './slices/cesiumSlice.js';
@@ -395,12 +396,7 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     // routes through this fn with the panel id), so it must land in its home
     // region instead of flipping side-panel flags it doesn't own (#1208).
     if (isBottomPanel(panel)) {
-      set({
-        scriptPanelVisible: panel === 'script',
-        ganttPanelVisible: panel === 'gantt',
-        listPanelVisible: panel === 'lists',
-        rightPanelCollapsed: false,
-      });
+      set({ ...bottomPanelFlags(panel), rightPanelCollapsed: false });
       return;
     }
     if (panel === 'properties') {
@@ -440,21 +436,16 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
   toggleBottomPanel: (panel) => {
     const [set, get] = args;
     const s = get();
-    const flagActive = panel === 'script' ? s.scriptPanelVisible : panel === 'gantt' ? s.ganttPanelVisible : s.listPanelVisible;
+    const flagActive = isBottomPanelOpen(s, panel);
     const detached = s.floatingPanels.some((p) => p.id === panel) || s.poppedOutIds.includes(panel);
     // Re-dock any float / OS window for it first.
     get().closeFloatingPanel(panel);
     get().setPanelPoppedOut(panel, false);
     if (flagActive && !detached) {
       // Toggle off (only one bottom panel shows at a time).
-      set({ scriptPanelVisible: false, ganttPanelVisible: false, listPanelVisible: false });
+      set(bottomPanelFlags(null));
     } else {
-      set({
-        scriptPanelVisible: panel === 'script',
-        ganttPanelVisible: panel === 'gantt',
-        listPanelVisible: panel === 'lists',
-        rightPanelCollapsed: false,
-      });
+      set({ ...bottomPanelFlags(panel), rightPanelCollapsed: false });
     }
   },
 
@@ -463,12 +454,7 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     if (isBottomPanel(panel)) {
       get().closeFloatingPanel(panel);
       get().setPanelPoppedOut(panel, false);
-      set({
-        scriptPanelVisible: panel === 'script',
-        ganttPanelVisible: panel === 'gantt',
-        listPanelVisible: panel === 'lists',
-        rightPanelCollapsed: false,
-      });
+      set({ ...bottomPanelFlags(panel), rightPanelCollapsed: false });
     } else {
       get().showWorkspacePanel(panel);
     }

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -125,7 +125,7 @@
    406 apps/viewer/src/components/viewer/useAnimationLoop.ts
    980 apps/viewer/src/components/viewer/useGeometryStreaming.ts
    946 apps/viewer/src/components/viewer/useMouseControls.ts
-   782 apps/viewer/src/components/viewer/ViewerLayout.tsx
+   686 apps/viewer/src/components/viewer/ViewerLayout.tsx
   1815 apps/viewer/src/components/viewer/Viewport.tsx
   1382 apps/viewer/src/components/viewer/ViewportContainer.tsx
    511 apps/viewer/src/components/viewer/ZonesPanel.tsx
@@ -172,7 +172,7 @@
    561 apps/viewer/src/services/ifc-cache.ts
    581 apps/viewer/src/store/basketVisibleSet.ts
    485 apps/viewer/src/store/constants.ts
-   579 apps/viewer/src/store/index.ts
+   564 apps/viewer/src/store/index.ts
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    992 apps/viewer/src/store/slices/clashSlice.ts

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -1,6 +1,6 @@
 {
-  "apps/viewer": 265,
-  "apps/viewer-embed": 267,
+  "apps/viewer": 258,
+  "apps/viewer-embed": 260,
   "examples/babylonjs-viewer": 1,
   "examples/collab-demo": 1,
   "examples/threejs-collab": 1,


### PR DESCRIPTION
Part of #3944 — prep for the charts panel (the fourth bottom-strip panel). No user-visible change.

## What changed

- **`apps/viewer/src/lib/panels/bottom-panels.ts`** (new): `BOTTOM_PANEL_IDS` (`gantt`, `script`, `lists`, in display precedence), `BOTTOM_PANEL_FLAG` (id → store flag), `bottomPanelFlags(active | null)` (a patch with exactly one flag on), `activeBottomPanel(flags)`, `isBottomPanelOpen`, `isBottomPanel`. The registry re-exports `BottomPanelId` / `isBottomPanel` from it.
- **Derived from the table** instead of hand-written per panel: `store/index.ts` (`showWorkspacePanel` / `toggleBottomPanel` / `openPanelInHome`, 579 → 564), `ViewerLayout.tsx` (782 → 686; the strip's resize edge, detach grip and body render move to a new `BottomStrip.tsx`, which renders the docked panel through `renderPanelBody` like every other host), `mobileSheet.ts` (input is now `bottomPanel: BottomPanelId | null`), `usePanelControls.ts`, `useWorkspacePanelControls.ts` (`BottomPanel = BottomPanelId`), `CommandPalette.tsx` (`activateBottomPanel(BottomPanelId)`, kept at its 751 budget by trimming a comment), `lib/tours/snapshot.ts`. Two of the six copies disagreed on which flag wins when two are on (`script` vs `gantt` first); the table's order (gantt, script, lists — the one the strip actually displayed) is now the single rule.
- **Overlay compositor mounted once**: `useOverlayCompositor()` moves from `GanttPanel` to `ViewerLayout`. It is the one writer from the overlay-layer registry into `hiddenEntities` / `pendingColorUpdates`; a second instance keeps its own ownership map and double-writes, and a layer registered while no Gantt panel is open was never composited. Doc comment updated to say so.
- Module-size allowlist: the two shrunk files' budgets ratcheted down (782→686, 579→564). Cleared the six pre-existing unused-variable warnings in the two touched files (`ViewerLayout`, `GanttPanel`).

## Why

Adding a fourth bottom panel by hand meant touching six files, three of them at their module-size budget, and re-deriving the same flag flips a seventh time. Charts (#3944) needs the strip; making it table-driven first keeps that PR to one table row. The compositor hoist is a prerequisite for the charts panel registering a colour/hide overlay layer without mounting its own compositor.

## Evidence

Windows 11, Node 22.16, pnpm 10.8.1; worktree `~/ci/wt-3944-pr1` off `origin/main` @ `3b7d86092`, `pnpm build` 51/51 first.

- New `lib/panels/bottom-panels.test.ts` (6 tests): the table equals the registry's `region: 'bottom'` set; `bottomPanelFlags` sets exactly one flag per id; precedence on a doubly-set state; **store behaviour** through the real store — `toggleBottomPanel` / `openPanelInHome` / `showWorkspacePanel` each leave exactly the requested flag on for every id, second toggle closes the strip, toggling a *floating* bottom panel re-docks it.
- New `schedule/useOverlayCompositor.test.tsx`: mounts the hook alone (no Gantt panel), registers a layer → `hiddenEntities` gains its ids and `pendingColorUpdates` its colours; removing the layer restores them while a user-hidden id stays hidden.
- `mobileSheet.test.ts` updated to the new input (7/7), `mobile-sheet-coverage`, `registry.test.ts`: pass. Broader affected suites run via `tsx --test`: all `schedule/*`, `lists/*`, `dock/*`, `sidebar/*`, `toolbar/*`, `ribbon/*`, `lib/tours/*`, `lib/panels/*`, `store/slices/overlay*`, `clearAllModels-overlay-stale` — **188/188 pass**, 0 fail.
- `pnpm exec turbo run typecheck --filter=@ifc-lite/viewer` 43/43 OK; `node scripts/check-module-size.mjs` OK (`v2` lowered); `oxlint` on every touched file: no findings.
- **Not run here**: the full viewer shard set and `pnpm lint` aggregate (`check-changesets.mjs` spawns `pnpm` without a shell → `ENOENT` on this Windows host); `toolbar-parity.test.ts` fails on this host before and after (its `STOP_PREFIXES` are `/`-separated vs `path.relative`'s `\`), and this PR does not touch either toolbar. No screenshot: the strip renders the same panels through `renderPanelBody`, which `mobile-sheet-coverage.test.ts` pins for every registry id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jqjBHL6kgmFbNS3twCQov
