### PR TITLE
fix(pointcloud): retain validated PLY normal provenance

### DIFF
--- a/.changeset/fix-ply-normal-provenance.md
+++ b/.changeset/fix-ply-normal-provenance.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/pointcloud': minor
+---
+
+Preserve invalid PLY normal provenance through streaming and exact worker transfers, and keep floating RGB normalization consistent across chunks.

--- a/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
@@ -8,13 +8,16 @@ import { act } from 'react';
 import { IfcParser } from '@ifc-lite/parser';
 import { Renderer } from '@ifc-lite/renderer';
 import { MutablePropertyView } from '@ifc-lite/mutations';
+import { decodePly } from '@ifc-lite/pointcloud';
 import { useViewerStore } from '@/store';
 import { fixtureModel } from '@/test/store-fixture';
 import { cleanup, render } from '@/test/render';
 import { emptyPlacementState } from '@/lib/model-placement/state';
 import { addPointsToScanCache, clearAllPointCloudScanCaches, getPointCloudScanSample, registerPointCloudScanCache, setPointCloudScanCacheOrigin } from '@/hooks/ingest/pointCloudScanCache';
+import { swapZupChunkToYup } from '@/hooks/ingest/pointCloudFrame';
 import { prepareScanSession } from '@/lib/appearance/scan/session';
 import { nativePointFromSample } from '@/lib/appearance/scan/point-source';
+import { transferSource } from '@/lib/appearance/scan/prepare-transfer';
 import { AppearanceScanPanel } from './AppearanceScanPanel';
 
 const initial = useViewerStore.getState();
@@ -29,14 +32,16 @@ async function fixture() {
   const store = await new IfcParser().parseColumnar(bytes.buffer, { disableWorkerScan: true });
   const target: ReturnType<typeof fixtureModel> = { ...fixtureModel('target'), maxExpressId: 10, ifcDataStore: store, schemaVersion: 'IFC4' as const };
   const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } };
-  const scan: ReturnType<typeof fixtureModel> = { ...fixtureModel('scan'), ifcDataStore: null, sourceFile: new File(['ply bytes'], 'room.ply'), pointCloudHandleId: HANDLE, loadState: 'complete',
+  const native = Array.from({ length: 8 }, (_, i) => [100 + i, 200 + (i % 3), 300 + (i % 2)]);
+  const ply = 'ply\nformat ascii 1.0\nelement vertex 8\nproperty float x\nproperty float y\nproperty float z\n'
+    + 'property uchar red\nproperty uchar green\nproperty uchar blue\nproperty float nx\nproperty float ny\nproperty float nz\nend_header\n'
+    + native.map(([x, y, z], i) => `${x} ${y} ${z} ${i * 20} 128 255 ${i + 1} ${i + 2} ${i + 3}`).join('\n') + '\n';
+  const scan: ReturnType<typeof fixtureModel> = { ...fixtureModel('scan'), ifcDataStore: null, sourceFile: new File([ply], 'room.ply'), pointCloudHandleId: HANDLE, loadState: 'complete',
     geometryResult: { meshes: [], pointClouds: [], totalTriangles: 0, totalVertices: 0, coordinateInfo: { originShift: { x: 0, y: 0, z: 0 }, originalBounds: bounds, shiftedBounds: bounds, hasLargeCoordinates: false } } };
   registerPointCloudScanCache(HANDLE, 1000);
   setPointCloudScanCacheOrigin(HANDLE, [100, 200, 300]);
   // Native (Z-up) points 101..108 around the origin, delivered Y-up decode-relative like the ingest does.
-  const native = Array.from({ length: 8 }, (_, i) => [100 + i, 200 + (i % 3), 300 + (i % 2)]);
-  const positions = new Float32Array(native.flatMap(([x, y, z]) => [x - 100, z - 300, -(y - 200)]));
-  addPointsToScanCache(HANDLE, { positions, colors: new Float32Array(native.flatMap((_, i) => [i / 8, 0.5, 1])), pointCount: 8 });
+  addPointsToScanCache(HANDLE, swapZupChunkToYup(decodePly(new TextEncoder().encode(ply), [100, 200, 300])));
   useViewerStore.setState({ models: new Map([['scan', scan], ['target', target]]), mutationViews: new Map([['target', new MutablePropertyView(store.properties, 'target')]]), mutationVersion: 0, modelPlacement: emptyPlacementState(), collabRoomId: null, sectionPlane: { ...initial.sectionPlane, enabled: false } });
   return { scan, target, native };
 }
@@ -48,12 +53,17 @@ test('a completely streamed point cloud is offered as a scan source with its ret
   if (session.source.kind !== 'points') throw new Error('unreachable');
   const { points } = session.source;
   assert.equal(points.count, 8);
+  assert.equal(points.normalState, 'supplied');
+  const planned = transferSource(session.source, { toleranceMetres: 0.01, reviewed: true, texelsPerMetre: 64,
+    maxDistanceMetres: 0.02, minNormalDot: 0.8, ambiguityDistanceMetres: 0.001, maxBehindMetres: 0.01,
+    neighborhoodRadiusMetres: 0.03, minNeighbors: 4, maxNeighbors: 32, surfaceBandMetres: 0.003 }).source;
+  assert.equal(planned.kind === 'points' && planned.orientation, 'source-normals');
   assert.match(session.sourceFrame.frameKey, /^pointcloud-native-z-up-metres-v1:[a-f0-9]{64}$/);
   assert.match(session.targetFrame.frameKey, /^workspace-ifc-z-up-metres:/);
   native.forEach((point, i) => assert.deepEqual(nativePointFromSample(points, i).map(v => Math.round(v * 1e4) / 1e4), point));
   assert.doesNotThrow(() => session.validate());
   // Another chunk reaching the reservoir means the pinned sample no longer describes the live scan.
-  addPointsToScanCache(HANDLE, { positions: new Float32Array([1, 1, 1]), pointCount: 1 });
+  addPointsToScanCache(HANDLE, { positions: new Float32Array([1, 1, 1]), normalState: 'absent', pointCount: 1 });
   assert.throws(() => session.validate(), /frame changed/);
   assert.equal(getPointCloudScanSample(HANDLE)!.count, 9);
 });

--- a/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
@@ -8,16 +8,19 @@ import { act } from 'react';
 import { IfcParser } from '@ifc-lite/parser';
 import { Renderer } from '@ifc-lite/renderer';
 import { MutablePropertyView } from '@ifc-lite/mutations';
-import { decodePly } from '@ifc-lite/pointcloud';
+import { PlyStreamingSource } from '@ifc-lite/pointcloud';
 import { useViewerStore } from '@/store';
 import { fixtureModel } from '@/test/store-fixture';
 import { cleanup, render } from '@/test/render';
 import { emptyPlacementState } from '@/lib/model-placement/state';
-import { addPointsToScanCache, clearAllPointCloudScanCaches, getPointCloudScanSample, registerPointCloudScanCache, setPointCloudScanCacheOrigin } from '@/hooks/ingest/pointCloudScanCache';
-import { swapZupChunkToYup } from '@/hooks/ingest/pointCloudFrame';
+import { addPointsToScanCache, clearAllPointCloudScanCaches, getPointCloudScanSample } from '@/hooks/ingest/pointCloudScanCache';
+import { ingestPointCloud } from '@/hooks/ingest/pointCloudIngest';
 import { prepareScanSession } from '@/lib/appearance/scan/session';
-import { nativePointFromSample } from '@/lib/appearance/scan/point-source';
+import { nativePointFromSample, pointTransferPayload } from '@/lib/appearance/scan/point-source';
 import { transferSource } from '@/lib/appearance/scan/prepare-transfer';
+import { createAppearancePlanner, type AppearanceWorker } from '@/lib/appearance/planner-worker-client';
+import type { AppearanceWorkerRequest } from '@/lib/appearance/planner-types';
+import type { MeshTransferRequest } from '@/lib/appearance/scan/transfer-types';
 import { AppearanceScanPanel } from './AppearanceScanPanel';
 
 const initial = useViewerStore.getState();
@@ -36,12 +39,20 @@ async function fixture() {
   const ply = 'ply\nformat ascii 1.0\nelement vertex 8\nproperty float x\nproperty float y\nproperty float z\n'
     + 'property uchar red\nproperty uchar green\nproperty uchar blue\nproperty float nx\nproperty float ny\nproperty float nz\nend_header\n'
     + native.map(([x, y, z], i) => `${x} ${y} ${z} ${i * 20} 128 255 ${i + 1} ${i + 2} ${i + 3}`).join('\n') + '\n';
-  const scan: ReturnType<typeof fixtureModel> = { ...fixtureModel('scan'), ifcDataStore: null, sourceFile: new File([ply], 'room.ply'), pointCloudHandleId: HANDLE, loadState: 'complete',
+  const scanFile = new File([ply], 'room.ply');
+  const scan: ReturnType<typeof fixtureModel> = { ...fixtureModel('scan'), ifcDataStore: null, sourceFile: scanFile, pointCloudHandleId: HANDLE, loadState: 'complete',
     geometryResult: { meshes: [], pointClouds: [], totalTriangles: 0, totalVertices: 0, coordinateInfo: { originShift: { x: 0, y: 0, z: 0 }, originalBounds: bounds, shiftedBounds: bounds, hasLargeCoordinates: false } } };
-  registerPointCloudScanCache(HANDLE, 1000);
-  setPointCloudScanCacheOrigin(HANDLE, [100, 200, 300]);
-  // Native (Z-up) points 101..108 around the origin, delivered Y-up decode-relative like the ingest does.
-  addPointsToScanCache(HANDLE, swapZupChunkToYup(decodePly(new TextEncoder().encode(ply), [100, 200, 300])));
+  const ingestRenderer = new Renderer(document.createElement('canvas'));
+  mock.method(ingestRenderer, 'beginPointCloudStream', () => ({ id: HANDLE }));
+  mock.method(ingestRenderer, 'setPointCloudTransform', () => {});
+  mock.method(ingestRenderer, 'appendPointCloudChunk', () => {});
+  mock.method(ingestRenderer, 'requestRender', () => {});
+  mock.method(ingestRenderer, 'endPointCloudStream', () => {});
+  mock.method(ingestRenderer, 'removePointCloudAsset', () => {});
+  const loaded = ingestPointCloud({ format: 'ply', blob: scanFile, fileName: scanFile.name,
+    fileSize: scanFile.size, renderer: ingestRenderer, maxScanCachePoints: 1000,
+    createSource: options => new PlyStreamingSource(options.blob, { downsample: { stride: options.stride ?? 1 }, originOffset: options.originOffset }) });
+  await loaded.done;
   useViewerStore.setState({ models: new Map([['scan', scan], ['target', target]]), mutationViews: new Map([['target', new MutablePropertyView(store.properties, 'target')]]), mutationVersion: 0, modelPlacement: emptyPlacementState(), collabRoomId: null, sectionPlane: { ...initial.sectionPlane, enabled: false } });
   return { scan, target, native };
 }
@@ -61,6 +72,31 @@ test('a completely streamed point cloud is offered as a scan source with its ret
   assert.match(session.sourceFrame.frameKey, /^pointcloud-native-z-up-metres-v1:[a-f0-9]{64}$/);
   assert.match(session.targetFrame.frameKey, /^workspace-ifc-z-up-metres:/);
   native.forEach((point, i) => assert.deepEqual(nativePointFromSample(points, i).map(v => Math.round(v * 1e4) / 1e4), point));
+  let delivered: AppearanceWorkerRequest | undefined;
+  const worker: AppearanceWorker = {
+    onmessage: null, onerror: null, onmessageerror: null,
+    postMessage(message) { delivered = structuredClone(message); },
+    terminate() {},
+  };
+  const planner = createAppearancePlanner({ workerFactory: () => worker });
+  const controller = new AbortController();
+  const request: MeshTransferRequest = { schema: 'IFC4', sourceRevision: session.revision, nextExpressId: session.nextExpressId,
+    productIds: [10], registration: { sourceFrame: session.sourceFrame, targetFrame: session.targetFrame, fit: [], heldOut: [] },
+    registrationSha256: 'a'.repeat(64), targetFromIfcWorld: { rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]], sourceAnchor: [0, 0, 0], targetAnchor: [0, 0, 0] },
+    source: planned, sourceImages: [], texelsPerMetre: 64, maxDistanceMetres: 0.02, minNormalDot: 0.8,
+    ambiguityDistanceMetres: 0.001, maxBehindMetres: 0.01 };
+  const pending = planner.pointTransfer(session.bytes, request, new Uint8Array(0),
+    { ...pointTransferPayload(points), stations: new Uint32Array(0) }, { signal: controller.signal });
+  assert.equal(delivered?.type, 'point-transfer');
+  if (delivered?.type !== 'point-transfer') throw new Error('point transfer did not reach the planner worker');
+  assert.equal(delivered.request.source.kind === 'points' && delivered.request.source.orientation, 'source-normals');
+  assert.equal(delivered.points.normals.length, 24);
+  assert.deepEqual(Array.from(delivered.points.normals.slice(0, 3)).map(v => Math.round(v * 1e6) / 1e6),
+    [1, 2, 3].map(v => v / Math.sqrt(14)).map(v => Math.round(v * 1e6) / 1e6));
+  assert.deepEqual(Array.from(delivered.points.positions.slice(0, 3)), native[0]);
+  controller.abort();
+  await assert.rejects(pending, { name: 'AbortError' });
+  planner.dispose();
   assert.doesNotThrow(() => session.validate());
   // Another chunk reaching the reservoir means the pinned sample no longer describes the live scan.
   addPointsToScanCache(HANDLE, { positions: new Float32Array([1, 1, 1]), normalState: 'absent', pointCount: 1 });

