### PR TITLE
chore(scripts,ci): module-size ratchet follow-ups from #4535 (#4536)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -996,12 +996,20 @@ jobs:
       # AGENTS.md has asked for TypeScript modules under ~400 lines since long
       # before this gate existed, and self-policing left 312 files over the
       # line. A convention with no gate ratchets the wrong way: the allowlist
-      # is the frozen debt. The gate has exactly two teeth and this step fails
-      # on either: a NEW source file over 400 lines with no allowlist row, and
-      # an allowlisted file that GREW past its recorded budget. Raising a
-      # budget by hand is NOT one of them (#3745) -- it is sanctioned, and the
-      # allowlist row's own diff is the reviewable line, read by a human in
-      # the PR rather than failed here.
+      # is the frozen debt. The gate's two teeth judge FILES against rows, and
+      # this step fails on either: a NEW source file over 400 lines with no
+      # allowlist row, and an allowlisted file that GREW past its recorded
+      # budget. Since #4388 (landed by #4535) it also judges the ROWS this
+      # change wrote, against the merge base with main: a row added or raised
+      # must equal the count `--update` would have written (a budget above the
+      # file, or a row for a file at or under 400, fails); a lowered row must
+      # still name a file over 400; and a kept row fails when this change's
+      # own diff took a file that was over 400 at the base under it, or
+      # removed it. Raising a budget is still not refused as such (#3745): the
+      # row's diff stays the reviewable line, and the audit only holds it to
+      # the measurement. Rows this change did not write, and files it did not
+      # touch, stay advisory notes. The full rationale is the header of
+      # scripts/check-module-size.mjs; this comment is its summary.
       - name: Check TypeScript module size ratchet
         run: node scripts/check-module-size.mjs
       # Executable proof the ratchet cannot pass vacuously: a gate that

