### PR TITLE
test(appearance): prove PDF face-mask portable workflow

### DIFF
--- a/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
@@ -44,6 +44,10 @@ const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 0, -1, 0, 0, -1]);
 const normals = new Float32Array(12).map((_, i) => i % 3 === 1 ? 1 : 0);
 
 interface RasterPixels { width: number; height: number; rgba: Uint8ClampedArray }
+interface FrozenTopologyOracle {
+  readonly sourceIndices: readonly number[];
+  readonly cornerPositions: readonly (readonly number[])[];
+}
 
 function meshSnapshot(parts: readonly MeshData[]) {
   return parts.map(part => ({
@@ -58,20 +62,61 @@ function meshSnapshot(parts: readonly MeshData[]) {
   }));
 }
 
-function assertCanonicalFragments(parts: readonly MeshData[], expected: readonly (readonly number[])[], message: string): void {
-  const canonicalIndices = parts[0]?.appearanceSource?.sourceIndices;
-  assert.ok(canonicalIndices && canonicalIndices.length === indices.length, `${message}: the complete canonical item is retained`);
+function freezeTopologyOracle(sourcePositions: Float32Array, sourceIndices: Uint32Array): FrozenTopologyOracle {
+  return Object.freeze({
+    sourceIndices: Object.freeze([...sourceIndices]),
+    cornerPositions: Object.freeze([...sourceIndices].map(vertex =>
+      Object.freeze([...sourcePositions.slice(vertex * 3, vertex * 3 + 3)]))),
+  });
+}
+
+function freezeExpandedTopologyOracle(source: FrozenTopologyOracle): FrozenTopologyOracle {
+  const cornerPositions = source.cornerPositions.map(point => [...point]);
+  return freezeTopologyOracle(new Float32Array(cornerPositions.flat()),
+    Uint32Array.from({ length: cornerPositions.length }, (_, corner) => corner));
+}
+
+function freezeCenteredTopologyOracle(source: FrozenTopologyOracle): FrozenTopologyOracle {
+  const axes = [0, 1, 2].map(axis => {
+    const values = source.cornerPositions.map(point => point[axis]);
+    return (Math.min(...values) + Math.max(...values)) / 2;
+  });
+  return Object.freeze({ sourceIndices: source.sourceIndices,
+    cornerPositions: Object.freeze(source.cornerPositions.map(point =>
+      Object.freeze(point.map((value, axis) => value - axes[axis])))) });
+}
+
+function assertCanonicalFragments(parts: readonly MeshData[], oracle: FrozenTopologyOracle,
+  expected: readonly (readonly number[])[], message: string): void {
   const actual = parts.map(part => {
     const source = part.appearanceSource;
     assert.ok(source?.cornerIndices, `${message}: each fragment retains canonical corners`);
-    assert.deepEqual([...source.sourceIndices], [...canonicalIndices], `${message}: every fragment names the same canonical item index buffer`);
+    assert.strictEqual(source.indices, part.indices, `${message}: provenance names the rendered fragment index buffer`);
+    assert.deepEqual([...source.sourceIndices], oracle.sourceIndices,
+      `${message}: every fragment retains the independently frozen full topology`);
     const corners = [...source.cornerIndices];
     assert.equal(corners.length, part.indices.length, `${message}: every rendered corner has canonical provenance`);
+    corners.forEach((canonicalCorner, localCorner) => {
+      const vertex = part.indices[localCorner];
+      assert.deepEqual([...part.positions.slice(vertex * 3, vertex * 3 + 3)], oracle.cornerPositions[canonicalCorner],
+        `${message}: rendered corner ${localCorner} matches canonical corner ${canonicalCorner}`);
+    });
     return corners;
   }).sort((a, b) => a[0] - b[0]);
   assert.deepEqual(actual, expected, message);
   assert.deepEqual(actual.map(corners => corners[0] / 3), expected.map(corners => corners[0] / 3),
     `${message}: canonical source triangle ordinals remain stable`);
+}
+
+function triangleGeometry(mesh: MeshData, message: string): number[][] {
+  assert.equal(mesh.indices.length, 3, `${message}: one triangle is present`);
+  return [...mesh.indices].map(vertex => [...mesh.positions.slice(vertex * 3, vertex * 3 + 3)])
+    .sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2]);
+}
+
+function oracleTriangle(oracle: FrozenTopologyOracle, ordinal: number): number[][] {
+  return oracle.cornerPositions.slice(ordinal * 3, ordinal * 3 + 3).map(point => [...point])
+    .sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2]);
 }
 
 function requireRasterPixels(raster: RasterPixels | undefined): RasterPixels {
@@ -147,6 +192,11 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const view = new MutablePropertyView(data.properties, 'evaluated');
     const idOffset = federationRegistry.registerModel('evaluated', 80);
     const globalId = (id: number) => federationRegistry.toGlobalId('evaluated', id);
+    // Freeze the renderer topology before any mesh enters preview ownership.
+    // This remains independent of every appearanceSource installed later.
+    const originalOracle = freezeTopologyOracle(positions.slice(), indices.slice());
+    const previewOracle = freezeExpandedTopologyOracle(originalOracle);
+    const reopenedOracle = freezeCenteredTopologyOracle(originalOracle);
     const makeMesh = (id: number): MeshData => ({ expressId: globalId(id), geometryItemId: globalId(11), modelIndex: 0, positions, normals, indices,
       color: [0.8, 0.2, 0.1, 1], appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } });
     const originals = [makeMesh(25), makeMesh(35)];
@@ -169,6 +219,9 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       appearanceSources: [], appearanceDraft: null, selectedEntityId: selection, selectedEntityIds: new Set([selection]) });
     const owner = { kind: 'source' as const, id: 'face-mask-image' };
     let decodedPdf: RasterPixels | undefined;
+    let pdfPagePng: Uint8Array | undefined;
+    let pdfPageBitmap: ImageBitmap | undefined;
+    let pdfPageBitmapDrawn = false;
     if (pageSource) {
       const bytes = controlledPdf(), backend = await pdfBackend(raster => { decodedPdf = raster; });
       const document = await PdfAppearanceSource.open(new File([bytes], 'Controlled plan.pdf', { type: 'application/pdf' }), appearanceAssets, {
@@ -177,6 +230,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       pdfKey = registerPdfDocument(document);
       const raster = await document.rasterize({ pageNumber: 1, dpi: 18 });
       const pagePng = appearanceAssets.encoded(raster.asset.id);
+      pdfPagePng = pagePng.slice();
       assert.ok(raster.recipe.pixelWidth > 1 && raster.recipe.pixelWidth <= 256
         && raster.recipe.pixelHeight > 1 && raster.recipe.pixelHeight <= 256 && pagePng.length > 100,
       'real PDF.js decoded a bounded page derivative');
@@ -187,15 +241,29 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
         calibration: { sourcePoints: [[10, 20], [110, 20]], distanceMetres: 1 } });
       Object.defineProperty(globalThis, 'OffscreenCanvas', { configurable: true, value: class {
         constructor(readonly width: number, readonly height: number) { assert.equal(width, rasterPixels.width); assert.equal(height, rasterPixels.height); }
-        getContext() { return { drawImage() {}, getImageData: () => ({ data: rasterPixels.rgba }) }; }
+        getContext() { return { drawImage(bitmap: ImageBitmap) {
+          assert.strictEqual(bitmap, pdfPageBitmap, 'the PDF compositor draws the bitmap decoded from the exact page PNG');
+          pdfPageBitmapDrawn = true;
+        }, getImageData: () => {
+          assert.equal(pdfPageBitmapDrawn, true, 'RGBA extraction follows the exact decoded PDF page bitmap draw');
+          return { data: rasterPixels.rgba };
+        } }; }
       } });
     } else {
       const asset = await appearanceAssets.add(png, { owner });
       useViewerStore.getState().addAppearanceSource({ id: asset.id, name: 'Texture', width: 1, height: 1 });
     }
     globalThis.createImageBitmap = async (blob: ImageBitmapSource) => {
-      assert.ok(blob instanceof Blob); const bytes = new DataView(await blob.arrayBuffer());
-      return { width: bytes.getUint32(16), height: bytes.getUint32(20), close() {} } as ImageBitmap;
+      assert.ok(blob instanceof Blob);
+      const encoded = new Uint8Array(await blob.arrayBuffer());
+      const bytes = new DataView(encoded.buffer, encoded.byteOffset, encoded.byteLength);
+      const bitmap = { width: bytes.getUint32(16), height: bytes.getUint32(20), close() {} } as ImageBitmap;
+      if (pageSource && pdfPageBitmap === undefined) {
+        assert.ok(pdfPagePng, 'the real PDF page PNG is frozen before browser decoding');
+        assert.deepEqual(encoded, pdfPagePng, 'createImageBitmap receives the exact PNG emitted by the PDF.js canvas');
+        pdfPageBitmap = bitmap;
+      }
+      return bitmap;
     };
     Object.defineProperty(globalThis, 'Worker', { configurable: true, value: NativeWorker });
     // The face-selection canvas has no GPU here. The main viewport hit below
