### PR TITLE
Fix PDF MuPDF omission extent contract

### DIFF
--- a/.changeset/tidy-pdfs-rest.md
+++ b/.changeset/tidy-pdfs-rest.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Keep PDF omission extents in the documented path-coordinate frame while using conservative painted-stroke bounds for crop safety.

--- a/rust/processing/src/pdf_vector/interpret_path.rs
+++ b/rust/processing/src/pdf_vector/interpret_path.rs
@@ -20,12 +20,13 @@ impl Interpreter {
         // unused zero-width setting does not itself paint a hairline.
         let painted = paint != PdfVectorPaint::EndPath && !commands.is_empty();
         if painted && !self.annotation {
-            let mut bbox = extent::bbox(extent::path_points(commands).map(|p| self.to_pdf(p)));
+            let path_bbox = extent::bbox(extent::path_points(commands).map(|p| self.to_pdf(p)));
+            let mut painted_bbox = path_bbox;
             // Visibility and crop containment apply to painted ink, not only
             // the path centreline. This deliberately overbounds joins/caps:
             // an uncertain boundary contact refuses instead of losing paint.
             if paint.strokes() && self.frame.state.line_width > 0. {
-                if let Some([mut x0, mut y0, mut x1, mut y1]) = bbox {
+                if let Some([mut x0, mut y0, mut x1, mut y1]) = painted_bbox {
                     let [a, b, c, d, _, _] = self.frame.pdf_from_path;
                     let points = extent::path_points(commands).count();
                     let closed = paint.closes() || extent::opcodes(commands).any(|op| op == 4);
@@ -46,13 +47,13 @@ impl Interpreter {
                     x1 += mx;
                     y0 -= my;
                     y1 += my;
-                    bbox = Some([x0, y0, x1, y1]);
+                    painted_bbox = Some([x0, y0, x1, y1]);
                 }
             }
             if self.hidden > 0 {
-                self.report.record("hidden", ordinal, bbox, false, true);
+                self.report.record("hidden", ordinal, path_bbox, false, true);
             } else {
-                self.record_visible_path(ordinal, paint, commands, bbox)?;
+                self.record_visible_path(ordinal, paint, commands, path_bbox, painted_bbox)?;
             }
         }
         // PDF paints first, then intersects the pending clip with the same path.
@@ -68,14 +69,16 @@ impl Interpreter {
         ordinal: u32,
         paint: PdfVectorPaint,
         commands: &[f64],
-        bbox: Option<Rect>,
+        path_bbox: Option<Rect>,
+        painted_bbox: Option<Rect>,
     ) -> Result<(), String> {
         // A PDF hairline has device-dependent minimum width. Without an
         // authenticated target raster, an interior selection cannot prove that
         // an outside centreline contributes no pixels.
         let uncertain_hairline =
             self.conversion_clip && paint.strokes() && self.frame.state.line_width == 0.;
-        let visible = uncertain_hairline || bbox.is_some_and(|b| extent::intersects(&b, &self.clip));
+        let visible = uncertain_hairline
+            || painted_bbox.is_some_and(|b| extent::intersects(&b, &self.clip));
         let fill_block = paint
             .fills()
             .then(|| self.state_block(self.frame.taint.fill_pattern))
@@ -91,7 +94,7 @@ impl Interpreter {
             _ => None,
         };
         if self.conversion_clip && visible {
-            if let (Some(_), Some([x0, y0, x1, y1])) = (kept, bbox) {
+            if let (Some(_), Some([x0, y0, x1, y1])) = (kept, painted_bbox) {
                 if x0 < self.clip[0] || y0 < self.clip[1]
                     || x1 > self.clip[2] || y1 > self.clip[3]
                 {
@@ -102,11 +105,11 @@ impl Interpreter {
             }
         }
         if let Some(kind) = &fill_block {
-            self.report.record(kind, ordinal, bbox, visible, true);
+            self.report.record(kind, ordinal, path_bbox, visible, true);
         }
         if let Some(kind) = &stroke_block {
             if fill_block.as_ref() != Some(kind) {
-                self.report.record(kind, ordinal, bbox, visible, true);
+                self.report.record(kind, ordinal, path_bbox, visible, true);
             }
         }
         if visible || !self.conversion_clip {

--- a/rust/processing/src/pdf_vector/tests.rs
+++ b/rust/processing/src/pdf_vector/tests.rs
@@ -113,6 +113,23 @@ fn issue_4406_conversion_clip_combines_square_caps_with_small_miter_limit() {
         "square end caps remain part of the envelope when the miter limit is smaller: {error}");
 }
 #[test]
+fn issue_4613_omission_extent_stays_in_the_independent_control_point_contract() {
+    let input = page(vec![
+        PdfVectorOperator::LineWidth { width: 2. },
+        PdfVectorOperator::Path {
+            paint: PdfVectorPaint::Stroke,
+            commands: vec![0., 120., 20., 2., 120., 100., 220., 100., 220., 20.],
+        },
+    ]);
+    let prepared = prepare_pdf_vector_page(&input).unwrap();
+    let omission = &prepared.fidelity.omissions[0];
+    assert_eq!(omission.kind, "curvedStroke");
+    // The MuPDF oracle records cubic controls in this frame. The separate
+    // painted-ink envelope expands by the default miter limit for fail-closed
+    // crop decisions, but must not shift this independently checked extent.
+    assert_eq!(omission.bbox_pdf, Some([120., 20., 220., 100.]));
+}
+#[test]
 fn issue_4406_preserves_curves_fill_rules_and_paint_order_without_claiming_flattening() {
     let commands = vec![
         0., 0., 0., 2., 1., 3., 2., 3., 3., 0., 3., 4., 1., 5., 0., 4.,


### PR DESCRIPTION
Closes #4613.

#4609 correctly started using a conservative painted-ink envelope for crop visibility and boundary rejection, but also exposed that envelope as the fidelity omission extent. For the controlled cubic, the default miter limit expanded PDF x=120 to x=110, so the independent MuPDF affine produced 200 instead of its measured control-point value 220.

This keeps separate bounds: fidelity reports retain the documented path/control-point frame checked by MuPDF, while conversion-crop decisions continue using the expanded painted-ink envelope and remain fail-closed.

Validation:

- Fresh `pnpm build:wasm`
- `pnpm test:wasm-contract`: 93 passed, 0 failed, 1 optional historical-baseline skip
- `cargo test -p ifc-lite-processing --lib pdf_vector::tests`: 13 passed
- `node scripts/check-module-size.mjs`: passed
- `git diff --check`: passed

The new #4613 regression pins the exact cubic control-point bbox and documents why the crop-safety miter expansion must not change the independent oracle frame.
