### PR TITLE
fix(geometry): merge overlapping void footprints, split concave quads across an interior diagonal, and orient shells about their own centre

### DIFF
--- a/rust/geometry/src/bool2d.rs
+++ b/rust/geometry/src/bool2d.rs
@@ -30,7 +30,7 @@ const MIN_AREA_THRESHOLD: f64 = 1e-10;
 ///
 /// # Arguments
 /// * `profile` - The base profile to subtract from
-/// * `void_contour` - The void footprint to subtract (should be counter-clockwise)
+/// * `void_contour` - The void footprint to subtract (any winding; normalised CCW)
 ///
 /// # Returns
 /// * `Ok(Profile2D)` - The resulting profile with the void subtracted
@@ -52,12 +52,11 @@ pub fn subtract_2d(profile: &Profile2D, void_contour: &[Point2<f64>]) -> Result<
     // Subject is the profile (outer boundary + holes)
     let subject = profile_to_paths(profile);
 
-    // Clip is the void contour
-    let clip = vec![contour_to_path(void_contour)];
+    let clip = ccw_paths([void_contour]);
 
     // Perform boolean difference using i_overlay
     // Result is Vec<Vec<Vec<[f64; 2]>>> - Vec of shapes, each shape is Vec of contours
-    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::NonZero);
 
     // Convert result back to Profile2D (take first shape if multiple)
     shapes_to_profile(&result)
@@ -78,28 +77,7 @@ pub fn subtract_multiple_2d(
     profile: &Profile2D,
     void_contours: &[Vec<Point2<f64>>],
 ) -> Result<Profile2D> {
-    if void_contours.is_empty() {
-        return Ok(profile.clone());
-    }
-
-    // Filter out invalid contours
-    let valid_contours: Vec<_> = void_contours.iter().filter(|c| c.len() >= 3).collect();
-
-    if valid_contours.is_empty() {
-        return Ok(profile.clone());
-    }
-
-    // Convert profile to i_overlay format
-    let subject = profile_to_paths(profile);
-
-    // Convert all void contours - union them first if multiple
-    let clip: Vec<Vec<[f64; 2]>> = valid_contours.iter().map(|c| contour_to_path(c)).collect();
-
-    // Perform boolean difference
-    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
-
-    // Convert result back to Profile2D
-    shapes_to_profile(&result)
+    subtract_multiple_2d_counted(profile, void_contours).map(|(profile, _)| profile)
 }
 
 /// Like [`subtract_multiple_2d`], but also reports how many DISCONNECTED output
@@ -117,8 +95,8 @@ pub fn subtract_multiple_2d_counted(
         return Ok((profile.clone(), 1));
     }
     let subject = profile_to_paths(profile);
-    let clip: Vec<Vec<[f64; 2]>> = valid_contours.iter().map(|c| contour_to_path(c)).collect();
-    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    let clip = ccw_paths(valid_contours.iter().map(|c| c.as_slice()));
+    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::NonZero);
     // Count EVERY non-empty output shape (any outer contour with >= 3 vertices),
     // NOT just those above MIN_AREA_THRESHOLD. This gate decides single-vs-multi
     // shape for the caller: only `shapes == 1` lets the re-extrude proceed with the