@@ -213,6 +281,8 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const readParts = (id: number) => instanceScene
       ? activePreview.getParts?.({ expressId: id, modelIndex: 0 }) ?? instanceScene.scene.getInstancedMeshDataPieces(id)
       : resident.get(id);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
+      'the initial resident fragments match the topology frozen before preview ownership');
     const siblingBefore = meshSnapshot(readParts(globalId(35))!);
     const renderer = { getAppearancePreview: () => activePreview,
       getScene: () => instanceScene?.scene ?? { getMeshDataPieces: (id: number) => resident.get(id) }, requestRender() {},
@@ -239,7 +309,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const wholeTextured = globalId(whole.plan.conversions![0].geometryItemId);
     assert.deepEqual(ids(selection), pageSource ? [wholeTextured, wholeTextured] : [wholeTextured],
       'a whole-surface conversion textures every resident fragment without changing its partition');
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, previewOracle, [[0, 1, 2], [3, 4, 5]],
       'the initial whole-surface preview preserves both stream fragments');
 
     // Select one of the two faces: the plan carries the mask, the preview splits.
@@ -264,6 +334,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       assert.ok(masked.page && masked.rgba, 'the selected faces reached the native page compositor');
       assert.equal(masked.page.appearance.repeatS, false); assert.equal(masked.page.appearance.repeatT, false);
       assert.equal(masked.page.page.width * masked.page.page.height * 4, masked.rgba.length);
+      assert.equal(pdfPageBitmapDrawn, true, 'the exact PDF page bitmap reaches the compositor before RGBA extraction');
       assert.deepEqual([...masked.rgba], [...requireRasterPixels(decodedPdf).rgba],
         'native page planning receives the exact RGBA decoded by PDF.js');
       assert.deepEqual(masked.page.appearance.mapping, { kind: 'planar', frame: 'world', origin: [1, 0, 0],
@@ -292,10 +363,10 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     assert.deepEqual(retainedPart && [...retainedPart.color], [0.8, 0.2, 0.1, 1], 'the retained part keeps the source colour');
     if (pageSource) {
       assert.equal(texturedPart?.textureRef?.repeatS, false, 'finite PDF pages clamp instead of tile');
-      assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
         'the masked preview preserves canonical source triangles across its textured/retained split');
-      assertCanonicalFragments([texturedPart!], [[3, 4, 5]], 'the picked face keeps canonical source ordinal 1');
-      assertCanonicalFragments([retainedPart!], [[0, 1, 2]], 'the unpicked face keeps canonical source ordinal 0');
+      assertCanonicalFragments([texturedPart!], originalOracle, [[3, 4, 5]], 'the picked face keeps canonical source ordinal 1');
+      assertCanonicalFragments([retainedPart!], originalOracle, [[0, 1, 2]], 'the unpicked face keeps canonical source ordinal 0');
     }
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
     assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,
@@ -321,18 +392,18 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
     await act(async () => button('Compare original').click());
     assert.deepEqual(ids(selection), originalIds);
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Compare restores both original canonical fragments');
     await act(async () => button('Show preview').click());
     assert.deepEqual(splitIds(), expectedSplitIds);
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Show preview restores the canonical masked split');
 
     // Discard restores the single original part and keeps the selection for the next preview.
     await act(async () => button('Discard').click());
     await until(() => (ui.textContent ?? '').includes('Preview discarded'));
     assert.deepEqual(ids(selection), originalIds);
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Discard restores both original canonical fragments');
     const mappingInput = pageSource
       ? ui.querySelector<HTMLInputElement>('input[aria-label="Distance A–B (m)"]')
@@ -350,7 +421,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
         axisU: [0, 0, 1], axisV: [-1, -0, -0], metresPerTile: [1.44, 2] },
       'doubling the measured distance deterministically doubles the calibrated page scale');
       assert.equal(again.page.texelsPerMetre, 25, 'doubling page scale halves the raster density');
-      assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
         'the re-preview keeps canonical provenance after calibration changes');
     }
 
@@ -362,7 +433,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const applied = useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.filter(mesh => mesh.expressId === selection);
     assert.deepEqual(partIds(applied).sort((a, b) => a - b), expectedSplitIds,
       'the model geometry carries both parts of the product');
-    if (pageSource) assertCanonicalFragments(applied, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(applied, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Apply commits the same canonical source ordinals');
     assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,
       'Apply leaves the sibling identity, geometry bytes, and style unchanged');
@@ -410,6 +481,10 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
         assert.equal(texturedMesh.textureRef.repeatS, false); assert.equal(texturedMesh.textureRef.repeatT, false);
         assert.equal(texturedMesh.expressId, 25); assert.equal(retainedMesh?.expressId, 25);
         assert.equal(retainedMesh?.textureRef, undefined); assert.ok(retainedMesh);
+        assert.deepEqual(triangleGeometry(texturedMesh, 'the reopened textured face set'), oracleTriangle(reopenedOracle, 1),
+          'the reopened textured face set is geometrically canonical ordinal 1');
+        assert.deepEqual(triangleGeometry(retainedMesh, 'the reopened retained face set'), oracleTriangle(reopenedOracle, 0),
+          'the reopened retained face set is geometrically the canonical complement');
         [0.8, 0.2, 0.1, 1].forEach((expected, index) => assert.ok(Math.abs(retainedMesh.color[index] - expected) <= 1 / 255,
           'the retained face keeps the original style through IFC colour quantization'));
       } finally { processor.dispose(); }
@@ -419,12 +494,12 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     await act(async () => { const undo = ui.querySelector<HTMLButtonElement>('button[aria-label="Undo"]'); assert.ok(undo && !undo.disabled); undo.click(); });
     assert.equal(view.getNewEntities().length, 0);
     assert.deepEqual(ids(selection), originalIds);
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Undo restores the original canonical fragments');
     if (instanced) assert.equal(useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.length, 0);
     await act(async () => { const redo = ui.querySelector<HTMLButtonElement>('button[aria-label="Redo"]'); assert.ok(redo && !redo.disabled); redo.click(); });
     assert.deepEqual(splitIds(), expectedSplitIds);
-    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, originalOracle, [[0, 1, 2], [3, 4, 5]],
       'Redo restores the canonical masked split');
     assert.equal(view.getNewEntities().filter(entity => entity.type === 'IfcTriangulatedFaceSet').length, 2);
     assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,

--- a/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
@@ -10,7 +10,7 @@ import { StrictMode, act } from 'react';
 import { IfcParser, unwrapIfcZipWithResources } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