--- a/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
+++ b/apps/viewer/src/components/viewer/appearance/AppearanceScanPanel.points.test.tsx
@@ -4,6 +4,7 @@
 import '@/test/setup-dom.js';
 import { afterEach, mock, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
 import { act } from 'react';
 import { IfcParser } from '@ifc-lite/parser';
 import { Renderer } from '@ifc-lite/renderer';
@@ -17,9 +18,10 @@ import { addPointsToScanCache, clearAllPointCloudScanCaches, getPointCloudScanSa
 import { ingestPointCloud } from '@/hooks/ingest/pointCloudIngest';
 import { prepareScanSession } from '@/lib/appearance/scan/session';
 import { nativePointFromSample, pointTransferPayload } from '@/lib/appearance/scan/point-source';
-import { transferSource } from '@/lib/appearance/scan/prepare-transfer';
+import { prepareMeshTransfer, transferSource } from '@/lib/appearance/scan/prepare-transfer';
 import { createAppearancePlanner, type AppearanceWorker } from '@/lib/appearance/planner-worker-client';
 import type { AppearanceWorkerRequest } from '@/lib/appearance/planner-types';
+import type { ScanCorrespondence, ScanRegistrationRequest } from '@/lib/appearance/scan/types';
 import type { MeshTransferRequest } from '@/lib/appearance/scan/transfer-types';
 import { AppearanceScanPanel } from './AppearanceScanPanel';
 
@@ -33,15 +35,18 @@ const HANDLE = 41;
 async function fixture() {
   const bytes = new TextEncoder().encode("ISO-10303-21;HEADER;FILE_DESCRIPTION(('point alignment'),'2;1');FILE_NAME('target.ifc','',(''),(''),'','','');FILE_SCHEMA(('IFC4'));ENDSEC;DATA;#10=IFCWALL('0Wall00000000000000001',$,'Wall',$,$,$,$,$,.NOTDEFINED.);ENDSEC;END-ISO-10303-21;");
   const store = await new IfcParser().parseColumnar(bytes.buffer, { disableWorkerScan: true });
-  const target: ReturnType<typeof fixtureModel> = { ...fixtureModel('target'), maxExpressId: 10, ifcDataStore: store, schemaVersion: 'IFC4' as const };
   const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } };
+  const emptyGeometry = { meshes: [], pointClouds: [], totalTriangles: 0, totalVertices: 0,
+    coordinateInfo: { originShift: { x: 0, y: 0, z: 0 }, originalBounds: bounds, shiftedBounds: bounds, hasLargeCoordinates: false } };
+  const target: ReturnType<typeof fixtureModel> = { ...fixtureModel('target'), maxExpressId: 10, ifcDataStore: store,
+    schemaVersion: 'IFC4' as const, geometryResult: emptyGeometry };
   const native = Array.from({ length: 8 }, (_, i) => [100 + i, 200 + (i % 3), 300 + (i % 2)]);
   const ply = 'ply\nformat ascii 1.0\nelement vertex 8\nproperty float x\nproperty float y\nproperty float z\n'
     + 'property uchar red\nproperty uchar green\nproperty uchar blue\nproperty float nx\nproperty float ny\nproperty float nz\nend_header\n'
     + native.map(([x, y, z], i) => `${x} ${y} ${z} ${i * 20} 128 255 ${i + 1} ${i + 2} ${i + 3}`).join('\n') + '\n';
   const scanFile = new File([ply], 'room.ply');
   const scan: ReturnType<typeof fixtureModel> = { ...fixtureModel('scan'), ifcDataStore: null, sourceFile: scanFile, pointCloudHandleId: HANDLE, loadState: 'complete',
-    geometryResult: { meshes: [], pointClouds: [], totalTriangles: 0, totalVertices: 0, coordinateInfo: { originShift: { x: 0, y: 0, z: 0 }, originalBounds: bounds, shiftedBounds: bounds, hasLargeCoordinates: false } } };
+    geometryResult: emptyGeometry };
   const ingestRenderer = new Renderer(document.createElement('canvas'));
   mock.method(ingestRenderer, 'beginPointCloudStream', () => ({ id: HANDLE }));
   mock.method(ingestRenderer, 'setPointCloudTransform', () => {});
