### PR TITLE
fix(parser): bound malformed-record recovery at the next declaration (#4573)

### DIFF
--- a/.changeset/parser-refused-record-scan.md
+++ b/.changeset/parser-refused-record-scan.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Bound the STEP scan's malformed-record recovery at the next declaration (#4573). `findEntityLength` and the Blob worker's hand-duplicate walked from a refused record to the `)` balancing it anywhere in the buffer, so a record with no `)` of its own read to end of input, the scan resumed one byte past its `#`, and the next declaration repeated the walk: a file of `#1=A(2;` repeated was O(n^2), measured 2.5s at 10 000 records and 10s at 20 000 in both `scanEntitiesFast` and the browser scan worker. The same walk balanced across a following declaration, so `#1=IFCA(2 #2=IFCWALL($));` dropped #2 with nothing reported. Both walks now stop at the next top-level `=` (ISO 10303-21 has `=` only in `entity_instance_name '=' record`), answer unbalanced, and the scan re-hunts from the refused record's `#`: each refusal costs its own record's bytes, and #2 is found. `scanEntities` (the balanced scan) stops and reports on that shape instead of yielding one mis-spanned record.

--- a/packages/parser/src/scan-entities-balanced.ts
+++ b/packages/parser/src/scan-entities-balanced.ts
@@ -164,12 +164,15 @@ export class BalancedEntityScan {
             line: startLine,
           };
         } else {
-          // Either classified failure (UNBALANCED_RECORD / UNREADABLE_RECORD)
-          // means findEntityLength ran off the end of the buffer without ever
-          // balancing the '('. Its own loop has no other exit, so this is
-          // always the EOF case, never a mid-file syntax choice to resume
-          // past; this scan stops on both, unlike scanEntitiesFast, which
-          // resumes past an unbalanced record (#4179).
+          // Either classified failure: UNREADABLE_RECORD (a literal or
+          // comment took the rest of the input) or UNBALANCED_RECORD (no ')'
+          // of this record's own before the next declaration's '=' or EOF,
+          // #4573). This scan STOPS on both, unlike scanEntitiesFast, which
+          // re-hunts past an unbalanced record (#4179): its one consumer is
+          // the CLI's mutate-step-record, a write path, where a refusal beats
+          // a guess. Before the '=' bound this walk balanced across the next
+          // declaration and yielded `#1=IFCA(2 #2=IFCWALL($))` as ONE record
+          // with nothing reported; now it stops here and reports it.
           stopped = true;
           break;
         }

--- a/packages/parser/src/scan-worker-lexing.ts
+++ b/packages/parser/src/scan-worker-lexing.ts
@@ -75,8 +75,12 @@ export const WORKER_LEXING = `
   // (#4179), and the exact answer for whether a ';' is the record's own.
   // Mirrors findEntityLength in step-record-boundary.ts; a literal is jumped
   // whole and a comment after it, in that order, so a paren inside either is
-  // text. NOTE: skipCommentAt advances the line counter, so a caller that
-  // re-walks the record must save and restore it.
+  // text. A top-level '=' is the NEXT declaration's, so the walk stops there
+  // and answers -1 rather than balancing across a record it has not read;
+  // that stop is also what keeps a file of unbalanced records linear instead
+  // of quadratic (#4573; the argument is on findEntityLength). NOTE:
+  // skipCommentAt advances the line counter, so a caller that re-walks the
+  // record must save and restore it.
   function findEntityLengthAt(p, startOffset) {
     var d = 0;
     while (p < len) {
@@ -92,7 +96,8 @@ export const WORKER_LEXING = `
         var q = skipCommentAt(p);
         if (q < 0) return -2;
         p = q;
-      } else if (b === 0x28) { d++; p++; }
+      } else if (b === 0x3D) { return -1; }
+      else if (b === 0x28) { d++; p++; }
       else if (b === 0x29) { if (d === 0) return -1; d--; p++; if (d === 0) return p - startOffset; }
       else { p++; }
     }

