### PR TITLE
fix(processing): make the presentation-layer walk iterative so a long mapped-item chain cannot abort the process

### DIFF
--- a/rust/processing/src/processor/color_layer.rs
+++ b/rust/processing/src/processor/color_layer.rs
@@ -5,7 +5,7 @@
 use super::{get_refs_from_list, normalize_optional_string};
 use crate::style::GeometryStyleInfo;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 pub(super) fn collect_presentation_layer_assignments(
     layer_by_assigned_representation: &mut FxHashMap<u32, String>,
@@ -53,7 +53,6 @@ pub(super) fn resolve_presentation_layer_for_product_definition_shape(
             layer_by_assigned_representation,
             cache_by_representation,
             decoder,
-            &mut Vec::new(),
         ) {
             return Some(layer_name);
         }
@@ -62,67 +61,171 @@ pub(super) fn resolve_presentation_layer_for_product_definition_shape(
     None
 }
 
+/// One unit of pending work. `IfcPresentationLayerAssignment.AssignedItems` is
+/// a SELECT over both representations and representation items, so the walk
+/// has to be able to test either.
+enum Step {
+    Representation { id: u32, parent: Option<u32> },
+    Item { item_id: u32, owner: u32 },
+}
+
+/// Memoise a hit: `Some(layer)` for `start` and every representation on the
+/// path that led to it, `None` for every other representation the walk
+/// visited.
+///
+/// The chain is sound because the walk is depth-first in document order and
+/// returns on the FIRST match: for each ancestor, everything earlier in its
+/// own traversal order was explored and missed, so this hit is that ancestor's
+/// first match too. The `None`s are sound because the stack is LIFO: a hit
+/// while a representation's items were still pending could only have come
+/// from inside its subtree, which puts it on the chain. So anything visited
+/// and NOT on the chain was explored to exhaustion.
+///
+/// Both halves are what the recursive version got for free on unwind, and both
+/// matter for mapped-item instancing, where every occurrence has its own root
+/// and what they share is the subtree below the map.
+fn memoise_hit(
+    start: u32,
+    layer: &str,
+    parent_of: &FxHashMap<u32, u32>,
+    visited: FxHashSet<u32>,
+    cache_by_representation: &mut FxHashMap<u32, Option<String>>,
+) {
+    let mut chain: FxHashSet<u32> = FxHashSet::default();
+    let mut at = Some(start);
+    while let Some(id) = at {
+        chain.insert(id);
+        at = parent_of.get(&id).copied();
+    }
+    for id in visited {
+        let answer = chain.contains(&id).then(|| layer.to_string());
+        cache_by_representation.insert(id, answer);
+    }
+}
+
+/// Resolve the presentation layer for one `IfcRepresentation`, chasing
+/// `IfcMappedItem` -> `IfcRepresentationMap` -> `MappedRepresentation`.
+///
+/// ITERATIVE, deliberately. The reference graph comes from the file, so it is
+/// exporter- and attacker-controlled, and this walk used to recurse with only
+/// a path-scoped cycle guard. A visited set bounds cycles and revisits but not
+/// a long ACYCLIC chain: every insert succeeds, the guard never fires, and the
+/// stack still overflows. A Rust stack overflow is SIGABRT, not a catchable
+/// panic, so nothing upstream turns it into a load error and in the wasm
+/// geometry worker it takes the instance down. Reproduced on 6.9 MB of
+/// well-formed IFC: 60 000 nested mapped items, every id distinct.
+///
+/// AGENTS.md asks for this shape over a depth cap, and the reason applies
+/// exactly here: with no call stack to consume there is nothing left for a cap
+/// to protect, and the visited set becomes sufficient on its own. A cap would
+/// also have to answer "what is a legitimate nesting depth", and answering it
+/// wrong loses a layer silently on a file no exporter would call malformed.
+/// `appearance::evaluated_source::validate_style_tree` walks a comparable
+/// graph the same way.
+///
+/// Work is bounded without a budget: each representation is expanded at most
+/// once, and items are pushed only from a representation being expanded for
+/// the first time, so the total is at most the number of item references in
+/// the file.
+///
+/// Traversal order is the document order the recursive version had, and it is
+/// load-bearing because the first match wins: a file may assign layers at more
+/// than one depth. Items are pushed in reverse so the first pops first, and
+/// pushing a mapped item's target representation on top descends into it
+/// before the next sibling item is examined.
 fn resolve_presentation_layer_name(
-    representation_id: u32,
+    root_representation_id: u32,
     layer_by_assigned_representation: &FxHashMap<u32, String>,
     cache_by_representation: &mut FxHashMap<u32, Option<String>>,
     decoder: &mut EntityDecoder,
-    traversal_stack: &mut Vec<u32>,
 ) -> Option<String> {
-    if let Some(cached) = cache_by_representation.get(&representation_id) {
+    if let Some(cached) = cache_by_representation.get(&root_representation_id) {
         return cached.clone();
     }
 
-    if traversal_stack.contains(&representation_id) {
-        return None;
-    }
-    traversal_stack.push(representation_id);
+    let mut visited: FxHashSet<u32> = FxHashSet::default();
+    // Recorded at pop time, not push time: the same representation can be
+    // pushed by two different items before either is popped, and the parent
+    // that counts is the one whose step was actually taken.
+    let mut parent_of: FxHashMap<u32, u32> = FxHashMap::default();
+    let mut stack = vec![Step::Representation { id: root_representation_id, parent: None }];
 
-    if let Some(layer_name) = layer_by_assigned_representation.get(&representation_id) {
-        let result = Some(layer_name.clone());
-        cache_by_representation.insert(representation_id, result.clone());
-        traversal_stack.pop();
-        return result;
-    }
-
-    let mut resolved: Option<String> = None;
-
-    if let Ok(representation) = decoder.decode_by_id(representation_id) {
-        if let Some(items) = get_refs_from_list(&representation, 3) {
-            for item_id in items {
-                if let Some(layer_name) = layer_by_assigned_representation.get(&item_id) {
-                    resolved = Some(layer_name.clone());
-                    break;
+    while let Some(step) = stack.pop() {
+        match step {
+            Step::Representation { id: representation_id, parent } => {
+                if !visited.insert(representation_id) {
+                    continue;
+                }
+                if let Some(parent) = parent {
+                    parent_of.insert(representation_id, parent);
                 }
 
-                if let Ok(item) = decoder.decode_by_id(item_id) {
-                    if item.ifc_type == IfcType::IfcMappedItem {
-                        if let Some(mapping_source_id) = item.get_ref(0) {
-                            if let Ok(mapping_source) = decoder.decode_by_id(mapping_source_id) {
-                                if let Some(mapped_representation_id) = mapping_source.get_ref(1) {
-                                    if let Some(layer_name) = resolve_presentation_layer_name(
-                                        mapped_representation_id,
-                                        layer_by_assigned_representation,
-                                        cache_by_representation,
-                                        decoder,
-                                        traversal_stack,
-                                    ) {
-                                        resolved = Some(layer_name);
-                                        break;
-                                    }
-                                }
-                            }
-                        }
+                match cache_by_representation.get(&representation_id) {
+                    // Explored to exhaustion by an earlier element, so this is
+                    // the whole subtree's answer, not a partial one.
+                    Some(Some(layer_name)) => {
+                        let hit = layer_name.clone();
+                        memoise_hit(representation_id, &hit, &parent_of, visited, cache_by_representation);
+                        return Some(hit);
                     }
+                    Some(None) => continue,
+                    None => {}
                 }
+
+                if let Some(layer_name) = layer_by_assigned_representation.get(&representation_id) {
+                    let hit = layer_name.clone();
+                    memoise_hit(representation_id, &hit, &parent_of, visited, cache_by_representation);
+                    return Some(hit);
+                }
+
+                let Ok(representation) = decoder.decode_by_id(representation_id) else {
+                    continue;
+                };
+                let Some(items) = get_refs_from_list(&representation, 3) else {
+                    continue;
+                };
+                for item_id in items.into_iter().rev() {
+                    stack.push(Step::Item { item_id, owner: representation_id });
+                }
+            }
+            Step::Item { item_id, owner } => {
+                if let Some(layer_name) = layer_by_assigned_representation.get(&item_id) {
+                    let hit = layer_name.clone();
+                    memoise_hit(owner, &hit, &parent_of, visited, cache_by_representation);
+                    return Some(hit);
+                }
+
+                let Ok(item) = decoder.decode_by_id(item_id) else {
+                    continue;
+                };
+                if item.ifc_type != IfcType::IfcMappedItem {
+                    continue;
+                }
+                let Some(mapping_source_id) = item.get_ref(0) else {
+                    continue;
+                };
+                let Ok(mapping_source) = decoder.decode_by_id(mapping_source_id) else {
+                    continue;
+                };
+                let Some(mapped_representation_id) = mapping_source.get_ref(1) else {
+                    continue;
+                };
+                stack.push(Step::Representation { id: mapped_representation_id, parent: Some(owner) });
             }
         }
     }
 
-    traversal_stack.pop();
-    cache_by_representation.insert(representation_id, resolved.clone());
-    resolved
+    // The walk ran to exhaustion, so every representation it reached had its
+    // whole closure searched. `None` is the true answer for all of them, not
+    // an artefact of where the walk started, and memoising the lot is what
+    // keeps a shared library representation from being re-walked per element.
+    for representation_id in visited {
+        cache_by_representation.insert(representation_id, None);
+    }
+
+    None
 }
+
 
 /// Find a color in a representation (`IfcProductDefinitionShape`) by
 /// traversing each of its `IfcShapeRepresentation`s.
@@ -187,145 +290,5 @@ fn find_color_in_shape_representation(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use ifc_lite_core::{build_entity_index, EntityDecoder};
-
-    /// `find_color_in_representation` used to bottom out after ONE level of
-    /// `IfcMappedItem` indirection: `find_color_in_shape_representation`
-    /// checked each item's own direct style but never chased a nested
-    /// `IfcMappedItem` inside a mapped representation's items, unlike the
-    /// canonical per-element resolver `element::find_geometry_item_color`
-    /// (#913 §2.7), which recurses to arbitrary depth.
-    ///
-    /// This fixture nests the styled geometry TWO mapped-item hops deep:
-    /// `#10 PDS -> #20 ShapeRepr -> #30 MappedItem -> #40 RepMap -> #50
-    /// ShapeRepr -> #60 MappedItem -> #70 RepMap -> #80 ShapeRepr -> #90
-    /// (styled leaf item)`.
-    #[test]
-    fn find_color_in_representation_follows_nested_mapped_items() {
-        let content = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
-            #10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n\
-            #20=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
-            #30=IFCMAPPEDITEM(#40,$);\n\
-            #40=IFCREPRESENTATIONMAP($,#50);\n\
-            #50=IFCSHAPEREPRESENTATION($,$,$,(#60));\n\
-            #60=IFCMAPPEDITEM(#70,$);\n\
-            #70=IFCREPRESENTATIONMAP($,#80);\n\
-            #80=IFCSHAPEREPRESENTATION($,$,$,(#90));\n\
-            #90=IFCEXTRUDEDAREASOLID($,$,$,$);\n\
-            ENDSEC;\nEND-ISO-10303-21;\n";
-        let index = build_entity_index(content);
-        let mut decoder = EntityDecoder::with_index(content, index);
-
-        let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-        styles.insert(
-            90,
-            GeometryStyleInfo {
-                color: [1.0, 0.0, 0.0, 1.0],
-                shading_color: None,
-                material_name: None,
-            },
-        );
-
-        let color = find_color_in_representation(10, &styles, &mut decoder);
-        assert_eq!(
-            color,
-            Some([1.0, 0.0, 0.0, 1.0]),
-            "a styled leaf item two IfcMappedItem hops deep must still resolve — \
-             find_color_in_shape_representation must chase nested IfcMappedItem \
-             the same way find_color_in_representation's own first hop does, \
-             mirroring element::find_geometry_item_color's unbounded recursion"
-        );
-    }
-
-    /// #2863's cyclic fixture, transplanted to this module's own entry
-    /// point: `#30`'s mapped representation lists `#30` itself, so the chase
-    /// re-enters where it started. Before the guard this stack-overflows and
-    /// SIGABRTs the whole test binary; asserting `None` (not merely "does not
-    /// crash") is the only way to see it pass or fail rather than vanish.
-    #[test]
-    fn find_color_in_representation_terminates_on_cyclic_mapping() {
-        let content = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
-            #10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n\
-            #20=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
-            #30=IFCMAPPEDITEM(#40,$);\n\
-            #40=IFCREPRESENTATIONMAP($,#50);\n\
-            #50=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
-            ENDSEC;\nEND-ISO-10303-21;\n";
-        let index = build_entity_index(content);
-        let mut decoder = EntityDecoder::with_index(content, index);
-        let styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-        assert_eq!(find_color_in_representation(10, &styles, &mut decoder), None);
-    }
-
-    /// Build a chain of `hops` nested `IfcMappedItem`s under one
-    /// `IfcProductDefinitionShape` (`#10`), terminating in a leaf
-    /// `IfcShapeRepresentation` (`#9000`) whose own item `#9999` carries the
-    /// style. `#9999` is never decoded as an entity — the resolver checks
-    /// styles by id before it ever needs to decode the item — so it does not
-    /// need its own STEP record.
-    fn nested_mapped_chain(hops: u32) -> Vec<u8> {
-        let mut s = String::from(
-            "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n#10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n",
-        );
-        for i in 0..hops {
-            let shape = 20 + i * 10;
-            let map_item = 21 + i * 10;
-            let rep_map = 22 + i * 10;
-            let next = if i + 1 == hops { 9000 } else { 20 + (i + 1) * 10 };
-            s.push_str(&format!(
-                "#{shape}=IFCSHAPEREPRESENTATION($,$,$,(#{map_item}));\n"
-            ));
-            s.push_str(&format!("#{map_item}=IFCMAPPEDITEM(#{rep_map},$);\n"));
-            s.push_str(&format!("#{rep_map}=IFCREPRESENTATIONMAP($,#{next});\n"));
-        }
-        s.push_str("#9000=IFCSHAPEREPRESENTATION($,$,$,(#9999));\n");
-        s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
-        s.into_bytes()
-    }
-
-    #[test]
-    fn find_color_in_representation_resolves_exactly_at_the_depth_cap() {
-        let red = [1.0, 0.0, 0.0, 1.0];
-        let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-        styles.insert(
-            9999,
-            GeometryStyleInfo {
-                color: red,
-                shading_color: None,
-                material_name: None,
-            },
-        );
-        let content = nested_mapped_chain(ifc_lite_core::MAX_MAPPED_ITEM_DEPTH);
-        let index = build_entity_index(&content);
-        let mut decoder = EntityDecoder::with_index(&content, index);
-        assert_eq!(
-            find_color_in_representation(10, &styles, &mut decoder),
-            Some(red),
-            "a chain exactly MAX_MAPPED_ITEM_DEPTH hops deep must still resolve"
-        );
-    }
-
-    #[test]
-    fn find_color_in_representation_stops_one_hop_past_the_depth_cap() {
-        let red = [1.0, 0.0, 0.0, 1.0];
-        let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
-        styles.insert(
-            9999,
-            GeometryStyleInfo {
-                color: red,
-                shading_color: None,
-                material_name: None,
-            },
-        );
-        let content = nested_mapped_chain(ifc_lite_core::MAX_MAPPED_ITEM_DEPTH + 1);
-        let index = build_entity_index(&content);
-        let mut decoder = EntityDecoder::with_index(&content, index);
-        assert_eq!(
-            find_color_in_representation(10, &styles, &mut decoder),
-            None,
-            "one hop past the cap the chase gives up rather than recursing on"
-        );
-    }
-}
+#[path = "color_layer_tests.rs"]
+mod tests;

--- a/rust/processing/src/processor/color_layer_tests.rs
+++ b/rust/processing/src/processor/color_layer_tests.rs
@@ -1,0 +1,404 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for `color_layer.rs`.
+//!
+//! A sibling `_tests.rs` rather than an inline `#[cfg(test)] mod tests`: the
+//! module-size ratchet counts every line of a production file, test code
+//! included, and `color_layer.rs` crossed 400 when the presentation-layer
+//! walk got its bounds. Splitting is what AGENTS.md asks for here; the
+//! allowlist is the fallback.
+
+use super::*;
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+
+/// `find_color_in_representation` used to bottom out after ONE level of
+/// `IfcMappedItem` indirection: `find_color_in_shape_representation`
+/// checked each item's own direct style but never chased a nested
+/// `IfcMappedItem` inside a mapped representation's items, unlike the
+/// canonical per-element resolver `element::find_geometry_item_color`
+/// (#913 §2.7), which recurses to arbitrary depth.
+///
+/// This fixture nests the styled geometry TWO mapped-item hops deep:
+/// `#10 PDS -> #20 ShapeRepr -> #30 MappedItem -> #40 RepMap -> #50
+/// ShapeRepr -> #60 MappedItem -> #70 RepMap -> #80 ShapeRepr -> #90
+/// (styled leaf item)`.
+#[test]
+fn find_color_in_representation_follows_nested_mapped_items() {
+    let content = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n\
+        #20=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
+        #30=IFCMAPPEDITEM(#40,$);\n\
+        #40=IFCREPRESENTATIONMAP($,#50);\n\
+        #50=IFCSHAPEREPRESENTATION($,$,$,(#60));\n\
+        #60=IFCMAPPEDITEM(#70,$);\n\
+        #70=IFCREPRESENTATIONMAP($,#80);\n\
+        #80=IFCSHAPEREPRESENTATION($,$,$,(#90));\n\
+        #90=IFCEXTRUDEDAREASOLID($,$,$,$);\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    let index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, index);
+
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(
+        90,
+        GeometryStyleInfo {
+            color: [1.0, 0.0, 0.0, 1.0],
+            shading_color: None,
+            material_name: None,
+        },
+    );
+
+    let color = find_color_in_representation(10, &styles, &mut decoder);
+    assert_eq!(
+        color,
+        Some([1.0, 0.0, 0.0, 1.0]),
+        "a styled leaf item two IfcMappedItem hops deep must still resolve — \
+         find_color_in_shape_representation must chase nested IfcMappedItem \
+         the same way find_color_in_representation's own first hop does, \
+         mirroring element::find_geometry_item_color's unbounded recursion"
+    );
+}
+
+/// #2863's cyclic fixture, transplanted to this module's own entry
+/// point: `#30`'s mapped representation lists `#30` itself, so the chase
+/// re-enters where it started. Before the guard this stack-overflows and
+/// SIGABRTs the whole test binary; asserting `None` (not merely "does not
+/// crash") is the only way to see it pass or fail rather than vanish.
+#[test]
+fn find_color_in_representation_terminates_on_cyclic_mapping() {
+    let content = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n\
+        #20=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
+        #30=IFCMAPPEDITEM(#40,$);\n\
+        #40=IFCREPRESENTATIONMAP($,#50);\n\
+        #50=IFCSHAPEREPRESENTATION($,$,$,(#30));\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    let index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, index);
+    let styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    assert_eq!(find_color_in_representation(10, &styles, &mut decoder), None);
+}
+
+/// Build a chain of `hops` nested `IfcMappedItem`s under one
+/// `IfcProductDefinitionShape` (`#10`), terminating in a leaf
+/// `IfcShapeRepresentation` (`#9000`) whose own item `#9999` carries the
+/// style. `#9999` is never decoded as an entity — the resolver checks
+/// styles by id before it ever needs to decode the item — so it does not
+/// need its own STEP record.
+fn nested_mapped_chain(hops: u32) -> Vec<u8> {
+    let mut s = String::from(
+        "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n#10=IFCPRODUCTDEFINITIONSHAPE($,$,(#20));\n",
+    );
+    for i in 0..hops {
+        let shape = 20 + i * 10;
+        let map_item = 21 + i * 10;
+        let rep_map = 22 + i * 10;
+        let next = if i + 1 == hops { 9000 } else { 20 + (i + 1) * 10 };
+        s.push_str(&format!(
+            "#{shape}=IFCSHAPEREPRESENTATION($,$,$,(#{map_item}));\n"
+        ));
+        s.push_str(&format!("#{map_item}=IFCMAPPEDITEM(#{rep_map},$);\n"));
+        s.push_str(&format!("#{rep_map}=IFCREPRESENTATIONMAP($,#{next});\n"));
+    }
+    s.push_str("#9000=IFCSHAPEREPRESENTATION($,$,$,(#9999));\n");
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s.into_bytes()
+}
+
+#[test]
+fn find_color_in_representation_resolves_exactly_at_the_depth_cap() {
+    let red = [1.0, 0.0, 0.0, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(
+        9999,
+        GeometryStyleInfo {
+            color: red,
+            shading_color: None,
+            material_name: None,
+        },
+    );
+    let content = nested_mapped_chain(ifc_lite_core::MAX_MAPPED_ITEM_DEPTH);
+    let index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, index);
+    assert_eq!(
+        find_color_in_representation(10, &styles, &mut decoder),
+        Some(red),
+        "a chain exactly MAX_MAPPED_ITEM_DEPTH hops deep must still resolve"
+    );
+}
+
+#[test]
+fn find_color_in_representation_stops_one_hop_past_the_depth_cap() {
+    let red = [1.0, 0.0, 0.0, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(
+        9999,
+        GeometryStyleInfo {
+            color: red,
+            shading_color: None,
+            material_name: None,
+        },
+    );
+    let content = nested_mapped_chain(ifc_lite_core::MAX_MAPPED_ITEM_DEPTH + 1);
+    let index = build_entity_index(&content);
+    let mut decoder = EntityDecoder::with_index(&content, index);
+    assert_eq!(
+        find_color_in_representation(10, &styles, &mut decoder),
+        None,
+        "one hop past the cap the chase gives up rather than recursing on"
+    );
+}
+
+/// Build an `IfcProductDefinitionShape` whose body is `hops` nested
+/// `IfcMappedItem` indirections, with the presentation layer assigned to the
+/// LEAF representation so only a walk that reaches the bottom finds it.
+///
+/// Strided so the three id spaces cannot overlap at any chain length. A
+/// `1000 + i` / `2000 + i` / `3000 + i` scheme collides past 1000 hops, and a
+/// collided fixture silently stops being a deep chain at all: at 4096 hops it
+/// passed against a deliberately broken walk, which is a test that cannot fail.
+fn layer_repr_id(i: u32) -> u32 {
+    10 * i + 1
+}
+
+fn nested_layer_chain(hops: u32) -> (String, u32) {
+    let item = |i: u32| 10 * i + 2;
+    let map = |i: u32| 10 * i + 3;
+
+    let mut s = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    s.push_str(&format!(
+        "#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#{}));\n",
+        layer_repr_id(0)
+    ));
+    for i in 0..hops {
+        s.push_str(&format!(
+            "#{}=IFCSHAPEREPRESENTATION($,$,$,(#{}));\n",
+            layer_repr_id(i),
+            item(i)
+        ));
+        s.push_str(&format!("#{}=IFCMAPPEDITEM(#{},$);\n", item(i), map(i)));
+        s.push_str(&format!(
+            "#{}=IFCREPRESENTATIONMAP($,#{});\n",
+            map(i),
+            layer_repr_id(i + 1)
+        ));
+    }
+    s.push_str(&format!(
+        "#{}=IFCSHAPEREPRESENTATION($,$,$,());\n",
+        layer_repr_id(hops)
+    ));
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    (s, layer_repr_id(hops))
+}
+
+/// Resolve with a layer assigned to `labelled`. Pass an id no entity uses to
+/// mean "this file assigns no layer at all".
+fn layer_of(content: &str, labelled: u32) -> Option<String> {
+    let index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content.as_bytes(), index);
+    let mut layers: FxHashMap<u32, String> = FxHashMap::default();
+    layers.insert(labelled, "L".to_string());
+    let mut cache: FxHashMap<u32, Option<String>> = FxHashMap::default();
+    resolve_presentation_layer_for_product_definition_shape(7, &layers, &mut cache, &mut decoder)
+}
+
+/// The walk used to recurse, so a long chain of DISTINCT ids overflowed the
+/// stack and took SIGABRT with it: not a catchable panic, and in the wasm
+/// geometry worker it kills the instance. Reproduced on 60 000 links, 6.9 MB.
+///
+/// The assertion is that the layer RESOLVES, not merely that the call returns.
+/// A depth cap would also return here, by giving up and reporting no layer on
+/// a file no exporter would call malformed. Being iterative, this walk has no
+/// depth to give up at.
+#[test]
+fn resolve_presentation_layer_follows_a_long_acyclic_chain() {
+    let (ifc, leaf) = nested_layer_chain(4096);
+    assert_eq!(
+        layer_of(&ifc, leaf),
+        Some("L".to_string()),
+        "a 4096-hop chain must resolve its layer, not overflow and not give up"
+    );
+}
+
+/// A cycle is bounded by the visited set alone once there is no call stack to
+/// protect. Four items each leading back into the same representation is also
+/// the fan-out shape that costs `k^depth` under a depth-only guard.
+#[test]
+fn resolve_presentation_layer_terminates_on_cyclic_fan_out() {
+    let ifc = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #7=IFCPRODUCTDEFINITIONSHAPE($,$,(#100));\n\
+        #100=IFCSHAPEREPRESENTATION($,$,$,(#201,#202,#203,#204));\n\
+        #201=IFCMAPPEDITEM(#301,$);\n\
+        #202=IFCMAPPEDITEM(#302,$);\n\
+        #203=IFCMAPPEDITEM(#303,$);\n\
+        #204=IFCMAPPEDITEM(#304,$);\n\
+        #301=IFCREPRESENTATIONMAP($,#100);\n\
+        #302=IFCREPRESENTATIONMAP($,#100);\n\
+        #303=IFCREPRESENTATIONMAP($,#100);\n\
+        #304=IFCREPRESENTATIONMAP($,#100);\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    assert_eq!(layer_of(ifc, 9_999_999), None);
+}
+
+/// First match wins, so WHICH layer is returned depends on traversal order,
+/// and the iterative rewrite has to reproduce the recursive one exactly.
+///
+/// `#100` holds two items. Item `#201` is a mapped item whose target `#110`
+/// carries layer "DEEP"; item `#202` carries layer "FLAT" directly. Document
+/// order plus depth-first means `#201`'s subtree is searched before `#202` is
+/// examined at all, so "DEEP" wins. A breadth-first walk, or one that tested
+/// every item's own layer before descending into any of them, returns "FLAT".
+#[test]
+fn the_first_match_is_the_one_document_order_reaches_first() {
+    let ifc = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #7=IFCPRODUCTDEFINITIONSHAPE($,$,(#100));\n\
+        #100=IFCSHAPEREPRESENTATION($,$,$,(#201,#202));\n\
+        #201=IFCMAPPEDITEM(#301,$);\n\
+        #301=IFCREPRESENTATIONMAP($,#110);\n\
+        #110=IFCSHAPEREPRESENTATION($,$,$,());\n\
+        #202=IFCEXTRUDEDAREASOLID($,$,$,$);\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    let index = build_entity_index(ifc);
+    let mut decoder = EntityDecoder::with_index(ifc.as_bytes(), index);
+    let mut layers: FxHashMap<u32, String> = FxHashMap::default();
+    layers.insert(110, "DEEP".to_string());
+    layers.insert(202, "FLAT".to_string());
+    let mut cache: FxHashMap<u32, Option<String>> = FxHashMap::default();
+    assert_eq!(
+        resolve_presentation_layer_for_product_definition_shape(7, &layers, &mut cache, &mut decoder),
+        Some("DEEP".to_string()),
+        "depth-first in document order: the first item's subtree outranks a later sibling"
+    );
+}
+
+/// A miss explores the whole reachable closure, so `None` is the true answer
+/// for every representation the walk touched, not an artefact of where it
+/// started. Memoising all of them is what stops a shared library
+/// representation being re-walked once per element.
+///
+/// This is the property the first attempt at this fix got wrong in the other
+/// direction: it carried a "truncated" bit up the return path and declined to
+/// memoise anything on a capped walk, which left the cache EMPTY for the whole
+/// model and turned a 100k-decode load into a 3.2M-decode one.
+#[test]
+fn a_miss_memoises_every_representation_it_explored() {
+    let (ifc, leaf) = nested_layer_chain(6);
+    let index = build_entity_index(&ifc);
+    let mut decoder = EntityDecoder::with_index(ifc.as_bytes(), index);
+    let layers: FxHashMap<u32, String> = FxHashMap::default();
+    let mut cache: FxHashMap<u32, Option<String>> = FxHashMap::default();
+
+    assert_eq!(
+        resolve_presentation_layer_for_product_definition_shape(7, &layers, &mut cache, &mut decoder),
+        None
+    );
+    for i in 0..=6 {
+        assert_eq!(
+            cache.get(&layer_repr_id(i)),
+            Some(&None),
+            "representation {} was explored to exhaustion and must be memoised",
+            layer_repr_id(i)
+        );
+    }
+    assert_eq!(cache.get(&leaf), Some(&None));
+}
+
+/// A hit memoises every representation on the path to it, not only the root.
+///
+/// Mapped-item instancing gives each occurrence its OWN root
+/// `IfcShapeRepresentation`; what the occurrences share is the subtree below
+/// the `IfcRepresentationMap`. Memoising the root alone would re-walk that
+/// shared subtree once per occurrence, which is what the first cut of this
+/// rewrite did. The fixture is two occurrences of one map target.
+#[test]
+fn a_hit_memoises_the_whole_path_so_a_sibling_occurrence_is_a_lookup() {
+    let ifc = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #7=IFCPRODUCTDEFINITIONSHAPE($,$,(#11));\n\
+        #8=IFCPRODUCTDEFINITIONSHAPE($,$,(#21));\n\
+        #11=IFCSHAPEREPRESENTATION($,$,$,(#12));\n\
+        #12=IFCMAPPEDITEM(#13,$);\n\
+        #21=IFCSHAPEREPRESENTATION($,$,$,(#22));\n\
+        #22=IFCMAPPEDITEM(#13,$);\n\
+        #13=IFCREPRESENTATIONMAP($,#500);\n\
+        #500=IFCSHAPEREPRESENTATION($,$,$,(#510));\n\
+        #510=IFCMAPPEDITEM(#511,$);\n\
+        #511=IFCREPRESENTATIONMAP($,#501);\n\
+        #501=IFCSHAPEREPRESENTATION($,$,$,());\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    let index = build_entity_index(ifc);
+    let mut decoder = EntityDecoder::with_index(ifc.as_bytes(), index);
+    let mut layers: FxHashMap<u32, String> = FxHashMap::default();
+    layers.insert(501, "L".to_string());
+    let mut cache: FxHashMap<u32, Option<String>> = FxHashMap::default();
+
+    assert_eq!(
+        resolve_presentation_layer_for_product_definition_shape(7, &layers, &mut cache, &mut decoder),
+        Some("L".to_string())
+    );
+    for id in [11, 500, 501] {
+        assert_eq!(
+            cache.get(&id),
+            Some(&Some("L".to_string())),
+            "representation #{id} is on the hit path and must be memoised"
+        );
+    }
+
+    // The second occurrence enters at its own root #21, whose first hop is
+    // the shared #500. With #500 memoised this resolves without expanding
+    // #500's subtree; the assertion on the cache is what makes that visible.
+    let before = cache.len();
+    assert_eq!(
+        resolve_presentation_layer_for_product_definition_shape(8, &layers, &mut cache, &mut decoder),
+        Some("L".to_string())
+    );
+    assert_eq!(
+        cache.len(),
+        before + 1,
+        "only the new root #21 should be added; the shared subtree was a cache hit"
+    );
+}
+
+/// A hit also memoises `None` for every representation the walk explored and
+/// missed on the way. Here the shared map target `#500` (and its child `#501`)
+/// is expanded and exhausted BEFORE the later sibling item `#14` carries the
+/// layer, so neither is on the hit chain. Without the `None`s, the second
+/// occurrence re-decodes `#500`'s whole subtree on every resolve.
+#[test]
+fn a_hit_memoises_none_for_the_exhausted_subtrees_it_passed() {
+    let ifc = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n\
+        #7=IFCPRODUCTDEFINITIONSHAPE($,$,(#11));\n\
+        #8=IFCPRODUCTDEFINITIONSHAPE($,$,(#21));\n\
+        #11=IFCSHAPEREPRESENTATION($,$,$,(#12,#14));\n\
+        #12=IFCMAPPEDITEM(#13,$);\n\
+        #14=IFCEXTRUDEDAREASOLID($,$,$,$);\n\
+        #21=IFCSHAPEREPRESENTATION($,$,$,(#22,#24));\n\
+        #22=IFCMAPPEDITEM(#13,$);\n\
+        #24=IFCEXTRUDEDAREASOLID($,$,$,$);\n\
+        #13=IFCREPRESENTATIONMAP($,#500);\n\
+        #500=IFCSHAPEREPRESENTATION($,$,$,(#510));\n\
+        #510=IFCMAPPEDITEM(#511,$);\n\
+        #511=IFCREPRESENTATIONMAP($,#501);\n\
+        #501=IFCSHAPEREPRESENTATION($,$,$,());\n\
+        ENDSEC;\nEND-ISO-10303-21;\n";
+    let index = build_entity_index(ifc);
+    let mut decoder = EntityDecoder::with_index(ifc.as_bytes(), index);
+    let mut layers: FxHashMap<u32, String> = FxHashMap::default();
+    layers.insert(14, "L".to_string());
+    layers.insert(24, "L".to_string());
+    let mut cache: FxHashMap<u32, Option<String>> = FxHashMap::default();
+
+    assert_eq!(
+        resolve_presentation_layer_for_product_definition_shape(7, &layers, &mut cache, &mut decoder),
+        Some("L".to_string())
+    );
+    assert_eq!(cache.get(&11), Some(&Some("L".to_string())), "the root is on the hit chain");
+    for id in [500, 501] {
+        assert_eq!(
+            cache.get(&id),
+            Some(&None),
+            "#{id} was explored to exhaustion before the hit and must be memoised as None"
+        );
+    }
+}

--- a/scripts/check-refwalk-guards.mjs
+++ b/scripts/check-refwalk-guards.mjs
@@ -173,8 +173,13 @@ const SCAN_ROOTS = ['rust/geometry/src', 'rust/processing/src', 'rust/wasm-bindi
  * roots. Set to 30, a small margin so ordinary churn does not force an edit,
  * while a broken detector -- every break measured while building this dropped
  * the count to zero or near it -- still fails.
+ *
+ * Re-measured at 29 when `resolve_presentation_layer_name` in
+ * `processing/src/processor/color_layer.rs` stopped recursing: the walk became
+ * iterative, so it is no longer a candidate, and the margin the 30 carried had
+ * already been spent by earlier refactors. Set to 28 to restore a margin of one.
  */
-const CANDIDATE_FLOOR = 30;
+const CANDIDATE_FLOOR = 28;
 
 /**
  * Allowlist for candidates that are genuinely unguarded and must stay that


### PR DESCRIPTION
## Defect

`resolve_presentation_layer_name` (`rust/processing/src/processor/color_layer.rs`) chased `IfcMappedItem -> IfcRepresentationMap -> MappedRepresentation` by recursion with only a path-scoped `Vec` cycle guard. A visited set bounds cycles; it does not bound a long acyclic chain, so the recursion runs until the stack overflows. A Rust stack overflow is SIGABRT, not a catchable panic: nothing upstream turns it into a load error, and in the wasm geometry worker it takes down the instance.

Reproduced on 6.9 MB of well-formed IFC (60 000 nested mapped items, every id distinct), default options, both the native orchestrator and the wasm batch. The same file with one extra `IfcPresentationLayerAssignment`, which makes the resolver return before it recurses, loads in 769 ms.

The sibling resolver for this same chain (`element/element_color.rs`) has been bounded since #2863/#2864. So has the colour walk in this very file. Only the layer walk was left unbounded.

## Fix

The walk is now iterative with a global visited set, which is what AGENTS.md asks for over a depth cap and what this case is easiest for: first match wins and nothing accumulates, so a global visited set is strictly stronger, and with no call stack to consume there is nothing for a cap to protect.

A cap was the first cut and was rejected under `/simplify` on three counts: it has to answer "what is a legitimate nesting depth" and loses a layer silently if it answers wrong; it would be a fourth separately-bounded copy of this traversal, which the docstring on `find_color_in_shape_representation` in the same file already argues against; and it forces a second channel on the memo, and measured on a simulation that left the shared memo empty for the whole model (3.2M decodes at 100k elements where the old code did 100k).

Being uncapped, the memo is exact without any flag. A miss memoises `None` for every representation explored. A hit memoises `Some` up the parent chain and `None` for every other representation visited, which is what the recursive version got for free on unwind and what keeps mapped-item instancing from re-walking the shared subtree once per occurrence.

Traversal order is preserved exactly (pinned by a test against both a breadth-first walk and one that tests every item before descending), because the first match wins and a file may assign layers at more than one depth.

`scripts/check-refwalk-guards.mjs` floors its candidate count; making this walk iterative drops it from 30 to 29, so the floor moves to 28 in this commit as the gate's own message asks.

## Evidence

- Mutation-checked: not reversing the push order fails the ordering test; removing the miss-memoise loop fails the memo test; removing the off-chain `None` memo fails its test; removing the visited guard makes the cyclic fan-out test loop forever.
- Reviewer ran a 3000-trial differential test against a copy of the old recursive walk (cycles included, random query order): identical results and identical cache contents after every call. Removing `.rev()` from the item push failed it on trial 0, so the instrument can fail.
- The old recursive walk SIGABRTs at 4096 hops in a test thread, so `resolve_presentation_layer_follows_a_long_acyclic_chain` would vanish rather than pass if the walk regressed to recursion.
- Caught my own fixture bug on the way: an id scheme that collided past 1000 hops made the deep test pass against a deliberately broken walk. Restrided by 10.
- `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo test --workspace --no-fail-fast` 3177 passed, 0 failed. Fixtures absent locally, so fixture-gated tests skipped here; CI fetches them.

Tests live in a sibling `color_layer_tests.rs` because the module-size ratchet counts test lines and the file crossed 400.

Part of the full Rust review; one defect class per PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved color resolution across deeply nested presentation layers.
  - Added safeguards for cyclic mappings and long traversal chains to prevent hangs or excessive processing.
  - Preserved document order when resolving the first applicable color match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->