### PR TITLE
fix(docs): repair closed-dash evidence link

### DIFF
--- a/docs/architecture/pdf-vector-annotations.md
+++ b/docs/architecture/pdf-vector-annotations.md
@@ -329,8 +329,8 @@ produces visual filled vector geometry, not editable centreline/text semantics.
 Original-PDF raster and independent IFC evidence lives in
 [the solid-stroke evidence](evidence/pdf-straight-stroke-annotations/README.md)
 and [the dashed-stroke evidence](evidence/pdf-dashed-stroke-annotations/README.md).
-Closed-path decoder, export and independent-reader evidence lives in
-[the closed-dash evidence](evidence/pdf-closed-dash-annotations/README.md).
+Closed-path decoder, export and independent-reader evidence is tracked in
+[the closed-dash evidence PR](https://github.com/LTplus-AG/ifc-lite/pull/4596).
 
 ## One lattice for the complete page
 


### PR DESCRIPTION
Current `main` fails the strict MkDocs build because its closed-dash contract links to an evidence directory that is still pending in stacked PR #4596.

Point that reference at the durable PR page until the evidence lands, preserving discoverability and restoring the docs build.

Closes #4599

Validation:
- `python3 -m mkdocs build --strict`
- `git diff --check`