--- a/packages/parser/src/scan-worker-source.malformed-record.test.ts
+++ b/packages/parser/src/scan-worker-source.malformed-record.test.ts
@@ -18,9 +18,15 @@ import { WORKER_CODE } from './scan-worker-source.js';
 import {
   LEGAL_BODIES,
   LINE_NUMBER_CASE,
+  NEXT_DECLARATION_CASE,
+  PHANTOM_NEIGHBOUR_CASE,
+  QUADRATIC_RECORDS,
+  QUADRATIC_SHAPES,
+  QUADRATIC_WELL_FORMED,
   SWALLOW_CASES,
   UNBALANCED_CASE,
   UNRESUMABLE_BODIES,
+  quadraticBudgetMs,
   type ScanDriver,
 } from './step-record-boundary.vectors.js';
 import { MAX_EXPRESS_ID } from './express-id.js';
@@ -237,4 +243,44 @@ describe('scan-worker-source WORKER_CODE: record-boundary guards (#4179)', () =>
       expect(malformed, body).toBe(0);
     }
   });
+
+  it('does not resume past the next declaration when a record balances only there (#4573)', () => {
+    const { spans, malformed } = scan(NEXT_DECLARATION_CASE.text);
+    expect(spans).toEqual(NEXT_DECLARATION_CASE.spans);
+    expect(malformed).toBe(1);
+  });
+
+  it('does not mint a phantom neighbour from a stray "=" in a refused body (#4573)', () => {
+    const { spans, malformed } = scan(PHANTOM_NEIGHBOUR_CASE.text);
+    expect(spans.map(([id]) => id)).toEqual(PHANTOM_NEIGHBOUR_CASE.ids);
+    expect(malformed).toBe(1);
+  });
+
+  // Same shape as tokenizer.test.ts's: a ratio against the well-formed twin,
+  // because this copy of the loop is the one the browser's upload actually
+  // runs, and it carried the same quadratic walk.
+  describe.each(QUADRATIC_SHAPES)(
+    'a file of refused records %s does not rescan the remainder per record (#4573)',
+    (_label, body, tail) => {
+      it('scans within 20x the well-formed twin', () => {
+        const timeWorker = (text: string) => {
+          const started = performance.now();
+          const result = runWorkerCode(text);
+          return { ms: performance.now() - started, found: result.count };
+        };
+        const baseline = timeWorker(QUADRATIC_WELL_FORMED.repeat(QUADRATIC_RECORDS));
+        expect(baseline.found).toBe(QUADRATIC_RECORDS);
+        const budget = quadraticBudgetMs(baseline.ms);
+
+        const malformed = timeWorker(body.repeat(QUADRATIC_RECORDS) + tail);
+        expect(malformed.found, 'every record is malformed').toBe(0);
+        expect(
+          malformed.ms,
+          `${QUADRATIC_RECORDS} refused records took ${malformed.ms.toFixed(0)}ms against a ` +
+            `${budget.toFixed(0)}ms budget (20x the ${baseline.ms.toFixed(1)}ms well-formed twin): ` +
+            'recovery is walking the remainder per record again',
+        ).toBeLessThan(budget);
+      }, 120_000);
+    },
+  );
 });

--- a/packages/parser/src/scan-worker-source.ts
+++ b/packages/parser/src/scan-worker-source.ts
@@ -292,7 +292,9 @@ ${WORKER_LEXING}
       // tokenizer.ts's scanEntitiesFast. Resume at the ')' balancing this
       // record's own '(' when there is one, dropping just this record;
       // otherwise run to len, ending the scan un-resynced rather than guessing
