### PR TITLE
fix(ci): make revert-oracle evidence attributable

### DIFF
--- a/.github/actions/setup-revert-oracle/action.yml
+++ b/.github/actions/setup-revert-oracle/action.yml
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Setup revert-oracle runners
+description: Provision the optional runner toolchains declared by the revert-oracle adapter manifest
+
+inputs:
+  python:
+    description: 'Python provisioning: none, pytest, or full IFC reference requirements'
+    required: false
+    default: none
+  rust:
+    description: 'Trigger the repository-pinned Rust toolchain'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Validate provisioning inputs
+      shell: bash
+      env:
+        PYTHON_MODE: ${{ inputs.python }}
+        RUST_MODE: ${{ inputs.rust }}
+      run: |
+        case "$PYTHON_MODE" in none|pytest|full) ;; *) echo "invalid python mode: $PYTHON_MODE" >&2; exit 2;; esac
+        case "$RUST_MODE" in true|false) ;; *) echo "invalid rust mode: $RUST_MODE" >&2; exit 2;; esac
+
+    - name: Setup Python 3.12
+      if: ${{ inputs.python != 'none' }}
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      with:
+        python-version: '3.12'
+
+    - name: Install pytest probe dependency
+      if: ${{ inputs.python == 'pytest' }}
+      shell: bash
+      run: pip install pytest
+
+    - name: Install IFC reference Python requirements
+      if: ${{ inputs.python == 'full' }}
+      shell: bash
+      run: pip install -r tools/ifcopenshell_reference/requirements.lock pytest
+
+    - name: Setup Rust pinned by rust-toolchain.toml
+      if: ${{ inputs.rust == 'true' }}
+      shell: bash
+      run: rustup show

--- a/.github/workflows/revert-oracle-selfcheck.yml
+++ b/.github/workflows/revert-oracle-selfcheck.yml
@@ -1,0 +1,48 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Revert-oracle selfcheck
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/actions/setup-revert-oracle/**'
+      - '.github/workflows/revert-oracle-selfcheck.yml'
+      - 'scripts/check-test-revert-oracle.mjs'
+      - 'scripts/lib/revert-oracle-*.mjs'
+      - 'scripts/revert-oracle-selfcheck.mjs'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: revert-oracle-selfcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  adapters:
+    name: Runner adapters retain all verdict directions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - uses: ./.github/actions/setup-revert-oracle
+        with:
+          python: pytest
+          rust: 'true'
+      - run: pnpm install --frozen-lockfile
+      - name: Run every adapter's observed, unobserved and not-executing probes
+        run: pnpm test:revert-oracle-selfcheck

--- a/.github/workflows/revert-oracle-selfcheck.yml
+++ b/.github/workflows/revert-oracle-selfcheck.yml
@@ -12,8 +12,10 @@ on:
       - '.github/actions/setup-revert-oracle/**'
       - '.github/workflows/revert-oracle-selfcheck.yml'
       - 'scripts/check-test-revert-oracle.mjs'
+      - 'scripts/lib/revert-oracle.mjs'
       - 'scripts/lib/revert-oracle-*.mjs'
       - 'scripts/revert-oracle-selfcheck.mjs'
+      - 'scripts/revert-oracle-selfcheck.test.mjs'
       - 'package.json'
       - 'pnpm-lock.yaml'
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -607,13 +607,11 @@ jobs:
       # `unittest.skipUnless(HAVE_IFCOPENSHELL, ...)` — bare pytest would run
       # them as silent skips instead of the real assertions the oracle needs
       # to revert against.
-      - if: needs.changes.outputs.python == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Provision optional revert-oracle runner toolchains
+        uses: ./.github/actions/setup-revert-oracle
         with:
-          python-version: "3.12"
-      - if: needs.changes.outputs.python == 'true'
-        name: Install the Python toolchain the oracle's pytest lane needs
-        run: pip install -r tools/ifcopenshell_reference/requirements.lock pytest
+          python: ${{ needs.changes.outputs.python == 'true' && 'full' || 'none' }}
+          rust: ${{ needs.changes.outputs.rust }}
       - name: Prove the changed tests observe the production change
         env:
           PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fixtures:manifest": "node scripts/fixtures/build-manifest.mjs",
     "fixtures:upload": "node scripts/fixtures/upload-fixtures.mjs",
     "test": "turbo test",
+    "test:revert-oracle-selfcheck": "node scripts/revert-oracle-selfcheck.mjs",
     "test:collab": "pnpm --filter @ifc-lite/collab --filter @ifc-lite/collab-server test",
     "test:e2e": "playwright test --project=viewer-e2e",
     "test:e2e:ci": "playwright test --project=viewer-e2e-ci",

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -49,7 +49,8 @@
  * too — see `LOAD_ERROR_PATTERNS` in `lib/revert-oracle.mjs`.
  *
  * CI runs it only in a throwaway, read-only checkout with a hard timeout. An
- * honest INCONCLUSIVE is advisory; UNOBSERVED and a broken baseline block.
+ * capability gaps, UNOBSERVED, and broken baselines all block, through
+ * distinguishable result channels.
  *
  * USAGE
  *   node scripts/check-test-revert-oracle.mjs [options]
@@ -68,7 +69,7 @@
  *                       Lets you point a version of the oracle you trust at a
  *                       checkout that predates it.
  *   --json              emit a machine-readable result alongside the report
- *   --ci                block UNOBSERVED/broken baselines; allow INCONCLUSIVE
+ *   --ci                block UNOBSERVED, broken baselines and capability gaps
  */
 
 import { spawnSync } from 'node:child_process';
@@ -80,19 +81,26 @@ import { tmpdir } from 'node:os';
 import {
   parseNameStatus,
   classifyDiff,
-  parseRunnerOutput,
   aggregate,
   verdict,
   UNOBSERVED,
-  SURGICAL_ADVICE, withoutBrowserSpecs,
+  withoutBrowserSpecs,
 } from './lib/revert-oracle.mjs';
 import { isDependabotDependencyOnly } from './lib/revert-oracle-dependabot.mjs';
 import { isVersionOnlyManifestDiff } from './lib/revert-oracle-version-bump.mjs';
 import { isCommentOnlyDiff } from './lib/revert-oracle-comment-only.mjs';
 import { requiredFeaturePlanOrDie, EXIT_UNHANDLED_CFG_SHAPE } from './lib/revert-oracle-rust-features.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
+import {
+  createResultEmitter,
+  ORACLE_CHANNEL,
+  PULL_REQUEST_CHANNEL,
+  resultRecord,
+} from './lib/revert-oracle-result.mjs';
 import { planRuns } from './lib/revert-oracle-plan-runs.mjs';
-import { loadTypeScript, typeOnlyProduction, typecheckPlans, runTypecheckPlan, gitShow } from './lib/revert-oracle-type-only.mjs';
+import { loadTypeScript, typeOnlyProduction, typecheckPlans, gitShow } from './lib/revert-oracle-type-only.mjs';
+import { runPlan } from './lib/revert-oracle-run-plan.mjs';
+import { printHumanReport } from './lib/revert-oracle-human-report.mjs';
 
 const SELF_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const rootFlag = process.argv.indexOf('--root');