--- a/scripts/check-source-text-assertions-identity.test.mjs
+++ b/scripts/check-source-text-assertions-identity.test.mjs
@@ -34,11 +34,12 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, rmSync
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { relocatedGateSource } from './lib/relocated-gate-source.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
-const DETECT = join(ROOT, 'scripts', 'source-text-assertion-detect.mjs');
+const SCRIPTS = join(ROOT, 'scripts');
+const GATE = join(SCRIPTS, 'check-source-text-assertions.mjs');
 
 /** A source-text-assertion test fixture the detector flags, naming `rel`. */
 function violatingTest(rel) {
@@ -74,18 +75,11 @@ function gitTree(testFiles, allowlistText) {
   // so the synthetic tree needs a copy of the real gate under the same path.
   // Copying the file under test, rather than writing a stub, is the point:
   // the identity check's own ceiling-parsing regex is exercised against the
-  // real file, not a hand-written approximation of it.
-  // The detector import is repointed at the REAL file's absolute path rather
-  // than copied alongside: it pulls in `typescript` from this repo's
-  // node_modules, which a temp dir outside the repo cannot resolve, and
-  // nothing under test here is the detector itself (that has its own harness,
-  // scripts/check-source-text-assertions.test.mjs).
-  const gateSrc = readFileSync(GATE, 'utf8').replace(
-    "from './source-text-assertion-detect.mjs'",
-    `from ${JSON.stringify(pathToFileURL(DETECT).href)}`,
-  );
-  assert.notEqual(gateSrc, readFileSync(GATE, 'utf8'), 'detector import rewrite did not match');
-  writeFileSync(join(dir, 'scripts', 'check-source-text-assertions.mjs'), gateSrc);
+  // real file, not a hand-written approximation of it. Its relative imports
+  // are repointed at the REAL files' absolute paths rather than copied
+  // alongside (see lib/relocated-gate-source.mjs for why); nothing under
+  // test here is the detector or the git helper themselves.
+  writeFileSync(join(dir, 'scripts', 'check-source-text-assertions.mjs'), relocatedGateSource(GATE, SCRIPTS));
 
   const git = (...argv) => {
     const res = spawnSync('git', ['-C', dir, ...argv], { encoding: 'utf8' });
@@ -185,6 +179,12 @@ test('an untouched allowlist and tree passes with no identity failure', () => {
   const { code, out } = run(dir);
   assert.equal(code, 0, out);
   assert.doesNotMatch(out, /New allowlist entries/);
+  // Every tree here has a local `main` and no `origin`, so the base comes
+  // from the fallback ref. The shared derivation (lib/module-size-git.mjs,
+  // #4536) reports that as `fellBack` rather than printing; the gate must
+  // still turn it into its own warning, and still run the check.
+  assert.match(out, /WARNING -- no merge base with origin\/main; fell back to local 'main'/);
+  assert.match(out, /identity-checked vs main \([0-9a-f]{9}\)/);
 });
 
 test('a genuinely new violation with no allowlist row still fails as before', () => {

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -126,8 +126,11 @@
 import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawnSync } from 'node:child_process';
 import { analyze } from './source-text-assertion-detect.mjs';
+// The merge-base derivation is the module-size ratchet's, imported rather
+// than carried as a second copy (#4536), so the two gates degrade the same
+// way under the same shallow-clone and no-remote conditions.
+import { readBlobAt, resolveBase } from './lib/module-size-git.mjs';
 
 // --root overrides the scanned tree; only the test harness passes it, to point
 // this UNMODIFIED script at a synthetic git repository. Production CI and
@@ -239,40 +242,6 @@ function parseAllowlistText(text) {
 function loadAllowlist() {
   if (!existsSync(ALLOWLIST_PATH)) return new Set();
   return parseAllowlistText(readFileSync(ALLOWLIST_PATH, 'utf8'));
-}
-
-/**
- * This worktree's merge base with origin/main, falling back to local main --
- * identical derivation to `resolveBase()` in scripts/lib/module-size-git.mjs
- * (the module-size ratchet's), kept in step so the two gates degrade the same
- * way under the same shallow-clone and no-remote conditions.
- *
- * Returns `{ ref, sha }` or `null` if neither ref has a merge base with HEAD
- * (no `origin` remote, or a clone too shallow to share history).
- */
-function resolveBase(root) {
-  const git = (...argv) => spawnSync('git', ['-C', root, ...argv], { encoding: 'utf8' });
-  for (const ref of ['origin/main', 'main']) {
-    const merged = git('merge-base', ref, 'HEAD');
-    const sha = merged.stdout.trim();
-    if (merged.status === 0 && sha !== '') {
-      if (ref !== 'origin/main') {
-        console.warn(
-          `check-source-text-assertions: WARNING -- no merge base with origin/main; fell back ` +
-            `to local '${ref}' (${sha.slice(0, 9)}) for the allowlist identity check. If that ` +
-            `ref is stale, a swapped-in violation could go undetected this run.`
-        );
-      }
-      return { ref, sha };
-    }
-  }
-  return null;
-}
-
-/** `git show <sha>:<relPath>` from `root`, or `null` if the blob is unreadable. */
-function readBlobAt(root, sha, relPath) {
-  const res = spawnSync('git', ['-C', root, 'show', `${sha}:${relPath}`], { encoding: 'utf8' });
-  return res.status === 0 ? res.stdout : null;
 }
 
 const allowlist = loadAllowlist();
@@ -388,8 +357,11 @@ ratcheting.
 // -- any path present now that was absent there is a NEW exemption, whether
 // or not it was offset by a removal elsewhere in the same change.
 let identitySuffix = '';
+// `{ error }` when neither origin/main nor main has a merge base with HEAD
+// (no `origin` remote, or a clone too shallow to share history); `fellBack`
+// when only the local main did, which may be stale.
 const base = resolveBase(ROOT);
-if (base === null) {
+if (base.error !== undefined) {
   console.warn(
     'check-source-text-assertions: WARNING -- could not resolve a merge base with ' +
       "origin/main or main; the allowlist identity check is SKIPPED this run. A same-size " +
@@ -397,6 +369,13 @@ if (base === null) {
       'origin/main and re-run for full coverage.'
   );
 } else {
+  if (base.fellBack) {
+    console.warn(
+      `check-source-text-assertions: WARNING -- no merge base with origin/main; fell back ` +
+        `to local '${base.ref}' (${base.sha.slice(0, 9)}) for the allowlist identity check. If that ` +
+        `ref is stale, a swapped-in violation could go undetected this run.`
+    );
+  }
   const baseAllowlistText = readBlobAt(ROOT, base.sha, 'scripts/source-text-assertion-allowlist.txt');
   const baseGateText = readBlobAt(ROOT, base.sha, 'scripts/check-source-text-assertions.mjs');
   if (baseAllowlistText === null || baseGateText === null) {

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -32,12 +32,13 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { analyze } from './source-text-assertion-detect.mjs';
+import { relocatedGateSource } from './lib/relocated-gate-source.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
-const DETECT = join(ROOT, 'scripts', 'source-text-assertion-detect.mjs');
+const SCRIPTS = join(ROOT, 'scripts');
+const GATE = join(SCRIPTS, 'check-source-text-assertions.mjs');
 
 const flagged = (src) => analyze(src).flagged;
 
@@ -1400,14 +1401,12 @@ test('PLANTED PROBE - delete me', () => {
     );
     writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), '');
     // A copy of the real gate with its ceiling zeroed (the synthetic allowlist
-    // is empty) and its detector import repointed at the real file, the same
-    // rewrite check-source-text-assertions-identity.test.mjs uses so this
+    // is empty) and its relative imports repointed at the real files
+    // (lib/relocated-gate-source.mjs, shared with the identity test), so this
     // exercises the shipped gate rather than a hand-written stand-in.
-    const realGateSrc = readFileSync(GATE, 'utf8');
-    const gateSrc = realGateSrc
-      .replace("from './source-text-assertion-detect.mjs'", `from ${JSON.stringify(pathToFileURL(DETECT).href)}`)
-      .replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
-    assert.notEqual(gateSrc, realGateSrc, 'ceiling/import rewrite did not match the real gate source');
+    const relocatedSrc = relocatedGateSource(GATE, SCRIPTS);
+    const gateSrc = relocatedSrc.replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
+    assert.notEqual(gateSrc, relocatedSrc, 'ceiling rewrite did not match the real gate source');
     const gateCopy = join(dir, 'scripts', 'check-source-text-assertions.mjs');
     writeFileSync(gateCopy, gateSrc);
 
@@ -1456,11 +1455,9 @@ test('PLANTED PROBE - delete me', () => {
 `,
     );
     writeFileSync(join(dir, 'scripts', 'source-text-assertion-allowlist.txt'), '');
-    const realGateSrc = readFileSync(GATE, 'utf8');
-    const gateSrc = realGateSrc
-      .replace("from './source-text-assertion-detect.mjs'", `from ${JSON.stringify(pathToFileURL(DETECT).href)}`)
-      .replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
-    assert.notEqual(gateSrc, realGateSrc, 'ceiling/import rewrite did not match the real gate source');
+    const relocatedSrc = relocatedGateSource(GATE, SCRIPTS);
+    const gateSrc = relocatedSrc.replace(/const ALLOWLIST_CEILING = \d+;/, 'const ALLOWLIST_CEILING = 0;');
+    assert.notEqual(gateSrc, relocatedSrc, 'ceiling rewrite did not match the real gate source');
     const gateCopy = join(dir, 'scripts', 'check-source-text-assertions.mjs');
     writeFileSync(gateCopy, gateSrc);
 

--- a/scripts/lib/module-size-git.mjs
+++ b/scripts/lib/module-size-git.mjs
@@ -7,9 +7,10 @@
  * (`scripts/check-module-size.mjs`): the merge base with main, the paths a
  * change touched, and a blob at a commit. Split out of the CLI when #4388
  * gave check mode its own use for the merge base — the CLI is allowlisted
- * and may not grow, and `check-source-text-assertions.mjs` carries the same
- * derivation, so this is the copy the next gate should import rather than
- * write a third time.
+ * and may not grow. `check-source-text-assertions.mjs` carried its own copy
+ * of `resolveBase`/`readBlobAt` until #4536 and imports these now, so this
+ * is the one derivation, and the copy the next gate should import rather
+ * than write again.
  *
  * Every function here FAILS CLOSED: an unreadable path, a root that is not
  * the top of its worktree, or no merge base at all is an `{ error }`, never a

--- a/scripts/lib/relocated-gate-source.mjs
+++ b/scripts/lib/relocated-gate-source.mjs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The source of `scripts/check-source-text-assertions.mjs` with its relative
+ * imports repointed at this checkout's real files, for the tests that copy
+ * the gate into a synthetic git tree and run the COPY (`--root <tmp>`).
+ *
+ * The copy has to be the shipped gate, not a stand-in, so the tests exercise
+ * the real ceiling regex and identity check; but a temp dir has none of the
+ * gate's siblings, and the detector pulls in `typescript` from this repo's
+ * node_modules, which nothing outside the repo can resolve. Rewriting each
+ * `./x.mjs` specifier to an absolute `file://` URL is what lets the copy run.
+ * Every specifier the gate imports is listed here ONCE: three test sites used
+ * to carry the detector rewrite each, and adding `./lib/module-size-git.mjs`
+ * (#4536) to the gate would have broken all three in the same way -- a copy
+ * that throws `ERR_MODULE_NOT_FOUND` still exits non-zero, which is exactly
+ * the verdict two of those tests assert first.
+ *
+ * Throws when a specifier is absent from the source: a gate that stopped
+ * importing one of these should drop it here in the same change, and a test
+ * running against a source that never matched would be running the wrong
+ * gate.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/** The gate's relative imports, as written in its source. */
+const RELATIVE_IMPORTS = ['./source-text-assertion-detect.mjs', './lib/module-size-git.mjs'];
+
+/**
+ * @param {string} gatePath   absolute path of the real gate
+ * @param {string} scriptsDir absolute path of the real `scripts/` directory
+ * @returns {string} the gate source with every relative import made absolute
+ */
+export function relocatedGateSource(gatePath, scriptsDir) {
+  let source = readFileSync(gatePath, 'utf8');
+  for (const specifier of RELATIVE_IMPORTS) {
+    const needle = `from '${specifier}'`;
+    if (!source.includes(needle)) {
+      throw new Error(`${gatePath} no longer imports ${specifier}; update RELATIVE_IMPORTS`);
+    }
+    const target = pathToFileURL(join(scriptsDir, specifier)).href;
+    source = source.replace(needle, `from ${JSON.stringify(target)}`);
+  }
+  return source;
+}

--- a/scripts/lib/revert-oracle-inert.mjs
+++ b/scripts/lib/revert-oracle-inert.mjs
@@ -47,16 +47,22 @@ export function isInertPath(path) {
 
 /**
  * Test-support modules outside any test directory and not named `*.test.*`,
- * which exist only to register assertions for a test entrypoint
- * (`scripts/test-wasm-contract.mjs` imports the one below; nothing else does).
- * Editing one changes what a test asserts. Classifying it as production tripped
- * the "changes production code and adds/changes NO test file" ABORT on #4501 —
- * the same classifier false-positive shape the inert list above fixed for
+ * which exist only to serve a test entrypoint: `shard-refusal-boundary`
+ * registers assertions for `scripts/test-wasm-contract.mjs`, and
+ * `relocated-gate-source` prepares the copy of the source-text gate that
+ * `check-source-text-assertions.test.mjs` and its identity twin run in a
+ * synthetic tree; nothing else imports either. Editing one changes what a
+ * test asserts or runs. Classifying it as production tripped the "changes
+ * production code and adds/changes NO test file" ABORT on #4501, and
+ * reverting one as production takes the tests that import it down at load
+ * time — an attribution gap (INCONCLUSIVE), never a verdict (#4536). The
+ * same classifier false-positive shape the inert list above fixed for
  * binary assets. Kept exact, not a pattern: `scripts/lib/` is otherwise real
  * production tooling and must keep reading as such.
  */
 const TEST_SUPPORT_EXACT = new Set([
   'scripts/lib/shard-refusal-boundary.mjs',
+  'scripts/lib/relocated-gate-source.mjs',
 ]);
 
 export function isTestSupportPath(path) {

--- a/scripts/lib/revert-oracle.test.mjs
+++ b/scripts/lib/revert-oracle.test.mjs
@@ -423,6 +423,9 @@ test('classifyPath: a test-support module that only registers assertions for a t
   // scripts/test-wasm-contract.mjs imports it and nothing else does; editing it
   // changes what that suite asserts, so it must not read as production.
   assert.equal(classifyPath('scripts/lib/shard-refusal-boundary.mjs'), 'test');
+  // Only the two source-text gate tests import this one; reverting it as
+  // production took both down at load time, an attribution gap (#4536).
+  assert.equal(classifyPath('scripts/lib/relocated-gate-source.mjs'), 'test');
   // The allowlist is exact: its siblings are real tooling and stay production.
   assert.equal(classifyPath('scripts/lib/revert-oracle.mjs'), 'production');
 });

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -353,7 +353,7 @@
    512 scripts/check-module-size.mjs
   1066 scripts/check-pr-review-signal.mjs
    855 scripts/check-review-posted.mjs
-   446 scripts/check-source-text-assertions.mjs
+   425 scripts/check-source-text-assertions.mjs
    423 scripts/check-test-glob-coverage.mjs
    605 scripts/check-test-revert-oracle.mjs
    703 scripts/check-test-wiring.mjs


### PR DESCRIPTION
Closes #4536

Both follow-ups deliberately left out of #4535, one commit each, plus one follow-on commit the revert oracle asked for (below).

## What changed

**1. `.github/workflows/test.yml` — the module-size ratchet comment.** It said the gate "has exactly two teeth" and that raising a budget by hand "is NOT one of them". Since #4388 (landed by #4535) check mode also audits the rows *this change* wrote against the merge base. The comment now states the audit's actual rules (added/raised row must equal the measured count; lowered row must still name a file over 400; kept row fails when this change's own diff took a file that was over 400 at the base under it or removed it; untouched rows/files stay advisory) and points at `check-module-size.mjs`'s header for the rationale instead of restating it. Comment-only.

**2. `scripts/check-source-text-assertions.mjs` imports `scripts/lib/module-size-git.mjs`.** The gate's private `resolveBase`/`readBlobAt` (and its `spawnSync` import) are deleted; it imports the shared pair. 446 → 425 lines; the allowlist row was lowered with `check-module-size.mjs --update`.

- The shared `resolveBase` answers `{ error }` rather than `null`, and reports a fallback to local `main` as `fellBack` rather than printing. The gate keeps both of its warnings with unchanged text and derives the second from the flag.
- Three test sites copy the gate into a temp git repo and rewrote its `./source-text-assertion-detect.mjs` import to an absolute `file://` URL so the copy can run. A second relative import would have broken all three identically — and silently in two of them, because a copy that throws `ERR_MODULE_NOT_FOUND` still exits non-zero, which is the verdict they assert first. The rewrite now lives once in `scripts/lib/relocated-gate-source.mjs`, which lists every relative import the gate has and throws when one stops matching. (`scripts/check-source-text-assertions-identity.test.mjs`, the two `plantEndToEnd` sites in `scripts/check-source-text-assertions.test.mjs`.)
- `module-size-git.mjs`'s header no longer says the other gate "carries the same derivation".
- `scripts/lib/relocated-gate-source.mjs` is listed in the revert oracle's `TEST_SUPPORT_EXACT` (third commit). CI's `Changed tests observe production` reverts production files and expects the changed tests to go RED; reverting a helper that only the two test files import took both down at *load* time instead (`ERR_MODULE_NOT_FOUND` -> `INCONCLUSIVE`, an attribution gap, not a verdict). Same shape as `shard-refusal-boundary.mjs` (#4501); pinned in `revert-oracle.test.mjs`. With that, the oracle's local run (`node scripts/check-test-revert-oracle.mjs --base origin/main --ci --json`) gives `OBSERVED`: reverting the gate makes the helper throw (the reverted gate no longer imports `./lib/module-size-git.mjs`), so 6/6 identity cases and the 3 `plantEndToEnd` cases go RED against green baselines.

## Evidence

- `node --test scripts/check-source-text-assertions.test.mjs scripts/check-source-text-assertions-identity.test.mjs` → 92 pass, 0 fail. The untouched-tree identity case now also asserts the fallback warning (`fell back to local 'main'`) and the `identity-checked vs main (<sha>)` suffix — every synthetic tree there has a local `main` and no `origin`, so that path runs on every case and pins the `fellBack` wiring.
- `node scripts/check-source-text-assertions.mjs` → `OK (33 allowlisted, 167 marked, 0 new), identity-checked vs origin/main (3bae57165)`.
- `node scripts/check-module-size.mjs` → `OK … vs merge-base 3bae57165: +0 ^0 v1 -0` (the one lowered row).
- `check-test-wiring`, `check-test-glob-coverage`, `add-license-headers --check`, `oxlint` on the touched files, `check-changesets` → OK / clean. No changeset: no published package touched.
- Windows-local false failures reproduced **identically on the untouched base** (path-separator issues, per prior notes): `check-test-wiring.test.mjs` subtests and `check-ci-path-coverage.mjs`'s stale-exemption complaints. CI decides those.

## Review

Plan reviewed adversarially before implementation (Fable was out of credits; Opus ran the review). Acted on: the two `plantEndToEnd` copy sites it found beyond the identity test (would have broken on the new import); the `test.yml` comment rewritten to match the audit's real rules (my draft summary said kept rows are always advisory, which is wrong); `#4388 (landed by #4535)` attribution; fallback-warning assertion added to an existing case rather than a duplicate test. Kept a gate-specific one-line warning instead of reusing `changedFilesWarned` (its text names the module-size gate and it runs a `git diff`/`ls-files` this gate has no use for) — reviewer agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