-import { federationRegistry, Raycaster, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
+import { federationRegistry, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
 import { GeometryProcessor, type MeshData, type GeometryResult } from '@ifc-lite/geometry';
 import { AppearancePreviewController } from '../../../../../../packages/renderer/src/appearance-preview.js';
 import { render, cleanup, advance, type } from '@/test/render.js';
@@ -31,7 +31,7 @@ import { publishPdfRaster } from '@/lib/appearance/pdf/publish-source.js';
 import { controlledPdf } from '@/lib/appearance/pdf/fixtures.js';
 import { runPdfJob, type PdfEngineBackend, type PdfRasterSurface } from '@/lib/appearance/pdf/engine.js';
 import type { AppearanceWorker } from '@/lib/appearance/planner-worker-client.js';
-import type { AppearancePlan, AppearanceCatalog, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse, PageAppearanceRequest } from '@/lib/appearance/planner-types.js';
+import type { AppearancePlan, AppearanceCatalog, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse, PageAppearancePlan, PageAppearanceRequest } from '@/lib/appearance/planner-types.js';
 import { AppearancePanel } from './AppearancePanel.js';
 import { AuthorTab } from '../ribbon/tabs/AuthorTab.js';
 import { pickViewportAppearanceFace } from './face-mask/viewport-face-picker.js';
@@ -44,6 +44,35 @@ const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 0, -1, 0, 0, -1]);
 const normals = new Float32Array(12).map((_, i) => i % 3 === 1 ? 1 : 0);
 
 interface RasterPixels { width: number; height: number; rgba: Uint8ClampedArray }
+
+function meshSnapshot(parts: readonly MeshData[]) {
+  return parts.map(part => ({
+    expressId: part.expressId, geometryItemId: part.geometryItemId, modelIndex: part.modelIndex, ifcType: part.ifcType,
+    positions: [...part.positions], normals: [...part.normals], indices: [...part.indices], color: [...part.color],
+    shadingColor: part.shadingColor && [...part.shadingColor], uvs: part.uvs && [...part.uvs],
+    texture: part.texture && { width: part.texture.width, height: part.texture.height, rgba: [...part.texture.rgba] },
+    textureRef: part.textureRef && { ...part.textureRef },
+    appearanceSource: part.appearanceSource && { kind: part.appearanceSource.kind,
+      indices: [...part.appearanceSource.indices], sourceIndices: [...part.appearanceSource.sourceIndices],
+      cornerIndices: part.appearanceSource.cornerIndices && [...part.appearanceSource.cornerIndices] },
+  }));
+}
+
+function assertCanonicalFragments(parts: readonly MeshData[], expected: readonly (readonly number[])[], message: string): void {
+  const canonicalIndices = parts[0]?.appearanceSource?.sourceIndices;
+  assert.ok(canonicalIndices && canonicalIndices.length === indices.length, `${message}: the complete canonical item is retained`);
+  const actual = parts.map(part => {
+    const source = part.appearanceSource;
+    assert.ok(source?.cornerIndices, `${message}: each fragment retains canonical corners`);
+    assert.deepEqual([...source.sourceIndices], [...canonicalIndices], `${message}: every fragment names the same canonical item index buffer`);
+    const corners = [...source.cornerIndices];
+    assert.equal(corners.length, part.indices.length, `${message}: every rendered corner has canonical provenance`);
+    return corners;
+  }).sort((a, b) => a[0] - b[0]);
+  assert.deepEqual(actual, expected, message);
+  assert.deepEqual(actual.map(corners => corners[0] / 3), expected.map(corners => corners[0] / 3),
+    `${message}: canonical source triangle ordinals remain stable`);
+}
 
 function requireRasterPixels(raster: RasterPixels | undefined): RasterPixels {
   if (!raster) throw new Error('the PDF backend must expose the exact pixels used to encode its page derivative');
@@ -83,7 +112,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
   let instanceScene: ReturnType<typeof appearanceInstanceScene> | undefined;
   const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
   await init({ module_or_path: await readFile(wasmUrl) });
-  const requests: Array<{ request: AppearanceRequest; plan: AppearancePlan; page?: PageAppearanceRequest; rgba?: Uint8Array }> = [];
+  const requests: Array<{ request: AppearanceRequest; plan: AppearancePlan; page?: PageAppearanceRequest; rgba?: Uint8Array; result?: PageAppearancePlan }> = [];
   class NativeWorker implements AppearanceWorker {
     onmessage: ((event: MessageEvent<AppearanceWorkerResponse>) => void) | null = null;
     onerror: ((event: ErrorEvent) => void) | null = null;
@@ -103,7 +132,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
             requests.push({ request: job.request, plan }); response = { type: 'complete', id: job.id, plan };
           } else if (job.type === 'page-plan') {
             const result = await import('@/workers/appearance.worker.js').then(module => module.runPageAppearancePlanning(new Uint8Array(job.source), job.request, job.rgba));
-            requests.push({ request: job.request.appearance, plan: result.plan, page: job.request, rgba: job.rgba.slice() });
+            requests.push({ request: job.request.appearance, plan: result.plan, page: job.request, rgba: job.rgba.slice(), result });
             response = { type: 'page-complete', id: job.id, result };
           } else throw new Error('Unexpected native fixture request');
           this.onmessage?.({ data: response } as MessageEvent<AppearanceWorkerResponse>);
@@ -139,9 +168,9 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       undoStacks: new Map(), redoStacks: new Map(), dirtyModels: new Set(), mutationVersion: 0, collabRoomId: null,
       appearanceSources: [], appearanceDraft: null, selectedEntityId: selection, selectedEntityIds: new Set([selection]) });
     const owner = { kind: 'source' as const, id: 'face-mask-image' };
