### PR TITLE
fix(export): validate exact STEP slots across writers

### DIFF
--- a/.changeset/quiet-step-slots.md
+++ b/.changeset/quiet-step-slots.md
@@ -1,0 +1,6 @@
+---
+"@ifc-lite/cli": patch
+"@ifc-lite/export": patch
+---
+
+Refuse malformed STEP slot lists consistently before positional CLI mutations, export decisions, or schema conversion can rewrite the wrong attribute. Binary literals are now handled by the CLI validator, export record consumers share one validated slot reader, and Rust schema conversion preserves UTF-8 while leaving refused records transactionally unchanged.

--- a/packages/cli/src/commands/step-args.ts
+++ b/packages/cli/src/commands/step-args.ts
@@ -236,6 +236,9 @@ function skipToken(text: string, from: number): number {
       if (char === "'") {
         i = skipString(text, i);
         if (i < 0) return -1;
+      } else if (char === '"') {
+        i = skipBinary(text, i);
+        if (i < 0) return -1;
       } else if (char === '(') {
         depth++;
         i++;
@@ -281,6 +284,12 @@ function skipString(text: string, from: number): number {
   return -1;
 }
 
+/** Index just past a binary literal, or -1 if its closing quote is absent. */
+function skipBinary(text: string, from: number): number {
+  const end = text.indexOf('"', from + 1);
+  return end < 0 ? -1 : end + 1;
+}
+
 /**
  * Can this character only begin or separate another token?
  *
@@ -295,6 +304,7 @@ function skipString(text: string, from: number): number {
 function isTokenBreak(char: string): boolean {
   return (
     char === "'" ||
+    char === '"' ||
     char === '(' ||
     char === ')' ||
     char === ',' ||

--- a/packages/cli/src/commands/step-refuse.parity.test.ts
+++ b/packages/cli/src/commands/step-refuse.parity.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { splitTopLevelStepArgs } from './step-args.js';
+
+interface Fixture {
+  cases: Array<{ name: string; input: string }>;
+}
+
+const path = fileURLToPath(
+  new URL('../../../../rust/export/tests/fixtures/step_refuse_vectors.json', import.meta.url),
+);
+const fixture: Fixture = JSON.parse(readFileSync(path, 'utf8'));
+
+describe('splitTopLevelStepArgs shared refusal parity (#4200)', () => {
+  it('contains a non-vacuous shared corpus', () => {
+    expect(fixture.cases.length).toBeGreaterThanOrEqual(8);
+  });
+
+  for (const vector of fixture.cases) {
+    it(`refuses ${vector.name}`, () => {
+      expect(splitTopLevelStepArgs(vector.input)).toBeNull();
+    });
+  }
+
+  it('accepts a complete binary literal', () => {
+    expect(splitTopLevelStepArgs(`'g',"0F",$`)).toEqual([`'g'`, '"0F"', '$']);
+  });
+});

--- a/packages/export/src/anonymize-export.test.ts
+++ b/packages/export/src/anonymize-export.test.ts
@@ -34,7 +34,7 @@ import { EMPTY_SOURCE_BYTES, IfcParser, parseSourceHeader, type IfcDataStore } f
 import { isValidIfcGuid, type RandomSource } from '@ifc-lite/encoding';
 import { exportAnonymizedSubset } from './anonymize-export.js';
 import type { AnonymizeOptions } from './anonymize-types.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelListItems } from './step-argument-parser.js';
 import { HAS_PROPERTY_SETS_SLOT } from './type-owned-psets.js';
 
 const enc = (s: string): ArrayBuffer => new TextEncoder().encode(s).buffer as ArrayBuffer;
@@ -76,7 +76,7 @@ function findDanglingRefs(content: string): number[] {
 function lineArgs(content: string, id: number): string[] {
   const match = content.match(new RegExp(`^#${id}=\\w+\\((.*)\\);$`, 'm'));
   if (!match) throw new Error(`no exported line for #${id}`);
-  return splitTopLevelArgs(match[1]);
+  return splitTopLevelListItems(match[1]);
 }
 
 /**
@@ -511,6 +511,24 @@ describe('exportAnonymizedSubset — IfcPropertyReferenceValue into an excluded 
     expect(findDanglingRefs(content)).toEqual([]);
     expect(lineArgs(content, 96)[3]).toBe('#51');
     expect(result.stats.droppedPropertyReferenceIds).toEqual([]);
+  });
+
+  it('does not report a drop when malformed slots make the positional edit unverifiable (#4200)', async () => {
+    const malformed = FIXTURE_MODEL.replace(
+      "#96=IFCPROPERTYREFERENCEVALUE('AddressRef',$,$,#51);",
+      "#96=IFCPROPERTYREFERENCEVALUE('AddressRef',\"01,23\",#51);",
+    );
+    const store = await parse(malformed);
+    const result = exportAnonymizedSubset(store, new Set([1, 3, 95, 96]), {
+      keepPropertySets: true,
+      guidRandom: seededRandom(18),
+    });
+
+    expect(result.stats.droppedPropertyReferenceIds).toEqual([]);
+    expect(result.stats.warnings.some(
+      (warning) => warning.includes('IfcPropertyReferenceValue #96')
+        && warning.includes('not changed or reported as dropped'),
+    )).toBe(true);
   });
 });
 

--- a/packages/export/src/anonymize-export.ts
+++ b/packages/export/src/anonymize-export.ts
@@ -121,6 +121,7 @@ function excludePropertySetsUnlessKept(
  * Null `PropertyReference` when an emitted `IfcPropertyReferenceValue` names
  * an entity the subset excludes. The value can be reached by the forward
  * closure rather than appearing in the caller's seed set, hence `closureIds`.
+ * Unreadable records are returned as warnings rather than counted as dropped.
  */
 function dropExcludedPropertyReferences(
   store: { readonly source: IfcSourceBytes },
@@ -129,13 +130,20 @@ function dropExcludedPropertyReferences(
   excludedIds: ReadonlySet<number>,
   view: MutablePropertyView,
   schema: ReturnType<typeof stepSourceSchema>,
-): number[] {
+): { droppedIds: number[]; warnings: string[] } {
   const droppedIds: number[] = [];
+  const warnings: string[] = [];
 
   for (const id of closureIds) {
     if ((index.typeOf(id) ?? '') !== 'IFCPROPERTYREFERENCEVALUE') continue;
     const record = readEntityArgs(store, index, id);
-    if (!record) continue;
+    if (!record) {
+      warnings.push(
+        `IfcPropertyReferenceValue #${id}: its source record could not be read, `
+          + 'so PropertyReference was not changed or reported as dropped.',
+      );
+      continue;
+    }
 
     const idx = attrIndex('IFCPROPERTYREFERENCEVALUE', 'PropertyReference', schema);
     if (idx === -1 || idx >= record.args.length) continue;
@@ -147,7 +155,7 @@ function dropExcludedPropertyReferences(
     droppedIds.push(id);
   }
 
-  return droppedIds;
+  return { droppedIds, warnings };
 }
 
 /**
@@ -261,7 +269,7 @@ export function exportAnonymizedSubset(
     index,
     subset.excludedIds,
   );
-  const droppedPropertyReferenceIds = dropExcludedPropertyReferences(
+  const propertyReferenceResult = dropExcludedPropertyReferences(
     store,
     index,
     exportClosure,
@@ -312,11 +320,12 @@ export function exportAnonymizedSubset(
       includedRootEntityCount,
       prunedRelationshipIds,
       droppedPropertySetIds,
-      droppedPropertyReferenceIds,
+      droppedPropertyReferenceIds: propertyReferenceResult.droppedIds,
       zeroedPlacements: placementResult.zeroedPlacements,
       warnings: [
         ...placementResult.warnings,
         ...scrubResult.warnings,
+        ...propertyReferenceResult.warnings,
         ...exportResult.stats.warnings,
       ],
     },

--- a/packages/export/src/anonymize-placement.test.ts
+++ b/packages/export/src/anonymize-placement.test.ts
@@ -20,7 +20,7 @@ import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import { StepExporter } from './step-exporter.js';
 import { getEffectiveEntityIndex } from './effective-index.js';
 import { applyPlacementAnonymization } from './anonymize-placement.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelListItems } from './step-argument-parser.js';
 
 const enc = (s: string): ArrayBuffer => new TextEncoder().encode(s).buffer as ArrayBuffer;
 const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
@@ -291,7 +291,7 @@ describe('applyPlacementAnonymization (anonymized isolated export, #2934)', () =
 
     const siteLine = content.match(/^#2=IFCSITE\(([^;]*)\);$/m);
     expect(siteLine).not.toBeNull();
-    const siteArgs = splitTopLevelArgs(siteLine![1]);
+    const siteArgs = splitTopLevelListItems(siteLine![1]);
     // RefLatitude, RefLongitude, RefElevation, LandTitleNumber, SiteAddress
     // are IfcSite's last five positional slots.
     const [refLatitude, refLongitude, refElevation, landTitleNumber, siteAddress] = siteArgs.slice(-5);
@@ -304,7 +304,7 @@ describe('applyPlacementAnonymization (anonymized isolated export, #2934)', () =
 
     const buildingLine = content.match(/^#3=IFCBUILDING\(([^;]*)\);$/m);
     expect(buildingLine).not.toBeNull();
-    const buildingArgs = splitTopLevelArgs(buildingLine![1]);
+    const buildingArgs = splitTopLevelListItems(buildingLine![1]);
     expect(buildingArgs.at(-1)).toBe('$'); // BuildingAddress
     expect(buildingArgs).not.toContain("''");
 

--- a/packages/export/src/anonymize-placement.ts
+++ b/packages/export/src/anonymize-placement.ts
@@ -43,7 +43,7 @@ import type { IfcAttributeValue } from '@ifc-lite/parser';
 import type { EffectiveEntityIndex } from './effective-index.js';
 import type { AnonymizeOptions } from './anonymize-types.js';
 import { attrIndex, readEntityArgs, type EntityByteRangeIndex } from './subset-entity-reader.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelListItems } from './step-argument-parser.js';
 import { entityRef, stepReal } from './step-serialization.js';
 import { BARE_REF_RE } from './reference-collector.js';
 
@@ -395,6 +395,6 @@ function parseCoordinateList(token: string | undefined): number[] | null {
   if (!token) return null;
   const trimmed = token.trim();
   if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) return null;
-  const numbers = splitTopLevelArgs(trimmed.slice(1, -1)).map((part) => Number(part.trim()));
+  const numbers = splitTopLevelListItems(trimmed.slice(1, -1)).map((part) => Number(part.trim()));
   return numbers.every((n) => Number.isFinite(n)) ? numbers : null;
 }

--- a/packages/export/src/anonymize-scrub.test.ts
+++ b/packages/export/src/anonymize-scrub.test.ts
@@ -22,7 +22,7 @@ import { MutablePropertyView } from '@ifc-lite/mutations';
 import { getEffectiveEntityIndex } from './effective-index.js';
 import { applyScrub, type ScrubOptions } from './anonymize-scrub.js';
 import { StepExporter } from './step-exporter.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelListItems } from './step-argument-parser.js';
 import { HAS_PROPERTY_SETS_SLOT } from './type-owned-psets.js';
 
 const enc = (s: string): ArrayBuffer => new TextEncoder().encode(s).buffer as ArrayBuffer;
@@ -57,7 +57,7 @@ function lineArgs(content: string, id: number): string[] {
   // capture would.
   const match = content.match(new RegExp(`^#${id}=\\w+\\((.*)\\);$`, 'm'));
   if (!match) throw new Error(`no exported line for #${id}`);
-  return splitTopLevelArgs(match[1]);
+  return splitTopLevelListItems(match[1]);
 }
 
 /**
@@ -275,6 +275,21 @@ describe('applyScrub: guidMap', () => {
 
     // Every replacement is unique (no two entities collided onto one guid).
     expect(new Set(guidMap.values()).size).toBe(guidMap.size);
+  });
+
+  it('does not create a GUID mapping from a record whose slots were refused (#4200)', async () => {
+    const malformed = MODEL.replace(
+      `#5=IFCWALL('${guid(5)}',#10,`,
+      `#5=IFCWALL('${guid(5)}',"01,23",`,
+    );
+    const store = await parse(malformed);
+    const view = new MutablePropertyView(null, 'anonymize');
+    const index = getEffectiveEntityIndex(store, view, true);
+    const result = applyScrub(store, index, INCLUDED_IDS, view, { guidRandom: seededRandom(5) });
+
+    expect(result.guidMap.has(guid(5))).toBe(false);
+    expect(result.warnings.some((warning) => warning.includes('Entity #5') && warning.includes('could not be read'))).toBe(true);
+    expect(view.getPositionalMutationsForEntity(5)).toBeNull();
   });
 
   it('is empty when regenerateGlobalIds is false, and the exported GlobalIds are unchanged', async () => {

--- a/packages/export/src/appearance-dependencies.ts
+++ b/packages/export/src/appearance-dependencies.ts
@@ -10,7 +10,7 @@ import type { IfcAttributeValue, MutablePropertyView } from '@ifc-lite/mutations
 import { getEffectiveEntityIndex } from './effective-index.js';
 import { effectiveAppearanceRecord } from './effective-appearance-record.js';
 import { collectRefsInByteRange, refGroupFromArg } from './reference-collector.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { readStepSlots } from './step-argument-parser.js';
 
 const RELATING = new Map([['IFCRELASSOCIATESMATERIAL', 'RelatingMaterial'], ['IFCRELDEFINESBYTYPE', 'RelatingType']]);
 const BINDINGS = new Map([
@@ -45,7 +45,7 @@ export function captureAppearanceDependencies(
     // dependency graph may contain both, including higher precision new UVs.
     const byteLimit = 192 * 1024 * 1024;
     const encoder = new TextEncoder(), scratch = new Uint8Array(16 * 1024);
-    const refuse = () => { throw new Error(`Appearance dependency validation exceeds its safety budget (${bytes} bytes, ${values} attribute values). Choose a smaller scope.`); };
+    const refuse = (): never => { throw new Error(`Appearance dependency validation exceeds its safety budget (${bytes} bytes, ${values} attribute values). Choose a smaller scope.`); };
     const inspect = (value: IfcAttributeValue | undefined) => {
       const frames: Array<{ values: ReadonlyArray<IfcAttributeValue | undefined>; cursor: number }> = [{ values: [value], cursor: 0 }];
       while (frames.length) {
@@ -105,8 +105,9 @@ export function captureAppearanceDependencies(
         // a type/material are not dependencies of this object's appearance.
         const slot = getAttributeNamesAcrossSchemas(type).indexOf(relating);
         if (slot < 0) refuse();
-        const args = splitTopLevelArgs(line.slice(line.indexOf('(') + 1, line.lastIndexOf(')')));
-        const ref = args[slot] === undefined ? undefined : refGroupFromArg(args[slot]);
+        const recordSlots = readStepSlots(line);
+        if (recordSlots === null) throw new Error('Invalid STEP record during appearance validation.');
+        const ref = recordSlots.slots[slot] === undefined ? undefined : refGroupFromArg(recordSlots.slots[slot]);
         forward = typeof ref === 'number' ? [ref] : ref ?? [];
       }
       result = { line, refs: forward };
@@ -120,8 +121,9 @@ export function captureAppearanceDependencies(
       if (slot < 0) throw new Error(`Cannot resolve ${type}.${attribute} for appearance validation.`);
       for (const id of index.byType.get(type) ?? []) {
         const line = row(id).line;
-        const args = splitTopLevelArgs(line.slice(line.indexOf('(') + 1, line.lastIndexOf(')')));
-        const target = args[slot] === undefined ? null : refGroupFromArg(args[slot]);
+        const recordSlots = readStepSlots(line);
+        if (recordSlots === null) throw new Error('Invalid STEP record during appearance validation.');
+        const target = recordSlots.slots[slot] === undefined ? null : refGroupFromArg(recordSlots.slots[slot]);
         for (const targetId of typeof target === 'number' ? [target] : target ?? []) {
           if (!Number.isSafeInteger(targetId)) refuse();
           const ids = inverse.get(targetId) ?? []; ids.push(id); inverse.set(targetId, ids);

--- a/packages/export/src/effective-appearance-record.ts
+++ b/packages/export/src/effective-appearance-record.ts
@@ -7,7 +7,7 @@ import type { EffectiveEntityIndex } from './effective-index.js';
 import { serializeEntityArgs } from './attribute-real-slots.js';
 import { applyOverlayEntityOverrides } from './step-overlay-attribute-overrides.js';
 import { applySourceLineMutations } from './step-attribute-mutations.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { readStepSlots, splitTopLevelStepArguments } from './step-argument-parser.js';
 import { retypeArgTokens } from './retype.js';
 import type { IfcSchemaVersion } from './schema-converter.js';
 
@@ -24,7 +24,11 @@ export function effectiveAppearanceRecord(
     const retype = view.getEntityTypeMutation(id);
     const type = retype?.newType ?? created.type;
     let args = serializeEntityArgs(created.type, created.attributes, schema);
-    if (retype) args = retypeArgTokens(splitTopLevelArgs(args), created.type, type, retype.predefinedType, schema).tokens.join(',');
+    if (retype) {
+      const slots = splitTopLevelStepArguments(args);
+      if (slots === null) throw new Error('Invalid authored IFC entity during appearance cleanup; resources were retained.');
+      args = retypeArgTokens(slots, created.type, type, retype.predefinedType, schema).tokens.join(',');
+    }
     args = applyOverlayEntityOverrides(args, type, named, view.getPositionalMutationsForEntity(id), schema);
     return `#${id}=${type.toUpperCase()}(${args});`;
   }
@@ -37,10 +41,10 @@ export function effectiveAppearanceRecord(
 
 /** URLReference occupies slot 5 after the inherited IfcSurfaceTexture fields. */
 export function effectiveImageUri(line: string): string | undefined {
-  const start = line.indexOf('('), end = line.lastIndexOf(')');
-  if (start < 0 || end < start) throw new Error('Unreadable IFC image during appearance cleanup; resources were retained.');
-  const argument = splitTopLevelArgs(line.slice(start + 1, end))[5];
+  const record = readStepSlots(line);
+  if (record === null) throw new Error('Unreadable IFC image during appearance cleanup; resources were retained.');
+  const argument = record.slots[5];
   if (argument === undefined) return undefined;
-  const value = parseStepValue(argument);
+  const value = parseStepValue(argument.trim());
   return typeof value === 'string' ? value : undefined;
 }

--- a/packages/export/src/merged-empty-containers.ts
+++ b/packages/export/src/merged-empty-containers.ts
@@ -25,8 +25,8 @@
  */
 
 import type { IfcSourceBytes } from '@ifc-lite/parser';
-import { asSourceBytes, STEP_TRIVIA } from '@ifc-lite/parser';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { asSourceBytes } from '@ifc-lite/parser';
+import { readStepSlots, splitTopLevelListItems } from './step-argument-parser.js';
 import { BARE_REF_RE } from './reference-collector.js';
 import type { CompleteEntityIndex } from './entity-iteration.js';
 
@@ -38,8 +38,6 @@ import type { CompleteEntityIndex } from './entity-iteration.js';
  * `null`), which the caller treats as "can't safely rewrite" and blocks the
  * empty-container drop for that entity.
  */
-const RECORD_RE = new RegExp(`^#\\d+\\s*=\\s*\\w+${STEP_TRIVIA}\\(([\\s\\S]*)\\)\\s*;?\\s*$`);
-
 /**
  * Spatial container types dropped when they end up empty. `IfcProject` is
  * deliberately absent: it is the file's root, never a candidate.
@@ -297,9 +295,8 @@ function lineOf(view: EmptyContainerModelView, localId: number): string {
 
 /** Top-level arguments of a `#id=TYPE(…);` line, or `null` when unparseable. */
 function topLevelAttrs(line: string): string[] | null {
-  const match = line.match(RECORD_RE);
-  if (!match) return null;
-  return splitTopLevelArgs(match[1]).map(arg => arg.trim());
+  const record = readStepSlots(line);
+  return record === null ? null : record.slots.map(arg => arg.trim());
 }
 
 /** `"#7"` → `7` via shared, trivia-tolerant {@link BARE_REF_RE} (#4227 — a narrower regex misclassified a comment-wrapped `RelatingObject`). */
@@ -315,7 +312,7 @@ function refList(arg: string): number[] {
   const inner = trimmed.slice(1, -1).trim();
   if (inner === '') return [];
   const ids: number[] = [];
-  for (const item of splitTopLevelArgs(inner)) {
+  for (const item of splitTopLevelListItems(inner)) {
     const id = singleRef(item);
     if (id !== null) ids.push(id);
   }
@@ -343,7 +340,7 @@ function classifyRefs(line: string): Array<[number, boolean]> | null {
     if (attr.startsWith('(') && attr.endsWith(')')) {
       const inner = attr.slice(1, -1).trim();
       if (inner === '') continue;
-      for (const item of splitTopLevelArgs(inner)) {
+      for (const item of splitTopLevelListItems(inner)) {
         const id = singleRef(item);
         if (id !== null) out.push([id, false]);
         else for (const nested of argRefs(item)) out.push([nested, true]);

--- a/packages/export/src/reference-collector.test.ts
+++ b/packages/export/src/reference-collector.test.ts
@@ -901,15 +901,21 @@ describe('filterHiddenRefsFromRelationshipLine: trivia between the type name and
     expect(out).toBe("#5=IFCRELAGGREGATES/* has ( and ; inside */('GUID',$,$,$,#1,(#2));");
   });
 
-  it('two-way rule: an unterminated comment before "(" leaves the line unchanged (falls through, not corrupted)', () => {
+  it('withholds an entity whose unterminated comment makes its slots unverifiable (#4200)', () => {
     const line = "#5=IFCRELAGGREGATES/* never closes ('GUID',$,$,$,#1,(#2,#3));";
-    expect(filterHiddenRefsFromRelationshipLine(line, (id) => id === 3)).toBe(line);
+    expect(filterHiddenRefsFromRelationshipLine(line, (id) => id === 3)).toBeNull();
   });
 
   it('still narrows an adjacent line correctly (no regression)', () => {
     const line = "#5=IFCRELAGGREGATES('GUID',$,$,$,#1,(#2,#3));";
     const out = filterHiddenRefsFromRelationshipLine(line, (id) => id === 3);
     expect(out).toBe("#5=IFCRELAGGREGATES('GUID',$,$,$,#1,(#2));");
+  });
+
+  it('recognizes a list surrounded by legal STEP whitespace (#4200)', () => {
+    const line = "#5=IFCRELAGGREGATES('GUID',$,$,$,#1, (#2,#3) );";
+    const out = filterHiddenRefsFromRelationshipLine(line, (id) => id === 3);
+    expect(out).toBe("#5=IFCRELAGGREGATES('GUID',$,$,$,#1, (#2) );");
   });
 
   // CodeRabbit finding on this PR: widening the record regex put the trivia
@@ -946,7 +952,7 @@ describe('filterHiddenRefsFromRelationshipLine: trivia between the type name and
 
 /**
  * #4227: a `/* ... *​/` comment INSIDE the argument list (not before the
- * record's `(`, which #3789 above already covers) hit `splitTopLevelArgs`
+ * record's `(`, which #3789 above already covers) hit `splitTopLevelListItems`
  * directly — the sibling splitter with no comment-skip logic at the time.
  * The comma inside the comment split a mandatory single-valued `#5` slot
  * into two phantom slots, neither of which matched the `^#(\d+)$` bare-ref

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -30,7 +30,7 @@
 import type { IfcDataStore, IfcSourceBytes } from '@ifc-lite/parser';
 import { asSourceBytes, STEP_TRIVIA } from '@ifc-lite/parser';
 import type { EffectiveEntityIndex } from './effective-index.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { readStepSlots, splitTopLevelListItems } from './step-argument-parser.js';
 // Schema-derived type-set machinery (INFRASTRUCTURE_TYPES, PRODUCT_TYPES,
 // collectDescendantNames) lives in `entity-type-sets.ts` — shared with
 // `subset-roots.ts`, which derives IFC_ROOT_TYPES the same way. Re-exported
@@ -52,7 +52,6 @@ export { INFRASTRUCTURE_TYPES, PRODUCT_TYPES, collectDescendantNames };
  * isOptionalTrailingRef} entry, so its omitted trailing ref dropped the WHOLE
  * line instead of becoming `$`. `.trim()` hides the whitespace-only form.
  */
-const RECORD_PREFIX_RE = new RegExp(`^(#\\d+\\s*=\\s*(\\w+)${STEP_TRIVIA}\\()([\\s\\S]*)(\\)\\s*;)\\s*$`);
 export const BARE_REF_RE = new RegExp(`^${STEP_TRIVIA}#(\\d+)${STEP_TRIVIA}$`); // bare `#N` ref, trivia-tolerant (#4227), exported for reuse
 /**
  * UTF-8 decode of `[start, end)` of the source. Mirrors `step-exporter.ts` /
@@ -536,10 +535,10 @@ export function collectReferencedEntityIds(
  *
  * Returns the line unchanged when it names nothing excluded, a rewritten line
  * when a list member was dropped, or `null` to mean "do not emit this
- * relationship at all". A line this cannot parse as a single `#N=TYPE(...);`
- * record is returned unchanged — the source-iteration pass's own byte-range
- * and mutation passes are what validate that shape; this function only ever
- * narrows what a well-formed one contains.
+ * relationship at all". A STEP entity line whose validated slot layout cannot
+ * be read is withheld too: retaining an unverified line here could retain the
+ * exact excluded reference this output gate exists to remove. Non-entity text
+ * is returned unchanged.
  *
  * `isExcluded` is a predicate rather than a fixed `Set` because "excluded"
  * has two independent sources that a caller may need to combine: a
@@ -554,19 +553,25 @@ export function filterHiddenRefsFromRelationshipLine(
   line: string,
   isExcluded: (id: number) => boolean,
 ): string | null {
-  const match = line.match(RECORD_PREFIX_RE);
-  if (!match) return line;
-  const [, prefix, typeName, argsText, suffix] = match;
-  const attrs = splitTopLevelArgs(argsText);
-  const entityType = typeName.toUpperCase();
+  const record = readStepSlots(line);
+  // This helper is also the output gate for relationship/source-style lines.
+  // Once a line identifies itself as a STEP entity, refusing its slot layout
+  // must withhold the whole record; emitting it unchanged can retain exactly
+  // the dangling reference this gate exists to remove (#4200).
+  if (record === null) return /^\s*#\d+\s*=/.test(line) ? null : line;
+  const attrs = [...record.slots];
+  const entityType = record.type;
 
   let changed = false;
   const nextAttrs: string[] = [];
   for (let index = 0; index < attrs.length; index++) {
-    const attr = attrs[index];
+    const rawAttr = attrs[index];
+    const attr = rawAttr.trim();
+    const leading = rawAttr.slice(0, rawAttr.indexOf(attr));
+    const trailing = rawAttr.slice(rawAttr.indexOf(attr) + attr.length);
     if (attr.length >= 2 && attr.charCodeAt(0) === 0x28 /* '(' */ && attr.charCodeAt(attr.length - 1) === 0x29 /* ')' */) {
       const inner = attr.slice(1, -1);
-      const items = inner.trim() === '' ? [] : splitTopLevelArgs(inner);
+      const items = inner.trim() === '' ? [] : splitTopLevelListItems(inner);
       const survivors = items.filter((item) => {
         const refMatch = item.match(BARE_REF_RE);
         return !(refMatch && isExcluded(Number(refMatch[1])));
@@ -574,10 +579,10 @@ export function filterHiddenRefsFromRelationshipLine(
       if (survivors.length !== items.length) {
         if (survivors.length === 0) return null;
         changed = true;
-        nextAttrs.push(`(${survivors.join(',')})`);
+        nextAttrs.push(`${leading}(${survivors.join(',')})${trailing}`);
         continue;
       }
-      nextAttrs.push(attr);
+      nextAttrs.push(rawAttr);
       continue;
     }
 
@@ -585,16 +590,16 @@ export function filterHiddenRefsFromRelationshipLine(
     if (refMatch && isExcluded(Number(refMatch[1]))) {
       if (isOptionalTrailingRef(entityType, attrs.length, index)) {
         changed = true;
-        nextAttrs.push('$');
+        nextAttrs.push(`${leading}$${trailing}`);
         continue;
       }
       return null;
     }
-    nextAttrs.push(attr);
+    nextAttrs.push(rawAttr);
   }
 
   if (!changed) return line;
-  return `${prefix}${nextAttrs.join(',')}${suffix}`;
+  return `${record.prefix}${nextAttrs.join(',')}${record.suffix}`;
 }
 
 /**
@@ -680,13 +685,12 @@ export function relationshipRefsSurviveExclusion(
  * {@link relationshipRefGroupsFromSourceLine} needs to splice a positional or
  * named-attribute override into the right slot.
  *
- * Built from the exact same primitives (`splitTopLevelArgs`, the `#(\d+)`
+ * Built from the exact same primitives (`splitTopLevelListItems`, the `#(\d+)`
  * ref pattern) `filterHiddenRefsFromRelationshipLine` uses, so the two
  * extraction routes (this one from text, `refGroupsOf` from an authored
  * attribute list) feed the SAME decision function identically. A line that
- * does not parse as a single `#N=TYPE(...);` record yields no groups —
- * nothing to exclude on, so the relationship survives, matching that
- * function's own "return line unchanged" behavior for the same input shape.
+ * does not parse as a single `#N=TYPE(...);` record yields no groups. Callers
+ * that emit source records separately apply the withholding gate above.
  *
  * A parenthesised list holding a NON-reference item (an inline typed value
  * alongside, or instead of, `#N` members) yields `undefined` for that slot
@@ -717,9 +721,10 @@ export function relationshipRefsSurviveExclusion(
  * comments (#2637) call out as a defect source.
  */
 export function refGroupFromArg(attr: string): number | number[] | undefined {
+  attr = attr.trim();
   if (attr.length >= 2 && attr.charCodeAt(0) === 0x28 /* '(' */ && attr.charCodeAt(attr.length - 1) === 0x29 /* ')' */) {
     const inner = attr.slice(1, -1);
-    const items = inner.trim() === '' ? [] : splitTopLevelArgs(inner);
+    const items = inner.trim() === '' ? [] : splitTopLevelListItems(inner);
     const ids: number[] = [];
     let hasNonRefItem = false;
     for (const item of items) {
@@ -734,10 +739,8 @@ export function refGroupFromArg(attr: string): number | number[] | undefined {
 }
 
 function extractRelationshipRefGroupsIndexed(line: string): Array<number | number[] | undefined> {
-  const match = line.match(RECORD_PREFIX_RE);
-  if (!match) return [];
-  const attrs = splitTopLevelArgs(match[3]);
-  return attrs.map(refGroupFromArg);
+  const record = readStepSlots(line);
+  return record === null ? [] : record.slots.map(refGroupFromArg);
 }
 
 /**

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -53,17 +53,6 @@ export { INFRASTRUCTURE_TYPES, PRODUCT_TYPES, collectDescendantNames };
  * line instead of becoming `$`. `.trim()` hides the whitespace-only form.
  */
 export const BARE_REF_RE = new RegExp(`^${STEP_TRIVIA}#(\\d+)${STEP_TRIVIA}$`); // bare `#N` ref, trivia-tolerant (#4227), exported for reuse
-/**
- * UTF-8 decode of `[start, end)` of the source. Mirrors `step-exporter.ts` /
- * `merged-exporter.ts`'s local `decodeRange` (SAB-safe via the accessor);
- * duplicated rather than shared because this is the only place in the file
- * that needs text instead of raw bytes, and it is only reached for `IFCREL*`
- * entities under `visibleOnly` (see `collectReferencedEntityIds`).
- */
-function decodeRange(src: IfcSourceBytes, start: number, end: number): string {
-  return src.decodeUtf8(start, end);
-}
-
 /** ASCII code points for byte-level scanning. */
 const HASH = 0x23;  // '#'
 const ZERO = 0x30;  // '0'
@@ -386,7 +375,7 @@ export function collectReferencedEntityIds(
         : (sourceRelGroups = relationshipRefGroupsFromSourceLine(
             entityIndex,
             entityId,
-            decodeRange(src, ref.byteOffset, ref.byteOffset + ref.byteLength),
+            src.decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength),
           ));
       if (!relationshipRefsSurviveExclusion(groups, isBridgeTargetExcluded)) {
         continue;
@@ -419,7 +408,7 @@ export function collectReferencedEntityIds(
       // at all). Gated on the cheap `hasSourceMutation` check so an entity
       // with nothing queued — the overwhelming majority — still takes the
       // plain byte scan below with no decode/parse cost.
-      const decodedLine = decodeRange(src, ref.byteOffset, ref.byteOffset + ref.byteLength);
+      const decodedLine = src.decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
       const generalGroups = relationshipRefGroupsFromSourceLine(entityIndex, entityId, decodedLine);
       for (const group of generalGroups) {
         if (Array.isArray(group)) refs.push(...group);

--- a/packages/export/src/schema-converter-attr-remap.test.ts
+++ b/packages/export/src/schema-converter-attr-remap.test.ts
@@ -4,20 +4,16 @@
 
 /**
  * `splitTopLevelAttributes` used to carry its own top-level-comma scanner,
- * near-identical to `step-argument-parser.ts`'s `splitTopLevelArgs`
- * (LTplus-AG/ifc-lite#4125). It is now a thin wrapper over that shared
- * splitter. These tests pin: (1) the two functions agree on every input
- * `remapRenamedAttributesByName`'s real callers can produce, so the
- * consolidation changed no observable output; (2) the one input where they
- * legitimately differ (a trailing empty argument), which
- * `remapRenamedAttributesByName`'s fixed-arity IFCDOORTYPE/IFCWINDOWTYPE
- * callers never produce.
+ * near-identical to the validated STEP slot parser (LTplus-AG/ifc-lite#4125).
+ * It is now a thin wrapper over that shared refusal boundary. These tests pin
+ * the actual tokens, including a trailing empty slot, instead of comparing
+ * one parser implementation with another copy.
  */
 import { describe, it, expect } from 'vitest';
 import { splitTopLevelAttributes } from './schema-converter-attr-remap.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 
-describe('splitTopLevelAttributes delegates to the shared splitTopLevelArgs', () => {
+describe('splitTopLevelAttributes delegates to the validated slot splitter', () => {
   it('returns [] for an empty or whitespace-only list', () => {
     expect(splitTopLevelAttributes('')).toEqual([]);
     expect(splitTopLevelAttributes('   ')).toEqual([]);
@@ -30,8 +26,8 @@ describe('splitTopLevelAttributes delegates to the shared splitTopLevelArgs', ()
     // embedded comma, and a doubled-quote escape.
     //
     // Expected tokens are authored by hand, not derived from
-    // `splitTopLevelArgs` itself: `splitTopLevelAttributes` is now a pure
-    // delegate to `splitTopLevelArgs` (see the export above), so asserting
+    // `splitTopLevelStepArguments` itself: `splitTopLevelAttributes` is a pure
+    // delegate to the validated parser (see the export above), so asserting
     // one against the other would only ever confirm `f(x) === f(x)` — a
     // parser defect shared by both sides (e.g. mis-scanning the embedded
     // comma in `'a, b'`) would pass unnoticed.
@@ -60,13 +56,16 @@ describe('splitTopLevelAttributes delegates to the shared splitTopLevelArgs', ()
     ["'a, b',#1,(#2,#3),$", ["'a, b'", '#1', '(#2,#3)', '$']],
     ["'it''s escaped',#1,$", ["'it''s escaped'", '#1', '$']],
     ['#1,#2,#3', ['#1', '#2', '#3']],
-  ])('splits %j into the expected tokens, in agreement with splitTopLevelArgs', (input, expected) => {
+  ])('splits %j into the expected validated tokens', (input, expected) => {
     expect(splitTopLevelAttributes(input)).toEqual(expected);
-    expect(splitTopLevelArgs(input)).toEqual(expected);
+    expect(splitTopLevelStepArguments(input)).toEqual(expected);
   });
 
-  it('a trailing empty argument is dropped, matching splitTopLevelArgs (not the old local scanner, which kept it) — never reached by a fixed-arity IFCDOORTYPE/IFCWINDOWTYPE list', () => {
-    expect(splitTopLevelAttributes('a,')).toEqual(['a']);
-    expect(splitTopLevelAttributes('a,')).toEqual(splitTopLevelArgs('a,'));
+  it('keeps an empty trailing slot position-addressable', () => {
+    expect(splitTopLevelAttributes('a,')).toEqual(['a', '']);
+  });
+
+  it('refuses malformed slots instead of remapping values at shifted positions', () => {
+    expect(splitTopLevelAttributes(`'g',"01,23"`)).toBeNull();
   });
 });

--- a/packages/export/src/schema-converter-attr-remap.ts
+++ b/packages/export/src/schema-converter-attr-remap.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 
 /**
  * Attribute-list reconciliation for a genuine cross-schema entity RENAME
@@ -16,29 +16,17 @@ import { splitTopLevelArgs } from './step-argument-parser.js';
  * value strings, respecting nested parentheses and single-quoted strings.
  * Empty list → [].
  *
- * A thin wrapper over `step-argument-parser.ts`'s `splitTopLevelArgs` — the
- * same package's general-purpose top-level-comma splitter, already used by
- * seven other read paths in this package (`retype.ts`, `reference-collector.ts`,
- * `merged-empty-containers.ts`, etc). This module used to carry its own
- * near-identical scan; kept here as `remapRenamedAttributesByName`'s only
- * caller expects, but no longer a fourth copy of the same rule
- * (LTplus-AG/ifc-lite#4125). `trimAttributes` in `schema-converter.ts` is
- * NOT folded in here: it stops early at a positional budget, which is a
- * genuinely different rule, not a copy of this one.
+ * A thin wrapper over `step-argument-parser.ts`'s validated
+ * `splitTopLevelStepArguments`. This module used to carry its own permissive
+ * scan; keeping the wrapper gives remapping an explicit refusal boundary
+ * without retaining a fourth parser (LTplus-AG/ifc-lite#4125/#4200).
  *
- * `splitTopLevelArgs` behaves differently from the old local scanner in two
- * ways: it drops a trailing empty argument (`"a,"` → `['a']`) rather than
- * keeping it as `['a', '']`, and it trims each token
- * (`"a, b,c"` → `['a','b','c']` instead of `['a',' b','c']`). Both are safe
- * for `remapRenamedAttributesByName`'s real inputs: neither `IFCDOORTYPE`
- * nor `IFCWINDOWTYPE`'s fixed-arity attribute list has a trailing comma in
- * well-formed STEP, so the first difference never fires; and STEP has no
- * semantic significance to whitespace between top-level tokens, so a trimmed
- * token is the same value either way. Pinned by
- * `schema-converter-attr-remap.test.ts`.
+ * The validated splitter preserves an empty trailing slot so malformed
+ * fixed-arity records cannot shift positional meaning, and trims legal STEP
+ * whitespace around each token. Pinned by the adjacent tests.
  */
-export function splitTopLevelAttributes(attrsRaw: string): string[] {
-  return splitTopLevelArgs(attrsRaw);
+export function splitTopLevelAttributes(attrsRaw: string): string[] | null {
+  return splitTopLevelStepArguments(attrsRaw);
 }
 
 /**
@@ -86,8 +74,9 @@ export function remapRenamedAttributesByName(
   attrsRaw: string,
   srcNames: readonly string[],
   tgtNames: readonly string[],
-): string {
+): string | null {
   const values = splitTopLevelAttributes(attrsRaw);
+  if (values === null) return null;
   const byName = new Map<string, string>();
   for (let i = 0; i < srcNames.length && i < values.length; i++) {
     byName.set(srcNames[i], values[i]);

--- a/packages/export/src/schema-converter.test.ts
+++ b/packages/export/src/schema-converter.test.ts
@@ -135,6 +135,19 @@ describe('schema-converter', () => {
       expect(convertStepLine('', 'IFC4', 'IFC2X3')).toBe('');
     });
 
+    it('refuses malformed slots before any type rename or proxy replacement (#4200)', () => {
+      expect(() => convertStepLine(
+        '#10=IFCBRIDGE(\'g\',"01,23",$);',
+        'IFC4X3',
+        'IFC4',
+      )).toThrow(/refused an invalid STEP argument list/);
+      expect(() => convertStepLine(
+        '#99=IFCALIGNMENTCANT(\'g\',"01,23",$);',
+        'IFC4X3',
+        'IFC4',
+      )).toThrow(/refused an invalid STEP argument list/);
+    });
+
     it('handles complex STEP attribute values correctly', () => {
       // Attributes with nested parentheses and strings
       const line = "#10=IFCWALL('2O2Fr$t4X7Zf8NOew3FLOH',$,'Basic Wall:Interior - 79mm Partition (1-hr):128475',$,'Basic Wall:Interior - 79mm Partition (1-hr)',$,#8,#9,.STANDARD.);";

--- a/packages/export/src/schema-converter.ts
+++ b/packages/export/src/schema-converter.ts
@@ -25,6 +25,7 @@ import { deterministicGlobalId } from '@ifc-lite/parser';
 import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, type IfcEntityInfo } from '@ifc-lite/data';
 import { resolveUnrepresentedEntity } from './schema-untranslatable.js';
 import { BY_NAME_ATTR_REMAP_TYPES, remapRenamedAttributesByName } from './schema-converter-attr-remap.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 
 export type IfcSchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
 
@@ -252,24 +253,10 @@ function isStrictAttrPrefix(shorter: readonly string[], longer: readonly string[
 
 /** Count top-level (comma-separated) STEP attributes, respecting nested
  *  parentheses and single-quoted strings. Empty list → 0. */
-function countTopLevelAttributes(attrsRaw: string): number {
-  if (!attrsRaw.trim()) return 0;
-  let count = 1;
-  let depth = 0;
-  let inString = false;
-  for (let i = 0; i < attrsRaw.length; i++) {
-    const ch = attrsRaw[i];
-    if (ch === "'" && !inString) inString = true;
-    else if (ch === "'" && inString) {
-      if (i + 1 < attrsRaw.length && attrsRaw[i + 1] === "'") { i++; continue; }
-      inString = false;
-    } else if (!inString) {
-      if (ch === '(') depth++;
-      else if (ch === ')') depth--;
-      else if (ch === ',' && depth === 0) count++;
-    }
-  }
-  return count;
+function requireTopLevelAttributes(attrsRaw: string): string[] {
+  const attrs = splitTopLevelStepArguments(attrsRaw);
+  if (attrs === null) throw new Error('Schema conversion refused an invalid STEP argument list.');
+  return attrs;
 }
 
 /**
@@ -308,6 +295,11 @@ export function convertStepLine(
   const prefix = match[1];  // "#123="
   const entityType = match[2].toUpperCase();
   const attrsRaw = match[3] ?? '';
+
+  // Validate before choosing any conversion branch. A malformed slot list
+  // must not still receive a type rename, proxy replacement, trim, or padding:
+  // that would partially convert a record whose positions are untrustworthy.
+  requireTopLevelAttributes(attrsRaw);
 
   // Convert entity type
   const newType = convertEntityType(entityType, fromSchema, toSchema);
@@ -381,13 +373,15 @@ export function convertStepLine(
     if (isStrictAttrPrefix(tgtAttrs, srcAttrs)) {
       finalAttrs = trimAttributes(attrsRaw, tgtAttrs.length);
     } else if (isStrictAttrPrefix(srcAttrs, tgtAttrs)) {
-      const currentCount = countTopLevelAttributes(finalAttrs);
+      const currentCount = requireTopLevelAttributes(finalAttrs).length;
       if (currentCount > 0 && currentCount < tgtAttrs.length) {
         finalAttrs = `${finalAttrs}${',$'.repeat(tgtAttrs.length - currentCount)}`;
       }
     } else if (entityType !== newType && BY_NAME_ATTR_REMAP_TYPES.has(entityType)) {
       // Neither list is a prefix of the other; see `BY_NAME_ATTR_REMAP_TYPES`.
-      finalAttrs = remapRenamedAttributesByName(attrsRaw, srcAttrs, tgtAttrs);
+      const remapped = remapRenamedAttributesByName(attrsRaw, srcAttrs, tgtAttrs);
+      if (remapped === null) throw new Error('Schema conversion refused an invalid STEP argument list.');
+      finalAttrs = remapped;
     }
   }
 
@@ -432,54 +426,7 @@ function trimAttributes(attrsRaw: string, maxCount: number): string {
   // schema keeps none.
   if (maxCount <= 0) return '';
 
-  const attrs: string[] = [];
-  let depth = 0;
-  let inString = false;
-  let current = '';
-
-  for (let i = 0; i < attrsRaw.length; i++) {
-    const ch = attrsRaw[i];
-
-    if (ch === "'" && !inString) {
-      inString = true;
-      current += ch;
-    } else if (ch === "'" && inString) {
-      // Check for escaped quote ''
-      if (i + 1 < attrsRaw.length && attrsRaw[i + 1] === "'") {
-        current += "''";
-        i++;
-        continue;
-      }
-      inString = false;
-      current += ch;
-    } else if (inString) {
-      current += ch;
-    } else if (ch === '(') {
-      depth++;
-      current += ch;
-    } else if (ch === ')') {
-      depth--;
-      current += ch;
-    } else if (ch === ',' && depth === 0) {
-      attrs.push(current);
-      current = '';
-      if (attrs.length >= maxCount) {
-        return attrs.join(',');
-      }
-    } else {
-      current += ch;
-    }
-  }
-
-  // Last attribute
-  attrs.push(current);
-
-  // Trim to maxCount
-  if (attrs.length > maxCount) {
-    return attrs.slice(0, maxCount).join(',');
-  }
-
-  return attrs.join(',');
+  return requireTopLevelAttributes(attrsRaw).slice(0, maxCount).join(',');
 }
 
 /**

--- a/packages/export/src/step-argument-parser.test.ts
+++ b/packages/export/src/step-argument-parser.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { replaceStepArgument, splitTopLevelArgs, splitTopLevelStepArguments } from './step-argument-parser.js';
+import { readStepSlots, replaceStepArgument, splitTopLevelListItems, splitTopLevelStepArguments } from './step-argument-parser.js';
 
 describe('replaceStepArgument slot validation', () => {
   const LINE = "#5=IFCWALLTYPE('0OSuGGYUFyIf0LtE29OSuT',$,'WT1',$,$,(#30),$,$,$,.STANDARD.);";
@@ -29,6 +29,21 @@ describe('replaceStepArgument slot validation', () => {
       expect(replaceStepArgument(LINE, slot, '(#33)')).toBeNull();
     });
   }
+});
+
+describe('readStepSlots (#4200)', () => {
+  it('returns the type, framing, and validated positional slots together', () => {
+    expect(readStepSlots("#5=IFCWALL('g',$,'Größe');")).toEqual({
+      prefix: '#5=IFCWALL(',
+      type: 'IFCWALL',
+      slots: ["'g'", '$', "'Größe'"],
+      suffix: ');',
+    });
+  });
+
+  it('refuses a record whose apparent slots fail the shared grammar', () => {
+    expect(readStepSlots(`#5=IFCWALL('g',"01,23");`)).toBeNull();
+  });
 });
 
 /**
@@ -248,7 +263,7 @@ describe('splitTopLevelStepArguments skips comment content in the outer scan', (
   });
 
   it('a top-level comma glued directly to the closing "*/" is still a boundary', () => {
-    // Same `skipStepComment` off-by-one hazard as `splitTopLevelArgs`: it must
+    // Same `skipStepComment` off-by-one hazard as `splitTopLevelListItems`: it must
     // stop AT `*/` (`end + 2`), not past it, or the comma right after a
     // comment attached to a real value gets swallowed into that value's slot.
     expect(splitTopLevelStepArguments('5/* c */,#2')).toEqual(['5/* c */', '#2']);
@@ -320,7 +335,7 @@ describe('replaceStepArgument still accepts every well-formed list', () => {
 });
 
 /**
- * #4227: `splitTopLevelArgs` shipped with none of `splitTopLevelStepArguments`'s
+ * #4227: `splitTopLevelListItems` shipped with none of `splitTopLevelStepArguments`'s
  * comment-skip logic, so a `,` inside a `/* ... *​/` comment inside an
  * argument list was read as a top-level argument separator — a phantom slot
  * boundary that let a hidden/deleted `#N` reference survive
@@ -329,11 +344,11 @@ describe('replaceStepArgument still accepts every well-formed list', () => {
  * ref attached to a slot like `comment *​/#5`, which never matches). Both
  * splitters now share `skipStepComment`.
  */
-describe('splitTopLevelArgs skips comment content in the outer scan (#4227)', () => {
+describe('splitTopLevelListItems skips comment content in the outer scan (#4227)', () => {
   it('does not read a comma inside a comment as an argument boundary', () => {
     // The exact adversarial argument list from #4227 (the record wrapper is
     // exercised end-to-end in reference-collector.test.ts).
-    expect(splitTopLevelArgs("'guid',$,$,$,#1,/* void, comment */#5")).toEqual([
+    expect(splitTopLevelListItems("'guid',$,$,$,#1,/* void, comment */#5")).toEqual([
       "'guid'",
       '$',
       '$',
@@ -344,7 +359,7 @@ describe('splitTopLevelArgs skips comment content in the outer scan (#4227)', ()
   });
 
   it('a commented comma inside a NESTED list still resolves to the right slot boundaries', () => {
-    expect(splitTopLevelArgs("$,(#2,/* c, with a comma */#3),#1")).toEqual([
+    expect(splitTopLevelListItems("$,(#2,/* c, with a comma */#3),#1")).toEqual([
       '$',
       '(#2,/* c, with a comma */#3)',
       '#1',
@@ -354,23 +369,23 @@ describe('splitTopLevelArgs skips comment content in the outer scan (#4227)', ()
   it('a comment containing an apostrophe (odd quote count) does not flip string-scan state', () => {
     // An undoubled `'` inside a comment must not be read as opening a string
     // — if it were, the comma in the next real argument would be swallowed.
-    expect(splitTopLevelArgs("$,/* it's a void */#5,$")).toEqual(['$', "/* it's a void */#5", '$']);
+    expect(splitTopLevelListItems("$,/* it's a void */#5,$")).toEqual(['$', "/* it's a void */#5", '$']);
   });
 
   it('a comment before the argument list even starts is untouched (no regression)', () => {
-    // splitTopLevelArgs only ever receives the text INSIDE a record's `(` and
+    // splitTopLevelListItems only ever receives the text INSIDE a record's `(` and
     // `)` — a comment before that `(` is stripped by the caller's record
     // regex before this function ever sees it. Pinned here as a control: the
     // comment-skip branch added for #4227 must not affect a plain list with
     // no comment in it at all.
-    expect(splitTopLevelArgs("'guid',$,$,$,#1,#5")).toEqual(["'guid'", '$', '$', '$', '#1', '#5']);
+    expect(splitTopLevelListItems("'guid',$,$,$,#1,#5")).toEqual(["'guid'", '$', '$', '$', '#1', '#5']);
   });
 
   it('a top-level comma glued directly to the closing "*/" is still a boundary', () => {
     // `skipStepComment` must stop exactly at `*/` (`end + 2`), not one char
     // past it. Consuming an extra char swallows a comma with zero whitespace
     // after the comment, merging the next argument into this one.
-    expect(splitTopLevelArgs('$,/* c */,#5')).toEqual(['$', '/* c */', '#5']);
+    expect(splitTopLevelListItems('$,/* c */,#5')).toEqual(['$', '/* c */', '#5']);
   });
 });
 

--- a/packages/export/src/step-argument-parser.ts
+++ b/packages/export/src/step-argument-parser.ts
@@ -14,7 +14,7 @@ import { isWellFormedStepSlot } from './step-slot-grammar.js';
  * repoint, see below), the same failure class. Compiled once since
  * `replaceStepArgument` runs per rewritten line.
  */
-const RECORD_PREFIX_RE = new RegExp(`^(#\\d+\\s*=\\s*\\w+${STEP_TRIVIA}\\()([\\s\\S]*)(\\)\\s*;)\\s*$`);
+const RECORD_PREFIX_RE = new RegExp(`^(#\\d+\\s*=\\s*(\\w+)${STEP_TRIVIA}\\()([\\s\\S]*)(\\)\\s*;)\\s*$`);
 
 /**
  * The STEP argument parser and rewriter: reading a record's top-level argument
@@ -36,9 +36,11 @@ const RECORD_PREFIX_RE = new RegExp(`^(#\\d+\\s*=\\s*\\w+${STEP_TRIVIA}\\()([\\s
  */
 /**
  * Split a STEP argument list on top-level commas, respecting nested
- * parens, quoted strings, and comments (#4227). Used by `applyAttributeMutations`.
+ * parens, quoted strings, and comments (#4227). This permissive helper is for
+ * already-extracted aggregate/list bodies; whole entity records must go
+ * through `readStepSlots` so every slot is validated before mutation.
  */
-export function splitTopLevelArgs(text: string): string[] {
+export function splitTopLevelListItems(text: string): string[] {
   const parts: string[] = [];
   let current = '';
   let depth = 0;
@@ -100,6 +102,23 @@ export function splitTopLevelArgs(text: string): string[] {
   return parts;
 }
 
+export interface StepRecordSlots {
+  readonly prefix: string;
+  readonly type: string;
+  readonly slots: readonly string[];
+  readonly suffix: string;
+}
+
+/** Parse a complete STEP record into validated, position-addressable slots. */
+export function readStepSlots(entityText: string): StepRecordSlots | null {
+  const match = entityText.match(RECORD_PREFIX_RE);
+  if (!match) return null;
+  const [, prefix, type, attrsText, suffix] = match;
+  const slots = splitTopLevelStepArguments(attrsText);
+  if (slots === null) return null;
+  return { prefix, type: type.toUpperCase(), slots, suffix };
+}
+
 /**
  * Replace ONE top-level argument of a STEP record, by zero-based slot, leaving
  * every other token — and the record's class keyword and id — byte-identical.
@@ -127,11 +146,7 @@ export function replaceStepArgument(
   attrIndex: number,
   replacement: string,
 ): string | null {
-  const match = entityText.match(RECORD_PREFIX_RE);
-  if (!match) return null;
-
-  const [, prefix, attrsText, suffix] = match;
-  const attrs = splitTopLevelStepArguments(attrsText);
+  const record = readStepSlots(entityText);
   // Load-bearing, and covered: the bounds check below READS `attrs.length`, so a
   // null reaches it as a TypeError rather than falling through to a rejection.
   // Deleting this line fails exactly the three malformed-input cases in
@@ -139,7 +154,8 @@ export function replaceStepArgument(
   // closing paren — which throw instead of returning null. Kept as its own line,
   // not folded into that check, because "could not scan it" and "that slot is
   // past the end" are different facts about the input.
-  if (attrs === null) return null;
+  if (record === null) return null;
+  const attrs = [...record.slots];
   // A negative or fractional slot must not reach the assignment below: it would
   // set a NAMED PROPERTY on the array rather than an element, `join` would skip
   // it, and this would hand back the line unchanged — but non-null, which the
@@ -150,14 +166,14 @@ export function replaceStepArgument(
   if (!Number.isInteger(attrIndex) || attrIndex < 0 || attrIndex >= attrs.length) return null;
 
   attrs[attrIndex] = replacement;
-  return `${prefix}${attrs.join(',')}${suffix}`;
+  return `${record.prefix}${attrs.join(',')}${record.suffix}`;
 }
 
 /**
  * Split a STEP argument list on top-level commas while preserving nested syntax,
  * or null when the text is not a well-formed argument list.
  *
- * Similar to `splitTopLevelArgs` but uses a slightly different accumulation style
+ * Similar to `splitTopLevelListItems` but uses a slightly different accumulation style
  * suited for the {@link replaceStepArgument} call-site.
  *
  * ## Why it validates

--- a/packages/export/src/step-comment-skip.ts
+++ b/packages/export/src/step-comment-skip.ts
@@ -10,7 +10,7 @@
  * (a comma, an unbalanced paren, an odd number of `'`) is skipped as one
  * unit rather than read as argument-list structure. Shared by both
  * `step-argument-parser.ts` splitters so the skip rule can't drift between
- * them again (#4227: `splitTopLevelArgs` shipped with no comment handling
+ * them again (#4227: `splitTopLevelListItems` shipped with no comment handling
  * at all while `splitTopLevelStepArguments` had this same logic inline).
  */
 export function skipStepComment(text: string, i: number): number {

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -1000,7 +1000,7 @@ describe('StepExporter', () => {
   // `@ifc-lite/data`: `entities-ifc2x3.ts` vs `entities-ifc4.ts`), so there is
   // no arity difference for THESE FOUR classes to exercise. What this test
   // instead confirms is that the closure/bridge mechanism — which is purely
-  // SYNTACTIC (byte/text parsing of the STEP line, `splitTopLevelArgs`) for a
+  // SYNTACTIC (byte/text parsing of the STEP line, `splitTopLevelListItems`) for a
   // SOURCE-backed relationship, and consults `getAttributeNamesAcrossSchemas`
   // (a version-invariant, IFC4-pinned-then-union resolver) only for a NAMED
   // attribute override — behaves identically when `dataStore.schemaVersion`
@@ -1202,7 +1202,7 @@ describe('StepExporter', () => {
   // at the SAME indices (4/5) in both schemas — the shorter arity is a
   // TRAILING difference — so this exercises the same retarget shape as the
   // IFC4 tests above, just on the schema that genuinely has fewer attributes
-  // to parse `splitTopLevelArgs` over.
+  // to parse `splitTopLevelListItems` over.
   it('does not leave a dangling ref for a retargeted IfcRelSequence on an IFC2X3 source (a genuine arity difference)', () => {
     const dataStore = buildMockDataStore([
       [1, 'IFCPROJECT', "#1=IFCPROJECT('1ys5Xwuxz8gPJk6N$NGhA1',$,'P',$,$,$,$,$,$);"],

--- a/packages/export/src/step-overlay-attribute-overrides.ts
+++ b/packages/export/src/step-overlay-attribute-overrides.ts
@@ -12,7 +12,7 @@
 
 import type { IfcAttributeValue } from '@ifc-lite/parser';
 import { getAttributeNamesAcrossSchemas } from '@ifc-lite/parser';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
 import { getRealTypedSlots } from './attribute-real-slots.js';
 import { serializeNamedAttribute, serializePositionalOverride } from './step-attribute-serializers.js';
 import type { IfcSchemaVersion } from './schema-converter.js';
@@ -46,7 +46,11 @@ export function applyOverlayEntityOverrides(
   schemaVersion: IfcSchemaVersion,
   onRejected?: (attrName: string, value: string) => void,
 ): string {
-  const args = argsText.length > 0 ? splitTopLevelArgs(argsText) : [];
+  const parsed = splitTopLevelStepArguments(argsText);
+  if (parsed === null) {
+    throw new Error('Cannot apply an overlay override to an invalid STEP argument list.');
+  }
+  const args = parsed;
   const attrNames = getAttributeNamesAcrossSchemas(entityType);
 
   const named: Array<[number, string]> = [];

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -11,7 +11,7 @@
  * Three neighbours are deliberately NOT here, because none turns a value into
  * a token and each has rules of its own worth finding on its own:
  *   - `step-argument-parser.ts` reads a record's arguments back OUT of a line
- *     and writes one slot by index (`splitTopLevelArgs`, `replaceStepArgument`,
+ *     and writes one slot by index (`splitTopLevelListItems`, `replaceStepArgument`,
  *     `splitTopLevelStepArguments`);
  *   - `step-file-assembly.ts` joins a finished header and finished entity lines
  *     into the delivered file (`assembleStepBytes`, `assembleStepBlob`);

--- a/packages/export/src/subset-entity-reader.trivia.test.ts
+++ b/packages/export/src/subset-entity-reader.trivia.test.ts
@@ -30,6 +30,7 @@ describe('readEntityArgs tolerates STEP trivia between the type name and "("', (
     ['space', "#1=IFCLOCALPLACEMENT ($,#9);"],
     ['block comment', "#1=IFCLOCALPLACEMENT/* c */($,#9);"],
     ['whitespace and comment interleaved', "#1=IFCLOCALPLACEMENT /* a */\t($,#9);"],
+    ['whitespace around positional values', "#1=IFCLOCALPLACEMENT( $ , #9 );"],
   ])('reads the arguments through %s', (_name, record) => {
     const { store: s, index } = store(record);
     expect(readEntityArgs(s, index, 1)).toEqual({ type: 'IFCLOCALPLACEMENT', args: ['$', '#9'] });
@@ -42,6 +43,11 @@ describe('readEntityArgs tolerates STEP trivia between the type name and "("', (
     ['"//" is not a STEP comment', "#1=IFCLOCALPLACEMENT//x\n($,#9);"],
   ])('still refuses %s', (_name, record) => {
     const { store: s, index } = store(record);
+    expect(readEntityArgs(s, index, 1)).toBeNull();
+  });
+
+  it('refuses a malformed binary before exposing position-addressable slots (#4200)', () => {
+    const { store: s, index } = store('#1=IFCLOCALPLACEMENT("01,23",#9);');
     expect(readEntityArgs(s, index, 1)).toBeNull();
   });
 });

--- a/packages/export/src/subset-entity-reader.ts
+++ b/packages/export/src/subset-entity-reader.ts
@@ -12,17 +12,17 @@
  * Deliberately thin: this module owns none of the parsing rules itself. It
  * composes `decodeRange` (`source-ref-bounds.ts`, the same readability gate
  * every other byte-range read in this package uses — #2491) with
- * `splitTopLevelArgs` (`step-argument-parser.ts`, the same quote/paren-aware
- * splitter `filterHiddenRefsFromRelationshipLine` uses) so a second,
- * independent STEP-line parser cannot disagree with the ones the rest of the
- * exporter already relies on.
+ * `readStepSlots` (`step-argument-parser.ts`, the same validated record reader
+ * `filterHiddenRefsFromRelationshipLine` uses) so a second, independent
+ * STEP-line parser cannot disagree with the ones the rest of the exporter
+ * already relies on.
  */
 
 import type { IfcSourceBytes } from '@ifc-lite/parser';
-import { STEP_TRIVIA, getAttributeNamesAcrossSchemas, resolveEntityNameAlias } from '@ifc-lite/parser';
+import { getAttributeNamesAcrossSchemas, resolveEntityNameAlias } from '@ifc-lite/parser';
 import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, type IfcEntityInfo } from '@ifc-lite/data';
 import { createSourceRefReader, decodeRange } from './source-ref-bounds.js';
-import { splitTopLevelArgs } from './step-argument-parser.js';
+import { readStepSlots } from './step-argument-parser.js';
 
 /**
  * `#N=TYPE(...);` record, with STEP trivia (whitespace and/or a
@@ -32,8 +32,6 @@ import { splitTopLevelArgs } from './step-argument-parser.js';
  * `null`, and `anonymize-placement.ts` / `anonymize-scrub.ts` silently skip
  * that entity instead of scrubbing it.
  */
-const RECORD_RE = new RegExp(`^#\\d+\\s*=\\s*(\\w+)${STEP_TRIVIA}\\(([\\s\\S]*)\\)\\s*;\\s*$`);
-
 /** One entity's parsed STEP record: its type token and top-level arguments,
  *  in declaration order (still raw STEP tokens — `#N`, `'text'`, `$`, `.T.`,
  *  a nested `(...)` list — not decoded values). */
@@ -74,10 +72,8 @@ export function readEntityArgs(
   if (!isReadable(ref)) return null;
 
   const line = decodeRange(store.source, ref.byteOffset, ref.byteOffset + ref.byteLength);
-  const match = line.match(RECORD_RE);
-  if (!match) return null;
-  const [, type, argsText] = match;
-  return { type: type.toUpperCase(), args: splitTopLevelArgs(argsText) };
+  const record = readStepSlots(line);
+  return record === null ? null : { type: record.type, args: record.slots.map((arg) => arg.trim()) };
 }
 
 /**

--- a/packages/export/src/unreadable-record-warning.test.ts
+++ b/packages/export/src/unreadable-record-warning.test.ts
@@ -17,8 +17,8 @@
  * The last two cases are the other direction — what the report must NOT claim.
  * A record whose line the export withholds must not also be reported as written,
  * which is why the report is buffered rather than pushed where it is produced;
- * and the report must not describe the written line at all, because a
- * cross-schema export rewrites it after the buffer is flushed (#4213).
+ * and a cross-schema export must abort before partially converting a record
+ * whose positional slots were refused (#4200).
  */
 
 import { describe, expect, it } from 'vitest';
@@ -178,31 +178,13 @@ END-ISO-10303-21;`;
 
 const CHIMNEY_ID = 50;
 
-describe('the refusal report does not claim how the record was written', () => {
-  it('a cross-schema export rewrites the record the refusal is about', async () => {
-    // Before #4213 the warning opened "was written exactly as the source file
-    // has it", produced by `applySourceLineMutationsReported` — which runs
-    // BEFORE `writeSourceEntityLines` hands the line to `convertStepLine`. On
-    // this path the conversion renames the type, so the sentence was false in
-    // exactly the case a caller needs it: it is asking what became of an edit
-    // the export dropped.
+describe('cross-schema refusal is transactional (#4200)', () => {
+  it('aborts instead of renaming or proxying a record whose slots were refused', async () => {
     const store = await parse(CROSS_SCHEMA_IFC);
     const { view, editor } = newSession(store);
     editor.setAttribute(CHIMNEY_ID, 'Description', 'NEWDESC');
 
-    const result = new StepExporter(store, view).export({ schema: 'IFC2X3' });
-    const text = new TextDecoder().decode(result.content);
-
-    // The edit really was dropped, and really was reported.
-    expect(text).not.toContain('NEWDESC');
-    expect(refusalReportsFor(result.stats.warnings, CHIMNEY_ID)).toHaveLength(1);
-
-    // The record went out under a different class than the source gave it, so
-    // no warning about it may say it went out as the source has it.
-    expect(text).toMatch(new RegExp(`^#${CHIMNEY_ID}\\s*=\\s*IFCBUILDINGELEMENTPROXY`, 'm'));
-    expect(text).not.toMatch(new RegExp(`^#${CHIMNEY_ID}\\s*=\\s*IFCCHIMNEY`, 'm'));
-    for (const warning of result.stats.warnings.filter((w) => w.includes(`#${CHIMNEY_ID}`))) {
-      expect(warning).not.toContain('exactly as the source');
-    }
+    expect(() => new StepExporter(store, view).export({ schema: 'IFC2X3' }))
+      .toThrow(/Schema conversion refused an invalid STEP argument list/);
   });
 });

--- a/rust/export/src/schema_convert.rs
+++ b/rust/export/src/schema_convert.rs
@@ -5,6 +5,8 @@
 //! trimming on downgrade, padding of the attributes a newer target schema appended
 //! (`schema_pad`), and a proxy fallback for types with no target representation.
 
+use crate::step_slot::split_top_level_args;
+
 /// Canonicalize a FILE_SCHEMA label to one of the four families we convert between.
 fn canon(s: &str) -> &'static str {
     let u = s.to_uppercase();
@@ -94,17 +96,17 @@ fn by_name_attr_remap_names(entity_type: &str) -> Option<(&'static [&'static str
 /// A target attribute with no same-named source attribute becomes `$`
 /// (unknown); a source attribute with no same-named target slot is dropped.
 /// Mirrors TS `schema-converter-attr-remap.ts`'s `remapRenamedAttributesByName`.
-fn remap_attrs_by_name(attrs: &str, src_names: &[&str], tgt_names: &[&str]) -> String {
-    let values = split_top_level(attrs);
+fn remap_attrs_by_name(attrs: &str, src_names: &[&str], tgt_names: &[&str]) -> Option<String> {
+    let values = split_top_level_args(attrs)?;
     let mut by_name: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
     for (name, value) in src_names.iter().zip(values.iter()) {
         by_name.insert(*name, value.as_str());
     }
-    tgt_names
+    Some(tgt_names
         .iter()
         .map(|name| by_name.get(name).copied().unwrap_or("$"))
         .collect::<Vec<_>>()
-        .join(",")
+        .join(","))
 }
 
 fn map_4x3_to_4(t: &str) -> Option<&'static str> {
@@ -200,58 +202,16 @@ pub(crate) fn placeholder_guid(id: u32) -> String {
 /// value strings, respecting nested parentheses and single-quoted strings.
 /// Empty list -> `[]`. Shared by `trim_attributes` (positional truncation)
 /// and `remap_attrs_by_name` (by-name reconciliation).
-fn split_top_level(attrs: &str) -> Vec<String> {
-    if attrs.trim().is_empty() {
-        return Vec::new();
-    }
-    let bytes = attrs.as_bytes();
-    let mut out: Vec<String> = Vec::new();
-    let mut depth = 0i32;
-    let mut in_string = false;
-    let mut current = String::new();
-    let mut i = 0;
-    while i < bytes.len() {
-        let ch = bytes[i] as char;
-        if ch == '\'' && !in_string {
-            in_string = true;
-            current.push(ch);
-        } else if ch == '\'' && in_string {
-            if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                current.push_str("''");
-                i += 2;
-                continue;
-            }
-            in_string = false;
-            current.push(ch);
-        } else if in_string {
-            current.push(ch);
-        } else if ch == '(' {
-            depth += 1;
-            current.push(ch);
-        } else if ch == ')' {
-            depth -= 1;
-            current.push(ch);
-        } else if ch == ',' && depth == 0 {
-            out.push(std::mem::take(&mut current));
-        } else {
-            current.push(ch);
-        }
-        i += 1;
-    }
-    out.push(current);
-    out
-}
-
 /// Trim a STEP attribute list to `max_count` top-level attributes (STEP-nesting aware).
-fn trim_attributes(attrs: &str, max_count: usize) -> String {
+fn trim_attributes(attrs: &str, max_count: usize) -> Option<String> {
     if attrs.trim().is_empty() {
-        return attrs.to_string();
+        return Some(attrs.to_string());
     }
-    let out = split_top_level(attrs);
+    let out = split_top_level_args(attrs)?;
     if out.len() > max_count {
-        out[..max_count].join(",")
+        Some(out[..max_count].join(","))
     } else {
-        out.join(",")
+        Some(out.join(","))
     }
 }
 
@@ -282,6 +242,13 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
     let entity_type = after[..popen].trim().to_uppercase();
     let attrs = &after[popen + 1..aclose];
 
+    // Validate before choosing any conversion branch. Otherwise a malformed
+    // slot list can still receive a type rename, proxy replacement, trim, or
+    // padding and become a partially converted record (#4200).
+    if split_top_level_args(attrs).is_none() {
+        return line.to_string();
+    }
+
     let new_type = convert_entity_type(&entity_type, cfrom, cto);
 
     if should_skip_entity(&new_type, cto) {
@@ -310,10 +277,16 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
     // the generic positional trim below.
     let mut final_attrs = if new_type != entity_type {
         if let Some((src_names, tgt_names)) = by_name_attr_remap_names(&entity_type) {
-            remap_attrs_by_name(attrs, src_names, tgt_names)
+            match remap_attrs_by_name(attrs, src_names, tgt_names) {
+                Some(value) => value,
+                None => return line.to_string(),
+            }
         } else if cto == "IFC2X3" {
             match ifc2x3_attr_count(&new_type) {
-                Some(max) => trim_attributes(attrs, max),
+                Some(max) => match trim_attributes(attrs, max) {
+                    Some(value) => value,
+                    None => return line.to_string(),
+                },
                 None => attrs.to_string(),
             }
         } else {
@@ -321,7 +294,10 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
         }
     } else if cto == "IFC2X3" {
         match ifc2x3_attr_count(&new_type) {
-            Some(max) => trim_attributes(attrs, max),
+            Some(max) => match trim_attributes(attrs, max) {
+                Some(value) => value,
+                None => return line.to_string(),
+            },
             None => attrs.to_string(),
         }
     } else {

--- a/rust/export/src/schema_convert_tests.rs
+++ b/rust/export/src/schema_convert_tests.rs
@@ -210,3 +210,25 @@ fn other_ifc2x3_downgrade_renames_still_use_positional_trim() {
     // IfcBuildingElementProxy caps at 9 IFC2X3 attrs; this line has exactly 9, so nothing trims.
     assert!(out.contains(".USERDEFINED."), "positional trim/pass-through unaffected: {out}");
 }
+
+#[test]
+fn schema_conversion_preserves_utf8_through_the_shared_slot_parser() {
+    let line = "#5=IFCCHIMNEY('g',$,'Größe',$,$,#6,#7,'tag',.USERDEFINED.,$);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 5);
+    assert!(out.contains("'Größe'"), "UTF-8 text must remain byte-correct: {out}");
+}
+
+#[test]
+fn schema_conversion_refuses_a_malformed_positional_split() {
+    let line = "#1=IFCDOORTYPE('g',\"01,23\",$,$,$,$,$,$,$,$,$,$,$);";
+    assert_eq!(convert_step_line(line, "IFC4", "IFC2X3", 1), line);
+}
+
+#[test]
+fn schema_conversion_refuses_before_type_rename_or_proxy_replacement() {
+    let rename = "#10=IFCBRIDGE('g',\"01,23\",$);";
+    assert_eq!(convert_step_line(rename, "IFC4X3", "IFC4", 10), rename);
+
+    let proxy = "#99=IFCALIGNMENTCANT('g',\"01,23\",$);";
+    assert_eq!(convert_step_line(proxy, "IFC4X3", "IFC4", 99), proxy);
+}

--- a/rust/export/src/step_slot.rs
+++ b/rust/export/src/step_slot.rs
@@ -17,13 +17,8 @@
 //! reaches them comes from the user's file, so a permissive sibling here would
 //! be a footgun with no consumer.
 //!
-//! The crate still HAS one, though, and this module does not replace it:
-//! `schema_convert.rs`'s `split_top_level` (`schema_convert.rs:203`) is the same
-//! quote/depth/comma state machine in its older `bytes[i] as char` form, and its
-//! callers `trim_attributes` and `remap_attrs_by_name` both rewrite records by
-//! pairing values with slots by POSITION — the failure above, in another file.
-//! Out of scope for #4125, which is the three by-index writers; tracked in
-//! LTplus-AG/ifc-lite#4200.
+//! Schema conversion uses this same splitter too: trimming and by-name remaps
+//! must not build a second, permissive position-addressable array (#4200).
 //!
 //! The TypeScript twin is `packages/export/src/step-argument-parser.ts`'s
 //! `splitTopLevelStepArguments`. The two cannot share code, so the inputs both


### PR DESCRIPTION
Fixes #4200

Validates SELECT, logical, binary, reference, and schema-remap slots without permissive by-index fallthrough; malformed records now fail transactionally across TypeScript, CLI, and Rust export paths.

Validation: export tests and typecheck; CLI tests and typecheck; Rust export tests; full STEP corpus zero-drift; module-size gate.

Adversarial plan and exact-head review: Astra GO at 2ef4224ee015fd9097e708f013aa8b15d9b773b1.