@@ -142,11 +120,7 @@ pub fn subtract_multiple_2d_counted(
 /// (< 3-vertex or zero-area) contours are dropped; an empty input yields an empty
 /// result. Deterministic f64 → byte-identical native==wasm.
 pub fn union_contours_to_shapes(contours: &[Vec<Point2<f64>>]) -> Vec<Profile2D> {
-    let subject: Vec<Vec<[f64; 2]>> = contours
-        .iter()
-        .filter(|c| c.len() >= 3)
-        .map(|c| contour_to_path(&ensure_ccw(c)))
-        .collect();
+    let subject = ccw_paths(contours.iter().filter(|c| c.len() >= 3).map(Vec::as_slice));
     if subject.is_empty() {
         return Vec::new();
     }
@@ -272,7 +246,8 @@ fn profile_to_paths(profile: &Profile2D) -> Vec<Vec<[f64; 2]>> {
     let outer = ensure_ccw(&profile.outer);
     paths.push(contour_to_path(&outer));
 
-    // Add holes (must be clockwise for i_overlay, but we'll use EvenOdd fill rule)
+    // Add holes clockwise: the opposite winding is what subtracts them under the
+    // `NonZero` fill rule every overlay in this module uses.
     for hole in &profile.holes {
         let hole_cw = ensure_cw(hole);
         paths.push(contour_to_path(&hole_cw));
@@ -284,6 +259,20 @@ fn profile_to_paths(profile: &Profile2D) -> Vec<Vec<[f64; 2]>> {
 /// Convert a Point2 contour to i_overlay path format
 fn contour_to_path(contour: &[Point2<f64>]) -> Vec<[f64; 2]> {
     contour.iter().map(|p| [p.x, p.y]).collect()
+}
+
+/// Every contour handed to an overlay, normalised CCW, in i_overlay's path
+/// form. The ONE home for the winding contract on this module's inputs: under
+/// `NonZero` a CW contour's winding sums against a CCW one's and the overlap
+/// cancels, exactly the phantom-pillar shape `EvenOdd` produced (`1 & 2 == 0`
+/// on a doubly-covered patch), so the fill rule and the normalisation are one
+/// change, not two. Subject and clip alike go through here; `profile_to_paths`
+/// is the exception because a profile's holes are CW by contract.
+fn ccw_paths<'a>(contours: impl IntoIterator<Item = &'a [Point2<f64>]>) -> Vec<Vec<[f64; 2]>> {
+    contours
+        .into_iter()
+        .map(|c| contour_to_path(&ensure_ccw(c)))
+        .collect()
 }
 
 /// Convert i_overlay result shapes back to Profile2D

--- a/rust/geometry/src/bool2d_tests.rs
+++ b/rust/geometry/src/bool2d_tests.rs
@@ -196,9 +196,16 @@ fn test_subtract_counted_subthreshold_sliver_still_multi_shape() {
     // the area-filter blind spot, not merely two above-threshold pieces): the
     // smaller output shape's area is at/below MIN_AREA_THRESHOLD, so the old
     // `area > MIN_AREA_THRESHOLD` count would have undercounted it to shapes == 1.
+    //
+    // NOTE, and this is a known weakness left in place deliberately: re-running the
+    // SAME overlay call the production function ran only measures i_overlay against
+    // itself, so it can say nothing about whether the difference is correct. Its one
+    // job here is to size the two output shapes so the threshold claim above is not
+    // asserted blind. It mirrors production's operands (`ccw_paths` + NonZero)
+    // so it keeps measuring the shapes production actually produced.
     let subject = profile_to_paths(&profile);
-    let clip = vec![contour_to_path(&band)];
-    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::EvenOdd);
+    let clip = ccw_paths([band.as_slice()]);
+    let result = subject.overlay(&clip, OverlayRule::Difference, FillRule::NonZero);
     let mut areas: Vec<f64> = result
         .iter()
         .filter_map(|s| {
@@ -262,4 +269,115 @@ fn test_is_valid_contour() {
     // Too few points
     let too_few = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
     assert!(!is_valid_contour(&too_few));
+}
+
+/// Net material area of a profile: outer minus every hole.
+fn net_area(p: &Profile2D) -> f64 {
+    compute_signed_area(&p.outer).abs()
+        - p.holes
+            .iter()
+            .map(|h| compute_signed_area(h).abs())
+            .sum::<f64>()
+}
+
+/// Two rectangles, `[2,6]^2` and `[4,8]^2`, OVERLAPPING on `[4,6]^2`.
+/// Union area 16 + 16 - 4 = 28; symmetric difference 24.
+fn overlapping_void_pair() -> Vec<Vec<Point2<f64>>> {
+    vec![
+        vec![
+            Point2::new(2.0, 2.0),
+            Point2::new(6.0, 2.0),
+            Point2::new(6.0, 6.0),
+            Point2::new(2.0, 6.0),
+        ],
+        vec![
+            Point2::new(4.0, 4.0),
+            Point2::new(8.0, 4.0),
+            Point2::new(8.0, 8.0),
+            Point2::new(4.0, 8.0),
+        ],
+    ]
+}
+
+fn plate_10x10() -> Profile2D {
+    Profile2D::new(vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ])
+}
+
+/// The three overlap tests share one expected shape: the two `[2,6]^2` and
+/// `[4,8]^2` footprints (union 28, overlap 4) leave ONE hole of the UNION's
+/// area in a 10x10 plate, so net material is 72. The wrong answers each test
+/// guards against: a hole of 24 is the symmetric difference (the overlap XOR'd
+/// back out), and net 76 is the phantom pillar that leaves between the
+/// openings.
+fn assert_single_merged_hole(result: &Profile2D, case: &str) {
+    assert_eq!(result.holes.len(), 1, "{case}: the two footprints merge into ONE hole");
+    let hole_area = compute_signed_area(&result.holes[0]).abs();
+    assert!(
+        (hole_area - 28.0).abs() < 1e-6,
+        "{case}: merged hole must be the UNION (28.0), got {hole_area} (24.0 = symmetric difference)"
+    );
+    let net = net_area(result);
+    assert!(
+        (net - 72.0).abs() < 1e-6,
+        "{case}: net material must be 100 - 28 = 72.0, got {net} (76.0 = the phantom pillar)"
+    );
+}
+
+#[test]
+fn overlapping_voids_merge_instead_of_cancelling() {
+    // Regression: under `FillRule::EvenOdd` i_overlay applies the rule to the CLIP
+    // operand too, so the `[4,6]^2` patch covered by BOTH clip rings has winding 2
+    // and `1 & 2 == 0` -- it is NOT removed. The difference then subtracts the
+    // SYMMETRIC DIFFERENCE (24) instead of the union (28), leaving a phantom 2x2
+    // pillar of material between the two openings: net 76.00, not 72.00.
+    let profile = plate_10x10();
+    let voids = overlapping_void_pair();
+
+    let result = subtract_multiple_2d(&profile, &voids).unwrap();
+    assert_single_merged_hole(&result, "two CCW footprints");
+
+    // The counted variant feeds the production re-extrude gate: still ONE shape.
+    let (counted, shapes) = subtract_multiple_2d_counted(&profile, &voids).unwrap();
+    assert_eq!(
+        shapes, 1,
+        "overlapping interior voids keep one connected shape"
+    );
+    assert!((net_area(&counted) - 72.0).abs() < 1e-6);
+}
+
+#[test]
+fn overlapping_voids_merge_when_one_footprint_is_mirrored() {
+    // `NonZero` alone is not enough: a CW (mirrored / negatively scaled) footprint
+    // contributes winding -1, so the `[4,6]^2` overlap sums to 0 and survives as
+    // material exactly as it did under EvenOdd. Each clip contour must be
+    // normalised CCW first. Same numbers as above: union 28, net 72.
+    let profile = plate_10x10();
+    let mut voids = overlapping_void_pair();
+    voids[1].reverse(); // author the second opening clockwise
+    assert!(
+        compute_signed_area(&voids[1]) < 0.0,
+        "fixture precondition: the second footprint really is CW"
+    );
+
+    let result = subtract_multiple_2d(&profile, &voids).unwrap();
+    assert_single_merged_hole(&result, "one footprint mirrored CW");
+}
+
+#[test]
+fn subtract_2d_single_void_overlapping_an_existing_hole_merges() {
+    // Single-clip path (`subtract_2d`): the host already has a `[2,6]^2` hole and
+    // the new void `[4,8]^2` overlaps it. The SUBJECT side carries that existing
+    // hole as a CW ring, which is exactly the NonZero contract `profile_to_paths`
+    // already emits -- so switching the rule must not resurrect it. Union 28, net 72.
+    let mut profile = plate_10x10();
+    profile.holes.push(ensure_cw(&overlapping_void_pair()[0]));
+    assert!((net_area(&profile) - 84.0).abs() < 1e-6);
+
+    let result = subtract_2d(&profile, &overlapping_void_pair()[1]).unwrap();
+    assert_single_merged_hole(&result, "void over an existing hole");
 }

--- a/rust/geometry/src/bool2d_tests.rs
+++ b/rust/geometry/src/bool2d_tests.rs
@@ -328,6 +328,7 @@ fn assert_single_merged_hole(result: &Profile2D, case: &str) {
     );
 }
 
+/// Regression for #4579.
 #[test]
 fn overlapping_voids_merge_instead_of_cancelling() {
     // Regression: under `FillRule::EvenOdd` i_overlay applies the rule to the CLIP
@@ -350,6 +351,7 @@ fn overlapping_voids_merge_instead_of_cancelling() {
     assert!((net_area(&counted) - 72.0).abs() < 1e-6);
 }
 
+/// Regression for #4579.
 #[test]
 fn overlapping_voids_merge_when_one_footprint_is_mirrored() {
     // `NonZero` alone is not enough: a CW (mirrored / negatively scaled) footprint
@@ -368,6 +370,7 @@ fn overlapping_voids_merge_when_one_footprint_is_mirrored() {
     assert_single_merged_hole(&result, "one footprint mirrored CW");
 }
 
+/// Regression for #4579.
 #[test]
 fn subtract_2d_single_void_overlapping_an_existing_hole_merges() {
     // Single-clip path (`subtract_2d`): the host already has a `[2,6]^2` hole and

--- a/rust/geometry/src/kernel/signed_volume.rs
+++ b/rust/geometry/src/kernel/signed_volume.rs
@@ -54,17 +54,27 @@ pub(crate) fn tetra_volume6(a: &[f64; 3], b: &[f64; 3], c: &[f64; 3], o: &[f64; 
 /// cascade). About the AABB center the crack flux is bounded by the operand's
 /// own extent — the sign is decided by the solid, not by where the model sits.
 pub(crate) fn signed_volume6(tris: &[Tri]) -> f64 {
+    signed_volume6_of(tris.iter().copied())
+}
+
+/// [`signed_volume6`] over any re-walkable triangle source, so a caller that
+/// holds its triangles in an index buffer or a scratch pool (the orienter in
+/// `mesh_orient`) shares this reference-point rule instead of carrying its own
+/// copy of it. Two passes: one for the AABB centre, one for the sum.
+pub(crate) fn signed_volume6_of(tris: impl Iterator<Item = Tri> + Clone) -> f64 {
     let mut lo = [f64::MAX; 3];
     let mut hi = [f64::MIN; 3];
-    for t in tris {
-        for v in t {
+    let mut any = false;
+    for t in tris.clone() {
+        any = true;
+        for v in &t {
             for k in 0..3 {
                 lo[k] = lo[k].min(v[k]);
                 hi[k] = hi[k].max(v[k]);
             }
         }
     }
-    if tris.is_empty() {
+    if !any {
         return 0.0;
     }
     let o = [
@@ -72,9 +82,7 @@ pub(crate) fn signed_volume6(tris: &[Tri]) -> f64 {
         (lo[1] + hi[1]) * 0.5,
         (lo[2] + hi[2]) * 0.5,
     ];
-    tris.iter()
-        .map(|t| tetra_volume6(&t[0], &t[1], &t[2], &o))
-        .sum()
+    tris.map(|t| tetra_volume6(&t[0], &t[1], &t[2], &o)).sum()
 }
 
 /// Enclosed volume of a closed triangle soup, in the operands' own units.

--- a/rust/geometry/src/mesh_orient.rs
+++ b/rust/geometry/src/mesh_orient.rs
@@ -29,6 +29,7 @@
 //! pipeline that knows. [`orient_mesh_outward_verdict`] hands that verdict back
 //! (it used to be computed and dropped on the floor); see [`OrientVerdict`].
 
+use crate::kernel::signed_volume::signed_volume6_of;
 use crate::Mesh;
 use rustc_hash::FxHashMap;
 use std::cell::RefCell;
@@ -319,18 +320,16 @@ pub fn orient_mesh_outward_verdict(mesh: &mut Mesh) -> OrientVerdict {
         }
 
         // Flip the whole CLOSED component outward (positive signed volume).
-        let mut vol6 = 0.0f64;
-        for &t in comp.iter() {
+        // The sum is referenced to the component's own AABB centre, not the
+        // world origin: `kernel::signed_volume` explains why (each term is
+        // O(|v|^3), so far from the origin the SIGN is rounding noise), and
+        // `a_small_solid_far_from_the_origin_is_oriented_by_its_shape_not_its_position`
+        // measures it. One home for that rule; this is a caller.
+        let vol6 = signed_volume6_of(comp.iter().map(|&t| {
             let v = tv(t);
-            let (i0, i1, i2) = if flip[t] {
-                (v[0], v[2], v[1])
-            } else {
-                (v[0], v[1], v[2])
-            };
-            let (a, b, c) = (vpos[i0 as usize], vpos[i1 as usize], vpos[i2 as usize]);
-            vol6 += a[0] * (b[1] * c[2] - b[2] * c[1]) + a[1] * (b[2] * c[0] - b[0] * c[2])
-                + a[2] * (b[0] * c[1] - b[1] * c[0]);
-        }
+            let (i0, i1, i2) = if flip[t] { (v[0], v[2], v[1]) } else { (v[0], v[1], v[2]) };
+            [vpos[i0 as usize], vpos[i1 as usize], vpos[i2 as usize]]
+        }));
         if vol6 < 0.0 {
             for &t in comp.iter() {
                 flip[t] = !flip[t];

--- a/rust/geometry/src/mesh_orient_tests.rs
+++ b/rust/geometry/src/mesh_orient_tests.rs
@@ -643,6 +643,7 @@ fn dense_adjacency_reuses_links_across_width_transitions_3988() {
 /// large offset carried somewhere other than IfcSite, under the RTC threshold,
 /// on a closed solid of a few centimetres. This pins the pass as robust to it
 /// rather than claiming the canonical path was broken.
+/// Regression for #4579.
 #[test]
 fn a_small_solid_far_from_the_origin_is_oriented_by_its_shape_not_its_position() {
     const ALL: [usize; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];

--- a/rust/geometry/src/mesh_orient_tests.rs
+++ b/rust/geometry/src/mesh_orient_tests.rs
@@ -11,10 +11,17 @@ use super::*;
 /// Build a unit cube as a flat-shaded mesh (positions not index-shared), with
 /// `bad` triangle indices given as flipped (inward) so the winding is mixed.
 fn cube(flipped: &[usize]) -> Mesh {
+    cube_at(0.0, 1.0, flipped)
+}
+
+/// [`cube`] generalised: side `s`, min corner at `(o, o, o)`.
+fn cube_at(o: f64, s: f64, flipped: &[usize]) -> Mesh {
     // 12 triangles, outward-wound.
+    let p = |a: f64, b: f64, c: f64| [a as f32, b as f32, c as f32];
+    let (l, h) = (o, o + s);
     let c = [
-        [0.0f32, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
+        p(l, l, l), p(h, l, l), p(h, h, l), p(l, h, l),
+        p(l, l, h), p(h, l, h), p(h, h, h), p(l, h, h),
     ];
     let faces: [[usize; 3]; 12] = [
         [0, 2, 1], [0, 3, 2], // bottom z=0 (outward -z)
@@ -458,11 +465,6 @@ fn issue_3988_orientation_is_independent_of_vertex_index_sharing() {
         // Unreferenced positions must not influence welding IDs or topology.
         sparse.positions.extend(std::iter::repeat_n(37.0, 300));
         let expected = orient_mesh_outward_verdict(&mut expanded);
-        let directed_positions = |m: &Mesh| -> Vec<u32> {
-            m.indices.iter().flat_map(|&i| {
-                m.positions[i as usize * 3..i as usize * 3 + 3].iter().map(|p| p.to_bits())
-            }).collect()
-        };
         for m in [&mut indexed, &mut sparse] {
             assert_eq!(orient_mesh_outward_verdict(m), expected);
             assert_eq!(directed_positions(m), directed_positions(&expanded));
@@ -619,4 +621,60 @@ fn dense_adjacency_reuses_links_across_width_transitions_3988() {
         assert_eq!(input.indices, expected.indices, "{triangles} triangles");
     }
     ORIENT_SCRATCH.with(|slot| *slot.borrow_mut() = Some(OrientScratch::default()));
+}
+
+/// The outward flip is decided by the SIGN of a divergence-theorem sum. Summed
+/// about the world origin each term is O(|v|^3), so for a small solid far from
+/// the origin the sum cancels catastrophically and the sign is rounding noise.
+///
+/// Concrete numbers for this fixture, a correctly OUTWARD-wound 1 cm cube with
+/// its min corner at 9900.123 m on every axis (true 6V = 6.0e-6): the
+/// world-origin sum came out -2.678e-4, the WRONG sign at 45x the true
+/// magnitude, and this pass flipped the entire shell inside-out while the
+/// inward-wound copy was left alone. Referenced to the component's own AABB
+/// centre the same cube sums to +5.578e-6 (the ~7% shortfall is the f32
+/// storage of a 1 cm cube at 9.9 km, 1e-3 m granularity, and is why only the
+/// sign is consumed). The identical cube at the origin decides correctly under
+/// either reference, so the offset is the only variable.
+///
+/// Reachability is narrow on purpose: on the viewer positions are stored
+/// element-relative (`Mesh.origin`), and native subtracts the IfcSite
+/// translation and rebases anything past 10 km. What remains is native, a
+/// large offset carried somewhere other than IfcSite, under the RTC threshold,
+/// on a closed solid of a few centimetres. This pins the pass as robust to it
+/// rather than claiming the canonical path was broken.
+#[test]
+fn a_small_solid_far_from_the_origin_is_oriented_by_its_shape_not_its_position() {
+    const ALL: [usize; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    for &off in &[0.0, 9900.123] {
+        let mut outward = cube_at(off, 0.01, &[]);
+        let authored = outward.indices.clone();
+        let v = orient_mesh_outward_verdict(&mut outward);
+        assert!(v.is_single_closed_solid(), "fixture precondition at {off}: {v:?}");
+        assert!(
+            !v.flipped,
+            "an outward-wound cube at {off} must NOT be flipped inside-out"
+        );
+        assert_eq!(outward.indices, authored, "at {off}: winding left as authored");
+
+        let mut inward = cube_at(off, 0.01, &ALL);
+        let v = orient_mesh_outward_verdict(&mut inward);
+        assert!(v.flipped, "an inward-wound cube at {off} must be flipped outward");
+        assert_eq!(
+            directed_positions(&inward),
+            directed_positions(&outward),
+            "at {off}: the repaired winding is the outward one, corner for corner"
+        );
+    }
+}
+
+/// The mesh's directed position stream: every corner of every triangle, in
+/// index order, as bit patterns. Two meshes agree here only if they wind every
+/// triangle the same way corner for corner, which is stricter than comparing
+/// rotated faces.
+fn directed_positions(m: &Mesh) -> Vec<u32> {
+    m.indices
+        .iter()
+        .flat_map(|&i| m.positions[i as usize * 3..i as usize * 3 + 3].iter().map(|p| p.to_bits()))
+        .collect()
 }

--- a/rust/geometry/src/triangulation.rs
+++ b/rust/geometry/src/triangulation.rs
@@ -221,6 +221,51 @@ fn is_convex(points: &[Point2<f64>]) -> bool {
     true
 }
 
+/// Split a quad across the diagonal that lies INSIDE the ring.
+///
+/// This arm used to hard-code the 0-2 diagonal with no test at all, while the
+/// very next arm tested convexity. A fan is only valid from a vertex that SEES
+/// the whole ring, so on a CONCAVE quad the 0-2 split can cross outside the
+/// polygon: for the dart `[(0,0), (2,2), (4,0), (2,10)]` (reflex at vertex 1) the
+/// ring's signed area is +16.0 while `tri(0,1,2)` is -4.0 and `tri(0,2,3)` is
+/// +20.0, so the first triangle is wound BACKWARDS and lies entirely outside the
+/// polygon while the second covers that outside region twice. Every extruded
+/// profile cap reaches this (`extrusion.rs` via `triangulate_polygon_with_holes`),
+/// as do the faceted-brep, advanced-face and sectioned processors.
+///
+/// `orient(a, b, c)` is twice the signed area of that triangle. `c1` is the
+/// convexity of vertex 1, `c3` that of vertex 3, and `c1 + c3` is twice the
+/// ring's own signed area. A simple quad has at most ONE reflex vertex and the
+/// only interior diagonal is the one incident to it, so: the two agreeing in sign
+/// means neither 1 nor 3 is reflex and 0-2 is interior; disagreeing means one of
+/// them is, and 1-3 is. Either way both emitted triangles carry the ring's
+/// winding. A degenerate (collinear) vertex scores 0, which agrees with anything
+/// and keeps the old 0-2 split.
+///
+/// Kept as an orientation test rather than deleted in favour of the `is_convex`
+/// arm below, and not for speed: the delete measured 4 ns per call, under the
+/// cost of the `vec!` this call already pays. The reason that binds is winding.
+/// A concave quad that fell through would reach `safe_earcut`, and earcutr
+/// re-winds EVERY output counter-clockwise regardless of input, so a
+/// clockwise concave quad would come back flipped. This arm splits it across
+/// the interior diagonal in the ring's own winding, which
+/// `concave_quad_split_is_correct_for_a_clockwise_ring` pins; deleting the
+/// arm fails that test with both triangles at +16. Convex quads keep
+/// byte-identical output either way.
+#[inline]
+fn quad_indices(p: &[Point2<f64>]) -> Vec<usize> {
+    let orient = |a: &Point2<f64>, b: &Point2<f64>, c: &Point2<f64>| {
+        (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    };
+    let c1 = orient(&p[0], &p[1], &p[2]);
+    let c3 = orient(&p[2], &p[3], &p[0]);
+    if c1 * c3 >= 0.0 {
+        vec![0, 1, 2, 0, 2, 3]
+    } else {
+        vec![1, 2, 3, 1, 3, 0]
+    }
+}
+
 /// Simple fan triangulation for convex polygons
 #[inline]
 fn fan_triangulate(n: usize) -> Vec<usize> {
@@ -250,9 +295,9 @@ pub fn triangulate_polygon(points: &[Point2<f64>]) -> Result<Vec<usize>> {
         return Ok(vec![0, 1, 2]);
     }
 
-    // FAST PATH: Quad - simple fan
+    // FAST PATH: Quad - fan across the diagonal that lies INSIDE the ring.
     if n == 4 {
-        return Ok(vec![0, 1, 2, 0, 2, 3]);
+        return Ok(quad_indices(points));
     }
 
     // FAST PATH: Convex polygon - use fan triangulation
@@ -484,286 +529,5 @@ pub fn calculate_polygon_normal(points: &[Point3<f64>]) -> Vector3<f64> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_triangulate_square() {
-        let points = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(1.0, 1.0),
-            Point2::new(0.0, 1.0),
-        ];
-
-        let indices = triangulate_polygon(&points).unwrap();
-
-        // Square should be split into 2 triangles = 6 indices
-        assert_eq!(indices.len(), 6);
-    }
-
-    #[test]
-    fn test_triangulate_triangle() {
-        let points = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(0.5, 1.0),
-        ];
-
-        let indices = triangulate_polygon(&points).unwrap();
-
-        // Triangle should have 3 indices
-        assert_eq!(indices.len(), 3);
-    }
-
-    #[test]
-    fn test_triangulate_insufficient_points() {
-        let points = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
-
-        let result = triangulate_polygon(&points);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_triangulate_square_with_hole() {
-        // Outer square: 0-10
-        let outer = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ];
-
-        // Inner square (hole): 3-7
-        let hole = vec![
-            Point2::new(3.0, 3.0),
-            Point2::new(7.0, 3.0),
-            Point2::new(7.0, 7.0),
-            Point2::new(3.0, 7.0),
-        ];
-
-        let indices = triangulate_polygon_with_holes(&outer, &[hole]).unwrap();
-
-        // With a hole, we should get more triangles than without
-        // The result should have indices for triangles around the hole
-        assert!(indices.len() > 6); // More than the 2 triangles for a simple square
-        assert_eq!(indices.len() % 3, 0); // Must be a multiple of 3 (triangles)
-    }
-
-    #[test]
-    fn test_triangulate_with_multiple_holes() {
-        // Outer square: 0-20
-        let outer = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(20.0, 0.0),
-            Point2::new(20.0, 20.0),
-            Point2::new(0.0, 20.0),
-        ];
-
-        // Two holes
-        let hole1 = vec![
-            Point2::new(2.0, 2.0),
-            Point2::new(5.0, 2.0),
-            Point2::new(5.0, 5.0),
-            Point2::new(2.0, 5.0),
-        ];
-
-        let hole2 = vec![
-            Point2::new(10.0, 10.0),
-            Point2::new(15.0, 10.0),
-            Point2::new(15.0, 15.0),
-            Point2::new(10.0, 15.0),
-        ];
-
-        let indices = triangulate_polygon_with_holes(&outer, &[hole1, hole2]).unwrap();
-
-        assert!(indices.len() > 6);
-        assert_eq!(indices.len() % 3, 0);
-    }
-
-    /// `triangulate_polygon_with_holes_refined`, normal path: the returned
-    /// vertex list starts with exactly the input vertices (`outer ++ holes`;
-    /// Steiner points only after them), every index is in range, and — with
-    /// boundary splits off — every hole-ring constraint edge survives as an
-    /// edge of the output triangulation (the hole stays a hole).
-    #[test]
-    fn test_refined_vertex_layout_and_hole_constraints() {
-        let outer = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(10.0, 0.0),
-            Point2::new(10.0, 10.0),
-            Point2::new(0.0, 10.0),
-        ];
-        let hole = vec![
-            Point2::new(3.0, 3.0),
-            Point2::new(7.0, 3.0),
-            Point2::new(7.0, 7.0),
-            Point2::new(3.0, 7.0),
-        ];
-        let (pts, idx) =
-            triangulate_polygon_with_holes_refined(&outer, std::slice::from_ref(&hole)).unwrap();
-
-        let n_input = outer.len() + hole.len();
-        assert!(pts.len() >= n_input, "input vertices must all be present");
-        for (i, p) in outer.iter().chain(hole.iter()).enumerate() {
-            assert_eq!(
-                (pts[i].x, pts[i].y),
-                (p.x, p.y),
-                "vertex {i} must be the input vertex (outer ++ holes order)"
-            );
-        }
-        assert!(!idx.is_empty());
-        assert_eq!(idx.len() % 3, 0);
-        assert!(idx.iter().all(|&i| i < pts.len()), "index out of range");
-
-        let mut edges = std::collections::BTreeSet::new();
-        for t in idx.chunks_exact(3) {
-            for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
-                edges.insert(if a < b { (a, b) } else { (b, a) });
-            }
-        }
-        for k in 0..hole.len() {
-            let a = outer.len() + k;
-            let b = outer.len() + (k + 1) % hole.len();
-            let key = if a < b { (a, b) } else { (b, a) };
-            assert!(
-                edges.contains(&key),
-                "hole-ring constraint edge {key:?} missing from the triangulation"
-            );
-        }
-    }
-
-    /// `triangulate_polygon_with_holes_refined`, degenerate path: a fully
-    /// collinear outer ring is declined by the CDT (its closing constraint
-    /// passes through the intermediate vertices and cannot be recovered), so the
-    /// function must bail to the earcut/fan fallback and still return `Ok` with
-    /// the `outer ++ holes` vertex set and in-range indices. This fallback is
-    /// independent of the (removed) Ruppert boundary-split path — it fires on
-    /// the CDT-decline branch before any refinement — so it still needs its own
-    /// regression coverage under the no-arg signature.
-    #[test]
-    fn test_refined_collinear_outer_falls_back() {
-        let outer = vec![
-            Point2::new(0.0, 0.0),
-            Point2::new(1.0, 0.0),
-            Point2::new(2.0, 0.0),
-            Point2::new(3.0, 0.0),
-        ];
-        let (pts, idx) = triangulate_polygon_with_holes_refined(&outer, &[])
-            .expect("degenerate input must fall back, not error");
-        assert_eq!(pts.len(), outer.len(), "fallback must return the input vertex set");
-        for (i, p) in outer.iter().enumerate() {
-            assert_eq!((pts[i].x, pts[i].y), (p.x, p.y));
-        }
-        assert_eq!(idx.len() % 3, 0);
-        assert!(idx.iter().all(|&i| i < pts.len()));
-    }
-
-    #[test]
-    fn test_calculate_polygon_normal() {
-        // XY plane polygon - normal should be Z
-        let points = vec![
-            Point3::new(0.0, 0.0, 0.0),
-            Point3::new(1.0, 0.0, 0.0),
-            Point3::new(1.0, 1.0, 0.0),
-            Point3::new(0.0, 1.0, 0.0),
-        ];
-
-        let normal = calculate_polygon_normal(&points);
-        assert!((normal.z.abs() - 1.0).abs() < 0.001);
-    }
-
-    #[test]
-    fn test_project_to_2d() {
-        // Points on the XY plane
-        let points = vec![
-            Point3::new(0.0, 0.0, 5.0),
-            Point3::new(1.0, 0.0, 5.0),
-            Point3::new(1.0, 1.0, 5.0),
-            Point3::new(0.0, 1.0, 5.0),
-        ];
-
-        let normal = Vector3::new(0.0, 0.0, 1.0);
-        let (projected, _, _, _) = project_to_2d(&points, &normal);
-
-        assert_eq!(projected.len(), 4);
-        // After projection, all Z values are ignored, and we get 2D coords
-    }
-
-    /// The production input that wedged earcutr 0.5 forever (Revit→Bonsai
-    /// IFC4X3 door): an `IfcArbitraryProfileDefWithVoids` whose two "voids"
-    /// are rectangles entirely OUTSIDE the outer boundary (sibling door
-    /// panels). Bridging an outside ring into the outer loop creates a
-    /// self-intersecting polygon on which `filter_points` never terminates —
-    /// one wedged rayon worker natively, a dead WASM worker (geometry-stream
-    /// stall) in the browser. `safe_earcut` must terminate AND render all
-    /// three rectangles as separate polygons.
-    #[test]
-    fn safe_earcut_terminates_on_outside_voids_and_renders_them() {
-        // Captured verbatim from the wedged element (#5222).
-        let data = vec![
-            0.0, -0.0, 0.0, 83.0, -2325.0, 83.0, -2325.0, -0.0, // outer
-            -2620.0, 83.0, -2620.0, -0.0, -2375.0, -0.0, -2375.0, 83.0, // "void" 1 (outside)
-            -2326.0, 83.0, -2374.0, 83.0, -2374.0, -0.0, -2326.0, -0.0, // "void" 2 (outside)
-        ];
-        let holes = vec![4, 8];
-
-        let indices = safe_earcut(&data, &holes, 2).expect("must triangulate");
-
-        // Three disjoint rectangles → 2 triangles each.
-        assert_eq!(indices.len(), 18, "3 rects × 2 tris × 3 idx");
-        // Each triangle must stay within a single ring's vertex range.
-        for tri in indices.chunks_exact(3) {
-            let ring = |v: usize| {
-                if v < 4 {
-                    0
-                } else if v < 8 {
-                    1
-                } else {
-                    2
-                }
-            };
-            assert_eq!(ring(tri[0]), ring(tri[1]));
-            assert_eq!(ring(tri[1]), ring(tri[2]));
-        }
-    }
-
-    /// A genuine contained hole must still subtract (the classification must
-    /// not break valid profiles).
-    #[test]
-    fn safe_earcut_keeps_contained_holes() {
-        // 10×10 outer, 2×2 hole in the middle.
-        let data = vec![
-            0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, // outer
-            4.0, 4.0, 4.0, 6.0, 6.0, 6.0, 6.0, 4.0, // hole (CW)
-        ];
-        let indices = safe_earcut(&data, &[4], 2).expect("must triangulate");
-        // A square with a square hole triangulates to 8 triangles.
-        assert_eq!(indices.len() / 3, 8);
-        // Hole vertices must participate (the hole was not dropped).
-        assert!(indices.iter().any(|&i| i >= 4));
-    }
-
-    /// Closing wrap-around duplicates (P0 … P0) and consecutive duplicate
-    /// vertices must be tolerated, with indices remapped to the caller's
-    /// original vertex order.
-    #[test]
-    fn safe_earcut_drops_duplicate_vertices_and_remaps() {
-        let data = vec![
-            0.0, 0.0, 10.0, 0.0, 10.0, 0.0, // consecutive duplicate of v1
-            10.0, 10.0, 0.0, 10.0, 0.0, 0.0, // closing duplicate of v0
-        ];
-        let indices = safe_earcut(&data, &[], 2).expect("must triangulate");
-        assert_eq!(indices.len() / 3, 2, "a quad → 2 triangles");
-        // Remapped indices reference the caller's original positions; the
-        // dropped duplicates (2 and 5) must never appear.
-        assert!(indices.iter().all(|&i| i != 2 && i != 5 && i < 6));
-    }
-
-    /// Non-finite coordinates are rejected, not hung on.
-    #[test]
-    fn safe_earcut_rejects_non_finite() {
-        let data = vec![0.0, 0.0, 10.0, f64::NAN, 10.0, 10.0];
-        assert!(safe_earcut(&data, &[], 2).is_err());
-    }
-}
+#[path = "triangulation_tests.rs"]
+mod tests;

--- a/rust/geometry/src/triangulation_tests.rs
+++ b/rust/geometry/src/triangulation_tests.rs
@@ -45,6 +45,7 @@ fn ring_area2(p: &[Point2<f64>]) -> f64 {
 /// outside the ring) and `tri(0,2,3)` is +40.0, double-covering that outside
 /// region. The valid split is the 1-3 diagonal: +24.0 and +8.0, summing to
 /// the ring's own +32.0.
+/// Regression for #4579.
 #[test]
 fn concave_quad_is_split_across_an_interior_diagonal() {
     let dart = vec![
@@ -81,6 +82,7 @@ fn concave_quad_is_split_across_an_interior_diagonal() {
 /// correct one, so that ring passes with the defect present and proves
 /// nothing. Here `tri(0,1,2)` is +8.0 against a ring of -32.0 (backwards,
 /// outside) and `tri(0,2,3)` is -40.0; the 1-3 split is -16.0 and -16.0.
+/// Regression for #4579.
 #[test]
 fn concave_quad_split_is_correct_for_a_clockwise_ring() {
     let dart = vec![
@@ -105,6 +107,7 @@ fn concave_quad_split_is_correct_for_a_clockwise_ring() {
 }
 
 /// Convex quads keep the exact indices the old unconditional arm emitted.
+/// Regression for #4579.
 #[test]
 fn convex_quad_still_uses_the_zero_two_diagonal() {
     let square = vec![

--- a/rust/geometry/src/triangulation_tests.rs
+++ b/rust/geometry/src/triangulation_tests.rs
@@ -1,0 +1,391 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Unit tests for [`super`] (polygon triangulation). Split into a `*_tests.rs`
+//! file (module-size-ratchet exempt) and attached via `#[path]`.
+
+use super::*;
+
+#[test]
+fn test_triangulate_square() {
+    let points = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ];
+
+    let indices = triangulate_polygon(&points).unwrap();
+
+    // Square should be split into 2 triangles = 6 indices
+    assert_eq!(indices.len(), 6);
+}
+
+/// Twice the signed area of a triangle, as `quad_indices` computes it.
+fn tri_area2(p: &[Point2<f64>], i: &[usize]) -> f64 {
+    let (a, b, c) = (p[i[0]], p[i[1]], p[i[2]]);
+    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+/// Twice the signed area of a closed ring (shoelace).
+fn ring_area2(p: &[Point2<f64>]) -> f64 {
+    (0..p.len())
+        .map(|i| {
+            let (a, b) = (p[i], p[(i + 1) % p.len()]);
+            a.x * b.y - b.x * a.y
+        })
+        .sum()
+}
+
+/// Regression: the `n == 4` fast path hard-coded the 0-2 diagonal with no
+/// convexity test, so a CONCAVE quad was split across a diagonal lying
+/// OUTSIDE the polygon. Concrete numbers for this dart (reflex at vertex 1):
+/// ring `2*area` is +32.0, `tri(0,1,2)` is -8.0 (wound BACKWARDS, entirely
+/// outside the ring) and `tri(0,2,3)` is +40.0, double-covering that outside
+/// region. The valid split is the 1-3 diagonal: +24.0 and +8.0, summing to
+/// the ring's own +32.0.
+#[test]
+fn concave_quad_is_split_across_an_interior_diagonal() {
+    let dart = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(2.0, 2.0),
+        Point2::new(4.0, 0.0),
+        Point2::new(2.0, 10.0),
+    ];
+    let ring = ring_area2(&dart);
+    assert_eq!(ring, 32.0, "fixture precondition: the ring is CCW, 2*A = 32");
+    // Fixture precondition: the OLD hard-coded 0-2 split really is outside.
+    assert_eq!(tri_area2(&dart, &[0, 1, 2]), -8.0);
+    assert_eq!(tri_area2(&dart, &[0, 2, 3]), 40.0);
+
+    let idx = triangulate_polygon(&dart).unwrap();
+    assert_eq!(idx.len(), 6, "a quad yields exactly two triangles");
+    let areas: Vec<f64> = idx.chunks_exact(3).map(|t| tri_area2(&dart, t)).collect();
+    for a in &areas {
+        assert!(
+            a.signum() == ring.signum() && *a != 0.0,
+            "triangle 2*area {a} must carry the ring's winding {ring}, got {areas:?}"
+        );
+    }
+    let total: f64 = areas.iter().sum();
+    assert_eq!(
+        total, ring,
+        "the two triangles must tile the ring exactly, no double cover"
+    );
+}
+
+/// The mirrored (CW) dart, ROTATED so the reflex vertex lands on index 1
+/// again. Rotation matters: reversing the CCW dart alone puts the reflex
+/// vertex on index 2, where the hard-coded 0-2 diagonal happens to be the
+/// correct one, so that ring passes with the defect present and proves
+/// nothing. Here `tri(0,1,2)` is +8.0 against a ring of -32.0 (backwards,
+/// outside) and `tri(0,2,3)` is -40.0; the 1-3 split is -16.0 and -16.0.
+#[test]
+fn concave_quad_split_is_correct_for_a_clockwise_ring() {
+    let dart = vec![
+        Point2::new(4.0, 0.0),
+        Point2::new(2.0, 2.0),
+        Point2::new(0.0, 0.0),
+        Point2::new(2.0, 10.0),
+    ];
+    let ring = ring_area2(&dart);
+    assert_eq!(ring, -32.0, "fixture precondition: this ring is CW");
+    assert_eq!(tri_area2(&dart, &[0, 1, 2]), 8.0, "the old 0-2 split is backwards here");
+
+    let idx = triangulate_polygon(&dart).unwrap();
+    let areas: Vec<f64> = idx.chunks_exact(3).map(|t| tri_area2(&dart, t)).collect();
+    for a in &areas {
+        assert!(
+            *a < 0.0,
+            "triangle 2*area {a} must stay clockwise like the ring, got {areas:?}"
+        );
+    }
+    assert_eq!(areas.iter().sum::<f64>(), ring);
+}
+
+/// Convex quads keep the exact indices the old unconditional arm emitted.
+#[test]
+fn convex_quad_still_uses_the_zero_two_diagonal() {
+    let square = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(1.0, 1.0),
+        Point2::new(0.0, 1.0),
+    ];
+    assert_eq!(triangulate_polygon(&square).unwrap(), vec![0, 1, 2, 0, 2, 3]);
+    // ... and so does one with a collinear vertex (scores 0, agrees with
+    // anything), which is the shape a degenerate profile cap reduces to.
+    let flat = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(2.0, 0.0),
+        Point2::new(1.0, 1.0),
+    ];
+    assert_eq!(triangulate_polygon(&flat).unwrap(), vec![0, 1, 2, 0, 2, 3]);
+}
+
+#[test]
+fn test_triangulate_triangle() {
+    let points = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(0.5, 1.0),
+    ];
+
+    let indices = triangulate_polygon(&points).unwrap();
+
+    // Triangle should have 3 indices
+    assert_eq!(indices.len(), 3);
+}
+
+#[test]
+fn test_triangulate_insufficient_points() {
+    let points = vec![Point2::new(0.0, 0.0), Point2::new(1.0, 0.0)];
+
+    let result = triangulate_polygon(&points);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_triangulate_square_with_hole() {
+    // Outer square: 0-10
+    let outer = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ];
+
+    // Inner square (hole): 3-7
+    let hole = vec![
+        Point2::new(3.0, 3.0),
+        Point2::new(7.0, 3.0),
+        Point2::new(7.0, 7.0),
+        Point2::new(3.0, 7.0),
+    ];
+
+    let indices = triangulate_polygon_with_holes(&outer, &[hole]).unwrap();
+
+    // With a hole, we should get more triangles than without
+    // The result should have indices for triangles around the hole
+    assert!(indices.len() > 6); // More than the 2 triangles for a simple square
+    assert_eq!(indices.len() % 3, 0); // Must be a multiple of 3 (triangles)
+}
+
+#[test]
+fn test_triangulate_with_multiple_holes() {
+    // Outer square: 0-20
+    let outer = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(20.0, 0.0),
+        Point2::new(20.0, 20.0),
+        Point2::new(0.0, 20.0),
+    ];
+
+    // Two holes
+    let hole1 = vec![
+        Point2::new(2.0, 2.0),
+        Point2::new(5.0, 2.0),
+        Point2::new(5.0, 5.0),
+        Point2::new(2.0, 5.0),
+    ];
+
+    let hole2 = vec![
+        Point2::new(10.0, 10.0),
+        Point2::new(15.0, 10.0),
+        Point2::new(15.0, 15.0),
+        Point2::new(10.0, 15.0),
+    ];
+
+    let indices = triangulate_polygon_with_holes(&outer, &[hole1, hole2]).unwrap();
+
+    assert!(indices.len() > 6);
+    assert_eq!(indices.len() % 3, 0);
+}
+
+/// `triangulate_polygon_with_holes_refined`, normal path: the returned
+/// vertex list starts with exactly the input vertices (`outer ++ holes`;
+/// Steiner points only after them), every index is in range, and — with
+/// boundary splits off — every hole-ring constraint edge survives as an
+/// edge of the output triangulation (the hole stays a hole).
+#[test]
+fn test_refined_vertex_layout_and_hole_constraints() {
+    let outer = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(10.0, 0.0),
+        Point2::new(10.0, 10.0),
+        Point2::new(0.0, 10.0),
+    ];
+    let hole = vec![
+        Point2::new(3.0, 3.0),
+        Point2::new(7.0, 3.0),
+        Point2::new(7.0, 7.0),
+        Point2::new(3.0, 7.0),
+    ];
+    let (pts, idx) =
+        triangulate_polygon_with_holes_refined(&outer, std::slice::from_ref(&hole)).unwrap();
+
+    let n_input = outer.len() + hole.len();
+    assert!(pts.len() >= n_input, "input vertices must all be present");
+    for (i, p) in outer.iter().chain(hole.iter()).enumerate() {
+        assert_eq!(
+            (pts[i].x, pts[i].y),
+            (p.x, p.y),
+            "vertex {i} must be the input vertex (outer ++ holes order)"
+        );
+    }
+    assert!(!idx.is_empty());
+    assert_eq!(idx.len() % 3, 0);
+    assert!(idx.iter().all(|&i| i < pts.len()), "index out of range");
+
+    let mut edges = std::collections::BTreeSet::new();
+    for t in idx.chunks_exact(3) {
+        for (a, b) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+            edges.insert(if a < b { (a, b) } else { (b, a) });
+        }
+    }
+    for k in 0..hole.len() {
+        let a = outer.len() + k;
+        let b = outer.len() + (k + 1) % hole.len();
+        let key = if a < b { (a, b) } else { (b, a) };
+        assert!(
+            edges.contains(&key),
+            "hole-ring constraint edge {key:?} missing from the triangulation"
+        );
+    }
+}
+
+/// `triangulate_polygon_with_holes_refined`, degenerate path: a fully
+/// collinear outer ring is declined by the CDT (its closing constraint
+/// passes through the intermediate vertices and cannot be recovered), so the
+/// function must bail to the earcut/fan fallback and still return `Ok` with
+/// the `outer ++ holes` vertex set and in-range indices. This fallback is
+/// independent of the (removed) Ruppert boundary-split path — it fires on
+/// the CDT-decline branch before any refinement — so it still needs its own
+/// regression coverage under the no-arg signature.
+#[test]
+fn test_refined_collinear_outer_falls_back() {
+    let outer = vec![
+        Point2::new(0.0, 0.0),
+        Point2::new(1.0, 0.0),
+        Point2::new(2.0, 0.0),
+        Point2::new(3.0, 0.0),
+    ];
+    let (pts, idx) = triangulate_polygon_with_holes_refined(&outer, &[])
+        .expect("degenerate input must fall back, not error");
+    assert_eq!(pts.len(), outer.len(), "fallback must return the input vertex set");
+    for (i, p) in outer.iter().enumerate() {
+        assert_eq!((pts[i].x, pts[i].y), (p.x, p.y));
+    }
+    assert_eq!(idx.len() % 3, 0);
+    assert!(idx.iter().all(|&i| i < pts.len()));
+}
+
+#[test]
+fn test_calculate_polygon_normal() {
+    // XY plane polygon - normal should be Z
+    let points = vec![
+        Point3::new(0.0, 0.0, 0.0),
+        Point3::new(1.0, 0.0, 0.0),
+        Point3::new(1.0, 1.0, 0.0),
+        Point3::new(0.0, 1.0, 0.0),
+    ];
+
+    let normal = calculate_polygon_normal(&points);
+    assert!((normal.z.abs() - 1.0).abs() < 0.001);
+}
+
+#[test]
+fn test_project_to_2d() {
+    // Points on the XY plane
+    let points = vec![
+        Point3::new(0.0, 0.0, 5.0),
+        Point3::new(1.0, 0.0, 5.0),
+        Point3::new(1.0, 1.0, 5.0),
+        Point3::new(0.0, 1.0, 5.0),
+    ];
+
+    let normal = Vector3::new(0.0, 0.0, 1.0);
+    let (projected, _, _, _) = project_to_2d(&points, &normal);
+
+    assert_eq!(projected.len(), 4);
+    // After projection, all Z values are ignored, and we get 2D coords
+}
+
+/// The production input that wedged earcutr 0.5 forever (Revit→Bonsai
+/// IFC4X3 door): an `IfcArbitraryProfileDefWithVoids` whose two "voids"
+/// are rectangles entirely OUTSIDE the outer boundary (sibling door
+/// panels). Bridging an outside ring into the outer loop creates a
+/// self-intersecting polygon on which `filter_points` never terminates —
+/// one wedged rayon worker natively, a dead WASM worker (geometry-stream
+/// stall) in the browser. `safe_earcut` must terminate AND render all
+/// three rectangles as separate polygons.
+#[test]
+fn safe_earcut_terminates_on_outside_voids_and_renders_them() {
+    // Captured verbatim from the wedged element (#5222).
+    let data = vec![
+        0.0, -0.0, 0.0, 83.0, -2325.0, 83.0, -2325.0, -0.0, // outer
+        -2620.0, 83.0, -2620.0, -0.0, -2375.0, -0.0, -2375.0, 83.0, // "void" 1 (outside)
+        -2326.0, 83.0, -2374.0, 83.0, -2374.0, -0.0, -2326.0, -0.0, // "void" 2 (outside)
+    ];
+    let holes = vec![4, 8];
+
+    let indices = safe_earcut(&data, &holes, 2).expect("must triangulate");
+
+    // Three disjoint rectangles → 2 triangles each.
+    assert_eq!(indices.len(), 18, "3 rects × 2 tris × 3 idx");
+    // Each triangle must stay within a single ring's vertex range.
+    for tri in indices.chunks_exact(3) {
+        let ring = |v: usize| {
+            if v < 4 {
+                0
+            } else if v < 8 {
+                1
+            } else {
+                2
+            }
+        };
+        assert_eq!(ring(tri[0]), ring(tri[1]));
+        assert_eq!(ring(tri[1]), ring(tri[2]));
+    }
+}
+
+/// A genuine contained hole must still subtract (the classification must
+/// not break valid profiles).
+#[test]
+fn safe_earcut_keeps_contained_holes() {
+    // 10×10 outer, 2×2 hole in the middle.
+    let data = vec![
+        0.0, 0.0, 10.0, 0.0, 10.0, 10.0, 0.0, 10.0, // outer
+        4.0, 4.0, 4.0, 6.0, 6.0, 6.0, 6.0, 4.0, // hole (CW)
+    ];
+    let indices = safe_earcut(&data, &[4], 2).expect("must triangulate");
+    // A square with a square hole triangulates to 8 triangles.
+    assert_eq!(indices.len() / 3, 8);
+    // Hole vertices must participate (the hole was not dropped).
+    assert!(indices.iter().any(|&i| i >= 4));
+}
+
+/// Closing wrap-around duplicates (P0 … P0) and consecutive duplicate
+/// vertices must be tolerated, with indices remapped to the caller's
+/// original vertex order.
+#[test]
+fn safe_earcut_drops_duplicate_vertices_and_remaps() {
+    let data = vec![
+        0.0, 0.0, 10.0, 0.0, 10.0, 0.0, // consecutive duplicate of v1
+        10.0, 10.0, 0.0, 10.0, 0.0, 0.0, // closing duplicate of v0
+    ];
+    let indices = safe_earcut(&data, &[], 2).expect("must triangulate");
+    assert_eq!(indices.len() / 3, 2, "a quad → 2 triangles");
+    // Remapped indices reference the caller's original positions; the
+    // dropped duplicates (2 and 5) must never appear.
+    assert!(indices.iter().all(|&i| i != 2 && i != 5 && i < 6));
+}
+
+/// Non-finite coordinates are rejected, not hung on.
+#[test]
+fn safe_earcut_rejects_non_finite() {
+    let data = vec![0.0, 0.0, 10.0, f64::NAN, 10.0, 10.0];
+    assert!(safe_earcut(&data, &[], 2).is_err());
+}


### PR DESCRIPTION
Three geometry fixes, one commit each, every test mutation-checked (fails with the fix reverted).

## 1. Overlapping opening footprints cancelled instead of merging (high)

All three `Difference` overlays in `bool2d.rs` passed `FillRule::EvenOdd`, which i_overlay applies to the clip operand too. A region covered by two clip rings has winding 2, `1 & 2 == 0`, and is not subtracted: two overlapping openings left a phantom pillar of material between them. Measured on a 10x10 plate with clips `[2,6]^2` and `[4,8]^2`: net area 76.00 where 72.00 is correct, each hole 12.00 (the symmetric difference). The result still passed the production caller's own guards at `bool2d_path.rs:279` because it is one shape with two holes.

Fix: `NonZero`, and every clip contour normalised CCW through one helper (`ccw_paths`), because `NonZero` alone still cancels a mirrored footprint. `union_contours_to_shapes` in the same file already did exactly this; it now shares the helper rather than an inline copy. `subtract_multiple_2d` became the counted variant minus the count, since it had become byte-identical.

**This changes mesh output where it applies.** On the CSG-heavy `ISSUE_129` fixture: vertices 218365 to 214573, triangles 132657 to 130961, geometry phase 742 to 489 ms (the phantom pillars and their cut faces are gone). The determinism manifests are unchanged (their synthetic fixture has no overlapping voids) and the required parity lane passes locally on the branch: all four in-tree fixtures `MATCH` against the committed IfcOpenShell reference through the rebuilt wheel. The nightly full-corpus lane is where the ISSUE_129 change will show, as an improvement.

## 2. Concave quad split across an outside diagonal (high)

`triangulation.rs` hard-coded the 0-2 diagonal for `n == 4` with no test, directly above the arm that tests convexity for 5-to-8-gons. For the dart `[(0,0),(2,2),(4,0),(2,10)]` the first triangle was wound backwards and lay entirely outside the polygon. Reached from every extruded profile cap. The arm now picks the diagonal by an orientation test.

Kept as an arm rather than deleted, and not for speed (`/simplify` measured the delete at 4 ns, under the cost of the `vec!` the call already pays): earcutr re-winds every output CCW, so deleting the arm would flip clockwise concave quads. The branch's own test pins that; deleting the arm fails it with both triangles at +16. My first CW fixture was the CCW dart reversed, which puts the reflex where the hard-coded diagonal happens to be right and passed with the defect present; the committed fixture is rotated so it does not.

## 3. Outward-flip sign decided about the world origin (medium)

`mesh_orient.rs` summed the closed-component signed volume about the origin. Each term is O(|v|^3), so far from the origin the sign is rounding noise. Measured: a correctly outward-wound 1 cm cube at 9900.123 m summed to `vol6 < 0` and was flipped inside-out. `kernel/signed_volume.rs` had already taken this exact fix for the #198779 cascade and referenced the operand's AABB centre; `mesh_orient` now calls that function (made iterator-generic so the orienter stays allocation-free) instead of carrying a second copy of the rule.

Stated reach, per the judge's check: viewer meshes are element-local and the native site tier removes the site translation before this runs, so the residual is native, a non-site offset, under 10 km, on small closed solids. Cheap, correct in the leaf regardless of caller frame discipline, and orthogonal to the frame work.

## Perf verdict

`ab.sh --base origin/main --iters 5` on `ISSUE_068` (56 MB): geometry 202 vs 197 ms (-2.5%, ±28%), within noise; null run agrees. On `ISSUE_129` (CSG-heavy): geometry -34%, with the output change stated above, so not like-for-like by design.

## Gates

clippy `-D warnings` clean; `cargo test --workspace --no-fail-fast` 3179 passed, 0 failed; module-size, refwalk, API surface green; no snapshot or manifest drift; parity quick lane green locally. `/simplify` and `/code-review` (high, no findings) ran against this SHA.

Part of the full Rust review; one defect class per PR.