+    let decodedPdf: RasterPixels | undefined;
     if (pageSource) {
-      let decoded: RasterPixels | undefined;
-      const bytes = controlledPdf(), backend = await pdfBackend(raster => { decoded = raster; });
+      const bytes = controlledPdf(), backend = await pdfBackend(raster => { decodedPdf = raster; });
       const document = await PdfAppearanceSource.open(new File([bytes], 'Controlled plan.pdf', { type: 'application/pdf' }), appearanceAssets, {
         worker: { run: (source, job, options) => runPdfJob(backend, source, job, options), cancel() {}, dispose() {} },
       });
@@ -151,7 +180,8 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       assert.ok(raster.recipe.pixelWidth > 1 && raster.recipe.pixelWidth <= 256
         && raster.recipe.pixelHeight > 1 && raster.recipe.pixelHeight <= 256 && pagePng.length > 100,
       'real PDF.js decoded a bounded page derivative');
-      const rasterPixels = requireRasterPixels(decoded);
+      const rasterPixels = requireRasterPixels(decodedPdf);
+      decodedPdf = rasterPixels;
       const published = publishPdfRaster(pdfKey, raster);
       useViewerStore.getState().updateAppearanceSource({ ...published,
         calibration: { sourcePoints: [[10, 20], [110, 20]], distanceMetres: 1 } });
@@ -183,7 +213,7 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const readParts = (id: number) => instanceScene
       ? activePreview.getParts?.({ expressId: id, modelIndex: 0 }) ?? instanceScene.scene.getInstancedMeshDataPieces(id)
       : resident.get(id);
-    const siblingBefore = readParts(globalId(35))!;
+    const siblingBefore = meshSnapshot(readParts(globalId(35))!);
     const renderer = { getAppearancePreview: () => activePreview,
       getScene: () => instanceScene?.scene ?? { getMeshDataPieces: (id: number) => resident.get(id) }, requestRender() {},
       getGPUDevice: () => instanceScene?.device, getPipeline: () => instanceScene?.pipeline, getCanvas: () => null, clearCaches() {},
@@ -209,6 +239,8 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const wholeTextured = globalId(whole.plan.conversions![0].geometryItemId);
     assert.deepEqual(ids(selection), pageSource ? [wholeTextured, wholeTextured] : [wholeTextured],
       'a whole-surface conversion textures every resident fragment without changing its partition');
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'the initial whole-surface preview preserves both stream fragments');
 
     // Select one of the two faces: the plan carries the mask, the preview splits.
     await act(async () => button('Select faces').click());
@@ -232,6 +264,12 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
       assert.ok(masked.page && masked.rgba, 'the selected faces reached the native page compositor');
       assert.equal(masked.page.appearance.repeatS, false); assert.equal(masked.page.appearance.repeatT, false);
       assert.equal(masked.page.page.width * masked.page.page.height * 4, masked.rgba.length);
+      assert.deepEqual([...masked.rgba], [...requireRasterPixels(decodedPdf).rgba],
+        'native page planning receives the exact RGBA decoded by PDF.js');
+      assert.deepEqual(masked.page.appearance.mapping, { kind: 'planar', frame: 'world', origin: [1, 0, 0],
+        axisU: [0, 0, 1], axisV: [-1, -0, -0], metresPerTile: [0.72, 1] },
+      'the known 100-unit PDF landmark span calibrates to exactly one metre');
+      assert.equal(masked.page.texelsPerMetre, 50);
       const staleFingerprint = `${whole.plan.conversions![0].surfaceFingerprint![0] === '0' ? '1' : '0'}${whole.plan.conversions![0].surfaceFingerprint!.slice(1)}`;
       const stale = await import('@/workers/appearance.worker.js').then(module => module.runPageAppearancePlanning(source, {
         ...masked.page!, appearance: { ...masked.page!.appearance,
@@ -252,9 +290,16 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     assert.ok(texturedPart?.uvs && (texturedPart.textureRef || texturedPart.texture));
     assert.equal(retainedPart?.uvs, undefined);
     assert.deepEqual(retainedPart && [...retainedPart.color], [0.8, 0.2, 0.1, 1], 'the retained part keeps the source colour');
-    if (pageSource) assert.equal(texturedPart?.textureRef?.repeatS, false, 'finite PDF pages clamp instead of tile');
+    if (pageSource) {
+      assert.equal(texturedPart?.textureRef?.repeatS, false, 'finite PDF pages clamp instead of tile');
+      assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+        'the masked preview preserves canonical source triangles across its textured/retained split');
+      assertCanonicalFragments([texturedPart!], [[3, 4, 5]], 'the picked face keeps canonical source ordinal 1');
+      assertCanonicalFragments([retainedPart!], [[0, 1, 2]], 'the unpicked face keeps canonical source ordinal 0');
+    }
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
-    assert.deepEqual(readParts(globalId(35))!, siblingBefore);
+    assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,
+      'preview leaves the sibling identity, geometry bytes, and style unchanged');
     assert.equal(view.getNewEntities().length, 0, 'preview publishes no IFC conversion');
 
     // Leaving the evaluated policy keeps the selection dormant: no mask enters a
@@ -276,13 +321,19 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
     await act(async () => button('Compare original').click());
     assert.deepEqual(ids(selection), originalIds);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'Compare restores both original canonical fragments');
     await act(async () => button('Show preview').click());
     assert.deepEqual(splitIds(), expectedSplitIds);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'Show preview restores the canonical masked split');
 
     // Discard restores the single original part and keeps the selection for the next preview.
     await act(async () => button('Discard').click());
     await until(() => (ui.textContent ?? '').includes('Preview discarded'));
     assert.deepEqual(ids(selection), originalIds);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'Discard restores both original canonical fragments');
     const mappingInput = pageSource
       ? ui.querySelector<HTMLInputElement>('input[aria-label="Distance A–B (m)"]')
       : ui.querySelector<HTMLInputElement>('input[aria-label="Tile width (m)"]') ?? [...ui.querySelectorAll('label')].find(label => label.textContent?.includes('Tile width'))?.querySelector('input');
@@ -293,6 +344,15 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const again = requests.at(-1)!;
     assert.deepEqual(again.request.faceMasks?.[0].triangles, [1], 'the selection survives Discard');
     assert.deepEqual(splitIds(), expectedSplitIds);
+    if (pageSource) {
+      assert.ok(again.page && again.result);
+      assert.deepEqual(again.page.appearance.mapping, { kind: 'planar', frame: 'world', origin: [2, 0, 0],
+        axisU: [0, 0, 1], axisV: [-1, -0, -0], metresPerTile: [1.44, 2] },
+      'doubling the measured distance deterministically doubles the calibrated page scale');
+      assert.equal(again.page.texelsPerMetre, 25, 'doubling page scale halves the raster density');
+      assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+        'the re-preview keeps canonical provenance after calibration changes');
+    }
 
     // Apply: one history step, two face sets in the IFC, the sibling untouched, selection intact.
     await act(async () => button('Apply').click());
@@ -302,7 +362,10 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     const applied = useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.filter(mesh => mesh.expressId === selection);
     assert.deepEqual(partIds(applied).sort((a, b) => a - b), expectedSplitIds,
       'the model geometry carries both parts of the product');
-    assert.deepEqual(readParts(globalId(35))!, siblingBefore);
+    if (pageSource) assertCanonicalFragments(applied, [[0, 1, 2], [3, 4, 5]],
+      'Apply commits the same canonical source ordinals');
+    assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,
+      'Apply leaves the sibling identity, geometry bytes, and style unchanged');
     assert.doesNotMatch(ui.textContent ?? '', /faces selected/, 'the applied selection is spent');
     const faceSets = view.getNewEntities().filter(entity => entity.type === 'IfcTriangulatedFaceSet').map(entity => entity.expressId);
     assert.deepEqual(faceSets, [conversion.geometryItemId, conversion.retainedGeometryItemId]);
