### PR TITLE
feat(viewer): add bounded PDF and Markdown context

### DIFF
--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -1167,8 +1167,10 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     const supportsImages = model?.supportsImages ?? false;
     const supportsFileAttachments = model?.supportsFileAttachments ?? true;
     let remainingSlots = Math.max(0, MAX_ATTACHMENTS_PER_MESSAGE - attachments.length);
+    const documentBatch = documentUploads.begin();
 
     for (const file of Array.from(files)) {
+      if (!documentBatch.current()) break;
       if (remainingSlots <= 0) {
         setChatError(`You can attach up to ${MAX_ATTACHMENTS_PER_MESSAGE} files per message.`);
         break;
@@ -1212,7 +1214,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
             setChatError(`PDF attachments must be smaller than ${Math.round(MAX_PDF_ATTACHMENT_BYTES / 1_000_000)} MB.`);
             continue;
           }
-          await attachPdfDocument(file, documentUploads, addAttachment);
+          await attachPdfDocument(file, documentBatch, addAttachment);
           remainingSlots -= 1;
           continue;
         }

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -44,6 +44,7 @@ import { buildStreamMessagesForModel, filterAttachmentsForModel } from '@/lib/ll
 import { buildSystemPrompt } from '@/lib/llm/system-prompt';
 import { getModelContext, parseCSV } from '@/lib/llm/context-builder';
 import { collectActiveFileAttachments } from '@/lib/attachments';
+import { extractPdfText, MAX_PDF_ATTACHMENT_BYTES } from '@/lib/llm/document-text';
 import { extractCodeBlocks } from '@/lib/llm/code-extractor';
 import { extractScriptEditOps, filterUnappliedScriptOps } from '@/lib/llm/script-edit-ops';
 import { createPatchDiagnostic, getPrimaryRootCause, type RepairScope } from '@/lib/llm/script-diagnostics';
@@ -89,22 +90,9 @@ const MAX_INLINE_IMAGE_DATA_URL_CHARS = 1_200_000;
 const MAX_ATTACHMENTS_PER_MESSAGE = 6;
 const MAX_TEXT_ATTACHMENT_BYTES = 512_000;
 const MAX_IMAGE_ATTACHMENT_BYTES = 8_000_000;
-/** Anthropic's PDF content-block limit is ~32 MB; keep our upload cap lower. */
-const MAX_PDF_ATTACHMENT_BYTES = 16_000_000;
 
 function createAttachmentId(): string {
   return crypto.randomUUID();
-}
-
-/** Convert an ArrayBuffer (binary file) to raw base64 — no data-URL prefix. */
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + chunk)));
-  }
-  return btoa(binary);
 }
 
 interface ChatSendOptions {
@@ -1206,9 +1194,8 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
           remainingSlots -= 1;
           continue;
         }
-        // PDFs are supported by Claude as native document content blocks.
-        // Route them separately from text attachments so the chat request
-        // can emit the correct multimodal block type.
+        // Extract PDF text locally so the same bounded document context works
+        // with every configured model and with bim.files scripts.
         if (file.name.match(/\.pdf$/i) || file.type === 'application/pdf') {
           if (!supportsFileAttachments) {
             setChatError('Selected model does not support file attachments. Switch model to attach PDFs.');
@@ -1218,15 +1205,12 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
             setChatError(`PDF attachments must be smaller than ${Math.round(MAX_PDF_ATTACHMENT_BYTES / 1_000_000)} MB.`);
             continue;
           }
-          const buffer = await file.arrayBuffer();
-          const base64 = arrayBufferToBase64(buffer);
           const attachment: FileAttachment = {
             id: createAttachmentId(),
             name: file.name,
             type: 'application/pdf',
             size: file.size,
-            pdfBase64: base64,
-            isPdf: true,
+            textContent: await extractPdfText(file),
           };
           addAttachment(attachment);
           remainingSlots -= 1;
@@ -1253,8 +1237,8 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
           remainingSlots -= 1;
           continue;
         }