@@ -103,6 +111,8 @@ const ROOT = rootFlag === -1 ? SELF_ROOT : resolve(process.argv[rootFlag + 1] ??
 let reverted = false;
 let restoreVerified = false;
 let patchPath = null;
+let resultContext = { base: null, head: null, production: [], tests: [] };
+const resultEmitter = createResultEmitter(process.argv.includes('--json'));
 
 // Exit codes. 0 is reserved for OBSERVED and nothing else.
 const EXIT_OBSERVED = 0;
@@ -112,18 +122,57 @@ const EXIT_INCONCLUSIVE = 3;
 const EXIT_REVERT_FAILED = 4;
 const EXIT_RESTORE_FAILED = 5;
 
-function die(code, message, extra = []) {
+function emitResult(channel, verdict, code, reason, details = {}) {
+  resultEmitter.emit(resultRecord({
+    ...details,
+    ...resultContext,
+    channel,
+    verdict,
+    exitCode: code,
+    reason,
+  }));
+}
+
+function die(code, message, extra = [], details = {}) {
   // `process.exit` skips the `finally` block, so every abort path restores the
   // tree itself. `restore` is a no-op until the revert has actually landed.
-  if (typeof restore === 'function') restore('abort');
+  const restored = typeof restore !== 'function' || restore('abort');
+  let channel = details.channel ?? ORACLE_CHANNEL;
+  let outcome = details.verdict ?? 'ERROR';
+  if (!restored) {
+    code = EXIT_RESTORE_FAILED;
+    message = `the oracle could not restore the working tree after: ${message}`;
+    channel = ORACLE_CHANNEL;
+    outcome = 'RESTORE-FAILED';
+  }
   console.error(`\n[revert-oracle] ABORT: ${message}`);
   for (const line of extra) console.error(`  ${line}`);
   console.error('');
+  if (!resultEmitter.emitted) {
+    emitResult(channel, outcome, code, message, details);
+  }
   process.exit(code);
 }
 
+process.on('uncaughtException', (error) => {
+  console.error(error?.stack ?? String(error));
+  die(EXIT_NOTHING_CHECKED, `the oracle crashed: ${error?.message ?? String(error)}`, [], {
+    error: { name: error?.name ?? 'Error' },
+  });
+});
+
+function notApplicable(message) {
+  console.log(`  NOT APPLICABLE: ${message}`);
+  emitResult(PULL_REQUEST_CHANNEL, 'NOT-APPLICABLE', 0, message);
+  process.exit(0);
+}
+
+function rawGit(args, opts = {}) {
+  return spawnSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+}
+
 function git(args, opts = {}) {
-  const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+  const r = rawGit(args, opts);
   if (r.error) die(EXIT_NOTHING_CHECKED, `git ${args.join(' ')} could not run: ${r.error.message}`);
   return r;
 }
@@ -159,6 +208,7 @@ function parseArgs(argv) {
     else if (a === '--ci') opts.ci = true;
     else if (a === '--help' || a === '-h') {
       console.log(readFileSync(fileURLToPath(import.meta.url), 'utf8').split('*/')[0]);
+      emitResult(ORACLE_CHANNEL, 'HELP', 0, 'help requested');
       process.exit(0);
     } else die(EXIT_NOTHING_CHECKED, `unknown argument: ${a}`);
   }
@@ -176,69 +226,6 @@ function parseArgs(argv) {
 // requiredFeaturePlanOrDie(), which also converts an UnhandledCfgShapeError
 // raised from inside it (via requiredFeatureCombos()) into a structured
 // failure instead of an unhandled crash.
-
-/** Resolve a runner binary the way the package itself would. */
-function resolveBin(bin, pkgDir) {
-  if (bin === 'node') return process.execPath;
-  if (bin === 'cargo' || bin === 'python3') return bin;
-  let dir = pkgDir;
-  for (;;) {
-    const candidate = join(dir, 'node_modules', '.bin', bin);
-    if (existsSync(candidate)) return candidate;
-    const parent = dirname(dir);
-    if (parent === dir || !parent.startsWith(ROOT)) return null;
-    dir = parent;
-  }
-}
-
-function runPlan(plan, label) {
-  const started = Date.now();
-  // #4472: a type-only branch is judged by tsc, not by running tests. Same
-  // result shape, same aggregate/verdict path -- see revert-oracle-type-only.mjs.
-  if (plan.typecheck) {
-    const parsed = runTypecheckPlan(plan, ROOT, label);
-    parsed.durationMs = Date.now() - started;
-    parsed.tail = parsed.evidence.join('\n');
-    logRun(plan, label, parsed, parsed.kind === 'runner-missing' ? '?' : parsed.kind === 'pass' ? 0 : 1);
-    return parsed;
-  }
-  const cwd = plan.crate ? ROOT : plan.dir;
-  const binPath = resolveBin(plan.runner.bin, plan.dir);
-  if (!binPath) {
-    return {
-      kind: 'runner-missing',
-      passed: null,
-      failed: null,
-      total: null,
-      evidence: [`runner binary "${plan.runner.bin}" not found from ${relative(ROOT, plan.dir) || '.'} — run pnpm install`],
-    };
-  }
-  const r = spawnSync(binPath, plan.runner.args, {
-    cwd,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
-  });
-  const parsed = parseRunnerOutput({
-    family: plan.runner.family,
-    stdout: r.stdout ?? '',
-    stderr: r.stderr ?? '',
-    exitCode: r.status,
-    spawnError: r.error ? `${r.error.message}` : undefined,
-  });
-  parsed.rawExitCode = r.status;
-  parsed.durationMs = Date.now() - started;
-  parsed.tail = `${r.stdout ?? ''}\n${r.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
-  logRun(plan, label, parsed, r.status);
-  return parsed;
-}
-
-function logRun(plan, label, parsed, exit) {
-  console.log(
-    `  [${label}] ${relative(ROOT, plan.dir) || '.'} (${plan.runner.family}) -> ${parsed.kind}` +
-      ` (pass ${parsed.passed ?? '?'}, fail ${parsed.failed ?? '?'}, total ${parsed.total ?? '?'}, exit ${exit}, ${parsed.durationMs}ms)`,
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main
@@ -261,6 +248,7 @@ if (preStatus !== '') {
 
 const baseSha = gitOrDie(['rev-parse', '--verify', `${opts.base}^{commit}`]).trim();
 const headSha = gitOrDie(['rev-parse', '--verify', `${opts.head}^{commit}`]).trim();
+resultContext = { ...resultContext, base: baseSha, head: headSha };
 const checkedOut = gitOrDie(['rev-parse', 'HEAD']).trim();
 if (headSha !== checkedOut) {
   die(EXIT_NOTHING_CHECKED, `--head ${opts.head} (${headSha.slice(0, 9)}) is not the checked-out commit (${checkedOut.slice(0, 9)}). Check it out first; this tool patches the working tree in place.`);
@@ -272,14 +260,18 @@ const entries = parseNameStatus(gitOrDie(['diff', '--name-status', `${mergeBase}
 if (entries.length === 0) die(EXIT_NOTHING_CHECKED, 'the diff is empty; nothing to check.');
 
 if (opts.ci && isDependabotDependencyOnly(process.env.PR_AUTHOR_LOGIN, entries)) {
-  console.log(
-    '  NOT APPLICABLE: Dependabot changed dependency manifests/lockfiles only; ' +
+  notApplicable(
+    'Dependabot changed dependency manifests/lockfiles only; ' +
       'the normal build and test lanes provide the compatibility verdict.',
   );
-  process.exit(0);
 }
 
 const { production, test: testEntries, ignored, inert, warnings } = classifyDiff(entries);
+resultContext = {
+  ...resultContext,
+  production: production.map((entry) => entry.path),
+  tests: testEntries.map((entry) => entry.path),
+};
 for (const w of warnings) console.log(`  WARNING: ${w}`);
 
 // The changesets release PR ("chore: version packages") changes only
@@ -294,11 +286,10 @@ if (
   production.length > 0 &&
   production.every((e) => isVersionOnlyManifestDiff(e.path, gitOrDie(['diff', '-U0', mergeBase, headSha, '--', e.path])))
 ) {
-  console.log(
-    '  NOT APPLICABLE: every production file is a package.json/Cargo.toml version-only bump ' +
+  notApplicable(
+    'every production file is a package.json/Cargo.toml version-only bump ' +
       '(release PR shape); nothing a test could observe.',
   );
-  process.exit(0);
 }
 
 // A diff whose every changed line is a JS/TS comment changes no runtime
@@ -313,11 +304,10 @@ if (
   production.length > 0 &&
   production.every((e) => isCommentOnlyDiff(e.path, gitOrDie(['diff', '-U0', mergeBase, headSha, '--', e.path])))
 ) {
-  console.log(
-    '  NOT APPLICABLE: every production file\'s diff is comment-only (no code changed); ' +
+  notApplicable(
+    'every production file\'s diff is comment-only (no code changed); ' +
       'nothing a test could observe.',
   );
-  process.exit(0);
 }
 
 let prodPaths = production.map((e) => e.path);
@@ -333,6 +323,7 @@ if (opts.tests.length > 0) {
   testPaths = testPaths.filter((p) => opts.tests.includes(p));
   if (testPaths.length === 0) die(EXIT_NOTHING_CHECKED, '--test matched none of the branch\'s changed test files.');
 }
+resultContext = { ...resultContext, production: prodPaths, tests: testPaths };
 
 console.log(
   `  files: ${production.length} production, ${testEntries.length} test, ${ignored.length} ignored, ${inert.length} inert`,
@@ -340,7 +331,7 @@ console.log(
 
 if (prodPaths.length === 0) {
   const message = 'this branch changes no production files; there is nothing whose absence a test could notice.';
-  if (opts.ci) { console.log(`  NOT APPLICABLE: ${message}`); process.exit(0); }
+  if (opts.ci) notApplicable(message);
   die(EXIT_NOTHING_CHECKED, message);
 }
 if (testPaths.length === 0) {
@@ -348,6 +339,7 @@ if (testPaths.length === 0) {
     opts.ci ? EXIT_UNOBSERVED : EXIT_NOTHING_CHECKED,
     'this branch changes production code and adds/changes NO test file. That is itself the finding: nothing can observe the change.',
     production.map((e) => `changed: ${e.path}`),
+    opts.ci ? { channel: PULL_REQUEST_CHANNEL, verdict: UNOBSERVED } : {},
   );
 }
 
@@ -363,11 +355,16 @@ if (observer === 'typecheck') {
   const t = typecheckPlans(testPaths, ROOT);
   for (const s of t.skipped) console.log(`  skipped: ${s} is not TypeScript, so it cannot observe a type-only change`);
   if (t.plans.length === 0 && t.unassigned.length === 0) {
-    die(opts.ci ? EXIT_UNOBSERVED : EXIT_NOTHING_CHECKED, 'type-only production change, and none of the changed test files is TypeScript: nothing can observe it.', prodPaths.map((p) => `changed: ${p}`));
+    die(
+      opts.ci ? EXIT_UNOBSERVED : EXIT_NOTHING_CHECKED,
+      'type-only production change, and none of the changed test files is TypeScript: nothing can observe it.',
+      prodPaths.map((p) => `changed: ${p}`),
+      opts.ci ? { channel: PULL_REQUEST_CHANNEL, verdict: UNOBSERVED } : {},
+    );
   }
   ({ plans, unassigned } = t);
 } else {
-  ({ plans, unassigned } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, opts.json, baseSha, headSha, prodPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
+  ({ plans, unassigned } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
 }
 if (unassigned.length > 0) {
   die(EXIT_NOTHING_CHECKED, 'could not find an owning package for some test files', unassigned);
@@ -410,16 +407,22 @@ writeFileSync(patchPath, patchText);
 
 function restore(context) {
   if (!reverted || !patchPath) return true;
-  const r = git(['apply', patchPath]);
-  if (r.status !== 0) {
+  const r = rawGit(['apply', patchPath]);
+  if (r.error || r.status !== 0) {
     console.error(`\n[revert-oracle] !!! RESTORE FAILED (${context}) !!!`);
-    console.error((r.stderr || '').trim());
+    console.error(r.error?.message ?? (r.stderr || '').trim());
     console.error(`The reverse patch is still on disk: ${patchPath}`);
     console.error(`Re-apply it by hand:  git apply ${patchPath}`);
     return false;
   }
   reverted = false;
-  const status = git(['status', '--porcelain']).stdout.trim();
+  const statusRun = rawGit(['status', '--porcelain']);
+  if (statusRun.error || statusRun.status !== 0) {
+    console.error(`\n[revert-oracle] !!! RESTORE VERIFICATION FAILED (${context}) !!!`);
+    console.error(statusRun.error?.message ?? (statusRun.stderr || '').trim());
+    return false;
+  }
+  const status = statusRun.stdout.trim();
   if (status !== '') {
     console.error(`\n[revert-oracle] !!! TREE NOT BYTE-IDENTICAL AFTER RESTORE (${context}) !!!`);
     console.error(status);
@@ -437,13 +440,11 @@ function emergency(signal) {
   cleaningUp = true;
   console.error(`\n[revert-oracle] interrupted by ${signal} — restoring the tree before exiting`);
   const ok = restore(signal);
-  process.exit(ok ? EXIT_INCONCLUSIVE : EXIT_RESTORE_FAILED);
+  const code = ok ? EXIT_INCONCLUSIVE : EXIT_RESTORE_FAILED;
+  emitResult(ORACLE_CHANNEL, ok ? 'INTERRUPTED' : 'RESTORE-FAILED', code, `the oracle was interrupted by ${signal}`);
+  process.exit(code);
 }
 for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) process.on(sig, () => emergency(sig));
-process.on('uncaughtException', (err) => {
-  console.error(err?.stack ?? String(err));
-  emergency('uncaughtException');
-});
 
 // --- run ---------------------------------------------------------------------
 
@@ -452,7 +453,7 @@ let result = null;
 
 try {
   console.log('\n[1/3] baseline: running the branch\'s own tests, unmodified');
-  const baselineResults = plans.map((p) => runPlan(p, 'baseline'));
+  const baselineResults = plans.map((p) => runPlan(p, ROOT, 'baseline'));
   const baseline = aggregate(baselineResults);
 
   console.log(`\n[2/3] reverting ${prodPaths.length} production file(s)`);
@@ -467,7 +468,7 @@ try {
   for (const p of prodPaths) console.log(`  reverted: ${p}`);
 
   console.log('\n[3/3] re-running the same tests with production reverted');
-  const revertedResults = plans.map((p) => runPlan(p, 'reverted'));
+  const revertedResults = plans.map((p) => runPlan(p, ROOT, 'reverted'));
   const revertedAgg = aggregate(revertedResults);
 
   result = verdict({ baseline, reverted: revertedAgg });
@@ -491,6 +492,7 @@ try {
     const ok = restore('normal exit');
     if (!ok) {
       console.error('[revert-oracle] the working tree was NOT restored. Do not push. Fix the tree first.');
+      emitResult(ORACLE_CHANNEL, 'RESTORE-FAILED', EXIT_RESTORE_FAILED, 'the oracle could not restore the working tree after measurement');
       process.exit(EXIT_RESTORE_FAILED);
     }
   }
@@ -502,57 +504,20 @@ if (!restoreVerified && reverted) {
 
 // --- report -------------------------------------------------------------------
 
-const banner = {
-  OBSERVED: '  ✔ OBSERVED',
-  UNOBSERVED: '  ✘ UNOBSERVED  <-- FINDING',
-  INCONCLUSIVE: '  ? INCONCLUSIVE',
-  'BASELINE-BROKEN': '  ! BASELINE-BROKEN',
-}[result.verdict];
-
-console.log('\n' + '='.repeat(78));
-console.log(banner);
-console.log('='.repeat(78));
-console.log(`  observer:  ${observer}`);
-console.log(`  reverted:  ${result.prodPaths.join('\n             ')}`);
-console.log(`  tests run: ${result.testPaths.join('\n             ')}`);
-console.log(`  baseline:  ${result.baseline.kind} — ${result.baseline.passed ?? '?'} passed / ${result.baseline.total ?? '?'} collected`);
-console.log(`  reverted:  ${result.revertedRun.kind} — ${result.revertedRun.passed ?? '?'} passed, ${result.revertedRun.failed ?? '?'} failed / ${result.revertedRun.total ?? '?'} collected`);
-console.log(`\n  ${result.reason}`);
-if (result.advice) console.log(`\n  NEXT: ${result.advice}`);
-// An OBSERVED earned by reverting many files at once can be carried by a single
-// line of the change while the rest is unobserved -- the shape of the
-// `device.ts` case this tool was written for. Say so rather than let the tick
-// read as a verdict on the whole branch.
-if (result.verdict === 'OBSERVED' && result.prodPaths.length > 1 && opts.only.length === 0) {
-  console.log(
-    `\n  NOTE: ${result.prodPaths.length} production files were reverted together, so this tick may be ` +
-      'earned by one of them. Re-run with --only <path> per file to find the unobserved ones.',
-  );
-}
-if (result.verdict === 'INCONCLUSIVE' && result.advice !== SURGICAL_ADVICE) console.log(`\n  ALSO: ${SURGICAL_ADVICE}`);
-console.log('');
-
-if (opts.json) {
-  console.log(
-    JSON.stringify(
-      {
-        verdict: result.verdict,
-        observer,
-        reason: result.reason,
-        base: baseSha,
-        head: headSha,
-        production: result.prodPaths,
-        tests: result.testPaths,
-        baseline: { kind: result.baseline.kind, passed: result.baseline.passed, total: result.baseline.total },
-        reverted: { kind: result.revertedRun.kind, passed: result.revertedRun.passed, failed: result.revertedRun.failed, total: result.revertedRun.total, evidence: result.revertedRun.evidence },
-      },
-      null,
-      2,
-    ),
-  );
-}
+printHumanReport(result, observer, opts.only.length > 0);
 
 rmSync(tmp, { recursive: true, force: true });
+emitResult(
+  result.verdict === OBSERVED || result.verdict === UNOBSERVED ? PULL_REQUEST_CHANNEL : ORACLE_CHANNEL,
+  result.verdict,
+  exitCode,
+  result.reason,
+  {
+    observer,
+    baseline: { kind: result.baseline.kind, passed: result.baseline.passed, total: result.baseline.total },
+    reverted: { kind: result.revertedRun.kind, passed: result.revertedRun.passed, failed: result.revertedRun.failed, total: result.revertedRun.total, evidence: result.revertedRun.evidence },
+  },
+);
 process.exit(exitCode);
 
 /* ---------------------------------------------------------------------------
@@ -634,7 +599,7 @@ process.exit(exitCode);
  * CI POLICY
  * ---------------------------------------------------------------------------
  * `test.yml` supplies the five required bounds: its own throwaway checkout, a
- * hard timeout and workflow concurrency, INCONCLUSIVE-as-advisory, a full clone
+ * hard timeout and workflow concurrency, blocking capability gaps, a full clone
  * with `--base origin/main`, and the maintainer-only `revert-oracle-exempt`
  * label for legitimate refactors. `--ci` implements that verdict policy.
  * --------------------------------------------------------------------------- */

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -77,6 +77,7 @@ import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from 'no
 import { join, dirname, resolve, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
 
 import {
   parseNameStatus,
@@ -89,7 +90,6 @@ import {
 import { isDependabotDependencyOnly } from './lib/revert-oracle-dependabot.mjs';
 import { isVersionOnlyManifestDiff } from './lib/revert-oracle-version-bump.mjs';
 import { isCommentOnlyDiff } from './lib/revert-oracle-comment-only.mjs';
-import { requiredFeaturePlanOrDie, EXIT_UNHANDLED_CFG_SHAPE } from './lib/revert-oracle-rust-features.mjs';
 import { ciExitCode } from './lib/revert-oracle-ci.mjs';
 import {
   createResultEmitter,
@@ -114,6 +114,9 @@ let restoreVerified = false;
 let patchPath = null;
 let resultContext = { base: null, head: null, production: [], tests: [] };
 const resultEmitter = createResultEmitter(process.argv.includes('--json'));
+const invocationId = randomUUID();
+const startedAt = new Date().toISOString();
+let cleaningUp = false;
 
 // Exit codes. 0 is reserved for OBSERVED and nothing else.
 const EXIT_OBSERVED = 0;
@@ -131,6 +134,10 @@ function emitResult(channel, verdict, code, reason, details = {}) {
     verdict,
     exitCode: code,
     reason,
+    invocationId,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    restoration: reverted ? 'failed' : restoreVerified ? 'verified' : 'not-required',
   }));
 }
 
@@ -154,6 +161,16 @@ function die(code, message, extra = [], details = {}) {
   }
   process.exit(code);
 }
+
+function emergency(signal) {
+  if (cleaningUp) return;
+  cleaningUp = true;
+  console.error(`\n[revert-oracle] interrupted by ${signal} — restoring the tree before exiting`);
+  const ok = restore(signal);
+  emitResult(ORACLE_CHANNEL, ok ? 'INTERRUPTED' : 'RESTORE-FAILED', ok ? EXIT_INCONCLUSIVE : EXIT_RESTORE_FAILED, `the oracle was interrupted by ${signal}`);
+  process.exit(ok ? EXIT_INCONCLUSIVE : EXIT_RESTORE_FAILED);
+}
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) process.on(sig, () => emergency(sig));
 
 process.on('uncaughtException', (error) => {
   console.error(error?.stack ?? String(error));
@@ -367,7 +384,7 @@ if (observer === 'typecheck') {
   ({ plans, unassigned } = t);
   support = t.skipped;
 } else {
-  ({ plans, unassigned, support } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
+  ({ plans, unassigned, support } = planRuns(testPaths, ROOT));
 }
 const partitioned = partitionRunnablePlans(plans, unassigned);
 plans = partitioned.runnable;
@@ -395,16 +412,9 @@ if (patchText.trim() === '') {
 }
 writeFileSync(patchPath, patchText);
 
-// --- restoration, guaranteed ------------------------------------------------
-//
-// Restoration is a FORWARD re-apply of the identical patch, never `git
-// checkout --` / `git restore` / `git reset --hard` / `git stash`: those
-// commands would also erase anything else in the tree if an assumption were
-// wrong, and they cannot be verified against the patch that was applied.
-
 function restore(context) {
   if (!reverted || !patchPath) return true;
-  const r = rawGit(['apply', patchPath]);
+  const r = rawGit(['-c', 'core.autocrlf=false', 'apply', patchPath]);
   if (r.error || r.status !== 0) {
     console.error(`\n[revert-oracle] !!! RESTORE FAILED (${context}) !!!`);
     console.error(r.error?.message ?? (r.stderr || '').trim());
@@ -431,18 +441,6 @@ function restore(context) {
   return true;
 }
 
-let cleaningUp = false;
-function emergency(signal) {
-  if (cleaningUp) return;
-  cleaningUp = true;
-  console.error(`\n[revert-oracle] interrupted by ${signal} — restoring the tree before exiting`);
-  const ok = restore(signal);
-  const code = ok ? EXIT_INCONCLUSIVE : EXIT_RESTORE_FAILED;
-  emitResult(ORACLE_CHANNEL, ok ? 'INTERRUPTED' : 'RESTORE-FAILED', code, `the oracle was interrupted by ${signal}`);
-  process.exit(code);
-}
-for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) process.on(sig, () => emergency(sig));
-
 // --- run ---------------------------------------------------------------------
 
 let exitCode = EXIT_INCONCLUSIVE;
@@ -454,7 +452,7 @@ try {
   const baseline = aggregate(baselineResults);
 
   console.log(`\n[2/3] reverting ${prodPaths.length} production file(s)`);
-  const applyR = git(['apply', '-R', '--verbose', patchPath]);
+  const applyR = git(['-c', 'core.autocrlf=false', 'apply', '-R', '--verbose', patchPath]);
   if (applyR.status !== 0) {
     die(EXIT_REVERT_FAILED, 'the production patch would not reverse-apply — nothing was checked.', [
       ...(applyR.stderr || '').trim().split('\n'),

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -109,8 +109,7 @@ const ROOT = rootFlag === -1 ? SELF_ROOT : resolve(process.argv[rootFlag + 1] ??
 
 // Restoration state, declared before the first abort path can fire: `die()`
 // consults it, and a `let` in the temporal dead zone would throw instead.
-let reverted = false;
-let restoreVerified = false;
+let restoration = 'not-required';
 let patchPath = null;
 let resultContext = { base: null, head: null, production: [], tests: [] };
 const resultEmitter = createResultEmitter(process.argv.includes('--json'));
@@ -137,7 +136,7 @@ function emitResult(channel, verdict, code, reason, details = {}) {
     invocationId,
     startedAt,
     finishedAt: new Date().toISOString(),
-    restoration: reverted ? 'failed' : restoreVerified ? 'verified' : 'not-required',
+    restoration,
   }));
 }
 
@@ -186,7 +185,7 @@ function notApplicable(message) {
 }
 
 function rawGit(args, opts = {}) {
-  return spawnSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
+  return spawnSync(process.env.IFC_LITE_ORACLE_GIT_BIN ?? 'git', [...(process.env.IFC_LITE_ORACLE_GIT_PREFIX ? [process.env.IFC_LITE_ORACLE_GIT_PREFIX] : []), ...args], { cwd: ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...opts });
 }
 
 function git(args, opts = {}) {
@@ -413,30 +412,33 @@ if (patchText.trim() === '') {
 writeFileSync(patchPath, patchText);
 
 function restore(context) {
-  if (!reverted || !patchPath) return true;
+  if (restoration === 'not-required' || restoration === 'verified') return true;
+  if (restoration === 'failed' || !patchPath) return false;
   const r = rawGit(['-c', 'core.autocrlf=false', 'apply', patchPath]);
   if (r.error || r.status !== 0) {
+    restoration = 'failed';
     console.error(`\n[revert-oracle] !!! RESTORE FAILED (${context}) !!!`);
     console.error(r.error?.message ?? (r.stderr || '').trim());
     console.error(`The reverse patch is still on disk: ${patchPath}`);
     console.error(`Re-apply it by hand:  git apply ${patchPath}`);
     return false;
   }
-  reverted = false;
   const statusRun = rawGit(['status', '--porcelain']);
   if (statusRun.error || statusRun.status !== 0) {
+    restoration = 'failed';
     console.error(`\n[revert-oracle] !!! RESTORE VERIFICATION FAILED (${context}) !!!`);
     console.error(statusRun.error?.message ?? (statusRun.stderr || '').trim());
     return false;
   }
   const status = statusRun.stdout.trim();
   if (status !== '') {
+    restoration = 'failed';
     console.error(`\n[revert-oracle] !!! TREE NOT BYTE-IDENTICAL AFTER RESTORE (${context}) !!!`);
     console.error(status);
     console.error(`Patch kept at: ${patchPath}`);
     return false;
   }
-  restoreVerified = true;
+  restoration = 'verified';
   console.log(`  restored: forward re-applied the patch; \`git status --porcelain\` is empty`);
   return true;
 }
@@ -459,7 +461,7 @@ try {
       'The tree is untouched (git apply is all-or-nothing).',
     ]);
   }
-  reverted = true;
+  restoration = 'required';
   for (const p of prodPaths) console.log(`  reverted: ${p}`);
 
   console.log('\n[3/3] re-running the same tests with production reverted');
@@ -495,7 +497,7 @@ try {
   }
 }
 
-if (!restoreVerified && reverted) {
+if (restoration === 'required' || restoration === 'failed') {
   die(EXIT_RESTORE_FAILED, 'restoration was never verified.');
 }
 

--- a/scripts/check-test-revert-oracle.mjs
+++ b/scripts/check-test-revert-oracle.mjs
@@ -82,7 +82,7 @@ import {
   parseNameStatus,
   classifyDiff,
   aggregate,
-  verdict,
+  OBSERVED,
   UNOBSERVED,
   withoutBrowserSpecs,
 } from './lib/revert-oracle.mjs';
@@ -101,6 +101,7 @@ import { planRuns } from './lib/revert-oracle-plan-runs.mjs';
 import { loadTypeScript, typeOnlyProduction, typecheckPlans, gitShow } from './lib/revert-oracle-type-only.mjs';
 import { runPlan } from './lib/revert-oracle-run-plan.mjs';
 import { printHumanReport } from './lib/revert-oracle-human-report.mjs';
+import { buildExecutionLedger, ledgerVerdict, partitionRunnablePlans } from './lib/revert-oracle-ledger.mjs';
 
 const SELF_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const rootFlag = process.argv.indexOf('--root');
@@ -351,6 +352,7 @@ const observer = typeOnly.typeOnly ? 'typecheck' : 'tests';
 console.log(`  observer: ${observer} (${typeOnly.reason})`);
 let plans;
 let unassigned;
+let support = [];
 if (observer === 'typecheck') {
   const t = typecheckPlans(testPaths, ROOT);
   for (const s of t.skipped) console.log(`  skipped: ${s} is not TypeScript, so it cannot observe a type-only change`);
@@ -363,20 +365,15 @@ if (observer === 'typecheck') {
     );
   }
   ({ plans, unassigned } = t);
+  support = t.skipped;
 } else {
-  ({ plans, unassigned } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
+  ({ plans, unassigned, support } = requiredFeaturePlanOrDie((tp) => planRuns(tp, ROOT), testPaths, die, EXIT_UNHANDLED_CFG_SHAPE));
 }
-if (unassigned.length > 0) {
-  die(EXIT_NOTHING_CHECKED, 'could not find an owning package for some test files', unassigned);
-}
-const runnerless = plans.filter((p) => !p.runner);
-if (runnerless.length > 0) {
-  die(
-    EXIT_NOTHING_CHECKED,
-    'no runner could be derived for some packages — refusing to report a clean result for tests that were never run',
-    runnerless.map((p) => `${relative(ROOT, p.dir) || '.'}: scripts.test = ${JSON.stringify(p.script)}`),
-  );
-}
+const partitioned = partitionRunnablePlans(plans, unassigned);
+plans = partitioned.runnable;
+const { gaps } = partitioned;
+for (const gap of gaps) console.log(`  capability gap: ${gap.file}: ${gap.reason}`);
+for (const file of support) console.log(`  support: ${file} (not an independently executable test entrypoint)`);
 for (const p of plans) {
   console.log(`  runner: ${relative(ROOT, p.dir) || '.'} -> ${p.runner.bin} ${p.runner.args.join(' ')}`);
 }
@@ -471,9 +468,11 @@ try {
   const revertedResults = plans.map((p) => runPlan(p, ROOT, 'reverted'));
   const revertedAgg = aggregate(revertedResults);
 
-  result = verdict({ baseline, reverted: revertedAgg });
+  const ledger = buildExecutionLedger({ plans, gaps, support, baselineResults, revertedResults });
+  result = ledgerVerdict(ledger);
   result.baseline = baseline;
   result.revertedRun = revertedAgg;
+  result.ledger = ledger;
   result.prodPaths = prodPaths;
   result.testPaths = testPaths;
   exitCode = opts.ci
@@ -516,6 +515,7 @@ emitResult(
     observer,
     baseline: { kind: result.baseline.kind, passed: result.baseline.passed, total: result.baseline.total },
     reverted: { kind: result.revertedRun.kind, passed: result.revertedRun.passed, failed: result.revertedRun.failed, total: result.revertedRun.total, evidence: result.revertedRun.evidence },
+    ledger: result.ledger,
   },
 );
 process.exit(exitCode);

--- a/scripts/lib/revert-oracle-adapters.mjs
+++ b/scripts/lib/revert-oracle-adapters.mjs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { cargoRunner } from './revert-oracle-cargo.mjs';
+import { pythonRunner } from './revert-oracle-python.mjs';
+import { detectRunner, rootScriptsRunner } from './revert-oracle.mjs';
+
+/**
+ * Executable manifest of the runtime families the oracle supports. Adding a
+ * family means adding an adapter here; an unclaimed executable is a gap.
+ */
+export const REVERT_ORACLE_ADAPTERS = Object.freeze([
+  {
+    id: 'cargo', family: 'cargo', binary: 'cargo',
+    claim: (context) => context.kind === 'cargo' && Boolean(context.target || context.moduleFilter),
+    runner: (context) => cargoRunner(context.crate, context.features, context.target, context.moduleFilter),
+    probeRunner: () => cargoRunner('revert-oracle-selfcheck', [], 'probe'),
+  },
+  {
+    id: 'python-pytest', family: 'python', binary: 'python3',
+    claim: (context) => context.kind === 'python',
+    runner: (context) => pythonRunner([context.relFile]),
+    probeRunner: (context) => pythonRunner([context.file]),
+  },
+  {
+    id: 'root-node-test', family: 'node-test', binary: 'node',
+    claim: (context) => context.kind === 'javascript' && context.rootPackage && /^scripts\/.*\.test\.(mjs|js|cjs)$/.test(context.file),
+    runner: (context) => rootScriptsRunner([context.file]),
+    probeRunner: (context) => ({ family: 'node-test', bin: 'node', args: ['--test', context.file] }),
+  },
+  {
+    id: 'vitest', family: 'vitest', binary: 'vitest',
+    claim: (context) => context.kind === 'javascript' && !context.rootPackage && /(^|[\s/])vitest\b/.test(context.script ?? ''),
+    runner: (context) => detectRunner(context.script, [context.relFile]),
+    probeRunner: (context) => {
+      const runner = detectRunner('vitest run', [context.file]);
+      return { ...runner, args: [...runner.args, '--globals'] };
+    },
+  },
+  {
+    id: 'node-test', family: 'node-test', binary: 'node',
+    claim: (context) => context.kind === 'javascript' && !context.rootPackage && /--test\b/.test(context.script ?? ''),
+    runner: (context) => detectRunner(context.script, [context.relFile]),
+    probeRunner: (context) => detectRunner('node --test', [context.file]),
+  },
+  {
+    id: 'typescript', family: 'typecheck', binary: 'node',
+    claim: (context) => context.kind === 'typecheck',
+    runner: () => ({ family: 'typecheck', bin: 'node', args: ['scripts/typecheck-tests.mjs'] }),
+    probeRunner: (context) => ({ family: 'typecheck', bin: 'node', args: [joinPath(context.root, 'node_modules/typescript/bin/tsc'), '-p', joinPath(context.dir, 'tsconfig.json')] }),
+  },
+]);
+
+const joinPath = (base, suffix) => `${base.replace(/[\\/]$/, '')}/${suffix}`;
+
+export function claimRuntimeAdapter(context) {
+  const adapter = REVERT_ORACLE_ADAPTERS.find((candidate) => candidate.claim(context));
+  if (!adapter) return null;
+  const runner = adapter.runner(context);
+  return runner ? { adapter: adapter.id, runner } : null;
+}

--- a/scripts/lib/revert-oracle-all-skipped.mjs
+++ b/scripts/lib/revert-oracle-all-skipped.mjs
@@ -47,7 +47,7 @@ export const ALL_SKIPPED = 'all-skipped';
  */
 export function classifyExecuted(parsed) {
   if (parsed.failed > 0) {
-    return { kind: ASSERTION_FAILURE, passed: parsed.passed, failed: parsed.failed, total: parsed.total, evidence: parsed.evidence ?? [] };
+    return { kind: ASSERTION_FAILURE, passed: parsed.passed, failed: parsed.failed, total: parsed.total, identities: parsed.identities, evidence: parsed.evidence ?? [] };
   }
   if (parsed.passed === 0) {
     return {
@@ -58,7 +58,7 @@ export function classifyExecuted(parsed) {
       evidence: [`runner executed zero of ${parsed.total} collected test(s) (all skipped)`],
     };
   }
-  return { kind: PASS, passed: parsed.passed, failed: parsed.failed, total: parsed.total, evidence: [] };
+  return { kind: PASS, passed: parsed.passed, failed: parsed.failed, total: parsed.total, identities: parsed.identities, evidence: [] };
 }
 
 /**

--- a/scripts/lib/revert-oracle-cargo.mjs
+++ b/scripts/lib/revert-oracle-cargo.mjs
@@ -5,6 +5,15 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 
+/** Exact Cargo integration target or filtered library-module invocation. */
+export function cargoRunner(crate, features = [], target = null, moduleFilter = null) {
+  if (!crate) return null;
+  const selection = target ? ['--test', target] : moduleFilter ? ['--lib'] : [];
+  const featureArgs = features.length ? ['--features', features.join(',')] : [];
+  const filterArgs = moduleFilter ? ['--', `${moduleFilter}::`] : [];
+  return { family: 'cargo', bin: 'cargo', args: ['test', '--no-fail-fast', '-p', crate, ...selection, ...featureArgs, ...filterArgs] };
+}
+
 /**
  * Directories the root workspace `Cargo.toml` excludes (`exclude = [...]`) — a
  * crate rooted there (e.g. `rust/python`, its own PyO3 workspace) cannot be run

--- a/scripts/lib/revert-oracle-ci.mjs
+++ b/scripts/lib/revert-oracle-ci.mjs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/** CI blocks real misses and broken baselines; an honest inconclusive is advisory. */
+/** CI blocks misses, broken baselines, and gaps in the oracle itself. */
 export function ciExitCode(result) {
   if (result === 'OBSERVED') return 0;
   if (result === 'UNOBSERVED') return 1;
-  if (result === 'INCONCLUSIVE') return 0;
+  if (result === 'INCONCLUSIVE') return 3;
   return 3;
 }

--- a/scripts/lib/revert-oracle-human-report.mjs
+++ b/scripts/lib/revert-oracle-human-report.mjs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { SURGICAL_ADVICE } from './revert-oracle.mjs';
+
+export function printHumanReport(result, observer, narrowed, log = console.log) {
+  const banner = {
+    OBSERVED: '  ✔ OBSERVED',
+    UNOBSERVED: '  ✘ UNOBSERVED  <-- FINDING',
+    INCONCLUSIVE: '  ? INCONCLUSIVE  <-- ORACLE CAPABILITY GAP',
+    'BASELINE-BROKEN': '  ! BASELINE-BROKEN  <-- ORACLE COULD NOT MEASURE',
+  }[result.verdict];
+
+  log('\n' + '='.repeat(78));
+  log(banner);
+  log('='.repeat(78));
+  log(`  observer:  ${observer}`);
+  log(`  reverted:  ${result.prodPaths.join('\n             ')}`);
+  log(`  tests run: ${result.testPaths.join('\n             ')}`);
+  log(`  baseline:  ${result.baseline.kind} — ${result.baseline.passed ?? '?'} passed / ${result.baseline.total ?? '?'} collected`);
+  log(`  reverted:  ${result.revertedRun.kind} — ${result.revertedRun.passed ?? '?'} passed, ${result.revertedRun.failed ?? '?'} failed / ${result.revertedRun.total ?? '?'} collected`);
+  log(`\n  ${result.reason}`);
+  if (result.advice) log(`\n  NEXT: ${result.advice}`);
+  if (result.verdict === 'OBSERVED' && result.prodPaths.length > 1 && !narrowed) {
+    log(
+      `\n  NOTE: ${result.prodPaths.length} production files were reverted together, so this tick may be ` +
+        'earned by one of them. Re-run with --only <path> per file to find the unobserved ones.',
+    );
+  }
+  if (result.verdict === 'INCONCLUSIVE' && result.advice !== SURGICAL_ADVICE) {
+    log(`\n  ALSO: ${SURGICAL_ADVICE}`);
+  }
+  log('');
+}

--- a/scripts/lib/revert-oracle-json.test.mjs
+++ b/scripts/lib/revert-oracle-json.test.mjs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const oracle = resolve(dirname(fileURLToPath(import.meta.url)), '../check-test-revert-oracle.mjs');
+
+test('#4109: an early argument refusal emits exactly one oracle JSON record', () => {
+  const result = spawnSync(process.execPath, [oracle, '--json', '--not-a-real-option'], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+  assert.equal(result.error, undefined);
+  assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+  const record = JSON.parse(result.stdout);
+  assert.equal(record.schemaVersion, 1);
+  assert.equal(record.channel, 'oracle');
+  assert.equal(record.verdict, 'ERROR');
+  assert.equal(record.exitCode, 2);
+  assert.match(record.reason, /unknown argument/);
+});

--- a/scripts/lib/revert-oracle-json.test.mjs
+++ b/scripts/lib/revert-oracle-json.test.mjs
@@ -17,7 +17,8 @@ test('#4109: an early argument refusal emits exactly one oracle JSON record', ()
   assert.equal(result.error, undefined);
   assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
   const record = JSON.parse(result.stdout);
-  assert.equal(record.schemaVersion, 1);
+  assert.equal(record.schemaVersion, 2);
+  assert.equal(record.restoration, 'not-required');
   assert.equal(record.channel, 'oracle');
   assert.equal(record.verdict, 'ERROR');
   assert.equal(record.exitCode, 2);

--- a/scripts/lib/revert-oracle-ledger.mjs
+++ b/scripts/lib/revert-oracle-ledger.mjs
@@ -49,6 +49,7 @@ export function buildExecutionLedger({ plans, gaps = [], support = [], baselineR
     file: plan.file,
     role: 'executable',
     runKey: plan.key,
+    adapter: plan.adapter ?? (plan.typecheck ? 'typescript' : null),
     runner: plan.runner ? {
       family: plan.runner.family,
       command: [plan.runner.bin, ...plan.runner.args],

--- a/scripts/lib/revert-oracle-ledger.mjs
+++ b/scripts/lib/revert-oracle-ledger.mjs
@@ -59,7 +59,7 @@ export function buildExecutionLedger({ plans, gaps = [], support = [], baselineR
       command: [plan.runner.bin, ...plan.runner.args],
     } : null,
     features: plan.features ?? [],
-    attribution: plan.typecheck ? 'compiler-program-membership' : plan.moduleFilter ? 'cargo-module-filter' : plan.crate ? 'cargo-integration-target' : 'exact-file-argument',
+    attribution: plan.typecheck ? 'compiler-program-membership' : plan.moduleFilter ? 'cargo-module-filter' : plan.crate ? 'cargo-integration-target' : plan.runner?.family === 'python' ? 'pytest-exact-file' : 'runtime-v8-file',
     baseline: measurement(baselineResults[index], plan),
     reverted: measurement(revertedResults[index], plan),
   }));

--- a/scripts/lib/revert-oracle-ledger.mjs
+++ b/scripts/lib/revert-oracle-ledger.mjs
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import {
+  ASSERTION_FAILURE,
+  BASELINE_BROKEN,
+  PASS,
+  OBSERVED,
+  UNOBSERVED,
+  INCONCLUSIVE,
+} from './revert-oracle.mjs';
+
+const completePass = (run) => run?.kind === PASS && Number.isInteger(run.total) && run.total > 0;
+const assertionWitness = (baseline, reverted) =>
+  completePass(baseline) &&
+  reverted?.kind === ASSERTION_FAILURE &&
+  Number.isInteger(reverted.total) &&
+  reverted.total >= baseline.total &&
+  Number.isInteger(reverted.failed) &&
+  reverted.failed > 0;
+
+/** Convert planning failures into ledger gaps without abandoning valid runs. */
+export function partitionRunnablePlans(plans, unassigned = []) {
+  const gaps = unassigned.map((gap) => typeof gap === 'string'
+    ? { file: gap, reason: 'could not find an owning package' }
+    : gap);
+  for (const plan of plans.filter((candidate) => !candidate.runner)) {
+    gaps.push({ file: plan.file, reason: `no runner derived; scripts.test = ${JSON.stringify(plan.script)}` });
+  }
+  return { runnable: plans.filter((plan) => plan.runner), gaps };
+}
+
+/** Join the baseline and reverted measurements to the exact changed file/run. */
+export function buildExecutionLedger({ plans, gaps = [], support = [], baselineResults, revertedResults }) {
+  const measurement = (run, plan) => run ? {
+    kind: run.kind,
+    passed: run.passed ?? null,
+    failed: run.failed ?? null,
+    total: run.total ?? null,
+    exitCode: run.rawExitCode ?? null,
+    signal: run.signal ?? null,
+    toolchain: run.toolchain ?? null,
+    files: typeof run.total === 'number' && run.total > 0 ? [plan.file] : [],
+    testIdentities: [...new Set(run.identities ?? [])],
+    evidence: run.evidence ?? [],
+  } : null;
+  const entries = plans.map((plan, index) => ({
+    file: plan.file,
+    role: 'executable',
+    runKey: plan.key,
+    runner: plan.runner ? {
+      family: plan.runner.family,
+      command: [plan.runner.bin, ...plan.runner.args],
+    } : null,
+    features: plan.features ?? [],
+    attribution: plan.typecheck ? 'compiler-program-membership' : plan.moduleFilter ? 'cargo-module-filter' : plan.crate ? 'cargo-integration-target' : 'exact-file-argument',
+    baseline: measurement(baselineResults[index], plan),
+    reverted: measurement(revertedResults[index], plan),
+  }));
+  for (const gap of gaps) entries.push({ file: gap.file, role: 'capability-gap', reason: gap.reason });
+  for (const file of support) entries.push({ file, role: 'support', reason: 'test support/fixture; executed through an entrypoint, not independently attributable' });
+  return entries;
+}
+
+/**
+ * Judge exact-file evidence asymmetrically: one valid witness is sufficient,
+ * while UNOBSERVED requires complete pass/pass evidence for every executable.
+ */
+export function ledgerVerdict(ledger) {
+  const runs = ledger.filter((entry) => entry.role === 'executable');
+  const witness = runs.find((entry) => assertionWitness(entry.baseline, entry.reverted));
+  if (witness) {
+    return {
+      verdict: OBSERVED,
+      exitCode: 0,
+      reason: `reverting production turned an assertion RED in ${witness.file}; that file has a green, attributable baseline.`,
+      witness: { file: witness.file, runKey: witness.runKey },
+    };
+  }
+
+  const broken = runs.find((entry) => entry.baseline && !completePass(entry.baseline));
+  if (broken) {
+    return {
+      verdict: BASELINE_BROKEN,
+      exitCode: 3,
+      reason: `${broken.file} has no green attributable baseline (${broken.baseline.kind}).`,
+    };
+  }
+
+  const gap = ledger.find((entry) => entry.role === 'capability-gap') ??
+    runs.find((entry) => !completePass(entry.baseline) || !completePass(entry.reverted));
+  if (gap) {
+    const detail = gap.reason ?? `${gap.file} produced incomplete reverted evidence (${gap.reverted?.kind ?? 'missing'}).`;
+    return { verdict: INCONCLUSIVE, exitCode: 3, reason: `the oracle has an attribution gap: ${detail}` };
+  }
+
+  if (runs.length === 0) {
+    return { verdict: INCONCLUSIVE, exitCode: 3, reason: 'no changed executable test file was measured.' };
+  }
+  return {
+    verdict: UNOBSERVED,
+    exitCode: 1,
+    reason: `all ${new Set(runs.map((entry) => entry.file)).size} changed executable test file(s) passed before and after the revert.`,
+  };
+}

--- a/scripts/lib/revert-oracle-ledger.mjs
+++ b/scripts/lib/revert-oracle-ledger.mjs
@@ -11,10 +11,13 @@ import {
   INCONCLUSIVE,
 } from './revert-oracle.mjs';
 
-const completePass = (run) => run?.kind === PASS && Number.isInteger(run.total) && run.total > 0;
+const completePass = (run) => run?.kind === PASS && run.attributed === true
+  && run.exitCode === 0 && run.signal === null && Number.isInteger(run.total) && run.total > 0;
 const assertionWitness = (baseline, reverted) =>
   completePass(baseline) &&
   reverted?.kind === ASSERTION_FAILURE &&
+  reverted.attributed === true &&
+  Number.isInteger(reverted.exitCode) && reverted.exitCode !== 0 && reverted.signal === null &&
   Number.isInteger(reverted.total) &&
   reverted.total >= baseline.total &&
   Number.isInteger(reverted.failed) &&
@@ -41,7 +44,8 @@ export function buildExecutionLedger({ plans, gaps = [], support = [], baselineR
     exitCode: run.rawExitCode ?? null,
     signal: run.signal ?? null,
     toolchain: run.toolchain ?? null,
-    files: typeof run.total === 'number' && run.total > 0 ? [plan.file] : [],
+    attributed: run.attributed === true,
+    files: run.attributed === true ? [plan.file] : [],
     testIdentities: [...new Set(run.identities ?? [])],
     evidence: run.evidence ?? [],
   } : null;
@@ -85,7 +89,7 @@ export function ledgerVerdict(ledger) {
     return {
       verdict: BASELINE_BROKEN,
       exitCode: 3,
-      reason: `${broken.file} has no green attributable baseline (${broken.baseline.kind}).`,
+      reason: `${broken.file} has no green attributable baseline (${broken.baseline.kind}${broken.baseline.evidence?.[0] ? `: ${broken.baseline.evidence[0]}` : ''}).`,
     };
   }
 
@@ -98,6 +102,16 @@ export function ledgerVerdict(ledger) {
 
   if (runs.length === 0) {
     return { verdict: INCONCLUSIVE, exitCode: 3, reason: 'no changed executable test file was measured.' };
+  }
+  const changedCollection = runs.find((entry) => entry.baseline.total !== entry.reverted.total
+    || (entry.baseline.testIdentities.length > 0 && entry.reverted.testIdentities.length > 0
+      && JSON.stringify(entry.baseline.testIdentities) !== JSON.stringify(entry.reverted.testIdentities)));
+  if (changedCollection) {
+    return {
+      verdict: INCONCLUSIVE,
+      exitCode: 3,
+      reason: `${changedCollection.file} did not execute the same test collection before and after the revert.`,
+    };
   }
   return {
     verdict: UNOBSERVED,

--- a/scripts/lib/revert-oracle-ledger.test.mjs
+++ b/scripts/lib/revert-oracle-ledger.test.mjs
@@ -7,8 +7,8 @@ import assert from 'node:assert/strict';
 
 import { ledgerVerdict } from './revert-oracle-ledger.mjs';
 
-const pass = (total = 2) => ({ kind: 'pass', passed: total, failed: 0, total, evidence: [] });
-const red = (total = 2) => ({ kind: 'assertion-failure', passed: total - 1, failed: 1, total, evidence: ['named assertion'] });
+const pass = (total = 2) => ({ kind: 'pass', passed: total, failed: 0, total, attributed: true, exitCode: 0, signal: null, testIdentities: [], evidence: [] });
+const red = (total = 2) => ({ kind: 'assertion-failure', passed: total - 1, failed: 1, total, attributed: true, exitCode: 1, signal: null, testIdentities: [], evidence: ['named assertion'] });
 
 test('#4109: one attributable witness survives an unrelated capability gap', () => {
   const verdict = ledgerVerdict([
@@ -28,6 +28,18 @@ test('#4109: UNOBSERVED requires complete measurements for every executable', ()
     { file: 'a.test.ts', role: 'executable', baseline: pass(), reverted: pass() },
     { file: 'b.test.ts', role: 'executable', baseline: pass(3), reverted: pass(3) },
   ]).verdict, 'UNOBSERVED');
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: pass(2), reverted: pass(1) },
+  ]).verdict, 'INCONCLUSIVE');
+});
+
+test('#4109: a green summary without process and selector proof is never complete evidence', () => {
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: { ...pass(), attributed: false }, reverted: pass() },
+  ]).verdict, 'BASELINE-BROKEN');
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: pass(), reverted: { ...pass(), exitCode: 9 } },
+  ]).verdict, 'INCONCLUSIVE');
 });
 
 test('#4109: an all-skipped baseline is broken, never synthetic coverage', () => {

--- a/scripts/lib/revert-oracle-ledger.test.mjs
+++ b/scripts/lib/revert-oracle-ledger.test.mjs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ledgerVerdict } from './revert-oracle-ledger.mjs';
+
+const pass = (total = 2) => ({ kind: 'pass', passed: total, failed: 0, total, evidence: [] });
+const red = (total = 2) => ({ kind: 'assertion-failure', passed: total - 1, failed: 1, total, evidence: ['named assertion'] });
+
+test('#4109: one attributable witness survives an unrelated capability gap', () => {
+  const verdict = ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', runKey: 'a', baseline: pass(), reverted: red() },
+    { file: 'tests/helper.rs', role: 'capability-gap', reason: 'Rust module cannot be invoked as a target' },
+  ]);
+  assert.equal(verdict.verdict, 'OBSERVED');
+  assert.equal(verdict.witness.file, 'a.test.ts');
+});
+
+test('#4109: UNOBSERVED requires complete measurements for every executable', () => {
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: pass(), reverted: pass() },
+    { file: 'b.test.ts', role: 'executable', baseline: pass(), reverted: { kind: 'no-tests', total: 0 } },
+  ]).verdict, 'INCONCLUSIVE');
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: pass(), reverted: pass() },
+    { file: 'b.test.ts', role: 'executable', baseline: pass(3), reverted: pass(3) },
+  ]).verdict, 'UNOBSERVED');
+});
+
+test('#4109: an all-skipped baseline is broken, never synthetic coverage', () => {
+  assert.equal(ledgerVerdict([
+    { file: 'a.test.ts', role: 'executable', baseline: { kind: 'all-skipped', total: 4 }, reverted: pass() },
+  ]).verdict, 'BASELINE-BROKEN');
+});

--- a/scripts/lib/revert-oracle-pass-verdict.mjs
+++ b/scripts/lib/revert-oracle-pass-verdict.mjs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A green reverted run supports a negative finding only when execution was
+ * complete. Positive witnesses are decided before this function, so an
+ * all-skipped sibling cannot erase a real assertion failure (#4109).
+ */
+export function passVerdict(baseline, reverted) {
+  const allSkippedRuns = (baseline.allSkippedRuns ?? 0) + (reverted.allSkippedRuns ?? 0);
+  if (allSkippedRuns > 0) {
+    return {
+      verdict: 'INCONCLUSIVE',
+      exitCode: 3,
+      reason:
+        `the oracle saw ${allSkippedRuns} all-skipped package run(s). The executed tests stayed green, ` +
+        'but incomplete execution cannot support an UNOBSERVED finding.',
+      advice: 'Provision the skipped test prerequisites, or narrow --test to a fully executable witness.',
+    };
+  }
+  return {
+    verdict: 'UNOBSERVED',
+    exitCode: 1,
+    reason:
+      `FINDING: with the production change fully reverted, all ${reverted.total} test(s) still PASS. ` +
+      'The branch\'s tests do not observe the branch\'s change.',
+    advice:
+      'Either the test asserts something the change does not affect, or it stubs the very module ' +
+      'the change lives in. Write a test that fails on this revert before shipping.',
+  };
+}

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -19,10 +19,10 @@
  */
 
 import { readFileSync, existsSync } from 'node:fs';
-import { join, dirname, relative } from 'node:path';
+import { join, dirname, relative, basename, sep } from 'node:path';
 
-import { cargoRunner, rootScriptsRunner, detectRunner } from './revert-oracle.mjs';
-import { cargoTestOwner } from './revert-oracle-cargo.mjs';
+import { rootScriptsRunner, detectRunner } from './revert-oracle.mjs';
+import { cargoRunner, cargoTestOwner } from './revert-oracle-cargo.mjs';
 import {
   requiredFeatureCombos,
   stripComments,
@@ -43,7 +43,7 @@ export function findUp(startDir, filename, root) {
   }
 }
 
-/** Group test files by the package that owns them and pick each one's runner. */
+/** Pick an exact-file/target runner for every executable changed test file. */
 /**
  * True when any of `relFiles` gates a `#[test]` behind a whole-expression
  * `not(...)` over non-default features.
@@ -98,67 +98,70 @@ function crateDefaultFeatures(dir) {
 }
 
 export function planRuns(testPaths, root) {
-  /** @type {Map<string, {dir: string, files: string[], script: string|undefined, crate: string|null}>} */
-  const groups = new Map();
+  const plans = [];
   const unassigned = [];
+  const support = [];
 
   for (const rel of testPaths) {
     const abs = join(root, rel);
     const c = cargoTestOwner(abs, root);
     if (c) {
-      const key = `cargo:${c.crate}`;
-      if (!groups.has(key)) groups.set(key, { dir: c.dir, files: [], script: undefined, crate: c.crate });
-      groups.get(key).files.push(rel);
-      continue;
-    }
-    if (rel.endsWith('.rs')) { unassigned.push(rel); continue; }
-    if (rel.endsWith('.py')) {
-      const p = pythonTestOwner(abs, root);
-      if (!p) { unassigned.push(rel); continue; }
-      const key = `python:${p.dir}`;
-      if (!groups.has(key)) groups.set(key, { dir: p.dir, files: [], script: undefined, crate: null, python: true });
-      groups.get(key).files.push(rel); continue;
-    }
-    const pkgDir = findUp(dirname(abs), 'package.json', root);
-    if (!pkgDir) { unassigned.push(rel); continue; }
-    if (!groups.has(pkgDir)) {
-      let script;
-      try {
-        script = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).scripts?.test;
-      } catch {
-        script = undefined;
+      const within = relative(c.dir, abs).split(sep).join('/');
+      const targetMatch = /^tests\/([^/]+)\.rs$/.exec(within);
+      const siblingMatch = /^src\/([^/]*(?:tests|_tests))\.rs$/.exec(within);
+      if (!targetMatch && !siblingMatch) {
+        if (/(^|\/)(?:fixtures?|test-data|testdata|corpus)(\/|$)/.test(within)) {
+          support.push(rel);
+          continue;
+        }
+        unassigned.push({ file: rel, reason: 'Rust unit/module/support files cannot be attributed to one executable cargo target' });
+        continue;
       }
-      groups.set(pkgDir, { dir: pkgDir, files: [], script, crate: null });
-    }
-    groups.get(pkgDir).files.push(rel);
-  }
-
-  const plans = [];
-  for (const [key, g] of groups) {
-    const relFiles = g.files.map((f) => relative(g.dir, join(root, f)) || f);
-    // #4050/#4024: a default build compiles a `#[cfg(feature = "x")]` test OUT
-    // entirely, so run one cargo invocation per feature-combo the changed
-    // files require; none found -> the old, single default-features run.
-    if (g.crate) {
-      // Crate default features: treating a `not(feature = "x")` gate as
-      // "the default build compiles it" is only sound when x is NOT default-on.
-      const defaults = crateDefaultFeatures(g.dir);
-      const combos = requiredFeatureCombos(root, g.files, defaults);
-      // A not()-gated test compiles only in the default build and contributes
-      // no combo, so the default run must happen ALONGSIDE any combos found.
+      const defaults = crateDefaultFeatures(c.dir);
+      const combos = requiredFeatureCombos(root, [rel], defaults);
       const runs = combos.length > 0
-        ? (requiresDefaultRun(root, g.files) ? [[], ...combos] : combos)
+        ? (requiresDefaultRun(root, [rel]) ? [[], ...combos] : combos)
         : [[]];
       for (const features of runs) {
-        const label = features.length > 0 ? `${key}+${features.join('+')}` : key;
-        plans.push({ key: label, dir: g.dir, files: g.files, relFiles, script: g.script, crate: g.crate, runner: cargoRunner(g.crate, features) });
+        const suffix = features.length > 0 ? `+${features.join('+')}` : '';
+        const identity = targetMatch?.[1] ?? siblingMatch[1];
+        plans.push({
+          key: `cargo:${c.crate}:${identity}${suffix}`,
+          file: rel,
+          dir: c.dir,
+          files: [rel],
+          relFiles: [within],
+          script: undefined,
+          crate: c.crate,
+          features,
+          moduleFilter: siblingMatch?.[1] ?? null,
+          runner: cargoRunner(c.crate, features, targetMatch?.[1] ?? null, siblingMatch?.[1] ?? null),
+        });
       }
       continue;
     }
-    const runner = g.python
-      ? pythonRunner(relFiles)
-      : (g.dir === root ? rootScriptsRunner(g.files) : null) ?? detectRunner(g.script, relFiles);
-    plans.push({ key, dir: g.dir, files: g.files, relFiles, runner, script: g.script, crate: null });
+    if (rel.endsWith('.rs')) { unassigned.push({ file: rel, reason: 'no owning Cargo package found' }); continue; }
+    if (rel.endsWith('.py')) {
+      const p = pythonTestOwner(abs, root);
+      if (!p) { unassigned.push({ file: rel, reason: 'no owning Python package found' }); continue; }
+      if (!/(^test_.+|.+_test)\.py$/.test(basename(rel))) { support.push(rel); continue; }
+      const relFile = relative(p.dir, abs);
+      plans.push({ key: `python:${rel}`, file: rel, dir: p.dir, files: [rel], relFiles: [relFile], script: undefined, crate: null, runner: pythonRunner([relFile]) });
+      continue;
+    }
+    const pkgDir = findUp(dirname(abs), 'package.json', root);
+    if (!/\.(test|spec)\.[^/]+$/.test(rel)) { support.push(rel); continue; }
+    if (!pkgDir) { unassigned.push({ file: rel, reason: 'no owning JavaScript package found' }); continue; }
+    let script;
+    try {
+      script = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8')).scripts?.test;
+    } catch (error) {
+      unassigned.push({ file: rel, reason: `could not read package.json: ${error.message}` });
+      continue;
+    }
+    const relFile = relative(pkgDir, abs);
+    const runner = (pkgDir === root ? rootScriptsRunner([rel]) : null) ?? detectRunner(script, [relFile]);
+    plans.push({ key: `test:${rel}`, file: rel, dir: pkgDir, files: [rel], relFiles: [relFile], runner, script, crate: null });
   }
-  return { plans, unassigned };
+  return { plans, unassigned, support };
 }

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -21,15 +21,15 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname, relative, basename, sep } from 'node:path';
 
-import { rootScriptsRunner, detectRunner } from './revert-oracle.mjs';
-import { cargoRunner, cargoTestOwner } from './revert-oracle-cargo.mjs';
+import { cargoTestOwner } from './revert-oracle-cargo.mjs';
+import { claimRuntimeAdapter } from './revert-oracle-adapters.mjs';
 import {
   requiredFeatureCombos,
   stripComments,
   INNER_CFG_RE,
   TEST_CFG_RE,
 } from './revert-oracle-rust-features.mjs';
-import { pythonTestOwner, pythonRunner } from './revert-oracle-python.mjs';
+import { pythonTestOwner } from './revert-oracle-python.mjs';
 
 /** Walk up from `startDir` looking for `filename`, stopping at `root`. */
 export function findUp(startDir, filename, root) {
@@ -125,6 +125,7 @@ export function planRuns(testPaths, root) {
       for (const features of runs) {
         const suffix = features.length > 0 ? `+${features.join('+')}` : '';
         const identity = targetMatch?.[1] ?? siblingMatch[1];
+        const claimed = claimRuntimeAdapter({ kind: 'cargo', crate: c.crate, features, target: targetMatch?.[1] ?? null, moduleFilter: siblingMatch?.[1] ?? null });
         plans.push({
           key: `cargo:${c.crate}:${identity}${suffix}`,
           file: rel,
@@ -135,7 +136,8 @@ export function planRuns(testPaths, root) {
           crate: c.crate,
           features,
           moduleFilter: siblingMatch?.[1] ?? null,
-          runner: cargoRunner(c.crate, features, targetMatch?.[1] ?? null, siblingMatch?.[1] ?? null),
+          adapter: claimed?.adapter ?? null,
+          runner: claimed?.runner ?? null,
         });
       }
       continue;
@@ -146,7 +148,8 @@ export function planRuns(testPaths, root) {
       if (!p) { unassigned.push({ file: rel, reason: 'no owning Python package found' }); continue; }
       if (!/(^test_.+|.+_test)\.py$/.test(basename(rel))) { support.push(rel); continue; }
       const relFile = relative(p.dir, abs);
-      plans.push({ key: `python:${rel}`, file: rel, dir: p.dir, files: [rel], relFiles: [relFile], script: undefined, crate: null, runner: pythonRunner([relFile]) });
+      const claimed = claimRuntimeAdapter({ kind: 'python', relFile });
+      plans.push({ key: `python:${rel}`, file: rel, dir: p.dir, files: [rel], relFiles: [relFile], script: undefined, crate: null, adapter: claimed?.adapter ?? null, runner: claimed?.runner ?? null });
       continue;
     }
     const pkgDir = findUp(dirname(abs), 'package.json', root);
@@ -160,8 +163,8 @@ export function planRuns(testPaths, root) {
       continue;
     }
     const relFile = relative(pkgDir, abs);
-    const runner = (pkgDir === root ? rootScriptsRunner([rel]) : null) ?? detectRunner(script, [relFile]);
-    plans.push({ key: `test:${rel}`, file: rel, dir: pkgDir, files: [rel], relFiles: [relFile], runner, script, crate: null });
+    const claimed = claimRuntimeAdapter({ kind: 'javascript', file: rel, relFile, script, rootPackage: pkgDir === root });
+    plans.push({ key: `test:${rel}`, file: rel, dir: pkgDir, files: [rel], relFiles: [relFile], adapter: claimed?.adapter ?? null, runner: claimed?.runner ?? null, script, crate: null });
   }
   return { plans, unassigned, support };
 }

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -18,8 +18,8 @@
  * no longer lives inside the dispatcher that freezes it as a top-level const.
  */
 
-import { readFileSync, existsSync } from 'node:fs';
-import { join, dirname, relative, basename, sep } from 'node:path';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname, relative, basename, sep, resolve } from 'node:path';
 
 import { cargoTestOwner } from './revert-oracle-cargo.mjs';
 import { claimRuntimeAdapter } from './revert-oracle-adapters.mjs';
@@ -28,6 +28,7 @@ import {
   stripComments,
   INNER_CFG_RE,
   TEST_CFG_RE,
+  UnhandledCfgShapeError,
 } from './revert-oracle-rust-features.mjs';
 import { pythonTestOwner } from './revert-oracle-python.mjs';
 
@@ -97,6 +98,25 @@ function crateDefaultFeatures(dir) {
   }
 }
 
+function rustModuleOwner(crateDir, abs) {
+  const sourceRoot = join(crateDir, 'src');
+  if (!existsSync(sourceRoot)) return null;
+  for (const entry of readdirSync(sourceRoot, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.rs')) continue;
+    const parent = join(entry.parentPath, entry.name);
+    const text = readFileSync(parent, 'utf8');
+    const declarations = /(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+    let match;
+    while ((match = declarations.exec(text)) !== null) {
+      const target = match[1]
+        ? resolve(dirname(parent), match[1])
+        : resolve(dirname(parent), `${match[2]}.rs`);
+      if (target === resolve(abs)) return match[2];
+    }
+  }
+  return null;
+}
+
 export function planRuns(testPaths, root) {
   const plans = [];
   const unassigned = [];
@@ -109,7 +129,8 @@ export function planRuns(testPaths, root) {
       const within = relative(c.dir, abs).split(sep).join('/');
       const targetMatch = /^tests\/([^/]+)\.rs$/.exec(within);
       const siblingMatch = /^src\/([^/]*(?:tests|_tests))\.rs$/.exec(within);
-      if (!targetMatch && !siblingMatch) {
+      const declaredModule = targetMatch ? null : rustModuleOwner(c.dir, abs);
+      if (!targetMatch && !siblingMatch && !declaredModule) {
         if (/(^|\/)(?:fixtures?|test-data|testdata|corpus)(\/|$)/.test(within)) {
           support.push(rel);
           continue;
@@ -118,14 +139,22 @@ export function planRuns(testPaths, root) {
         continue;
       }
       const defaults = crateDefaultFeatures(c.dir);
-      const combos = requiredFeatureCombos(root, [rel], defaults);
+      let combos;
+      try {
+        combos = requiredFeatureCombos(root, [rel], defaults);
+      } catch (error) {
+        if (!(error instanceof UnhandledCfgShapeError)) throw error;
+        unassigned.push({ file: rel, reason: error.message });
+        continue;
+      }
       const runs = combos.length > 0
         ? (requiresDefaultRun(root, [rel]) ? [[], ...combos] : combos)
         : [[]];
       for (const features of runs) {
         const suffix = features.length > 0 ? `+${features.join('+')}` : '';
-        const identity = targetMatch?.[1] ?? siblingMatch[1];
-        const claimed = claimRuntimeAdapter({ kind: 'cargo', crate: c.crate, features, target: targetMatch?.[1] ?? null, moduleFilter: siblingMatch?.[1] ?? null });
+        const moduleFilter = declaredModule ?? siblingMatch?.[1];
+        const identity = targetMatch?.[1] ?? moduleFilter;
+        const claimed = claimRuntimeAdapter({ kind: 'cargo', crate: c.crate, features, target: targetMatch?.[1] ?? null, moduleFilter });
         plans.push({
           key: `cargo:${c.crate}:${identity}${suffix}`,
           file: rel,
@@ -135,7 +164,8 @@ export function planRuns(testPaths, root) {
           script: undefined,
           crate: c.crate,
           features,
-          moduleFilter: siblingMatch?.[1] ?? null,
+          moduleFilter,
+          integrationTarget: targetMatch?.[1] ?? null,
           adapter: claimed?.adapter ?? null,
           runner: claimed?.runner ?? null,
         });
@@ -143,6 +173,7 @@ export function planRuns(testPaths, root) {
       continue;
     }
     if (rel.endsWith('.rs')) { unassigned.push({ file: rel, reason: 'no owning Cargo package found' }); continue; }
+    if (rel.endsWith('.go')) { unassigned.push({ file: rel, reason: 'Go test entrypoints have no revert-oracle adapter' }); continue; }
     if (rel.endsWith('.py')) {
       const p = pythonTestOwner(abs, root);
       if (!p) { unassigned.push({ file: rel, reason: 'no owning Python package found' }); continue; }
@@ -153,7 +184,10 @@ export function planRuns(testPaths, root) {
       continue;
     }
     const pkgDir = findUp(dirname(abs), 'package.json', root);
-    if (!/\.(test|spec)\.[^/]+$/.test(rel)) { support.push(rel); continue; }
+    if (!/\.(test|spec)\.[^/]+$/.test(rel)) {
+      support.push(rel);
+      continue;
+    }
     if (!pkgDir) { unassigned.push({ file: rel, reason: 'no owning JavaScript package found' }); continue; }
     let script;
     try {

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -98,8 +98,14 @@ function crateDefaultFeatures(dir) {
   }
 }
 
-function withoutRustComments(source) {
+function sanitizeRustSource(source) {
   let result = '', index = 0, blockDepth = 0;
+  const strings = new Map();
+  const keepString = (value) => {
+    const token = `__RUST_STRING_${strings.size}__`;
+    strings.set(token, value);
+    return `"${token}"`;
+  };
   while (index < source.length) {
     if (blockDepth > 0) {
       if (source.startsWith('/*', index)) { blockDepth += 1; result += '  '; index += 2; continue; }
@@ -110,7 +116,7 @@ function withoutRustComments(source) {
     }
     if (source.startsWith('//', index)) {
       const end = source.indexOf('\n', index);
-      if (end < 0) return result + ' '.repeat(source.length - index);
+      if (end < 0) return { text: result + ' '.repeat(source.length - index), strings };
       result += ' '.repeat(end - index) + '\n';
       index = end + 1;
       continue;
@@ -121,7 +127,8 @@ function withoutRustComments(source) {
       const hashes = raw[1] ?? '', terminator = `"${hashes}`;
       const end = source.indexOf(terminator, index + raw[0].length);
       const length = end < 0 ? source.length - index : end + terminator.length - index;
-      result += source.slice(index, index + length); index += length; continue;
+      const literal = source.slice(index, index + length);
+      result += keepString(literal.slice(raw[0].length, length - terminator.length)); index += length; continue;
     }
     if (source[index] === '"') {
       const start = index++;
@@ -129,12 +136,12 @@ function withoutRustComments(source) {
         if (source[index] === '\\') { index += 2; continue; }
         if (source[index++] === '"') break;
       }
-      result += source.slice(start, index);
+      result += keepString(source.slice(start + 1, Math.max(start + 1, index - 1)));
       continue;
     }
     result += source[index++];
   }
-  return result;
+  return { text: result, strings };
 }
 
 function rustModuleOwner(crateDir, abs) {
@@ -147,7 +154,7 @@ function rustModuleOwner(crateDir, abs) {
     const key = `${resolve(parent)}\0${modules.join('::')}`;
     if (visited.has(key) || !existsSync(parent)) continue;
     visited.add(key);
-    const text = withoutRustComments(readFileSync(parent, 'utf8'));
+    const { text, strings } = sanitizeRustSource(readFileSync(parent, 'utf8'));
     const declarations = /((?:\s*#\s*\[[\s\S]*?\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
@@ -155,7 +162,8 @@ function rustModuleOwner(crateDir, abs) {
         ? dirname(parent)
         : join(dirname(parent), basename(parent, '.rs'));
       const attributes = match[1], moduleName = match[2];
-      const explicitPath = /#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]/.exec(attributes)?.[1];
+      const pathToken = /#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]/.exec(attributes)?.[1];
+      const explicitPath = pathToken ? (strings.get(pathToken) ?? pathToken) : undefined;
       const target = explicitPath
         ? resolve(dirname(parent), explicitPath)
         : [resolve(ordinaryBase, `${moduleName}.rs`), resolve(ordinaryBase, moduleName, 'mod.rs')].find(existsSync);

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -98,6 +98,45 @@ function crateDefaultFeatures(dir) {
   }
 }
 
+function withoutRustComments(source) {
+  let result = '', index = 0, blockDepth = 0;
+  while (index < source.length) {
+    if (blockDepth > 0) {
+      if (source.startsWith('/*', index)) { blockDepth += 1; result += '  '; index += 2; continue; }
+      if (source.startsWith('*/', index)) { blockDepth -= 1; result += '  '; index += 2; continue; }
+      result += source[index] === '\n' ? '\n' : ' ';
+      index += 1;
+      continue;
+    }
+    if (source.startsWith('//', index)) {
+      const end = source.indexOf('\n', index);
+      if (end < 0) return result + ' '.repeat(source.length - index);
+      result += ' '.repeat(end - index) + '\n';
+      index = end + 1;
+      continue;
+    }
+    if (source.startsWith('/*', index)) { blockDepth = 1; result += '  '; index += 2; continue; }
+    const raw = /^r(#+)?"/.exec(source.slice(index));
+    if (raw) {
+      const hashes = raw[1] ?? '', terminator = `"${hashes}`;
+      const end = source.indexOf(terminator, index + raw[0].length);
+      const length = end < 0 ? source.length - index : end + terminator.length - index;
+      result += source.slice(index, index + length); index += length; continue;
+    }
+    if (source[index] === '"') {
+      const start = index++;
+      while (index < source.length) {
+        if (source[index] === '\\') { index += 2; continue; }
+        if (source[index++] === '"') break;
+      }
+      result += source.slice(start, index);
+      continue;
+    }
+    result += source[index++];
+  }
+  return result;
+}
+
 function rustModuleOwner(crateDir, abs) {
   const root = join(crateDir, 'src', 'lib.rs');
   if (!existsSync(root)) return null;
@@ -108,8 +147,8 @@ function rustModuleOwner(crateDir, abs) {
     const key = `${resolve(parent)}\0${modules.join('::')}`;
     if (visited.has(key) || !existsSync(parent)) continue;
     visited.add(key);
-    const text = readFileSync(parent, 'utf8');
-    const declarations = /((?:\s*(?:#\s*\[[\s\S]*?\]|\/\/[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+    const text = withoutRustComments(readFileSync(parent, 'utf8'));
+    const declarations = /((?:\s*#\s*\[[\s\S]*?\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
       const ordinaryBase = /(?:^|[\\/])(?:lib|mod)\.rs$/.test(parent)

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -18,7 +18,7 @@
  * no longer lives inside the dispatcher that freezes it as a top-level const.
  */
 
-import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { join, dirname, relative, basename, sep, resolve } from 'node:path';
 
 import { cargoTestOwner } from './revert-oracle-cargo.mjs';
@@ -99,19 +99,29 @@ function crateDefaultFeatures(dir) {
 }
 
 function rustModuleOwner(crateDir, abs) {
-  const sourceRoot = join(crateDir, 'src');
-  if (!existsSync(sourceRoot)) return null;
-  for (const entry of readdirSync(sourceRoot, { recursive: true, withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith('.rs')) continue;
-    const parent = join(entry.parentPath, entry.name);
+  const root = join(crateDir, 'src', 'lib.rs');
+  if (!existsSync(root)) return null;
+  const queue = [{ file: root, modules: [] }];
+  const visited = new Set();
+  while (queue.length > 0) {
+    const { file: parent, modules } = queue.shift();
+    const key = `${resolve(parent)}\0${modules.join('::')}`;
+    if (visited.has(key) || !existsSync(parent)) continue;
+    visited.add(key);
     const text = readFileSync(parent, 'utf8');
     const declarations = /(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
+      const ordinaryBase = /(?:^|[\\/])(?:lib|mod)\.rs$/.test(parent)
+        ? dirname(parent)
+        : join(dirname(parent), basename(parent, '.rs'));
       const target = match[1]
         ? resolve(dirname(parent), match[1])
-        : resolve(dirname(parent), `${match[2]}.rs`);
-      if (target === resolve(abs)) return match[2];
+        : [resolve(ordinaryBase, `${match[2]}.rs`), resolve(ordinaryBase, match[2], 'mod.rs')].find(existsSync);
+      if (!target) continue;
+      const targetModules = [...modules, match[2]];
+      if (resolve(target) === resolve(abs)) return targetModules.join('::');
+      queue.push({ file: target, modules: targetModules });
     }
   }
   return null;
@@ -128,9 +138,8 @@ export function planRuns(testPaths, root) {
     if (c) {
       const within = relative(c.dir, abs).split(sep).join('/');
       const targetMatch = /^tests\/([^/]+)\.rs$/.exec(within);
-      const siblingMatch = /^src\/([^/]*(?:tests|_tests))\.rs$/.exec(within);
       const declaredModule = targetMatch ? null : rustModuleOwner(c.dir, abs);
-      if (!targetMatch && !siblingMatch && !declaredModule) {
+      if (!targetMatch && !declaredModule) {
         if (/(^|\/)(?:fixtures?|test-data|testdata|corpus)(\/|$)/.test(within)) {
           support.push(rel);
           continue;
@@ -152,7 +161,7 @@ export function planRuns(testPaths, root) {
         : [[]];
       for (const features of runs) {
         const suffix = features.length > 0 ? `+${features.join('+')}` : '';
-        const moduleFilter = declaredModule ?? siblingMatch?.[1];
+        const moduleFilter = declaredModule;
         const identity = targetMatch?.[1] ?? moduleFilter;
         const claimed = claimRuntimeAdapter({ kind: 'cargo', crate: c.crate, features, target: targetMatch?.[1] ?? null, moduleFilter });
         plans.push({

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -109,20 +109,20 @@ function rustModuleOwner(crateDir, abs) {
     if (visited.has(key) || !existsSync(parent)) continue;
     visited.add(key);
     const text = readFileSync(parent, 'utf8');
-    const declarations = /((?:\s*#\[[\s\S]*?\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+    const declarations = /((?:\s*(?:#\s*\[[\s\S]*?\]|\/\/[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
       const ordinaryBase = /(?:^|[\\/])(?:lib|mod)\.rs$/.test(parent)
         ? dirname(parent)
         : join(dirname(parent), basename(parent, '.rs'));
       const attributes = match[1], moduleName = match[2];
-      const explicitPath = /#\[\s*path\s*=\s*"([^"]+)"\s*\]/.exec(attributes)?.[1];
+      const explicitPath = /#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]/.exec(attributes)?.[1];
       const target = explicitPath
         ? resolve(dirname(parent), explicitPath)
         : [resolve(ordinaryBase, `${moduleName}.rs`), resolve(ordinaryBase, moduleName, 'mod.rs')].find(existsSync);
       if (!target) continue;
       const targetModules = [...modules, moduleName];
-      const conditional = [...attributes.matchAll(/#\[\s*cfg[\s\S]*?\]/g)]
+      const conditional = [...attributes.matchAll(/#\s*\[\s*cfg[\s\S]*?\]/g)]
         .some((cfg) => cfg[0].replaceAll(/\s/g, '') !== '#[cfg(test)]');
       if (resolve(target) === resolve(abs)) matches.push({ moduleFilter: targetModules.join('::'), conditional });
       if (conditional) continue;

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -101,7 +101,7 @@ function crateDefaultFeatures(dir) {
 function rustModuleOwner(crateDir, abs) {
   const root = join(crateDir, 'src', 'lib.rs');
   if (!existsSync(root)) return null;
-  const queue = [{ file: root, modules: [] }];
+  const queue = [{ file: root, modules: [] }], matches = [];
   const visited = new Set();
   while (queue.length > 0) {
     const { file: parent, modules } = queue.shift();
@@ -109,22 +109,28 @@ function rustModuleOwner(crateDir, abs) {
     if (visited.has(key) || !existsSync(parent)) continue;
     visited.add(key);
     const text = readFileSync(parent, 'utf8');
-    const declarations = /(?:#\[path\s*=\s*"([^"]+)"\]\s*)?(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+    const declarations = /((?:\s*#\[[^\]\r\n]+\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
       const ordinaryBase = /(?:^|[\\/])(?:lib|mod)\.rs$/.test(parent)
         ? dirname(parent)
         : join(dirname(parent), basename(parent, '.rs'));
-      const target = match[1]
-        ? resolve(dirname(parent), match[1])
-        : [resolve(ordinaryBase, `${match[2]}.rs`), resolve(ordinaryBase, match[2], 'mod.rs')].find(existsSync);
+      const attributes = match[1], moduleName = match[2];
+      const explicitPath = /#\[\s*path\s*=\s*"([^"]+)"\s*\]/.exec(attributes)?.[1];
+      const target = explicitPath
+        ? resolve(dirname(parent), explicitPath)
+        : [resolve(ordinaryBase, `${moduleName}.rs`), resolve(ordinaryBase, moduleName, 'mod.rs')].find(existsSync);
       if (!target) continue;
-      const targetModules = [...modules, match[2]];
-      if (resolve(target) === resolve(abs)) return targetModules.join('::');
+      const targetModules = [...modules, moduleName];
+      const conditional = [...attributes.matchAll(/#\[\s*cfg[^\]]*\]/g)]
+        .some((cfg) => cfg[0].replaceAll(/\s/g, '') !== '#[cfg(test)]');
+      if (resolve(target) === resolve(abs)) matches.push({ moduleFilter: targetModules.join('::'), conditional });
+      if (conditional) continue;
       queue.push({ file: target, modules: targetModules });
     }
   }
-  return null;
+  if (matches.length !== 1 || matches[0].conditional) return matches.length > 0 ? { ambiguous: true } : null;
+  return matches[0];
 }
 
 export function planRuns(testPaths, root) {
@@ -138,13 +144,15 @@ export function planRuns(testPaths, root) {
     if (c) {
       const within = relative(c.dir, abs).split(sep).join('/');
       const targetMatch = /^tests\/([^/]+)\.rs$/.exec(within);
-      const declaredModule = targetMatch ? null : rustModuleOwner(c.dir, abs);
-      if (!targetMatch && !declaredModule) {
+      const owner = targetMatch ? null : rustModuleOwner(c.dir, abs);
+      if (!targetMatch && (!owner || owner.ambiguous)) {
         if (/(^|\/)(?:fixtures?|test-data|testdata|corpus)(\/|$)/.test(within)) {
           support.push(rel);
           continue;
         }
-        unassigned.push({ file: rel, reason: 'Rust unit/module/support files cannot be attributed to one executable cargo target' });
+        unassigned.push({ file: rel, reason: owner?.ambiguous
+          ? 'Rust module ownership is conditional or ambiguous; active compiled source ownership was not proven'
+          : 'Rust unit/module/support files cannot be attributed to one executable cargo target' });
         continue;
       }
       const defaults = crateDefaultFeatures(c.dir);
@@ -161,7 +169,7 @@ export function planRuns(testPaths, root) {
         : [[]];
       for (const features of runs) {
         const suffix = features.length > 0 ? `+${features.join('+')}` : '';
-        const moduleFilter = declaredModule;
+      const moduleFilter = owner?.moduleFilter ?? null;
         const identity = targetMatch?.[1] ?? moduleFilter;
         const claimed = claimRuntimeAdapter({ kind: 'cargo', crate: c.crate, features, target: targetMatch?.[1] ?? null, moduleFilter });
         plans.push({

--- a/scripts/lib/revert-oracle-plan-runs.mjs
+++ b/scripts/lib/revert-oracle-plan-runs.mjs
@@ -109,7 +109,7 @@ function rustModuleOwner(crateDir, abs) {
     if (visited.has(key) || !existsSync(parent)) continue;
     visited.add(key);
     const text = readFileSync(parent, 'utf8');
-    const declarations = /((?:\s*#\[[^\]\r\n]+\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+    const declarations = /((?:\s*#\[[\s\S]*?\]\s*)*)(?:pub(?:\([^)]*\))?\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;/g;
     let match;
     while ((match = declarations.exec(text)) !== null) {
       const ordinaryBase = /(?:^|[\\/])(?:lib|mod)\.rs$/.test(parent)
@@ -122,7 +122,7 @@ function rustModuleOwner(crateDir, abs) {
         : [resolve(ordinaryBase, `${moduleName}.rs`), resolve(ordinaryBase, moduleName, 'mod.rs')].find(existsSync);
       if (!target) continue;
       const targetModules = [...modules, moduleName];
-      const conditional = [...attributes.matchAll(/#\[\s*cfg[^\]]*\]/g)]
+      const conditional = [...attributes.matchAll(/#\[\s*cfg[\s\S]*?\]/g)]
         .some((cfg) => cfg[0].replaceAll(/\s/g, '') !== '#[cfg(test)]');
       if (resolve(target) === resolve(abs)) matches.push({ moduleFilter: targetModules.join('::'), conditional });
       if (conditional) continue;

--- a/scripts/lib/revert-oracle-process-result.mjs
+++ b/scripts/lib/revert-oracle-process-result.mjs
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/** Refuse summaries that contradict or outlive the runner process. */
+export function processResultGap(parsed, run) {
+  if (run.signal || run.exitCode === null) {
+    return {
+      kind: 'unparseable', passed: parsed.passed ?? null, failed: parsed.failed ?? null,
+      total: parsed.total ?? null,
+      evidence: [run.signal ? `runner terminated by ${run.signal}` : 'runner returned no exit status'],
+    };
+  }
+  if (run.exitCode !== 0 && (parsed.kind === 'pass' || (parsed.failed === 0 && (parsed.total ?? 0) > 0))) {
+    return {
+      kind: 'unparseable', passed: parsed.passed ?? null, failed: parsed.failed ?? null,
+      total: parsed.total ?? null, evidence: [`runner printed a green summary but exited ${run.exitCode}`],
+    };
+  }
+  if (run.exitCode === 0 && ((parsed.failed ?? 0) > 0 || parsed.kind === 'assertion-failure')) {
+    return {
+      kind: 'unparseable', passed: parsed.passed ?? null, failed: parsed.failed ?? null,
+      total: parsed.total ?? null, evidence: ['runner printed failures but exited 0'],
+    };
+  }
+  return null;
+}

--- a/scripts/lib/revert-oracle-result.mjs
+++ b/scripts/lib/revert-oracle-result.mjs
@@ -21,6 +21,10 @@ export function resultRecord({
   head = null,
   production = [],
   tests = [],
+  invocationId = null,
+  startedAt = null,
+  finishedAt = null,
+  restoration = 'not-required',
   ...details
 }) {
   if (channel !== PULL_REQUEST_CHANNEL && channel !== ORACLE_CHANNEL) {
@@ -31,7 +35,7 @@ export function resultRecord({
   }
   return {
     ...details,
-    schemaVersion: 1,
+    schemaVersion: 2,
     channel,
     verdict,
     exitCode,
@@ -40,6 +44,9 @@ export function resultRecord({
     head,
     production,
     tests,
+    invocationId,
+    timing: { startedAt, finishedAt },
+    restoration,
   };
 }
 

--- a/scripts/lib/revert-oracle-result.mjs
+++ b/scripts/lib/revert-oracle-result.mjs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The oracle reports two different subjects. A pull-request result says what
+ * the measurement established about the changed tests. An oracle result says
+ * that the measuring instrument could not establish that result. Keeping this
+ * discriminator in every JSON record prevents a capability gap from being
+ * rendered as a finding about the submitter (#4109).
+ */
+export const PULL_REQUEST_CHANNEL = 'pull-request';
+export const ORACLE_CHANNEL = 'oracle';
+
+export function resultRecord({
+  channel,
+  verdict,
+  exitCode,
+  reason,
+  base = null,
+  head = null,
+  production = [],
+  tests = [],
+  ...details
+}) {
+  if (channel !== PULL_REQUEST_CHANNEL && channel !== ORACLE_CHANNEL) {
+    throw new Error(`unknown revert-oracle result channel: ${channel}`);
+  }
+  if (!Number.isInteger(exitCode) || exitCode < 0) {
+    throw new Error(`invalid revert-oracle exit code: ${exitCode}`);
+  }
+  return {
+    ...details,
+    schemaVersion: 1,
+    channel,
+    verdict,
+    exitCode,
+    reason,
+    base,
+    head,
+    production,
+    tests,
+  };
+}
+
+/** Emit at most one JSON record for a process invocation. */
+export function createResultEmitter(enabled, write = console.log) {
+  let emitted = false;
+  return {
+    emit(record) {
+      if (!enabled) return;
+      if (emitted) throw new Error('revert-oracle attempted to emit more than one JSON result');
+      emitted = true;
+      write(JSON.stringify(record, null, 2));
+    },
+    get emitted() {
+      return emitted;
+    },
+  };
+}

--- a/scripts/lib/revert-oracle-result.test.mjs
+++ b/scripts/lib/revert-oracle-result.test.mjs
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createResultEmitter,
+  ORACLE_CHANNEL,
+  PULL_REQUEST_CHANNEL,
+  resultRecord,
+} from './revert-oracle-result.mjs';
+
+test('#4109: every result identifies whether it describes the PR or the oracle', () => {
+  const finding = resultRecord({
+    channel: PULL_REQUEST_CHANNEL,
+    verdict: 'UNOBSERVED',
+    exitCode: 1,
+    reason: 'tests stayed green',
+  });
+  const gap = resultRecord({
+    channel: ORACLE_CHANNEL,
+    verdict: 'ERROR',
+    exitCode: 2,
+    reason: 'runner missing',
+  });
+  assert.equal(finding.channel, 'pull-request');
+  assert.equal(gap.channel, 'oracle');
+  assert.equal(finding.schemaVersion, 1);
+});
+
+test('#4109: a process result emitter refuses a second JSON record', () => {
+  const writes = [];
+  const emitter = createResultEmitter(true, (text) => writes.push(text));
+  emitter.emit(resultRecord({ channel: ORACLE_CHANNEL, verdict: 'ERROR', exitCode: 2, reason: 'first' }));
+  assert.throws(
+    () => emitter.emit(resultRecord({ channel: ORACLE_CHANNEL, verdict: 'ERROR', exitCode: 2, reason: 'second' })),
+    /more than one JSON result/,
+  );
+  assert.equal(writes.length, 1);
+  assert.equal(JSON.parse(writes[0]).reason, 'first');
+});
+
+test('#4109: malformed channels and exit codes refuse instead of weakening the schema', () => {
+  assert.throws(
+    () => resultRecord({ channel: 'unknown', verdict: 'ERROR', exitCode: 2, reason: 'bad channel' }),
+    /unknown revert-oracle result channel/,
+  );
+  assert.throws(
+    () => resultRecord({ channel: ORACLE_CHANNEL, verdict: 'ERROR', exitCode: -1, reason: 'bad exit' }),
+    /invalid revert-oracle exit code/,
+  );
+});
+
+test('#4109: detail fields cannot overwrite the versioned result envelope', () => {
+  const record = resultRecord({
+    channel: ORACLE_CHANNEL,
+    verdict: 'ERROR',
+    exitCode: 2,
+    reason: 'canonical',
+    schemaVersion: 99,
+  });
+  assert.equal(record.schemaVersion, 1);
+  assert.equal(record.reason, 'canonical');
+});
+
+test('#4109: disabled JSON output does not consume the one allowed emission', () => {
+  const emitter = createResultEmitter(false, () => assert.fail('disabled emitter wrote output'));
+  emitter.emit(resultRecord({ channel: ORACLE_CHANNEL, verdict: 'ERROR', exitCode: 2, reason: 'first' }));
+  emitter.emit(resultRecord({ channel: ORACLE_CHANNEL, verdict: 'ERROR', exitCode: 2, reason: 'second' }));
+  assert.equal(emitter.emitted, false);
+});

--- a/scripts/lib/revert-oracle-result.test.mjs
+++ b/scripts/lib/revert-oracle-result.test.mjs
@@ -25,7 +25,9 @@ test('#4109: every result identifies whether it describes the PR or the oracle',
   });
   assert.equal(finding.channel, 'pull-request');
   assert.equal(gap.channel, 'oracle');
-  assert.equal(finding.schemaVersion, 1);
+  assert.equal(finding.schemaVersion, 2);
+  assert.deepEqual(finding.timing, { startedAt: null, finishedAt: null });
+  assert.equal(finding.restoration, 'not-required');
 });
 
 test('#4109: a process result emitter refuses a second JSON record', () => {
@@ -59,7 +61,7 @@ test('#4109: detail fields cannot overwrite the versioned result envelope', () =
     reason: 'canonical',
     schemaVersion: 99,
   });
-  assert.equal(record.schemaVersion, 1);
+  assert.equal(record.schemaVersion, 2);
   assert.equal(record.reason, 'canonical');
 });
 

--- a/scripts/lib/revert-oracle-root-scaffolding.test.mjs
+++ b/scripts/lib/revert-oracle-root-scaffolding.test.mjs
@@ -43,21 +43,25 @@ test('#4036: root Node assertions run through retained benchmark scaffolding aft
     run('git', ['commit', '-qm', 'change production, helper and assertion']);
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
-    assert.match(output, /1 assertion\(s\) RED out of 1 collected/);
+    assert.match(output, /reverting production turned an assertion RED in scripts\/value\.test\.mjs/);
     const payload = JSON.parse(output.slice(output.indexOf('{')));
     assert.equal(payload.channel, 'pull-request');
     assert.equal(payload.verdict, 'OBSERVED');
     assert.equal(readFileSync(join(root, 'src/value.mjs'), 'utf8'), 'export const value = 2;\n');
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
 
-    // A real unsupported entrypoint must not disappear when helpers are filtered.
+    // A real unsupported entrypoint stays visible as a capability gap, while
+    // the already-proved exact-file witness remains sufficient (#4109).
     writeFileSync(join(root, 'tests/benchmark/unsupported.spec.ts'), 'throw new Error("requires a declared runner");\n');
     run('git', ['add', '.']);
     run('git', ['commit', '-qm', 'add unsupported actual root test']);
     const rejected = spawnSync(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], { cwd: root, env, encoding: 'utf8', timeout: 20_000 });
     assert.equal(rejected.error, undefined);
-    assert.notEqual(rejected.status, 0);
-    assert.match(rejected.stdout + rejected.stderr, /no runner could be derived/);
+    assert.equal(rejected.status, 0);
+    assert.match(rejected.stdout + rejected.stderr, /capability gap: tests\/benchmark\/unsupported\.spec\.ts/);
+    const rejectedPayload = JSON.parse(rejected.stdout.slice(rejected.stdout.indexOf('{')));
+    assert.equal(rejectedPayload.verdict, 'OBSERVED');
+    assert.equal(rejectedPayload.ledger.some((entry) => entry.file === 'tests/benchmark/unsupported.spec.ts' && entry.role === 'capability-gap'), true);
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/lib/revert-oracle-root-scaffolding.test.mjs
+++ b/scripts/lib/revert-oracle-root-scaffolding.test.mjs
@@ -44,6 +44,9 @@ test('#4036: root Node assertions run through retained benchmark scaffolding aft
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
     assert.match(output, /1 assertion\(s\) RED out of 1 collected/);
+    const payload = JSON.parse(output.slice(output.indexOf('{')));
+    assert.equal(payload.channel, 'pull-request');
+    assert.equal(payload.verdict, 'OBSERVED');
     assert.equal(readFileSync(join(root, 'src/value.mjs'), 'utf8'), 'export const value = 2;\n');
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
 

--- a/scripts/lib/revert-oracle-run-plan.mjs
+++ b/scripts/lib/revert-oracle-run-plan.mjs
@@ -8,6 +8,8 @@ import { dirname, join, relative } from 'node:path';
 import { parseRunnerOutput } from './revert-oracle.mjs';
 import { runTypecheckPlan } from './revert-oracle-type-only.mjs';
 
+const toolchainVersions = new Map();
+
 /** Resolve a runner binary the way the owning package would. */
 function resolveBin(bin, pkgDir, root) {
   if (bin === 'node') return process.execPath;
@@ -29,12 +31,28 @@ function logRun(plan, root, label, parsed, exit, log) {
   );
 }
 
+function toolchainIdentity(binPath, family) {
+  const key = `${family}:${binPath}`;
+  if (toolchainVersions.has(key)) return toolchainVersions.get(key);
+  const identity = family === 'node-test' || family === 'typecheck'
+    ? `node ${process.version}`
+    : (() => {
+        const version = spawnSync(binPath, ['--version'], { encoding: 'utf8' });
+        return version.status === 0 ? `${version.stdout ?? version.stderr}`.trim() : `${family} (version unavailable)`;
+      })();
+  toolchainVersions.set(key, identity);
+  return identity;
+}
+
 export function runPlan(plan, root, label, log = console.log) {
   const started = Date.now();
   if (plan.typecheck) {
     const parsed = runTypecheckPlan(plan, root, label);
     parsed.durationMs = Date.now() - started;
     parsed.tail = parsed.evidence.join('\n');
+    parsed.rawExitCode ??= null;
+    parsed.signal = null;
+    parsed.toolchain = `node ${process.version}`;
     logRun(plan, root, label, parsed, parsed.kind === 'runner-missing' ? '?' : parsed.kind === 'pass' ? 0 : 1, log);
     return parsed;
   }
@@ -47,6 +65,9 @@ export function runPlan(plan, root, label, log = console.log) {
       failed: null,
       total: null,
       evidence: [`runner binary "${plan.runner.bin}" not found from ${relative(root, plan.dir) || '.'} — run pnpm install`],
+      rawExitCode: null,
+      signal: null,
+      toolchain: null,
     };
   }
   const run = spawnSync(binPath, plan.runner.args, {
@@ -62,7 +83,17 @@ export function runPlan(plan, root, label, log = console.log) {
     exitCode: run.status,
     spawnError: run.error ? run.error.message : undefined,
   });
+  if (
+    plan.moduleFilter &&
+    (parsed.kind === 'pass' || parsed.kind === 'assertion-failure') &&
+    (!Array.isArray(parsed.identities) || parsed.identities.length === 0 || parsed.identities.some((name) => !name.startsWith(`${plan.moduleFilter}::`)))
+  ) {
+    parsed.kind = 'unparseable';
+    parsed.evidence = [`cargo's ${plan.moduleFilter}:: filter also selected tests outside that source module`];
+  }
   parsed.rawExitCode = run.status;
+  parsed.signal = run.signal ?? null;
+  parsed.toolchain = toolchainIdentity(binPath, plan.runner.family);
   parsed.durationMs = Date.now() - started;
   parsed.tail = `${run.stdout ?? ''}\n${run.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
   logRun(plan, root, label, parsed, run.status, log);

--- a/scripts/lib/revert-oracle-run-plan.mjs
+++ b/scripts/lib/revert-oracle-run-plan.mjs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, relative } from 'node:path';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { parseRunnerOutput } from './revert-oracle.mjs';
 import { runTypecheckPlan } from './revert-oracle-type-only.mjs';
@@ -83,16 +85,40 @@ export function runPlan(plan, root, label, log = console.log) {
       toolchain: null,
     };
   }
+  const recordsExecution = plan.runner.family === 'node-test';
+  const coverageDir = recordsExecution ? mkdtempSync(join(tmpdir(), 'revert-oracle-execution-')) : null;
   const spawnOptions = {
     cwd,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
     timeout: RUN_TIMEOUT_MS,
-    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
+    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1', ...(coverageDir ? { NODE_V8_COVERAGE: coverageDir } : {}) },
   };
-  const run = plan.moduleFilter
-    ? runExactCargoModule(command.bin, [...command.prefix, ...plan.runner.args], plan.moduleFilter, spawnOptions)
-    : spawnSync(command.bin, [...command.prefix, ...plan.runner.args], spawnOptions);
+  let run;
+  let executionFiles = [];
+  let executionEvidenceError = null;
+  try {
+    if (plan.runner.family === 'vitest') {
+      const selected = plan.relFiles?.[0] ?? plan.file;
+      const listed = spawnSync(command.bin, [...command.prefix, 'list', selected, '--filesOnly'], spawnOptions);
+      if (listed.error || listed.status !== 0 || listed.signal) {
+        throw listed.error ?? new Error(`vitest file discovery failed (${listed.signal ?? listed.status})`);
+      }
+      executionFiles = `${listed.stdout ?? ''}\n${listed.stderr ?? ''}`.split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(line))
+        .map((line) => resolve(plan.dir, line));
+    }
+    run = plan.moduleFilter
+      ? runExactCargoModule(command.bin, [...command.prefix, ...plan.runner.args], plan.moduleFilter, spawnOptions)
+      : spawnSync(command.bin, [...command.prefix, ...plan.runner.args], spawnOptions);
+    if (coverageDir) executionFiles = readCoveredFiles(coverageDir);
+  } catch (error) {
+    executionEvidenceError = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (coverageDir) rmSync(coverageDir, { recursive: true, force: true });
+  }
+  if (!run) throw new Error(`runner did not produce a process result: ${executionEvidenceError ?? 'unknown error'}`);
   const parsed = parseRunnerOutput({
     family: plan.runner.family,
     stdout: run.stdout ?? '',
@@ -104,7 +130,7 @@ export function runPlan(plan, root, label, log = console.log) {
   if (
     plan.moduleFilter &&
     (parsed.kind === 'pass' || parsed.kind === 'assertion-failure') &&
-    (!Array.isArray(parsed.identities) || parsed.identities.length === 0 || parsed.identities.some((name) => !name.split('::').includes(plan.moduleFilter)))
+    (!Array.isArray(parsed.identities) || parsed.identities.length === 0 || parsed.identities.some((name) => !name.startsWith(`${plan.moduleFilter}::`)))
   ) {
     parsed.kind = 'unparseable';
     parsed.evidence = [`cargo's ${plan.moduleFilter}:: filter also selected tests outside that source module`];
@@ -112,11 +138,26 @@ export function runPlan(plan, root, label, log = console.log) {
   parsed.rawExitCode = run.status;
   parsed.signal = run.signal ?? null;
   parsed.toolchain = toolchainIdentity(command.bin, plan.runner.family);
-  parsed.attributed = attributableExecution(plan, parsed);
+  parsed.executionFiles = executionFiles;
+  parsed.attributed = executionEvidenceError === null && attributableExecution(plan, parsed);
+  if (executionEvidenceError) parsed.evidence.push(`could not read runtime execution evidence: ${executionEvidenceError}`);
   parsed.durationMs = Date.now() - started;
   parsed.tail = `${run.stdout ?? ''}\n${run.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
   logRun(plan, root, label, parsed, run.status, log);
   return parsed;
+}
+
+function readCoveredFiles(dir) {
+  const files = new Set();
+  for (const entry of readdirSync(dir).filter((name) => name.endsWith('.json'))) {
+    const report = JSON.parse(readFileSync(join(dir, entry), 'utf8'));
+    if (!Array.isArray(report.result)) throw new Error(`${entry} has no V8 coverage result array`);
+    for (const script of report.result) {
+      if (typeof script?.url !== 'string' || !script.url.startsWith('file:')) continue;
+      files.add(resolve(fileURLToPath(script.url)));
+    }
+  }
+  return [...files];
 }
 
 function runExactCargoModule(binPath, args, moduleFilter, options) {
@@ -127,7 +168,7 @@ function runExactCargoModule(binPath, args, moduleFilter, options) {
   const identities = `${listed.stdout ?? ''}\n${listed.stderr ?? ''}`
     .split(/\r?\n/)
     .map((line) => /^(.+): test$/.exec(line)?.[1])
-    .filter((identity) => identity && identity.split('::').includes(moduleFilter));
+    .filter((identity) => identity && identity.startsWith(`${moduleFilter}::`));
   if (identities.length === 0) {
     return { status: 0, signal: null, stdout: 'test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n', stderr: '' };
   }
@@ -146,11 +187,21 @@ function attributableExecution(plan, parsed) {
   if (!Number.isInteger(parsed.total) || parsed.total <= 0) return false;
   if (plan.moduleFilter) {
     return Array.isArray(parsed.identities) && parsed.identities.length > 0
-      && parsed.identities.every((name) => name.split('::').includes(plan.moduleFilter));
+      && parsed.identities.every((name) => name.startsWith(`${plan.moduleFilter}::`));
   }
   if (plan.crate) {
     return Boolean(plan.integrationTarget) && Array.isArray(parsed.identities) && parsed.identities.length > 0;
   }
   const selected = plan.relFiles?.[0] ?? plan.file;
-  return plan.files?.length === 1 && plan.runner.args.some((arg) => arg === selected || arg === plan.file);
+  if (plan.runner.family === 'python') {
+    return plan.files?.length === 1 && plan.runner.args.some((arg) => arg === selected || arg === plan.file);
+  }
+  const expected = resolve(plan.dir, selected);
+  const samePath = (candidate) => process.platform === 'win32'
+    ? candidate.toLowerCase() === expected.toLowerCase()
+    : candidate === expected;
+  if (plan.runner.family === 'vitest') {
+    return plan.files?.length === 1 && parsed.executionFiles?.length === 1 && samePath(parsed.executionFiles[0]);
+  }
+  return plan.files?.length === 1 && parsed.executionFiles?.some(samePath);
 }

--- a/scripts/lib/revert-oracle-run-plan.mjs
+++ b/scripts/lib/revert-oracle-run-plan.mjs
@@ -2,22 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
 
 import { parseRunnerOutput } from './revert-oracle.mjs';
 import { runTypecheckPlan } from './revert-oracle-type-only.mjs';
 
 const toolchainVersions = new Map();
+const RUN_TIMEOUT_MS = 10 * 60 * 1000;
 
 /** Resolve a runner binary the way the owning package would. */
-function resolveBin(bin, pkgDir, root) {
-  if (bin === 'node') return process.execPath;
-  if (bin === 'cargo' || bin === 'python3') return bin;
+function resolveCommand(bin, pkgDir, root) {
+  if (bin === 'node') return { bin: process.execPath, prefix: [] };
+  if (bin === 'python3' && process.platform === 'win32') return { bin: 'py', prefix: ['-3'] };
+  if (bin === 'cargo' || bin === 'python3') return { bin, prefix: [] };
   let dir = pkgDir;
   for (;;) {
+    const manifest = join(dir, 'node_modules', bin, 'package.json');
+    if (existsSync(manifest)) {
+      try {
+        const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+        const target = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.[bin];
+        if (typeof target === 'string') return { bin: process.execPath, prefix: [join(dirname(manifest), target)] };
+      } catch (error) {
+        throw new Error(`cannot resolve ${bin} from ${manifest}: ${error.message}`);
+      }
+    }
     const candidate = join(dir, 'node_modules', '.bin', bin);
-    if (existsSync(candidate)) return candidate;
+    if (process.platform !== 'win32' && existsSync(candidate)) return { bin: candidate, prefix: [] };
     const parent = dirname(dir);
     if (parent === dir || !parent.startsWith(root)) return null;
     dir = parent;
@@ -53,12 +65,13 @@ export function runPlan(plan, root, label, log = console.log) {
     parsed.rawExitCode ??= null;
     parsed.signal = null;
     parsed.toolchain = `node ${process.version}`;
+    parsed.attributed = parsed.attributed === true;
     logRun(plan, root, label, parsed, parsed.kind === 'runner-missing' ? '?' : parsed.kind === 'pass' ? 0 : 1, log);
     return parsed;
   }
   const cwd = plan.crate ? root : plan.dir;
-  const binPath = resolveBin(plan.runner.bin, plan.dir, root);
-  if (!binPath) {
+  const command = resolveCommand(plan.runner.bin, plan.dir, root);
+  if (!command) {
     return {
       kind: 'runner-missing',
       passed: null,
@@ -70,32 +83,74 @@ export function runPlan(plan, root, label, log = console.log) {
       toolchain: null,
     };
   }
-  const run = spawnSync(binPath, plan.runner.args, {
+  const spawnOptions = {
     cwd,
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
+    timeout: RUN_TIMEOUT_MS,
     env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
-  });
+  };
+  const run = plan.moduleFilter
+    ? runExactCargoModule(command.bin, [...command.prefix, ...plan.runner.args], plan.moduleFilter, spawnOptions)
+    : spawnSync(command.bin, [...command.prefix, ...plan.runner.args], spawnOptions);
   const parsed = parseRunnerOutput({
     family: plan.runner.family,
     stdout: run.stdout ?? '',
     stderr: run.stderr ?? '',
     exitCode: run.status,
+    signal: run.signal ?? null,
     spawnError: run.error ? run.error.message : undefined,
   });
   if (
     plan.moduleFilter &&
     (parsed.kind === 'pass' || parsed.kind === 'assertion-failure') &&
-    (!Array.isArray(parsed.identities) || parsed.identities.length === 0 || parsed.identities.some((name) => !name.startsWith(`${plan.moduleFilter}::`)))
+    (!Array.isArray(parsed.identities) || parsed.identities.length === 0 || parsed.identities.some((name) => !name.split('::').includes(plan.moduleFilter)))
   ) {
     parsed.kind = 'unparseable';
     parsed.evidence = [`cargo's ${plan.moduleFilter}:: filter also selected tests outside that source module`];
   }
   parsed.rawExitCode = run.status;
   parsed.signal = run.signal ?? null;
-  parsed.toolchain = toolchainIdentity(binPath, plan.runner.family);
+  parsed.toolchain = toolchainIdentity(command.bin, plan.runner.family);
+  parsed.attributed = attributableExecution(plan, parsed);
   parsed.durationMs = Date.now() - started;
   parsed.tail = `${run.stdout ?? ''}\n${run.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
   logRun(plan, root, label, parsed, run.status, log);
   return parsed;
+}
+
+function runExactCargoModule(binPath, args, moduleFilter, options) {
+  const separator = args.indexOf('--');
+  const cargoArgs = separator === -1 ? args : args.slice(0, separator);
+  const listed = spawnSync(binPath, [...cargoArgs, '--', '--list'], options);
+  if (listed.error || listed.status !== 0 || listed.signal) return listed;
+  const identities = `${listed.stdout ?? ''}\n${listed.stderr ?? ''}`
+    .split(/\r?\n/)
+    .map((line) => /^(.+): test$/.exec(line)?.[1])
+    .filter((identity) => identity && identity.split('::').includes(moduleFilter));
+  if (identities.length === 0) {
+    return { status: 0, signal: null, stdout: 'test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n', stderr: '' };
+  }
+  const runs = identities.map((identity) => spawnSync(binPath, [...cargoArgs, '--', identity, '--exact'], options));
+  const failed = runs.find((candidate) => candidate.error || candidate.signal || candidate.status !== 0);
+  return {
+    status: failed?.status ?? 0,
+    signal: failed?.signal ?? null,
+    error: failed?.error,
+    stdout: runs.map((candidate) => candidate.stdout ?? '').join('\n'),
+    stderr: runs.map((candidate) => candidate.stderr ?? '').join('\n'),
+  };
+}
+
+function attributableExecution(plan, parsed) {
+  if (!Number.isInteger(parsed.total) || parsed.total <= 0) return false;
+  if (plan.moduleFilter) {
+    return Array.isArray(parsed.identities) && parsed.identities.length > 0
+      && parsed.identities.every((name) => name.split('::').includes(plan.moduleFilter));
+  }
+  if (plan.crate) {
+    return Boolean(plan.integrationTarget) && Array.isArray(parsed.identities) && parsed.identities.length > 0;
+  }
+  const selected = plan.relFiles?.[0] ?? plan.file;
+  return plan.files?.length === 1 && plan.runner.args.some((arg) => arg === selected || arg === plan.file);
 }

--- a/scripts/lib/revert-oracle-run-plan.mjs
+++ b/scripts/lib/revert-oracle-run-plan.mjs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+import { parseRunnerOutput } from './revert-oracle.mjs';
+import { runTypecheckPlan } from './revert-oracle-type-only.mjs';
+
+/** Resolve a runner binary the way the owning package would. */
+function resolveBin(bin, pkgDir, root) {
+  if (bin === 'node') return process.execPath;
+  if (bin === 'cargo' || bin === 'python3') return bin;
+  let dir = pkgDir;
+  for (;;) {
+    const candidate = join(dir, 'node_modules', '.bin', bin);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir || !parent.startsWith(root)) return null;
+    dir = parent;
+  }
+}
+
+function logRun(plan, root, label, parsed, exit, log) {
+  log(
+    `  [${label}] ${relative(root, plan.dir) || '.'} (${plan.runner.family}) -> ${parsed.kind}` +
+      ` (pass ${parsed.passed ?? '?'}, fail ${parsed.failed ?? '?'}, total ${parsed.total ?? '?'}, exit ${exit}, ${parsed.durationMs}ms)`,
+  );
+}
+
+export function runPlan(plan, root, label, log = console.log) {
+  const started = Date.now();
+  if (plan.typecheck) {
+    const parsed = runTypecheckPlan(plan, root, label);
+    parsed.durationMs = Date.now() - started;
+    parsed.tail = parsed.evidence.join('\n');
+    logRun(plan, root, label, parsed, parsed.kind === 'runner-missing' ? '?' : parsed.kind === 'pass' ? 0 : 1, log);
+    return parsed;
+  }
+  const cwd = plan.crate ? root : plan.dir;
+  const binPath = resolveBin(plan.runner.bin, plan.dir, root);
+  if (!binPath) {
+    return {
+      kind: 'runner-missing',
+      passed: null,
+      failed: null,
+      total: null,
+      evidence: [`runner binary "${plan.runner.bin}" not found from ${relative(root, plan.dir) || '.'} — run pnpm install`],
+    };
+  }
+  const run = spawnSync(binPath, plan.runner.args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
+  });
+  const parsed = parseRunnerOutput({
+    family: plan.runner.family,
+    stdout: run.stdout ?? '',
+    stderr: run.stderr ?? '',
+    exitCode: run.status,
+    spawnError: run.error ? run.error.message : undefined,
+  });
+  parsed.rawExitCode = run.status;
+  parsed.durationMs = Date.now() - started;
+  parsed.tail = `${run.stdout ?? ''}\n${run.stderr ?? ''}`.trim().split('\n').slice(-25).join('\n');
+  logRun(plan, root, label, parsed, run.status, log);
+  return parsed;
+}

--- a/scripts/lib/revert-oracle-runtime-evidence.test.mjs
+++ b/scripts/lib/revert-oracle-runtime-evidence.test.mjs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const oracle = join(repo, 'scripts/check-test-revert-oracle.mjs');
+
+function resultPayload(output) {
+  const start = output.indexOf('{');
+  for (let end = output.indexOf('\n}', start); end !== -1; end = output.indexOf('\n}', end + 2)) {
+    try {
+      return JSON.parse(output.slice(start, end + 2));
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+  }
+  throw new Error(`oracle output contained no complete result payload:\n${output}`);
+}
+
+function fixture(prefix) {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  const env = { ...process.env };
+  delete env.NODE_TEST_CONTEXT;
+  const run = (bin, args, expected = 0, options = {}) => {
+    const result = spawnSync(bin, args, { cwd: root, env, encoding: 'utf8', timeout: 30_000, ...options });
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, expected, `${result.stdout}\n${result.stderr}`);
+    return result.stdout + result.stderr;
+  };
+  run('git', ['init', '-q']);
+  run('git', ['config', 'user.name', 'Revert oracle fixture']);
+  run('git', ['config', 'user.email', 'oracle@example.invalid']);
+  return { root, env, run };
+}
+
+test('#4109: a Vitest substring match cannot impersonate the requested test file', { timeout: 60_000 }, () => {
+  const { root, run } = fixture('oracle-vitest-identity-');
+  try {
+    mkdirSync(join(root, 'packages/probe/src'), { recursive: true });
+    writeFileSync(join(root, '.gitignore'), 'node_modules\n');
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ private: true, workspaces: ['packages/*'] }));
+    writeFileSync(join(root, 'packages/probe/package.json'), JSON.stringify({ scripts: { test: 'vitest run' } }));
+    writeFileSync(join(root, 'packages/probe/src/value.ts'), 'export const value = 1;\n');
+    writeFileSync(join(root, 'packages/probe/src/probe.test.ts'), "import { test, expect } from 'vitest';\nimport { value } from './value';\ntest.skip('requested witness', () => expect(value).toBe(1));\n");
+    writeFileSync(join(root, 'packages/probe/src/probe.test.tsx'), "import { test, expect } from 'vitest';\ntest('substring neighbor', () => expect(true).toBe(true));\n");
+    symlinkSync(join(repo, 'packages/pointcloud/node_modules'), join(root, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir');
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'control']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+    writeFileSync(join(root, 'packages/probe/src/value.ts'), 'export const value = 2;\n');
+    writeFileSync(join(root, 'packages/probe/src/probe.test.ts'), "import { test, expect } from 'vitest';\nimport { value } from './value';\ntest.skip('requested witness', () => expect(value).toBe(2));\n");
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'change production and skipped witness']);
+
+    const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], 3);
+    const payload = resultPayload(output);
+    assert.equal(payload.verdict, 'BASELINE-BROKEN');
+    assert.equal(payload.ledger.some((entry) => entry.file.endsWith('probe.test.ts') && entry.baseline?.attributed === false), true);
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('#4109: failed cleanliness verification remains RESTORE-FAILED', { timeout: 60_000 }, () => {
+  const { root, env, run } = fixture('oracle-restore-state-');
+  const shim = mkdtempSync(join(tmpdir(), 'oracle-git-shim-'));
+  try {
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ type: 'module', scripts: { test: 'node --test' } }));
+    writeFileSync(join(root, 'src/value.mjs'), 'export const value = 1;\n');
+    writeFileSync(join(root, 'src/value.test.mjs'), "import test from 'node:test';\nimport assert from 'node:assert/strict';\nimport { value } from './value.mjs';\ntest('value', () => assert.equal(value, 1));\n");
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'control']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+    writeFileSync(join(root, 'src/value.mjs'), 'export const value = 2;\n');
+    writeFileSync(join(root, 'src/value.test.mjs'), "import test from 'node:test';\nimport assert from 'node:assert/strict';\nimport { value } from './value.mjs';\ntest('value', () => assert.equal(value, 2));\n");
+    run('git', ['add', '.']);
+    run('git', ['commit', '-qm', 'change production and witness']);
+
+    const realGit = process.platform === 'win32'
+      ? spawnSync('where.exe', ['git'], { encoding: 'utf8' }).stdout.split(/\r?\n/)[0]
+      : spawnSync('which', ['git'], { encoding: 'utf8' }).stdout.trim();
+    const shimScript = join(shim, 'git-shim.cjs');
+    writeFileSync(shimScript, "const { spawnSync } = require('node:child_process');\nconst { writeFileSync } = require('node:fs');\nconst args = process.argv.slice(2);\nconst result = spawnSync(process.env.ORACLE_REAL_GIT, args, { stdio: 'inherit' });\nif (result.status === 0 && args.includes('apply') && !args.includes('-R')) writeFileSync('.restore-dirty', 'verification must fail\\n');\nprocess.exit(result.status ?? 1);\n");
+    const shimEnv = {
+      ...env,
+      ORACLE_REAL_GIT: realGit,
+      IFC_LITE_ORACLE_GIT_BIN: process.execPath,
+      IFC_LITE_ORACLE_GIT_PREFIX: shimScript,
+    };
+    const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], 5, { env: shimEnv });
+    const payload = resultPayload(output);
+    assert.equal(payload.verdict, 'RESTORE-FAILED');
+    assert.equal(payload.restoration, 'failed');
+    assert.equal(readFileSync(join(root, 'src/value.mjs'), 'utf8'), 'export const value = 2;\n');
+    rmSync(join(root, '.restore-dirty'));
+    assert.equal(run(realGit, ['status', '--porcelain']).trim(), '');
+  } finally {
+    rmSync(shim, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/revert-oracle-rust-features.mjs
+++ b/scripts/lib/revert-oracle-rust-features.mjs
@@ -347,21 +347,6 @@ export function requiredFeatureCombos(root, relFiles, defaultFeatures = null) {
  */
 export const EXIT_UNHANDLED_CFG_SHAPE = 6;
 
-/** The `--json` payload for an UnhandledCfgShapeError, in the same shape the
- * dispatcher's normal report uses (verdict/reason/base/head/production/tests),
- * plus an `error` object naming what could not be planned and where. */
-export function unhandledCfgShapeReport(err, base, head, production, tests) {
-  return {
-    verdict: 'ERROR',
-    reason: err.message,
-    base,
-    head,
-    production,
-    tests,
-    error: { name: err.name, shape: err.shape, file: err.file, line: err.line },
-  };
-}
-
 /**
  * Run `planRuns(testPaths)`, catching UnhandledCfgShapeError so it becomes a
  * structured, distinguishable failure — die()'s ABORT formatting, JSON when
@@ -374,15 +359,16 @@ export function unhandledCfgShapeReport(err, base, head, production, tests) {
  * are defined in check-test-revert-oracle.mjs (`planRuns` closes over its
  * `ROOT`; `die` closes over its restoration state), and this module has no
  * dependency on that file today. Keeping the call site there to one line —
- * matching what it replaces — is what let this defect's fix land without
- * raising that file's module-size budget.
+ * matching what it replaces — keeps the runner-specific refusal here while
+ * the dispatcher owns the process-wide exactly-one result record.
  */
-export function requiredFeaturePlanOrDie(planRuns, testPaths, json, base, head, production, die, exitCode) {
+export function requiredFeaturePlanOrDie(planRuns, testPaths, die, exitCode) {
   try {
     return planRuns(testPaths);
   } catch (err) {
     if (!(err instanceof UnhandledCfgShapeError)) throw err;
-    if (json) console.log(JSON.stringify(unhandledCfgShapeReport(err, base, head, production, testPaths), null, 2));
-    die(exitCode, err.message);
+    die(exitCode, err.message, [], {
+      error: { name: err.name, shape: err.shape, file: err.file, line: err.line },
+    });
   }
 }

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -83,7 +83,7 @@ test('#4109: a cfg-disabled path alias cannot borrow an active module test ident
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n#[cfg(\n  any()\n)]\n#[path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* The active test module has the same Rust module name. */\n#[path="active.rs"]\nmod tests;\n');
     writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
     writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -83,7 +83,7 @@ test('#4109: a cfg-disabled path alias cannot borrow an active module test ident
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* The active test module has the same Rust module name. */\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n// Example only: #[path="renamed_tests.rs"] mod tests;\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* Example only: #[path="renamed_tests.rs"] mod tests; */\n#[path="active.rs"]\nmod tests;\n');
     writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
     writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -31,7 +31,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname = "oracle-rust-siblings"\nversion = "0.1.0"\nedition = "2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub mod value;\n#[cfg(test)] mod value_tests;\n#[cfg(test)] mod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub mod value;\n#[cfg(test)] mod value_tests;\n#[cfg(test)] mod tests;\n#[cfg(test)]\n#[path = "renamed_tests.rs"]\nmod path_owned;\n');
     // A later Cargo target must still execute after the library target fails.
     // Its supported-version invariant holds for both production revisions.
     mkdirSync(join(root, 'tests'));
@@ -39,7 +39,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
       '#[test]\nfn version_stays_supported() { assert!((1..=2).contains(&oracle_rust_siblings::value::value())); }\n');
     const writeVersion = (value) => {
       writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n`);
-      for (const file of ['value_tests.rs', 'tests.rs']) {
+      for (const file of ['value_tests.rs', 'tests.rs', 'renamed_tests.rs']) {
         writeFileSync(join(root, 'src', file), `#[test]\nfn observes_value() { assert_eq!(crate::value::value(), ${value}); }\n`);
       }
     };
@@ -54,7 +54,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     run('git', ['commit', '-qm', 'change production and both sibling assertions']);
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
-    assert.match(output, /reverting production turned an assertion RED in src\/value_tests\.rs/);
+    assert.match(output, /reverting production turned an assertion RED in src\/(?:renamed_tests|value_tests)\.rs/);
     assert.equal(readFileSync(join(root, 'src/value.rs'), 'utf8'), 'pub fn value() -> u32 { 2 }\n');
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -64,3 +64,39 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('#4109: a cfg-disabled path alias cannot borrow an active module test identity', { timeout: 60_000 }, () => {
+  const root = mkdtempSync(join(tmpdir(), 'oracle-rust-cfg-owner-'));
+  const env = { ...process.env, CARGO_TARGET_DIR: join(root, 'target') };
+  delete env.RUSTFLAGS;
+  delete env.CARGO_ENCODED_RUSTFLAGS;
+  const run = (bin, args, expected = 0) => {
+    const result = spawnSync(bin, args, { cwd: root, env, encoding: 'utf8', timeout: 50_000, maxBuffer: 16 * 1024 * 1024 });
+    assert.equal(result.error, undefined, `${bin}: ${result.error?.message}`);
+    assert.equal(result.status, expected, `${bin} ${args.join(' ')}\n${result.stdout}\n${result.stderr}`);
+    return result.stdout + result.stderr;
+  };
+  try {
+    run('git', ['init', '-q']);
+    run('git', ['config', 'user.name', 'Revert oracle fixture']);
+    run('git', ['config', 'user.email', 'oracle@example.invalid']);
+    mkdirSync(join(root, 'src'));
+    writeFileSync(join(root, '.gitignore'), '/target/\n');
+    writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n#[cfg(any())]\n#[path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
+    writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
+    run('cargo', ['generate-lockfile', '--offline']);
+    run('git', ['add', '.']); run('git', ['commit', '-qm', 'control']);
+    const base = run('git', ['rev-parse', 'HEAD']).trim();
+    writeFileSync(join(root, 'src/lib.rs'), readFileSync(join(root, 'src/lib.rs'), 'utf8').replace('{ 1 }', '{ 2 }'));
+    writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 2); }\n');
+    run('git', ['add', '.']); run('git', ['commit', '-qm', 'change disabled witness']);
+    const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json'], 3);
+    assert.match(output, /conditional or ambiguous/);
+    assert.doesNotMatch(output, /"verdict": "UNOBSERVED"/);
+    assert.equal(run('git', ['status', '--porcelain']).trim(), '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -83,7 +83,7 @@ test('#4109: a cfg-disabled path alias cannot borrow an active module test ident
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\nconst EXAMPLE: &str = r#"#[path="renamed_tests.rs"] mod tests;"#;\n// Example only: #[path="renamed_tests.rs"] mod tests;\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* Example only: #[path="renamed_tests.rs"] mod tests; */\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\nconst EXAMPLE: &str = r#"#[path="renamed_tests.rs"] mod tests;"#;\nconst ESCAPED: &str = "#[path=\\"renamed_tests.rs\\"] mod tests;";\n// Example only: #[path="renamed_tests.rs"] mod tests;\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* Example only: #[path="renamed_tests.rs"] mod tests; */\n#[path="active.rs"]\nmod tests;\n');
     writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
     writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -54,7 +54,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     run('git', ['commit', '-qm', 'change production and both sibling assertions']);
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
-    assert.match(output, /2 assertion\(s\) RED out of 3 collected/);
+    assert.match(output, /reverting production turned an assertion RED in src\/value_tests\.rs/);
     assert.equal(readFileSync(join(root, 'src/value.rs'), 'utf8'), 'pub fn value() -> u32 { 2 }\n');
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -58,7 +58,9 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
     assert.match(output, /reverting production turned an assertion RED in src\/(?:renamed_tests|value_tests)\.rs/);
-    assert.match(readFileSync(join(root, 'src/value.rs'), 'utf8'), /^pub fn value\(\) -> u32 \{ 2 \}/);
+    // Execute the restored production/test pair instead of trusting its source
+    // text: this goes red if either side was left at the reverted revision.
+    run('cargo', ['test', '--offline', '--lib', 'path_owned::observes_value', '--', '--exact']);
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -38,7 +38,10 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     writeFileSync(join(root, 'tests/later_target.rs'),
       '#[test]\nfn version_stays_supported() { assert!((1..=2).contains(&oracle_rust_siblings::value::value())); }\n');
     const writeVersion = (value) => {
-      writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n`);
+      // This unrelated nested `tests` module is intentionally always red. A
+      // leaf-only `tests::` selector falsely credits/runs it while measuring
+      // the top-level `src/tests.rs`; the full module path must exclude it.
+      writeFileSync(join(root, 'src/value.rs'), `pub fn value() -> u32 { ${value} }\n#[cfg(test)] mod tests { #[test] fn must_not_run() { panic!("unrelated nested test"); } }\n`);
       for (const file of ['value_tests.rs', 'tests.rs', 'renamed_tests.rs']) {
         writeFileSync(join(root, 'src', file), `#[test]\nfn observes_value() { assert_eq!(crate::value::value(), ${value}); }\n`);
       }
@@ -55,7 +58,7 @@ test('#4016: the complete oracle executes changed Rust sibling assertions and re
     const output = run(process.execPath, [oracle, '--root', root, '--base', base, '--ci', '--json']);
     assert.match(output, /OBSERVED/);
     assert.match(output, /reverting production turned an assertion RED in src\/(?:renamed_tests|value_tests)\.rs/);
-    assert.equal(readFileSync(join(root, 'src/value.rs'), 'utf8'), 'pub fn value() -> u32 { 2 }\n');
+    assert.match(readFileSync(join(root, 'src/value.rs'), 'utf8'), /^pub fn value\(\) -> u32 \{ 2 \}/);
     assert.equal(run('git', ['status', '--porcelain']).trim(), '');
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -83,7 +83,7 @@ test('#4109: a cfg-disabled path alias cannot borrow an active module test ident
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n// Example only: #[path="renamed_tests.rs"] mod tests;\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* Example only: #[path="renamed_tests.rs"] mod tests; */\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\nconst EXAMPLE: &str = r#"#[path="renamed_tests.rs"] mod tests;"#;\n// Example only: #[path="renamed_tests.rs"] mod tests;\n# [cfg(\n  any()\n)]\n// This alias is deliberately compiled out.\n# [path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n/* Example only: #[path="renamed_tests.rs"] mod tests; */\n#[path="active.rs"]\nmod tests;\n');
     writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
     writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-rust-siblings.test.mjs
+++ b/scripts/lib/revert-oracle-rust-siblings.test.mjs
@@ -83,7 +83,7 @@ test('#4109: a cfg-disabled path alias cannot borrow an active module test ident
     mkdirSync(join(root, 'src'));
     writeFileSync(join(root, '.gitignore'), '/target/\n');
     writeFileSync(join(root, 'Cargo.toml'), '[package]\nname="cfg-owner"\nversion="0.1.0"\nedition="2021"\n');
-    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n#[cfg(any())]\n#[path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n#[path="active.rs"]\nmod tests;\n');
+    writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n#[cfg(\n  any()\n)]\n#[path="renamed_tests.rs"]\nmod tests;\n#[cfg(test)]\n#[path="active.rs"]\nmod tests;\n');
     writeFileSync(join(root, 'src/renamed_tests.rs'), '#[test]\nfn observes() { assert_eq!(crate::value(), 1); }\n');
     writeFileSync(join(root, 'src/active.rs'), '#[test]\nfn unrelated() { assert!(true); }\n');
     run('cargo', ['generate-lockfile', '--offline']);

--- a/scripts/lib/revert-oracle-type-only.mjs
+++ b/scripts/lib/revert-oracle-type-only.mjs
@@ -62,6 +62,7 @@ import { createRequire } from 'node:module';
 import { dirname, join, relative, sep } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
+import { claimRuntimeAdapter } from './revert-oracle-adapters.mjs';
 
 const TS_EXTS = ['.ts', '.tsx', '.mts', '.cts'];
 const typecheckRuns = new Map();
@@ -189,6 +190,7 @@ export function typecheckPlans(testPaths, root) {
     const pkgDir = findUp(dirname(abs), 'package.json', root);
     if (!pkgDir || pkgDir === root || !existsSync(join(pkgDir, 'tsconfig.json'))) { unassigned.push(rel); continue; }
     const relFile = relative(pkgDir, join(root, rel)).split(sep).join('/');
+    const claimed = claimRuntimeAdapter({ kind: 'typecheck' });
     plans.push({
       key: `typecheck:${rel}`,
       file: rel,
@@ -198,7 +200,8 @@ export function typecheckPlans(testPaths, root) {
       script: undefined,
       crate: null,
       typecheck: true,
-      runner: { family: 'typecheck', bin: 'node', args: [TYPECHECK_SCRIPT] },
+      adapter: claimed?.adapter ?? null,
+      runner: claimed?.runner ?? null,
     });
   }
   return { plans, skipped, unassigned };

--- a/scripts/lib/revert-oracle-type-only.mjs
+++ b/scripts/lib/revert-oracle-type-only.mjs
@@ -256,12 +256,19 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync, program
       cwd: plan.dir,
       encoding: 'utf8',
       maxBuffer: 64 * 1024 * 1024,
+      timeout: 10 * 60 * 1000,
       env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
     });
     if (spawn === spawnSync) typecheckRuns.set(cacheKey, r);
   }
   if (r.error) {
     return { kind: 'runner-missing', passed: null, failed: null, total: null, rawExitCode: null, evidence: [`could not spawn ${TYPECHECK_SCRIPT}: ${r.error.message}`] };
+  }
+  if (r.signal || r.status === null) {
+    return {
+      kind: 'unparseable', passed: null, failed: null, total: null, rawExitCode: r.status, signal: r.signal ?? null,
+      attributed: false, evidence: [r.signal ? `typecheck terminated by ${r.signal}` : 'typecheck returned no exit status'],
+    };
   }
   const output = `${r.stdout ?? ''}\n${r.stderr ?? ''}`;
   const diagnostics = parseTscDiagnostics(output);
@@ -270,6 +277,7 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync, program
   if (!inclusion.included) {
     return {
       kind: 'runner-missing', passed: null, failed: null, total: null, rawExitCode: r.status,
+      signal: r.signal ?? null, attributed: false,
       evidence: [`cannot prove ${plan.file} entered the compiler program: ${inclusion.evidence} -- refusing a synthetic typecheck result`],
     };
   }
@@ -279,11 +287,13 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync, program
 
   if (phase === 'baseline') {
     if (r.status === 0 && diagnostics.length === 0) {
-      return { kind: 'pass', passed: total, failed: 0, total, rawExitCode: r.status, evidence: [] };
+      return { kind: 'pass', passed: total, failed: 0, total, rawExitCode: r.status, signal: null, attributed: true, evidence: [] };
     }
     return {
       kind: 'load-failure',
       rawExitCode: r.status,
+      signal: null,
+      attributed: true,
       passed: null,
       failed: null,
       total,
@@ -295,19 +305,34 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync, program
     };
   }
   if (inChanged.length > 0) {
+    if (r.status === 0) {
+      return { kind: 'unparseable', rawExitCode: 0, signal: null, attributed: false, passed: null, failed: null, total,
+        evidence: ['typecheck reported diagnostics in the changed test file but exited 0'] };
+    }
     const hit = new Set(inChanged.map((d) => plan.files.find((f) => samePath(d.file, f)))).size;
     return {
       kind: 'assertion-failure',
       rawExitCode: r.status,
+      signal: null,
+      attributed: true,
       passed: total - hit,
       failed: hit,
       total,
       evidence: inChanged.slice(0, 5).map(describe),
     };
   }
+  if (r.status !== 0) {
+    return {
+      kind: 'load-failure', rawExitCode: r.status, signal: null, attributed: true,
+      passed: null, failed: null, total,
+      evidence: [diagnostics[0] ? `typecheck failed outside the changed test file: ${describe(diagnostics[0])}` : `typecheck exited ${r.status} with no diagnostic`],
+    };
+  }
   return {
     kind: 'pass',
     rawExitCode: r.status,
+    signal: null,
+    attributed: true,
     passed: total,
     failed: 0,
     total,

--- a/scripts/lib/revert-oracle-type-only.mjs
+++ b/scripts/lib/revert-oracle-type-only.mjs
@@ -29,9 +29,9 @@
  *      when EVERY production file is TypeScript and type-only. One runtime
  *      change anywhere and the runtime observer is the right one for the
  *      whole revert set (a mixed revert is judged by the stricter tool).
- *   3. `typecheckPlans` / `runTypecheckPlan`: group the changed TypeScript
- *      test files by owning package and type-check that package's test
- *      program through `scripts/typecheck-tests.mjs` (the repo's dedicated
+ *   3. `typecheckPlans` / `runTypecheckPlan`: make an attributable ledger
+ *      entry for each changed TypeScript test while type-checking each owning
+ *      package program once through `scripts/typecheck-tests.mjs` (the repo's dedicated
  *      lane for test-only type errors, #2457), at baseline and again with
  *      production reverted. The result carries the SAME shape
  *      `parseRunnerOutput` produces, so `aggregate()` and `verdict()` in
@@ -57,13 +57,14 @@
  * of the verdict knows which channel it came from.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, relative, sep } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const TS_EXTS = ['.ts', '.tsx', '.mts', '.cts'];
+const typecheckRuns = new Map();
 
 export const TYPECHECK_SCRIPT = 'scripts/typecheck-tests.mjs';
 
@@ -169,7 +170,8 @@ function findUp(startDir, filename, root) {
 }
 
 /**
- * One plan per package that owns a changed TypeScript test file. Non-TypeScript
+ * One ledger plan per changed TypeScript test file. Package compiler runs are
+ * cached per phase, and generated-program membership proves attribution. Non-TypeScript
  * test files can never observe a type-only change and are listed in `skipped`
  * by name so the dispatcher can say so.
  *
@@ -178,7 +180,7 @@ function findUp(startDir, filename, root) {
  * script that will be spawned, for the log line.
  */
 export function typecheckPlans(testPaths, root) {
-  const groups = new Map();
+  const plans = [];
   const skipped = [];
   const unassigned = [];
   for (const rel of testPaths) {
@@ -186,19 +188,19 @@ export function typecheckPlans(testPaths, root) {
     const abs = join(root, rel);
     const pkgDir = findUp(dirname(abs), 'package.json', root);
     if (!pkgDir || pkgDir === root || !existsSync(join(pkgDir, 'tsconfig.json'))) { unassigned.push(rel); continue; }
-    if (!groups.has(pkgDir)) groups.set(pkgDir, { dir: pkgDir, files: [] });
-    groups.get(pkgDir).files.push(rel);
+    const relFile = relative(pkgDir, join(root, rel)).split(sep).join('/');
+    plans.push({
+      key: `typecheck:${rel}`,
+      file: rel,
+      dir: pkgDir,
+      files: [rel],
+      relFiles: [relFile],
+      script: undefined,
+      crate: null,
+      typecheck: true,
+      runner: { family: 'typecheck', bin: 'node', args: [TYPECHECK_SCRIPT] },
+    });
   }
-  const plans = [...groups.values()].map((g) => ({
-    key: `typecheck:${g.dir}`,
-    dir: g.dir,
-    files: g.files,
-    relFiles: g.files.map((f) => relative(g.dir, join(root, f)).split(sep).join('/')),
-    script: undefined,
-    crate: null,
-    typecheck: true,
-    runner: { family: 'typecheck', bin: 'node', args: [TYPECHECK_SCRIPT] },
-  }));
   return { plans, skipped, unassigned };
 }
 
@@ -226,33 +228,59 @@ const samePath = (a, b) => a === b || a.endsWith(`/${b}`) || b.endsWith(`/${a}`)
  * @param {'baseline'|'reverted'} phase which run this is -- see the header table
  * @param {{spawn?: typeof spawnSync}} [deps] injectable for tests
  */
-export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync } = {}) {
+export function compilerProgramIncludes(plan, root) {
+  const generated = join(plan.dir, 'tsconfig.tests.json');
+  try {
+    const config = JSON.parse(readFileSync(generated, 'utf8'));
+    const included = Array.isArray(config.files) && config.files.some((file) => samePath(file.replace(/^\.\//, ''), plan.relFiles[0]));
+    return included
+      ? { included: true, evidence: relative(root, generated).split(sep).join('/') }
+      : { included: false, evidence: `${plan.file} is absent from ${relative(root, generated).split(sep).join('/')}` };
+  } catch (error) {
+    return { included: false, evidence: `cannot read the generated compiler program: ${error.message}` };
+  }
+}
+
+export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync, programIncludes = compilerProgramIncludes } = {}) {
   const script = join(root, TYPECHECK_SCRIPT);
   if (!existsSync(script)) {
-    return { kind: 'runner-missing', passed: null, failed: null, total: null, evidence: [`${TYPECHECK_SCRIPT} not found under ${root}`] };
+    return { kind: 'runner-missing', passed: null, failed: null, total: null, rawExitCode: null, evidence: [`${TYPECHECK_SCRIPT} not found under ${root}`] };
   }
-  const r = spawn(process.execPath, [script], {
-    cwd: plan.dir,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-    env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
-  });
+  const cacheKey = `${phase}:${plan.dir}`;
+  let r = spawn === spawnSync ? typecheckRuns.get(cacheKey) : null;
+  if (!r) {
+    r = spawn(process.execPath, [script], {
+      cwd: plan.dir,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1' },
+    });
+    if (spawn === spawnSync) typecheckRuns.set(cacheKey, r);
+  }
   if (r.error) {
-    return { kind: 'runner-missing', passed: null, failed: null, total: null, evidence: [`could not spawn ${TYPECHECK_SCRIPT}: ${r.error.message}`] };
+    return { kind: 'runner-missing', passed: null, failed: null, total: null, rawExitCode: null, evidence: [`could not spawn ${TYPECHECK_SCRIPT}: ${r.error.message}`] };
   }
   const output = `${r.stdout ?? ''}\n${r.stderr ?? ''}`;
   const diagnostics = parseTscDiagnostics(output);
-  const total = plan.files.length;
+  const total = 1;
+  const inclusion = programIncludes(plan, root);
+  if (!inclusion.included) {
+    return {
+      kind: 'runner-missing', passed: null, failed: null, total: null, rawExitCode: r.status,
+      evidence: [`cannot prove ${plan.file} entered the compiler program: ${inclusion.evidence} -- refusing a synthetic typecheck result`],
+    };
+  }
   const inChanged = diagnostics.filter((d) => plan.files.some((f) => samePath(d.file, f)));
   const elsewhere = diagnostics.length - inChanged.length;
   const describe = (d) => `${d.file}(${d.line},${d.col}): ${d.code} ${d.message}`;
 
   if (phase === 'baseline') {
     if (r.status === 0 && diagnostics.length === 0) {
-      return { kind: 'pass', passed: total, failed: 0, total, evidence: [] };
+      return { kind: 'pass', passed: total, failed: 0, total, rawExitCode: r.status, evidence: [] };
     }
     return {
       kind: 'load-failure',
+      rawExitCode: r.status,
       passed: null,
       failed: null,
       total,
@@ -267,6 +295,7 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync } = {}) 
     const hit = new Set(inChanged.map((d) => plan.files.find((f) => samePath(d.file, f)))).size;
     return {
       kind: 'assertion-failure',
+      rawExitCode: r.status,
       passed: total - hit,
       failed: hit,
       total,
@@ -275,6 +304,7 @@ export function runTypecheckPlan(plan, root, phase, { spawn = spawnSync } = {}) 
   }
   return {
     kind: 'pass',
+    rawExitCode: r.status,
     passed: total,
     failed: 0,
     total,

--- a/scripts/lib/revert-oracle-type-only.test.mjs
+++ b/scripts/lib/revert-oracle-type-only.test.mjs
@@ -194,12 +194,12 @@ test('the pre-fix answer, for contrast: the runtime observer saw pass/pass and s
   assert.equal(verdict({ baseline: pass4, reverted: pass4 }).verdict, 'UNOBSERVED');
 });
 
-test('a diagnostic that lands ONLY in some other test file is UNOBSERVED, with the reason named', () => {
+test('a nonzero typecheck with diagnostics only elsewhere is inconclusive, never a synthetic pass', () => {
   const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, ''), ...included });
   const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, ELSEWHERE), ...included });
-  assert.equal(reverted.kind, 'pass');
-  assert.match(reverted.evidence[0], /outside the changed test files/);
-  assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'UNOBSERVED');
+  assert.equal(reverted.kind, 'load-failure');
+  assert.match(reverted.evidence[0], /outside the changed test file/);
+  assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'INCONCLUSIVE');
 });
 
 test('a baseline that does not type-check is BASELINE-BROKEN, whichever file the diagnostic is in', () => {

--- a/scripts/lib/revert-oracle-type-only.test.mjs
+++ b/scripts/lib/revert-oracle-type-only.test.mjs
@@ -161,6 +161,7 @@ const TS2339 = `${TEST_FILE}(35,37): error TS2339: Property 'getMeshData' does n
 const ELSEWHERE = `packages/renderer/src/other.test.ts(9,3): error TS2339: Property 'getMeshData' does not exist on type 'SceneContents'.\n`;
 
 const fakeSpawn = (status, stdout) => () => ({ status, stdout, stderr: '' });
+const included = { programIncludes: () => ({ included: true, evidence: 'fixture program' }) };
 
 test('parseTscDiagnostics reads tsc\'s `file(line,col): error TSnnnn:` lines and nothing else', () => {
   const d = parseTscDiagnostics(`typecheck-tests: packages/renderer FAILED (110 test files)\n${TS2339}${ELSEWHERE}some prose\n`);
@@ -172,11 +173,11 @@ test('parseTscDiagnostics reads tsc\'s `file(line,col): error TSnnnn:` lines and
 });
 
 test('#4472 through verdict(): baseline clean, revert puts TS2339 in the changed test -> OBSERVED', () => {
-  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, 'typecheck-tests: packages/renderer OK (110 test files)\n') });
+  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, 'typecheck-tests: packages/renderer OK (110 test files)\n'), ...included });
   assert.equal(baseline.kind, 'pass');
   assert.deepEqual([baseline.passed, baseline.failed, baseline.total], [1, 0, 1]);
 
-  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339) });
+  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339), ...included });
   assert.equal(reverted.kind, 'assertion-failure');
   assert.deepEqual([reverted.passed, reverted.failed, reverted.total], [0, 1, 1]);
   assert.match(reverted.evidence[0], /TS2339/);
@@ -194,8 +195,8 @@ test('the pre-fix answer, for contrast: the runtime observer saw pass/pass and s
 });
 
 test('a diagnostic that lands ONLY in some other test file is UNOBSERVED, with the reason named', () => {
-  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, '') });
-  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, ELSEWHERE) });
+  const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(0, ''), ...included });
+  const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, ELSEWHERE), ...included });
   assert.equal(reverted.kind, 'pass');
   assert.match(reverted.evidence[0], /outside the changed test files/);
   assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'UNOBSERVED');
@@ -203,14 +204,14 @@ test('a diagnostic that lands ONLY in some other test file is UNOBSERVED, with t
 
 test('a baseline that does not type-check is BASELINE-BROKEN, whichever file the diagnostic is in', () => {
   for (const out of [TS2339, ELSEWHERE]) {
-    const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(1, out) });
+    const baseline = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(1, out), ...included });
     assert.equal(baseline.kind, 'load-failure');
     assert.match(baseline.evidence[0], /before any revert/);
-    const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339) });
+    const reverted = runTypecheckPlan(PLAN, REPO_ROOT, 'reverted', { spawn: fakeSpawn(1, TS2339), ...included });
     assert.equal(verdict({ baseline: aggregate([baseline]), reverted: aggregate([reverted]) }).verdict, 'BASELINE-BROKEN');
   }
   // A non-zero exit with nothing parseable is broken too, never a pass.
-  assert.equal(runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(2, 'boom') }).kind, 'load-failure');
+  assert.equal(runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', { spawn: fakeSpawn(2, 'boom'), ...included }).kind, 'load-failure');
 });
 
 test('a runner that cannot be spawned, or a root without typecheck-tests.mjs, is runner-missing', () => {
@@ -218,13 +219,22 @@ test('a runner that cannot be spawned, or a root without typecheck-tests.mjs, is
   assert.equal(runTypecheckPlan(PLAN, mkdtempSync(join(tmpdir(), 'oracle-no-script-')), 'baseline').kind, 'runner-missing');
 });
 
-test('typecheckPlans groups TypeScript tests by package, names non-TypeScript tests as skipped', () => {
+test('#4109: a green tsc exit is rejected when the changed file is absent from its compiler program', () => {
+  const result = runTypecheckPlan(PLAN, REPO_ROOT, 'baseline', {
+    spawn: fakeSpawn(0, 'typecheck-tests: packages/renderer OK (110 test files)\n'),
+    programIncludes: () => ({ included: false, evidence: 'not listed' }),
+  });
+  assert.equal(result.kind, 'runner-missing');
+  assert.match(result.evidence[0], /refusing a synthetic typecheck result/);
+});
+
+test('typecheckPlans creates one attributable plan per TypeScript file and names non-TypeScript tests as skipped', () => {
   const { plans, skipped, unassigned } = typecheckPlans(
     ['packages/renderer/src/a.test.ts', 'packages/renderer/src/b.test.tsx', 'packages/parser/src/c.test.ts', 'scripts/lib/d.test.mjs'],
     REPO_ROOT,
   );
-  assert.deepEqual(plans.map((p) => p.files), [['packages/renderer/src/a.test.ts', 'packages/renderer/src/b.test.tsx'], ['packages/parser/src/c.test.ts']]);
-  assert.deepEqual(plans[0].relFiles, ['src/a.test.ts', 'src/b.test.tsx']);
+  assert.deepEqual(plans.map((p) => p.files), [['packages/renderer/src/a.test.ts'], ['packages/renderer/src/b.test.tsx'], ['packages/parser/src/c.test.ts']]);
+  assert.deepEqual(plans[0].relFiles, ['src/a.test.ts']);
   assert.equal(plans[0].runner.family, 'typecheck');
   assert.deepEqual(skipped, ['scripts/lib/d.test.mjs']);
   assert.deepEqual(unassigned, []);

--- a/scripts/lib/revert-oracle-unhandled-cfg.test.mjs
+++ b/scripts/lib/revert-oracle-unhandled-cfg.test.mjs
@@ -52,7 +52,7 @@ function makeCrate() {
   writeFileSync(
     join(root, 'Cargo.toml'),
     '[package]\nname = "oracle-unhandled-cfg"\nversion = "0.1.0"\nedition = "2021"\n\n' +
-      '[features]\ndefault = [\"gate_a\"]\ngate_a = []\n',
+      '[features]\ndefault = ["gate_a"]\ngate_a = []\n',
   );
   writeFileSync(join(root, 'src/lib.rs'), 'pub fn value() -> u32 { 1 }\n');
   run('cargo', ['generate-lockfile', '--offline']);
@@ -99,7 +99,10 @@ test(
       const jsonStart = result.stdout.indexOf('{');
       assert.ok(jsonStart >= 0, `no JSON in stdout:\n${result.stdout}`);
       const payload = JSON.parse(result.stdout.slice(jsonStart));
+      assert.equal(payload.schemaVersion, 1);
+      assert.equal(payload.channel, 'oracle');
       assert.equal(payload.verdict, 'ERROR');
+      assert.equal(payload.exitCode, EXIT_UNHANDLED_CFG_SHAPE);
       assert.equal(payload.error.name, 'UnhandledCfgShapeError');
       assert.equal(payload.error.shape, 'not(...) over default feature "gate_a"');
       assert.match(payload.reason, /not\(\.\.\.\)/);

--- a/scripts/lib/revert-oracle-unhandled-cfg.test.mjs
+++ b/scripts/lib/revert-oracle-unhandled-cfg.test.mjs
@@ -30,7 +30,7 @@ import { spawnSync } from 'node:child_process';
 const oracle = resolve(dirname(fileURLToPath(import.meta.url)), '../check-test-revert-oracle.mjs');
 const EXIT_OBSERVED = 0;
 const EXIT_UNOBSERVED = 1;
-const EXIT_UNHANDLED_CFG_SHAPE = 6;
+const EXIT_INCONCLUSIVE = 3;
 
 function makeCrate() {
   const root = mkdtempSync(join(tmpdir(), 'oracle-unhandled-cfg-'));
@@ -76,7 +76,7 @@ function makeCrate() {
 }
 
 test(
-  'UnhandledCfgShapeError from planRuns() is caught, not an unhandled crash: distinct exit code, no ambiguity with EXIT_UNOBSERVED',
+  'an unsupported cfg becomes a per-file capability gap instead of aborting other planning',
   { timeout: 60_000 },
   () => {
     const { root, base, env } = makeCrate();
@@ -89,23 +89,21 @@ test(
       // Not an unhandled-exception exit and not EXIT_UNOBSERVED: a CI consumer
       // keyed on exit code must be able to tell this apart from "tests ran and
       // did not observe the change".
-      assert.equal(result.status, EXIT_UNHANDLED_CFG_SHAPE, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+      assert.equal(result.status, EXIT_INCONCLUSIVE, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
       assert.notEqual(result.status, EXIT_OBSERVED);
       assert.notEqual(result.status, EXIT_UNOBSERVED);
-      // die()'s own ABORT formatting, not a raw Node stack trace.
-      assert.match(result.stderr, /\[revert-oracle\] ABORT:/);
+      assert.match(result.stdout, /capability gap: tests\/gated\.rs:.*unhandled cfg shape/);
       assert.doesNotMatch(result.stderr, /at parseCfgExpr/);
       // JSON was still emitted despite the crash path, per --json.
       const jsonStart = result.stdout.indexOf('{');
       assert.ok(jsonStart >= 0, `no JSON in stdout:\n${result.stdout}`);
       const payload = JSON.parse(result.stdout.slice(jsonStart));
-      assert.equal(payload.schemaVersion, 1);
+      assert.equal(payload.schemaVersion, 2);
       assert.equal(payload.channel, 'oracle');
-      assert.equal(payload.verdict, 'ERROR');
-      assert.equal(payload.exitCode, EXIT_UNHANDLED_CFG_SHAPE);
-      assert.equal(payload.error.name, 'UnhandledCfgShapeError');
-      assert.equal(payload.error.shape, 'not(...) over default feature "gate_a"');
-      assert.match(payload.reason, /not\(\.\.\.\)/);
+      assert.equal(payload.verdict, 'INCONCLUSIVE');
+      assert.equal(payload.exitCode, EXIT_INCONCLUSIVE);
+      assert.equal(payload.ledger[0].role, 'capability-gap');
+      assert.match(payload.ledger[0].reason, /not\(\.\.\.\) over default feature/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -38,6 +38,7 @@ import { parsePython, PYTEST_MISSING_PATTERN } from './revert-oracle-python.mjs'
 import { ALL_SKIPPED, classifyExecuted, severityCandidates } from './revert-oracle-all-skipped.mjs';
 import { passVerdict } from './revert-oracle-pass-verdict.mjs';
 import { isInertPath, isTestSupportPath, withoutBrowserSpecs } from './revert-oracle-inert.mjs';
+export { cargoRunner } from './revert-oracle-cargo.mjs';
 // ---------------------------------------------------------------------------
 // Diff classification
 // ---------------------------------------------------------------------------
@@ -182,12 +183,6 @@ export function rootScriptsRunner(files) {
   if (entries.length === 0 || !entries.every((f) => /^scripts\/.*\.test\.(mjs|js|cjs)$/.test(f))) return null;
   return { family: 'node-test', bin: 'node', args: ['--test', ...entries] };
 }
-/** Cargo test invocation for a crate, optionally under a `--features` combo. */
-export function cargoRunner(crate, features = []) {
-  if (!crate) return null;
-  return { family: 'cargo', bin: 'cargo', args: ['test', '--no-fail-fast', '-p', crate, ...(features.length ? ['--features', features.join(',')] : [])] };
-}
-
 // Runner output parsing — the core of the tool
 // ---------------------------------------------------------------------------
 
@@ -301,7 +296,10 @@ export function parseRunnerOutput(run) {
   // rather than a test) and the TEXTUAL one (the actual import/compile error).
   // A human reading an INCONCLUSIVE needs the error text to write the surgical
   // mutation, so it must never be shadowed by the structural summary.
-  const textualHit = firstMatch(text, LOAD_ERROR_PATTERNS);
+  // A successful, structurally parsed run may print error-shaped fixture text
+  // (including the literal `SyntaxError:`). Text alone cannot turn that green
+  // execution into a collection failure (#4109).
+  const textualHit = run.exitCode === 0 && parsed.total > 0 ? null : firstMatch(text, LOAD_ERROR_PATTERNS);
   for (const hit of [textualHit, parsed.loadEvidence]) if (hit) evidence.push(hit);
   if (evidence.length > 0) {
     return { kind: LOAD_FAILURE, passed: parsed.passed, failed: parsed.failed, total: parsed.total, evidence };
@@ -384,7 +382,8 @@ function parseCargo(text) {
     passed += Number(r[2]);
     failed += Number(r[3]);
   }
-  return { passed, failed, total: passed + failed, loadEvidence: null };
+  const identities = [...text.matchAll(/^test (.+?) \.\.\. (?:ok|FAILED|ignored)\r?$/gm)].map((match) => match[1]);
+  return { passed, failed, total: passed + failed, identities, loadEvidence: null };
 }
 
 function num(m) {

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -37,6 +37,7 @@
 import { parsePython, PYTEST_MISSING_PATTERN } from './revert-oracle-python.mjs';
 import { ALL_SKIPPED, classifyExecuted, severityCandidates } from './revert-oracle-all-skipped.mjs';
 import { passVerdict } from './revert-oracle-pass-verdict.mjs';
+import { processResultGap } from './revert-oracle-process-result.mjs';
 import { isInertPath, isTestSupportPath, withoutBrowserSpecs } from './revert-oracle-inert.mjs';
 export { cargoRunner } from './revert-oracle-cargo.mjs';
 // ---------------------------------------------------------------------------
@@ -57,8 +58,8 @@ const IGNORED_SUFFIXES = ['.md', '.mdx', '.txt', '.snap.orig'];
  */
 const DEPLOY_CONFIG_RE = /(^|\/)(vercel\.json|\.vercelignore|vercel-[a-z0-9-]*\.sh)$/;
 
-/** A file that IS a test: JS/TS `*.test.*`/`*.spec.*`, or Python's `test_*.py` / `*_test.py` (#4050). */
-const TEST_FILE_RE = /(^|\/)(?:[^/]*\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)|test_[^/]*\.py|[^/]*_test\.py)$/;
+/** Known test entrypoint names. Unsupported families still classify as tests so planning reports a capability gap. */
+const TEST_FILE_RE = /(^|\/)(?:[^/]*\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)|test_[^/]*\.py|[^/]*_test\.(?:py|go))$/;
 /** Directories whose entire contents are test scaffolding, not production. `__corpus__`/`corpus`/`__test__`/`test-data` added for #4142 -- see `revert-oracle.test.mjs` for the trade-off and sibling sweep. */
 const TEST_DIR_RE = /(^|\/)(__corpus__|__fixtures__|__snapshots__|__test__|__tests__|corpus|test-data|test-fixtures|testdata)(\/|$)/;
 /** `tests/` and `test/` as a directory segment (but not `src/test-utils.ts`). */
@@ -289,21 +290,20 @@ export function parseRunnerOutput(run) {
     return { kind: UNPARSEABLE, passed: null, failed: null, total: null, evidence: [`unknown runner family: ${family}`] };
   }
 
-  // A load error ANYWHERE outranks every other signal. Some files may have run
-  // their assertions, but at least one subject never loaded, so the run cannot
-  // be read as "the tests observed the change".
-  // Both signals are recorded: the STRUCTURAL one (the runner reported a file
-  // rather than a test) and the TEXTUAL one (the actual import/compile error).
-  // A human reading an INCONCLUSIVE needs the error text to write the surgical
-  // mutation, so it must never be shadowed by the structural summary.
-  // A successful, structurally parsed run may print error-shaped fixture text
-  // (including the literal `SyntaxError:`). Text alone cannot turn that green
-  // execution into a collection failure (#4109).
+  const earlyProcessGap = processResultGap(parsed, run);
+  if (earlyProcessGap && (run.signal || run.exitCode === null)) return earlyProcessGap;
+
+  // Load/collection evidence outranks assertion output; green processes may
+  // contain error-shaped fixture text without becoming failures (#4109).
   const textualHit = run.exitCode === 0 && parsed.total > 0 ? null : firstMatch(text, LOAD_ERROR_PATTERNS);
   for (const hit of [textualHit, parsed.loadEvidence]) if (hit) evidence.push(hit);
   if (evidence.length > 0) {
     return { kind: LOAD_FAILURE, passed: parsed.passed, failed: parsed.failed, total: parsed.total, evidence };
   }
+
+
+  const processGap = processResultGap(parsed, run);
+  if (processGap) return processGap;
 
   if (parsed.kind) return { ...parsed, evidence: parsed.evidence ?? [] };
 

--- a/scripts/lib/revert-oracle.mjs
+++ b/scripts/lib/revert-oracle.mjs
@@ -36,6 +36,7 @@
 
 import { parsePython, PYTEST_MISSING_PATTERN } from './revert-oracle-python.mjs';
 import { ALL_SKIPPED, classifyExecuted, severityCandidates } from './revert-oracle-all-skipped.mjs';
+import { passVerdict } from './revert-oracle-pass-verdict.mjs';
 import { isInertPath, isTestSupportPath, withoutBrowserSpecs } from './revert-oracle-inert.mjs';
 // ---------------------------------------------------------------------------
 // Diff classification
@@ -472,16 +473,7 @@ export function verdict({ baseline, reverted }) {
     };
   }
   if (reverted.kind === PASS) {
-    return {
-      verdict: UNOBSERVED,
-      exitCode: 1,
-      reason:
-        `FINDING: with the production change fully reverted, all ${reverted.total} test(s) still PASS. ` +
-        'The branch\'s tests do not observe the branch\'s change.',
-      advice:
-        'Either the test asserts something the change does not affect, or it stubs the very module ' +
-        'the change lives in. Write a test that fails on this revert before shipping.',
-    };
+    return passVerdict(baseline, reverted);
   }
   return { verdict: INCONCLUSIVE, exitCode: 3, reason: `unhandled reverted kind: ${reverted.kind}`, advice: SURGICAL_ADVICE };
 }
@@ -518,6 +510,7 @@ export function aggregate(results) {
     passed: sum('passed'),
     failed: sum('failed'),
     total: sum('total'),
+    allSkippedRuns: results.filter((r) => r.kind === ALL_SKIPPED).length,
     evidence: results.flatMap((r) => r.evidence ?? []),
   };
 }

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -1115,6 +1115,17 @@ test('#4131 regression: multi-package all-skipped-plus-evidence run does not blo
   assert.equal(v.exitCode, 0);
 });
 
+test('#4109: a green structured run may log the literal `SyntaxError:` as fixture data', () => {
+  const parsed = parseRunnerOutput({
+    family: 'node-test',
+    stdout: 'fixture caught: SyntaxError: expected\n# tests 120\n# pass 120\n# fail 0\n',
+    stderr: '',
+    exitCode: 0,
+  });
+  assert.equal(parsed.kind, 'pass');
+  assert.equal(parsed.total, 120);
+});
+
 test('#4109: incomplete execution cannot support a negative UNOBSERVED finding', () => {
   const baseline = aggregate([
     { kind: PASS, passed: 12, failed: 0, total: 12, evidence: [] },

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -1037,10 +1037,10 @@ test('verdict: a missing run never reports clean', () => {
   assert.notEqual(verdict({ baseline: green, reverted: null }).exitCode, 0);
 });
 
-test('#3661: CI blocks misses and broken baselines, but not honest inconclusives', () => {
+test('#4109: CI blocks misses, broken baselines, and oracle capability gaps', () => {
   assert.equal(ciExitCode(OBSERVED), 0);
   assert.equal(ciExitCode(UNOBSERVED), 1);
-  assert.equal(ciExitCode(INCONCLUSIVE), 0);
+  assert.notEqual(ciExitCode(INCONCLUSIVE), 0);
   assert.notEqual(ciExitCode(BASELINE_BROKEN), 0);
 });
 
@@ -1113,6 +1113,21 @@ test('#4131 regression: multi-package all-skipped-plus-evidence run does not blo
   const v = verdict({ baseline, reverted });
   assert.equal(v.verdict, OBSERVED);
   assert.equal(v.exitCode, 0);
+});
+
+test('#4109: incomplete execution cannot support a negative UNOBSERVED finding', () => {
+  const baseline = aggregate([
+    { kind: PASS, passed: 12, failed: 0, total: 12, evidence: [] },
+    { kind: ALL_SKIPPED, passed: 0, failed: 0, total: 2, evidence: ['all skipped'] },
+  ]);
+  const reverted = aggregate([
+    { kind: PASS, passed: 12, failed: 0, total: 12, evidence: [] },
+    { kind: ALL_SKIPPED, passed: 0, failed: 0, total: 2, evidence: ['all skipped'] },
+  ]);
+  const v = verdict({ baseline, reverted });
+  assert.equal(v.verdict, INCONCLUSIVE);
+  assert.match(v.reason, /cannot support an UNOBSERVED finding/);
+  assert.notEqual(ciExitCode(v.verdict), 0);
 });
 
 test('#4108 (still fixed): aggregate: a SINGLE all-skipped package is still ALL_SKIPPED and still blocks', () => {

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -464,6 +464,10 @@ test('classifyPath: Python `test_*.py` / `*_test.py` are tests, not production (
   assert.equal(classifyPath('a/b/c/test_deep.py'), 'test');
 });
 
+test('#4109: unsupported Go entrypoints stay tests so planning can expose a capability gap', () => {
+  assert.equal(classifyPath('cmd/widget_test.go'), 'test');
+});
+
 test('classifyPath: a Python module that merely CONTAINS "test" stays production', () => {
   assert.equal(classifyPath('tools/ifcopenshell_reference/canonical.py'), 'production');
   assert.equal(classifyPath('tools/ifcopenshell_reference/latest_export.py'), 'production');
@@ -796,6 +800,13 @@ test('node --test: all green', () => {
   assert.equal(r.kind, PASS);
   assert.equal(r.total, 197);
   assert.equal(r.passed, 197);
+});
+
+test('#4109: a green summary cannot override nonzero, missing, or signalled process status', () => {
+  for (const processState of [{ exitCode: 9 }, { exitCode: null }, { exitCode: null, signal: 'SIGTERM' }]) {
+    const parsed = parseRunnerOutput({ family: 'node-test', stdout: NODE_ALL_PASS, stderr: '', ...processState });
+    assert.equal(parsed.kind, UNPARSEABLE);
+  }
 });
 
 test('node --test: zero collected tests is never a pass', () => {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -355,7 +355,7 @@
    855 scripts/check-review-posted.mjs
    446 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
-   640 scripts/check-test-revert-oracle.mjs
+   605 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs
    488 scripts/check-wasm-disposal.mjs
    499 scripts/docs/check-doc-samples.mjs
@@ -367,7 +367,7 @@
   1113 scripts/lib/pr-review-signal.mjs
    443 scripts/lib/prepass-class-boundary.mjs
    734 scripts/lib/refwalk-classify.mjs
-   523 scripts/lib/revert-oracle.mjs
+   516 scripts/lib/revert-oracle.mjs
    494 scripts/lib/rust-source-text-detect.mjs
   1165 scripts/lib/vitest-timeout-audit.mjs
    691 scripts/review/build-context-pack.mjs

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -367,7 +367,7 @@
   1113 scripts/lib/pr-review-signal.mjs
    443 scripts/lib/prepass-class-boundary.mjs
    734 scripts/lib/refwalk-classify.mjs
-   516 scripts/lib/revert-oracle.mjs
+   515 scripts/lib/revert-oracle.mjs
    494 scripts/lib/rust-source-text-detect.mjs
   1165 scripts/lib/vitest-timeout-audit.mjs
    691 scripts/review/build-context-pack.mjs

--- a/scripts/revert-oracle-selfcheck.mjs
+++ b/scripts/revert-oracle-selfcheck.mjs
@@ -4,29 +4,32 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { REVERT_ORACLE_ADAPTERS } from './lib/revert-oracle-adapters.mjs';
-import { parseRunnerOutput } from './lib/revert-oracle.mjs';
-
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ORACLE = join(ROOT, 'scripts/check-test-revert-oracle.mjs');
 export const EXPECTED_PROBES = Object.freeze({
-  observed: Object.freeze(['assertion-failure']),
-  unobserved: Object.freeze(['pass']),
-  notExecuting: Object.freeze(['no-tests', 'all-skipped']),
+  observed: Object.freeze(['OBSERVED']),
+  unobserved: Object.freeze(['UNOBSERVED']),
+  notExecuting: Object.freeze(['BASELINE-BROKEN', 'INCONCLUSIVE']),
 });
 
 export function validateSelfcheckResult(adapterId, mode, actual, expected = EXPECTED_PROBES) {
   const wanted = expected[mode];
-  if (wanted.includes(actual.kind)) return null;
-  return `adapter ${adapterId} ${mode} probe: expected ${wanted.join(' or ')}, got ${actual.kind}`;
+  if (wanted.includes(actual.verdict)) return null;
+  return `adapter ${adapterId} ${mode} probe: expected ${wanted.join(' or ')}, got ${actual.verdict}`;
 }
 
 function resolveBinary(adapter) {
   if (adapter.binary === 'node') return { bin: process.execPath, prefix: [] };
+  if (adapter.binary === 'python3' && process.platform === 'win32') {
+    const probe = spawnSync('py', ['-3', '--version'], { encoding: 'utf8' });
+    return probe.error || probe.status !== 0 ? null : { bin: 'py', prefix: ['-3'] };
+  }
   if (adapter.binary === 'vitest') {
     for (const parent of ['packages', 'apps']) {
       for (const name of readdirSync(join(ROOT, parent))) {
@@ -40,83 +43,120 @@ function resolveBinary(adapter) {
   return probe.error || probe.status !== 0 ? null : { bin: adapter.binary, prefix: [] };
 }
 
-function jsSource(mode) {
-  if (mode === 'notExecuting') return "import { test } from 'node:test';\ntest.skip('intentionally skipped', () => {});\n";
-  const expected = mode === 'observed' ? 2 : 1;
-  return `import test from 'node:test';\nimport assert from 'node:assert/strict';\ntest('probe', () => assert.equal(1, ${expected}));\n`;
-}
-
-function vitestSource(mode) {
-  if (mode === 'notExecuting') return "test.skip('intentionally skipped', () => {});\n";
-  const expected = mode === 'observed' ? 2 : 1;
-  return `test('probe', () => expect(1).toBe(${expected}));\n`;
+function jsSource(mode, importPath, vitest = false) {
+  const imports = vitest
+    ? "import { test, expect } from 'vitest';"
+    : "import test from 'node:test';\nimport assert from 'node:assert/strict';";
+  if (mode === 'notExecuting') return `${imports}\ntest.skip('intentionally skipped', () => {});\n`;
+  const assertion = mode === 'observed'
+    ? vitest ? 'expect(value).toBe(1)' : 'assert.equal(value, 1)'
+    : vitest ? 'expect(1).toBe(1)' : 'assert.equal(1, 1)';
+  return `${imports}\nimport { value } from '${importPath}';\ntest('probe', () => ${assertion});\n`;
 }
 
 function pythonSource(mode) {
   if (mode === 'notExecuting') return 'import pytest\n\n@pytest.mark.skip(reason="intentional")\ndef test_probe():\n    pass\n';
-  const expected = mode === 'observed' ? 2 : 1;
-  return `def test_probe():\n    assert 1 == ${expected}\n`;
+  return mode === 'observed'
+    ? 'from value import value\n\ndef test_probe():\n    assert value == 1\n'
+    : 'def test_probe():\n    assert 1 == 1\n';
 }
 
 function rustSource(mode) {
   const ignored = mode === 'notExecuting' ? '#[ignore]\n' : '';
-  const expected = mode === 'observed' ? 2 : 1;
-  return `${ignored}#[test]\nfn probe() { assert_eq!(1, ${expected}); }\n`;
+  const assertion = mode === 'observed' ? 'assert_eq!(revert_oracle_selfcheck::value(), 1)' : 'assert_eq!(1, 1)';
+  return `${ignored}#[test]\nfn probe() { ${assertion}; }\n`;
 }
 
-function probeCommand(adapter, mode, dir) {
-  const file = join(dir, 'probe.test.mjs');
-  if (adapter.id === 'root-node-test' || adapter.id === 'node-test') {
-    writeFileSync(file, jsSource(mode));
-    return { cwd: dir, runner: adapter.probeRunner({ file, dir, root: ROOT }) };
-  }
-  if (adapter.id === 'vitest') {
-    const spec = join(dir, 'probe.test.js');
-    writeFileSync(spec, vitestSource(mode));
-    return { cwd: dir, runner: adapter.probeRunner({ file: spec, dir, root: ROOT }) };
-  }
+function buildFixture(adapter, mode, dir) {
+  let production;
+  let testFile;
   if (adapter.id === 'python-pytest') {
-    const testFile = join(dir, 'test_probe.py');
-    writeFileSync(testFile, pythonSource(mode));
-    return { cwd: dir, runner: adapter.probeRunner({ file: testFile, dir, root: ROOT }) };
-  }
-  if (adapter.id === 'cargo') {
+    writeFileSync(join(dir, 'requirements.txt'), 'pytest\n');
+    production = 'value.py'; testFile = 'test_probe.py';
+    writeFileSync(join(dir, testFile), pythonSource(mode));
+  } else if (adapter.id === 'cargo') {
     mkdirSync(join(dir, 'src'));
     mkdirSync(join(dir, 'tests'));
     writeFileSync(join(dir, 'Cargo.toml'), '[package]\nname="revert-oracle-selfcheck"\nversion="0.0.0"\nedition="2021"\n');
-    writeFileSync(join(dir, 'src/lib.rs'), 'pub fn marker() {}\n');
-    writeFileSync(join(dir, 'tests/probe.rs'), rustSource(mode));
-    return { cwd: dir, runner: adapter.probeRunner({ dir, root: ROOT }) };
+    production = 'src/lib.rs'; testFile = 'tests/probe.rs';
+    writeFileSync(join(dir, testFile), rustSource(mode));
+  } else if (adapter.id === 'typescript') {
+    mkdirSync(join(dir, 'scripts')); mkdirSync(join(dir, 'pkg/src'), { recursive: true });
+    copyFileSync(join(ROOT, 'scripts/typecheck-tests.mjs'), join(dir, 'scripts/typecheck-tests.mjs'));
+    copyFileSync(join(ROOT, 'tsconfig.tests.base.json'), join(dir, 'tsconfig.tests.base.json'));
+    symlinkSync(join(ROOT, 'node_modules'), join(dir, 'node_modules'), 'junction');
+    writeFileSync(join(dir, 'package.json'), '{"private":true}\n');
+    writeFileSync(join(dir, 'pkg/package.json'), '{"private":true}\n');
+    writeFileSync(join(dir, 'pkg/tsconfig.json'), JSON.stringify({ compilerOptions: { strict: true, noEmit: true }, include: ['src/**/*'] }));
+    production = 'pkg/src/value.ts'; testFile = 'pkg/src/probe.test.ts';
+    writeFileSync(join(dir, testFile), mode === 'observed'
+      ? "import type { Value } from './value';\nconst probe: Value['marker'] = 1;\nvoid probe;\n"
+      : mode === 'notExecuting' ? 'const probe: never = 1;\nvoid probe;\n' : 'const probe: 1 = 1;\nvoid probe;\n');
+  } else {
+    const nested = adapter.id === 'root-node-test' ? '' : 'pkg';
+    const base = nested ? join(dir, nested) : dir;
+    mkdirSync(join(base, 'src'), { recursive: true });
+    if (nested) writeFileSync(join(base, 'package.json'), JSON.stringify({ type: 'module', scripts: { test: adapter.id === 'vitest' ? 'vitest run' : 'node --test' } }));
+    else writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module', scripts: { test: 'turbo test' } }));
+    if (adapter.id === 'vitest') {
+      const binary = resolveBinary(adapter);
+      if (!binary) throw new Error('lost runner vitest: vitest is unavailable');
+      const modules = dirname(dirname(binary.prefix[0]));
+      symlinkSync(modules, join(base, 'node_modules'), 'junction');
+    }
+    production = nested ? `${nested}/src/value.mjs` : 'src/value.mjs';
+    testFile = nested ? `${nested}/src/probe.test.mjs` : 'scripts/probe.test.mjs';
+    if (!nested) mkdirSync(join(dir, 'scripts'));
+    writeFileSync(join(dir, testFile), jsSource(mode, './value.mjs'.replace('./', nested ? './' : '../src/'), adapter.id === 'vitest'));
   }
-  if (adapter.id === 'typescript') {
-    const source = mode === 'observed' ? 'const value: 1 = 2;\n' : 'const value: 1 = 1;\n';
-    if (mode !== 'notExecuting') writeFileSync(join(dir, 'probe.ts'), source);
-    writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { noEmit: true }, files: mode === 'notExecuting' ? [] : ['probe.ts'] }));
-    return { cwd: dir, runner: adapter.probeRunner({ dir, root: ROOT }) };
-  }
-  throw new Error(`adapter ${adapter.id} has no selfcheck probe`);
+  const head = adapter.id === 'typescript' ? 'export interface Value { marker: 1 }\n'
+    : adapter.id === 'cargo' ? 'pub fn value() -> u32 { 1 }\n'
+    : adapter.id === 'python-pytest' ? 'value = 1\n' : 'export const value = 1;\n';
+  const reverted = adapter.id === 'typescript' ? 'export interface Value {}\n'
+    : adapter.id === 'cargo' ? 'pub fn value() -> u32 { 0 }\n'
+    : adapter.id === 'python-pytest' ? 'value = 0\n' : 'export const value = 0;\n';
+  writeFileSync(join(dir, production), head);
+  return { production, testFile, head, reverted };
 }
 
 function runProbe(adapter, mode) {
-  const binary = resolveBinary(adapter);
-  if (!binary) throw new Error(`lost runner ${adapter.id}: ${adapter.binary} is unavailable`);
+  if (!resolveBinary(adapter)) throw new Error(`lost runner ${adapter.id}: ${adapter.binary} is unavailable`);
   const dir = mkdtempSync(join(tmpdir(), `revert-oracle-${adapter.id}-`));
-  try {
-    const { cwd, runner } = probeCommand(adapter, mode, dir);
-    const run = spawnSync(binary.bin, [...binary.prefix, ...runner.args], {
-      cwd,
-      encoding: 'utf8',
-      timeout: 120_000,
-      maxBuffer: 32 * 1024 * 1024,
+  const run = (bin, args, expected = 0) => {
+    const result = spawnSync(bin, args, {
+      cwd: dir, encoding: 'utf8', timeout: 120_000, maxBuffer: 32 * 1024 * 1024,
       env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1', CARGO_TARGET_DIR: join(dir, 'target') },
     });
-    if (run.error) throw new Error(`lost runner ${adapter.id}: ${run.error.message}`);
-    if (runner.family === 'typecheck') {
-      const output = `${run.stdout ?? ''}\n${run.stderr ?? ''}`;
-      if (/TS18002/.test(output)) return { kind: 'no-tests' };
-      return { kind: run.status === 0 ? 'pass' : 'assertion-failure' };
-    }
-    return parseRunnerOutput({ family: runner.family, stdout: run.stdout ?? '', stderr: run.stderr ?? '', exitCode: run.status });
+    if (result.error) throw new Error(`${bin} failed: ${result.error.message}`);
+    if (result.status !== expected) throw new Error(`${bin} ${args.join(' ')} exited ${result.status}, expected ${expected}\n${result.stdout}\n${result.stderr}`);
+    return result;
+  };
+  try {
+    const fixture = buildFixture(adapter, mode, dir);
+    const testSource = readFileSync(join(dir, fixture.testFile), 'utf8');
+    writeFileSync(join(dir, '.gitignore'), 'node_modules\ntarget\n.pytest_cache\ntsconfig.tests.json\n');
+    writeFileSync(join(dir, fixture.production), fixture.reverted);
+    rmSync(join(dir, fixture.testFile));
+    run('git', ['init', '-q']);
+    run('git', ['config', 'core.autocrlf', 'false']);
+    run('git', ['config', 'user.name', 'Revert oracle selfcheck']);
+    run('git', ['config', 'user.email', 'oracle@example.invalid']);
+    if (adapter.id === 'cargo') run('cargo', ['generate-lockfile', '--offline']);
+    run('git', ['add', '.']); run('git', ['commit', '-qm', 'base']);
+    const base = run('git', ['rev-parse', 'HEAD']).stdout.trim();
+    writeFileSync(join(dir, fixture.production), fixture.reverted);
+    writeFileSync(join(dir, fixture.production), fixture.head);
+    writeFileSync(join(dir, fixture.testFile), testSource);
+    run('git', ['add', '.']); run('git', ['commit', '-qm', 'head']);
+    const expectedExit = mode === 'observed' ? 0 : mode === 'unobserved' ? 1 : 3;
+    const measured = run(process.execPath, [ORACLE, '--root', dir, '--base', base, '--ci', '--json'], expectedExit);
+    const jsonStart = measured.stdout.indexOf('{');
+    if (jsonStart < 0) throw new Error(`adapter ${adapter.id} emitted no JSON result`);
+    const result = JSON.parse(measured.stdout.slice(jsonStart));
+    if (result.restoration !== 'verified') throw new Error(`adapter ${adapter.id} did not verify restoration`);
+    if (readFileSync(join(dir, fixture.production), 'utf8') !== fixture.head) throw new Error(`adapter ${adapter.id} fixture did not restore`);
+    if (run('git', ['status', '--porcelain']).stdout.trim() !== '') throw new Error(`adapter ${adapter.id} left a dirty fixture`);
+    return result;
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -145,7 +185,7 @@ export function main(argv = process.argv.slice(2)) {
     for (const mode of Object.keys(EXPECTED_PROBES)) {
       const actual = runProbe(adapter, mode);
       const failure = validateSelfcheckResult(adapter.id, mode, actual);
-      console.log(`[selfcheck] ${adapter.id} ${mode}: ${actual.kind}`);
+      console.log(`[selfcheck] ${adapter.id} ${mode}: ${actual.verdict}${actual.reason ? ` — ${actual.reason}` : ''}`);
       if (failure) failures.push(failure);
     }
   }

--- a/scripts/revert-oracle-selfcheck.mjs
+++ b/scripts/revert-oracle-selfcheck.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { REVERT_ORACLE_ADAPTERS } from './lib/revert-oracle-adapters.mjs';
+import { parseRunnerOutput } from './lib/revert-oracle.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+export const EXPECTED_PROBES = Object.freeze({
+  observed: Object.freeze(['assertion-failure']),
+  unobserved: Object.freeze(['pass']),
+  notExecuting: Object.freeze(['no-tests', 'all-skipped']),
+});
+
+export function validateSelfcheckResult(adapterId, mode, actual, expected = EXPECTED_PROBES) {
+  const wanted = expected[mode];
+  if (wanted.includes(actual.kind)) return null;
+  return `adapter ${adapterId} ${mode} probe: expected ${wanted.join(' or ')}, got ${actual.kind}`;
+}
+
+function resolveBinary(adapter) {
+  if (adapter.binary === 'node') return { bin: process.execPath, prefix: [] };
+  if (adapter.binary === 'vitest') {
+    for (const parent of ['packages', 'apps']) {
+      for (const name of readdirSync(join(ROOT, parent))) {
+        const module = join(ROOT, parent, name, 'node_modules', 'vitest', 'vitest.mjs');
+        if (existsSync(module)) return { bin: process.execPath, prefix: [module] };
+      }
+    }
+    return null;
+  }
+  const probe = spawnSync(adapter.binary, ['--version'], { encoding: 'utf8' });
+  return probe.error || probe.status !== 0 ? null : { bin: adapter.binary, prefix: [] };
+}
+
+function jsSource(mode) {
+  if (mode === 'notExecuting') return "import { test } from 'node:test';\ntest.skip('intentionally skipped', () => {});\n";
+  const expected = mode === 'observed' ? 2 : 1;
+  return `import test from 'node:test';\nimport assert from 'node:assert/strict';\ntest('probe', () => assert.equal(1, ${expected}));\n`;
+}
+
+function vitestSource(mode) {
+  if (mode === 'notExecuting') return "test.skip('intentionally skipped', () => {});\n";
+  const expected = mode === 'observed' ? 2 : 1;
+  return `test('probe', () => expect(1).toBe(${expected}));\n`;
+}
+
+function pythonSource(mode) {
+  if (mode === 'notExecuting') return 'import pytest\n\n@pytest.mark.skip(reason="intentional")\ndef test_probe():\n    pass\n';
+  const expected = mode === 'observed' ? 2 : 1;
+  return `def test_probe():\n    assert 1 == ${expected}\n`;
+}
+
+function rustSource(mode) {
+  const ignored = mode === 'notExecuting' ? '#[ignore]\n' : '';
+  const expected = mode === 'observed' ? 2 : 1;
+  return `${ignored}#[test]\nfn probe() { assert_eq!(1, ${expected}); }\n`;
+}
+
+function probeCommand(adapter, mode, dir) {
+  const file = join(dir, 'probe.test.mjs');
+  if (adapter.id === 'root-node-test' || adapter.id === 'node-test') {
+    writeFileSync(file, jsSource(mode));
+    return { cwd: dir, runner: adapter.probeRunner({ file, dir, root: ROOT }) };
+  }
+  if (adapter.id === 'vitest') {
+    const spec = join(dir, 'probe.test.js');
+    writeFileSync(spec, vitestSource(mode));
+    return { cwd: dir, runner: adapter.probeRunner({ file: spec, dir, root: ROOT }) };
+  }
+  if (adapter.id === 'python-pytest') {
+    const testFile = join(dir, 'test_probe.py');
+    writeFileSync(testFile, pythonSource(mode));
+    return { cwd: dir, runner: adapter.probeRunner({ file: testFile, dir, root: ROOT }) };
+  }
+  if (adapter.id === 'cargo') {
+    mkdirSync(join(dir, 'src'));
+    mkdirSync(join(dir, 'tests'));
+    writeFileSync(join(dir, 'Cargo.toml'), '[package]\nname="revert-oracle-selfcheck"\nversion="0.0.0"\nedition="2021"\n');
+    writeFileSync(join(dir, 'src/lib.rs'), 'pub fn marker() {}\n');
+    writeFileSync(join(dir, 'tests/probe.rs'), rustSource(mode));
+    return { cwd: dir, runner: adapter.probeRunner({ dir, root: ROOT }) };
+  }
+  if (adapter.id === 'typescript') {
+    const source = mode === 'observed' ? 'const value: 1 = 2;\n' : 'const value: 1 = 1;\n';
+    if (mode !== 'notExecuting') writeFileSync(join(dir, 'probe.ts'), source);
+    writeFileSync(join(dir, 'tsconfig.json'), JSON.stringify({ compilerOptions: { noEmit: true }, files: mode === 'notExecuting' ? [] : ['probe.ts'] }));
+    return { cwd: dir, runner: adapter.probeRunner({ dir, root: ROOT }) };
+  }
+  throw new Error(`adapter ${adapter.id} has no selfcheck probe`);
+}
+
+function runProbe(adapter, mode) {
+  const binary = resolveBinary(adapter);
+  if (!binary) throw new Error(`lost runner ${adapter.id}: ${adapter.binary} is unavailable`);
+  const dir = mkdtempSync(join(tmpdir(), `revert-oracle-${adapter.id}-`));
+  try {
+    const { cwd, runner } = probeCommand(adapter, mode, dir);
+    const run = spawnSync(binary.bin, [...binary.prefix, ...runner.args], {
+      cwd,
+      encoding: 'utf8',
+      timeout: 120_000,
+      maxBuffer: 32 * 1024 * 1024,
+      env: { ...process.env, CI: '1', FORCE_COLOR: '0', NO_COLOR: '1', CARGO_TARGET_DIR: join(dir, 'target') },
+    });
+    if (run.error) throw new Error(`lost runner ${adapter.id}: ${run.error.message}`);
+    if (runner.family === 'typecheck') {
+      const output = `${run.stdout ?? ''}\n${run.stderr ?? ''}`;
+      if (/TS18002/.test(output)) return { kind: 'no-tests' };
+      return { kind: run.status === 0 ? 'pass' : 'assertion-failure' };
+    }
+    return parseRunnerOutput({ family: runner.family, stdout: run.stdout ?? '', stderr: run.stderr ?? '', exitCode: run.status });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export function validateAdapterManifest(adapters = REVERT_ORACLE_ADAPTERS) {
+  const ids = new Set();
+  for (const adapter of adapters) {
+    if (!adapter.id || !adapter.family || !adapter.binary || typeof adapter.claim !== 'function' || typeof adapter.runner !== 'function' || typeof adapter.probeRunner !== 'function') {
+      throw new Error('every revert-oracle adapter needs id, family, binary, claim, runner and probeRunner');
+    }
+    if (ids.has(adapter.id)) throw new Error(`duplicate revert-oracle adapter id: ${adapter.id}`);
+    ids.add(adapter.id);
+  }
+}
+
+export function main(argv = process.argv.slice(2)) {
+  validateAdapterManifest();
+  const adapterFlag = argv.indexOf('--adapter');
+  const selected = adapterFlag === -1
+    ? REVERT_ORACLE_ADAPTERS
+    : REVERT_ORACLE_ADAPTERS.filter((adapter) => adapter.id === argv[adapterFlag + 1]);
+  if (selected.length === 0) throw new Error(`unknown selfcheck adapter: ${argv[adapterFlag + 1] ?? '(missing)'}`);
+  const failures = [];
+  for (const adapter of selected) {
+    for (const mode of Object.keys(EXPECTED_PROBES)) {
+      const actual = runProbe(adapter, mode);
+      const failure = validateSelfcheckResult(adapter.id, mode, actual);
+      console.log(`[selfcheck] ${adapter.id} ${mode}: ${actual.kind}`);
+      if (failure) failures.push(failure);
+    }
+  }
+  if (failures.length > 0) throw new Error(`revert-oracle selfcheck failed:\n${failures.join('\n')}`);
+  console.log(`[selfcheck] all ${selected.length} selected adapter(s) passed all three probes`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();

--- a/scripts/revert-oracle-selfcheck.test.mjs
+++ b/scripts/revert-oracle-selfcheck.test.mjs
@@ -19,8 +19,8 @@ test('#4109: adapter IDs are the executable supported-runner manifest', () => {
 
 test('#4109: corrupting one expected selfcheck value makes the selfcheck fail', () => {
   const corrupt = { ...EXPECTED_PROBES, observed: ['pass'] };
-  const failure = validateSelfcheckResult('node-test', 'observed', { kind: 'assertion-failure' }, corrupt);
-  assert.match(failure, /expected pass, got assertion-failure/);
+  const failure = validateSelfcheckResult('node-test', 'observed', { verdict: 'OBSERVED' }, corrupt);
+  assert.match(failure, /expected pass, got OBSERVED/);
 });
 
 test('#4109: removing runner provisioning fails by naming the lost adapter', () => {

--- a/scripts/revert-oracle-selfcheck.test.mjs
+++ b/scripts/revert-oracle-selfcheck.test.mjs
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { REVERT_ORACLE_ADAPTERS } from './lib/revert-oracle-adapters.mjs';
+import { EXPECTED_PROBES, validateAdapterManifest, validateSelfcheckResult } from './revert-oracle-selfcheck.mjs';
+
+test('#4109: adapter IDs are the executable supported-runner manifest', () => {
+  validateAdapterManifest();
+  assert.deepEqual(REVERT_ORACLE_ADAPTERS.map((adapter) => adapter.id), [
+    'cargo', 'python-pytest', 'root-node-test', 'vitest', 'node-test', 'typescript',
+  ]);
+});
+
+test('#4109: corrupting one expected selfcheck value makes the selfcheck fail', () => {
+  const corrupt = { ...EXPECTED_PROBES, observed: ['pass'] };
+  const failure = validateSelfcheckResult('node-test', 'observed', { kind: 'assertion-failure' }, corrupt);
+  assert.match(failure, /expected pass, got assertion-failure/);
+});
+
+test('#4109: removing runner provisioning fails by naming the lost adapter', () => {
+  const result = spawnSync(process.execPath, [resolve('scripts/revert-oracle-selfcheck.mjs'), '--adapter', 'python-pytest'], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: '' },
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /lost runner python-pytest: python3 is unavailable/);
+});
+
+test('#4109: a supported file has exactly one claimant and an unknown runner has none', () => {
+  const vitest = { kind: 'javascript', rootPackage: false, script: 'vitest run', file: 'src/a.test.ts' };
+  assert.equal(REVERT_ORACLE_ADAPTERS.filter((adapter) => adapter.claim(vitest)).length, 1);
+  assert.equal(REVERT_ORACLE_ADAPTERS.filter((adapter) => adapter.claim({ kind: 'go', file: 'x_test.go' })).length, 0);
+});


### PR DESCRIPTION
Fixes #4109

Separates capability failures from PR findings, requires exact per-test runtime evidence, covers every adapter with real self-check probes, restores dirty worktrees deterministically, and conservatively refuses ambiguous Rust module ownership including cfg/path aliases, comments, and string literals.

Validation: 191 oracle tests; all 18 adapter self-check probes; real CLI/Cargo alias attacks; module-size gate.

Adversarial plan and exact-head review: Astra GO at ca1a68e7f0733b7fb976e1077a56a9dd62688366.