@@ -102,6 +107,45 @@ test('a completely streamed point cloud is offered as a scan source with its ret
   addPointsToScanCache(HANDLE, { positions: new Float32Array([1, 1, 1]), normalState: 'absent', pointCount: 1 });
   assert.throws(() => session.validate(), /frame changed/);
   assert.equal(getPointCloudScanSample(HANDLE)!.count, 9);
+});
+
+test('the bounded PLY ingest completes the Rust planner with retained source normals (#4561)', async t => {
+  const wasmUrl = new URL('../../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
+  try { await access(wasmUrl); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    t.skip('Build WASM with pnpm build:wasm to run the completed point-transfer journey'); return;
+  }
+  const { native } = await fixture();
+  const session = await prepareScanSession('scan', 'points', 'target', new AbortController().signal);
+  if (session.source.kind !== 'points') throw new Error('fixture did not retain its streamed PLY');
+  const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
+  await init({ module_or_path: await readFile(wasmUrl) });
+  const { runPointTransfer } = await import('@/workers/appearance.worker');
+  const api = new IfcAPI();
+  const pairs: ScanCorrespondence[] = native.map((point, index) => ({ id: `p${index}`, sourceObservation: `point:${index}:seen:8`,
+    targetFeature: `target-${index}`, source: [point[0], point[1], point[2]], target: [point[0], point[1], point[2]] }));
+  const registration: ScanRegistrationRequest = { sourceFrame: session.sourceFrame, targetFrame: session.targetFrame, fit: pairs.slice(0, 4), heldOut: pairs.slice(4) };
+  try {
+    const report = JSON.parse(new TextDecoder().decode(api.registerScanCorrespondences(JSON.stringify(registration)))) as import('@/lib/appearance/scan/types').ScanRegistrationReport;
+    const settings = { toleranceMetres: 0.01, reviewed: true, texelsPerMetre: 64, maxDistanceMetres: 0.02,
+      minNormalDot: 0.8, ambiguityDistanceMetres: 0.001, maxBehindMetres: 0.01,
+      neighborhoodRadiusMetres: 0.03, minNeighbors: 4, maxNeighbors: 32, surfaceBandMetres: 0.003 };
+    let deliveredRows = 0;
+    const worker: AppearanceWorker = { onmessage: null, onerror: null, onmessageerror: null, terminate() {}, postMessage(message) {
+      if (message.type !== 'point-transfer') throw new Error(`unexpected planner job ${message.type}`);
+      deliveredRows = message.points.normals.length / 3;
+      void runPointTransfer(message.source, message.request, message.rgba, message.points).then(result => {
+        worker.onmessage?.({ data: { type: 'mesh-transfer-complete', id: message.id, result } } as MessageEvent);
+      }, error => worker.onerror?.({ message: error instanceof Error ? error.message : String(error) } as ErrorEvent));
+    } };
+    const planner = createAppearancePlanner({ workerFactory: () => worker });
+    try {
+      const result = await prepareMeshTransfer(session, { request: registration, report }, [10], settings, planner,
+        { kind: 'draft', id: 'ply-normal-journey' }, new AbortController().signal);
+      assert.equal(deliveredRows, 8);
+      assert.deepEqual(result.transfer.source, { kind: 'points', orientation: 'source-normals', pointCount: 8 });
+    } finally { planner.dispose(); }
+  } finally { api.free(); }
 });
 
 test('the workbench lists the point cloud and mounts the point preview through the real session, not a GLB path (#4381)', async () => {

--- a/apps/viewer/src/hooks/ingest/pointCloudFrame.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudFrame.test.ts
@@ -9,7 +9,7 @@ import type { DecodedPointChunk } from '@ifc-lite/pointcloud';
 test('Z-up ingest rotates source normals with positions without mutating the decoder arrays (#4561)', () => {
   const positions = new Float32Array([1, 2, 3, 4, 5, 6]);
   const normals = new Float32Array([0.1, 0.2, 0.3, -0.4, -0.5, -0.6]);
-  const chunk: DecodedPointChunk = { positions, normals, pointCount: 2, bbox: { min: [1, 2, 3], max: [4, 5, 6] } };
+  const chunk: DecodedPointChunk = { positions, normals, normalState: 'supplied', pointCount: 2, bbox: { min: [1, 2, 3], max: [4, 5, 6] } };
   const yUp = swapZupChunkToYup(chunk);
   assert.deepEqual(Array.from(yUp.positions), [1, 3, -2, 4, 6, -5]);
   assert.deepEqual(Array.from(yUp.normals!), [0.1, 0.3, -0.2, -0.4, -0.6, 0.5].map(Math.fround));

--- a/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudIngest.ts
@@ -19,6 +19,7 @@ import {
   createClassificationCounts,
   streamPointCloud,
   type DecodedPointChunk,
+  type StreamPointCloudOptions,
   type StreamHandle,
 } from '@ifc-lite/pointcloud';
 import type { CoordinateInfo, GeometryResult, PointCloudAsset } from '@ifc-lite/geometry';
@@ -123,6 +124,8 @@ export interface PointCloudIngestOptions {
   onClassCounts?: (handleId: number, counts: Record<number, number> | null) => void;
   /** Abort signal to cancel ingest. */
   signal?: AbortSignal;
+  /** In-process decoder seam used by integration tests; production uses the worker source. */
+  createSource?: StreamPointCloudOptions['createSource'];
   /**
    * IfcMapConversion-derived alignment transform for this scan (issue
    * #1804), computed by the caller from the reference model's
@@ -378,6 +381,7 @@ export function ingestPointCloud(opts: PointCloudIngestOptions): PointCloudInges
       maxPointsInMemory: opts.maxPointsInMemory,
       maxFileSize: opts.maxFileSize,
       signal: opts.signal,
+      createSource: opts.createSource,
       autoOrigin: true,
       onOpen: (info) => {
         if (info.originOffset) { retargetPointCloudDecodeOrigin(opts.renderer, handle, info.originOffset); setPointCloudScanCacheOrigin(handle.id, info.originOffset); }

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.test.ts
@@ -12,14 +12,14 @@ import {
   clearAllPointCloudScanCaches,
 } from './pointCloudScanCache.js';
 
-function makeChunk(count: number, startAt = 0): { positions: Float32Array; pointCount: number } {
+function makeChunk(count: number, startAt = 0): { positions: Float32Array; normalState: 'absent'; pointCount: number } {
   const positions = new Float32Array(count * 3);
   for (let i = 0; i < count; i++) {
     positions[i * 3] = startAt + i;
     positions[i * 3 + 1] = 0;
     positions[i * 3 + 2] = 0;
   }
-  return { positions, pointCount: count };
+  return { positions, normalState: 'absent', pointCount: count };
 }
 
 describe('pointCloudScanCache', () => {
@@ -58,6 +58,7 @@ describe('pointCloudScanCache', () => {
       positions: new Float32Array([1, 2, 3]),
       colors: new Float32Array([1, 0, 0]),
       normals: new Float32Array([0.1, 0.2, 0.3]),
+      normalState: 'supplied' as const,
       classifications: new Uint8Array([5]),
       pointCount: 1,
     };
@@ -71,17 +72,30 @@ describe('pointCloudScanCache', () => {
 
   it('replaces position, colour and normal as one reservoir row and refuses misaligned channels (#4561)', () => {
     registerPointCloudScanCache(10, 1);
-    addPointsToScanCache(10, { positions: new Float32Array([1, 2, 3]), colors: new Float32Array([1, 0, 0]), normals: new Float32Array([1, 0, 0]), pointCount: 1 });
+    addPointsToScanCache(10, { positions: new Float32Array([1, 2, 3]), colors: new Float32Array([1, 0, 0]), normals: new Float32Array([1, 0, 0]), normalState: 'supplied', pointCount: 1 });
     const random = Math.random;
     Math.random = () => 0;
     try {
-      addPointsToScanCache(10, { positions: new Float32Array([4, 5, 6]), colors: new Float32Array([0, 1, 0]), normals: new Float32Array([0, 0, 1]), pointCount: 1 });
+      addPointsToScanCache(10, { positions: new Float32Array([4, 5, 6]), colors: new Float32Array([0, 1, 0]), normals: new Float32Array([0, 0, 1]), normalState: 'supplied', pointCount: 1 });
     } finally { Math.random = random; }
     const sample = getPointCloudScanSample(10)!;
     assert.deepEqual(Array.from(sample.positions), [4, 5, 6]);
     assert.deepEqual(Array.from(sample.colors!), [0, 255, 0]);
     assert.deepEqual(Array.from(sample.normals!), [0, 0, 1]);
-    assert.throws(() => addPointsToScanCache(10, { positions: new Float32Array(6), normals: new Float32Array(3), pointCount: 2 }), /row-aligned/);
+    assert.throws(() => addPointsToScanCache(10, { positions: new Float32Array(6), normals: new Float32Array(3), normalState: 'supplied', pointCount: 2 }), /row-aligned/);
+  });
+
+  it('latches invalid normal provenance even when no row from that chunk enters a full reservoir', () => {
+    registerPointCloudScanCache(11, 1);
+    addPointsToScanCache(11, makeChunk(1));
+    const random = Math.random;
+    Math.random = () => 0.99;
+    try {
+      addPointsToScanCache(11, { positions: new Float32Array([4, 5, 6]), normals: new Float32Array([Number.NaN, 0, 1]), normalState: 'invalid', pointCount: 1 });
+    } finally { Math.random = random; }
+    const sample = getPointCloudScanSample(11)!;
+    assert.equal(sample.normals, null);
+    assert.equal(sample.normalState, 'invalid');
   });
 
   it('removePointCloudScanCache drops the sample', () => {
@@ -129,7 +143,7 @@ describe('pointCloudScanCache', () => {
       colors[i * 3] = (i % 256) / 255;
       classifications[i] = i % 256;
     }
-    addPointsToScanCache(8, { positions, colors, classifications, pointCount: total });
+    addPointsToScanCache(8, { positions, colors, classifications, normalState: 'absent', pointCount: total });
 
     const sample = getPointCloudScanSample(8)!;
     assert.strictEqual(sample.count, total);
@@ -142,10 +156,11 @@ describe('pointCloudScanCache', () => {
 
   it('backfills neutral grey for points retained before the first coloured chunk', () => {
     registerPointCloudScanCache(7, 10);
-    addPointsToScanCache(7, { positions: new Float32Array([1, 2, 3]), pointCount: 1 });
+    addPointsToScanCache(7, { positions: new Float32Array([1, 2, 3]), normalState: 'absent', pointCount: 1 });
     addPointsToScanCache(7, {
       positions: new Float32Array([4, 5, 6]),
       colors: new Float32Array([1, 0, 0]),
+      normalState: 'absent',
       pointCount: 1,
     });
     const sample = getPointCloudScanSample(7)!;

--- a/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
+++ b/apps/viewer/src/hooks/ingest/pointCloudScanCache.ts
@@ -25,7 +25,9 @@
  * error or when `usePointCloudLifecycle` frees the GPU asset for a removed
  * model — mirroring the classification-histogram cleanup already done
  * there so this cache can't outlive its point cloud.
- */
+*/
+
+import type { PointNormalState } from '@ifc-lite/pointcloud';
 
 /** Points retained per asset by default — at most 28 bytes/point with normals, ≈ 56 MB at the cap. */
 export const DEFAULT_SCAN_CACHE_CAPACITY = 2_000_000;
@@ -35,6 +37,7 @@ export interface RetainedPointCloudSample {
   colors: Uint8Array | null;
   /** Source-supplied Y-up normals, or null when no streamed row declared normals. */
   normals: Float32Array | null;
+  normalState: PointNormalState;
   classifications: Uint8Array | null;
   /** Points actually held in the reservoir (<= capacity). */
   count: number;
@@ -78,6 +81,7 @@ function createReservoir(capacity: number): ReservoirCache {
     positions: new Float32Array(allocated * 3),
     colors: null,
     normals: null,
+    normalState: 'absent',
     classifications: null,
     count: 0,
     seen: 0,
@@ -223,16 +227,27 @@ export function setPointCloudScanCacheOrigin(handleId: number, origin: readonly 
  */
 export function addPointsToScanCache(
   handleId: number,
-  chunk: { positions: Float32Array; colors?: Float32Array; normals?: Float32Array; classifications?: Uint8Array; pointCount: number },
+  chunk: { positions: Float32Array; colors?: Float32Array; normals?: Float32Array; normalState: PointNormalState; classifications?: Uint8Array; pointCount: number },
 ): void {
   const cache = caches.get(handleId);
   if (!cache) return;
   if (!Number.isInteger(chunk.pointCount) || chunk.pointCount < 0 || chunk.positions.length !== chunk.pointCount * 3
     || (chunk.colors !== undefined && chunk.colors.length !== chunk.pointCount * 3)
     || (chunk.normals !== undefined && chunk.normals.length !== chunk.pointCount * 3)
-    || (chunk.classifications !== undefined && chunk.classifications.length !== chunk.pointCount)) {
+    || (chunk.classifications !== undefined && chunk.classifications.length !== chunk.pointCount)
+    || (chunk.normalState === 'supplied' && chunk.normals === undefined)) {
     throw new Error('Point-cloud chunk channels must contain one complete, row-aligned value per point.');
   }
+  let incomingState = chunk.normalState;
+  if (incomingState === 'supplied') {
+    for (let i = 0; i < chunk.normals!.length; i += 3) {
+      const x = chunk.normals![i], y = chunk.normals![i + 1], z = chunk.normals![i + 2];
+      if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z) || x * x + y * y + z * z === 0) incomingState = 'invalid';
+    }
+  } else if (chunk.normals) incomingState = 'invalid';
+  if (cache.normalState === 'invalid' || incomingState === 'invalid'
+    || (cache.seen > 0 && cache.normalState !== incomingState)) cache.normalState = 'invalid';
+  else cache.normalState = incomingState;
   const { capacity } = cache;
   for (let i = 0; i < chunk.pointCount; i++) {
     const seenIndex = cache.seen++;

--- a/apps/viewer/src/hooks/useScanSectionLayer.placement.test.tsx
+++ b/apps/viewer/src/hooks/useScanSectionLayer.placement.test.tsx
@@ -23,7 +23,7 @@ it('uses the final GPU world matrix without applying IFC RTC a second time (#422
   setGlobalRendererRef({ current: renderer });
   useViewerStore.setState({ ...fixtureModels({ ...fixtureModel('scan'), pointCloudHandleId: 7 }), pointCloudAlignmentEnabled: false });
   registerPointCloudScanCache(7, 1);
-  addPointsToScanCache(7, { positions: new Float32Array([1, 0, 0]), pointCount: 1 });
+  addPointsToScanCache(7, { positions: new Float32Array([1, 0, 0]), normalState: 'absent', pointCount: 1 });
   const bounds = { min: { x: 1000, y: 0, z: 0 }, max: { x: 1010, y: 1, z: 1 } };
   function Scan() {
     const result = useScanSectionLayer({ enabled: true, thickness: 0.01,

--- a/apps/viewer/src/lib/appearance/scan/point-source.test.ts
+++ b/apps/viewer/src/lib/appearance/scan/point-source.test.ts
@@ -14,7 +14,9 @@ function retained(native: number[][], origin: readonly [number, number, number] 
   native.forEach(([x, y, z], i) => { const o = origin ?? [0, 0, 0]; positions.set([x - o[0], z - o[2], -(y - o[1])], i * 3); });
   const normals = nativeNormals ? new Float32Array(nativeNormals.length) : null;
   if (normals) for (let i = 0; i < native.length; i++) normals.set([nativeNormals![i * 3], nativeNormals![i * 3 + 2], -nativeNormals![i * 3 + 1]], i * 3);
-  return { positions, colors: colors ? Uint8Array.from(colors) : null, normals, classifications: null, count: native.length, seen: native.length * 10, capacity: 2_000_000, origin };
+  return { positions, colors: colors ? Uint8Array.from(colors) : null, normals,
+    normalState: normals ? 'supplied' : 'absent', classifications: null,
+    count: native.length, seen: native.length * 10, capacity: 2_000_000, origin };
 }
 
 test('retained sample positions map back to the file\'s native Z-up metres exactly, including a georeferenced decode origin (#4381)', () => {
@@ -128,6 +130,7 @@ test('qualified PLY normals survive snapshot/frame conversion and select source-
   assert.equal(request.kind === 'points' && request.orientation, 'source-normals');
   const payload = pointTransferPayload(points);
   assert.deepEqual(Array.from(payload.normals), [1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0, 0]);
+  assert.throws(() => transferSource({ kind: 'points', points: { ...points, normalState: 'absent' } }, settings), /provenance.*no longer matches/i);
   assert.deepEqual(Array.from(sample.normals!, value => value === 0 ? 0 : value), [2, 0, 0, 0, 0, -1, 0, 1, 0, -1, 0, 0], 'live Y-up source stays unchanged');
   sample.normals![0] = 0;
   assert.equal(samePointSource(points, sample), false, 'mutating only the live normal channel invalidates the session');

--- a/apps/viewer/src/lib/appearance/scan/point-source.ts
+++ b/apps/viewer/src/lib/appearance/scan/point-source.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import type { Ray } from '@ifc-lite/renderer';
 import type { RetainedPointCloudSample } from '@/hooks/ingest/pointCloudScanCache';
+import type { PointNormalState } from '@ifc-lite/pointcloud';
 import type { ScanLandmark, ScanPoint, ScanRegistrationReport } from './types';
 import { registeredPoint } from './landmarks';
 
@@ -37,6 +38,7 @@ export interface ScanPointSource {
   hadColors: boolean;
   /** Source-supplied decode-relative Y-up normals, 3n, or null when absent. */
   normals: Float32Array | null;
+  normalState: PointNormalState;
   /** The retained sample this snapshot was taken from, for identity checks. */
   retained: RetainedPointCloudSample;
 }
@@ -46,11 +48,12 @@ export function snapshotPointSource(handleId: number, retained: RetainedPointClo
   const positions = retained.positions.slice(0, retained.count * 3);
   const colors = retained.colors ? retained.colors.slice(0, retained.count * 3) : new Uint8Array(retained.count * 3).fill(200);
   const normals = retained.normals?.slice(0, retained.count * 3) ?? null;
-  return { handleId, count: retained.count, seen: retained.seen, origin: retained.origin ? [...retained.origin] : null, positions, colors, hadColors: retained.colors !== null, normals, retained };
+  return { handleId, count: retained.count, seen: retained.seen, origin: retained.origin ? [...retained.origin] : null, positions, colors, hadColors: retained.colors !== null, normals, normalState: retained.normalState, retained };
 }
 /** True while the snapshot still describes the live reservoir. */
 export function samePointSource(snapshot: ScanPointSource, live: RetainedPointCloudSample | null): boolean {
   return live === snapshot.retained && live.count === snapshot.count && live.seen === snapshot.seen
+    && live.normalState === snapshot.normalState
     && (live.origin === null ? snapshot.origin === null : snapshot.origin !== null && live.origin.every((v, i) => v === snapshot.origin![i]))
     && equalPrefix(live.positions, snapshot.positions)
     && (live.colors === null ? !snapshot.hadColors && neutralColors(snapshot.colors) : snapshot.hadColors && equalPrefix(live.colors, snapshot.colors))
@@ -67,6 +70,9 @@ function neutralColors(colors: Uint8Array): boolean {
 }
 /** Choose the planner orientation without silently ignoring malformed supplied normals. */
 export function pointSourceOrientation(source: ScanPointSource): 'source-normals' | 'target-referenced' {
+  if (source.normalState === 'invalid') throw new Error('This PLY declares incomplete or unusable normals. Repair or remove its nx/ny/nz channels before transfer.');
+  if (source.normalState === 'supplied' && !source.normals) throw new Error('The point cloud lost its supplied normal rows. Reload the scan.');
+  if (source.normalState === 'absent' && source.normals) throw new Error('The point cloud normal provenance no longer matches its retained rows. Reload the scan.');
   if (!source.normals) return 'target-referenced';
   if (source.normals.length !== source.count * 3) throw new Error('The point cloud normal rows no longer match its retained points. Reload the scan.');
   for (let i = 0; i < source.count; i++) {

--- a/packages/pointcloud/README.md
+++ b/packages/pointcloud/README.md
@@ -32,9 +32,10 @@ if (chunk) {
 `DecodedPointChunk.normals` carries source-supplied oriented normals as
 row-aligned `nx, ny, nz` float triples when a decoder provides them. PLY
 supports complete `nx`/`ny`/`nz` properties in ASCII and binary files and
-preserves their values and vertex order exactly. A partial normal declaration
-is rejected; consumers decide whether finite, nonzero normals are required for
-their operation.
+preserves their values and vertex order exactly. Partial, duplicate, list-valued,
+non-finite, and zero normal declarations leave XYZ loadable but set
+`normalState: 'invalid'`; consumers decide whether valid normals are required
+for their operation.
 
 The canonical PLY streaming source scans headers and bounds in bounded byte
 windows, then decodes directly into host-sized, stride-filtered chunks. A
@@ -61,6 +62,12 @@ const source = createDecodeWorkerSource({ format: 'las', blob: file });
 const info = await source.open();
 // drive source.next(maxPoints) → DecodedPointChunk until it returns null
 ```
+
+PLY chunks retain complete scalar `nx`/`ny`/`nz` channels as raw, row-aligned
+`Float32Array` values. `normalState` explicitly distinguishes `supplied`,
+`absent`, and `invalid` declarations; consumers must not silently treat an
+invalid declaration as an un-oriented scan. Stride sampling and worker
+transfer keep each normal with the same position and colour row.
 
 Notes:
 

--- a/packages/pointcloud/src/formats/ascii-points.ts
+++ b/packages/pointcloud/src/formats/ascii-points.ts
@@ -294,6 +294,7 @@ export function decodeAsciiPointsFromText(
   return {
     positions: written === dataLineCount ? positions : new Float32Array(trimmedPositions),
     colors,
+    normalState: 'absent',
     intensities,
     pointCount: written,
     bbox,

--- a/packages/pointcloud/src/formats/e57-decode.ts
+++ b/packages/pointcloud/src/formats/e57-decode.ts
@@ -594,7 +594,7 @@ function finalize(
   pointCount: number,
 ): DecodedPointChunk {
   return {
-    positions: new Float32Array(positions),
+    positions: new Float32Array(positions), normalState: 'absent',
     colors: colors ? new Float32Array(colors) : undefined,
     intensities: intensities ? new Uint16Array(intensities) : undefined,
     classifications: classifications ? new Uint8Array(classifications) : undefined,

--- a/packages/pointcloud/src/formats/e57.ts
+++ b/packages/pointcloud/src/formats/e57.ts
@@ -98,6 +98,7 @@ export function decodeE57(
   return {
     positions,
     colors,
+    normalState: 'absent',
     intensities,
     classifications,
     pointCount: total,

--- a/packages/pointcloud/src/formats/ifcx-points.ts
+++ b/packages/pointcloud/src/formats/ifcx-points.ts
@@ -73,6 +73,7 @@ export function decodePointsArray(attr: PointsArrayAttribute): DecodedPointChunk
   return {
     positions,
     colors,
+    normalState: 'absent',
     pointCount: count,
     bbox: computeBBox(positions),
   };
@@ -108,6 +109,7 @@ export function decodePointsBase64(attr: PointsBase64Attribute): DecodedPointChu
   return {
     positions,
     colors,
+    normalState: 'absent',
     pointCount: count,
     bbox: computeBBox(positions),
   };

--- a/packages/pointcloud/src/formats/las.ts
+++ b/packages/pointcloud/src/formats/las.ts
@@ -279,6 +279,7 @@ export function decodeLasPoints(
   return {
     positions,
     colors,
+    normalState: 'absent',
     classifications,
     intensities,
     pointCount: count,

--- a/packages/pointcloud/src/formats/pcd.ts
+++ b/packages/pointcloud/src/formats/pcd.ts
@@ -90,7 +90,7 @@ export function decodePcd(
   }
 
   return {
-    positions,
+    positions, normalState: 'absent',
     colors,
     pointCount: header.pointCount,
     bbox: computeBBox(positions),

--- a/packages/pointcloud/src/formats/ply-color.ts
+++ b/packages/pointcloud/src/formats/ply-color.ts
@@ -18,6 +18,12 @@ function isFloatColorType(type: string): boolean {
   return type === 'float' || type === 'float32' || type === 'double' || type === 'float64';
 }
 
+/** Match the value that will actually survive assignment into the Float32 RGB buffer. */
+export function floatColorSelectsByteRange(value: number, type: string): boolean {
+  const stored = Math.fround(value);
+  return isFloatColorType(type) && Number.isFinite(stored) && stored > 1;
+}
+
 /**
  * Normalize a decoded RGB channel value to 0..1.
  *
@@ -88,7 +94,7 @@ export function normalizePlyColors(
   types: readonly [string, string, string],
 ): void {
   const floatUsesByteRange = colors.some(
-    (value, index) => isFloatColorType(types[index % 3]) && Number.isFinite(value) && value > 1,
+    (value, index) => floatColorSelectsByteRange(value, types[index % 3]),
   );
   for (let index = 0; index < colors.length; index++) {
     colors[index] = normalizeColorChannel(colors[index], types[index % 3], floatUsesByteRange);

--- a/packages/pointcloud/src/formats/ply-fixed-binary.ts
+++ b/packages/pointcloud/src/formats/ply-fixed-binary.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PlyPropertyDecl } from './ply.js';
+
+interface FixedBinaryLayout {
+  count: number;
+  recordSize: number;
+  properties: PlyPropertyDecl[];
+}
+
+export function decodeFixedBinaryPlyBody(
+  view: DataView, vertex: FixedBinaryLayout, positions: Float32Array,
+  colors: Float32Array | undefined, normals: Float32Array | undefined,
+  intensities: Uint16Array | undefined, littleEndian: boolean,
+  originOffset?: readonly [number, number, number],
+): void {
+  const offX = originOffset?.[0] ?? 0;
+  const offY = originOffset?.[1] ?? 0;
+  const offZ = originOffset?.[2] ?? 0;
+  const find = (name: string) => vertex.properties.find((property) => property.name === name);
+  const xProp = find('x')!;
+  const yProp = find('y')!;
+  const zProp = find('z')!;
+  const rProp = colors ? find('red') ?? find('r') : undefined;
+  const gProp = colors ? find('green') ?? find('g') : undefined;
+  const bProp = colors ? find('blue') ?? find('b') : undefined;
+  const nxProp = normals ? find('nx') : undefined;
+  const nyProp = normals ? find('ny') : undefined;
+  const nzProp = normals ? find('nz') : undefined;
+  const iProp = intensities ? find('intensity') ?? find('scalar_Intensity') : undefined;
+
+  for (let i = 0; i < vertex.count; i++) {
+    const base = i * vertex.recordSize;
+    positions[i * 3] = readScalar(view, base + xProp.offset, xProp.type, littleEndian) - offX;
+    positions[i * 3 + 1] = readScalar(view, base + yProp.offset, yProp.type, littleEndian) - offY;
+    positions[i * 3 + 2] = readScalar(view, base + zProp.offset, zProp.type, littleEndian) - offZ;
+    if (colors && rProp && gProp && bProp) {
+      colors[i * 3] = readScalar(view, base + rProp.offset, rProp.type, littleEndian);
+      colors[i * 3 + 1] = readScalar(view, base + gProp.offset, gProp.type, littleEndian);
+      colors[i * 3 + 2] = readScalar(view, base + bProp.offset, bProp.type, littleEndian);
+    }
+    if (normals && nxProp && nyProp && nzProp) {
+      normals[i * 3] = readScalar(view, base + nxProp.offset, nxProp.type, littleEndian);
+      normals[i * 3 + 1] = readScalar(view, base + nyProp.offset, nyProp.type, littleEndian);
+      normals[i * 3 + 2] = readScalar(view, base + nzProp.offset, nzProp.type, littleEndian);
+    }
+    if (intensities && iProp) {
+      intensities[i] = Math.min(65535, Math.max(0, readScalar(view, base + iProp.offset, iProp.type, littleEndian) | 0));
+    }
+  }
+}
+
+function readScalar(view: DataView, offset: number, type: string, littleEndian: boolean): number {
+  switch (type) {
+    case 'char': case 'int8': return view.getInt8(offset);
+    case 'uchar': case 'uint8': return view.getUint8(offset);
+    case 'short': case 'int16': return view.getInt16(offset, littleEndian);
+    case 'ushort': case 'uint16': return view.getUint16(offset, littleEndian);
+    case 'int': case 'int32': return view.getInt32(offset, littleEndian);
+    case 'uint': case 'uint32': return view.getUint32(offset, littleEndian);
+    case 'float': case 'float32': return view.getFloat32(offset, littleEndian);
+    case 'double': case 'float64': return view.getFloat64(offset, littleEndian);
+    default: throw new Error(`PLY: cannot read scalar of type "${type}"`);
+  }
+}

--- a/packages/pointcloud/src/formats/ply-variable-row.ts
+++ b/packages/pointcloud/src/formats/ply-variable-row.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PlyPropertyOrderEntry } from './ply.js';
+import { readPlyScalar } from './ply-scalar.js';
+
+export function parseAsciiVariableRow(tokens: readonly string[], order: readonly PlyPropertyOrderEntry[], row: number): Map<string, number> {
+  const values = new Map<string, number>();
+  let cursor = 0;
+  for (const entry of order) {
+    if (entry.kind === 'scalar') {
+      if (cursor >= tokens.length) throw new Error(`PLY ascii: vertex row ${row + 1} is missing property ${entry.property.name}`);
+      values.set(entry.property.name, Number(tokens[cursor++]));
+      continue;
+    }
+    const count = Number(tokens[cursor++]);
+    if (!Number.isSafeInteger(count) || count < 0 || cursor + count > tokens.length) throw new Error(`PLY ascii: vertex row ${row + 1} has an invalid ${entry.name} list`);
+    cursor += count;
+  }
+  if (cursor !== tokens.length) throw new Error(`PLY ascii: vertex row ${row + 1} has unexpected trailing values`);
+  return values;
+}
+
+export function parseBinaryVariableRow(view: DataView, start: number, order: readonly PlyPropertyOrderEntry[], littleEndian: boolean, row: number): { values: Map<string, number>; end: number } {
+  const values = new Map<string, number>();
+  let cursor = start;
+  for (const entry of order) {
+    if (entry.kind === 'scalar') {
+      if (cursor + entry.property.size > view.byteLength) throw new Error(`PLY binary: vertex row ${row + 1} is truncated`);
+      values.set(entry.property.name, readPlyScalar(view, cursor, entry.property, littleEndian));
+      cursor += entry.property.size;
+      continue;
+    }
+    if (cursor + entry.countSize > view.byteLength) throw new Error(`PLY binary: vertex row ${row + 1} list count is truncated`);
+    const count = readPlyScalar(view, cursor, { type: entry.countType }, littleEndian);
+    cursor += entry.countSize;
+    const bytes = count * entry.itemSize;
+    if (!Number.isSafeInteger(count) || count < 0 || cursor + bytes > view.byteLength) throw new Error(`PLY binary: vertex row ${row + 1} has an invalid ${entry.name} list`);
+    cursor += bytes;
+  }
+  return { values, end: cursor };
+}
+
+export interface VariablePlyOutputs {
+  positions: Float32Array; colors?: Float32Array; normals?: Float32Array; intensities?: Uint16Array;
+  originOffset?: readonly [number, number, number];
+}
+
+export function writeVariablePlyRow(values: ReadonlyMap<string, number>, row: number, output: VariablePlyOutputs): void {
+  const origin = output.originOffset ?? [0, 0, 0];
+  output.positions[row * 3] = (values.get('x') ?? Number.NaN) - origin[0];
+  output.positions[row * 3 + 1] = (values.get('y') ?? Number.NaN) - origin[1];
+  output.positions[row * 3 + 2] = (values.get('z') ?? Number.NaN) - origin[2];
+  if (output.colors) {
+    output.colors[row * 3] = values.get('red') ?? values.get('r') ?? Number.NaN;
+    output.colors[row * 3 + 1] = values.get('green') ?? values.get('g') ?? Number.NaN;
+    output.colors[row * 3 + 2] = values.get('blue') ?? values.get('b') ?? Number.NaN;
+  }
+  if (output.normals) {
+    output.normals[row * 3] = values.get('nx') ?? Number.NaN;
+    output.normals[row * 3 + 1] = values.get('ny') ?? Number.NaN;
+    output.normals[row * 3 + 2] = values.get('nz') ?? Number.NaN;
+  }
+  if (output.intensities) {
+    const value = values.get('intensity') ?? values.get('scalar_Intensity') ?? 0;
+    output.intensities[row] = Math.min(65535, Math.max(0, value | 0));
+  }
+}

--- a/packages/pointcloud/src/formats/ply.test.ts
+++ b/packages/pointcloud/src/formats/ply.test.ts
@@ -126,7 +126,7 @@ describe('decodePly originOffset (extends #1804 to PLY)', () => {
 });
 
 describe('decodePly', () => {
-  it('preserves complete ascii source normals in vertex order and rejects a partial declaration (#4561)', () => {
+  it('preserves complete ascii source normals and keeps partial/duplicate declarations loadable but invalid (#4561)', () => {
     const header = 'ply\nformat ascii 1.0\nelement vertex 2\n'
       + 'property float x\nproperty float y\nproperty float z\n'
       + 'property float nx\nproperty float ny\nproperty float nz\nend_header\n';
@@ -136,10 +136,8 @@ describe('decodePly', () => {
       Math.fround(0.1), Math.fround(0.2), Math.fround(0.3),
       Math.fround(-0.4), Math.fround(-0.5), Math.fround(-0.6),
     ]);
-    expect(() => decodePly(enc.encode(header.replace('property float nz\n', '') + '1 2 3 0 1\n4 5 6 0 1\n')))
-      .toThrow(/all of nx, ny and nz/);
-    expect(() => decodePly(enc.encode(header.replace('property float nx\n', 'property float nx\nproperty float nx\n') + '1 2 3 0 0 0 1\n4 5 6 1 1 0 0\n')))
-      .toThrow(/property "nx" must not be declared more than once/);
+    expect(decodePly(enc.encode(header.replace('property float nz\n', '') + '1 2 3 0 1\n4 5 6 0 1\n')).normalState).toBe('invalid');
+    expect(decodePly(enc.encode(header.replace('property float nx\n', 'property float nx\nproperty float nx\n') + '1 2 3 0 0 0 1\n4 5 6 1 1 0 0\n')).normalState).toBe('invalid');
   });
 
   it('preserves binary source normals, including unusable values for transfer-time refusal (#4561)', () => {
@@ -396,10 +394,8 @@ describe('decodePly', () => {
     expect(() => decodePly(enc.encode(header + '1 2 3\n'))).toThrow(/invalid element count/);
   });
 
-  it('rejects list-valued properties on the vertex element, allows them on faces', () => {
-    // A list on the vertex element makes records variable length: the fixed
-    // binary stride / ascii column map would silently drift into garbage.
-    const badVertex =
+  it('walks list-valued vertex properties without drifting and allows them on faces', () => {
+    const listedVertex =
       'ply\n' +
       'format binary_little_endian 1.0\n' +
       'element vertex 1\n' +
@@ -407,9 +403,9 @@ describe('decodePly', () => {
       'property list uchar int vertex_indices\n' +
       'end_header\n';
     const body = new Uint8Array(32);
-    const buf = new Uint8Array(enc.encode(badVertex).length + body.length);
-    buf.set(enc.encode(badVertex), 0);
-    expect(() => decodePly(buf)).toThrow(/list-valued properties on the vertex element/);
+    const buf = new Uint8Array(enc.encode(listedVertex).length + body.length);
+    buf.set(enc.encode(listedVertex), 0);
+    expect(Array.from(decodePly(buf).positions)).toEqual([0, 0, 0]);
 
     // Face lists (skipped elements) stay supported.
     const withFaces =
@@ -423,5 +419,86 @@ describe('decodePly', () => {
     const chunk = decodePly(enc.encode(withFaces + '1 2 3\n4 5 6\n2 0 1\n'));
     expect(chunk.pointCount).toBe(2);
     expect(Array.from(chunk.positions)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+});
+
+describe('decodePly source normals (#4561)', () => {
+  it('keeps distinct ASCII XYZ/RGB/normal rows aligned without mutating the input', () => {
+    const header = 'ply\nformat ascii 1.0\nelement vertex 2\n'
+      + 'property float x\nproperty float y\nproperty float z\n'
+      + 'property uchar red\nproperty uchar green\nproperty uchar blue\n'
+      + 'property float nx\nproperty float ny\nproperty float nz\nend_header\n';
+    const bytes = enc.encode(header + '1 2 3 10 20 30 4 5 6\n7 8 9 40 50 60 -1 -2 -3\n');
+    const before = bytes.slice();
+    const chunk = decodePly(bytes);
+    expect(chunk.normalState).toBe('supplied');
+    expect(Array.from(chunk.positions)).toEqual([1, 2, 3, 7, 8, 9]);
+    expect(Array.from(chunk.normals!)).toEqual([4, 5, 6, -1, -2, -3]);
+    expect(Array.from(bytes)).toEqual(Array.from(before));
+  });
+
+  it.each([
+    ['partial', 'property float nx\nproperty float ny\n', '1 2 3 4 5\n'],
+    ['duplicate', 'property float nx\nproperty float ny\nproperty float nz\nproperty float nx\n', '1 2 3 4 5 6 7\n'],
+  ])('marks a %s normal declaration invalid without hiding valid positions', (_name, props, row) => {
+    const bytes = enc.encode('ply\nformat ascii 1.0\nelement vertex 1\n'
+      + 'property float x\nproperty float y\nproperty float z\n' + props + 'end_header\n' + row);
+    const chunk = decodePly(bytes);
+    expect(Array.from(chunk.positions)).toEqual([1, 2, 3]);
+    expect(chunk.normalState).toBe('invalid');
+    expect(chunk.normals).toBeUndefined();
+  });
+
+  it.each([
+    ['ascii', 'format ascii 1.0', enc.encode('1 2 3 2 9 10\n')],
+    ['binary', 'format binary_little_endian 1.0', (() => {
+      const body = new ArrayBuffer(21);
+      const view = new DataView(body);
+      view.setFloat32(0, 1, true); view.setFloat32(4, 2, true); view.setFloat32(8, 3, true);
+      view.setUint8(12, 2); view.setFloat32(13, 9, true); view.setFloat32(17, 10, true);
+      return new Uint8Array(body);
+    })()],
+  ] as const)('keeps XYZ loadable but marks a non-scalar nx declaration invalid in %s PLY', (_name, format, body) => {
+    const header = `ply\n${format}\nelement vertex 1\nproperty float x\nproperty float y\nproperty float z\nproperty list uchar float nx\nend_header\n`;
+    const headerBytes = enc.encode(header);
+    const bytes = new Uint8Array(headerBytes.length + body.length);
+    bytes.set(headerBytes); bytes.set(body, headerBytes.length);
+    const chunk = decodePly(bytes);
+    expect(Array.from(chunk.positions)).toEqual([1, 2, 3]);
+    expect(chunk.normalState).toBe('invalid');
+    expect(chunk.normals).toBeUndefined();
+  });
+
+  it.each([
+    ['zero', '0 0 0'],
+    ['non-finite', 'NaN 1 0'],
+  ])('preserves %s complete normal rows but marks the source invalid', (_name, normal) => {
+    const bytes = enc.encode('ply\nformat ascii 1.0\nelement vertex 1\n'
+      + 'property float x\nproperty float y\nproperty float z\n'
+      + 'property float nx\nproperty float ny\nproperty float nz\nend_header\n1 2 3 ' + normal + '\n');
+    const chunk = decodePly(bytes);
+    expect(chunk.normalState).toBe('invalid');
+    expect(chunk.normals).toBeDefined();
+  });
+
+  it.each([
+    ['binary_little_endian', true],
+    ['binary_big_endian', false],
+  ] as const)('decodes %s normal scalars in row order', (format, littleEndian) => {
+    const header = `ply\nformat ${format} 1.0\nelement vertex 2\n`
+      + 'property float x\nproperty float y\nproperty float z\n'
+      + 'property float nx\nproperty float ny\nproperty float nz\nend_header\n';
+    const headerBytes = enc.encode(header);
+    const body = new ArrayBuffer(48);
+    const view = new DataView(body);
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -2, -3].forEach((value, index) => {
+      view.setFloat32(index * 4, value, littleEndian);
+    });
+    const bytes = new Uint8Array(headerBytes.length + body.byteLength);
+    bytes.set(headerBytes);
+    bytes.set(new Uint8Array(body), headerBytes.length);
+    const chunk = decodePly(bytes);
+    expect(chunk.normalState).toBe('supplied');
+    expect(Array.from(chunk.normals!)).toEqual([4, 5, 6, -1, -2, -3]);
   });
 });

--- a/packages/pointcloud/src/formats/ply.ts
+++ b/packages/pointcloud/src/formats/ply.ts
@@ -18,9 +18,10 @@
  * channels before applying its host-selected stride.
  */
 
-import type { DecodedPointChunk, PointCloudBBox } from '../types.js';
+import type { DecodedPointChunk, PointCloudBBox, PointNormalState } from '../types.js';
 import { normalizePlyColors } from './ply-color.js';
-import { readPlyScalar } from './ply-scalar.js';
+import { parseAsciiVariableRow, parseBinaryVariableRow, writeVariablePlyRow } from './ply-variable-row.js';
+import { decodeFixedBinaryPlyBody } from './ply-fixed-binary.js';
 
 /** Name → byte size for the PLY-defined scalar types. */
 const TYPE_SIZES: Record<string, number> = {
@@ -38,10 +39,18 @@ export interface PlyPropertyDecl {
   offset: number;
 }
 
+export interface PlyListPropertyDecl {
+  kind: 'list'; name: string; countType: string; itemType: string;
+  countSize: number; itemSize: number;
+}
+
+export type PlyPropertyOrderEntry = { kind: 'scalar'; property: PlyPropertyDecl } | PlyListPropertyDecl;
+
 export interface PlyElementDecl {
   name: string;
   count: number;
   properties: PlyPropertyDecl[];
+  propertyOrder: PlyPropertyOrderEntry[];
   /** Bytes per record (binary mode); unused for ascii. */
   recordSize: number;
   /**
@@ -51,6 +60,7 @@ export interface PlyElementDecl {
    * decoders walk with a fixed stride.
    */
   hasListProperty: boolean;
+  listPropertyNames: string[];
 }
 
 export interface PlyHeader {
@@ -116,8 +126,10 @@ export function parsePlyHeader(buffer: Uint8Array): PlyHeader {
         name: parts[1],
         count: parseInt(parts[2], 10),
         properties: [],
+        propertyOrder: [],
         recordSize: 0,
         hasListProperty: false,
+        listPropertyNames: [],
       };
       elements.push(current);
       continue;
@@ -131,7 +143,12 @@ export function parsePlyHeader(buffer: Uint8Array): PlyHeader {
       // fact and skip them — harmless on elements we never decode, rejected
       // for the vertex element in decodePly.
       if (parts[1] === 'list') {
+        const countType = parts[2], itemType = parts[3], name = parts[4];
+        const countSize = TYPE_SIZES[countType], itemSize = TYPE_SIZES[itemType];
+        if (!name || countSize === undefined || itemSize === undefined) throw new Error(`PLY: invalid list property declaration "${line}"`);
         current.hasListProperty = true;
+        current.listPropertyNames.push(name);
+        current.propertyOrder.push({ kind: 'list', name, countType, itemType, countSize, itemSize });
         continue;
       }
       const type = parts[1];
@@ -140,7 +157,9 @@ export function parsePlyHeader(buffer: Uint8Array): PlyHeader {
       if (size === undefined) {
         throw new Error(`PLY: unknown property type "${type}"`);
       }
-      current.properties.push({ name, type, size, offset: current.recordSize });
+      const property = { name, type, size, offset: current.recordSize };
+      current.properties.push(property);
+      current.propertyOrder.push({ kind: 'scalar', property });
       current.recordSize += size;
       continue;
     }
@@ -157,6 +176,7 @@ export interface PlyVertexLayout {
   vertex: PlyElementDecl;
   xProp: PlyPropertyDecl; yProp: PlyPropertyDecl; zProp: PlyPropertyDecl;
   nxProp?: PlyPropertyDecl; nyProp?: PlyPropertyDecl; nzProp?: PlyPropertyDecl;
+  normalState: PointNormalState;
 }
 
 /** Validate the fixed-row vertex schema shared by whole-file and streaming decode. */
@@ -166,9 +186,7 @@ export function inspectPlyVertex(header: PlyHeader): PlyVertexLayout {
   if (header.elements[0] !== vertex) {
     throw new Error(`PLY: vertex element must appear first; saw "${header.elements[0]?.name}" first`);
   }
-  if (vertex.hasListProperty) {
-    throw new Error('PLY: list-valued properties on the vertex element are not supported (variable-length records)');
-  }
+  const normalNames = new Set(['nx', 'ny', 'nz']);
   const one = (name: string): PlyPropertyDecl | undefined => {
     const matches = vertex.properties.filter((property) => property.name === name);
     if (matches.length > 1) throw new Error(`PLY: vertex property "${name}" must not be declared more than once`);
@@ -176,12 +194,13 @@ export function inspectPlyVertex(header: PlyHeader): PlyVertexLayout {
   };
   const xProp = one('x'), yProp = one('y'), zProp = one('z');
   if (!xProp || !yProp || !zProp) throw new Error('PLY: vertex element must define x, y, z properties');
-  const nxProp = one('nx'), nyProp = one('ny'), nzProp = one('nz');
-  const normalCount = Number(!!nxProp) + Number(!!nyProp) + Number(!!nzProp);
-  if (normalCount !== 0 && normalCount !== 3) {
-    throw new Error('PLY: vertex normals must declare all of nx, ny and nz');
-  }
-  return { vertex, xProp, yProp, zProp, nxProp, nyProp, nzProp };
+  const normalProps = (name: string) => vertex.properties.filter((property) => property.name === name);
+  const nx = normalProps('nx'), ny = normalProps('ny'), nz = normalProps('nz');
+  const declared = nx.length + ny.length + nz.length + vertex.listPropertyNames.filter((name) => normalNames.has(name)).length;
+  const complete = declared === 3 && nx.length === 1 && ny.length === 1 && nz.length === 1;
+  return { vertex, xProp, yProp, zProp, nxProp: complete ? nx[0] : undefined,
+    nyProp: complete ? ny[0] : undefined, nzProp: complete ? nz[0] : undefined,
+    normalState: declared === 0 ? 'absent' : complete ? 'supplied' : 'invalid' };
 }
 
 export function decodePly(
@@ -240,19 +259,26 @@ export function decodePly(
   const intensities = intensityProp ? new Uint16Array(count) : undefined;
 
   if (header.format === 'ascii') {
-    decodeAsciiBody(buffer, header, vertex, positions, colors, normals, intensities, originOffset);
+    if (vertex.hasListProperty) {
+      const lines = TEXT_DECODER.decode(buffer.subarray(header.bodyOffset)).split(/\r?\n/).filter(line => line.trim());
+      if (lines.length < count) throw new Error(`PLY ascii: expected ${count} vertex lines, got ${lines.length}`);
+      for (let row = 0; row < count; row++) writeVariablePlyRow(parseAsciiVariableRow(lines[row].trim().split(/\s+/), vertex.propertyOrder, row), row,
+        { positions, colors, normals, intensities, originOffset });
+    } else decodeAsciiBody(buffer, header, vertex, positions, colors, normals, intensities, originOffset);
   } else {
-    decodeBinaryBody(
-      buffer,
-      header,
-      vertex,
-      positions,
-      colors,
-      normals,
-      intensities,
-      header.format === 'binary_little_endian',
-      originOffset,
-    );
+    const littleEndian = header.format === 'binary_little_endian';
+    if (vertex.hasListProperty) {
+      const view = new DataView(buffer.buffer, buffer.byteOffset + header.bodyOffset, buffer.length - header.bodyOffset);
+      let cursor = 0;
+      for (let row = 0; row < count; row++) {
+        const parsed = parseBinaryVariableRow(view, cursor, vertex.propertyOrder, littleEndian, row);
+        writeVariablePlyRow(parsed.values, row, { positions, colors, normals, intensities, originOffset });
+        cursor = parsed.end;
+      }
+    } else {
+      const view = new DataView(buffer.buffer, buffer.byteOffset + header.bodyOffset, count * vertex.recordSize);
+      decodeFixedBinaryPlyBody(view, vertex, positions, colors, normals, intensities, littleEndian, originOffset);
+    }
   }
 
   if (colors && rProp && gProp && bProp) {
@@ -263,10 +289,16 @@ export function decodePly(
     positions,
     colors,
     normals,
+    normalState: normals && normals.every(Number.isFinite) && everyNormalNonzero(normals) ? 'supplied' : layout.normalState === 'supplied' ? 'invalid' : layout.normalState,
     intensities,
     pointCount: count,
     bbox: computeBBox(positions),
   };
+}
+
+function everyNormalNonzero(normals: Float32Array): boolean {
+  for (let i = 0; i < normals.length; i += 3) if (normals[i] ** 2 + normals[i + 1] ** 2 + normals[i + 2] ** 2 === 0) return false;
+  return true;
 }
 
 function decodeAsciiBody(
@@ -328,60 +360,6 @@ function decodeAsciiBody(
   }
   if (written !== vertex.count) {
     throw new Error(`PLY ascii: expected ${vertex.count} vertex lines, got ${written}`);
-  }
-}
-
-function decodeBinaryBody(
-  buffer: Uint8Array,
-  header: PlyHeader,
-  vertex: PlyElementDecl,
-  positions: Float32Array,
-  colors: Float32Array | undefined,
-  normals: Float32Array | undefined,
-  intensities: Uint16Array | undefined,
-  littleEndian: boolean,
-  originOffset?: readonly [number, number, number],
-): void {
-  const stride = vertex.recordSize;
-  const need = vertex.count * stride;
-  if (buffer.length < header.bodyOffset + need) {
-    throw new Error(`PLY binary: expected ${need} body bytes, got ${buffer.length - header.bodyOffset}`);
-  }
-  const view = new DataView(buffer.buffer, buffer.byteOffset + header.bodyOffset, need);
-  const offX = originOffset?.[0] ?? 0;
-  const offY = originOffset?.[1] ?? 0;
-  const offZ = originOffset?.[2] ?? 0;
-  const xProp = vertex.properties.find((p) => p.name === 'x')!;
-  const yProp = vertex.properties.find((p) => p.name === 'y')!;
-  const zProp = vertex.properties.find((p) => p.name === 'z')!;
-  const rProp = colors ? vertex.properties.find((p) => p.name === 'red' || p.name === 'r') : undefined;
-  const gProp = colors ? vertex.properties.find((p) => p.name === 'green' || p.name === 'g') : undefined;
-  const bProp = colors ? vertex.properties.find((p) => p.name === 'blue' || p.name === 'b') : undefined;
-  const nxProp = normals ? vertex.properties.find((p) => p.name === 'nx') : undefined;
-  const nyProp = normals ? vertex.properties.find((p) => p.name === 'ny') : undefined;
-  const nzProp = normals ? vertex.properties.find((p) => p.name === 'nz') : undefined;
-  const iProp = intensities
-    ? vertex.properties.find((p) => p.name === 'intensity' || p.name === 'scalar_Intensity')
-    : undefined;
-
-  for (let i = 0; i < vertex.count; i++) {
-    const base = i * stride;
-    positions[i * 3] = readPlyScalar(view, base + xProp.offset, xProp, littleEndian) - offX;
-    positions[i * 3 + 1] = readPlyScalar(view, base + yProp.offset, yProp, littleEndian) - offY;
-    positions[i * 3 + 2] = readPlyScalar(view, base + zProp.offset, zProp, littleEndian) - offZ;
-    if (colors && rProp && gProp && bProp) {
-      colors[i * 3] = readPlyScalar(view, base + rProp.offset, rProp, littleEndian);
-      colors[i * 3 + 1] = readPlyScalar(view, base + gProp.offset, gProp, littleEndian);
-      colors[i * 3 + 2] = readPlyScalar(view, base + bProp.offset, bProp, littleEndian);
-    }
-    if (normals && nxProp && nyProp && nzProp) {
-      normals[i * 3] = readPlyScalar(view, base + nxProp.offset, nxProp, littleEndian);
-      normals[i * 3 + 1] = readPlyScalar(view, base + nyProp.offset, nyProp, littleEndian);
-      normals[i * 3 + 2] = readPlyScalar(view, base + nzProp.offset, nzProp, littleEndian);
-    }
-    if (intensities && iProp) {
-      intensities[i] = Math.min(65535, Math.max(0, readPlyScalar(view, base + iProp.offset, iProp, littleEndian) | 0));
-    }
   }
 }
 

--- a/packages/pointcloud/src/index.ts
+++ b/packages/pointcloud/src/index.ts
@@ -11,7 +11,7 @@
  * Phase 2: streaming `.laz` (laz-perf in the worker).
  */
 
-export type { DecodedPointChunk, PointCloudBBox } from './types.js';
+export type { DecodedPointChunk, PointCloudBBox, PointNormalState } from './types.js';
 
 // Inline / IFCx decoders (Phase 0)
 export { decodePcd } from './formats/pcd.js';

--- a/packages/pointcloud/src/streaming/ascii-points-source.ts
+++ b/packages/pointcloud/src/streaming/ascii-points-source.ts
@@ -109,6 +109,7 @@ function applyStride(chunk: DecodedPointChunk, stride: number): DecodedPointChun
   return {
     positions,
     colors,
+    normalState: chunk.normalState,
     intensities,
     pointCount: newCount,
     bbox: chunk.bbox,

--- a/packages/pointcloud/src/streaming/e57-source.ts
+++ b/packages/pointcloud/src/streaming/e57-source.ts
@@ -494,7 +494,7 @@ function concatParts(
     off += p.count;
   }
   return {
-    positions,
+    positions, normalState: 'absent',
     colors,
     intensities,
     classifications,

--- a/packages/pointcloud/src/streaming/host.test.ts
+++ b/packages/pointcloud/src/streaming/host.test.ts
@@ -282,11 +282,13 @@ describe('streamPointCloud (in-process source)', () => {
     // here and report a bbox that includes the origin even though no real
     // point is anywhere near it.
     const goodChunk: DecodedPointChunk = {
+      normalState: 'absent',
       positions: new Float32Array([500000, 200000, 100, 500100, 200100, 120]),
       pointCount: 2,
       bbox: { min: [500000, 200000, 100], max: [500100, 200100, 120] },
     };
     const badChunk: DecodedPointChunk = {
+      normalState: 'absent',
       positions: new Float32Array(0),
       pointCount: 0,
       bbox: {
@@ -323,6 +325,7 @@ describe('streamPointCloud (in-process source)', () => {
 
   it('falls back to the header bbox when every chunk in the stream is non-finite', async () => {
     const badChunk: DecodedPointChunk = {
+      normalState: 'absent',
       positions: new Float32Array(0),
       pointCount: 0,
       bbox: {

--- a/packages/pointcloud/src/streaming/pcd-source.ts
+++ b/packages/pointcloud/src/streaming/pcd-source.ts
@@ -101,6 +101,7 @@ function applyStride(chunk: DecodedPointChunk, stride: number): DecodedPointChun
   return {
     positions,
     colors,
+    normalState: chunk.normalState,
     classifications,
     intensities,
     pointCount: newCount,

--- a/packages/pointcloud/src/streaming/ply-source.test.ts
+++ b/packages/pointcloud/src/streaming/ply-source.test.ts
@@ -66,6 +66,23 @@ describe('PlyStreamingSource source normals (#4561)', () => {
     expect((await source.next(10))?.normalState).toBe('invalid');
   });
 
+  it.each([1e-100, 1e100])('applies Float32 normal validity to unretained binary-double rows (%s)', async (nx) => {
+    const header = new TextEncoder().encode('ply\nformat binary_little_endian 1.0\nelement vertex 3\n'
+      + 'property float x\nproperty float y\nproperty float z\n'
+      + 'property double nx\nproperty double ny\nproperty double nz\nend_header\n');
+    const body = new ArrayBuffer(3 * 36), view = new DataView(body);
+    for (let row = 0; row < 3; row++) {
+      const base = row * 36;
+      view.setFloat32(base, row, true);
+      view.setFloat64(base + 12, row === 1 ? nx : 1, true);
+      view.setFloat64(base + 20, 0, true);
+      view.setFloat64(base + 28, 0, true);
+    }
+    const source = new PlyStreamingSource(new Blob([header, body]), { downsample: { stride: 2 } });
+    await source.open();
+    expect((await source.next(10))?.normalState).toBe('invalid');
+  });
+
   it('selects the floating RGB convention once for the whole file, independent of chunk size', async () => {
     const text = 'ply\nformat ascii 1.0\nelement vertex 2\nproperty float x\nproperty float y\nproperty float z\n'
       + 'property float red\nproperty float green\nproperty float blue\nend_header\n0 0 0 .5 0 0\n1 0 0 255 0 0\n';

--- a/packages/pointcloud/src/streaming/ply-source.test.ts
+++ b/packages/pointcloud/src/streaming/ply-source.test.ts
@@ -57,6 +57,15 @@ describe('PlyStreamingSource source normals (#4561)', () => {
     expect((await source.next(2))?.normalState).toBe('invalid');
   });
 
+  it.each(['1e-100', '1e100'])('invalidates an unretained normal that cannot survive Float32 storage (%s)', async (nx) => {
+    const text = 'ply\nformat ascii 1.0\nelement vertex 3\nproperty float x\nproperty float y\nproperty float z\n'
+      + 'property double nx\nproperty double ny\nproperty double nz\nend_header\n'
+      + `0 0 0 1 0 0\n1 0 0 ${nx} 0 0\n2 0 0 1 0 0\n`;
+    const source = new PlyStreamingSource(new Blob([text]), { downsample: { stride: 2 } });
+    await source.open();
+    expect((await source.next(10))?.normalState).toBe('invalid');
+  });
+
   it('selects the floating RGB convention once for the whole file, independent of chunk size', async () => {
     const text = 'ply\nformat ascii 1.0\nelement vertex 2\nproperty float x\nproperty float y\nproperty float z\n'
       + 'property float red\nproperty float green\nproperty float blue\nend_header\n0 0 0 .5 0 0\n1 0 0 255 0 0\n';
@@ -64,6 +73,15 @@ describe('PlyStreamingSource source normals (#4561)', () => {
     await source.open();
     expect((await source.next(1))!.colors![0]).toBeCloseTo(0.5 / 255);
     expect((await source.next(1))!.colors![0]).toBe(1);
+  });
+
+  it.each(['Infinity', '1.0000000001'])('matches whole-buffer Float32 color convention for %s', async (red) => {
+    const text = 'ply\nformat ascii 1.0\nelement vertex 2\nproperty float x\nproperty float y\nproperty float z\n'
+      + 'property double red\nproperty double green\nproperty double blue\nend_header\n'
+      + `0 0 0 .5 0 0\n1 0 0 ${red} 0 0\n`;
+    const source = new PlyStreamingSource(new Blob([text]));
+    await source.open();
+    expect((await source.next(1))!.colors![0]).toBe(0.5);
   });
 
   it('traverses variable ASCII normal lists without losing XYZ and marks the source invalid', async () => {

--- a/packages/pointcloud/src/streaming/ply-source.test.ts
+++ b/packages/pointcloud/src/streaming/ply-source.test.ts
@@ -47,6 +47,50 @@ describe('PlyStreamingSource source normals (#4561)', () => {
     expect(chunks.slice(0, 3).every(chunk => chunk?.pointCount === 1 && chunk.normals?.length === 3)).toBe(true);
   });
 
+  it('latches an invalid normal from an unretained stride row across every emitted chunk', async () => {
+    const rows = Array.from({ length: 8 }, (_, i) => `${i} 0 0 ${i === 1 ? 0 : 1} 0 0`);
+    const text = 'ply\nformat ascii 1.0\nelement vertex 8\nproperty float x\nproperty float y\nproperty float z\n'
+      + 'property float nx\nproperty float ny\nproperty float nz\nend_header\n' + rows.join('\n') + '\n';
+    const source = new PlyStreamingSource(new Blob([text]), { downsample: { stride: 2 } });
+    await source.open();
+    expect((await source.next(2))?.normalState).toBe('invalid');
+    expect((await source.next(2))?.normalState).toBe('invalid');
+  });
+
+  it('selects the floating RGB convention once for the whole file, independent of chunk size', async () => {
+    const text = 'ply\nformat ascii 1.0\nelement vertex 2\nproperty float x\nproperty float y\nproperty float z\n'
+      + 'property float red\nproperty float green\nproperty float blue\nend_header\n0 0 0 .5 0 0\n1 0 0 255 0 0\n';
+    const source = new PlyStreamingSource(new Blob([text]));
+    await source.open();
+    expect((await source.next(1))!.colors![0]).toBeCloseTo(0.5 / 255);
+    expect((await source.next(1))!.colors![0]).toBe(1);
+  });
+
+  it('traverses variable ASCII normal lists without losing XYZ and marks the source invalid', async () => {
+    const text = 'ply\nformat ascii 1.0\nelement vertex 2\nproperty float x\nproperty list uchar float nx\nproperty float y\nproperty float z\nend_header\n'
+      + '1 2 9 10 2 3\n4 1 8 5 6\n';
+    const source = new PlyStreamingSource(new Blob([text]));
+    await source.open();
+    const chunk = await source.next(2);
+    expect(Array.from(chunk!.positions)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(chunk!.normalState).toBe('invalid');
+    expect(chunk!.normals).toBeUndefined();
+  });
+
+  it('traverses variable binary normal lists across rows without fixed-stride drift', async () => {
+    const header = new TextEncoder().encode('ply\nformat binary_little_endian 1.0\nelement vertex 2\nproperty float x\nproperty list uchar float nx\nproperty float y\nproperty float z\nend_header\n');
+    const body = new ArrayBuffer(4 + 1 + 8 + 8 + 4 + 1 + 4 + 8), view = new DataView(body);
+    let at = 0;
+    const scalar = (value: number) => { view.setFloat32(at, value, true); at += 4; };
+    scalar(1); view.setUint8(at++, 2); scalar(9); scalar(10); scalar(2); scalar(3);
+    scalar(4); view.setUint8(at++, 1); scalar(8); scalar(5); scalar(6);
+    const source = new PlyStreamingSource(new Blob([header, body]));
+    await source.open();
+    const chunk = await source.next(2);
+    expect(Array.from(chunk!.positions)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(chunk!.normalState).toBe('invalid');
+  });
+
   it('keeps safe-integer strides above the 32-bit range instead of wrapping to one (#4561 review)', async () => {
     const text = 'ply\nformat ascii 1.0\nelement vertex 3\n'
       + 'property float x\nproperty float y\nproperty float z\nend_header\n'

--- a/packages/pointcloud/src/streaming/ply-source.ts
+++ b/packages/pointcloud/src/streaming/ply-source.ts
@@ -54,14 +54,15 @@ export class PlyStreamingSource implements StreamingPointSource {
     }
     const header = parsePlyHeader(headerBytes);
     const layout = inspectPlyVertex(header);
-    const bbox = await scanPlyBounds(this.blob, header, layout, this.originOffset, signal);
+    const scan = await scanPlyBounds(this.blob, header, layout, this.originOffset, signal);
     const stride = normalizePointStride(this.downsample.stride);
-    this.reader = new PlyChunkReader(this.blob, header, layout, stride, this.originOffset, this.instrumentation);
+    this.reader = new PlyChunkReader(this.blob, header, layout, stride, this.originOffset,
+      scan.normalState, scan.floatColorsUseByteRange, this.instrumentation);
     const properties = layout.vertex.properties;
     const has = (...names: string[]) => properties.some((property) => names.includes(property.name));
     return {
       totalPointCount: Math.ceil(layout.vertex.count / stride),
-      bbox,
+      bbox: scan.bbox,
       hasColor: has('red', 'r') && has('green', 'g') && has('blue', 'b'),
       hasClassification: false,
       hasIntensity: has('intensity', 'scalar_Intensity'),

--- a/packages/pointcloud/src/streaming/ply-stream-decode.ts
+++ b/packages/pointcloud/src/streaming/ply-stream-decode.ts
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { normalizePlyColors } from '../formats/ply-color.js';
+import { normalizeColorChannel } from '../formats/ply-color.js';
 import { readPlyScalar } from '../formats/ply-scalar.js';
-import type { DecodedPointChunk, PointCloudBBox } from '../types.js';
+import { parseAsciiVariableRow, writeVariablePlyRow } from '../formats/ply-variable-row.js';
+import type { DecodedPointChunk, PointCloudBBox, PointNormalState } from '../types.js';
 import type { PlyHeader, PlyPropertyDecl, PlyVertexLayout } from '../formats/ply.js';
+import { BinaryPlyRowCursor } from './ply-variable-stream.js';
 
 export const PLY_STREAM_READ_BYTES = 4 * 1024 * 1024;
 const TEXT_DECODER = new TextDecoder();
@@ -26,11 +28,14 @@ export async function scanPlyBounds(
   layout: PlyVertexLayout,
   origin: readonly [number, number, number] | undefined,
   signal?: AbortSignal,
-): Promise<PointCloudBBox> {
+): Promise<{ bbox: PointCloudBBox; normalState: PointNormalState; floatColorsUseByteRange: boolean }> {
   if (!Number.isSafeInteger(layout.vertex.count) || layout.vertex.count < 0) {
     throw new Error(`PLY: invalid vertex count ${layout.vertex.count}`);
   }
   const bounds = emptyBounds();
+  let normalState = layout.normalState;
+  let floatColorsUseByteRange = false;
+  const channels = findChannels(layout);
   if (header.format === 'ascii') {
     const cursor = new AsciiLineCursor(blob, header.bodyOffset);
     const indices = positionColumns(layout);
@@ -39,10 +44,29 @@ export async function scanPlyBounds(
       const line = await cursor.next(signal);
       if (line === null) throw new Error(`PLY ascii: expected ${layout.vertex.count} vertex lines, got ${row}`);
       const parts = line.split(/\s+/);
-      requireColumns(parts, layout.vertex.properties.length, row);
-      extendBounds(bounds, Number(parts[indices[0]]) - (origin?.[0] ?? 0), Number(parts[indices[1]]) - (origin?.[1] ?? 0), Number(parts[indices[2]]) - (origin?.[2] ?? 0));
+      if (layout.vertex.hasListProperty) {
+        const values = parseAsciiVariableRow(parts, layout.vertex.propertyOrder, row);
+        extendBounds(bounds, (values.get('x') ?? Number.NaN) - (origin?.[0] ?? 0), (values.get('y') ?? Number.NaN) - (origin?.[1] ?? 0), (values.get('z') ?? Number.NaN) - (origin?.[2] ?? 0));
+        normalState = observeValues(values, normalState);
+        floatColorsUseByteRange ||= valuesUseByteColors(values, channels);
+      } else {
+        requireColumns(parts, layout.vertex.properties.length, row);
+        extendBounds(bounds, Number(parts[indices[0]]) - (origin?.[0] ?? 0), Number(parts[indices[1]]) - (origin?.[1] ?? 0), Number(parts[indices[2]]) - (origin?.[2] ?? 0));
+        normalState = observeAsciiRow(parts, layout, channels, normalState);
+        floatColorsUseByteRange ||= asciiUsesByteColors(parts, layout, channels);
+      }
     }
   } else {
+    if (layout.vertex.hasListProperty) {
+      const cursor = new BinaryPlyRowCursor(blob, header.bodyOffset, header.format === 'binary_little_endian');
+      for (let row = 0; row < layout.vertex.count; row++) {
+        const values = await cursor.row(layout.vertex.propertyOrder, row, signal);
+        extendBounds(bounds, (values.get('x') ?? Number.NaN) - (origin?.[0] ?? 0), (values.get('y') ?? Number.NaN) - (origin?.[1] ?? 0), (values.get('z') ?? Number.NaN) - (origin?.[2] ?? 0));
+        normalState = observeValues(values, normalState);
+        floatColorsUseByteRange ||= valuesUseByteColors(values, channels);
+      }
+      return { bbox: bounds, normalState, floatColorsUseByteRange };
+    }
     const recordSize = layout.vertex.recordSize;
     const bodyBytes = layout.vertex.count * recordSize;
     const requiredEnd = header.bodyOffset + bodyBytes;
@@ -54,16 +78,22 @@ export async function scanPlyBounds(
       const count = Math.min(recordsPerRead, layout.vertex.count - first);
       const bytes = await readSlice(blob, header.bodyOffset + first * recordSize, count * recordSize, signal);
       const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-      for (let row = 0; row < count; row++) extendBinaryBounds(bounds, view, row * recordSize, layout, header, origin);
+      for (let row = 0; row < count; row++) {
+        const base = row * recordSize;
+        extendBinaryBounds(bounds, view, base, layout, header, origin);
+        normalState = observeBinaryRow(view, base, layout, header, normalState);
+        floatColorsUseByteRange ||= binaryUsesByteColors(view, base, layout, channels, header);
+      }
     }
   }
-  return bounds;
+  return { bbox: bounds, normalState, floatColorsUseByteRange };
 }
 
 export class PlyChunkReader {
   private sourceRow = 0;
   private readonly ascii: AsciiLineCursor | null;
   private readonly channels: Channels;
+  private readonly variableBinary: BinaryPlyRowCursor | null;
 
   constructor(
     private readonly blob: Blob,
@@ -71,9 +101,13 @@ export class PlyChunkReader {
     private readonly layout: PlyVertexLayout,
     private readonly stride: number,
     private readonly origin: readonly [number, number, number] | undefined,
+    private readonly normalState: PointNormalState,
+    private readonly floatColorsUseByteRange: boolean,
     private readonly instrumentation?: PlyStreamInstrumentation,
   ) {
     this.ascii = header.format === 'ascii' ? new AsciiLineCursor(blob, header.bodyOffset) : null;
+    this.variableBinary = header.format !== 'ascii' && layout.vertex.hasListProperty
+      ? new BinaryPlyRowCursor(blob, header.bodyOffset, header.format === 'binary_little_endian') : null;
     this.channels = findChannels(layout);
   }
 
@@ -85,14 +119,15 @@ export class PlyChunkReader {
     if (remainingOutput === 0) return null;
     const capacity = Math.min(limit, remainingOutput);
     this.instrumentation?.onOutputAllocation?.(capacity);
-    const output = allocateChunk(capacity, this.layout, this.channels);
+    const output = allocateChunk(capacity, this.layout, this.channels, this.normalState);
     const written = this.ascii
       ? await this.readAscii(output, capacity, signal)
       : await this.readBinary(output, capacity, signal);
-    return finishChunk(output, written, this.channels);
+    return finishChunk(output, written, this.channels, this.floatColorsUseByteRange);
   }
 
   private async readBinary(output: DecodedPointChunk, capacity: number, signal?: AbortSignal): Promise<number> {
+    if (this.variableBinary) return this.readVariableBinary(output, capacity, signal);
     const recordSize = this.layout.vertex.recordSize;
     const recordsPerRead = Math.max(1, Math.floor(PLY_STREAM_READ_BYTES / recordSize));
     let written = 0;
@@ -118,6 +153,16 @@ export class PlyChunkReader {
     return written;
   }
 
+  private async readVariableBinary(output: DecodedPointChunk, capacity: number, signal?: AbortSignal): Promise<number> {
+    let written = 0;
+    while (written < capacity && this.sourceRow < this.layout.vertex.count) {
+      const values = await this.variableBinary!.row(this.layout.vertex.propertyOrder, this.sourceRow, signal);
+      if (this.sourceRow % this.stride === 0) writeVariablePlyRow(values, written++, { ...output, originOffset: this.origin });
+      this.sourceRow++;
+    }
+    return written;
+  }
+
   private async readAscii(output: DecodedPointChunk, capacity: number, signal?: AbortSignal): Promise<number> {
     const columns = asciiColumns(this.layout, this.channels);
     let written = 0;
@@ -125,8 +170,13 @@ export class PlyChunkReader {
       const line = await this.ascii!.next(signal);
       if (line === null) throw new Error(`PLY ascii: expected ${this.layout.vertex.count} vertex lines, got ${this.sourceRow}`);
       const parts = line.split(/\s+/);
-      requireColumns(parts, this.layout.vertex.properties.length, this.sourceRow);
-      if (this.sourceRow % this.stride === 0) writeAsciiRow(output, written++, parts, columns, this.origin);
+      if (this.layout.vertex.hasListProperty) {
+        const values = parseAsciiVariableRow(parts, this.layout.vertex.propertyOrder, this.sourceRow);
+        if (this.sourceRow % this.stride === 0) writeVariablePlyRow(values, written++, { ...output, originOffset: this.origin });
+      } else {
+        requireColumns(parts, this.layout.vertex.properties.length, this.sourceRow);
+        if (this.sourceRow % this.stride === 0) writeAsciiRow(output, written++, parts, columns, this.origin);
+      }
       this.sourceRow++;
     }
     return written;
@@ -175,19 +225,23 @@ class AsciiLineCursor {
   }
 }
 
-function allocateChunk(capacity: number, layout: PlyVertexLayout, channels: Channels): DecodedPointChunk {
+function allocateChunk(capacity: number, layout: PlyVertexLayout, channels: Channels, normalState: PointNormalState): DecodedPointChunk {
   return {
     positions: new Float32Array(capacity * 3),
     colors: channels.r && channels.g && channels.b ? new Float32Array(capacity * 3) : undefined,
     normals: layout.nxProp && layout.nyProp && layout.nzProp ? new Float32Array(capacity * 3) : undefined,
+    normalState,
     intensities: channels.intensity ? new Uint16Array(capacity) : undefined,
     pointCount: capacity,
     bbox: emptyBounds(),
   };
 }
 
-function finishChunk(output: DecodedPointChunk, written: number, channels: Channels): DecodedPointChunk {
-  if (output.colors && channels.r && channels.g && channels.b) normalizePlyColors(output.colors, [channels.r.type, channels.g.type, channels.b.type]);
+function finishChunk(output: DecodedPointChunk, written: number, channels: Channels, floatColorsUseByteRange: boolean): DecodedPointChunk {
+  if (output.colors && channels.r && channels.g && channels.b) {
+    const types = [channels.r.type, channels.g.type, channels.b.type];
+    for (let i = 0; i < output.colors.length; i++) output.colors[i] = normalizeColorChannel(output.colors[i], types[i % 3], floatColorsUseByteRange);
+  }
   output.pointCount = written;
   output.bbox = computeBounds(output.positions, written);
   if (written === output.positions.length / 3) return output;
@@ -234,6 +288,36 @@ function extendBinaryBounds(bounds: PointCloudBBox, view: DataView, base: number
 function findChannels(layout: PlyVertexLayout): Channels {
   const find = (...names: string[]) => layout.vertex.properties.find((property) => names.includes(property.name));
   return { r: find('red', 'r'), g: find('green', 'g'), b: find('blue', 'b'), intensity: find('intensity', 'scalar_Intensity') };
+}
+const isFloatType = (type: string) => type === 'float' || type === 'float32' || type === 'double' || type === 'float64';
+function usableNormal(x: number, y: number, z: number): boolean {
+  return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z) && x * x + y * y + z * z !== 0;
+}
+function observeValues(values: ReadonlyMap<string, number>, state: PointNormalState): PointNormalState {
+  if (state !== 'supplied') return state;
+  return usableNormal(values.get('nx') ?? Number.NaN, values.get('ny') ?? Number.NaN, values.get('nz') ?? Number.NaN) ? state : 'invalid';
+}
+function valuesUseByteColors(values: ReadonlyMap<string, number>, channels: Channels): boolean {
+  return [channels.r, channels.g, channels.b].some(property => property && isFloatType(property.type)
+    && (values.get(property.name) ?? Number.NaN) > 1);
+}
+function observeAsciiRow(parts: string[], layout: PlyVertexLayout, _channels: Channels, state: PointNormalState): PointNormalState {
+  if (state !== 'supplied' || !layout.nxProp || !layout.nyProp || !layout.nzProp) return state;
+  const index = (property: PlyPropertyDecl) => layout.vertex.properties.indexOf(property);
+  return usableNormal(Number(parts[index(layout.nxProp)]), Number(parts[index(layout.nyProp)]), Number(parts[index(layout.nzProp)])) ? state : 'invalid';
+}
+function observeBinaryRow(view: DataView, base: number, layout: PlyVertexLayout, header: PlyHeader, state: PointNormalState): PointNormalState {
+  if (state !== 'supplied' || !layout.nxProp || !layout.nyProp || !layout.nzProp) return state;
+  const le = header.format === 'binary_little_endian';
+  return usableNormal(scalar(view, base, layout.nxProp, le), scalar(view, base, layout.nyProp, le), scalar(view, base, layout.nzProp, le)) ? state : 'invalid';
+}
+function asciiUsesByteColors(parts: string[], layout: PlyVertexLayout, channels: Channels): boolean {
+  return [channels.r, channels.g, channels.b].some((property) => property && isFloatType(property.type)
+    && Number(parts[layout.vertex.properties.indexOf(property)]) > 1);
+}
+function binaryUsesByteColors(view: DataView, base: number, layout: PlyVertexLayout, channels: Channels, header: PlyHeader): boolean {
+  const le = header.format === 'binary_little_endian';
+  return [channels.r, channels.g, channels.b].some((property) => property && isFloatType(property.type) && scalar(view, base, property, le) > 1);
 }
 function positionColumns(layout: PlyVertexLayout): [number, number, number] { return [layout.vertex.properties.indexOf(layout.xProp), layout.vertex.properties.indexOf(layout.yProp), layout.vertex.properties.indexOf(layout.zProp)]; }
 function asciiColumns(layout: PlyVertexLayout, channels: Channels): AsciiColumns {

--- a/packages/pointcloud/src/streaming/ply-stream-decode.ts
+++ b/packages/pointcloud/src/streaming/ply-stream-decode.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { normalizeColorChannel } from '../formats/ply-color.js';
+import { floatColorSelectsByteRange, normalizeColorChannel } from '../formats/ply-color.js';
 import { readPlyScalar } from '../formats/ply-scalar.js';
 import { parseAsciiVariableRow, writeVariablePlyRow } from '../formats/ply-variable-row.js';
 import type { DecodedPointChunk, PointCloudBBox, PointNormalState } from '../types.js';
@@ -289,17 +289,17 @@ function findChannels(layout: PlyVertexLayout): Channels {
   const find = (...names: string[]) => layout.vertex.properties.find((property) => names.includes(property.name));
   return { r: find('red', 'r'), g: find('green', 'g'), b: find('blue', 'b'), intensity: find('intensity', 'scalar_Intensity') };
 }
-const isFloatType = (type: string) => type === 'float' || type === 'float32' || type === 'double' || type === 'float64';
 function usableNormal(x: number, y: number, z: number): boolean {
-  return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z) && x * x + y * y + z * z !== 0;
+  const stored = [Math.fround(x), Math.fround(y), Math.fround(z)];
+  return stored.every(Number.isFinite) && stored.some(value => value !== 0);
 }
 function observeValues(values: ReadonlyMap<string, number>, state: PointNormalState): PointNormalState {
   if (state !== 'supplied') return state;
   return usableNormal(values.get('nx') ?? Number.NaN, values.get('ny') ?? Number.NaN, values.get('nz') ?? Number.NaN) ? state : 'invalid';
 }
 function valuesUseByteColors(values: ReadonlyMap<string, number>, channels: Channels): boolean {
-  return [channels.r, channels.g, channels.b].some(property => property && isFloatType(property.type)
-    && (values.get(property.name) ?? Number.NaN) > 1);
+  return [channels.r, channels.g, channels.b].some(property => property
+    && floatColorSelectsByteRange(values.get(property.name) ?? Number.NaN, property.type));
 }
 function observeAsciiRow(parts: string[], layout: PlyVertexLayout, _channels: Channels, state: PointNormalState): PointNormalState {
   if (state !== 'supplied' || !layout.nxProp || !layout.nyProp || !layout.nzProp) return state;
@@ -312,12 +312,13 @@ function observeBinaryRow(view: DataView, base: number, layout: PlyVertexLayout,
   return usableNormal(scalar(view, base, layout.nxProp, le), scalar(view, base, layout.nyProp, le), scalar(view, base, layout.nzProp, le)) ? state : 'invalid';
 }
 function asciiUsesByteColors(parts: string[], layout: PlyVertexLayout, channels: Channels): boolean {
-  return [channels.r, channels.g, channels.b].some((property) => property && isFloatType(property.type)
-    && Number(parts[layout.vertex.properties.indexOf(property)]) > 1);
+  return [channels.r, channels.g, channels.b].some((property) => property
+    && floatColorSelectsByteRange(Number(parts[layout.vertex.properties.indexOf(property)]), property.type));
 }
 function binaryUsesByteColors(view: DataView, base: number, layout: PlyVertexLayout, channels: Channels, header: PlyHeader): boolean {
   const le = header.format === 'binary_little_endian';
-  return [channels.r, channels.g, channels.b].some((property) => property && isFloatType(property.type) && scalar(view, base, property, le) > 1);
+  return [channels.r, channels.g, channels.b].some((property) => property
+    && floatColorSelectsByteRange(scalar(view, base, property, le), property.type));
 }
 function positionColumns(layout: PlyVertexLayout): [number, number, number] { return [layout.vertex.properties.indexOf(layout.xProp), layout.vertex.properties.indexOf(layout.yProp), layout.vertex.properties.indexOf(layout.zProp)]; }
 function asciiColumns(layout: PlyVertexLayout, channels: Channels): AsciiColumns {

--- a/packages/pointcloud/src/streaming/ply-variable-stream.ts
+++ b/packages/pointcloud/src/streaming/ply-variable-stream.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { PlyPropertyOrderEntry } from '../formats/ply.js';
+import { readPlyScalar } from '../formats/ply-scalar.js';
+
+const READ_BYTES = 4 * 1024 * 1024;
+
+/** Bounded sequential traversal for binary PLY rows containing variable-length lists. */
+export class BinaryPlyRowCursor {
+  private offset: number;
+  private window = new Uint8Array(0);
+  private windowOffset = 0;
+
+  constructor(private readonly blob: Blob, bodyOffset: number, private readonly littleEndian: boolean) {
+    this.offset = bodyOffset;
+  }
+
+  async row(order: readonly PlyPropertyOrderEntry[], row: number, signal?: AbortSignal): Promise<Map<string, number>> {
+    const values = new Map<string, number>();
+    for (const entry of order) {
+      if (entry.kind === 'scalar') {
+        const bytes = await this.take(entry.property.size, row, signal);
+        values.set(entry.property.name, readPlyScalar(new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength), 0, entry.property, this.littleEndian));
+        continue;
+      }
+      const countBytes = await this.take(entry.countSize, row, signal);
+      const count = readPlyScalar(new DataView(countBytes.buffer, countBytes.byteOffset, countBytes.byteLength), 0, { type: entry.countType }, this.littleEndian);
+      const byteCount = count * entry.itemSize;
+      if (!Number.isSafeInteger(count) || count < 0 || !Number.isSafeInteger(byteCount)) throw new Error(`PLY binary: vertex row ${row + 1} has an invalid ${entry.name} list`);
+      await this.skip(byteCount, row, signal);
+    }
+    return values;
+  }
+
+  private async take(length: number, row: number, signal?: AbortSignal): Promise<Uint8Array> {
+    const output = new Uint8Array(length);
+    let written = 0;
+    while (written < length) {
+      await this.refill(signal);
+      const available = this.window.length - this.windowOffset;
+      if (available === 0) throw new Error(`PLY binary: vertex row ${row + 1} is truncated`);
+      const count = Math.min(length - written, available);
+      output.set(this.window.subarray(this.windowOffset, this.windowOffset + count), written);
+      this.windowOffset += count; written += count;
+    }
+    return output;
+  }
+
+  private async skip(length: number, row: number, signal?: AbortSignal): Promise<void> {
+    let remaining = length;
+    while (remaining > 0) {
+      await this.refill(signal);
+      const available = this.window.length - this.windowOffset;
+      if (available === 0) throw new Error(`PLY binary: vertex row ${row + 1} list is truncated`);
+      const count = Math.min(remaining, available);
+      this.windowOffset += count; remaining -= count;
+    }
+  }
+
+  private async refill(signal?: AbortSignal): Promise<void> {
+    if (this.windowOffset < this.window.length) return;
+    signal?.throwIfAborted();
+    const end = Math.min(this.blob.size, this.offset + READ_BYTES);
+    this.window = new Uint8Array(await this.blob.slice(this.offset, end).arrayBuffer());
+    this.offset = end; this.windowOffset = 0;
+    signal?.throwIfAborted();
+  }
+}

--- a/packages/pointcloud/src/streaming/protocol.test.ts
+++ b/packages/pointcloud/src/streaming/protocol.test.ts
@@ -8,11 +8,21 @@ import type { DecodedPointChunk } from '../types.js';
 describe('decode worker normal channel (#4561)', () => {
   it('transfers and reconstructs normals without disturbing row order', () => {
     const chunk: DecodedPointChunk = { positions: new Float32Array([1, 2, 3, 4, 5, 6]), colors: new Float32Array([0, 0.1, 0.2, 0.3, 0.4, 0.5]),
-      normals: new Float32Array([0, 0, 1, 1, 0, 0]), pointCount: 2, bbox: { min: [1, 2, 3], max: [4, 5, 6] } };
+      normals: new Float32Array([0, 0, 1, 1, 0, 0]), normalState: 'supplied', pointCount: 2, bbox: { min: [1, 2, 3], max: [4, 5, 6] } };
     const { payload, transfer } = chunkToWire(chunk);
     expect(transfer).toContain(payload.normals);
     const decoded = chunkFromWire(payload);
     expect(Array.from(decoded.positions)).toEqual([1, 2, 3, 4, 5, 6]);
     expect(Array.from(decoded.normals!)).toEqual([0, 0, 1, 1, 0, 0]);
+    expect(decoded.normalState).toBe('supplied');
+  });
+
+  it('structured-clones only the exact normal view span', () => {
+    const backing = new Float32Array([99, 99, 99, 0, 0, 1, 88, 88, 88]);
+    const chunk: DecodedPointChunk = { positions: new Float32Array([1, 2, 3]), normals: backing.subarray(3, 6),
+      normalState: 'supplied', pointCount: 1, bbox: { min: [1, 2, 3], max: [1, 2, 3] } };
+    const wire = chunkToWire(chunk);
+    const cloned = structuredClone(wire.payload, { transfer: wire.transfer });
+    expect(Array.from(chunkFromWire(cloned).normals!)).toEqual([0, 0, 1]);
   });
 });

--- a/packages/pointcloud/src/streaming/protocol.ts
+++ b/packages/pointcloud/src/streaming/protocol.ts
@@ -9,7 +9,7 @@
  * in transferable buffers so we don't double-allocate.
  */
 
-import type { DecodedPointChunk, PointCloudBBox } from '../types.js';
+import type { DecodedPointChunk, PointCloudBBox, PointNormalState } from '../types.js';
 import type { PointSourceInfo } from './types.js';
 
 export type WorkerSourceFormat = 'las' | 'laz' | 'ply' | 'pcd' | 'e57' | 'pts' | 'xyz';
@@ -67,10 +67,18 @@ export interface SerializedChunk {
   positions: ArrayBuffer;
   colors?: ArrayBuffer;
   normals?: ArrayBuffer;
+  normalState: PointNormalState;
   classifications?: ArrayBuffer;
   intensities?: ArrayBuffer;
   pointCount: number;
   bbox: PointCloudBBox;
+}
+
+function exactBuffer(view: ArrayBufferView): ArrayBuffer {
+  if (view.buffer instanceof ArrayBuffer && view.byteOffset === 0 && view.byteLength === view.buffer.byteLength) {
+    return view.buffer;
+  }
+  return new Uint8Array(view.buffer, view.byteOffset, view.byteLength).slice().buffer;
 }
 
 /** Convert a chunk into a transferable wire payload + transfer list. */
@@ -82,30 +90,31 @@ export function chunkToWire(chunk: DecodedPointChunk): {
   // friends, so `.buffer` is always a plain `ArrayBuffer`. The `as ArrayBuffer`
   // cast is safe and required because TS widens the type to `ArrayBufferLike`
   // (which formally includes `SharedArrayBuffer`).
-  const positions = chunk.positions.buffer as ArrayBuffer;
+  const positions = exactBuffer(chunk.positions);
   const transfer: ArrayBuffer[] = [positions];
   const payload: SerializedChunk = {
     positions,
     pointCount: chunk.pointCount,
     bbox: chunk.bbox,
+    normalState: chunk.normalState,
   };
   if (chunk.colors) {
-    const buf = chunk.colors.buffer as ArrayBuffer;
+    const buf = exactBuffer(chunk.colors);
     payload.colors = buf;
     transfer.push(buf);
   }
   if (chunk.normals) {
-    const buf = chunk.normals.buffer as ArrayBuffer;
+    const buf = exactBuffer(chunk.normals);
     payload.normals = buf;
     transfer.push(buf);
   }
   if (chunk.classifications) {
-    const buf = chunk.classifications.buffer as ArrayBuffer;
+    const buf = exactBuffer(chunk.classifications);
     payload.classifications = buf;
     transfer.push(buf);
   }
   if (chunk.intensities) {
-    const buf = chunk.intensities.buffer as ArrayBuffer;
+    const buf = exactBuffer(chunk.intensities);
     payload.intensities = buf;
     transfer.push(buf);
   }
@@ -118,6 +127,7 @@ export function chunkFromWire(payload: SerializedChunk): DecodedPointChunk {
     positions: new Float32Array(payload.positions),
     colors: payload.colors ? new Float32Array(payload.colors) : undefined,
     normals: payload.normals ? new Float32Array(payload.normals) : undefined,
+    normalState: payload.normalState,
     classifications: payload.classifications ? new Uint8Array(payload.classifications) : undefined,
     intensities: payload.intensities ? new Uint16Array(payload.intensities) : undefined,
     pointCount: payload.pointCount,

--- a/packages/pointcloud/src/types.ts
+++ b/packages/pointcloud/src/types.ts
@@ -14,6 +14,9 @@ export interface PointCloudBBox {
   max: [number, number, number];
 }
 
+/** Whether a decoded source omitted normals, supplied usable rows, or declared unusable normal data. */
+export type PointNormalState = 'absent' | 'supplied' | 'invalid';
+
 /**
  * A decoded chunk of points ready for upload to a GPU buffer.
  *
@@ -32,6 +35,8 @@ export interface DecodedPointChunk {
   colors?: Float32Array;
   /** Source-supplied oriented normals [nx,ny,nz, ...], row-aligned with positions. */
   normals?: Float32Array;
+  /** Source-wide normal provenance; invalid must never silently become absent after sampling. */
+  normalState: PointNormalState;
   /** Per-point u8 classification — undefined when source has none */
   classifications?: Uint8Array;
   /** Per-point u16 intensity — undefined when source has none */

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -7531,6 +7531,7 @@
     "PcdStreamingSource: class",
     "PlyStreamingSource: class",
     "PointCloudBBox: interface",
+    "PointNormalState: type",
     "PointSourceInfo: interface",
     "PointsArrayAttribute: interface",
     "PointsBase64Attribute: interface",


### PR DESCRIPTION
Follow-up to #4561 and #4570.

Retains validated PLY normals through bounded streaming and cache/session transfer, applies Float32-equivalent channel validation, and reports accurate source-normal provenance to the planner.

Validation: 238 point-cloud tests; point-cloud and viewer typechecks; real PLY ingest through production prepareMeshTransfer, planner client, and Rust WASM with no skip; module-size gate.

Adversarial plan and exact-head review: Astra GO at cef690820563d1ab0a398b8666f540091881ec86.