-        // Text-based files — CSV, TSV, JSON, TXT
-        if (!file.name.match(/\.(csv|json|txt|tsv)$/i)) continue;
+        // Text-based files — CSV, TSV, JSON, TXT and Markdown.
+        if (!file.name.match(/\.(csv|json|txt|tsv|md|markdown)$/i)) continue;
         if (!supportsFileAttachments) {
           setChatError('Selected model does not support file attachments. Switch model to attach files.');
           continue;
@@ -1352,7 +1336,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
   const modelSupportsFiles = modelForUi?.supportsFileAttachments ?? true;
   const attachmentAccept = [
     modelSupportsFiles
-      ? '.csv,.json,.txt,.tsv,.pdf,application/pdf,.xlsx,.xls,.ods,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet'
+      ? '.csv,.json,.txt,.tsv,.md,.markdown,text/markdown,.pdf,application/pdf,.xlsx,.xls,.ods,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,application/vnd.oasis.opendocument.spreadsheet'
       : '',
     modelSupportsImages ? 'image/*' : '',
   ].filter(Boolean).join(',');

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -44,7 +44,8 @@ import { buildStreamMessagesForModel, filterAttachmentsForModel } from '@/lib/ll
 import { buildSystemPrompt } from '@/lib/llm/system-prompt';
 import { getModelContext, parseCSV } from '@/lib/llm/context-builder';
 import { collectActiveFileAttachments } from '@/lib/attachments';
-import { extractPdfText, MAX_PDF_ATTACHMENT_BYTES } from '@/lib/llm/document-text';
+import { MAX_PDF_ATTACHMENT_BYTES } from '@/lib/llm/document-text';
+import { attachPdfDocument, createDocumentUploadGate } from '@/lib/llm/document-upload';
 import { extractCodeBlocks } from '@/lib/llm/code-extractor';
 import { extractScriptEditOps, filterUnappliedScriptOps } from '@/lib/llm/script-edit-ops';
 import { createPatchDiagnostic, getPrimaryRootCause, type RepairScope } from '@/lib/llm/script-diagnostics';
@@ -338,6 +339,9 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const documentUploadsRef = useRef<ReturnType<typeof createDocumentUploadGate> | null>(null);
+  documentUploadsRef.current ??= createDocumentUploadGate();
+  const documentUploads = documentUploadsRef.current;
   const dragCounterRef = useRef(0);
   const autoRepairAttemptCountsRef = useRef(new Map<string, { attempts: number; lastScope: RepairScope }>());
 
@@ -351,6 +355,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
   useEffect(() => {
     resizeInput();
   }, [inputText, resizeInput]);
+  useEffect(() => () => documentUploads.cancel(), [activeModel, documentUploads]);
 
   // ── Smart auto-scroll ──
   // Only auto-scroll if user hasn't scrolled up to read old messages
@@ -1132,6 +1137,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
 
   // ── Clear with confirmation ──
   const handleClearClick = useCallback(() => {
+    documentUploads.cancel();
     if (messages.length <= 2) {
       resetScriptEditorForNewChat();
       clearMessages();
@@ -1142,9 +1148,10 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     } else {
       setShowClearConfirm(true);
     }
-  }, [messages.length, clearMessages, resetScriptEditorForNewChat, setChatToolReady]);
+  }, [messages.length, clearMessages, resetScriptEditorForNewChat, setChatToolReady, documentUploads]);
 
   const confirmClear = useCallback(() => {
+    documentUploads.cancel();
     resetScriptEditorForNewChat();
     clearMessages();
     setChatToolReady(null);
@@ -1152,7 +1159,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
     setInputText('');
     setLastFinishReason(null);
     setShowClearConfirm(false);
-  }, [clearMessages, resetScriptEditorForNewChat, setChatToolReady]);
+  }, [clearMessages, resetScriptEditorForNewChat, setChatToolReady, documentUploads]);
 
   // ── File upload (button + drag-drop + paste) ──
   const processFiles = useCallback(async (files: FileList | File[]) => {
@@ -1205,14 +1212,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
             setChatError(`PDF attachments must be smaller than ${Math.round(MAX_PDF_ATTACHMENT_BYTES / 1_000_000)} MB.`);
             continue;
           }
-          const attachment: FileAttachment = {
-            id: createAttachmentId(),
-            name: file.name,
-            type: 'application/pdf',
-            size: file.size,
-            textContent: await extractPdfText(file),
-          };
-          addAttachment(attachment);
+          await attachPdfDocument(file, documentUploads, addAttachment);
           remainingSlots -= 1;
           continue;
         }
@@ -1263,10 +1263,11 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         addAttachment(attachment);
         remainingSlots -= 1;
       } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') continue;
         setChatError(`Could not read ${file.name}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
-  }, [activeModel, addAttachment, attachments.length, setChatError]);
+  }, [activeModel, addAttachment, attachments.length, setChatError, documentUploads]);
 
   const handleFileUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;

--- a/apps/viewer/src/components/viewer/ChatPanel.tsx
+++ b/apps/viewer/src/components/viewer/ChatPanel.tsx
@@ -45,7 +45,7 @@ import { buildSystemPrompt } from '@/lib/llm/system-prompt';
 import { getModelContext, parseCSV } from '@/lib/llm/context-builder';
 import { collectActiveFileAttachments } from '@/lib/attachments';
 import { MAX_PDF_ATTACHMENT_BYTES } from '@/lib/llm/document-text';
-import { attachPdfDocument, createDocumentUploadGate } from '@/lib/llm/document-upload';
+import { attachPdfDocument, createDocumentUploadGate, shouldContinueDocumentUploadBatch } from '@/lib/llm/document-upload';
 import { extractCodeBlocks } from '@/lib/llm/code-extractor';
 import { extractScriptEditOps, filterUnappliedScriptOps } from '@/lib/llm/script-edit-ops';
 import { createPatchDiagnostic, getPrimaryRootCause, type RepairScope } from '@/lib/llm/script-diagnostics';
@@ -1263,7 +1263,7 @@ export function ChatPanel({ onClose }: ChatPanelProps) {
         addAttachment(attachment);
         remainingSlots -= 1;
       } catch (error) {
-        if (error instanceof Error && error.name === 'AbortError') continue;
+        if (!shouldContinueDocumentUploadBatch(error)) break;
         setChatError(`Could not read ${file.name}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }

