### PR TITLE
feat(appearance): bind closed PDF dashes to source version

### DIFF
--- a/.changeset/pdf-closed-dashes.md
+++ b/.changeset/pdf-closed-dashes.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Convert qualified positive-pattern dashed PDF strokes on closed straight subpaths into styled IFC annotation fill geometry. The closing edge continues the dash cycle, with capped closure seams for PDF 1.0–1.7 and joined first/last on-dash pieces for PDF 2.0. Unknown versions and PDF 1.x single-dash full loops remain explicit omissions. Explicit close-path and close-and-stroke operators share the behavior, including paths that mix open and closed subpaths.

--- a/apps/viewer/src/lib/appearance/pdf/engine.ts
+++ b/apps/viewer/src/lib/appearance/pdf/engine.ts
@@ -108,8 +108,29 @@ export async function runPdfJob(
       if (job.kind === 'vectors') {
         if (!backend.vectorDecoder) throw new PdfAppearanceError('unsupported', 'PDF vector decoding is unavailable.');
         // Optional-content visibility is a document setting; the adapter resolves it per marked-content scope.
-        const optionalContent = await document.getOptionalContentConfig({ intent: 'display' });
-        return { kind: 'vectors', page: await decodePdfVectorPage(page, source, job.request, backend.vectorDecoder, options.signal, { optionalContent }) };
+        const [optionalContent, metadata] = await Promise.all([
+          document.getOptionalContentConfig({ intent: 'display' }),
+          document.getMetadata(),
+        ]);
+        const info: unknown = metadata.info;
+        const candidate =
+          typeof info === 'object' &&
+          info !== null &&
+          'PDFFormatVersion' in info
+            ? info.PDFFormatVersion
+            : null;
+        const pdfFormatVersion = typeof candidate === 'string' ? candidate : null;
+        return {
+          kind: 'vectors',
+          page: await decodePdfVectorPage(
+            page,
+            source,
+            job.request,
+            backend.vectorDecoder,
+            options.signal,
+            { optionalContent, pdfFormatVersion },
+          ),
+        };
       }
       const recipe = rasterRecipe(page, job.request),
         scale = recipe.effectiveDpi / 72;

--- a/apps/viewer/src/lib/appearance/pdf/fidelity-report-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/pdf/fidelity-report-wasm.test.ts
@@ -31,7 +31,8 @@ async function decode(control: string): Promise<PdfVectorPage> {
   if (result.kind !== 'vectors') throw new Error('Wrong PDF job response');
   return result.page;
 }
-const report = (api: NativeApi, page: PdfVectorPage) => (JSON.parse(new TextDecoder().decode(api.preparePdfVectorPage(JSON.stringify(page)))) as PreparedPdfVectorPage).fidelity;
+const prepare = (api: NativeApi, page: PdfVectorPage) => JSON.parse(new TextDecoder().decode(api.preparePdfVectorPage(JSON.stringify(page)))) as PreparedPdfVectorPage;
+const report = (api: NativeApi, page: PdfVectorPage) => prepare(api, page).fidelity;
 const summary = (verdict: PdfFidelityReport) => verdict.summary.map(entry => [entry.kind, entry.count, entry.visibleCount]);
 
 test('controlled pages report each fidelity category with page extent and visibility through the real decoder (#4406)', async t => {
@@ -60,6 +61,18 @@ test('controlled pages report each fidelity category with page extent and visibi
     assert.deepEqual([strokes.exact, strokes.convertiblePaths, strokes.omittedPaints], [true, 3, 0],
       'the positive-pattern open straight dash is converted through the real decoder and WASM');
     assert.deepEqual(summary(strokes), []);
+    const pdf1Page = await decode('closedDashes'), pdf1 = prepare(api, pdf1Page);
+    assert.equal(pdf1Page.pdfFormatVersion, '1.7', 'PDF.js supplies the effective version used at the native boundary');
+    assert.deepEqual([pdf1.fidelity.exact, pdf1.fidelity.convertiblePaths, pdf1.fidelity.omittedPaints], [true, 3, 0],
+      'PDF 1.7 explicit close, close-paint and mixed open/closed dashed paths convert with capped seams');
+    assert.deepEqual(pdf1.paths.map(path => path.dashClosure), ['capped', 'capped', 'capped']);
+    assert.deepEqual(summary(pdf1.fidelity), []);
+    const pdf2Page = await decode('closedDashesV2'), pdf2 = prepare(api, pdf2Page);
+    assert.equal(pdf2Page.pdfFormatVersion, '2.0', 'PDF.js honors the Catalog /Version override');
+    assert.deepEqual([pdf2.fidelity.exact, pdf2.fidelity.convertiblePaths, pdf2.fidelity.omittedPaints], [true, 3, 0],
+      'the same PDF 2.0 paths convert with joined seams through the real decoder and WASM');
+    assert.deepEqual(pdf2.paths.map(path => path.dashClosure), ['joined', 'joined', 'joined']);
+    assert.deepEqual(summary(pdf2.fidelity), []);
     const form = report(api, await decode('form'));
     assert.deepEqual([form.exact, form.convertiblePaths], [false, 1]);
     assert.deepEqual(summary(form), [['clip', 1, 1]], 'a form BBox that does not contain the page clips its content');
@@ -110,8 +123,9 @@ test('an accepted partial conversion plans, exports and reopens with its provena
     const provenance = reopened.getProperties(result.annotationId).find(set => set.name === 'IfcLite_PdfVectorConversion');
     assert.ok(provenance, 'the provenance property set reopens on the annotation through the ordinary parser');
     const property = (name: string) => provenance.properties.find(entry => entry.name === name)?.value;
-    assert.equal(provenance.properties.length, 20);
+    assert.equal(provenance.properties.length, 21);
     assert.equal(property('SourcePdfSha256'), page.pdfSha256);
+    assert.equal(property('SourcePdfFormatVersion'), '1.7');
     assert.equal(property('FidelitySha256'), verdict.sha256);
     assert.equal(property('Omissions'), '[{"kind":"text","count":1,"visible":1}]');
     assert.equal(property('AcceptedPartialConversion'), true);

--- a/apps/viewer/src/lib/appearance/pdf/fixtures.ts
+++ b/apps/viewer/src/lib/appearance/pdf/fixtures.ts
@@ -31,6 +31,7 @@ export function controlledPdf(contents = '1 0 0 rg 10 20 30 30 re f\n0 1 0 rg 90
   return new TextEncoder().encode(pdf);
 }
 const HELVETICA = '/Font << /F1 << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> >>';
+const CLOSED_DASHES = '0 0 1 RG 2 w 0 J 0 j\n[10 10] 3 d 20 30 m 40 30 l 40 50 l 20 50 l h S\n[10 10] 13 d 55 30 m 75 30 l 75 50 l 55 50 l s\n[10 10] 3 d 20 70 m 45 70 l 60 62 m 80 62 l 80 82 l 60 82 l h S\n';
 /** Controlled fidelity pages (#4406), CC0. Each exercises one report category on the
  * same CropBox [10 20 110 92] / Rotate 90 / UserUnit 2 page so extents, visibility and
  * the exact/partial/raster-only verdicts are checked through the real decoder. */
@@ -41,6 +42,8 @@ export const fidelityControls: Readonly<Record<string, { contents: string; resou
   clip: { contents: 'q 0 0 40 40 re W n 1 0 0 rg 0 0 80 80 re f Q\n0 1 0 rg 90 60 20 30 re f\n' },
   transparency: { contents: 'q /GS1 gs 0 0 1 rg 20 30 10 10 re f Q\n1 0 0 rg 60 60 20 20 re f\n', resources: '/ExtGState << /GS1 << /ca 0.5 >> >>' },
   strokes: { contents: '0 0 1 RG 2 w 1 j 20 30 m 60 30 l S\n0 j [3 2] 0 d 20 50 m 60 50 l S\n[] 0 d 20 70 m 60 70 l S\n' },
+  closedDashes: { contents: CLOSED_DASHES },
+  closedDashesV2: { contents: CLOSED_DASHES, catalog: '/Version /2.0' },
   form: { contents: 'q /Fx1 Do Q\n1 0 0 rg 60 60 20 20 re f\n', resources: '/XObject << /Fx1 6 0 R >>',
     extraObjects: [pdfStream('/Type /XObject /Subtype /Form /BBox [0 0 50 50] /Matrix [2 0 0 2 5 5]', '0 0 1 rg 0 0 10 10 re f\n')] },
   hiddenLayer: { contents: '/OC /OC1 BDC 0 1 0 rg 20 30 10 10 re f EMC\n1 0 0 rg 20 30 30 30 re f\n', resources: '/Properties << /OC1 6 0 R >>',

--- a/apps/viewer/src/lib/appearance/pdf/vector-adapter.test.ts
+++ b/apps/viewer/src/lib/appearance/pdf/vector-adapter.test.ts
@@ -32,6 +32,7 @@ test('actual PDF vectors retain native CropBox/UserUnit/rotation and paint order
   assert.deepEqual(page.viewBox, [10,20,110,92]);
   assert.equal(page.userUnit, 2);
   assert.equal(page.intrinsicRotation, 90);
+  assert.equal(page.pdfFormatVersion, '1.7');
   assert.match(page.pdfSha256, /^[a-f0-9]{64}$/);
   const colors = page.operations.flatMap(({ operation }) => operation.kind === 'fillColor' ? [operation.rgb] : []);
   assert.deepEqual(colors, [[1,0,0],[0,1,0]]);
@@ -39,6 +40,10 @@ test('actual PDF vectors retain native CropBox/UserUnit/rotation and paint order
   assert.equal(paths.length, 2);
   assert.ok(paths[0]!.ordinal < paths[1]!.ordinal);
   assert.ok(!page.operations.some(({ operation }) => operation.kind === 'unsupported'));
+});
+test('effective PDF version includes a Catalog override (#4583)', async () => {
+  const page = await decode(controlledPdf(undefined, '', [], '/Version /2.0'));
+  assert.equal(page.pdfFormatVersion, '2.0');
 });
 test('actual PDF dash, nonuniform transform, cubic commands and unused font setup survive (#4406)', async () => {
   // Source drawing invariant: the cubic and stroke are constructed BEFORE a

--- a/apps/viewer/src/lib/appearance/pdf/vector-adapter.ts
+++ b/apps/viewer/src/lib/appearance/pdf/vector-adapter.ts
@@ -10,6 +10,7 @@ export interface PdfVectorDecoder { version: string; ops: Readonly<Record<string
 export interface PdfVectorDecodeContext {
   optionalContent?: { isVisible(group: unknown): unknown } | null;
   fonts?: PdfFontObjects;
+  pdfFormatVersion?: string | null;
 }
 const MAX_OPERATIONS = 100_000, MAX_NUMBERS = 2_000_000, MAX_PLACEMENTS = 4096;
 function unsupported(operator: string): PdfVectorOperator { return { kind: 'unsupported', operator }; }
@@ -191,7 +192,8 @@ export async function decodePdfVectorPage(
   const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', new Uint8Array(source)));
   return {
     ...request, pdfSha256: Array.from(hash, byte => byte.toString(16).padStart(2,'0')).join(''),
-    decoderVersion: decoder.version, viewBox: view as PdfPageRect,
+    decoderVersion: decoder.version, pdfFormatVersion: context.pdfFormatVersion ?? null,
+    viewBox: view as PdfPageRect,
     userUnit: page.userUnit, intrinsicRotation: page.rotate, operations,
   };
 }

--- a/apps/viewer/src/lib/appearance/pdf/vector-types.ts
+++ b/apps/viewer/src/lib/appearance/pdf/vector-types.ts
@@ -52,6 +52,8 @@ export interface PdfVectorRequest {
 export interface PdfVectorPage extends PdfVectorRequest {
   pdfSha256: string;
   decoderVersion: string;
+  /** Effective PDF version reported by PDF.js; absent on older hosts. */
+  pdfFormatVersion?: string | null;
   viewBox: PdfPageRect;
   userUnit: number;
   intrinsicRotation: number;
@@ -86,6 +88,13 @@ export interface PreparedPdfVectorPage {
   calibrationKey: string;
   toleranceMetres: number;
   pageClipPdf: PdfPageRect;
-  paths: Array<{ operatorOrdinal: number; paint: PdfVectorPaint; commands: number[]; state: PdfVectorGraphicsState }>;
+  paths: Array<{
+    operatorOrdinal: number;
+    paint: PdfVectorPaint;
+    commands: number[];
+    state: PdfVectorGraphicsState;
+    /** Version-bound closed-dash seam behavior; absent for other paths. */
+    dashClosure: 'capped' | 'joined' | null;
+  }>;
   fidelity: PdfFidelityReport;
 }

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -955,7 +955,9 @@ containment GlobalId, `Name` and plane frame, plus a canonical decoded
 `PdfVectorPage`, host-owned `propertySetGlobalId` and `propertyRelationGlobalId`
 for the provenance rows, and `acceptedFidelitySha256` (a string or `null`). Its
 calibrated PDF-to-plane affine determines model scale; `frame.sizeMetres` is
-descriptive page extent, not a second scale.
+descriptive page extent, not a second scale. The decoded page also carries
+PDF.js's effective `pdfFormatVersion`, including a Catalog `/Version` override,
+because PDF 2.0 resolves an ambiguity in the earlier closed-dash seam rules.
 
 The planner recomputes the fidelity report and applies the acceptance rule: an
 exact page plans directly; a page with visible omissions plans only when
@@ -966,9 +968,17 @@ page refuses regardless. Acceptance covers the listed omissions, not geometry.
 The geometry scope accepts opaque RGB pages made of straight fill edges,
 qualified quadratic/cubic curved rings, and qualified solid straight strokes.
 Strokes support positive width, butt/square/round caps, bevel/miter/round joins,
-miter-limit fallback and positive dash patterns on open straight subpaths,
+miter-limit fallback and positive dash patterns on open or closed straight subpaths,
 outlined before the full affine transform. Dash phase, odd-array repetition,
-per-subpath reset and joins across vertices are preserved. Combined fill and
+per-subpath reset and joins across vertices are preserved. A closed subpath
+includes its closing edge. PDF 1.0–1.7 retain caps where first and last on-dash
+pieces meet at the closure seam; PDF 2.0 joins them as the newer specification
+requires. Explicit close-path and close-and-stroke operators use the same path.
+An absent, malformed or unsupported effective version reports the closed stroke
+as a `dashVersion` omission. A PDF 1.x dash that covers the entire closed
+perimeter reports `dashTopology` until coincident independent caps can be
+decomposed without weakening the topology qualifier.
+Combined fill and
 dashed-stroke paints still pass the same region-composition qualifier; a page
 with multiple dash-run crossings that it cannot prove refuses atomically. Round arcs
 are subdivided against the declared metric tolerance after accounting for
@@ -987,7 +997,7 @@ multiple untextured colored `meshes`, `coordinateSpace: 'ifc-z-up'`, `rtcOffset`
 declared tolerance, actual grid size/work count, per-region source operator/RGB
 provenance and the `fidelity` report the plan was built under. The plan's rows
 include an `IfcLite_PdfVectorConversion` `IfcPropertySet` (source PDF digest,
-page, CropBox, UserUnit, rotation, decoder, calibration key and affine,
+page, CropBox, UserUnit, rotation, effective PDF format version, decoder, calibration key and affine,
 `ToleranceMetres`, grid, request/fidelity digests, `ExactConversion`,
 `AcceptedPartialConversion`, converted paths, fill regions, omitted paints and
 the omission summary as JSON) attached through `IfcRelDefinesByProperties`, and

--- a/docs/architecture/pdf-vector-annotations.md
+++ b/docs/architecture/pdf-vector-annotations.md
@@ -213,7 +213,7 @@ kinds spelled out for readers (`1 text run`, `556 hairline strokes`,
 tokens stay in the property set's `Omissions` JSON. The
 `IfcLite_PdfVectorConversion` property set (attached through
 `IfcRelDefinesByProperties`) records the source PDF digest, page, CropBox,
-UserUnit, rotation, decoder version, calibration key, PDF-to-model affine,
+UserUnit, rotation, effective PDF format version, decoder version, calibration key, PDF-to-model affine,
 declared tolerance in metres, composition grid, request and fidelity digests,
 `ExactConversion`, `AcceptedPartialConversion`, converted paths, fill regions,
 omitted paints (visible painted parts only, so an exact page records zero) and
@@ -301,13 +301,24 @@ self-contact/crossings refuse the whole page. This first sufficient qualifier
 does not repair wide/self-overlapping stroke arrangements. Round arcs are
 subdivided with a post-affine metric error bound; a request below the numerical
 precision of its transformed coordinates refuses rather than overstating that
-bound. Qualified positive dash patterns on open straight subpaths are split in
+bound. Qualified positive dash patterns on open or closed straight subpaths are split in
 construction space before the complete affine transform. Odd arrays repeat to
 form an even cycle, phase (including a negative phase) is normalized over that
 cycle, and pattern state resets for each subpath while remaining continuous
 across its vertices. An on-run crossing a vertex therefore keeps the configured
-join; each separated run receives the configured cap. Closed dashed contours,
-curved dashed paths and patterns containing a zero remain reported omissions;
+join; each separated run receives the configured cap. The closing edge of a
+closed subpath participates in the same cycle. For PDF 1.0–1.7 compatibility,
+the conversion retains the first and last on-dash pieces as independently
+capped at the closure seam; PDF 2.0 explicitly requires those pieces to be
+joined. The host binds PDF.js's effective
+format version, including a Catalog `/Version` override, into the decoded page.
+An absent, malformed or unsupported version therefore makes a closed dashed
+paint a `dashVersion` omission instead of guessing. A PDF 1.x dash covering the
+entire closed perimeter is a `dashTopology` omission until its coincident caps
+can be decomposed under the existing self-contact qualifier. Explicit close-path
+commands and close-and-stroke paints share this rule, including in a path that
+also contains open subpaths. Curved dashed paths and patterns containing a zero
+remain reported omissions;
 an invalid all-zero array refuses during preparation. Expansion shares the page
 work and piece budgets and refuses atomically when numeric progress cannot be
 proved. A combined fill-and-dashed-stroke paint is supported when the composed
@@ -318,6 +329,8 @@ produces visual filled vector geometry, not editable centreline/text semantics.
 Original-PDF raster and independent IFC evidence lives in
 [the solid-stroke evidence](evidence/pdf-straight-stroke-annotations/README.md)
 and [the dashed-stroke evidence](evidence/pdf-dashed-stroke-annotations/README.md).
+Closed-path decoder, export and independent-reader evidence lives in
+[the closed-dash evidence](evidence/pdf-closed-dash-annotations/README.md).
 
 ## One lattice for the complete page
 

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -165,8 +165,14 @@ page only when the request quotes that report's digest as the user's
 acceptance. It emits no IFC entities and makes no flattened-geometry fidelity
 claim; see the
 [preparation contract](../../docs/api/wasm.md#pdf-vector-graphics-state-preparation-and-fidelity-report).
-Qualified positive dash patterns on open straight subpaths preserve phase,
-odd-array repetition, subpath reset, joins across vertices and run caps.
+Qualified positive dash patterns on open and closed straight subpaths preserve
+phase, odd-array repetition, subpath reset, joins across vertices and run caps.
+The closing edge participates in the pattern. PDF 1.0–1.7 retain caps where the
+first and last on-dash pieces meet at the closure seam; PDF 2.0 joins them.
+PDF.js's effective format version is bound into the page DTO; an unknown version
+reports `dashVersion`, and a PDF 1.x dash covering the complete closed perimeter
+reports `dashTopology`. Explicit close-path and close-and-stroke operators share
+the versioned behavior.
 Combined fill and dashed-stroke paints can still refuse atomically when
 multiple run boundaries produce crossings outside the current fill-region
 qualifier.

--- a/rust/processing/src/appearance/pdf_fill_provenance.rs
+++ b/rust/processing/src/appearance/pdf_fill_provenance.rs
@@ -76,6 +76,10 @@ impl Provenance<'_> {
         let boolean = |b: bool| typed("IfcBoolean", A::Enum(if b { "T" } else { "F" }.into()));
         vec![
             ("SourcePdfSha256", identifier(&page.pdf_sha256)),
+            (
+                "SourcePdfFormatVersion",
+                label(page.pdf_format_version.as_deref().unwrap_or("not reported")),
+            ),
             ("SourcePageNumber", integer(i64::from(page.page_number))),
             ("SourceCropBox", text(json_numbers(&page.view_box))),
             ("SourceUserUnit", real(page.user_unit)),

--- a/rust/processing/src/appearance/pdf_fill_tests.rs
+++ b/rust/processing/src/appearance/pdf_fill_tests.rs
@@ -48,6 +48,7 @@ fn fixture() -> (String, PdfFillAnnotationRequest) {
             page: PdfVectorPage {
                 pdf_sha256: "a".repeat(64),
                 decoder_version: "6.3.289".into(),
+                pdf_format_version: Some("2.0".into()),
                 page_number: 1,
                 view_box: [0., 0., 8., 8.],
                 user_unit: 1.,

--- a/rust/processing/src/appearance/pdf_fill_tests.rs
+++ b/rust/processing/src/appearance/pdf_fill_tests.rs
@@ -87,6 +87,26 @@ fn area(mesh: &crate::types::mesh::MeshData) -> f64 {
         })
         .sum()
 }
+fn reopened_property_value(ifc: &str, property_name: &str) -> Option<String> {
+    let mut scanner = ifc_lite_core::EntityScanner::new(ifc.as_bytes());
+    let mut decoder = ifc_lite_core::EntityDecoder::new(ifc);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name != "IFCPROPERTYSINGLEVALUE" {
+            continue;
+        }
+        let property = decoder.decode_at_with_id(id, start, end).ok()?;
+        if property.get_string(0) != Some(property_name) {
+            continue;
+        }
+        return property.get(2).and_then(|value| match value {
+            ifc_lite_core::AttributeValue::List(typed) => {
+                typed.get(1).and_then(ifc_lite_core::AttributeValue::as_string).map(str::to_owned)
+            }
+            value => value.as_string().map(str::to_owned),
+        });
+    }
+    None
+}
 #[test]
 fn issue_4459_direct_pdf_fill_provenance_matches_mesh_without_removing_2d_symbols() {
     let (source, request) = fixture();
@@ -390,6 +410,7 @@ fn issue_4406_partial_page_needs_the_accepted_fidelity_digest_and_records_its_om
     assert!(step.contains(r#"IFCPROPERTYSINGLEVALUE('Omissions',$,IFCTEXT('[{"kind":"text","count":1,"visible":1}]'),$)"#), "{step}");
     assert!(step.contains(&format!("IFCPROPERTYSINGLEVALUE('FidelitySha256',$,IFCIDENTIFIER('{}'),$)", report.sha256)));
     assert!(step.contains("IFCPROPERTYSINGLEVALUE('SourcePdfSha256',$,IFCIDENTIFIER('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),$)"));
+    assert!(step.contains("IFCPROPERTYSINGLEVALUE('SourcePdfFormatVersion',$,IFCLABEL('2.0'),$)"));
     assert!(step.contains("IFCPROPERTYSINGLEVALUE('ToleranceMetres',$,IFCREAL(0.0001),$)"));
     assert!(step.contains("IFCPROPERTYSINGLEVALUE('SourceCropBox',$,IFCTEXT('[0.0,0.0,8.0,8.0]'),$)"), "{step}");
     assert!(step.contains(&format!("IFCRELDEFINESBYPROPERTIES('0cccccccccccccccccccc2',$,$,$,(#{}),#{});", plan.annotation_id, plan.property_set_id)), "{step}");
@@ -397,6 +418,10 @@ fn issue_4406_partial_page_needs_the_accepted_fidelity_digest_and_records_its_om
     // The provenance rows do not disturb canonical geometry on reopen.
     let reopened = crate::process_geometry(step.as_bytes());
     assert_eq!(reopened.meshes.iter().filter(|m| m.express_id == plan.annotation_id).count(), 2);
+    assert_eq!(
+        reopened_property_value(&step, "SourcePdfFormatVersion").as_deref(),
+        Some("2.0")
+    );
     // An exact page records the same set without acceptance.
     let exact = plan_pdf_fill_annotation(source.as_bytes(), &request).unwrap();
     assert!(exact.fidelity.exact);
@@ -405,6 +430,18 @@ fn issue_4406_partial_page_needs_the_accepted_fidelity_digest_and_records_its_om
     assert!(exact_step.contains("IFCPROPERTYSINGLEVALUE('Omissions',$,IFCTEXT('[]'),$)"));
     assert!(exact_step.contains("IFCPROPERTYSINGLEVALUE('FillRegions',$,IFCINTEGER(2),$)"));
     assert!(exact_step.contains("'PDF vectors, page 1: exact conversion'"));
+
+    // Older hosts omit the optional version. Preserve that fact explicitly so
+    // a reopened IFC can explain why version-sensitive closed dashes were not
+    // converted rather than silently implying either PDF 1.x or PDF 2.0.
+    let mut unversioned = request.clone();
+    unversioned.page.pdf_format_version = None;
+    let unversioned = plan_pdf_fill_annotation(source.as_bytes(), &unversioned).unwrap();
+    let unversioned_step = apply(&source, &unversioned.plan);
+    assert_eq!(
+        reopened_property_value(&unversioned_step, "SourcePdfFormatVersion").as_deref(),
+        Some("not reported")
+    );
 }
 
 #[test]

--- a/rust/processing/src/appearance/pdf_stroke_tests.rs
+++ b/rust/processing/src/appearance/pdf_stroke_tests.rs
@@ -373,6 +373,109 @@ fn issue_4406_dash_boundary_uses_caps_while_an_on_run_crossing_a_vertex_uses_the
 }
 
 #[test]
+fn issue_4583_closed_dash_seam_on_and_gap_use_exactly_the_visible_run_caps() {
+    let commands = rectangle(0., 0., 10., 10.);
+    for (pattern, phase, expected_butt_area, expected_square_cap_area) in [
+        (vec![10., 10.], 3., 40., 48.),
+        (vec![10., 10.], 13., 40., 48.),
+        // The two runs meet only at the seam boundary. Their independently
+        // capped outlines overlap there; fixed-grid composition unions that
+        // overlap, rather than replacing the two caps with a join.
+        (vec![15., 10.], 0., 59., 64.),
+    ] {
+        let mut areas = vec![];
+        for cap in [0, 2] {
+            let (source, mut request) = stroke(
+                commands.clone(), cap, 0, 10., [1., 0., 0., 1., 0., 0.],
+            );
+            request.page.operations.insert(5, PdfVectorOperation {
+                ordinal: 5,
+                operation: PdfVectorOperator::Dash { lengths: pattern.clone(), phase },
+            });
+            request.page.operations[6].ordinal = 6;
+            let result = plan_pdf_fill_annotation(source.as_bytes(), &request).unwrap();
+            assert!(result.fidelity.exact);
+            assert!(result.regions.iter().all(|region| {
+                region.source_operator_ordinal == 6 && region.rgb == [0., 1., 0.]
+            }));
+            areas.push(result.meshes.iter().map(area).sum::<f64>());
+        }
+        assert!((areas[0] - expected_butt_area).abs() < 0.0001,
+            "butt-cap area at pattern {pattern:?}, phase {phase}: {areas:?}");
+        assert!((areas[1] - expected_square_cap_area).abs() < 0.0001,
+            "closure seam gained or lost a cap at pattern {pattern:?}, phase {phase}: {areas:?}");
+    }
+}
+
+#[test]
+fn issue_4583_explicit_close_and_close_paint_match_after_affine_and_reopen() {
+    let matrix = [-1., 0.3, 0.4, 1.7, -2., 5.];
+    let plan = |commands, paint| {
+        let (source, mut request) = stroke(commands, 2, 0, 10., matrix);
+        request.page.operations.insert(5, PdfVectorOperation {
+            ordinal: 5,
+            operation: PdfVectorOperator::Dash { lengths: vec![10., 10.], phase: 3. },
+        });
+        request.page.operations[6].ordinal = 6;
+        if let PdfVectorOperator::Path { paint: target, .. } = &mut request.page.operations[6].operation {
+            *target = paint;
+        }
+        let result = plan_pdf_fill_annotation(source.as_bytes(), &request).unwrap();
+        assert!(result.fidelity.exact);
+        let planned = result.meshes.iter().map(area).sum::<f64>();
+        let reopened = crate::process_geometry(apply(&source, &result.plan).as_bytes());
+        let reopened_area = reopened.meshes.iter()
+            .filter(|mesh| mesh.express_id == result.annotation_id)
+            .map(area)
+            .sum::<f64>();
+        assert!((planned - reopened_area).abs() < 0.0001);
+        planned
+    };
+    let explicit = plan(rectangle(0., 0., 10., 10.), PdfVectorPaint::Stroke);
+    let close_paint = plan(
+        vec![0., 0., 0., 1., 10., 0., 1., 10., 10., 1., 0., 10.],
+        PdfVectorPaint::CloseStroke,
+    );
+    assert!((explicit - close_paint).abs() < 0.0001);
+    let determinant: f64 = matrix[0] * matrix[3] - matrix[1] * matrix[2];
+    assert!((explicit - 48. * determinant.abs()).abs() < 0.0001);
+}
+
+#[test]
+fn issue_4583_fully_on_closed_dash_has_joins_and_ignores_caps() {
+    let mut areas = vec![];
+    for cap in [0, 1, 2] {
+        let (source, mut request) = stroke(
+            rectangle(0., 0., 4., 4.), cap, 0, 10., [1., 0., 0., 1., 0., 0.],
+        );
+        request.page.operations.insert(5, PdfVectorOperation {
+            ordinal: 5,
+            operation: PdfVectorOperator::Dash { lengths: vec![100., 1.], phase: 0. },
+        });
+        request.page.operations[6].ordinal = 6;
+        areas.push(plan_pdf_fill_annotation(source.as_bytes(), &request).unwrap()
+            .meshes.iter().map(area).sum::<f64>());
+    }
+    assert!(areas.iter().all(|actual| (*actual - 32.).abs() < 0.0001), "{areas:?}");
+}
+
+#[test]
+fn issue_4583_mixed_open_and_closed_subpaths_reset_and_keep_one_paint_identity() {
+    let mut commands = rectangle(0., 0., 10., 10.);
+    commands.extend([0., 20., 0., 1., 30., 0.]);
+    let (source, mut request) = stroke(commands, 0, 0, 10., [1., 0., 0., 1., 0., 0.]);
+    request.page.operations.insert(5, PdfVectorOperation {
+        ordinal: 5,
+        operation: PdfVectorOperator::Dash { lengths: vec![10., 10.], phase: 3. },
+    });
+    request.page.operations[6].ordinal = 6;
+    let result = plan_pdf_fill_annotation(source.as_bytes(), &request).unwrap();
+    assert!(result.fidelity.exact);
+    assert!((result.meshes.iter().map(area).sum::<f64>() - 54.).abs() < 0.0001);
+    assert!(result.regions.iter().all(|region| region.source_operator_ordinal == 6));
+}
+
+#[test]
 fn issue_4406_strokes_refuse_collapsed_offsets_reversals_crossings_and_exhaustion() {
     for commands in [
         rectangle(0., 0., 1., 1.),

--- a/rust/processing/src/pdf_vector/dashes.rs
+++ b/rust/processing/src/pdf_vector/dashes.rs
@@ -11,21 +11,28 @@ type Point = [f64; 2];
 const MAX_DASH_RUNS: usize = 1024;
 
 /// Preparation may call a dashed stroke convertible only when the planner can
-/// preserve its semantics. Closed and curved paths remain reportable omissions.
-pub(super) fn supported(commands: &[f64], close_last: bool, pattern: &[f64]) -> bool {
-    if close_last || pattern.is_empty() || pattern.iter().any(|length| *length <= 0.) {
+/// preserve its semantics. Straight open and closed subpaths are supported;
+/// curves remain reportable omissions.
+pub(super) fn supported(commands: &[f64], _close_last: bool, pattern: &[f64]) -> bool {
+    if pattern.is_empty() || pattern.iter().any(|length| *length <= 0.) {
         return false;
     }
     let mut cursor = 0;
     while cursor < commands.len() {
         match commands[cursor] {
             0. | 1. => cursor += 3,
-            // Curves and explicit close-paths require separate qualifications.
-            2. | 3. | 4. => return false,
+            2. | 3. => return false,
+            4. => cursor += 1,
             _ => return false,
         }
     }
     true
+}
+
+#[derive(Debug, PartialEq)]
+pub(super) struct DashRun {
+    pub points: Vec<Point>,
+    pub closed: bool,
 }
 
 fn point_at(a: Point, b: Point, distance: f64, length: f64) -> Point {
@@ -44,15 +51,20 @@ fn finish(run: &mut Vec<Point>, runs: &mut Vec<Vec<Point>>) -> Result<(), String
     Ok(())
 }
 
-/// Expand one open polyline. Pattern state resets at each PDF subpath and is
-/// continuous across its vertices, so an on-run crossing a corner keeps the
-/// ordinary PDF join instead of gaining two artificial caps.
+/// Expand one polyline. Pattern state resets at each PDF subpath and is
+/// continuous across its vertices. For a closed subpath the closing edge is
+/// traversed too, and visible pieces meeting across the closure seam are joined.
 fn subpath(
-    points: &[Point], pattern: &[f64], phase: f64,
-    runs: &mut Vec<Vec<Point>>, remaining: &mut u64,
-) -> Result<(), String> {
+    points: &[Point], closed: bool, pattern: &[f64], phase: f64,
+    remaining: &mut u64,
+) -> Result<Vec<DashRun>, String> {
+    let points = if closed && points.len() > 1 && points.first() == points.last() {
+        &points[..points.len() - 1]
+    } else {
+        points
+    };
     if points.len() < 2 {
-        return Ok(());
+        return Ok(vec![]);
     }
     let cycle: f64 = pattern.iter().sum();
     if !cycle.is_finite() || cycle <= 0. {
@@ -65,9 +77,12 @@ fn subpath(
         pattern_index = (pattern_index + 1) % pattern.len();
     }
     let mut dash_left = pattern[pattern_index] - offset;
+    let starts_on = pattern_index % 2 == 0;
     let mut run = Vec::new();
-    for segment in points.windows(2) {
-        let [a, b] = [segment[0], segment[1]];
+    let segment_count = points.len() - usize::from(!closed);
+    let mut raw_runs = Vec::new();
+    for i in 0..segment_count {
+        let [a, b] = [points[i], points[(i + 1) % points.len()]];
         let length = (b[0] - a[0]).hypot(b[1] - a[1]);
         if !length.is_finite() || length == 0. {
             return Err("PDF dashed stroke has a zero-length segment".into());
@@ -97,22 +112,37 @@ fn subpath(
             let boundary = dash_left <= 0. || dash_left + step == step;
             if boundary {
                 if pattern_index % 2 == 0 {
-                    finish(&mut run, runs)?;
+                    finish(&mut run, &mut raw_runs)?;
                 }
                 pattern_index = (pattern_index + 1) % pattern.len();
                 dash_left = pattern[pattern_index];
             }
         }
     }
-    finish(&mut run, runs)
+    finish(&mut run, &mut raw_runs)?;
+
+    let ends_on = pattern_index % 2 == 0 && dash_left < pattern[pattern_index];
+    if closed && starts_on && ends_on && !raw_runs.is_empty() {
+        if raw_runs.len() == 1 {
+            return Ok(vec![DashRun { points: raw_runs.pop().unwrap(), closed: true }]);
+        }
+        let first = raw_runs.remove(0);
+        let last = raw_runs.last_mut().unwrap();
+        if last.last() == first.first() {
+            last.extend(first.into_iter().skip(1));
+        } else {
+            last.extend(first);
+        }
+    }
+    Ok(raw_runs.into_iter().map(|points| DashRun { points, closed: false }).collect())
 }
 
-/// Split all open straight subpaths into their visible on-runs. An odd pattern
+/// Split all straight subpaths into their visible on-runs. An odd pattern
 /// is repeated once as required by PDF, and phase is normalized over that
 /// effective even cycle.
 pub(super) fn expand(
-    commands: &[f64], pattern: &[f64], phase: f64, remaining: &mut u64,
-) -> Result<Vec<Vec<Point>>, String> {
+    commands: &[f64], close_last: bool, pattern: &[f64], phase: f64, remaining: &mut u64,
+) -> Result<Vec<DashRun>, String> {
     if pattern.is_empty() || pattern.iter().any(|length| !length.is_finite() || *length <= 0.) {
         return Err("Planner invariant: unsupported PDF dash pattern reached expansion".into());
     }
@@ -122,24 +152,48 @@ pub(super) fn expand(
     }
     let mut runs = Vec::new();
     let mut points = Vec::new();
+    let mut just_closed = false;
     let mut cursor = 0;
     while cursor < commands.len() {
         match commands[cursor] {
             0. => {
-                subpath(&points, &effective, phase, &mut runs, remaining)?;
+                append_subpath(&mut runs, subpath(&points, false, &effective, phase, remaining)?)?;
                 points.clear();
                 points.push([commands[cursor + 1], commands[cursor + 2]]);
                 cursor += 3;
+                just_closed = false;
             }
             1. => {
                 points.push([commands[cursor + 1], commands[cursor + 2]]);
                 cursor += 3;
+                just_closed = false;
+            }
+            4. => {
+                if !just_closed {
+                    append_subpath(&mut runs, subpath(&points, true, &effective, phase, remaining)?)?;
+                }
+                points.truncate(1);
+                cursor += 1;
+                just_closed = true;
             }
             _ => return Err("Planner invariant: unsupported dashed PDF path reached expansion".into()),
         }
     }
-    subpath(&points, &effective, phase, &mut runs, remaining)?;
+    if !just_closed {
+        append_subpath(
+            &mut runs,
+            subpath(&points, close_last, &effective, phase, remaining)?,
+        )?;
+    }
     Ok(runs)
+}
+
+fn append_subpath(runs: &mut Vec<DashRun>, mut next: Vec<DashRun>) -> Result<(), String> {
+    if runs.len() + next.len() > MAX_DASH_RUNS {
+        return Err("PDF dashed stroke exceeds 1024 visible run pieces".into());
+    }
+    runs.append(&mut next);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/rust/processing/src/pdf_vector/dashes.rs
+++ b/rust/processing/src/pdf_vector/dashes.rs
@@ -29,6 +29,79 @@ pub(super) fn supported(commands: &[f64], _close_last: bool, pattern: &[f64]) ->
     true
 }
 
+/// A capped closed dash whose first on interval covers the whole perimeter has
+/// coincident, independently capped ends. The general open-stroke contour is
+/// self-touching there, so this remains an explicit topology omission until it
+/// has a dedicated multi-ring decomposition.
+pub(super) fn has_capped_loop(
+    commands: &[f64],
+    close_last: bool,
+    pattern: &[f64],
+    phase: f64,
+) -> bool {
+    let mut effective = pattern.to_vec();
+    if effective.len() % 2 == 1 {
+        effective.extend_from_slice(pattern);
+    }
+    let cycle: f64 = effective.iter().sum();
+    let mut offset = phase.rem_euclid(cycle);
+    let mut index = 0;
+    while offset >= effective[index] {
+        offset -= effective[index];
+        index = (index + 1) % effective.len();
+    }
+    if index % 2 == 1 {
+        return false;
+    }
+    let first_on_left = effective[index] - offset;
+    let qualifies = |points: &[[f64; 2]], closed: bool| {
+        if !closed || points.len() < 2 {
+            return false;
+        }
+        let points = if points.first() == points.last() {
+            &points[..points.len() - 1]
+        } else {
+            points
+        };
+        let perimeter = (0..points.len())
+            .map(|i| {
+                let [a, b] = [points[i], points[(i + 1) % points.len()]];
+                (b[0] - a[0]).hypot(b[1] - a[1])
+            })
+            .sum::<f64>();
+        let error = 32.
+            * f64::EPSILON
+            * perimeter.abs().max(first_on_left.abs())
+            * points.len() as f64;
+        perimeter.is_finite()
+            && (perimeter <= first_on_left || (perimeter - first_on_left).abs() <= error)
+    };
+    let mut points = Vec::new();
+    let mut cursor = 0;
+    while cursor < commands.len() {
+        match commands[cursor] {
+            0. => {
+                points.clear();
+                points.push([commands[cursor + 1], commands[cursor + 2]]);
+                cursor += 3;
+            }
+            1. => {
+                points.push([commands[cursor + 1], commands[cursor + 2]]);
+                cursor += 3;
+            }
+            4. => {
+                if qualifies(&points, true) {
+                    return true;
+                }
+                points.truncate(1);
+                cursor += 1;
+            }
+            _ => return false,
+        }
+    }
+    qualifies(&points, close_last)
+}
+
 #[derive(Debug, PartialEq)]
 pub(super) struct DashRun {
     pub points: Vec<Point>,
@@ -55,7 +128,7 @@ fn finish(run: &mut Vec<Point>, runs: &mut Vec<Vec<Point>>) -> Result<(), String
 /// continuous across its vertices. For a closed subpath the closing edge is
 /// traversed too, and visible pieces meeting across the closure seam are joined.
 fn subpath(
-    points: &[Point], closed: bool, pattern: &[f64], phase: f64,
+    points: &[Point], closed: bool, join_seam: bool, pattern: &[f64], phase: f64,
     remaining: &mut u64,
 ) -> Result<Vec<DashRun>, String> {
     let points = if closed && points.len() > 1 && points.first() == points.last() {
@@ -149,7 +222,7 @@ fn subpath(
     finish(&mut run, &mut raw_runs)?;
 
     let ends_on = pattern_index % 2 == 0 && dash_left < pattern[pattern_index];
-    if closed && starts_on && ends_on && !raw_runs.is_empty() {
+    if closed && join_seam && starts_on && ends_on && !raw_runs.is_empty() {
         if raw_runs.len() == 1 {
             return Ok(vec![DashRun { points: raw_runs.pop().unwrap(), closed: true }]);
         }
@@ -168,7 +241,8 @@ fn subpath(
 /// is repeated once as required by PDF, and phase is normalized over that
 /// effective even cycle.
 pub(super) fn expand(
-    commands: &[f64], close_last: bool, pattern: &[f64], phase: f64, remaining: &mut u64,
+    commands: &[f64], close_last: bool, join_seam: bool, pattern: &[f64], phase: f64,
+    remaining: &mut u64,
 ) -> Result<Vec<DashRun>, String> {
     if pattern.is_empty() || pattern.iter().any(|length| !length.is_finite() || *length <= 0.) {
         return Err("Planner invariant: unsupported PDF dash pattern reached expansion".into());
@@ -184,7 +258,10 @@ pub(super) fn expand(
     while cursor < commands.len() {
         match commands[cursor] {
             0. => {
-                append_subpath(&mut runs, subpath(&points, false, &effective, phase, remaining)?)?;
+                append_subpath(
+                    &mut runs,
+                    subpath(&points, false, false, &effective, phase, remaining)?,
+                )?;
                 points.clear();
                 points.push([commands[cursor + 1], commands[cursor + 2]]);
                 cursor += 3;
@@ -197,7 +274,10 @@ pub(super) fn expand(
             }
             4. => {
                 if !just_closed {
-                    append_subpath(&mut runs, subpath(&points, true, &effective, phase, remaining)?)?;
+                    append_subpath(
+                        &mut runs,
+                        subpath(&points, true, join_seam, &effective, phase, remaining)?,
+                    )?;
                 }
                 points.truncate(1);
                 cursor += 1;
@@ -209,7 +289,14 @@ pub(super) fn expand(
     if !just_closed {
         append_subpath(
             &mut runs,
-            subpath(&points, close_last, &effective, phase, remaining)?,
+            subpath(
+                &points,
+                close_last,
+                join_seam,
+                &effective,
+                phase,
+                remaining,
+            )?,
         )?;
     }
     Ok(runs)

--- a/rust/processing/src/pdf_vector/dashes.rs
+++ b/rust/processing/src/pdf_vector/dashes.rs
@@ -81,6 +81,7 @@ fn subpath(
     let mut run = Vec::new();
     let segment_count = points.len() - usize::from(!closed);
     let mut raw_runs = Vec::new();
+    let mut decisions = 0_u64;
     for i in 0..segment_count {
         let [a, b] = [points[i], points[(i + 1) % points.len()]];
         let length = (b[0] - a[0]).hypot(b[1] - a[1]);
@@ -93,7 +94,33 @@ fn subpath(
             // segments terminate on the shared page budget without allocating
             // an attacker-controlled number of runs.
             charge(remaining, 8)?;
-            let step = dash_left.min(length - travelled);
+            decisions = decisions.saturating_add(1);
+            let segment_left = length - travelled;
+            // `dash_left` and `segment_left` arrive through independent chains
+            // of floating-point subtraction. At a mathematical dash boundary
+            // on a vertex they can differ by a few ulps (for example a 0.2/0.1
+            // pattern around a 0.075 square). Without snapping inside the
+            // propagated error envelope, that residue becomes a microscopic
+            // extra run and changes a seam cap into a join. The second check
+            // refuses inputs whose progress itself is smaller than the error
+            // envelope: snapping those would choose topology without evidence.
+            let scale = length
+                .abs()
+                .max(cycle.abs())
+                .max(dash_left.abs())
+                .max(segment_left.abs());
+            let progress_error = 32. * f64::EPSILON * scale * decisions as f64;
+            let coincident_boundary = (dash_left - segment_left).abs() <= progress_error;
+            if coincident_boundary
+                && progress_error * 4. >= dash_left.abs().min(segment_left.abs())
+            {
+                return Err("PDF dash boundary is unresolved at numeric precision".into());
+            }
+            let step = if coincident_boundary {
+                segment_left
+            } else {
+                dash_left.min(segment_left)
+            };
             if step <= 0. || travelled + step == travelled {
                 return Err("PDF dash cannot advance at numeric precision".into());
             }
@@ -108,7 +135,7 @@ fn subpath(
                     run.push(end);
                 }
             }
-            dash_left -= step;
+            dash_left = if coincident_boundary { 0. } else { dash_left - step };
             let boundary = dash_left <= 0. || dash_left + step == step;
             if boundary {
                 if pattern_index % 2 == 0 {

--- a/rust/processing/src/pdf_vector/dashes_tests.rs
+++ b/rust/processing/src/pdf_vector/dashes_tests.rs
@@ -4,7 +4,11 @@
 use super::*;
 
 fn expand_all(commands: &[f64], pattern: &[f64], phase: f64) -> Vec<Vec<Point>> {
-    expand(commands, pattern, phase, &mut 4_000_000).unwrap()
+    expand(commands, false, pattern, phase, &mut 4_000_000)
+        .unwrap()
+        .into_iter()
+        .map(|run| run.points)
+        .collect()
 }
 
 #[test]
@@ -80,18 +84,113 @@ fn issue_4406_exact_vertex_boundary_ends_a_run_but_crossing_keeps_the_join() {
 }
 
 #[test]
-fn issue_4406_closed_curved_and_zero_patterns_are_not_qualified() {
-    assert!(!supported(&[0., 0., 0., 1., 4., 0.], true, &[2., 1.]));
+fn issue_4583_closed_straight_paths_qualify_but_curves_and_zero_patterns_do_not() {
+    assert!(supported(&[0., 0., 0., 1., 4., 0.], true, &[2., 1.]));
     assert!(!supported(&[0., 0., 0., 2., 1., 0., 2., 1., 3., 0.], false, &[2., 1.]));
-    assert!(!supported(&[0., 0., 0., 1., 4., 0., 4.], false, &[2., 1.]));
+    assert!(supported(&[0., 0., 0., 1., 4., 0., 4.], false, &[2., 1.]));
     assert!(!supported(&[0., 0., 0., 1., 4., 0.], false, &[2., 0.]));
     assert!(supported(&[0., 0., 0., 1., 4., 0.], false, &[2., 1.]));
+}
+
+fn square(close: bool) -> Vec<f64> {
+    let mut commands = vec![0., 0., 0., 1., 4., 0., 1., 4., 4., 1., 0., 4.];
+    if close {
+        commands.push(4.);
+    }
+    commands
+}
+
+#[test]
+fn issue_4583_on_run_crossing_closure_seam_is_one_joined_open_run() {
+    let runs = expand(&square(true), false, &[4., 4.], 1., &mut 4_000_000).unwrap();
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0], DashRun {
+        points: vec![[4., 3.], [4., 4.], [1., 4.]],
+        closed: false,
+    });
+    assert_eq!(runs[1], DashRun {
+        points: vec![[0., 1.], [0., 0.], [3., 0.]],
+        closed: false,
+    });
+}
+
+#[test]
+fn issue_4583_gap_at_closure_seam_keeps_visible_runs_separate() {
+    let runs = expand(&square(true), false, &[4., 4.], 5., &mut 4_000_000).unwrap();
+    assert_eq!(runs, [
+        DashRun { points: vec![[3., 0.], [4., 0.], [4., 3.]], closed: false },
+        DashRun { points: vec![[1., 4.], [0., 4.], [0., 1.]], closed: false },
+    ]);
+}
+
+#[test]
+fn issue_4583_dash_boundary_exactly_at_seam_does_not_merge_caps() {
+    let runs = expand(&square(true), false, &[6., 4.], 0., &mut 4_000_000).unwrap();
+    assert_eq!(runs, [
+        DashRun {
+            points: vec![[0., 0.], [4., 0.], [4., 2.]],
+            closed: false,
+        },
+        DashRun {
+            points: vec![[2., 4.], [0., 4.], [0., 0.]],
+            closed: false,
+        },
+    ]);
+}
+
+#[test]
+fn issue_4583_fully_visible_closed_dash_uses_a_closed_outline() {
+    let runs = expand(&square(false), true, &[100., 1.], 0., &mut 4_000_000).unwrap();
+    assert_eq!(runs, [DashRun {
+        points: vec![[0., 0.], [4., 0.], [4., 4.], [0., 4.], [0., 0.]],
+        closed: true,
+    }]);
+}
+
+#[test]
+fn issue_4583_explicit_close_and_close_paint_have_identical_dash_geometry() {
+    assert_eq!(
+        expand(&square(true), false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&square(false), true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+    );
+}
+
+#[test]
+fn issue_4583_redundant_line_to_start_before_close_adds_no_zero_length_edge() {
+    let mut redundant = square(false);
+    redundant.extend([1., 0., 0., 4.]);
+    assert_eq!(
+        expand(&redundant, false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&square(true), false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+    );
+}
+
+#[test]
+fn issue_4583_mixed_open_and_closed_subpaths_reset_phase_independently() {
+    let mut commands = square(true);
+    commands.extend([0., 10., 0., 1., 14., 0.]);
+    let runs = expand(&commands, false, &[4., 4.], 1., &mut 4_000_000).unwrap();
+    assert_eq!(runs.last().unwrap(), &DashRun {
+        points: vec![[10., 0.], [13., 0.]],
+        closed: false,
+    });
+}
+
+#[test]
+fn issue_4583_visible_piece_limit_is_global_across_subpaths() {
+    let commands = [
+        0., 0., 0., 1., 1_200., 0.,
+        0., 0., 2., 1., 1_200., 2.,
+    ];
+    let error = expand(&commands, false, &[1., 1.], 0., &mut 4_000_000).unwrap_err();
+    assert!(error.contains("1024 visible run pieces"), "{error}");
 }
 
 #[test]
 fn issue_4406_dash_expansion_is_bounded_before_unbounded_output() {
     let error = expand(
         &[0., 0., 0., 1., 1_000_000., 0.],
+        false,
         &[0.000001, 0.000001],
         0.,
         &mut 128,
@@ -107,7 +206,7 @@ fn issue_4406_one_run_across_many_vertices_charges_each_growth_step() {
     for x in 1..=100 {
         commands.extend([1., f64::from(x), 0.]);
     }
-    let error = expand(&commands, &[1_000., 1.], 0., &mut 64).unwrap_err();
+    let error = expand(&commands, false, &[1_000., 1.], 0., &mut 64).unwrap_err();
     assert!(error.contains("shared work budget"), "{error}");
 }
 

--- a/rust/processing/src/pdf_vector/dashes_tests.rs
+++ b/rust/processing/src/pdf_vector/dashes_tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 
 fn expand_all(commands: &[f64], pattern: &[f64], phase: f64) -> Vec<Vec<Point>> {
-    expand(commands, false, pattern, phase, &mut 4_000_000)
+    expand(commands, false, false, pattern, phase, &mut 4_000_000)
         .unwrap()
         .into_iter()
         .map(|run| run.points)
@@ -102,7 +102,7 @@ fn square(close: bool) -> Vec<f64> {
 
 #[test]
 fn issue_4583_on_run_crossing_closure_seam_is_one_joined_open_run() {
-    let runs = expand(&square(true), false, &[4., 4.], 1., &mut 4_000_000).unwrap();
+    let runs = expand(&square(true), false, true, &[4., 4.], 1., &mut 4_000_000).unwrap();
     assert_eq!(runs.len(), 2);
     assert_eq!(runs[0], DashRun {
         points: vec![[4., 3.], [4., 4.], [1., 4.]],
@@ -116,7 +116,7 @@ fn issue_4583_on_run_crossing_closure_seam_is_one_joined_open_run() {
 
 #[test]
 fn issue_4583_gap_at_closure_seam_keeps_visible_runs_separate() {
-    let runs = expand(&square(true), false, &[4., 4.], 5., &mut 4_000_000).unwrap();
+    let runs = expand(&square(true), false, true, &[4., 4.], 5., &mut 4_000_000).unwrap();
     assert_eq!(runs, [
         DashRun { points: vec![[3., 0.], [4., 0.], [4., 3.]], closed: false },
         DashRun { points: vec![[1., 4.], [0., 4.], [0., 1.]], closed: false },
@@ -125,7 +125,7 @@ fn issue_4583_gap_at_closure_seam_keeps_visible_runs_separate() {
 
 #[test]
 fn issue_4583_dash_boundary_exactly_at_seam_does_not_merge_caps() {
-    let runs = expand(&square(true), false, &[6., 4.], 0., &mut 4_000_000).unwrap();
+    let runs = expand(&square(true), false, true, &[6., 4.], 0., &mut 4_000_000).unwrap();
     assert_eq!(runs, [
         DashRun {
             points: vec![[0., 0.], [4., 0.], [4., 2.]],
@@ -144,7 +144,7 @@ fn issue_4583_decimal_cycle_boundary_at_seam_does_not_create_a_phantom_join() {
     let commands = vec![
         0., 0., 0., 1., side, 0., 1., side, side, 1., 0., side, 4.,
     ];
-    let runs = expand(&commands, false, &[0.2, 0.1], 0., &mut 4_000_000).unwrap();
+    let runs = expand(&commands, false, true, &[0.2, 0.1], 0., &mut 4_000_000).unwrap();
     assert_eq!(
         runs.len(),
         1,
@@ -157,7 +157,7 @@ fn issue_4583_decimal_cycle_boundary_at_seam_does_not_create_a_phantom_join() {
 
 #[test]
 fn issue_4583_fully_visible_closed_dash_uses_a_closed_outline() {
-    let runs = expand(&square(false), true, &[100., 1.], 0., &mut 4_000_000).unwrap();
+    let runs = expand(&square(false), true, true, &[100., 1.], 0., &mut 4_000_000).unwrap();
     assert_eq!(runs, [DashRun {
         points: vec![[0., 0.], [4., 0.], [4., 4.], [0., 4.], [0., 0.]],
         closed: true,
@@ -165,10 +165,59 @@ fn issue_4583_fully_visible_closed_dash_uses_a_closed_outline() {
 }
 
 #[test]
+fn issue_4583_pdf_1x_keeps_seam_crossing_dash_ends_capped() {
+    let runs = expand(
+        &square(true),
+        false,
+        false,
+        &[4., 4.],
+        1.,
+        &mut 4_000_000,
+    )
+    .unwrap();
+    assert_eq!(runs.len(), 3);
+    assert_eq!(runs.first().unwrap().points.first(), Some(&[0., 0.]));
+    assert_eq!(runs.last().unwrap().points.last(), Some(&[0., 0.]));
+    assert!(runs.iter().all(|run| !run.closed));
+}
+
+#[test]
+fn issue_4583_pdf_1x_full_perimeter_dash_remains_open_with_coincident_caps() {
+    let runs = expand(
+        &square(true),
+        false,
+        false,
+        &[100., 1.],
+        0.,
+        &mut 4_000_000,
+    )
+    .unwrap();
+    assert_eq!(runs.len(), 1);
+    assert!(!runs[0].closed);
+    assert_eq!(runs[0].points.first(), runs[0].points.last());
+}
+
+#[test]
+fn issue_4583_capped_full_loop_is_detected_before_stroke_composition() {
+    assert!(has_capped_loop(&square(true), false, &[100., 1.], 0.));
+    assert!(has_capped_loop(
+        &[
+            0., 0., 0., 1., 0.07500000000000001, 0., 1.,
+            0.07500000000000001, 0.07500000000000001, 1., 0.,
+            0.07500000000000001, 4.,
+        ],
+        false,
+        &[0.3, 0.1],
+        0.,
+    ));
+    assert!(!has_capped_loop(&square(true), false, &[4., 4.], 1.));
+}
+
+#[test]
 fn issue_4583_explicit_close_and_close_paint_have_identical_dash_geometry() {
     assert_eq!(
-        expand(&square(true), false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
-        expand(&square(false), true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&square(true), false, true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&square(false), true, true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
     );
 }
 
@@ -177,8 +226,8 @@ fn issue_4583_redundant_line_to_start_before_close_adds_no_zero_length_edge() {
     let mut redundant = square(false);
     redundant.extend([1., 0., 0., 4.]);
     assert_eq!(
-        expand(&redundant, false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
-        expand(&square(true), false, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&redundant, false, true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
+        expand(&square(true), false, true, &[3., 2.], -1., &mut 4_000_000).unwrap(),
     );
 }
 
@@ -186,7 +235,7 @@ fn issue_4583_redundant_line_to_start_before_close_adds_no_zero_length_edge() {
 fn issue_4583_mixed_open_and_closed_subpaths_reset_phase_independently() {
     let mut commands = square(true);
     commands.extend([0., 10., 0., 1., 14., 0.]);
-    let runs = expand(&commands, false, &[4., 4.], 1., &mut 4_000_000).unwrap();
+    let runs = expand(&commands, false, true, &[4., 4.], 1., &mut 4_000_000).unwrap();
     assert_eq!(runs.last().unwrap(), &DashRun {
         points: vec![[10., 0.], [13., 0.]],
         closed: false,
@@ -199,7 +248,7 @@ fn issue_4583_visible_piece_limit_is_global_across_subpaths() {
         0., 0., 0., 1., 1_200., 0.,
         0., 0., 2., 1., 1_200., 2.,
     ];
-    let error = expand(&commands, false, &[1., 1.], 0., &mut 4_000_000).unwrap_err();
+    let error = expand(&commands, false, true, &[1., 1.], 0., &mut 4_000_000).unwrap_err();
     assert!(error.contains("1024 visible run pieces"), "{error}");
 }
 
@@ -207,6 +256,7 @@ fn issue_4583_visible_piece_limit_is_global_across_subpaths() {
 fn issue_4406_dash_expansion_is_bounded_before_unbounded_output() {
     let error = expand(
         &[0., 0., 0., 1., 1_000_000., 0.],
+        false,
         false,
         &[0.000001, 0.000001],
         0.,
@@ -223,7 +273,7 @@ fn issue_4406_one_run_across_many_vertices_charges_each_growth_step() {
     for x in 1..=100 {
         commands.extend([1., f64::from(x), 0.]);
     }
-    let error = expand(&commands, false, &[1_000., 1.], 0., &mut 64).unwrap_err();
+    let error = expand(&commands, false, true, &[1_000., 1.], 0., &mut 64).unwrap_err();
     assert!(error.contains("shared work budget"), "{error}");
 }
 

--- a/rust/processing/src/pdf_vector/dashes_tests.rs
+++ b/rust/processing/src/pdf_vector/dashes_tests.rs
@@ -139,6 +139,23 @@ fn issue_4583_dash_boundary_exactly_at_seam_does_not_merge_caps() {
 }
 
 #[test]
+fn issue_4583_decimal_cycle_boundary_at_seam_does_not_create_a_phantom_join() {
+    let side = 0.07500000000000001;
+    let commands = vec![
+        0., 0., 0., 1., side, 0., 1., side, side, 1., 0., side, 4.,
+    ];
+    let runs = expand(&commands, false, &[0.2, 0.1], 0., &mut 4_000_000).unwrap();
+    assert_eq!(
+        runs.len(),
+        1,
+        "a rounding residue must not become a second visible run: {runs:?}"
+    );
+    assert!(!runs[0].closed, "the gap immediately before the seam keeps the run capped");
+    assert_eq!(runs[0].points.first(), Some(&[0., 0.]));
+    assert_ne!(runs[0].points.last(), Some(&[0., 0.]));
+}
+
+#[test]
 fn issue_4583_fully_visible_closed_dash_uses_a_closed_outline() {
     let runs = expand(&square(false), true, &[100., 1.], 0., &mut 4_000_000).unwrap();
     assert_eq!(runs, [DashRun {

--- a/rust/processing/src/pdf_vector/fills.rs
+++ b/rust/processing/src/pdf_vector/fills.rs
@@ -96,7 +96,7 @@ pub(crate) fn compose(
         if path.paint.strokes() {
             let close = matches!(path.paint, PdfVectorPaint::CloseStroke |
                 PdfVectorPaint::CloseFillStroke | PdfVectorPaint::CloseEvenOddFillStroke);
-            paths.push(super::strokes::rings(&path.commands, close, &path.state,
+            paths.push(super::strokes::rings(&path.commands, close, path.dash_closure, &path.state,
                 &mut budget.remaining, stroke_arc_error).map_err(|e| format!("PDF operator {}: {e}", path.operator_ordinal))?);
             // A combined operator fills first, then strokes. Expansion retains
             // its original operator identity and distinct fill/stroke colours.

--- a/rust/processing/src/pdf_vector/interpret.rs
+++ b/rust/processing/src/pdf_vector/interpret.rs
@@ -8,8 +8,8 @@
 use super::extent::{self, Rect};
 use super::report::ReportBuilder;
 use super::{
-    multiply, scalar, validate_matrix, validate_path, PdfVectorGraphicsState, PdfVectorPage,
-    PdfVectorPaint, PreparedPdfVectorPath,
+    multiply, scalar, validate_matrix, validate_path, PdfDashClosure, PdfVectorGraphicsState,
+    PdfVectorPage, PdfVectorPaint, PreparedPdfVectorPath,
 };
 
 #[path = "interpret_ops.rs"]
@@ -61,6 +61,17 @@ struct Interpreter {
     numbers: usize,
     paths: Vec<PreparedPdfVectorPath>,
     report: ReportBuilder,
+    dash_closure: Option<PdfDashClosure>,
+}
+
+fn dash_closure(version: Option<&str>) -> Option<PdfDashClosure> {
+    match version {
+        Some("1.0" | "1.1" | "1.2" | "1.3" | "1.4" | "1.5" | "1.6" | "1.7") => {
+            Some(PdfDashClosure::Capped)
+        }
+        Some("2.0") => Some(PdfDashClosure::Joined),
+        _ => None,
+    }
 }
 
 pub(super) fn run(page: &PdfVectorPage) -> Result<Interpreted, String> {
@@ -92,6 +103,7 @@ pub(super) fn run(page: &PdfVectorPage) -> Result<Interpreted, String> {
         numbers: 0,
         paths: Vec::new(),
         report: ReportBuilder::default(),
+        dash_closure: dash_closure(page.pdf_format_version.as_deref()),
     };
     let mut previous = None;
     for entry in &page.operations {
@@ -233,6 +245,21 @@ impl Interpreter {
             && !super::dashes::supported(commands, close_last, &s.dash_lengths)
         {
             Some("dash".into())
+        } else if !s.dash_lengths.is_empty()
+            && (close_last || extent::opcodes(commands).any(|op| op == 4))
+            && self.dash_closure.is_none()
+        {
+            Some("dashVersion".into())
+        } else if !s.dash_lengths.is_empty()
+            && self.dash_closure == Some(PdfDashClosure::Capped)
+            && super::dashes::has_capped_loop(
+                commands,
+                close_last,
+                &s.dash_lengths,
+                s.dash_phase,
+            )
+        {
+            Some("dashTopology".into())
         } else if extent::opcodes(commands).any(|op| op == 2 || op == 3) {
             Some("curvedStroke".into())
         } else {
@@ -308,6 +335,15 @@ impl Interpreter {
                         paint,
                         commands: commands.to_vec(),
                         state: self.frame.state.clone(),
+                        dash_closure: if paint.strokes()
+                            && !self.frame.state.dash_lengths.is_empty()
+                            && (paint.closes()
+                                || extent::opcodes(commands).any(|op| op == 4))
+                        {
+                            self.dash_closure
+                        } else {
+                            None
+                        },
                     });
                 }
             }

--- a/rust/processing/src/pdf_vector/mod.rs
+++ b/rust/processing/src/pdf_vector/mod.rs
@@ -60,6 +60,14 @@ fn validate_page(page: &PdfVectorPage) -> Result<(), String> {
     if page.decoder_version != "6.3.289" {
         return Err("Unqualified PDF decoder version".into());
     }
+    if page.pdf_format_version.as_ref().is_some_and(|version| {
+        version.is_empty()
+            || version.len() > 16
+            || !version.is_ascii()
+            || version.chars().any(char::is_control)
+    }) {
+        return Err("Invalid PDF format version".into());
+    }
     if page.page_number == 0 || page.page_number > 2000 {
         return Err("Invalid PDF page number".into());
     }

--- a/rust/processing/src/pdf_vector/report_tests.rs
+++ b/rust/processing/src/pdf_vector/report_tests.rs
@@ -403,7 +403,7 @@ fn issue_4406_stroke_features_and_pattern_colours_split_combined_paints() {
     assert_eq!(
         paints,
         [
-            (2, PdfVectorPaint::EvenOddFill),
+            (2, PdfVectorPaint::CloseEvenOddFillStroke),
             (8, PdfVectorPaint::Stroke),
             (16, PdfVectorPaint::Fill),
             (22, PdfVectorPaint::CloseStroke),
@@ -413,18 +413,17 @@ fn issue_4406_stroke_features_and_pattern_colours_split_combined_paints() {
     assert_eq!(
         kinds(&report),
         [
-            (2, "dash".into(), true),
             (12, "curvedStroke".into(), true),
             (16, "pattern".into(), true),
             (22, "pattern".into(), true),
         ]
     );
-    assert_eq!(report.fidelity.omitted_paints, 4);
+    assert_eq!(report.fidelity.omitted_paints, 3);
     assert_eq!(report.fidelity.convertible_paths, 5);
 }
 
 #[test]
-fn issue_4406_only_qualified_open_straight_dashes_leave_the_fidelity_report() {
+fn issue_4583_qualified_open_and_closed_straight_dashes_leave_the_fidelity_report() {
     let dashed = |commands| Op::Path {
         paint: PdfVectorPaint::Stroke,
         commands,
@@ -440,18 +439,18 @@ fn issue_4406_only_qualified_open_straight_dashes_leave_the_fidelity_report() {
     .unwrap();
     assert_eq!(
         report.paths.iter().map(|path| path.operator_ordinal).collect::<Vec<_>>(),
-        [2],
-        "only the open straight positive-pattern stroke is convertible",
+        [2, 4],
+        "open and closed straight positive-pattern strokes are convertible",
     );
     assert_eq!(
         kinds(&report),
-        [(4, "dash".into(), true), (6, "dash".into(), false), (10, "dash".into(), true)],
+        [(6, "dash".into(), false), (10, "dash".into(), true)],
     );
-    assert_eq!(report.fidelity.omitted_paints, 2);
+    assert_eq!(report.fidelity.omitted_paints, 1);
 }
 
 #[test]
-fn issue_4406_explicit_and_paint_time_dash_closure_are_separate_omissions() {
+fn issue_4583_explicit_and_paint_time_dash_closure_are_both_convertible() {
     let report = prepare_pdf_vector_page(&page(vec![
         Op::Dash { lengths: vec![3., 2.], phase: 0. },
         Op::Path {
@@ -464,9 +463,10 @@ fn issue_4406_explicit_and_paint_time_dash_closure_are_separate_omissions() {
         },
     ]))
     .unwrap();
-    assert!(report.paths.is_empty());
-    assert_eq!(kinds(&report), [(2, "dash".into(), true), (4, "dash".into(), true)]);
-    assert_eq!(report.fidelity.omitted_paints, 2);
+    assert!(report.fidelity.exact);
+    assert_eq!(report.paths.iter().map(|path| path.operator_ordinal).collect::<Vec<_>>(), [2, 4]);
+    assert!(kinds(&report).is_empty());
+    assert_eq!(report.fidelity.omitted_paints, 0);
 }
 
 #[test]

--- a/rust/processing/src/pdf_vector/report_tests.rs
+++ b/rust/processing/src/pdf_vector/report_tests.rs
@@ -470,6 +470,44 @@ fn issue_4583_explicit_and_paint_time_dash_closure_are_both_convertible() {
 }
 
 #[test]
+fn issue_4583_closed_dash_semantics_are_version_bound_or_omitted() {
+    let operations = vec![
+        Op::Dash { lengths: vec![3., 2.], phase: 0. },
+        Op::Path {
+            paint: PdfVectorPaint::CloseStroke,
+            commands: vec![0., 0., 0., 1., 4., 0., 1., 4., 4.],
+        },
+    ];
+    let mut pdf_1 = page(operations.clone());
+    pdf_1.pdf_format_version = Some("1.7".into());
+    let capped = prepare_pdf_vector_page(&pdf_1).unwrap();
+    assert_eq!(capped.paths[0].dash_closure, Some(PdfDashClosure::Capped));
+
+    let mut capped_loop = page(vec![
+        Op::Dash { lengths: vec![100., 1.], phase: 0. },
+        Op::Path {
+            paint: PdfVectorPaint::CloseStroke,
+            commands: vec![0., 20., 30., 1., 24., 30., 1., 24., 34.],
+        },
+    ]);
+    capped_loop.pdf_format_version = Some("1.7".into());
+    let capped_loop = prepare_pdf_vector_page(&capped_loop).unwrap();
+    assert!(capped_loop.paths.is_empty());
+    assert_eq!(kinds(&capped_loop), [(2, "dashTopology".into(), true)]);
+
+    let joined = prepare_pdf_vector_page(&page(operations.clone())).unwrap();
+    assert_eq!(joined.paths[0].dash_closure, Some(PdfDashClosure::Joined));
+
+    for version in [None, Some("future".into())] {
+        let mut unknown = page(operations.clone());
+        unknown.pdf_format_version = version;
+        let report = prepare_pdf_vector_page(&unknown).unwrap();
+        assert!(report.paths.is_empty());
+        assert_eq!(kinds(&report), [(2, "dashVersion".into(), false)]);
+    }
+}
+
+#[test]
 fn issue_4406_combined_fill_and_supported_dash_keep_paint_colours_and_ordinal() {
     let report = prepare_pdf_vector_page(&page(vec![
         Op::FillColor { rgb: [1., 0., 0.] },

--- a/rust/processing/src/pdf_vector/strokes.rs
+++ b/rust/processing/src/pdf_vector/strokes.rs
@@ -7,7 +7,7 @@
 use super::{
     fill_paths::{point, PathRings},
     flatten::charge,
-    PdfVectorGraphicsState,
+    PdfDashClosure, PdfVectorGraphicsState,
 };
 use ifc_lite_geometry::{kernel::Sign, Ring2D};
 type Point = [f64; 2];
@@ -296,6 +296,7 @@ fn outline(
 pub(super) fn rings(
     commands: &[f64],
     close_last: bool,
+    dash_closure: Option<PdfDashClosure>,
     state: &PdfVectorGraphicsState,
     remaining: &mut u64,
     tolerance: f64,
@@ -309,7 +310,12 @@ pub(super) fn rings(
         }
         let mut out = PathRings { rings: vec![], curved: vec![] };
         for run in super::dashes::expand(
-            commands, close_last, &state.dash_lengths, state.dash_phase, remaining,
+            commands,
+            close_last,
+            dash_closure == Some(PdfDashClosure::Joined),
+            &state.dash_lengths,
+            state.dash_phase,
+            remaining,
         )? {
             outline(&run.points, run.closed, state, &mut out, remaining, tolerance)?;
         }

--- a/rust/processing/src/pdf_vector/strokes.rs
+++ b/rust/processing/src/pdf_vector/strokes.rs
@@ -309,9 +309,9 @@ pub(super) fn rings(
         }
         let mut out = PathRings { rings: vec![], curved: vec![] };
         for run in super::dashes::expand(
-            commands, &state.dash_lengths, state.dash_phase, remaining,
+            commands, close_last, &state.dash_lengths, state.dash_phase, remaining,
         )? {
-            outline(&run, false, state, &mut out, remaining, tolerance)?;
+            outline(&run.points, run.closed, state, &mut out, remaining, tolerance)?;
         }
         return Ok(out);
     }

--- a/rust/processing/src/pdf_vector/strokes_tests.rs
+++ b/rust/processing/src/pdf_vector/strokes_tests.rs
@@ -27,6 +27,7 @@ fn issue_4406_round_caps_extend_outward_at_both_ends() {
     let result = rings(
         &[0., 0., 0., 1., 4., 0.],
         false,
+        None,
         &state([1., 0., 0., 1., 0., 0.]),
         &mut remaining,
         0.01,

--- a/rust/processing/src/pdf_vector/tests.rs
+++ b/rust/processing/src/pdf_vector/tests.rs
@@ -6,6 +6,7 @@ pub(super) fn page(ops: Vec<PdfVectorOperator>) -> PdfVectorPage {
     PdfVectorPage {
         pdf_sha256: "a".repeat(64),
         decoder_version: "6.3.289".into(),
+        pdf_format_version: Some("2.0".into()),
         page_number: 1,
         view_box: [10., 20., 110., 92.],
         user_unit: 2.,
@@ -179,6 +180,19 @@ fn issue_4406_strict_json_rejects_unknown_semantics_instead_of_dropping_them() {
     let mut json = serde_json::to_value(page(vec![path()])).unwrap();
     json["operations"][0]["operation"]["alpha"] = serde_json::json!(0.5);
     assert!(serde_json::from_value::<PdfVectorPage>(json).is_err());
+}
+#[test]
+fn issue_4583_older_hosts_without_a_pdf_version_remain_decodable() {
+    let mut json = serde_json::to_value(page(vec![path()])).unwrap();
+    json.as_object_mut().unwrap().remove("pdfFormatVersion");
+    let decoded: PdfVectorPage = serde_json::from_value(json).unwrap();
+    assert_eq!(decoded.pdf_format_version, None);
+
+    let mut invalid = page(vec![path()]);
+    invalid.pdf_format_version = Some("x".repeat(17));
+    assert!(prepare_pdf_vector_page(&invalid)
+        .unwrap_err()
+        .contains("format version"));
 }
 #[test]
 fn issue_4406_report_operators_use_the_adapter_camel_case_wire_shape() {

--- a/rust/processing/src/pdf_vector/types.rs
+++ b/rust/processing/src/pdf_vector/types.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 pub struct PdfVectorPage {
     pub pdf_sha256: String,
     pub decoder_version: String,
+    /// Effective document version reported by the pinned decoder. Older hosts
+    /// may omit it; version-sensitive paints then remain explicit omissions.
+    #[serde(default)]
+    pub pdf_format_version: Option<String>,
     pub page_number: u32,
     /// Unrotated native PDF user-space CropBox.
     pub view_box: [f64; 4],
@@ -208,6 +212,16 @@ pub struct PreparedPdfVectorPath {
     /// No flattening or contour/fill classification has happened in this report.
     pub commands: Vec<f64>,
     pub state: PdfVectorGraphicsState,
+    /// Authenticated resolution of the version-sensitive closed-dash seam.
+    /// Open dashes and paths without a dashed stroke carry no value.
+    pub dash_closure: Option<PdfDashClosure>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum PdfDashClosure {
+    Capped,
+    Joined,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
PDF 1.x and PDF 2.0 define different closure-seam behavior for dashed closed subpaths. A closed dashed path now binds its seam semantics to PDF.js's effective `PDFFormatVersion`: PDF 1.0–1.7 keeps capped first/last runs, PDF 2.0 joins a seam-crossing run, and an absent or unknown version explicitly omits only the ambiguous closed dashed stroke. Open dashed paths and fills remain eligible.

The implementation resolves closure during bounded preparation, preserves that decision through hashing and provenance, handles decimal boundary drift without phantom seam runs, and keeps the existing global work/piece limits. The committed changeset and public WASM/PDF-vector docs describe the new optional wire field and compatibility behavior.

Part of #4583. Parent roadmap: #4406.

Validation:
- `pnpm typecheck` — 94/94 tasks, 2,023 test files covered
- `pnpm test` — 102/102 tasks; viewer 8,067 passed, 0 failed, 10 skipped
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test:wasm-contract` — 91 passed, 0 failed, 3 fixture-dependent skips
- `pnpm lint`
- `pnpm docs:check-generated && pnpm docs:check-samples`
- 21 focused #4583 Rust tests and the real PDF.js → WASM → IFC contract test

Performance: the stacked evidence PR records interleaved native-load A/B runs with identical mesh/triangle counts and FNV output hash; no material normal-load regression was resolved.