@@ -312,10 +375,25 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     assert.match(text, new RegExp(`#23=IFCSHAPEREPRESENTATION\\(#2,'Body','Tessellation',\\(#${faceSets[0]},#${faceSets[1]}\\)\\)`), 'the occurrence Body lists both face sets');
     assert.match(text, /#33=IFCSHAPEREPRESENTATION\(#2,'Body','MappedRepresentation',\(#22\)\)/, 'the sibling keeps its mapped Body');
     assert.equal((text.match(/IFCTRIANGULATEDFACESET\(/g) ?? []).length, 3, 'source quad plus textured and retained face sets');
+    const registered = modelAppearanceAssets.exportResources('evaluated').resources;
+    assert.equal(registered.size, 1, 'the applied command registers exactly one baked image');
+    const expectedAsset = pageSource ? again.result?.assets[0] : undefined;
+    if (pageSource) {
+      assert.ok(expectedAsset && again.result?.assets.length === 1, 'native page planning bakes exactly one selected-face image');
+      assert.deepEqual(again.result.itemImages, [{ geometryItemId: again.plan.conversions![0].geometryItemId,
+        imageUri: expectedAsset.imageUri }], 'the sole native image is owned by the selected-face geometry item');
+      assert.equal(registered.has(expectedAsset.imageUri), true, 'the registered resource retains the native image identity');
+      assert.deepEqual(registered.get(expectedAsset.imageUri), expectedAsset.png,
+        'the registered resource retains the exact native PNG bytes');
+    }
     const archive = await unwrapIfcZipWithResources(new Uint8Array((await packagePortableIfcAsync('evaluated', text, serialized.resources)).content as Uint8Array).buffer);
+    assert.equal(archive.originalResources.size, 1, 'the IFCZIP contains exactly one image resource');
     const derivative = [...archive.originalResources.values()][0];
     const derivativeUri = [...archive.originalResources.keys()][0];
-    if (pageSource) assert.ok(derivative && derivative.length > 100, 'the portable archive carries the PDF page derivative');
+    if (pageSource) {
+      assert.equal(derivativeUri, expectedAsset!.imageUri, 'the archive keeps the native baked resource identity');
+      assert.deepEqual(derivative, expectedAsset!.png, 'the archive keeps the exact registered native PNG bytes');
+    }
     else assert.deepEqual(derivative, png);
     const reopened = await new IfcParser().parseColumnar(archive.model, { disableWorkerScan: true });
     assert.equal(reopened.entities.getGlobalId(25), '0Proxy000000000000000a');
@@ -341,11 +419,16 @@ for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as co
     await act(async () => { const undo = ui.querySelector<HTMLButtonElement>('button[aria-label="Undo"]'); assert.ok(undo && !undo.disabled); undo.click(); });
     assert.equal(view.getNewEntities().length, 0);
     assert.deepEqual(ids(selection), originalIds);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'Undo restores the original canonical fragments');
     if (instanced) assert.equal(useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.length, 0);
     await act(async () => { const redo = ui.querySelector<HTMLButtonElement>('button[aria-label="Redo"]'); assert.ok(redo && !redo.disabled); redo.click(); });
     assert.deepEqual(splitIds(), expectedSplitIds);
+    if (pageSource) assertCanonicalFragments(readParts(selection)!, [[0, 1, 2], [3, 4, 5]],
+      'Redo restores the canonical masked split');
     assert.equal(view.getNewEntities().filter(entity => entity.type === 'IfcTriangulatedFaceSet').length, 2);
-    assert.deepEqual(readParts(globalId(35))!, siblingBefore);
+    assert.deepEqual(meshSnapshot(readParts(globalId(35))!), siblingBefore,
+      'Redo leaves the sibling identity, geometry bytes, and style unchanged');
   } finally {
     cleanup(); instanceScene?.scene.clear(); setGlobalRendererRef({ current: previousRenderer });
     mock.restoreAll(); HTMLElement.prototype.setPointerCapture = capture;

--- a/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx
@@ -10,8 +10,8 @@ import { StrictMode, act } from 'react';
 import { IfcParser, unwrapIfcZipWithResources } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
-import { federationRegistry, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
-import type { MeshData, GeometryResult } from '@ifc-lite/geometry';
+import { federationRegistry, Raycaster, Renderer as PreviewRenderer, type Renderer } from '@ifc-lite/renderer';
+import { GeometryProcessor, type MeshData, type GeometryResult } from '@ifc-lite/geometry';
 import { AppearancePreviewController } from '../../../../../../packages/renderer/src/appearance-preview.js';
 import { render, cleanup, advance, type } from '@/test/render.js';
 import { AppearanceStreamingHarness } from '@/test/appearance-streaming-harness.js';
@@ -25,8 +25,13 @@ import { getGlobalRenderer, setGlobalRendererRef } from '@/hooks/useBCF';
 import { appearanceAssets, modelAppearanceAssets } from '@/lib/appearance/model-assets.js';
 import { prepareAppearanceSerialization } from '@/lib/appearance/serialization.js';
 import { packagePortableIfcAsync } from '@/lib/export/portable-ifc.js';
+import { PdfAppearanceSource } from '@/lib/appearance/pdf/source-document.js';
+import { registerPdfDocument, removePdfDocument } from '@/lib/appearance/pdf/documents.js';
+import { publishPdfRaster } from '@/lib/appearance/pdf/publish-source.js';
+import { controlledPdf } from '@/lib/appearance/pdf/fixtures.js';
+import { runPdfJob, type PdfEngineBackend, type PdfRasterSurface } from '@/lib/appearance/pdf/engine.js';
 import type { AppearanceWorker } from '@/lib/appearance/planner-worker-client.js';
-import type { AppearancePlan, AppearanceCatalog, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse } from '@/lib/appearance/planner-types.js';
+import type { AppearancePlan, AppearanceCatalog, AppearanceRequest, AppearanceWorkerRequest, AppearanceWorkerResponse, PageAppearanceRequest } from '@/lib/appearance/planner-types.js';
 import { AppearancePanel } from './AppearancePanel.js';
 import { AuthorTab } from '../ribbon/tabs/AuthorTab.js';
 import { pickViewportAppearanceFace } from './face-mask/viewport-face-picker.js';
@@ -38,18 +43,47 @@ const indices = new Uint32Array([0, 1, 2, 0, 2, 3]);
 const positions = new Float32Array([0, 0, 0, 1, 0, 0, 1, 0, -1, 0, 0, -1]);
 const normals = new Float32Array(12).map((_, i) => i % 3 === 1 ? 1 : 0);
 
-for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' : 'resident'} face selection previews a split, survives discard, applies, exports and undoes/redoes (#4404)`, {
+interface RasterPixels { width: number; height: number; rgba: Uint8ClampedArray }
+
+function requireRasterPixels(raster: RasterPixels | undefined): RasterPixels {
+  if (!raster) throw new Error('the PDF backend must expose the exact pixels used to encode its page derivative');
+  return raster;
+}
+
+async function pdfBackend(onRaster: (raster: RasterPixels) => void): Promise<PdfEngineBackend> {
+  const pdf = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  type NativeCanvas = HTMLCanvasElement & { toBuffer(type: string): Uint8Array };
+  type Target = { canvas: NativeCanvas; context: CanvasRenderingContext2D };
+  let factory: { create(width: number, height: number): Target; destroy(target: Target): void };
+  return { getDocument(options) {
+    const task = pdf.getDocument(options);
+    void task.promise.then(document => { factory = document.canvasFactory as typeof factory; }, () => {});
+    return task;
+  }, options: { disableFontFace: true, useSystemFonts: false },
+  surface(width, height): PdfRasterSurface {
+    const target = factory.create(width, height);
+    return { ...target, async png() {
+      onRaster({ width, height, rgba: new Uint8ClampedArray(target.context.getImageData(0, 0, width, height).data) });
+      return new Uint8Array(target.canvas.toBuffer('image/png'));
+    }, dispose() { factory.destroy(target); } };
+  } };
+}
+
+for (const mode of ['resident-image', 'instanced-image', 'fragmented-pdf'] as const) test(`mounted ${mode} face selection previews a split, survives discard, applies, exports and undoes/redoes (#4404, #4557)`, {
   skip: !existsSync(wasmUrl) && 'Run pnpm build:wasm for the native appearance contract',
 }, async () => {
+  const instanced = mode === 'instanced-image', pageSource = mode === 'fragmented-pdf';
   const initial = useViewerStore.getState(), previousRenderer = getGlobalRenderer();
   modelIndices(new Map());
   const workerDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'Worker');
   const oldDecode = globalThis.createImageBitmap;
   const capture = HTMLElement.prototype.setPointerCapture;
+  const canvasDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'OffscreenCanvas');
+  let pdfKey: string | undefined;
   let instanceScene: ReturnType<typeof appearanceInstanceScene> | undefined;
   const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
   await init({ module_or_path: await readFile(wasmUrl) });
-  const requests: { request: AppearanceRequest; plan: AppearancePlan }[] = [];
+  const requests: Array<{ request: AppearanceRequest; plan: AppearancePlan; page?: PageAppearanceRequest; rgba?: Uint8Array }> = [];
   class NativeWorker implements AppearanceWorker {
     onmessage: ((event: MessageEvent<AppearanceWorkerResponse>) => void) | null = null;
     onerror: ((event: ErrorEvent) => void) | null = null;
@@ -57,7 +91,7 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     stopped = false;
     terminate() { this.stopped = true; }
     postMessage(job: AppearanceWorkerRequest) {
-      queueMicrotask(() => {
+      queueMicrotask(async () => {
         if (this.stopped) return;
         const api = new IfcAPI();
         try {
@@ -67,6 +101,10 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
           else if (job.type === 'plan') {
             const plan = JSON.parse(new TextDecoder().decode(api.planAppearance(new Uint8Array(job.source), JSON.stringify(job.request)))) as AppearancePlan;
             requests.push({ request: job.request, plan }); response = { type: 'complete', id: job.id, plan };
+          } else if (job.type === 'page-plan') {
+            const result = await import('@/workers/appearance.worker.js').then(module => module.runPageAppearancePlanning(new Uint8Array(job.source), job.request, job.rgba));
+            requests.push({ request: job.request.appearance, plan: result.plan, page: job.request, rgba: job.rgba.slice() });
+            response = { type: 'page-complete', id: job.id, result };
           } else throw new Error('Unexpected native fixture request');
           this.onmessage?.({ data: response } as MessageEvent<AppearanceWorkerResponse>);
         } catch (error) { this.onerror?.({ message: String(error) } as ErrorEvent); }
@@ -83,7 +121,13 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     const makeMesh = (id: number): MeshData => ({ expressId: globalId(id), geometryItemId: globalId(11), modelIndex: 0, positions, normals, indices,
       color: [0.8, 0.2, 0.1, 1], appearanceSource: { kind: 'canonical-item', indices, sourceIndices: indices } });
     const originals = [makeMesh(25), makeMesh(35)];
-    const resident = new Map(originals.map(mesh => [mesh.expressId, [mesh] as readonly MeshData[]]));
+    const fragment = (mesh: MeshData, from: number): MeshData => {
+      const part = mesh.indices.slice(from, from + 3);
+      return { ...mesh, indices: part, appearanceSource: { kind: 'canonical-item', indices: part,
+        sourceIndices: mesh.indices, cornerIndices: Uint32Array.from([from, from + 1, from + 2]) } };
+    };
+    const resident = new Map<number, MeshData[]>(originals.map(mesh => [mesh.expressId,
+      pageSource && mesh.expressId === globalId(25) ? [fragment(mesh, 0), fragment(mesh, 3)] : [mesh]]));
     const bounds = { min: { x: 0, y: 0, z: -1 }, max: { x: 1, y: 0, z: 0 } };
     const geometry: GeometryResult = { meshes: instanced ? [] : originals, totalTriangles: instanced ? 0 : 4, totalVertices: instanced ? 0 : 8,
       ...(instanced ? { instancedGeometryAabbs: new Map(originals.map(mesh => [mesh.expressId, { min: [0, 0, -1] as [number, number, number], max: [1, 0, 0] as [number, number, number] }])) } : {}),
@@ -95,8 +139,30 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
       undoStacks: new Map(), redoStacks: new Map(), dirtyModels: new Set(), mutationVersion: 0, collabRoomId: null,
       appearanceSources: [], appearanceDraft: null, selectedEntityId: selection, selectedEntityIds: new Set([selection]) });
     const owner = { kind: 'source' as const, id: 'face-mask-image' };
-    const asset = await appearanceAssets.add(png, { owner });
-    useViewerStore.getState().addAppearanceSource({ id: asset.id, name: 'Texture', width: 1, height: 1 });
+    if (pageSource) {
+      let decoded: RasterPixels | undefined;
+      const bytes = controlledPdf(), backend = await pdfBackend(raster => { decoded = raster; });
+      const document = await PdfAppearanceSource.open(new File([bytes], 'Controlled plan.pdf', { type: 'application/pdf' }), appearanceAssets, {
+        worker: { run: (source, job, options) => runPdfJob(backend, source, job, options), cancel() {}, dispose() {} },
+      });
+      pdfKey = registerPdfDocument(document);
+      const raster = await document.rasterize({ pageNumber: 1, dpi: 18 });
+      const pagePng = appearanceAssets.encoded(raster.asset.id);
+      assert.ok(raster.recipe.pixelWidth > 1 && raster.recipe.pixelWidth <= 256
+        && raster.recipe.pixelHeight > 1 && raster.recipe.pixelHeight <= 256 && pagePng.length > 100,
+      'real PDF.js decoded a bounded page derivative');
+      const rasterPixels = requireRasterPixels(decoded);
+      const published = publishPdfRaster(pdfKey, raster);
+      useViewerStore.getState().updateAppearanceSource({ ...published,
+        calibration: { sourcePoints: [[10, 20], [110, 20]], distanceMetres: 1 } });
+      Object.defineProperty(globalThis, 'OffscreenCanvas', { configurable: true, value: class {
+        constructor(readonly width: number, readonly height: number) { assert.equal(width, rasterPixels.width); assert.equal(height, rasterPixels.height); }
+        getContext() { return { drawImage() {}, getImageData: () => ({ data: rasterPixels.rgba }) }; }
+      } });
+    } else {
+      const asset = await appearanceAssets.add(png, { owner });
+      useViewerStore.getState().addAppearanceSource({ id: asset.id, name: 'Texture', width: 1, height: 1 });
+    }
     globalThis.createImageBitmap = async (blob: ImageBitmapSource) => {
       assert.ok(blob instanceof Blob); const bytes = new DataView(await blob.arrayBuffer());
       return { width: bytes.getUint32(16), height: bytes.getUint32(20), close() {} } as ImageBitmap;
@@ -110,7 +176,7 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     mock.method(PreviewRenderer.prototype, 'fitToView', () => {});
     HTMLElement.prototype.setPointerCapture = () => {};
     const gpu = new AppearancePreviewController<number>({ capture: owner => ({ parts: resident.get(owner.expressId)!, resources: [] }),
-      stage: () => [], install: (owner, parts) => { resident.set(owner.expressId, parts); }, release() {} });
+      stage: () => [], install: (owner, parts) => { resident.set(owner.expressId, [...parts]); }, release() {} });
     // Instanced shards take their template in IFC Z-up; the scene converts.
     if (instanced) instanceScene = appearanceInstanceScene(originals, { positions: new Float32Array([0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0]), normals: new Float32Array(12).map((_, i) => i % 3 === 2 ? 1 : 0), indices });
     const activePreview = instanceScene?.preview ?? gpu;
@@ -126,7 +192,12 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     const ui = render(<StrictMode>{instanced && <AppearanceStreamingHarness renderer={renderer} />}<AppearancePanel /><AuthorTab /></StrictMode>);
     const until = async (predicate: () => boolean) => { for (let i = 0; i < 200 && !predicate(); i++) await advance(10); assert.ok(predicate(), ui.textContent ?? 'UI stalled'); };
     const button = (name: string) => [...ui.querySelectorAll('button')].find(item => item.textContent?.trim() === name)!;
-    const ids = (id: number) => readParts(id)!.map(part => part.geometryItemId);
+    const partIds = (parts: readonly MeshData[]) => parts.map(part => {
+      if (part.geometryItemId === undefined) assert.fail('every appearance part must retain its geometry item identity');
+      return part.geometryItemId;
+    });
+    const ids = (id: number) => partIds(readParts(id)!);
+    const originalIds = pageSource ? [globalId(11), globalId(11)] : [globalId(11)];
     await until(() => requests.length > 0);
     const consent = ui.querySelector<HTMLInputElement>('input[type=checkbox]'); assert.ok(consent);
     await act(async () => consent.click());
@@ -135,7 +206,9 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     assert.equal(whole.request.faceMasks, undefined);
     assert.equal(whole.plan.conversions?.length, 1); assert.equal(whole.plan.conversions![0].sourceIndices.length, 6);
     assert.match(ui.textContent ?? '', /all 2 faces/);
-    assert.deepEqual(ids(selection), [globalId(whole.plan.conversions![0].geometryItemId)], 'a whole-surface conversion previews as one textured part');
+    const wholeTextured = globalId(whole.plan.conversions![0].geometryItemId);
+    assert.deepEqual(ids(selection), pageSource ? [wholeTextured, wholeTextured] : [wholeTextured],
+      'a whole-surface conversion textures every resident fragment without changing its partition');
 
     // Select one of the two faces: the plan carries the mask, the preview splits.
     await act(async () => button('Select faces').click());
@@ -153,13 +226,33 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     assert.deepEqual(masked.request.faceMasks, [{ productId: 25, surfaceFingerprint: whole.plan.conversions![0].surfaceFingerprint, triangles: [1] }]);
     assert.deepEqual(masked.plan.exclusions, []);
     const conversion = masked.plan.conversions![0];
+    assert.equal(conversion.surfaceFingerprint, whole.plan.conversions![0].surfaceFingerprint);
     assert.deepEqual(conversion.maskedTriangles, [1]);
-    const textured = globalId(conversion.geometryItemId), retained = globalId(conversion.retainedGeometryItemId!);
-    assert.deepEqual(ids(selection), [textured, retained], 'the masked preview stages the textured and the retained face set under one owner');
-    assert.equal(readParts(selection)![0].indices.length, 3); assert.equal(readParts(selection)![1].indices.length, 3);
-    assert.ok(readParts(selection)![0].uvs && (readParts(selection)![0].textureRef || readParts(selection)![0].texture));
-    assert.equal(readParts(selection)![1].uvs, undefined);
-    assert.deepEqual([...readParts(selection)![1].color], [0.8, 0.2, 0.1, 1], 'the retained part keeps the source colour');
+    if (pageSource) {
+      assert.ok(masked.page && masked.rgba, 'the selected faces reached the native page compositor');
+      assert.equal(masked.page.appearance.repeatS, false); assert.equal(masked.page.appearance.repeatT, false);
+      assert.equal(masked.page.page.width * masked.page.page.height * 4, masked.rgba.length);
+      const staleFingerprint = `${whole.plan.conversions![0].surfaceFingerprint![0] === '0' ? '1' : '0'}${whole.plan.conversions![0].surfaceFingerprint!.slice(1)}`;
+      const stale = await import('@/workers/appearance.worker.js').then(module => module.runPageAppearancePlanning(source, {
+        ...masked.page!, appearance: { ...masked.page!.appearance,
+          faceMasks: [{ ...masked.page!.appearance.faceMasks![0], surfaceFingerprint: staleFingerprint }] },
+      }, masked.rgba!));
+      assert.equal(stale.plan.items.length, 0); assert.match(stale.plan.exclusions[0].reason, /Face selection is stale:.*geometry changed/);
+      await assert.rejects(import('@/workers/appearance.worker.js').then(module => module.runPageAppearancePlanning(source,
+        { ...masked.page!, texelsPerMetre: 1e9 }, masked.rgba!)), /budget/);
+    }
+    assert.ok(conversion.geometryItemId !== undefined && conversion.retainedGeometryItemId !== undefined);
+    const textured = globalId(conversion.geometryItemId), retained = globalId(conversion.retainedGeometryItemId);
+    const expectedSplitIds = [textured, retained].sort((a, b) => a - b);
+    const splitIds = () => ids(selection).sort((a, b) => a - b);
+    assert.deepEqual(splitIds(), expectedSplitIds, 'the masked preview stages the textured and the retained face set under one owner');
+    const texturedPart = readParts(selection)!.find(part => part.geometryItemId === textured);
+    const retainedPart = readParts(selection)!.find(part => part.geometryItemId === retained);
+    assert.equal(texturedPart?.indices.length, 3); assert.equal(retainedPart?.indices.length, 3);
+    assert.ok(texturedPart?.uvs && (texturedPart.textureRef || texturedPart.texture));
+    assert.equal(retainedPart?.uvs, undefined);
+    assert.deepEqual(retainedPart && [...retainedPart.color], [0.8, 0.2, 0.1, 1], 'the retained part keeps the source colour');
+    if (pageSource) assert.equal(texturedPart?.textureRef?.repeatS, false, 'finite PDF pages clamp instead of tile');
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
     assert.deepEqual(readParts(globalId(35))!, siblingBefore);
     assert.equal(view.getNewEntities().length, 0, 'preview publishes no IFC conversion');
@@ -179,33 +272,36 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     await act(async () => consent.click());
     await until(() => requests.length > beforePolicy + 1 && requests.at(-1)!.request.faceMasks !== undefined && (ui.textContent ?? '').includes('Preview ready'));
     assert.deepEqual(requests.at(-1)!.request.faceMasks?.[0].triangles, [1], 'the dormant selection returns with the evaluated policy');
-    assert.deepEqual(ids(selection), [textured, retained]);
+    assert.deepEqual(splitIds(), expectedSplitIds);
     assert.match(ui.textContent ?? '', /1 of 2 faces selected/);
     await act(async () => button('Compare original').click());
-    assert.deepEqual(ids(selection), [globalId(11)]);
+    assert.deepEqual(ids(selection), originalIds);
     await act(async () => button('Show preview').click());
-    assert.deepEqual(ids(selection), [textured, retained]);
+    assert.deepEqual(splitIds(), expectedSplitIds);
 
     // Discard restores the single original part and keeps the selection for the next preview.
     await act(async () => button('Discard').click());
     await until(() => (ui.textContent ?? '').includes('Preview discarded'));
-    assert.deepEqual(ids(selection), [globalId(11)]);
-    const tile = ui.querySelector<HTMLInputElement>('input[aria-label="Tile width (m)"]') ?? [...ui.querySelectorAll('label')].find(label => label.textContent?.includes('Tile width'))?.querySelector('input');
-    assert.ok(tile, 'a mapping field re-enables the preview');
+    assert.deepEqual(ids(selection), originalIds);
+    const mappingInput = pageSource
+      ? ui.querySelector<HTMLInputElement>('input[aria-label="Distance A–B (m)"]')
+      : ui.querySelector<HTMLInputElement>('input[aria-label="Tile width (m)"]') ?? [...ui.querySelectorAll('label')].find(label => label.textContent?.includes('Tile width'))?.querySelector('input');
+    assert.ok(mappingInput, 'a mapping field re-enables the preview');
     const planned = requests.length;
-    type(tile, '2');
+    type(mappingInput, '2');
     await until(() => requests.length > planned && !!button('Apply') && !button('Apply').disabled);
     const again = requests.at(-1)!;
     assert.deepEqual(again.request.faceMasks?.[0].triangles, [1], 'the selection survives Discard');
-    assert.deepEqual(ids(selection), [textured, retained]);
+    assert.deepEqual(splitIds(), expectedSplitIds);
 
     // Apply: one history step, two face sets in the IFC, the sibling untouched, selection intact.
     await act(async () => button('Apply').click());
     await until(() => (useViewerStore.getState().undoStacks.get('evaluated')?.length ?? 0) === 1);
     assert.equal(useViewerStore.getState().selectedEntityId, selection);
-    assert.deepEqual(ids(selection), [textured, retained]);
+    assert.deepEqual(splitIds(), expectedSplitIds);
     const applied = useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.filter(mesh => mesh.expressId === selection);
-    assert.deepEqual(applied.map(mesh => mesh.geometryItemId), [textured, retained], 'the model geometry carries both parts of the product');
+    assert.deepEqual(partIds(applied).sort((a, b) => a - b), expectedSplitIds,
+      'the model geometry carries both parts of the product');
     assert.deepEqual(readParts(globalId(35))!, siblingBefore);
     assert.doesNotMatch(ui.textContent ?? '', /faces selected/, 'the applied selection is spent');
     const faceSets = view.getNewEntities().filter(entity => entity.type === 'IfcTriangulatedFaceSet').map(entity => entity.expressId);
@@ -217,18 +313,37 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     assert.match(text, /#33=IFCSHAPEREPRESENTATION\(#2,'Body','MappedRepresentation',\(#22\)\)/, 'the sibling keeps its mapped Body');
     assert.equal((text.match(/IFCTRIANGULATEDFACESET\(/g) ?? []).length, 3, 'source quad plus textured and retained face sets');
     const archive = await unwrapIfcZipWithResources(new Uint8Array((await packagePortableIfcAsync('evaluated', text, serialized.resources)).content as Uint8Array).buffer);
-    assert.deepEqual([...archive.originalResources.values()][0], png, 'the portable archive carries the image');
+    const derivative = [...archive.originalResources.values()][0];
+    const derivativeUri = [...archive.originalResources.keys()][0];
+    if (pageSource) assert.ok(derivative && derivative.length > 100, 'the portable archive carries the PDF page derivative');
+    else assert.deepEqual(derivative, png);
     const reopened = await new IfcParser().parseColumnar(archive.model, { disableWorkerScan: true });
     assert.equal(reopened.entities.getGlobalId(25), '0Proxy000000000000000a');
     assert.ok(reopened.entityIndex.byId.has(faceSets[0]) && reopened.entityIndex.byId.has(faceSets[1]));
+    if (pageSource) {
+      const processor = new GeometryProcessor();
+      try {
+        await processor.init();
+        const meshes = (await processor.process(new Uint8Array(archive.model))).meshes.filter(mesh => mesh.expressId === 25);
+        const texturedMesh = meshes.find(mesh => mesh.geometryItemId === conversion.geometryItemId);
+        const retainedMesh = meshes.find(mesh => mesh.geometryItemId === conversion.retainedGeometryItemId);
+        assert.ok(texturedMesh?.uvs && texturedMesh.textureRef?.url === derivativeUri,
+          'reopen preserves the selected-face UV/image association and selectable product identity');
+        assert.equal(texturedMesh.textureRef.repeatS, false); assert.equal(texturedMesh.textureRef.repeatT, false);
+        assert.equal(texturedMesh.expressId, 25); assert.equal(retainedMesh?.expressId, 25);
+        assert.equal(retainedMesh?.textureRef, undefined); assert.ok(retainedMesh);
+        [0.8, 0.2, 0.1, 1].forEach((expected, index) => assert.ok(Math.abs(retainedMesh.color[index] - expected) <= 1 / 255,
+          'the retained face keeps the original style through IFC colour quantization'));
+      } finally { processor.dispose(); }
+    }
 
     // Undo joins the parts back into the original; Redo splits them again.
     await act(async () => { const undo = ui.querySelector<HTMLButtonElement>('button[aria-label="Undo"]'); assert.ok(undo && !undo.disabled); undo.click(); });
     assert.equal(view.getNewEntities().length, 0);
-    assert.deepEqual(ids(selection), [globalId(11)]);
+    assert.deepEqual(ids(selection), originalIds);
     if (instanced) assert.equal(useViewerStore.getState().models.get('evaluated')!.geometryResult!.meshes.length, 0);
     await act(async () => { const redo = ui.querySelector<HTMLButtonElement>('button[aria-label="Redo"]'); assert.ok(redo && !redo.disabled); redo.click(); });
-    assert.deepEqual(ids(selection), [textured, retained]);
+    assert.deepEqual(splitIds(), expectedSplitIds);
     assert.equal(view.getNewEntities().filter(entity => entity.type === 'IfcTriangulatedFaceSet').length, 2);
     assert.deepEqual(readParts(globalId(35))!, siblingBefore);
   } finally {
@@ -236,6 +351,8 @@ for (const instanced of [false, true]) test(`mounted ${instanced ? 'instanced' :
     mock.restoreAll(); HTMLElement.prototype.setPointerCapture = capture;
     if (workerDescriptor) Object.defineProperty(globalThis, 'Worker', workerDescriptor); else Reflect.deleteProperty(globalThis, 'Worker');
     globalThis.createImageBitmap = oldDecode;
+    if (canvasDescriptor) Object.defineProperty(globalThis, 'OffscreenCanvas', canvasDescriptor); else Reflect.deleteProperty(globalThis, 'OffscreenCanvas');
+    if (pdfKey) removePdfDocument(pdfKey);
     useViewerStore.getState().clearAllMutations(); modelAppearanceAssets.clear(); appearanceAssets.clear(); federationRegistry.clear();
     useViewerStore.setState(initial);
     modelIndices(new Map());

--- a/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
+++ b/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
@@ -135,7 +135,7 @@ remesh. The planar member reopens 1:1.
   deliberately resident in two stream fragments. The test proves the complete
   fingerprint plus `maskedTriangles`, finite-page clamp, textured and retained
   preview fragments, stale-fingerprint and excessive-memory refusal, IFCZIP
-  derivative transport, and reopened selectable product ownership with the
+  derivative transport, and reopened product ownership with the
   selected-face UV/image association and retained original style.
 - `apps/viewer/src/lib/appearance/face-mask-reopen-wasm.test.ts`: the AC20
   member's masked export (6 of 12) reopened through the loader's parser and

--- a/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
+++ b/docs/architecture/evidence/evaluated-occurrences/face-mask-ui/README.md
@@ -128,7 +128,15 @@ remesh. The planar member reopens 1:1.
   re-plan), preview the split, turn the evaluated policy off (the request
   carries no mask, the policy's own exclusion shows) and on again (the
   selection returns), Compare, Discard, preview again, Apply, export with the
-  image, reopen, Undo, Redo; the sibling occurrence unchanged.
+  image, reopen, Undo, Redo; the sibling occurrence unchanged. Its #4557 mode
+  rasterizes page 1 of the CC0 controlled PDF through PDF.js at a bounded 18
+  dpi, calibrates a measured source span, and sends the actual page pixels and
+  one-of-two face mask through native page planning. The selected product is
+  deliberately resident in two stream fragments. The test proves the complete
+  fingerprint plus `maskedTriangles`, finite-page clamp, textured and retained
+  preview fragments, stale-fingerprint and excessive-memory refusal, IFCZIP
+  derivative transport, and reopened selectable product ownership with the
+  selected-face UV/image association and retained original style.
 - `apps/viewer/src/lib/appearance/face-mask-reopen-wasm.test.ts`: the AC20
   member's masked export (6 of 12) reopened through the loader's parser and
   wasm geometry pipeline: two items under one product, textured binds the


### PR DESCRIPTION
## What and why

The face-mask journey previously stopped at generated image fixtures, so it did not prove that a real PDF page survives decode, calibration, native masked planning, preview history, portable export, and reopen as one coherent workflow. This adds a mounted three-mode regression whose PDF mode decodes the controlled CC0 document through PDF.js, selects canonical face ordinal 1 through the main viewport picker, and follows the multipart result through Compare, Discard, Apply, Undo, and Redo.

The assertions pin exact PDF RGBA input, 1 m and 2 m calibration mappings, canonical source corners, immutable sibling geometry/style, native baked-image ownership, and exact registered/IFCZIP resource identity and bytes. The evidence guide describes the product ownership actually demonstrated by the test.

Closes #4557

## How it was verified

- Node 22.23.2: `node --import tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 src/components/viewer/appearance/AppearancePanel.faceMask.test.tsx` from `apps/viewer`: 3/3 resident, instanced, and fragmented-PDF journeys passed.
- Node 22.23.2: `pnpm typecheck`: 94/94 tasks passed; all 2,005 test files are in a typecheck program.
- Node 22.23.2: `pnpm lint`: zero errors.
- Node 22.23.2: `pnpm docs:check-samples`: 383 snippets passed; `pnpm docs:check-generated`: all generated regions current.
- `git diff --check origin/main...HEAD` passed.

- [x] Focused TypeScript test and root typecheck pass locally
- [ ] Geometry/WASM change: not applicable; this PR changes tests and documentation only

## Checklist

- [x] The new test exercises a real controlled PDF and native planner; main has no PDF mode in this mounted lifecycle test.
- [x] Published `packages/*` touched: not applicable; no package or public API changes
- [x] Geometry-output change: not applicable
- [x] House rules checked; production module sizes are unchanged
- [x] No client or project identifiers introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded face-mask coverage across resident, instanced-image, and fragmented-PDF workflows.
  * Added validation for PDF rasterization, calibration scaling, geometry integrity, masking, history actions, stale selections, and resource cleanup.
  * Added checks for preserving sibling meshes and maintaining image associations after reopening IFC files.

* **Documentation**
  * Documented fragmented-PDF face-mask validation, page planning, transport, fingerprints, and retained styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->