--- a/apps/viewer/src/lib/llm/document-text.test.ts
+++ b/apps/viewer/src/lib/llm/document-text.test.ts
@@ -14,7 +14,9 @@ function backend(pages: unknown[][]): { value: PdfTextBackend; cleaned: number[]
     destroyed: () => didDestroy,
     value: { load() { return {
       promise: Promise.resolve({ numPages: pages.length, async getPage(pageNumber) {
-        return { async getTextContent() { return { items: pages[pageNumber - 1] }; }, cleanup() { cleaned.push(pageNumber); } };
+        return { streamTextContent() { return new ReadableStream({ start(controller) {
+          controller.enqueue({ items: pages[pageNumber - 1] }); controller.close();
+        } }); }, cleanup() { cleaned.push(pageNumber); } };
       } }),
       async destroy() { didDestroy = true; },
     }; } },
@@ -68,6 +70,15 @@ test('#4177 bounds a silent parser by cancellation and a deadline', async () => 
   await assert.rejects(cancelled, /upload cancelled/);
   await assert.rejects(extractPdfText(new Blob(['%PDF hangs']), silent, { timeoutMs: 5 }), /timed out/);
   assert.equal(destroyed, 2);
+});
+
+test('#4177 a nonsettling destroy cannot extend the overall deadline', async () => {
+  const stuck: PdfTextBackend = { load() { return {
+    promise: new Promise(() => undefined), destroy: () => new Promise(() => undefined),
+  }; } };
+  const started = Date.now();
+  await assert.rejects(extractPdfText(new Blob(['%PDF hangs']), stuck, { timeoutMs: 5 }), /timed out/);
+  assert.ok(Date.now() - started < 100, 'cleanup must not outlive the extraction deadline');
 });
 
 test('#4177 destroys the PDF task when text extraction fails', async () => {

--- a/apps/viewer/src/lib/llm/document-text.test.ts
+++ b/apps/viewer/src/lib/llm/document-text.test.ts
@@ -52,6 +52,22 @@ test('#4177 refuses scanned/no-text and oversized PDFs without inventing OCR', a
   const inflated = backend([[{ str: 'x'.repeat(MAX_DOCUMENT_TEXT_CHARS + 1) }]]);
   await assert.rejects(extractPdfText(new Blob(['%PDF compressed']), inflated.value), /character attachment limit/);
   assert.equal(inflated.destroyed(), true);
+  const excessiveWork = backend([Array(250_001).fill({ type: 'layout-only' })]);
+  await assert.rejects(extractPdfText(new Blob(['%PDF item bomb']), excessiveWork.value), /item work limit/);
+  assert.equal(excessiveWork.destroyed(), true);
+});
+
+test('#4177 bounds a silent parser by cancellation and a deadline', async () => {
+  let destroyed = 0;
+  const silent: PdfTextBackend = { load() { return {
+    promise: new Promise(() => undefined), async destroy() { destroyed += 1; },
+  }; } };
+  const controller = new AbortController();
+  const cancelled = extractPdfText(new Blob(['%PDF hangs']), silent, { signal: controller.signal });
+  controller.abort(new Error('upload cancelled'));
+  await assert.rejects(cancelled, /upload cancelled/);
+  await assert.rejects(extractPdfText(new Blob(['%PDF hangs']), silent, { timeoutMs: 5 }), /timed out/);
+  assert.equal(destroyed, 2);
 });
 
 test('#4177 destroys the PDF task when text extraction fails', async () => {

--- a/apps/viewer/src/lib/llm/document-text.test.ts
+++ b/apps/viewer/src/lib/llm/document-text.test.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { extractPdfText, MAX_DOCUMENT_TEXT_CHARS, type PdfTextBackend } from './document-text';
+
+function backend(pages: unknown[][]): { value: PdfTextBackend; cleaned: number[]; destroyed: () => boolean } {
+  const cleaned: number[] = [];
+  let didDestroy = false;
+  return {
+    cleaned,
+    destroyed: () => didDestroy,
+    value: { load() { return {
+      promise: Promise.resolve({ numPages: pages.length, async getPage(pageNumber) {
+        return { async getTextContent() { return { items: pages[pageNumber - 1] }; }, cleanup() { cleaned.push(pageNumber); } };
+      } }),
+      async destroy() { didDestroy = true; },
+    }; } },
+  };
+}
+
+test('#4177 extracts ordered, page-labelled PDF text and disposes every page', async () => {
+  const fake = backend([[{ str: 'Fire', hasEOL: false }, { str: 'rating', hasEOL: true }, { str: 'EI60' }], [{ str: 'Door schedule' }]]);
+  const text = await extractPdfText(new Blob(['%PDF fixture']), fake.value);
+  assert.equal(text, '[Page 1]\nFire rating\nEI60\n\n[Page 2]\nDoor schedule');
+  assert.deepEqual(fake.cleaned, [1, 2]);
+  assert.equal(fake.destroyed(), true);
+});
+
+test('#4177 extracts text through the real PDF.js parser', async () => {
+  const pdf = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const realBackend: PdfTextBackend = { load(data) {
+    const task = pdf.getDocument({ data, enableXfa: false, stopAtErrors: true });
+    return { promise: task.promise, destroy: () => task.destroy() };
+  } };
+  const fixture = await readFile(new URL('../../../../../docs/architecture/evidence/pdf-fidelity-report/control-text-accepted.pdf', import.meta.url));
+  const text = await extractPdfText(new Blob([fixture]), realBackend);
+  assert.match(text, /^\[Page 1\]/);
+  assert.match(text, /Visible text/);
+});
+
+test('#4177 refuses scanned/no-text and oversized PDFs without inventing OCR', async () => {
+  const scanned = backend([[{ type: 'image' }]]);
+  await assert.rejects(extractPdfText(new Blob(['%PDF image']), scanned.value), /no machine-readable text.*OCR/);
+  assert.deepEqual(scanned.cleaned, [1]);
+  assert.equal(scanned.destroyed(), true);
+  const oversized = new Blob();
+  Object.defineProperty(oversized, 'size', { value: 16_000_001 });
+  await assert.rejects(extractPdfText(oversized, scanned.value), /smaller than 16 MB/);
+  const inflated = backend([[{ str: 'x'.repeat(MAX_DOCUMENT_TEXT_CHARS + 1) }]]);
+  await assert.rejects(extractPdfText(new Blob(['%PDF compressed']), inflated.value), /character attachment limit/);
+  assert.equal(inflated.destroyed(), true);
+});
+
+test('#4177 destroys the PDF task when text extraction fails', async () => {
+  let destroyed = false;
+  const broken: PdfTextBackend = { load() { return { promise: Promise.reject(Object.assign(new Error('password'), { name: 'PasswordException' })), async destroy() { destroyed = true; } }; } };
+  await assert.rejects(extractPdfText(new Blob(['%PDF locked']), broken), /must be unlocked/);
+  assert.equal(destroyed, true);
+});

--- a/apps/viewer/src/lib/llm/document-text.ts
+++ b/apps/viewer/src/lib/llm/document-text.ts
@@ -4,6 +4,8 @@
 export const MAX_PDF_ATTACHMENT_BYTES = 16_000_000;
 export const MAX_DOCUMENT_TEXT_CHARS = 1_000_000;
 const MAX_PDF_PAGES = 500;
+const MAX_PDF_TEXT_ITEMS = 250_000;
+const PDF_EXTRACTION_TIMEOUT_MS = 30_000;
 
 interface PdfTextItem { str: string; hasEOL?: boolean }
 interface PdfTextPage {
@@ -21,14 +23,19 @@ interface PdfLoadingTask {
 export interface PdfTextBackend {
   load(data: Uint8Array): PdfLoadingTask;
 }
+export interface PdfTextOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
 
 const browserBackend: PdfTextBackend = {
   load(data) {
-    // Lazy loading keeps PDF.js out of the initial viewer bundle.
+    // Lazy loading keeps PDF.js out of the initial viewer bundle. Reuse the
+    // canonical browser backend so CMaps and standard fonts are never omitted.
     let task: ReturnType<(typeof import('pdfjs-dist'))['getDocument']> | undefined;
-    const pending = Promise.all([import('pdfjs-dist'), import('pdfjs-dist/build/pdf.worker.min.mjs?url')]).then(([pdf, worker]) => {
-      pdf.GlobalWorkerOptions.workerSrc = worker.default;
-      task = pdf.getDocument({ data, enableXfa: false, stopAtErrors: true });
+    const pending = import('../appearance/pdf/browser-backend.js').then(({ browserPdfBackend }) => {
+      const backend = browserPdfBackend();
+      task = backend.getDocument({ ...backend.options, data, enableXfa: false, stopAtErrors: true });
       return task.promise;
     });
     return { promise: pending, async destroy() {
@@ -43,22 +50,58 @@ function textItem(value: unknown): value is PdfTextItem {
     && typeof (value as { str?: unknown }).str === 'string';
 }
 
-export async function extractPdfText(file: Blob, backend: PdfTextBackend = browserBackend): Promise<string> {
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new DOMException('PDF extraction was cancelled.', 'AbortError');
+}
+
+function waitFor<T>(promise: Promise<T>, signal: AbortSignal | undefined, deadline: number): Promise<T> {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) return Promise.reject(new Error('PDF text extraction timed out.'));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(() => reject(new Error('PDF text extraction timed out.'))), remaining);
+    const onAbort = () => finish(() => reject(abortError(signal!)));
+    const finish = (settle: () => void) => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      settle();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    promise.then(value => finish(() => resolve(value)), error => finish(() => reject(error)));
+  });
+}
+
+export async function extractPdfText(
+  file: Blob,
+  backend: PdfTextBackend = browserBackend,
+  options: PdfTextOptions = {},
+): Promise<string> {
   if (file.size === 0) throw new Error('The PDF is empty.');
   if (file.size > MAX_PDF_ATTACHMENT_BYTES) throw new Error(`PDF attachments must be smaller than ${MAX_PDF_ATTACHMENT_BYTES / 1_000_000} MB.`);
+  const timeoutMs = options.timeoutMs ?? PDF_EXTRACTION_TIMEOUT_MS;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error('PDF extraction timeout must be positive.');
+  const deadline = Date.now() + timeoutMs;
+  options.signal?.throwIfAborted();
   const loading = backend.load(new Uint8Array(await file.arrayBuffer()));
   try {
-    const document = await loading.promise;
+    const document = await waitFor(loading.promise, options.signal, deadline);
     if (!Number.isSafeInteger(document.numPages) || document.numPages < 1 || document.numPages > MAX_PDF_PAGES) {
       throw new Error(`PDF attachments must contain 1..${MAX_PDF_PAGES} pages.`);
     }
     let result = '';
+    let itemCount = 0;
     for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
-      const page = await document.getPage(pageNumber);
+      const page = await waitFor(document.getPage(pageNumber), options.signal, deadline);
       try {
-        const content = await page.getTextContent();
+        const content = await waitFor(page.getTextContent(), options.signal, deadline);
         let pageText = '';
         for (const item of content.items) {
+          itemCount += 1;
+          if (itemCount > MAX_PDF_TEXT_ITEMS) throw new Error(`PDF text exceeds the ${MAX_PDF_TEXT_ITEMS.toLocaleString()} item work limit.`);
+          if ((itemCount & 1023) === 0) {
+            options.signal?.throwIfAborted();
+            if (Date.now() >= deadline) throw new Error('PDF text extraction timed out.');
+          }
           if (!textItem(item)) continue;
           const separator = item.hasEOL ? '\n' : ' ';
           if (result.length + pageText.length + item.str.length + separator.length > MAX_DOCUMENT_TEXT_CHARS) {

--- a/apps/viewer/src/lib/llm/document-text.ts
+++ b/apps/viewer/src/lib/llm/document-text.ts
@@ -9,7 +9,7 @@ const PDF_EXTRACTION_TIMEOUT_MS = 30_000;
 
 interface PdfTextItem { str: string; hasEOL?: boolean }
 interface PdfTextPage {
-  getTextContent(): Promise<{ items: unknown[] }>;
+  streamTextContent(): ReadableStream<{ items: unknown[] }>;
   cleanup(): void;
 }
 interface PdfTextDocument {
@@ -33,13 +33,15 @@ const browserBackend: PdfTextBackend = {
     // Lazy loading keeps PDF.js out of the initial viewer bundle. Reuse the
     // canonical browser backend so CMaps and standard fonts are never omitted.
     let task: ReturnType<(typeof import('pdfjs-dist'))['getDocument']> | undefined;
+    let cancelled = false;
     const pending = import('../appearance/pdf/browser-backend.js').then(({ browserPdfBackend }) => {
+      if (cancelled) throw new DOMException('PDF extraction was cancelled.', 'AbortError');
       const backend = browserPdfBackend();
       task = backend.getDocument({ ...backend.options, data, enableXfa: false, stopAtErrors: true });
       return task.promise;
     });
     return { promise: pending, async destroy() {
-      if (!task) await pending.catch(() => undefined);
+      cancelled = true;
       await task?.destroy();
     } };
   },
@@ -71,6 +73,13 @@ function waitFor<T>(promise: Promise<T>, signal: AbortSignal | undefined, deadli
   });
 }
 
+async function settleWithin(promise: Promise<unknown>, deadline: number, warning: string): Promise<void> {
+  const settled = promise.then(() => true, error => { console.warn(warning, error); return true; });
+  const remaining = Math.max(0, Math.min(1_000, deadline - Date.now()));
+  if (remaining === 0) return;
+  await Promise.race([settled, new Promise(resolve => setTimeout(resolve, remaining))]);
+}
+
 export async function extractPdfText(
   file: Blob,
   backend: PdfTextBackend = browserBackend,
@@ -92,27 +101,34 @@ export async function extractPdfText(
     let itemCount = 0;
     for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
       const page = await waitFor(document.getPage(pageNumber), options.signal, deadline);
+      const reader = page.streamTextContent().getReader();
+      let streamDone = false;
       try {
-        const content = await waitFor(page.getTextContent(), options.signal, deadline);
         let pageText = '';
-        for (const item of content.items) {
-          itemCount += 1;
-          if (itemCount > MAX_PDF_TEXT_ITEMS) throw new Error(`PDF text exceeds the ${MAX_PDF_TEXT_ITEMS.toLocaleString()} item work limit.`);
-          if ((itemCount & 1023) === 0) {
-            options.signal?.throwIfAborted();
-            if (Date.now() >= deadline) throw new Error('PDF text extraction timed out.');
+        while (!streamDone) {
+          const chunk = await waitFor(reader.read(), options.signal, deadline);
+          streamDone = chunk.done;
+          if (chunk.done) break;
+          for (const item of chunk.value.items) {
+            itemCount += 1;
+            if (itemCount > MAX_PDF_TEXT_ITEMS) throw new Error(`PDF text exceeds the ${MAX_PDF_TEXT_ITEMS.toLocaleString()} item work limit.`);
+            if ((itemCount & 1023) === 0) {
+              options.signal?.throwIfAborted();
+              if (Date.now() >= deadline) throw new Error('PDF text extraction timed out.');
+            }
+            if (!textItem(item)) continue;
+            const separator = item.hasEOL ? '\n' : ' ';
+            if (result.length + pageText.length + item.str.length + separator.length > MAX_DOCUMENT_TEXT_CHARS) {
+              throw new Error(`PDF text exceeds the ${MAX_DOCUMENT_TEXT_CHARS.toLocaleString()} character attachment limit.`);
+            }
+            pageText += item.str + separator;
           }
-          if (!textItem(item)) continue;
-          const separator = item.hasEOL ? '\n' : ' ';
-          if (result.length + pageText.length + item.str.length + separator.length > MAX_DOCUMENT_TEXT_CHARS) {
-            throw new Error(`PDF text exceeds the ${MAX_DOCUMENT_TEXT_CHARS.toLocaleString()} character attachment limit.`);
-          }
-          pageText += item.str + separator;
         }
         pageText = pageText.trim();
         if (pageText) result += `${result ? '\n\n' : ''}[Page ${pageNumber}]\n${pageText}`;
         if (result.length > MAX_DOCUMENT_TEXT_CHARS) throw new Error(`PDF text exceeds the ${MAX_DOCUMENT_TEXT_CHARS.toLocaleString()} character attachment limit.`);
       } finally {
+        if (!streamDone) await settleWithin(reader.cancel(), deadline, '[PDF text] stream cancellation failed');
         page.cleanup();
       }
     }
@@ -122,6 +138,6 @@ export async function extractPdfText(
     if (error instanceof Error && error.name === 'PasswordException') throw new Error('Password-protected PDFs must be unlocked before attachment.');
     throw error;
   } finally {
-    await loading.destroy().catch(error => console.warn('[PDF text] cleanup failed', error));
+    await settleWithin(loading.destroy(), deadline, '[PDF text] cleanup failed');
   }
 }

--- a/apps/viewer/src/lib/llm/document-text.ts
+++ b/apps/viewer/src/lib/llm/document-text.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+export const MAX_PDF_ATTACHMENT_BYTES = 16_000_000;
+export const MAX_DOCUMENT_TEXT_CHARS = 1_000_000;
+const MAX_PDF_PAGES = 500;
+
+interface PdfTextItem { str: string; hasEOL?: boolean }
+interface PdfTextPage {
+  getTextContent(): Promise<{ items: unknown[] }>;
+  cleanup(): void;
+}
+interface PdfTextDocument {
+  numPages: number;
+  getPage(pageNumber: number): Promise<PdfTextPage>;
+}
+interface PdfLoadingTask {
+  promise: Promise<PdfTextDocument>;
+  destroy(): Promise<void>;
+}
+export interface PdfTextBackend {
+  load(data: Uint8Array): PdfLoadingTask;
+}
+
+const browserBackend: PdfTextBackend = {
+  load(data) {
+    // Lazy loading keeps PDF.js out of the initial viewer bundle.
+    let task: ReturnType<(typeof import('pdfjs-dist'))['getDocument']> | undefined;
+    const pending = Promise.all([import('pdfjs-dist'), import('pdfjs-dist/build/pdf.worker.min.mjs?url')]).then(([pdf, worker]) => {
+      pdf.GlobalWorkerOptions.workerSrc = worker.default;
+      task = pdf.getDocument({ data, enableXfa: false, stopAtErrors: true });
+      return task.promise;
+    });
+    return { promise: pending, async destroy() {
+      if (!task) await pending.catch(() => undefined);
+      await task?.destroy();
+    } };
+  },
+};
+
+function textItem(value: unknown): value is PdfTextItem {
+  return typeof value === 'object' && value !== null && 'str' in value
+    && typeof (value as { str?: unknown }).str === 'string';
+}
+
+export async function extractPdfText(file: Blob, backend: PdfTextBackend = browserBackend): Promise<string> {
+  if (file.size === 0) throw new Error('The PDF is empty.');
+  if (file.size > MAX_PDF_ATTACHMENT_BYTES) throw new Error(`PDF attachments must be smaller than ${MAX_PDF_ATTACHMENT_BYTES / 1_000_000} MB.`);
+  const loading = backend.load(new Uint8Array(await file.arrayBuffer()));
+  try {
+    const document = await loading.promise;
+    if (!Number.isSafeInteger(document.numPages) || document.numPages < 1 || document.numPages > MAX_PDF_PAGES) {
+      throw new Error(`PDF attachments must contain 1..${MAX_PDF_PAGES} pages.`);
+    }
+    let result = '';
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
+      const page = await document.getPage(pageNumber);
+      try {
+        const content = await page.getTextContent();
+        let pageText = '';
+        for (const item of content.items) {
+          if (!textItem(item)) continue;
+          const separator = item.hasEOL ? '\n' : ' ';
+          if (result.length + pageText.length + item.str.length + separator.length > MAX_DOCUMENT_TEXT_CHARS) {
+            throw new Error(`PDF text exceeds the ${MAX_DOCUMENT_TEXT_CHARS.toLocaleString()} character attachment limit.`);
+          }
+          pageText += item.str + separator;
+        }
+        pageText = pageText.trim();
+        if (pageText) result += `${result ? '\n\n' : ''}[Page ${pageNumber}]\n${pageText}`;
+        if (result.length > MAX_DOCUMENT_TEXT_CHARS) throw new Error(`PDF text exceeds the ${MAX_DOCUMENT_TEXT_CHARS.toLocaleString()} character attachment limit.`);
+      } finally {
+        page.cleanup();
+      }
+    }
+    if (!result) throw new Error('This PDF contains no machine-readable text. Run OCR on the document, then attach the searchable PDF.');
+    return result;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'PasswordException') throw new Error('Password-protected PDFs must be unlocked before attachment.');
+    throw error;
+  } finally {
+    await loading.destroy().catch(error => console.warn('[PDF text] cleanup failed', error));
+  }
+}

--- a/apps/viewer/src/lib/llm/document-upload.test.ts
+++ b/apps/viewer/src/lib/llm/document-upload.test.ts
@@ -6,7 +6,7 @@ import assert from 'node:assert/strict';
 import type { FileAttachment } from './types.js';
 import { collectActiveFileAttachments } from '../attachments.js';
 import { buildSystemPrompt } from './system-prompt.js';
-import { attachPdfDocument, createDocumentUploadGate } from './document-upload.js';
+import { attachPdfDocument, createDocumentUploadGate, shouldContinueDocumentUploadBatch } from './document-upload.js';
 
 test('#4177 attaches extracted PDF text at the upload boundary', async () => {
   const added: FileAttachment[] = [];
@@ -31,4 +31,26 @@ test('#4177 a late extraction cannot attach after its composer is cancelled', as
   resolve('late text');
   await assert.rejects(pending, /stale/);
   assert.deepEqual(added, []);
+});
+
+test('#4177 validation and attachment commit are one gate transaction', async () => {
+  const gate = createDocumentUploadGate(async () => 'extracted');
+  const added: FileAttachment[] = [];
+  const pending = attachPdfDocument(new File(['pdf'], 'race.pdf'), gate, value => added.push(value));
+  queueMicrotask(() => gate.cancel());
+  await pending;
+  assert.deepEqual(added.map(item => item.name), ['race.pdf']);
+});
+
+test('#4177 cancellation stops the whole selected-file batch', async () => {
+  const visited: string[] = [];
+  for (const file of ['first.pdf', 'second.pdf']) {
+    try {
+      visited.push(file);
+      throw new DOMException('composer cleared', 'AbortError');
+    } catch (error) {
+      if (!shouldContinueDocumentUploadBatch(error)) break;
+    }
+  }
+  assert.deepEqual(visited, ['first.pdf']);
 });

--- a/apps/viewer/src/lib/llm/document-upload.test.ts
+++ b/apps/viewer/src/lib/llm/document-upload.test.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { FileAttachment } from './types.js';
+import { collectActiveFileAttachments } from '../attachments.js';
+import { buildSystemPrompt } from './system-prompt.js';
+import { attachPdfDocument, createDocumentUploadGate } from './document-upload.js';
+
+test('#4177 attaches extracted PDF text at the upload boundary', async () => {
+  const added: FileAttachment[] = [];
+  const gate = createDocumentUploadGate(async () => '[Page 1]\nFire rating EI60');
+  await attachPdfDocument(new File(['pdf'], 'datasheet.pdf', { type: 'application/pdf' }), gate, value => added.push(value));
+  assert.equal(added.length, 1);
+  assert.equal(added[0].textContent, '[Page 1]\nFire rating EI60');
+  const runtimeFiles = collectActiveFileAttachments([], added);
+  assert.equal(runtimeFiles[0].textContent, '[Page 1]\nFire rating EI60');
+  const prompt = buildSystemPrompt(undefined, runtimeFiles);
+  assert.match(prompt, /bim\.files\.text\(name\)/);
+  assert.match(prompt, /bim\.mutate\.setProperty/);
+  assert.match(prompt, /bim\.export\.ifc/);
+});
+
+test('#4177 a late extraction cannot attach after its composer is cancelled', async () => {
+  let resolve!: (text: string) => void;
+  const gate = createDocumentUploadGate(() => new Promise(done => { resolve = done; }));
+  const added: FileAttachment[] = [];
+  const pending = attachPdfDocument(new File(['pdf'], 'old.pdf'), gate, value => added.push(value));
+  gate.cancel();
+  resolve('late text');
+  await assert.rejects(pending, /stale/);
+  assert.deepEqual(added, []);
+});

--- a/apps/viewer/src/lib/llm/document-upload.test.ts
+++ b/apps/viewer/src/lib/llm/document-upload.test.ts
@@ -11,7 +11,7 @@ import { attachPdfDocument, createDocumentUploadGate, shouldContinueDocumentUplo
 test('#4177 attaches extracted PDF text at the upload boundary', async () => {
   const added: FileAttachment[] = [];
   const gate = createDocumentUploadGate(async () => '[Page 1]\nFire rating EI60');
-  await attachPdfDocument(new File(['pdf'], 'datasheet.pdf', { type: 'application/pdf' }), gate, value => added.push(value));
+  await attachPdfDocument(new File(['pdf'], 'datasheet.pdf', { type: 'application/pdf' }), gate.begin(), value => added.push(value));
   assert.equal(added.length, 1);
   assert.equal(added[0].textContent, '[Page 1]\nFire rating EI60');
   const runtimeFiles = collectActiveFileAttachments([], added);
@@ -26,7 +26,7 @@ test('#4177 a late extraction cannot attach after its composer is cancelled', as
   let resolve!: (text: string) => void;
   const gate = createDocumentUploadGate(() => new Promise(done => { resolve = done; }));
   const added: FileAttachment[] = [];
-  const pending = attachPdfDocument(new File(['pdf'], 'old.pdf'), gate, value => added.push(value));
+  const pending = attachPdfDocument(new File(['pdf'], 'old.pdf'), gate.begin(), value => added.push(value));
   gate.cancel();
   resolve('late text');
   await assert.rejects(pending, /stale/);
@@ -36,21 +36,22 @@ test('#4177 a late extraction cannot attach after its composer is cancelled', as
 test('#4177 validation and attachment commit are one gate transaction', async () => {
   const gate = createDocumentUploadGate(async () => 'extracted');
   const added: FileAttachment[] = [];
-  const pending = attachPdfDocument(new File(['pdf'], 'race.pdf'), gate, value => added.push(value));
+  const pending = attachPdfDocument(new File(['pdf'], 'race.pdf'), gate.begin(), value => added.push(value));
   queueMicrotask(() => gate.cancel());
   await pending;
   assert.deepEqual(added.map(item => item.name), ['race.pdf']);
 });
 
 test('#4177 cancellation stops the whole selected-file batch', async () => {
-  const visited: string[] = [];
+  const gate = createDocumentUploadGate(async file => file.size.toString());
+  const batch = gate.begin();
+  const added: string[] = [];
   for (const file of ['first.pdf', 'second.pdf']) {
-    try {
-      visited.push(file);
-      throw new DOMException('composer cleared', 'AbortError');
-    } catch (error) {
-      if (!shouldContinueDocumentUploadBatch(error)) break;
-    }
+    if (!batch.current()) break;
+    await attachPdfDocument(new File(['pdf'], file), batch, attachment => {
+      added.push(attachment.name);
+      if (file === 'first.pdf') { gate.cancel(); added.length = 0; }
+    }).catch(error => { if (shouldContinueDocumentUploadBatch(error)) throw error; });
   }
-  assert.deepEqual(visited, ['first.pdf']);
+  assert.deepEqual(added, []);
 });

--- a/apps/viewer/src/lib/llm/document-upload.ts
+++ b/apps/viewer/src/lib/llm/document-upload.ts
@@ -6,8 +6,12 @@ import { extractPdfText, type PdfTextOptions } from './document-text.js';
 
 type Extractor = (file: Blob, options: PdfTextOptions) => Promise<string>;
 
-export interface DocumentUploadGate {
+export interface DocumentUploadBatch {
+  current(): boolean;
   run<T>(file: Blob, commit: (text: string) => T): Promise<T>;
+}
+export interface DocumentUploadGate {
+  begin(): DocumentUploadBatch;
   cancel(): void;
 }
 
@@ -21,17 +25,21 @@ export function createDocumentUploadGate(
   let generation = 0;
   const active = new Set<AbortController>();
   return {
-    async run(file, commit) {
+    begin() {
       const ownGeneration = generation;
-      const controller = new AbortController();
-      active.add(controller);
-      try {
-        const text = await extractor(file, { signal: controller.signal });
-        if (generation !== ownGeneration) throw new DOMException('PDF upload became stale.', 'AbortError');
-        return commit(text);
-      } finally {
-        active.delete(controller);
-      }
+      const current = () => generation === ownGeneration;
+      return { current, async run(file, commit) {
+        if (!current()) throw new DOMException('PDF upload became stale.', 'AbortError');
+        const controller = new AbortController();
+        active.add(controller);
+        try {
+          const text = await extractor(file, { signal: controller.signal });
+          if (!current()) throw new DOMException('PDF upload became stale.', 'AbortError');
+          return commit(text);
+        } finally {
+          active.delete(controller);
+        }
+      } };
     },
     cancel() {
       generation += 1;
@@ -43,10 +51,10 @@ export function createDocumentUploadGate(
 
 export async function attachPdfDocument(
   file: File,
-  gate: DocumentUploadGate,
+  batch: DocumentUploadBatch,
   add: (attachment: FileAttachment) => void,
 ): Promise<void> {
-  await gate.run(file, textContent => {
+  await batch.run(file, textContent => {
     add({ id: crypto.randomUUID(), name: file.name, type: 'application/pdf', size: file.size, textContent });
   });
 }

--- a/apps/viewer/src/lib/llm/document-upload.ts
+++ b/apps/viewer/src/lib/llm/document-upload.ts
@@ -7,8 +7,12 @@ import { extractPdfText, type PdfTextOptions } from './document-text.js';
 type Extractor = (file: Blob, options: PdfTextOptions) => Promise<string>;
 
 export interface DocumentUploadGate {
-  extract(file: Blob): Promise<string>;
+  run<T>(file: Blob, commit: (text: string) => T): Promise<T>;
   cancel(): void;
+}
+
+export function shouldContinueDocumentUploadBatch(error: unknown): boolean {
+  return !(error instanceof Error && error.name === 'AbortError');
 }
 
 export function createDocumentUploadGate(
@@ -17,14 +21,14 @@ export function createDocumentUploadGate(
   let generation = 0;
   const active = new Set<AbortController>();
   return {
-    async extract(file) {
+    async run(file, commit) {
       const ownGeneration = generation;
       const controller = new AbortController();
       active.add(controller);
       try {
         const text = await extractor(file, { signal: controller.signal });
         if (generation !== ownGeneration) throw new DOMException('PDF upload became stale.', 'AbortError');
-        return text;
+        return commit(text);
       } finally {
         active.delete(controller);
       }
@@ -42,6 +46,7 @@ export async function attachPdfDocument(
   gate: DocumentUploadGate,
   add: (attachment: FileAttachment) => void,
 ): Promise<void> {
-  const textContent = await gate.extract(file);
-  add({ id: crypto.randomUUID(), name: file.name, type: 'application/pdf', size: file.size, textContent });
+  await gate.run(file, textContent => {
+    add({ id: crypto.randomUUID(), name: file.name, type: 'application/pdf', size: file.size, textContent });
+  });
 }

--- a/apps/viewer/src/lib/llm/document-upload.ts
+++ b/apps/viewer/src/lib/llm/document-upload.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import type { FileAttachment } from './types.js';
+import { extractPdfText, type PdfTextOptions } from './document-text.js';
+
+type Extractor = (file: Blob, options: PdfTextOptions) => Promise<string>;
+
+export interface DocumentUploadGate {
+  extract(file: Blob): Promise<string>;
+  cancel(): void;
+}
+
+export function createDocumentUploadGate(
+  extractor: Extractor = (file, options) => extractPdfText(file, undefined, options),
+): DocumentUploadGate {
+  let generation = 0;
+  const active = new Set<AbortController>();
+  return {
+    async extract(file) {
+      const ownGeneration = generation;
+      const controller = new AbortController();
+      active.add(controller);
+      try {
+        const text = await extractor(file, { signal: controller.signal });
+        if (generation !== ownGeneration) throw new DOMException('PDF upload became stale.', 'AbortError');
+        return text;
+      } finally {
+        active.delete(controller);
+      }
+    },
+    cancel() {
+      generation += 1;
+      for (const controller of active) controller.abort(new DOMException('PDF upload was cancelled.', 'AbortError'));
+      active.clear();
+    },
+  };
+}
+
+export async function attachPdfDocument(
+  file: File,
+  gate: DocumentUploadGate,
+  add: (attachment: FileAttachment) => void,
+): Promise<void> {
+  const textContent = await gate.extract(file);
+  add({ id: crypto.randomUUID(), name: file.name, type: 'application/pdf', size: file.size, textContent });
+}

--- a/apps/viewer/src/lib/llm/types.ts
+++ b/apps/viewer/src/lib/llm/types.ts
@@ -135,10 +135,6 @@ export interface FileAttachment {
   imageBase64?: string;
   /** Whether this is an image attachment */
   isImage?: boolean;
-  /** Base64-encoded PDF data (for PDF attachments — Anthropic native document blocks) */
-  pdfBase64?: string;
-  /** Whether this is a PDF attachment */
-  isPdf?: boolean;
   /** Whether this is a binary spreadsheet (xlsx/xls/ods) that we can't parse here yet. */
   isSpreadsheetBinary?: boolean;
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
   projects: [
     {
       name: 'viewer-e2e',
-      testMatch: /(viewer-smoke|usd-export|laz-wasm|model-reposition)\.e2e\.spec\.ts/,
+      testMatch: /(viewer-smoke|usd-export|laz-wasm|model-reposition|document-text)\.e2e\.spec\.ts/,
       timeout: 240000,
       use: {
         ...devices['Desktop Chrome'],
@@ -72,7 +72,7 @@ export default defineConfig({
     },
     {
       name: 'viewer-e2e-ci',
-      testMatch: /(viewer-smoke|usd-export|laz-wasm|model-reposition)\.e2e\.spec\.ts/,
+      testMatch: /(viewer-smoke|usd-export|laz-wasm|model-reposition|document-text)\.e2e\.spec\.ts/,
       timeout: 240000,
       use: {
         baseURL: BASE_URL,

--- a/tests/e2e/document-text.e2e.spec.ts
+++ b/tests/e2e/document-text.e2e.spec.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { test, expect } from '@playwright/test';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
+interface DevServer {
+  listen(): Promise<void>;
+  close(): Promise<void>;
+  resolvedUrls: { local: string[] } | null;
+}
+let vite: DevServer;
+let viewerUrl: string;
+
+function mixedFontPdf(): number[] {
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 600 800] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 7 0 R >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Type /Font /Subtype /Type0 /BaseFont /HeiseiMin-W3 /Encoding /UniJIS-UTF16-H /DescendantFonts [6 0 R] >>',
+    '<< /Type /Font /Subtype /CIDFontType0 /BaseFont /HeiseiMin-W3 /CIDSystemInfo << /Registry (Adobe) /Ordering (Japan1) /Supplement 5 >> /DW 1000 >>',
+  ];
+  const content = 'BT /F1 12 Tf 20 700 Td (Fire rating EI60) Tj /F2 12 Tf 0 -30 Td <65E5672C> Tj ET';
+  objects.push(`<< /Length ${content.length} >>\nstream\n${content}\nendstream`);
+  let source = '%PDF-1.7\n';
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(source.length);
+    source += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const start = source.length;
+  source += `xref\n0 ${offsets.length}\n0000000000 65535 f \n`;
+  source += offsets.slice(1).map(offset => `${String(offset).padStart(10, '0')} 00000 n \n`).join('');
+  source += `trailer\n<< /Size ${offsets.length} /Root 1 0 R >>\nstartxref\n${start}\n%%EOF\n`;
+  return Array.from(new TextEncoder().encode(source));
+}
+
+test.beforeAll(async () => {
+  const requireFromViewer = createRequire(join(ROOT, 'apps/viewer/package.json'));
+  const { createServer } = await import(pathToFileURL(requireFromViewer.resolve('vite')).href);
+  vite = await createServer({ root: join(ROOT, 'apps/viewer'), logLevel: 'error', server: { host: '127.0.0.1', port: 0 } });
+  await vite.listen();
+  viewerUrl = vite.resolvedUrls?.local[0] ?? '';
+  if (!viewerUrl) throw new Error('Vite did not expose its browser test URL');
+});
+
+test.afterAll(async () => { await vite.close(); });
+
+test('#4177 production browser resources preserve mixed Latin and CMap text', async ({ page }) => {
+  await page.goto(viewerUrl);
+  const text = await page.evaluate(async ({ bytes, moduleUrl }) => {
+    const documentText: typeof import('../../apps/viewer/src/lib/llm/document-text') = await import(moduleUrl);
+    return documentText.extractPdfText(new Blob([new Uint8Array(bytes)]));
+  }, { bytes: mixedFontPdf(), moduleUrl: '/src/lib/llm/document-text.ts' });
+  expect(text).toContain('Fire rating EI60');
+  expect(text).toContain('日本');
+});


### PR DESCRIPTION
Fixes #4177

Adds PDF and Markdown assistant context for datasheet-to-Pset and specification checking. PDF text is streamed through the canonical resource-backed browser loader with file, page, item, character, cancellation, and deadline bounds; OCR-only and locked documents get actionable errors. Upload batches are generation-scoped so cleared or changed composers cannot receive stale files.

Validation: 10 focused unit/integration tests; real Chrome/Vite mixed Latin and UniJIS CMap extraction; viewer typecheck/build; test-glob and module-size gates.

Adversarial plan and exact-head review: Astra GO at 94d921b7520729e4b590e06d0c6935b64c2ec939. Appearance conversion files were not edited.