### PR TITLE
Fix placement-invariant appearance face masks

### DIFF
--- a/.changeset/appearance-fingerprint-parity.md
+++ b/.changeset/appearance-fingerprint-parity.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Make evaluated-surface face-mask fingerprints placement-invariant and identical between native and WebAssembly appearance planners. Pure object translations now retain a reviewed face selection, while geometry and topology edits continue to report it stale.

--- a/apps/viewer/src/lib/appearance/face-masks-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/face-masks-wasm.test.ts
@@ -45,16 +45,11 @@ test('reconciliation drops a mask the planner reports stale or direct-bodied and
 // The workspace never judges staleness itself: it drops a mask when the real
 // planner excludes the product as stale and says so. A geometry edit of the
 // masked body (the box profile widened from 2 m to 3 m) is such a verdict.
-// For a pure translation the planner's verdict is platform-dependent today
-// (#4550: the native test asserts the translated swept box stale, the wasm
-// build reports the same fingerprint), so this test asserts the viewer's
-// invariant rather than either verdict: a selection is kept only on a
-// conversion that reports the identical fingerprint; otherwise the product is
-// excluded as stale and the selection is dropped with a diagnostic. Never a
-// misapplied mask.
-test('a geometry edit on a masked product invalidates the selection through the real planner; a translation keeps or drops it, never misapplies it (#4404)', async t => {
+// A pure translation keeps the authored product-local identity on every target
+// (#4550), while a geometry edit is stale and can never misapply a mask.
+test('a geometry edit invalidates a mask while translation retains it through the real wasm planner (#4404, #4550)', async t => {
   const wasmUrl = new URL('../../../../../packages/wasm/pkg/ifc-lite_bg.wasm', import.meta.url);
-  if (!existsSync(wasmUrl)) { t.skip('Run pnpm build:wasm for the native face-mask contract'); return; }
+  if (!existsSync(wasmUrl)) { t.skip('Run pnpm build:wasm for the real wasm face-mask contract'); return; }
   const { default: init, IfcAPI } = await import('@ifc-lite/wasm');
   await init({ module_or_path: await readFile(wasmUrl) });
   const api = new IfcAPI();
@@ -74,23 +69,18 @@ test('a geometry edit on a masked product invalidates the selection through the 
     assert.deepEqual(conversion(masked, 25).maskedTriangles, [0]);
     assert.deepEqual(conversion(masked, 70).maskedTriangles, [0, 1, 2]);
     assert.equal(reconcileFaceMasks(masks, masked, label).masks, masks, 'matching fingerprints keep both selections');
-    // Translation (12.345, 67.891, 0.1) m of both products: kept on the identical identity or dropped as stale (#4550).
+    // Translation (12.345, 67.891, 0.1) m of both products keeps the authored surface identity.
     const moved = planOn(faceMaskProductSource({ movedPlacement: true }), { faceMasks: faceMaskRequests(masks, [25, 70]) });
     const movedVerdict = reconcileFaceMasks(masks, moved, label);
     for (const productId of [25, 70]) {
       const kept = moved.conversions?.find(item => item.productId === productId);
-      const excluded = moved.exclusions.find(item => item.productId === productId);
-      assert.ok(!!kept !== !!excluded, `product ${productId} is either converted or excluded after the move`);
-      if (kept) {
-        assert.equal(kept.surfaceFingerprint, conversion(before, productId).surfaceFingerprint, 'a kept selection sits on the identical surface identity');
-        assert.deepEqual(kept.maskedTriangles, [...masks.get(productId)!.triangles], 'the kept selection applies exactly as drawn');
-        assert.ok(movedVerdict.masks.has(productId));
-      } else {
-        assert.match(excluded!.reason, /^Face selection is stale/, 'a changed identity is the explicit stale exclusion');
-        assert.ok(!movedVerdict.masks.has(productId), 'the stale selection is dropped');
-        assert.ok(movedVerdict.diagnostics.some(item => item.includes(`#${productId} is stale`)), 'and said so');
-      }
+      assert.ok(kept, `product ${productId} remains convertible after a pure move`);
+      assert.equal(kept.surfaceFingerprint, conversion(before, productId).surfaceFingerprint);
+      assert.deepEqual(kept.maskedTriangles, [...masks.get(productId)!.triangles], 'the selection applies exactly as drawn');
+      assert.ok(movedVerdict.masks.has(productId));
     }
+    assert.deepEqual(moved.exclusions, []);
+    assert.deepEqual(movedVerdict.diagnostics, []);
     // Geometry edit: the box's surface changed; the planner refuses the old selection and the workspace drops it.
     const resized = planOn(faceMaskProductSource({ resizedBox: true }), { faceMasks: faceMaskRequests(masks, [25, 70]) });
     assert.deepEqual(resized.exclusions.map(item => item.productId), [70]);

--- a/apps/viewer/src/lib/appearance/face-masks-wasm.test.ts
+++ b/apps/viewer/src/lib/appearance/face-masks-wasm.test.ts
@@ -69,6 +69,11 @@ test('a geometry edit invalidates a mask while translation retains it through th
     assert.deepEqual(conversion(masked, 25).maskedTriangles, [0]);
     assert.deepEqual(conversion(masked, 70).maskedTriangles, [0, 1, 2]);
     assert.equal(reconcileFaceMasks(masks, masked, label).masks, masks, 'matching fingerprints keep both selections');
+    const millimetres = new TextEncoder().encode(new TextDecoder().decode(faceMaskProductSource())
+      .replace('.LENGTHUNIT.,$,.METRE.', '.LENGTHUNIT.,.MILLI.,.METRE.'));
+    const millimetrePlan = planOn(millimetres);
+    assert.deepEqual(millimetrePlan.exclusions, [], 'no-opening millimetre occurrences convert across the real wasm boundary');
+    assert.equal(millimetrePlan.conversions?.length, 2);
     // Translation (12.345, 67.891, 0.1) m of both products keeps the authored surface identity.
     const moved = planOn(faceMaskProductSource({ movedPlacement: true }), { faceMasks: faceMaskRequests(masks, [25, 70]) });
     const movedVerdict = reconcileFaceMasks(masks, moved, label);

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -479,6 +479,12 @@ new cache whenever the source model changes: signatures are keyed by express
 ID. Tessellation quality, unit scale and RTC remain router-local and are folded
 into the final deduplication key. The native processing pipeline manages this lifetime automatically.
 
+`GeometryRouter::with_scale_and_local_frame(unit_scale, enabled)` fixes the
+mesh-coordinate frame when the router is created. Use it when one operation
+must produce identical local-frame geometry across native and wasm targets;
+ordinary routers continue to use the target and environment default. The frame
+choice cannot be changed after construction because router caches depend on it.
+
 Other notable re-exports: `orient_mesh_outward`, `calculate_normals`, `ClippingProcessor`, `Plane`, `Triangle` (CSG), `hash_mesh_world` / `GeometryHasher` (geometry-diff hashing), instancing encode/decode helpers, and the nalgebra types `Point2`, `Point3`, `Vector2`, `Vector3`.
 
 `embedded_raster_dimensions(step_binary)` returns optional PNG/JPEG dimensions

--- a/docs/architecture/appearance-evaluated-occurrences.md
+++ b/docs/architecture/appearance-evaluated-occurrences.md
@@ -95,12 +95,9 @@ product-local coordinates quantised to one micrometre, and the triangle
 topology. Express ids are deliberately excluded, so a renumbered export keeps
 a mask, while any change to the evaluated surface (an edited opening, a
 different profile, another tessellator) changes the fingerprint. The authored
-coordinates are rebuilt from the canonical f32 world evaluation, so the
-fingerprint binds to the surface at its current placement: a placement edit
-generally changes it and reports the mask stale, because f32 spacing exceeds
-one micrometre a few metres from the origin; only a move that is exactly
-representable in f32 (the controlled test's 10 m offset) keeps it. Stale is
-the safe direction, and a viewer must treat a placement edit as invalidating. A mask is `{ productId, surfaceFingerprint, triangles }` with
+coordinates are rebuilt from a precision-preserving canonical local-frame
+evaluation on every target, so a pure placement edit keeps the fingerprint. A
+mask is `{ productId, surfaceFingerprint, triangles }` with
 source triangle ordinals in the same order as `sourceIndices`.
 
 The planner never reuses triangle ordinals by position. Faults in one mask
@@ -173,16 +170,9 @@ without it, and the diagnostic stays through that automatic re-plan until the
 next selection change, Discard or Apply. A conversion that reports a different
 fingerprint than the mask it was drawn on is treated the same way. Which edits
 change the fingerprint is the planner's call, and the viewer only relays it.
-Measured on this build: a geometry edit (a widened box profile) reports the
-mask stale; an ordinary (12.345, 67.891, 0.1) m translation of the same swept
-box or of a mapped quad keeps the fingerprint in the wasm planner (the authored
-coordinates are rebuilt around a per-element origin), while the native Rust
-unit test of the same fixture asserts the translated box stale. Native and wasm
-currently differ in the fingerprint's placement sensitivity — tracked as
-[#4550](https://github.com/LTplus-AG/ifc-lite/issues/4550). Either verdict is
-safe for a mask (kept only when the planner reproduces the identical surface
-identity, otherwise dropped with the diagnostic), and the viewer test asserts
-that invariant rather than either verdict.
+Measured on native and wasm builds: a geometry edit (a widened box profile)
+reports the mask stale, while an ordinary (12.345, 67.891, 0.1) m translation
+of the same swept box or of a mapped quad keeps the fingerprint and selection.
 
 The renderer preview stages a masked plan through an explicit
 `AppearancePartition`: each resident fragment contributes a textured subset, a

--- a/rust/geometry/src/router/mod.rs
+++ b/rust/geometry/src/router/mod.rs
@@ -145,6 +145,10 @@ pub struct GeometryRouter {
     /// RTC (Relative-to-Center) offset, subtracted from world positions in f64
     /// before converting to f32 to preserve precision (e.g. Swiss UTM).
     rtc_offset: (f64, f64, f64),
+    /// Per-router local-frame choice. `None` retains the target/env default;
+    /// appearance authoring sets this explicitly so its canonical surface
+    /// identity cannot vary between native and wasm builds (#4550).
+    local_frame_enabled: Option<bool>,
     /// Material-layer buildup index. When set, `process_element_with_submeshes`
     /// and `process_element_with_submeshes_and_voids` first attempt to slice
     /// single-solid elements by their `IfcMaterialLayerSetUsage` buildup.
@@ -248,6 +252,7 @@ impl GeometryRouter {
             content_hash_oversized_ref_drops: RefCell::new(0),
             unit_scale: 1.0,             // Default to base meters
             rtc_offset: (0.0, 0.0, 0.0), // Default to no offset
+            local_frame_enabled: None,
             material_layer_index: None,
             csg_failures: RefCell::new(FxHashMap::default()),
             classification_stats: RefCell::new(ClassificationStats::default()),
@@ -317,6 +322,17 @@ impl GeometryRouter {
     pub fn with_scale(unit_scale: f64) -> Self {
         let mut router = Self::new();
         router.unit_scale = unit_scale;
+        router
+    }
+
+    /// Create a router with an explicit per-mesh local-frame policy.
+    ///
+    /// This is intentionally a constructor rather than a mutable switch: mesh
+    /// caches are frame-dependent, so the policy must be fixed before any
+    /// geometry is produced.
+    pub fn with_scale_and_local_frame(unit_scale: f64, enabled: bool) -> Self {
+        let mut router = Self::with_scale(unit_scale);
+        router.local_frame_enabled = Some(enabled);
         router
     }
 

--- a/rust/geometry/src/router/transforms/mesh_world.rs
+++ b/rust/geometry/src/router/transforms/mesh_world.rs
@@ -34,7 +34,7 @@ impl GeometryRouter {
     /// during raw world-coordinate triangulation are guarded by `rtc_applied`.
     #[inline]
     pub(crate) fn transform_mesh_world(&self, mesh: &mut Mesh, transform: &Matrix4<f64>) {
-        self.transform_mesh_world_framed(mesh, transform, super::local_frame_enabled());
+        self.transform_mesh_world_framed(mesh, transform, self.local_frame_enabled());
     }
 
     /// World placement with an explicit choice of whether to relativize positions
@@ -250,5 +250,19 @@ mod local_bounds_tests {
         assert_eq!(mesh2.local_bounds, mesh.local_bounds);
         assert_eq!(mesh2.local_to_world, mesh.local_to_world);
         assert_eq!(mesh2.origin, [0.0; 3], "absolute path never sets origin");
+    }
+
+    #[test]
+    fn issue_4550_router_local_frame_policy_is_explicit_per_instance() {
+        let transform = Translation3::new(12.345, 67.891, 0.1).to_homogeneous();
+        let mut framed = unit_box();
+        GeometryRouter::with_scale_and_local_frame(1.0, true)
+            .transform_mesh_world(&mut framed, &transform);
+        assert_ne!(framed.origin, [0.0; 3]);
+
+        let mut absolute = unit_box();
+        GeometryRouter::with_scale_and_local_frame(1.0, false)
+            .transform_mesh_world(&mut absolute, &transform);
+        assert_eq!(absolute.origin, [0.0; 3]);
     }
 }

--- a/rust/geometry/src/router/transforms/mod.rs
+++ b/rust/geometry/src/router/transforms/mod.rs
@@ -55,8 +55,9 @@ use nalgebra::Matrix4;
 
 static LOCAL_FRAME_OVERRIDE: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
 
-/// Test/harness-only: force [`local_frame_enabled`] on/off, or `None` for the
-/// target default. Mirrors `rect_fast::param_set_enabled_override`. The
+/// Test/harness-only: force the target/env fallback on/off, or `None` for the
+/// target default. A router constructed with an explicit frame policy does not
+/// consult this process-global hook. Mirrors `rect_fast::param_set_enabled_override`. The
 /// mesh-output determinism manifest uses it to run native and wasm with the
 /// SAME flag state (wasm defaults ON, native defaults OFF below), so the two
 /// targets' outputs are comparable byte-for-byte.
@@ -79,8 +80,8 @@ pub fn local_frame_set_enabled_override(v: Option<bool>) {
 /// local frame. Consumers reconstruct world = `MeshData.origin` + position.
 /// Default is ON for wasm (the precision-critical viewer path, whose renderer
 /// consumes `origin`) and OFF for native, where `IFC_LITE_LOCAL_FRAME=1` opts
-/// in. Env/cfg default read once and cached; the
-/// [`local_frame_set_enabled_override`] hook takes precedence on every call.
+/// in. Env/cfg default read once and cached. An explicit per-router policy takes
+/// precedence; otherwise [`local_frame_set_enabled_override`] selects this fallback.
 pub(crate) fn local_frame_enabled() -> bool {
     match LOCAL_FRAME_OVERRIDE.load(std::sync::atomic::Ordering::Relaxed) {
         0 => return false,
@@ -143,6 +144,10 @@ pub(crate) fn mat4_to_row_major(m: &Matrix4<f64>) -> [f64; 16] {
 }
 
 impl GeometryRouter {
+    pub(super) fn local_frame_enabled(&self) -> bool {
+        self.local_frame_enabled.unwrap_or_else(local_frame_enabled)
+    }
+
     /// Apply local placement transformation to mesh
     ///
     /// Welds the source vertices FIRST (#4103). This is the last point at which

--- a/rust/processing/src/appearance/canonical.rs
+++ b/rust/processing/src/appearance/canonical.rs
@@ -130,6 +130,28 @@ pub(super) fn produce(
     textures: &FxHashMap<u32, ResolvedTextureMap>,
     appearance: Option<&crate::prepass::ResolvedPrepass>,
 ) -> Result<Vec<MeshData>, String> {
+    produce_with_frame(source, product_id, textures, appearance, false)
+}
+
+/// Evaluate an occurrence in the same placement-independent frame on native
+/// and wasm. This is kept separate from ordinary canonical production because
+/// authoring previews must retain the target's established output frame.
+pub(super) fn produce_evaluated(
+    source: &mut Source<'_>,
+    product_id: u32,
+    textures: &FxHashMap<u32, ResolvedTextureMap>,
+    appearance: Option<&crate::prepass::ResolvedPrepass>,
+) -> Result<Vec<MeshData>, String> {
+    produce_with_frame(source, product_id, textures, appearance, true)
+}
+
+fn produce_with_frame(
+    source: &mut Source<'_>,
+    product_id: u32,
+    textures: &FxHashMap<u32, ResolvedTextureMap>,
+    appearance: Option<&crate::prepass::ResolvedPrepass>,
+    evaluated: bool,
+) -> Result<Vec<MeshData>, String> {
     let product = source.entity(product_id)?;
     source.validate_world_placement(&product)?;
     let scale = source.decoder.length_unit_scale();
@@ -145,7 +167,7 @@ pub(super) fn produce(
     if context.layers.is_sliceable(product_id) {
         return Err("Material-layer slicing is unsupported for appearance authoring".into());
     }
-    let router = context.router();
+    let router = if evaluated { context.evaluated_router() } else { context.router() };
     let voids = FxHashMap::default();
     let styles = FxHashMap::default();
     let colours = FxHashMap::default();

--- a/rust/processing/src/appearance/context.rs
+++ b/rust/processing/src/appearance/context.rs
@@ -44,7 +44,14 @@ impl Context {
         Self { meta, layers }
     }
     pub fn router(&self) -> GeometryRouter {
-        let mut router = GeometryRouter::with_scale(self.meta.length_unit_scale);
+        self.configure(GeometryRouter::with_scale(self.meta.length_unit_scale))
+    }
+    /// Evaluated-occurrence identity and replacement use one frame on every
+    /// target. Other appearance paths retain their established native output.
+    pub fn evaluated_router(&self) -> GeometryRouter {
+        self.configure(GeometryRouter::with_scale_and_local_frame(self.meta.length_unit_scale, true))
+    }
+    fn configure(&self, mut router: GeometryRouter) -> GeometryRouter {
         if self.meta.needs_shift {
             router.set_rtc_offset(self.meta.rtc_offset);
         }

--- a/rust/processing/src/appearance/evaluated.rs
+++ b/rust/processing/src/appearance/evaluated.rs
@@ -100,7 +100,11 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
             if matches!(request.mapping,Mapping::ExistingUv {..}) { return Err("Evaluated occurrence conversion requires a new planar or box mapping".into()); }
             let (product, body)=evaluated_source::body(source,product_id)?;
             let layers=super::evaluated_replacement::layers(source,body.id)?;
-            let mut meshes=canonical::produce(source,product_id,&textures,Some(&styles))?;
+            // One explicit local-frame evaluation supplies both the authored
+            // replacement and its placement-independent fingerprint (#4550).
+            // Re-evaluating the same CSG surface solely for identity would
+            // double the opt-in appearance planner's dominant work.
+            let mut meshes=canonical::produce_evaluated(source,product_id,&textures,Some(&styles))?;
             if meshes.len()!=1 { return Err("Evaluated appearance currently requires one unambiguous source surface".into()); }
             let mesh=meshes.remove(0);
             if mesh.texture.is_some() || mesh.uvs.is_some() { return Err("Evaluated conversion of textured source surfaces is not supported yet".into()); }
@@ -118,9 +122,12 @@ pub(super) fn prepare(bytes: &[u8], request: &AppearanceRequest, source: &mut So
                 styles.void_index.get(&product_id).map_or(&[],Vec::as_slice),
                 &opening_edits,&textures,&styles,&mut budget)?;
             let points=evaluated_source::local_points(source,&product,&mesh)?;
-            let rounding_bounds=if opening_edits.is_empty() {None} else {
-                Some(super::evaluated_precision::local_cast_bounds(&points,source.decoder.length_unit_scale())?)
-            };
+            // The explicit local frame and the normal target frame can round
+            // equivalent f64 world corners through different f32 values. Use
+            // the existing per-corner cast bound for that representation-only
+            // difference, with or without opening edits.
+            let rounding_bounds=Some(super::evaluated_precision::local_cast_bounds(
+                &points,source.decoder.length_unit_scale())?);
             let fingerprint=super::evaluated_mask::fingerprint(product.get_string(0).ok_or("Product has no GlobalId")?,
                 &points,source.decoder.length_unit_scale(),&mesh.indices)?;
             let partition=masks.get(&product_id).map(|mask|super::evaluated_mask::partition(mask,&fingerprint,&mesh.indices)).transpose()?.flatten();

--- a/rust/processing/src/appearance/evaluated_mask.rs
+++ b/rust/processing/src/appearance/evaluated_mask.rs
@@ -13,11 +13,9 @@ pub(super) const DIRECT_BODY: &str =
     "Face masks currently apply to converted occurrence bodies only; this object already has a direct tessellated Body";
 /// Coordinates are quantised to one micrometre before hashing so that
 /// sub-micrometre noise between two plans of the same file cannot drop a mask.
-/// The points come from the canonical f32 world evaluation, so the fingerprint
-/// binds to the surface at its current placement: a renumbered export keeps a
-/// mask, while a placement edit generally reports it stale (f32 spacing exceeds
-/// one micrometre beyond a few metres from the origin) unless the move is
-/// exactly representable. Stale is the safe direction; a mask is never reused.
+/// The canonical evaluation uses a per-element local frame before the inverse
+/// product transform, so a pure placement edit does not change this product-local
+/// identity on either native or wasm. Geometry and topology edits still do.
 const QUANTUM_PER_METRE: f64 = 1e6;
 /// Equals the plan geometry budget's triangle capacity (1 500 000 corners).
 const MASK_ORDINAL_BUDGET: usize = 500_000;

--- a/rust/processing/src/appearance/evaluated_mask_tests.rs
+++ b/rust/processing/src/appearance/evaluated_mask_tests.rs
@@ -46,6 +46,10 @@ fn selected_corners(mesh: &crate::types::mesh::MeshData, triangles: &[u32], keep
     let all: Vec<[f64; 3]> = corners(mesh);
     all.chunks_exact(3).enumerate().filter(|(t, _)| triangles.contains(&(*t as u32)) == keep).flat_map(|(_, c)| c.iter().copied()).collect()
 }
+fn assert_same_surface(actual: Vec<[f64; 3]>, expected: Vec<[f64; 3]>) {
+    assert_eq!(actual.len(), expected.len());
+    assert!(actual.iter().flatten().zip(expected.iter().flatten()).all(|(a, b)| (a - b).abs() < 1e-6));
+}
 
 #[test]
 fn issue_4404_unique_swept_body_converts_only_under_evaluated_policy() {
@@ -171,16 +175,14 @@ fn issue_4404_stale_or_malformed_face_masks_are_explicit_refusals() {
 }
 
 #[test]
-fn issue_4404_surface_fingerprint_binds_to_the_placed_surface_not_express_ids() {
+fn issue_4550_surface_fingerprint_is_placement_invariant_on_native() {
     let source = swept_source();
     let fingerprint = fingerprint_of(&source, 40);
     assert_eq!(fingerprint_of(&source, 40), fingerprint, "deterministic across plans");
     let renumbered = source.replace("#44", "#94");
     assert_eq!(fingerprint_of(&renumbered, 40), fingerprint, "express ids are not part of the surface identity");
-    // The local coordinates are rebuilt from the f32 world evaluation, so the
-    // placement is part of the identity except where the move is exactly
-    // representable: (10, 20, 0) keeps the fingerprint, an ordinary survey
-    // offset does not and the mask is reported stale rather than reapplied.
+    // The fingerprint is authored product-local surface identity: both an exact
+    // offset and an ordinary survey offset retain it on native, matching wasm.
     let place = |x: &str, y: &str, z: &str| source.replace("#41=IFCLOCALPLACEMENT($,#5);",
         &format!("#41=IFCLOCALPLACEMENT($,#52);\n#52=IFCAXIS2PLACEMENT3D(#53,$,$);\n#53=IFCCARTESIANPOINT(({x},{y},{z}));"));
     let exact = place("10.", "20.", "0.");
@@ -188,12 +190,22 @@ fn issue_4404_surface_fingerprint_binds_to_the_placed_surface_not_express_ids() 
     let mask_on_exact = plan_appearance(exact.as_bytes(), &request(40, vec![mask(40, &fingerprint, vec![0, 1])])).unwrap();
     assert!(mask_on_exact.exclusions.is_empty(), "{:?}", mask_on_exact.exclusions);
     let moved = place("12.345", "67.891", "0.1");
-    assert_ne!(fingerprint_of(&moved, 40), fingerprint, "a placement edit generally changes the placed surface");
-    assert_eq!(fingerprint_of(&moved, 40), fingerprint_of(&moved, 40), "the placed surface is itself stable");
+    assert_eq!(fingerprint_of(&moved, 40), fingerprint, "a pure placement edit keeps the authored surface identity");
     let mask_on_moved = plan_appearance(moved.as_bytes(), &request(40, vec![mask(40, &fingerprint, vec![0, 1])])).unwrap();
-    assert_eq!(mask_on_moved.exclusions.len(), 1, "{:?}", mask_on_moved.exclusions);
-    assert_eq!(mask_on_moved.exclusions[0].reason, super::STALE);
-    assert!(mask_on_moved.items.is_empty() && mask_on_moved.created.is_empty() && mask_on_moved.edits.is_empty());
+    assert!(mask_on_moved.exclusions.is_empty(), "{:?}", mask_on_moved.exclusions);
+    assert_eq!(mask_on_moved.conversions[0].masked_triangles.as_deref(), Some(&[0, 1][..]));
+    // The framing choice changes storage precision, not the authored surface:
+    // after applying and reopening, the two partitions cover the same placed
+    // triangle corners within the fingerprint's one-micrometre quantum.
+    let original = meshes_of(&moved, 40).remove(0);
+    let output = apply(&moved, &mask_on_moved);
+    let reopened = meshes_of(&output, 40);
+    assert_eq!(reopened.len(), 2);
+    let conversion = &mask_on_moved.conversions[0];
+    let textured = reopened.iter().find(|mesh| mesh.geometry_item_id == Some(conversion.geometry_item_id)).unwrap();
+    let retained = reopened.iter().find(|mesh| mesh.geometry_item_id == conversion.retained_geometry_item_id).unwrap();
+    assert_same_surface(corners(textured), selected_corners(&original, &[0, 1], true));
+    assert_same_surface(corners(retained), selected_corners(&original, &[0, 1], false));
     let resized = source.replace("#45=IFCRECTANGLEPROFILEDEF(.AREA.,$,#46,2.,1.);", "#45=IFCRECTANGLEPROFILEDEF(.AREA.,$,#46,3.,1.);");
     let changed = fingerprint_of(&resized, 40);
     assert_ne!(changed, fingerprint);
@@ -233,7 +245,10 @@ fn issue_4404_real_unique_swept_slab_converts_with_a_cloned_type_shared_wrapper(
     assert_eq!(before.meshes.len(), after.meshes.len());
     for mesh in &before.meshes {
         let other = after.meshes.iter().find(|m| m.express_id == mesh.express_id && (m.express_id == 34509 || m.geometry_item_id == mesh.geometry_item_id)).unwrap();
-        if mesh.express_id == 34509 { assert_eq!(corners(mesh), corners(other)); assert!(other.texture.is_some()); assert_eq!(mesh.global_id, other.global_id); }
+        if mesh.express_id == 34509 {
+            assert_same_surface(corners(mesh), corners(other));
+            assert!(other.texture.is_some()); assert_eq!(mesh.global_id, other.global_id);
+        }
         else { assert_eq!(serde_json::to_value(mesh).unwrap(), serde_json::to_value(other).unwrap()); }
     }
 }

--- a/rust/processing/src/appearance/evaluated_mask_tests.rs
+++ b/rust/processing/src/appearance/evaluated_mask_tests.rs
@@ -225,6 +225,20 @@ fn issue_4550_surface_fingerprint_is_placement_invariant_on_native() {
 }
 
 #[test]
+fn issue_4550_no_opening_millimetre_occurrence_converts_and_reopens() {
+    let source=swept_source().replace(".LENGTHUNIT.,$,.METRE.",".LENGTHUNIT.,.MILLI.,.METRE.");
+    let original=meshes_of(&source,40).remove(0);
+    let plan=plan_appearance(source.as_bytes(),&request(40,Vec::new())).unwrap();
+    assert!(plan.exclusions.is_empty(),"{:?}",plan.exclusions);
+    assert_eq!(plan.conversions.len(),1);
+    assert!(plan.conversions[0].source_removed_meshes.is_empty(),"the fixture has no opening companions");
+    let output=apply(&source,&plan);
+    let reopened=meshes_of(&output,40);
+    assert_eq!(reopened.len(),1);
+    assert_same_surface(corners(&reopened[0]),corners(&original));
+}
+
+#[test]
 fn issue_4404_real_unique_swept_slab_converts_with_a_cloned_type_shared_wrapper() {
     let Some(source) = real_source() else { return };
     let mut request = request(34509, vec![]);

--- a/rust/processing/src/appearance/evaluated_precision.rs
+++ b/rust/processing/src/appearance/evaluated_precision.rs
@@ -3,16 +3,26 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //! Explicit error accounting for post-CSG f64-origin → IFC → f32 tessellation.
 
-/// Tessellation parsing first stores product-local IFC coordinates in f32.
-/// A rigid placement coefficient has absolute value at most one, so the sum of
-/// the three actual cast errors bounds each world-axis error after rotation.
-/// This initial slice requires metre units; an additional f32 scale operation
-/// must be accounted for before enabling other unit systems.
+/// Tessellation parsing first stores product-local IFC coordinates in f32 and
+/// multiplies them by the model-unit scale in f32. A rigid placement
+/// coefficient has absolute value at most one, so the sum of the three actual
+/// metre-space errors bounds each world-axis error after rotation.
 pub(super) fn local_cast_bounds(points: &[[f64;3]], scale:f64)->Result<Vec<f64>,String> {
-    if scale!=1. {return Err("Post-opening conversion currently requires metre model units".into());}
+    if !scale.is_finite() || scale<=0. {return Err("Invalid model length unit scale".into());}
+    let scale_f32=scale as f32;
+    if !scale_f32.is_finite() || scale_f32<=0. {return Err("Model length unit scale is not a positive finite f32".into());}
     points.iter().map(|point| {
-        let bound=point.iter().map(|&v|(v-f64::from(v as f32)).abs()).sum::<f64>();
-        if bound.is_finite() {Ok(bound)}else{Err("Post-opening coordinate exceeds f32 range".into())}
+        let mut bound=0.;
+        for &value in point {
+            let ideal_metres=value*scale;
+            let reparsed_metres=f64::from((value as f32)*scale_f32);
+            let error=(ideal_metres-reparsed_metres).abs();
+            if !ideal_metres.is_finite() || !reparsed_metres.is_finite() || !error.is_finite() {
+                return Err("Evaluated coordinate exceeds f32 range".into());
+            }
+            bound+=error;
+        }
+        if bound.is_finite() {Ok(bound)}else{Err("Evaluated coordinate exceeds f32 range".into())}
     }).collect()
 }
 
@@ -58,8 +68,23 @@ mod tests {
     }
 
     #[test]
-    fn issue_4404_frame_bound_refuses_unaccounted_scale_and_nonfinite_coordinates() {
-        assert!(local_cast_bounds(&[[1.,2.,3.]],0.001).is_err());
+    fn issue_4550_frame_bound_accounts_for_file_unit_and_scale_casts() {
+        let point=[1_000.123_456,2_000.234_567,3_000.345_678];
+        let scale=0.001;
+        let scale_f32=scale as f32;
+        let expected=point.iter().map(|&value| {
+            let ideal_metres=value*scale;
+            let reparsed_metres=f64::from((value as f32)*scale_f32);
+            (ideal_metres-reparsed_metres).abs()
+        }).sum::<f64>();
+        assert_eq!(local_cast_bounds(&[point],scale).unwrap(),vec![expected]);
+    }
+
+    #[test]
+    fn issue_4550_frame_bound_refuses_invalid_scale_and_nonfinite_products() {
+        for scale in [0.,-1.,f64::NAN,f64::INFINITY,f64::from(f32::MAX)*2.] {
+            assert!(local_cast_bounds(&[[1.,2.,3.]],scale).is_err());
+        }
         assert!(local_cast_bounds(&[[f64::MAX,0.,0.]],1.).is_err());
         assert!(local_cast_bounds(&[[f64::NAN,0.,0.]],1.).is_err());
         assert!(!same_corner(&[0.;3],[0.;3],&[f32::INFINITY,0.,0.],[0.;3],0.));

--- a/rust/processing/src/appearance/evaluated_tests.rs
+++ b/rust/processing/src/appearance/evaluated_tests.rs
@@ -32,6 +32,16 @@ pub(crate) fn real_source()->Option<String> {
 pub(crate) fn corners(mesh:&crate::types::mesh::MeshData)->Vec<[f64;3]> {
     mesh.indices.iter().map(|&i|std::array::from_fn(|axis|f64::from(mesh.positions[i as usize*3+axis])+mesh.origin[axis])).collect()
 }
+fn assert_binding_surface(binding:&AppearanceConversion, mesh:&crate::types::mesh::MeshData) {
+    assert_eq!(binding.source_normals,mesh.normals);
+    assert_eq!(binding.source_indices,mesh.indices);
+    assert_eq!(binding.source_color,mesh.color);
+    let actual:Vec<[f64;3]>=binding.source_indices.iter().map(|&i|std::array::from_fn(|axis|
+        f64::from(binding.source_positions[i as usize*3+axis])+binding.source_origin[axis])).collect();
+    for (a,b) in actual.iter().zip(corners(mesh)) {
+        assert!((0..3).all(|axis|(a[axis]-b[axis]).abs()<1e-6),"{a:?} != {b:?}");
+    }
+}
 #[test]
 fn issue_4404_real_mapped_member_is_opt_in_and_preserves_every_sibling_and_world_corner() {
     let Some(source)=real_source() else{return};
@@ -57,11 +67,7 @@ fn issue_4404_real_mapped_member_is_opt_in_and_preserves_every_sibling_and_world
         if mesh.express_id==35169 {
             assert_eq!(corners(mesh),corners(other));assert!(other.uvs.is_some());assert!(other.texture.is_some());
             let binding=&plan.conversions[0];
-            assert_eq!(binding.source_positions,mesh.positions);
-            assert_eq!(binding.source_normals,mesh.normals);
-            assert_eq!(binding.source_indices,mesh.indices);
-            assert_eq!(binding.source_origin,mesh.origin);
-            assert_eq!(binding.source_color,mesh.color);
+            assert_binding_surface(binding,mesh);
             assert_eq!(binding.rtc_offset,[0.;3]);
             assert_eq!(mesh.global_id,other.global_id);
         } else { assert_eq!(serde_json::to_value(mesh).unwrap(),serde_json::to_value(other).unwrap()); }
@@ -227,9 +233,7 @@ fn issue_4404_materialization_payload_restores_georeferenced_native_frame_once()
     let textures=ifc_lite_geometry::build_texture_index(source.as_bytes(),&mut effective.decoder);
     let meshes=canonical::produce(&mut effective,35169,&textures,Some(&styles)).unwrap();
     let mesh=&meshes[0];
-    assert_eq!(binding.source_positions,mesh.positions);
-    assert_eq!(binding.source_normals,mesh.normals);
-    assert_eq!(binding.source_origin,mesh.origin);
+    assert_binding_surface(binding,mesh);
     let output=apply(&source,&plan);
     let reopened=crate::process_geometry(output.as_bytes());
     let target=reopened.meshes.iter().find(|m|m.express_id==35169).unwrap();
@@ -338,9 +342,7 @@ fn issue_4404_real_cut_slab_preserves_type_semantics_and_accepts_second_appearan
     for mesh in before.meshes.iter().filter(|mesh|mesh.express_id!=59365) {
         let other=after.meshes.iter().find(|m|m.express_id==mesh.express_id && (m.express_id==59290 || m.geometry_item_id==mesh.geometry_item_id)).unwrap();
         if mesh.express_id==59290 {
-            assert_eq!(plan.conversions[0].source_positions,mesh.positions);
-            assert_eq!(plan.conversions[0].source_indices,mesh.indices);
-            assert_eq!(plan.conversions[0].source_origin,mesh.origin);
+            assert_binding_surface(&plan.conversions[0],mesh);
             assert_eq!(mesh.indices.len()/3,32);assert_eq!(other.indices.len()/3,32);
             assert!(other.uvs.is_some());assert!(other.texture.is_some());
             assert_eq!(mesh.global_id,other.global_id);

--- a/rust/processing/src/appearance/types.rs
+++ b/rust/processing/src/appearance/types.rs
@@ -147,9 +147,9 @@ pub struct AppearanceConversion {
     pub rtc_offset: [f64; 3],
     /// Hex SHA-256 of the product GlobalId, its quantised local evaluated
     /// surface and topology. Face masks bind to this value; express ids are
-    /// excluded so a renumbered export keeps its selection. The surface is
-    /// evaluated in f32 world space at its current placement, so a placement
-    /// edit generally changes the value and reports a mask stale.
+    /// excluded so a renumbered export keeps its selection. The surface uses a
+    /// precision-preserving product-local evaluation on every target, so a pure
+    /// placement edit keeps the value while geometry or topology edits change it.
     pub surface_fingerprint: String,
     /// Accepted ascending source triangle ordinals that received the
     /// appearance. Absent when the whole surface was converted.

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -1171,6 +1171,20 @@ directly and checked the run count. #4541 fixed the guard with
 `pathToFileURL`; always check the round count `ab.sh` reports.
 [Raw rounds](../../docs/architecture/evidence/evaluated-face-masks/native-load.json) and [fingerprints](../../docs/architecture/evidence/evaluated-face-masks/native-fingerprints.json).
 
+The #4550 native/wasm fingerprint-parity follow-up makes the existing
+per-element local frame explicit only inside opt-in appearance planning. Fresh
+interleaved base/branch and branch/base AC20 normal-load controls resolved no
+change at the probe's phase precision, and every run retained identical mesh,
+vertex and triangle counts plus ordered geometry fingerprint. The useful lesson
+is to select frame policy per router before its caches are populated: a
+process-global override would make concurrent native planning unsafe, while
+changing the native load default would needlessly disturb deterministic output.
+An interleaved release A/B over the real AC20 mapped-member
+`plan_appearance` path also retained the same source-index checksum and
+fingerprint with no slowdown. The final implementation evaluates the canonical
+surface once and shares that mesh between replacement and fingerprinting; a
+second identity-only evaluation was measured and removed before review.
+
 ### Shared appearance atlas sampling (#4381)
 
 Factoring target appearance preservation, charts and canonical image binding into


### PR DESCRIPTION
A reviewed face selection now survives a pure object translation in both the native and WebAssembly appearance planners. Before this change, the native planner baked ordinary world placement into f32 coordinates before reconstructing product-local points, so `(12.345, 67.891, 0.1)` could change `surfaceFingerprint` while the WebAssembly planner retained it.

The evaluated-occurrence path now constructs one canonical geometry router with an explicit local-frame policy. The same single evaluation drives replacement geometry, the materialization payload, and the fingerprint; normal model loading and the annotation, PDF, and captured-surface authoring paths keep their existing frame policy. Geometry or topology edits still report the selection stale. Existing real-model tests verify the authored IFC reopens over the same world corners, topology, normals, and appearance.

Validation:
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p ifc-lite-processing --lib` (383 passed)
- rebuilt WASM + real `IfcAPI.planAppearance` regression (3 passed; mapped quad and swept box)
- `pnpm typecheck` (96/96 tasks, 2026/2026 test files audited)
- `pnpm docs:check-samples`
- `pnpm docs:check-generated`
- `pnpm check:rust-api-surface`
- AC20 normal-load perf probe: 285 meshes / 35,940 vertices / 19,456 triangles / FNV `25ac885b6ff4ad00` on every base and branch run, best total 8 ms throughout
- AC20 evaluated-appearance release A/B, 20 plans per process: branch 2.293 s / base 2.705 s / base 2.712 s / branch 2.426 s, with identical 720-index checksum and `6fb4ffdfa4e2266120a241c6ced3318cc8839a287362efef100d30968988367e` fingerprint

A local root `pnpm test` rerun completed 96 tasks successfully; its sole remaining failure was two unrelated `create-ifc-lite` subprocess cases exceeding their 30-second timeout under concurrent repository-wide jobs. CI provides the clean full-suite run.

Closes #4550


Review follow-up (`afff46954`): generalized the unconditional post-conversion f32 rounding bound to non-metre model units by measuring both the file-coordinate cast and f32 unit-scale multiplication. Added direct overflow/invalid-scale tests plus native and real-WASM no-opening millimetre occurrence regressions.

Additional validation:
- `cargo test -p ifc-lite-processing issue_4550 --lib -- --nocapture` (4 passed)
- `cargo test -p ifc-lite-processing --lib` (391 passed)
- rebuilt WASM + focused real-WASM test (3 passed, including millimetre conversion)
- `cargo clippy --workspace --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Face-mask selections now remain associated with surfaces when objects are translated.
  * Native and WebAssembly appearance processing now produce consistent face-mask results.
  * Geometry or topology changes correctly mark affected masks as stale.
  * Appearance conversion now handles valid millimetre-based inputs more reliably.

* **Documentation**
  * Documented configuration options for coordinate-frame selection and placement-independent appearance evaluation.
  * Added performance documentation covering fingerprint consistency and appearance-planning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->