-      // a resume point from misaligned bytes.
+      // a resume point from misaligned bytes. The balance walk stops at the
+      // next declaration's '=' (#4573), so a refusal costs this record's
+      // bytes, never a re-walk of the remainder per refusal.
       if (!foundTerminator) {
         stopped = true;
         if (recordClose === -3) {
@@ -306,7 +308,8 @@ ${WORKER_LEXING}
           line = startLine;
           for (var q = startOffset; q < pos; q++) if (buf[q] === 0x0A) line++;
         } else if (recordClose === -1) {
-          // Unbalanced but readable: re-hunt from past this record's '#'.
+          // No ')' before the next '=' (or EOF), bytes after readable:
+          // re-hunt from past this record's '#'.
           pos = startOffset + 1;
           line = startLine;
         } else {

--- a/packages/parser/src/step-record-boundary.test.ts
+++ b/packages/parser/src/step-record-boundary.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `findEntityLength` against the table Rust's `close_step_record` is held to
+ * (`close_step_record_finds_the_balancing_paren` and
+ * `close_step_record_stops_at_the_next_declaration` in
+ * rust/core/src/parser/lexical.rs). Rust is the source of truth for the rule;
+ * this pins the TS half to the same answers so the two cannot drift apart
+ * one case at a time. The two full scans (tokenizer.test.ts and the worker
+ * test) cover what a caller does with the answer.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findEntityLength, UNBALANCED_RECORD, UNREADABLE_RECORD } from './step-record-boundary.js';
+
+/** `findEntityLength` over `body`, whose '(' is the first one in it. */
+function close(body: string): number {
+  const buf = new TextEncoder().encode(body);
+  return findEntityLength(buf, buf.indexOf(0x28), 0);
+}
+
+describe('findEntityLength', () => {
+  it('finds the balancing paren', () => {
+    expect(close('IFCWALL($);rest')).toBe(10);
+    expect(close('IFCWALL((\'a\'),(1.,2.))\ntail')).toBe(22);
+    // A paren inside a literal or a comment is text, and '' stays inside.
+    expect(close("IFCWALL('a)b');")).toBe(14);
+    expect(close("IFCWALL('a''(b');")).toBe(16);
+    expect(close('IFCWALL(/* ) ( */$);')).toBe(19);
+  });
+
+  it('classifies the two failures apart', () => {
+    expect(close("IFCWALL('never closes")).toBe(UNREADABLE_RECORD);
+    expect(close('IFCWALL(/* never closes')).toBe(UNREADABLE_RECORD);
+    expect(close('IFCWALL($')).toBe(UNBALANCED_RECORD);
+    // A ')' before any '(' closes nothing, but the bytes after are readable.
+    expect(findEntityLength(new TextEncoder().encode(')))'), 0, 0)).toBe(UNBALANCED_RECORD);
+  });
+
+  /**
+   * A ')' after a top-level '=' closes a LATER record's parameter list, so
+   * the walk stops at that '=' rather than balancing across a declaration it
+   * has not read. Pre-fix `IFCA(2 #2=IFCWALL($));` answered 22 and the
+   * scanner resumed past #2 and lost it. The same bound is what keeps a file
+   * of unbalanced records linear instead of O(n^2). Regression for #4573.
+   */
+  it('stops at the next declaration (#4573)', () => {
+    expect(close('IFCA(2 #2=IFCWALL($));')).toBe(UNBALANCED_RECORD);
+    expect(close('IFCA(2;\n#2=IFCB(3);')).toBe(UNBALANCED_RECORD);
+    // An '=' inside a literal or a comment is text, not a declaration, so a
+    // record carrying one still closes where it really closes.
+    expect(close("IFCA('a=b');")).toBe(11);
+    expect(close('IFCA(/* a=b */$);')).toBe(16);
+    expect(close("IFCDOCUMENTREFERENCE('http://h/q?a=b&c=d',$);")).toBe(44);
+  });
+});

--- a/packages/parser/src/step-record-boundary.ts
+++ b/packages/parser/src/step-record-boundary.ts
@@ -19,6 +19,7 @@ import { opensComment, skipComment, skipStringLiteral, skipTrivia } from './step
 const QUOTE = 0x27; // '\''
 const LPAREN = 0x28; // '('
 const RPAREN = 0x29; // ')'
+const EQUALS = 0x3D; // '='
 
 // Byte length of the record starting at `startOffset` whose argument list
 // opens at `pos`: up to and including the ')' balancing that '('.
@@ -39,6 +40,22 @@ const RPAREN = 0x29; // ')'
 // test comes first, so a '/*' inside a value is text; the comment is then taken
 // whole, so a '(' or a quote inside it is text. Without that, the comment in
 // `#1=IFCWALL('a', /* see IFCWALL( */ $);` opened a depth that never closed.
+//
+// The walk STOPS at the next top-level '=' and answers UNBALANCED_RECORD
+// (#4573; "Why the scan stops at the next `=`" in lexical.rs). 10303-21 has
+// '=' only in `entity_instance_name '=' record`, so a ')' past one closes a
+// LATER record's list, never this one's: `#1=IFCA(2 #2=IFCWALL($));`
+// balanced at #2's ')' and the recovery resumed past #2, dropping it with
+// nothing reported. The same stop is what bounds the walk. Without it a record
+// with no ')' of its own read to end of input, the caller resumed one byte
+// past its '#', and the next declaration repeated the whole walk: a file of
+// `#1=A(2;` repeated measured 2.5s at 10 000 records and 10s at 20 000, 4x
+// per doubling, in this scan and the Blob worker's copy alike. Stopping at
+// the '=' makes each refusal cost its own record's bytes, so a file of refused
+// records costs its length. A byte-window cap is not monotone (work is
+// records x window, and the adversary shrinks the record), and a suffix memo
+// of "no terminator from here on" is disarmed by the `ENDSEC;` every real
+// file ends with; neither substitutes for the grammar rule.
 export const UNBALANCED_RECORD = -1;
 export const UNREADABLE_RECORD = -2;
 export function findEntityLength(buf: Uint8Array, pos: number, startOffset: number): number {
@@ -59,10 +76,16 @@ export function findEntityLength(buf: Uint8Array, pos: number, startOffset: numb
       // Unterminated: the rest of the input is inside the comment.
       if (end < 0) return UNREADABLE_RECORD;
       pos = end;
+    } else if (char === EQUALS) {
+      // The NEXT declaration's: this record's own ')' cannot lie past it.
+      return UNBALANCED_RECORD;
     } else if (char === LPAREN) {
       depth++;
       pos++;
     } else if (char === RPAREN) {
+      // A ')' before any '(' closes nothing, but the bytes after it are
+      // readable: the answer the Rust and worker copies already give.
+      if (depth === 0) return UNBALANCED_RECORD;
       depth--;
       pos++;
       if (depth === 0) return pos - startOffset;

--- a/packages/parser/src/step-record-boundary.vectors.ts
+++ b/packages/parser/src/step-record-boundary.vectors.ts
@@ -67,6 +67,60 @@ export const UNRESUMABLE_BODIES: readonly string[] = [
   'IFCWALL(/* never closes $)',
 ];
 
+/**
+ * A record whose parens balance only PAST a later declaration must not hand
+ * back a resume point past that declaration (#4573). Pre-fix the balance walk
+ * closed #1 at #2's ')' and the fast scan resumed after it, so #2 vanished
+ * with nothing reported. The walk now stops at #2's '=', #1 is dropped alone,
+ * and #2 (its own ')' then ';') is found by the re-hunt. Matches Rust's
+ * `recovery_does_not_resume_past_the_next_declaration_4179`.
+ */
+export const NEXT_DECLARATION_CASE = {
+  text: '#1=IFCA(2 #2=IFCWALL($));\n#3=IFCC(3);\n',
+  spans: [[2, '#2=IFCWALL($));'], [3, '#3=IFCC(3);']] as const,
+};
+
+/**
+ * A refused record must not damage its NEIGHBOUR. #1 is refused at the stray
+ * '=' in its body and re-hunted from past its '#'; the hunt then meets
+ * `#5 = 3);`, which has a declaration's `#<digits> =` prefix. It is refused
+ * at the type-name check (a record needs a keyword after the '='), so the
+ * real #5 declared a line earlier is the only #5. Matches Rust's
+ * `a_stray_equals_in_a_refused_body_does_not_mint_a_phantom_neighbour`.
+ */
+export const PHANTOM_NEIGHBOUR_CASE = {
+  text: '#5=IFCCARTESIANPOINT((0.,0.));\n#1=IFCWALL(#5 = 3);\n#6=IFCWALL($);\n',
+  ids: [5, 6] as const,
+};
+
+/**
+ * Files that are nothing but refused records, one per way of reaching the
+ * balance walk (#4573). `#1=A(2;` finds a ';' with no ')' before it, so the
+ * exact check balances the record; `#1=A(` never finds a ';' at all, so the
+ * recovery balances it. The trailers are what disarmed a suffix-memo cut of
+ * the fix: a lone ';', and the `ENDSEC;` every real file ends with.
+ *
+ * Pre-fix each walk read to end of input and the next declaration repeated
+ * it: measured 1.8-2.5s at 10 000 records and 7.4-10s at 20 000, 4x per
+ * doubling, on the fast scan and the worker copy alike. Bounded at the next
+ * '=', all four cost the file's length. `RECORDS` is sized so the unfixed
+ * walk overruns the budget many times over on any machine (the well-formed
+ * twin takes ~2ms here; the 20ms floor keeps timer noise out), while a fixed
+ * scan finishes in single-digit milliseconds.
+ */
+export const QUADRATIC_SHAPES: readonly (readonly [string, string, string])[] = [
+  ['#1=A(2;\\n', '#1=A(2;\n', ''],
+  ['#1=A(\\n', '#1=A(\n', ''],
+  ['#1=A(\\n then ;', '#1=A(\n', ';'],
+  ['#1=A(\\n then ENDSEC', '#1=A(\n', 'ENDSEC;\nEND-ISO-10303-21;\n'],
+];
+export const QUADRATIC_RECORDS = 20_000;
+export const QUADRATIC_WELL_FORMED = '#1=A();\n';
+/** The budget a refused-record file must scan within, from the well-formed twin's time. */
+export function quadraticBudgetMs(baselineMs: number): number {
+  return Math.max(baselineMs, 20) * 20;
+}
+
 /** The two shapes #4179 is about, as `[label, text, expected spans]`. */
 /**
  * Records whose LINE numbers a cold re-walk must not disturb.

--- a/packages/parser/src/tokenizer.test.ts
+++ b/packages/parser/src/tokenizer.test.ts
@@ -7,11 +7,26 @@ import { StepTokenizer } from './tokenizer.js';
 import {
   LEGAL_BODIES,
   LINE_NUMBER_CASE,
+  NEXT_DECLARATION_CASE,
+  PHANTOM_NEIGHBOUR_CASE,
+  QUADRATIC_RECORDS,
+  QUADRATIC_SHAPES,
+  QUADRATIC_WELL_FORMED,
   SWALLOW_CASES,
   UNBALANCED_CASE,
   UNRESUMABLE_BODIES,
+  quadraticBudgetMs,
   type ScanDriver,
 } from './step-record-boundary.vectors.js';
+
+/** Wall-clock milliseconds to fully drain `scan` over `text`, and how many records it found. */
+function timeScan(text: string, scan: (buf: Uint8Array) => Iterable<unknown>): { ms: number; found: number } {
+  const buf = new TextEncoder().encode(text);
+  const started = performance.now();
+  let found = 0;
+  for (const _ of scan(buf)) found++;
+  return { ms: performance.now() - started, found };
+}
 
 describe('StepTokenizer.scanEntitiesFast', () => {
   it('finds entities and reports correct expressId/type/line', () => {
@@ -177,6 +192,31 @@ describe('StepTokenizer.scanEntities (balanced-parenthesis path)', () => {
     expect(tokenizer.malformedRecordCount).toBe(1);
     expect(refs.map((r) => r.expressId)).toEqual([1]);
   });
+
+  // This scan closes a record on the ')' balancing its '(' and yields the
+  // span WITHOUT the ';', so the shared vectors' spans do not apply verbatim;
+  // ids are what the two scans must agree on.
+  const scanIds = (text: string) => {
+    const tokenizer = new StepTokenizer(new TextEncoder().encode(text));
+    const ids = Array.from(tokenizer.scanEntities()).map((r) => r.expressId);
+    return { ids, malformed: tokenizer.malformedRecordCount };
+  };
+
+  it('stops, and reports, instead of balancing across the next declaration (#4573)', () => {
+    // Pre-fix: [1, 3] with malformed 0, #1's span running through #2's ')'
+    // -- a mis-spanned record and a swallowed one, and nothing reported. The
+    // balance walk now stops at #2's '=' and this scan, which does not
+    // re-hunt (see scan-entities-balanced.ts), stops there and says so.
+    expect(scanIds(NEXT_DECLARATION_CASE.text)).toEqual({ ids: [], malformed: 1 });
+  });
+
+  it('never falsely refuses a legal record at the "=" bound', () => {
+    // findEntityLength runs on EVERY record of this scan, so an '=' inside a
+    // literal or comment being read as a declaration would drop real records.
+    for (const body of LEGAL_BODIES) {
+      expect(scanIds(`#1=${body}\n#2=IFCDOOR($);\n`), body).toEqual({ ids: [1, 2], malformed: 0 });
+    }
+  });
 });
 
 
@@ -229,4 +269,43 @@ describe('StepTokenizer.scanEntitiesFast: record-boundary guards (#4179)', () =>
       expect(malformed, body).toBe(0);
     }
   });
+
+  it('does not resume past the next declaration when a record balances only there (#4573)', () => {
+    const { spans, malformed } = scan(NEXT_DECLARATION_CASE.text);
+    expect(spans).toEqual(NEXT_DECLARATION_CASE.spans);
+    expect(malformed).toBe(1);
+  });
+
+  it('does not mint a phantom neighbour from a stray "=" in a refused body (#4573)', () => {
+    const { spans, malformed } = scan(PHANTOM_NEIGHBOUR_CASE.text);
+    expect(spans.map(([id]) => id)).toEqual(PHANTOM_NEIGHBOUR_CASE.ids);
+    expect(malformed).toBe(1);
+  });
+
+  // The budget is a RATIO against the well-formed twin of the same record
+  // count, so it holds in any build mode on any machine; the unfixed walk is
+  // ~20x over it at this size (see QUADRATIC_SHAPES). Vitest cannot interrupt
+  // a synchronous scan, so an overrun fails by finishing late, not by
+  // timing out: the explicit timeout below only keeps the runner from
+  // reporting a misleading "timed out" before the real assertion runs.
+  describe.each(QUADRATIC_SHAPES)(
+    'a file of refused records %s does not rescan the remainder per record (#4573)',
+    (_label, body, tail) => {
+      it('scans within 20x the well-formed twin', () => {
+        const fast = (buf: Uint8Array) => new StepTokenizer(buf).scanEntitiesFast();
+        const baseline = timeScan(QUADRATIC_WELL_FORMED.repeat(QUADRATIC_RECORDS), fast);
+        expect(baseline.found).toBe(QUADRATIC_RECORDS);
+        const budget = quadraticBudgetMs(baseline.ms);
+
+        const malformed = timeScan(body.repeat(QUADRATIC_RECORDS) + tail, fast);
+        expect(malformed.found, 'every record is malformed').toBe(0);
+        expect(
+          malformed.ms,
+          `${QUADRATIC_RECORDS} refused records took ${malformed.ms.toFixed(0)}ms against a ` +
+            `${budget.toFixed(0)}ms budget (20x the ${baseline.ms.toFixed(1)}ms well-formed twin): ` +
+            'recovery is walking the remainder per record again',
+        ).toBeLessThan(budget);
+      }, 120_000);
+    },
+  );
 });

--- a/packages/parser/src/tokenizer.ts
+++ b/packages/parser/src/tokenizer.ts
@@ -335,7 +335,9 @@ export class StepTokenizer {
         // dropping just this record; otherwise run to `len`, ending the scan
         // un-resynced rather than guessing a resume point from misaligned
         // bytes. The pre-existing exits reach the second case, which is the
-        // `pos = len` they used to set for themselves.
+        // `pos = len` they used to set for themselves. The balance walk stops
+        // at the next declaration's '=' (#4573), so a refusal costs this
+        // record's bytes, never a re-walk of the remainder per refusal.
         if (!foundTerminator) {
           stopped = true;
           if (recordClose === NOT_COMPUTED) {
@@ -345,8 +347,9 @@ export class StepTokenizer {
             pos = recordClose;
             line = startLine + countNewlines(buf, startOffset, pos);
           } else if (recordClose === UNBALANCED_RECORD) {
-            // No balancing ')', but the bytes after are readable: re-hunt from
-            // past this record's '#' so the NEXT declaration is still found.
+            // No balancing ')' before the next '=' (or EOF), but the bytes
+            // after are readable: re-hunt from past this record's '#' so the
+            // NEXT declaration is still found.
             pos = startOffset + 1;
             line = startLine;
           } else {


### PR DESCRIPTION
Closes #4573

## What changed

The TypeScript half of the record-boundary walk now stops at the next top-level `=`, the same rule the Rust half takes in #4577 (`close_step_record` → `Unbalanced`, `=` in `find_entity_end`'s `memchr3` triple).

- `packages/parser/src/step-record-boundary.ts` — `findEntityLength` returns `UNBALANCED_RECORD` on a top-level `=` (after the literal/comment branches, so an `=` inside either is still skipped whole). Also answers `UNBALANCED_RECORD` on a `)` before any `(`, the answer the Rust and worker copies already gave (unreachable from today's callers, aligned so the three copies agree).
- `packages/parser/src/scan-worker-lexing.ts` — the Blob worker's hand-duplicate `findEntityLengthAt` gets the same branch.
- `tokenizer.ts` / `scan-worker-source.ts` — no logic change; the inline `scanEntitiesFast` loop already broke on `=`, only its recovery walk was unbounded. Comments updated. Both files stay under the 400-line limit (385 / 390).
- `scan-entities-balanced.ts` — no logic change; its comment claimed `UNBALANCED_RECORD` was "always the EOF case", which the bound makes false. That scan (`StepTokenizer.scanEntities`, consumed only by the CLI's `mutate-step-record`) keeps **stopping** on it: on `#1=IFCA(2 #2=IFCWALL($));` it used to yield one mis-spanned #1 with `malformedRecordCount 0`; it now stops and reports 1, which is the right answer for a write path. Recovery there was considered and rejected (see Review).
- Changeset: `@ifc-lite/parser` patch. No API-surface change.

## Why / root cause

`findEntityLength` walked from a refused record's `(` to the `)` balancing it *anywhere* in the buffer. A record with no `)` of its own read to end of input to answer `UNBALANCED_RECORD`; the caller resumed at `#`+1 and the next declaration repeated the whole walk. ISO 10303-21 has `=` only in `entity_instance_name '=' record`, so a `)` past the next `=` closes a *later* record's list — the walk may stop there. That one rule fixes both defects: each refusal now costs its own record's bytes, and `#1=IFCA(2 #2=IFCWALL($));` no longer balances at #2's `)` and drops #2.

Per the issue, neither rejected remedy is used (byte-window cap: not monotone; suffix memo: disarmed by `ENDSEC;`).

## Evidence

Measured pre-fix on this box (`scanEntitiesFast`, vitest):

| records | `#1=A(2;\n` | `#1=A(\n` | `#1=A(\n` + `;` | `#1=A(\n` + `ENDSEC;…` | well-formed `#1=A();\n` |
|---|---|---|---|---|---|
| 5 000 | 721 ms | 463 ms | 469 ms | 465 ms | 2.6 ms |
| 10 000 | 2 479 ms | 1 849 ms | 1 841 ms | 1 834 ms | 2.2 ms |
| 20 000 | 9 966 ms | 7 399 ms | 7 435 ms | 7 459 ms | 2.3 ms |

Tests added (all cite #4573):
- `step-record-boundary.test.ts` (new): `findEntityLength` against the Rust `close_step_record` table, including the five `=` cases (`IFCA(2 #2=IFCWALL($));` → unbalanced; `IFCA('a=b');` → 11; `IFCA(/* a=b */$);` → 16; the `http://h/q?a=b&c=d` URL → 44).
- `step-record-boundary.vectors.ts`: `NEXT_DECLARATION_CASE` (→ `[#2, #3]`, malformed 1 — Rust `recovery_does_not_resume_past_the_next_declaration_4179`), `PHANTOM_NEIGHBOUR_CASE` (`#1=IFCWALL(#5 = 3);` mints no phantom #5 — Rust's test of the same name; TS already refused it at the type-name check, pinned for parity), and `QUADRATIC_SHAPES` (the four shapes the issue names).
- `tokenizer.test.ts` + `scan-worker-source.malformed-record.test.ts`: the two cases above on both TS copies, plus a ratio-budgeted regression per shape: 20 000 refused records must scan within `max(baseline, 20 ms) × 20` of the well-formed twin (`it.each` per shape, explicit timeout, because vitest cannot interrupt a synchronous scan — fail-fast comes from sizing N, not from the timeout). Balanced scan: `NEXT_DECLARATION_CASE` now stops/reports, and every `LEGAL_BODIES` entry still yields both ids (the `=`-in-literal/comment false-refusal direction, which no balanced test covered).

With the fix stashed, the 12 assertions that depend on it fail (`Tests 12 failed | 37 passed`): unfixed 20 000-record scans took 3.4–3.7 s (worker) and 11–19 s (tokenizer) against the 400 ms budget; fixed, 4–20 ms.

Run locally (Windows, via root turbo per AGENTS.md):
- `pnpm test --filter=@ifc-lite/parser` → 124 files passed, 1 skipped; 1371 tests passed, 10 skipped.
- `pnpm exec turbo typecheck --filter=@ifc-lite/parser` → OK (125 test files).
- `node scripts/check-module-size.mjs` → OK; `check-source-text-assertions` → OK (0 new); `add-license-headers --check` → OK; `check-test-wiring` → OK; `check-changesets` → exit 0; `oxlint packages/parser/src` → no new warnings in touched files.
- Not run: `check-api-surface` (needs a full `pnpm build`; no export changed), Rust (untouched), CLI test suite (no CLI change; the balanced scan's only behaviour delta is refuse-instead-of-mis-span, covered in `tokenizer.test.ts`).

`packages/parser` is not on AGENTS.md's perf-sensitive path list, so no probe run.

## Review

Plan was reviewed adversarially before implementation (Fable was out of credits; Opus ran the same review). Acted on:
- Its blocker: the plan originally had the balanced scan *recover* on `UNBALANCED` like the fast scan. Reviewer showed that lets `mutate-step-record` (first-sighting-wins) rewrite a phantom `#2` nested inside a refused `#1` and exit 0 — a wrong write reporting success. Verified; dropped recovery, kept the stop, documented why in the file.
- The balanced scan yields `)`-terminated spans, so its tests compare ids; a `LEGAL_BODIES` balanced test was added.
- Raised the perf test from 10 000 to 20 000 records so the unfixed walk is ≥8× over budget rather than ~4.5×; `it.each` per shape with an explicit timeout.
- Not taken: the reviewer's suggestion of a CLI duplicate-id guard — out of this issue's scope and moot once the balanced scan does not recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery from malformed STEP records by stopping at the next declaration boundary.
  - Prevented malformed records from consuming or hiding neighboring valid records.
  - Correctly reports unbalanced records as malformed instead of extending them across declarations.
  - Preserved valid `=` characters within supported record content.

- **Performance**
  - Reduced repeated scanning during malformed-record recovery, improving behavior on files with multiple invalid records.

- **Tests**
  - Added regression coverage for malformed records, declaration boundaries, neighboring records, and scan performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->